### PR TITLE
Remove CreatePool CLI flags

### DIFF
--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -115,7 +115,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	  "%s": "0.001",
 	  "%s": "0.001"
 	}
-	`, cli.FlagWeights, cli.FlagInitialDeposit, cli.FlagSwapFee, cli.FlagExitFee))
+	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee))
 
 	badJSON := testutil.WriteToNewTempFile(s.T(), "bad json")
 
@@ -127,10 +127,11 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	  "%s": "0.001",
 	  "%s": 0.001
 	}
-	`, cli.FlagWeights, cli.FlagInitialDeposit, cli.FlagSwapFee, cli.FlagExitFee))
+	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee))
 
 	testCases := []struct {
 		name         string
+		json         string
 		args         []string
 		expectErr    bool
 		respType     proto.Message
@@ -138,11 +139,15 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	}{
 		{
 			"one token pair pool",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token",
+			  "%s": "100node0token",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee))),
 			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
 				// common args
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),

--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -78,7 +78,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	val := s.network.Validators[0]
 
 	// create a new pool
-	_, err = gammtestutil.MsgCreatePool(val.ClientCtx, val.Address, "5stake,5node0token", "100stake,100node0token", "0.01", "0.01")
+	_, err = gammtestutil.MsgCreatePool(s.T(), val.ClientCtx, val.Address, "5stake,5node0token", "100stake,100node0token", "0.01", "0.01", "")
 	s.Require().NoError(err)
 
 	_, err = s.network.WaitForHeight(1)
@@ -108,31 +108,9 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	)
 	s.Require().NoError(err)
 
-	okJSON := testutil.WriteToNewTempFile(s.T(), fmt.Sprintf(`
-	{
-	  "%s": "1node0token,3stake",
-	  "%s": "100node0token,100stake",
-	  "%s": "0.001",
-	  "%s": "0.001"
-	}
-	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee))
-
-	badJSON := testutil.WriteToNewTempFile(s.T(), "bad json")
-
-	// this badJSON is missing quotes around the FlagExitFee value
-	badJSON2 := testutil.WriteToNewTempFile(s.T(), fmt.Sprintf(`
-	{
-	  "%s": "1node0token,3stake",
-	  "%s": "100node0token,100stake",
-	  "%s": "0.001",
-	  "%s": 0.001
-	}
-	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee))
-
 	testCases := []struct {
 		name         string
 		json         string
-		args         []string
 		expectErr    bool
 		respType     proto.Message
 		expectedCode uint32
@@ -146,169 +124,105 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": "0.001",
 			  "%s": "0.001"
 			}
-			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee))),
-			[]string{
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
 			false, &sdk.TxResponse{}, 4,
 		},
 		{
 			"two tokens pair pool",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
 			false, &sdk.TxResponse{}, 0,
 		},
 		{ // --record-tokens=100.0stake2 --record-tokens=100.0stake --record-tokens-weight=5 --record-tokens-weight=5 --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
 			"three tokens pair pool - insufficient balance check",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,1stake,2btc"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake,100btc"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,1stake,2btc",
+			  "%s": "100node0token,100stake,100btc",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
 			false, &sdk.TxResponse{}, 5,
 		},
 		{
 			"future governor address",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "cosmos1fqlr98d45v5ysqgp6h56kpujcj4cvsjn6mkrwy"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001",
+			  "%s": "cosmos1fqlr98d45v5ysqgp6h56kpujcj4cvsjn6mkrwy"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
 			false, &sdk.TxResponse{}, 0,
 		},
 		{
 			"future governor time",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "2h"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001",
+			  "%s": "2h"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
 			false, &sdk.TxResponse{}, 0,
 		},
 		{
 			"future governor token + time",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "token,1000h"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001",
+			  "%s": "token,1000h"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
 			false, &sdk.TxResponse{}, 0,
 		},
 		{
 			"invalid future governor",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagWeights, "1node0token,3stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagInitialDeposit, "100node0token,100stake"),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagExitFee, "0.001"),
-				fmt.Sprintf("--%s=%s", cli.FlagFutureGovernor, "validdenom,invalidtime"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001",
+			  "%s": "validdenom,invalidtime"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
 			false, &sdk.TxResponse{}, 7,
 		},
 		{
-			"pool json",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, okJSON.Name()),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
-			false, &sdk.TxResponse{}, 0,
-		},
-		{
-			"bad pool json",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, badJSON.Name()),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			"not valid json",
+			"bad json",
 			true, &sdk.TxResponse{}, 0,
 		},
 		{
-			"bad pool json 2",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, badJSON2.Name()),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			"bad pool json - missing quotes around exit fee",
+			fmt.Sprintf(`
+	{
+	  "%s": "1node0token,3stake",
+	  "%s": "100node0token,100stake",
+	  "%s": "0.001",
+	  "%s": 0.001
+	}
+	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
 			true, &sdk.TxResponse{}, 0,
 		},
 		{
-			"nonexistant pool json",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, "fileDoesNotExist"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
-			true, &sdk.TxResponse{}, 0,
-		},
-		{
-			"incompatible flags with --pool-file",
-			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, okJSON.Name()),
-				fmt.Sprintf("--%s=%s", cli.FlagSwapFee, "0.001"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
-				// common args
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
-			},
+			"empty pool json",
+			"",
 			true, &sdk.TxResponse{}, 0,
 		},
 	}
@@ -320,7 +234,18 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			cmd := cli.NewCreatePoolCmd()
 			clientCtx := val.ClientCtx
 
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			jsonFile := testutil.WriteToNewTempFile(s.T(), tc.json)
+
+			args := []string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, jsonFile.Name()),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			}
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
 			if tc.expectErr {
 				s.Require().Error(err)
 			} else {

--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -211,19 +211,18 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 		{
 			"bad pool json - missing quotes around exit fee",
 			fmt.Sprintf(`
-	{
-	  "%s": "1node0token,3stake",
-	  "%s": "100node0token,100stake",
-	  "%s": "0.001",
-	  "%s": 0.001
-	}
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": 0.001
+			}
 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
 			true, &sdk.TxResponse{}, 0,
 		},
 		{
 			"empty pool json",
-			"",
-			true, &sdk.TxResponse{}, 0,
+			"", true, &sdk.TxResponse{}, 0,
 		},
 	}
 

--- a/x/gamm/client/cli/flags.go
+++ b/x/gamm/client/cli/flags.go
@@ -8,16 +8,12 @@ const (
 	// Will be parsed to string
 	FlagPoolFile = "pool-file"
 
-	// Will be parsed to []sdk.DecCoin
-	FlagWeights = "weights"
-	// Will be parsed to []sdk.Coin
-	FlagInitialDeposit = "initial-deposit"
-	// Will be parsed to sdk.Dec
-	FlagSwapFee = "swap-fee"
-	// Will be parsed to sdk.Dec
-	FlagExitFee = "exit-fee"
-	// FlagFutureGovernor can be an address, or a This LP Token, lockup time pair
-	FlagFutureGovernor = "future-governor"
+	// Names of fields in pool json file
+	PoolFileWeights        = "weights"
+	PoolFileInitialDeposit = "initial-deposit"
+	PoolFileSwapFee        = "swap-fee"
+	PoolFileExitFee        = "exit-fee"
+	PoolFileFutureGovernor = "future-governor"
 
 	FlagPoolId = "pool-id"
 	// Will be parsed to sdk.Int
@@ -37,17 +33,6 @@ const (
 	// Will be parsed to []string
 	FlagSwapRouteDenoms = "swap-route-denoms"
 )
-
-// CreatePoolFlags defines the core required fields of creating a pool. It is used to
-// verify that these values are not provided in conjunction with a JSON pool
-// file.
-var CreatePoolFlags = []string{
-	FlagWeights,
-	FlagInitialDeposit,
-	FlagSwapFee,
-	FlagExitFee,
-	FlagFutureGovernor,
-}
 
 type createPoolInputs struct {
 	Weights        string `json:"weights"`
@@ -77,11 +62,6 @@ func FlagSetCreatePool() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
 	fs.String(FlagPoolFile, "", "Pool json file path (if this path is given, other create pool flags should not be used)")
-	fs.String(FlagWeights, "", "The amm weights of the tokens in the pool")
-	fs.String(FlagInitialDeposit, "", "The tokens to be deposited to the pool initially")
-	fs.String(FlagSwapFee, "", "Swap fee of the pool")
-	fs.String(FlagExitFee, "", "Exit fee of the pool")
-	fs.String(FlagFutureGovernor, "", "Future governor of the pool")
 	return fs
 }
 

--- a/x/gamm/client/cli/parse.go
+++ b/x/gamm/client/cli/parse.go
@@ -13,18 +13,7 @@ func parseCreatePoolFlags(fs *pflag.FlagSet) (*createPoolInputs, error) {
 	poolFile, _ := fs.GetString(FlagPoolFile)
 
 	if poolFile == "" {
-		pool.Weights, _ = fs.GetString(FlagWeights)
-		pool.InitialDeposit, _ = fs.GetString(FlagInitialDeposit)
-		pool.SwapFee, _ = fs.GetString(FlagSwapFee)
-		pool.ExitFee, _ = fs.GetString(FlagExitFee)
-		pool.FutureGovernor, _ = fs.GetString(FlagFutureGovernor)
-		return pool, nil
-	}
-
-	for _, flag := range CreatePoolFlags {
-		if v, _ := fs.GetString(flag); v != "" {
-			return nil, fmt.Errorf("--%s flag provided alongside --%s, which is a noop", flag, FlagPoolFile)
-		}
+		return nil, fmt.Errorf("must pass in a pool json using the --%s flag", FlagPoolFile)
 	}
 
 	contents, err := ioutil.ReadFile(poolFile)

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -47,10 +47,11 @@ func NewCreatePoolCmd() *cobra.Command {
 		Short: "create a new pool and provide the liquidity to it",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`create a new pool and provide the liquidity to it.
-Pool initialization parameters can be given directly as CLI flags or through a pool JSON file.
+Pool initialization parameters must be provided through a pool JSON file.
 
 Example:
 $ %s tx gamm create-pool --pool-file="path/to/pool.json" --from mykey
+
 Where pool.json contains:
 {
 	"weights": "4uatom,4osmo,2uakt",
@@ -59,11 +60,8 @@ Where pool.json contains:
 	"exit-fee": "0.01",
 	"future-governor": "168h"
 }
-
-Which is equivalent to:
-$ %s tx gamm create-pool --weights 4uatom,4osmo,2uakt --initial-deposit 100uatom,5osmo,20uakt --swap-fee=0.01 --exit-fee=0.01 --future-governor 168h --from=mykey
 `,
-				version.AppName, version.AppName,
+				version.AppName,
 			),
 		),
 		Args: cobra.ExactArgs(0),
@@ -87,9 +85,7 @@ $ %s tx gamm create-pool --weights 4uatom,4osmo,2uakt --initial-deposit 100uatom
 	cmd.Flags().AddFlagSet(FlagSetCreatePool())
 	flags.AddTxFlagsToCmd(cmd)
 
-	// _ = cmd.MarkFlagRequired(FlagInitialDeposit)
-	// _ = cmd.MarkFlagRequired(FlagSwapFee)
-	// _ = cmd.MarkFlagRequired(FlagExitFee)
+	_ = cmd.MarkFlagRequired(FlagPoolFile)
 
 	return cmd
 }

--- a/x/gamm/client/testutil/test_helpers.go
+++ b/x/gamm/client/testutil/test_helpers.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"fmt"
+	"testing"
 
 	gammcli "github.com/c-osmosis/osmosis/x/gamm/client/cli"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -20,21 +21,42 @@ var commonArgs = []string{
 
 // MsgCreatePool broadcast a pool creation message.
 func MsgCreatePool(
+	t *testing.T,
 	clientCtx client.Context,
 	owner fmt.Stringer,
 	tokenWeights string,
 	initialDeposit string,
 	swapFee string,
 	exitFee string,
+	futureGovernor string,
 	extraArgs ...string,
 ) (testutil.BufferWriter, error) {
 	args := []string{}
 
+	jsonFile := testutil.WriteToNewTempFile(t,
+		fmt.Sprintf(`
+		{
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s"
+		}
+		`, gammcli.PoolFileWeights,
+			tokenWeights,
+			gammcli.PoolFileInitialDeposit,
+			initialDeposit,
+			gammcli.PoolFileSwapFee,
+			swapFee,
+			gammcli.PoolFileExitFee,
+			exitFee,
+			gammcli.PoolFileExitFee,
+			exitFee,
+		),
+	)
+
 	args = append(args,
-		fmt.Sprintf("--%s=%s", gammcli.FlagWeights, tokenWeights),
-		fmt.Sprintf("--%s=%s", gammcli.FlagInitialDeposit, initialDeposit),
-		fmt.Sprintf("--%s=%s", gammcli.FlagSwapFee, swapFee),
-		fmt.Sprintf("--%s=%s", gammcli.FlagExitFee, exitFee),
+		fmt.Sprintf("--%s=%s", gammcli.FlagPoolFile, jsonFile.Name()),
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, owner.String()),
 	)
 


### PR DESCRIPTION
As recommended by @ValarDragon, this removes the ability to use CLI flags for the CreatePool msg.  Instead, it only supports the pool.json method added in #120.

This is done because the CreatePool cli flags were quite confusing and likely to be error prone.