### PR TITLE
Add CreatePool from JSON to x/gamm CLI

### DIFF
--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -119,6 +119,16 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 
 	badJSON := testutil.WriteToNewTempFile(s.T(), "bad json")
 
+	// this badJSON is missing quotes around the FlagExitFee value
+	badJSON2 := testutil.WriteToNewTempFile(s.T(), fmt.Sprintf(`
+	{
+	  "%s": "1node0token,3stake",
+	  "%s": "100node0token,100stake",
+	  "%s": "0.001",
+	  "%s": 0.001
+	}
+	`, cli.FlagWeights, cli.FlagInitialDeposit, cli.FlagSwapFee, cli.FlagExitFee))
+
 	testCases := []struct {
 		name         string
 		args         []string
@@ -251,6 +261,18 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			"bad pool json",
 			[]string{
 				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, badJSON.Name()),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"bad pool json 2",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, badJSON2.Name()),
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
 				// common args
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),

--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -19,6 +19,7 @@ import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -107,6 +108,17 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	)
 	s.Require().NoError(err)
 
+	okJSON := testutil.WriteToNewTempFile(s.T(), fmt.Sprintf(`
+	{
+	  "%s": "1node0token,3stake",
+	  "%s": "100node0token,100stake",
+	  "%s": "0.001",
+	  "%s": "0.001"
+	}
+	`, cli.FlagWeights, cli.FlagInitialDeposit, cli.FlagSwapFee, cli.FlagExitFee))
+
+	badJSON := testutil.WriteToNewTempFile(s.T(), "bad json")
+
 	testCases := []struct {
 		name         string
 		args         []string
@@ -117,7 +129,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 		{
 			"one token pair pool",
 			[]string{
-				"1node0token",
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token"),
 				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token"),
 				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
 				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
@@ -132,7 +144,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 		{
 			"two tokens pair pool",
 			[]string{
-				"1node0token,3stake",
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
 				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
 				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
 				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
@@ -147,7 +159,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 		{ // --record-tokens=100.0stake2 --record-tokens=100.0stake --record-tokens-weight=5 --record-tokens-weight=5 --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
 			"three tokens pair pool - insufficient balance check",
 			[]string{
-				"1node0token,1stake,2btc",
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,1stake,2btc"),
 				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake,100btc"),
 				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
 				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
@@ -158,6 +170,119 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
 			false, &sdk.TxResponse{}, 5,
+		},
+		{
+			"future governor address",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "cosmos1fqlr98d45v5ysqgp6h56kpujcj4cvsjn6mkrwy"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"future governor time",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "2h"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"future governor token + time",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "token,1000h"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"invalid future governor",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
+				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "validdenom,invalidtime"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 7,
+		},
+		{
+			"pool json",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, okJSON.Name()),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"bad pool json",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, badJSON.Name()),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"nonexistant pool json",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, "fileDoesNotExist"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"incompatible flags with --pool-file",
+			[]string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, okJSON.Name()),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			true, &sdk.TxResponse{}, 0,
 		},
 	}
 

--- a/x/gamm/client/cli/flags.go
+++ b/x/gamm/client/cli/flags.go
@@ -76,7 +76,7 @@ func FlagSetSwapAmountOutRoutes() *flag.FlagSet {
 func FlagSetCreatePool() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.String(FlagPoolFile, "", "Pool json file path (if this path is given, other proposal flags should not be used)")
+	fs.String(FlagPoolFile, "", "Pool json file path (if this path is given, other create pool flags should not be used)")
 	fs.String(FlagWeights, "", "The amm weights of the tokens in the pool")
 	fs.String(FlagInitialDeposit, "", "The tokens to be deposited to the pool initially")
 	fs.String(FlagSwapFee, "", "Swap fee of the pool")

--- a/x/gamm/client/cli/flags.go
+++ b/x/gamm/client/cli/flags.go
@@ -5,12 +5,19 @@ import (
 )
 
 const (
+	// Will be parsed to string
+	FlagPoolFile = "pool-file"
+
+	// Will be parsed to []sdk.DecCoin
+	FlagWeights = "weights"
 	// Will be parsed to []sdk.Coin
 	FlagInitialDeposit = "initial-deposit"
 	// Will be parsed to sdk.Dec
 	FlagSwapFee = "swap-fee"
 	// Will be parsed to sdk.Dec
 	FlagExitFee = "exit-fee"
+	// FlagFutureGovernor can be an address, or a This LP Token, lockup time pair
+	FlagFutureGovernor = "future-governor"
 
 	FlagPoolId = "pool-id"
 	// Will be parsed to sdk.Int
@@ -29,10 +36,26 @@ const (
 	FlagSwapRouteAmounts = "swap-route-amounts"
 	// Will be parsed to []string
 	FlagSwapRouteDenoms = "swap-route-denoms"
-
-	// FlagFutureGovernor can be an address, or a This LP Token, lockup time pair
-	FlagFutureGovernor = "future-governor"
 )
+
+// CreatePoolFlags defines the core required fields of creating a pool. It is used to
+// verify that these values are not provided in conjunction with a JSON pool
+// file.
+var CreatePoolFlags = []string{
+	FlagWeights,
+	FlagInitialDeposit,
+	FlagSwapFee,
+	FlagExitFee,
+	FlagFutureGovernor,
+}
+
+type createPoolInputs struct {
+	Weights        string `json:"weights"`
+	InitialDeposit string `json:"initial-deposit"`
+	SwapFee        string `json:"swap-fee"`
+	ExitFee        string `json:"exit-fee"`
+	FutureGovernor string `json:"future-governor"`
+}
 
 func FlagSetQuerySwapRoutes() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
@@ -53,6 +76,8 @@ func FlagSetSwapAmountOutRoutes() *flag.FlagSet {
 func FlagSetCreatePool() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
+	fs.String(FlagPoolFile, "", "Pool json file path (if this path is given, other proposal flags should not be used)")
+	fs.String(FlagWeights, "", "The amm weights of the tokens in the pool")
 	fs.String(FlagInitialDeposit, "", "The tokens to be deposited to the pool initially")
 	fs.String(FlagSwapFee, "", "Swap fee of the pool")
 	fs.String(FlagExitFee, "", "Exit fee of the pool")

--- a/x/gamm/client/cli/parse.go
+++ b/x/gamm/client/cli/parse.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/pflag"
+)
+
+func parseCreatePoolFlags(fs *pflag.FlagSet) (*createPoolInputs, error) {
+	pool := &createPoolInputs{}
+	poolFile, _ := fs.GetString(FlagPoolFile)
+
+	if poolFile == "" {
+		pool.Weights, _ = fs.GetString(FlagWeights)
+		pool.InitialDeposit, _ = fs.GetString(FlagInitialDeposit)
+		pool.SwapFee, _ = fs.GetString(FlagSwapFee)
+		pool.ExitFee, _ = fs.GetString(FlagExitFee)
+		pool.FutureGovernor, _ = fs.GetString(FlagFutureGovernor)
+		return pool, nil
+	}
+
+	for _, flag := range CreatePoolFlags {
+		if v, _ := fs.GetString(flag); v != "" {
+			return nil, fmt.Errorf("--%s flag provided alongside --%s, which is a noop", flag, FlagPoolFile)
+		}
+	}
+
+	contents, err := ioutil.ReadFile(poolFile)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(contents, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -41,12 +41,12 @@ func NewTxCmd() *cobra.Command {
 
 func NewCreatePoolCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create-pool <token-weights> [flags]",
+		Use:   "create-pool [flags]",
 		Short: "create a new pool and provide the liquidity to it",
 		Long: `create a new pool and provide the liquidity to it.
-			e.g. create-pool 4uatom,4osmo,2uakt --initial-deposit 100uatom,5osmo,20uakt --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
+			e.g. create-pool --weights 4uatom,4osmo,2uakt --initial-deposit 100uatom,5osmo,20uakt --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
 		`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -55,7 +55,7 @@ func NewCreatePoolCmd() *cobra.Command {
 
 			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
 
-			txf, msg, err := NewBuildCreatePoolMsg(clientCtx, txf, args[0], cmd.Flags())
+			txf, msg, err := NewBuildCreatePoolMsg(clientCtx, txf, cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -67,9 +67,9 @@ func NewCreatePoolCmd() *cobra.Command {
 	cmd.Flags().AddFlagSet(FlagSetCreatePool())
 	flags.AddTxFlagsToCmd(cmd)
 
-	_ = cmd.MarkFlagRequired(FlagInitialDeposit)
-	_ = cmd.MarkFlagRequired(FlagSwapFee)
-	_ = cmd.MarkFlagRequired(FlagExitFee)
+	// _ = cmd.MarkFlagRequired(FlagInitialDeposit)
+	// _ = cmd.MarkFlagRequired(FlagSwapFee)
+	// _ = cmd.MarkFlagRequired(FlagExitFee)
 
 	return cmd
 }
@@ -314,18 +314,19 @@ func NewExitSwapShareAmountIn() *cobra.Command {
 	return cmd
 }
 
-func NewBuildCreatePoolMsg(clientCtx client.Context, txf tx.Factory, tokenWeights string, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
-	initialDepositStr, err := fs.GetString(FlagInitialDeposit)
+func NewBuildCreatePoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+
+	pool, err := parseCreatePoolFlags(fs)
+	if err != nil {
+		return txf, nil, fmt.Errorf("failed to parse pool: %w", err)
+	}
+
+	deposit, err := sdk.ParseCoinsNormalized(pool.InitialDeposit)
 	if err != nil {
 		return txf, nil, err
 	}
 
-	deposit, err := sdk.ParseCoinsNormalized(initialDepositStr)
-	if err != nil {
-		return txf, nil, err
-	}
-
-	poolAssetCoins, err := sdk.ParseDecCoins(tokenWeights)
+	poolAssetCoins, err := sdk.ParseDecCoins(pool.Weights)
 	if err != nil {
 		return txf, nil, err
 	}
@@ -334,20 +335,12 @@ func NewBuildCreatePoolMsg(clientCtx client.Context, txf tx.Factory, tokenWeight
 		return txf, nil, errors.New("deposit tokens and token weights should have same length")
 	}
 
-	swapFeeStr, err := fs.GetString(FlagSwapFee)
-	if err != nil {
-		return txf, nil, err
-	}
-	swapFee, err := sdk.NewDecFromStr(swapFeeStr)
+	swapFee, err := sdk.NewDecFromStr(pool.SwapFee)
 	if err != nil {
 		return txf, nil, err
 	}
 
-	exitFeeStr, err := fs.GetString(FlagExitFee)
-	if err != nil {
-		return txf, nil, err
-	}
-	exitFee, err := sdk.NewDecFromStr(exitFeeStr)
+	exitFee, err := sdk.NewDecFromStr(pool.ExitFee)
 	if err != nil {
 		return txf, nil, err
 	}
@@ -365,11 +358,6 @@ func NewBuildCreatePoolMsg(clientCtx client.Context, txf tx.Factory, tokenWeight
 		})
 	}
 
-	futureGovernor, err := fs.GetString(FlagFutureGovernor)
-	if err != nil {
-		return txf, nil, err
-	}
-
 	msg := &types.MsgCreatePool{
 		Sender: clientCtx.GetFromAddress().String(),
 		PoolParams: types.PoolParams{
@@ -377,7 +365,7 @@ func NewBuildCreatePoolMsg(clientCtx client.Context, txf tx.Factory, tokenWeight
 			ExitFee: exitFee,
 		},
 		PoolAssets:         poolAssets,
-		FuturePoolGovernor: futureGovernor,
+		FuturePoolGovernor: pool.FutureGovernor,
 	}
 
 	return txf, msg, nil

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -47,10 +47,10 @@ func NewCreatePoolCmd() *cobra.Command {
 		Short: "create a new pool and provide the liquidity to it",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`create a new pool and provide the liquidity to it.
-Proposal initialization parameters can be given directly as CLI flags or through a pool JSON file.
+Pool initialization parameters can be given directly as CLI flags or through a pool JSON file.
 
 Example:
-$ %s tx gamm create-pool --proposal="path/to/pool.json" --from mykey
+$ %s tx gamm create-pool --pool-file="path/to/pool.json" --from mykey
 Where pool.json contains:
 {
 	"weights": "4uatom,4osmo,2uakt",

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -13,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
 )
 
 func NewTxCmd() *cobra.Command {
@@ -43,9 +45,27 @@ func NewCreatePoolCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-pool [flags]",
 		Short: "create a new pool and provide the liquidity to it",
-		Long: `create a new pool and provide the liquidity to it.
-			e.g. create-pool --weights 4uatom,4osmo,2uakt --initial-deposit 100uatom,5osmo,20uakt --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
-		`,
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`create a new pool and provide the liquidity to it.
+Proposal initialization parameters can be given directly as CLI flags or through a pool JSON file.
+
+Example:
+$ %s tx gamm create-pool --proposal="path/to/pool.json" --from mykey
+Where pool.json contains:
+{
+	"weights": "4uatom,4osmo,2uakt",
+	"initial-deposit": "100uatom,5osmo,20uakt",
+	"swap-fee": "0.01",
+	"exit-fee": "0.01",
+	"future-governor": "168h"
+}
+
+Which is equivalent to:
+$ %s tx gamm create-pool --weights 4uatom,4osmo,2uakt --initial-deposit 100uatom,5osmo,20uakt --swap-fee=0.01 --exit-fee=0.01 --future-governor 168h --from=mykey
+`,
+				version.AppName, version.AppName,
+			),
+		),
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/x/gamm/client/testutil/test_helpers.go
+++ b/x/gamm/client/testutil/test_helpers.go
@@ -31,7 +31,7 @@ func MsgCreatePool(
 	args := []string{}
 
 	args = append(args,
-		tokenWeights,
+		fmt.Sprintf("--%s=%s", gammcli.FlagWeights, tokenWeights),
 		fmt.Sprintf("--%s=%s", gammcli.FlagInitialDeposit, initialDeposit),
 		fmt.Sprintf("--%s=%s", gammcli.FlagSwapFee, swapFee),
 		fmt.Sprintf("--%s=%s", gammcli.FlagExitFee, exitFee),


### PR DESCRIPTION
Instead of passing in all parameters as CLI flags, you can define them in a pool.json file and pass to the create pool command.

Example:

`$ osmosisd tx gamm create-pool --pool-file="path/to/pool.json" --from mykey`
Where pool.json contains:
```
{
	"weights": "4uatom,4osmo,2uakt",
	"initial-deposit": "100uatom,5osmo,20uakt",
	"swap-fee": "0.01",
	"exit-fee": "0.01",
	"future-governor": "168h"
}
```

Which is equivalent to:
`$ osmosisd tx gamm create-pool --weights 4uatom,4osmo,2uakt --initial-deposit 100uatom,5osmo,20uakt --swap-fee=0.01 --exit-fee=0.01 --future-governor 168h --from=mykey`