### PR TITLE
only end airdrop once

### DIFF
--- a/x/claim/abci.go
+++ b/x/claim/abci.go
@@ -13,10 +13,13 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 		panic(err)
 	}
 
-	// End Airdrop
-	goneTime := ctx.BlockTime().Sub(params.AirdropStart)
-	if goneTime > params.DurationUntilDecay+params.DurationOfDecay {
-		// airdrop time passed
-		k.EndAirdrop(ctx)
+	// Only check whether to end airdrop if it hasn't already ended
+	if !k.GetAirdropCompleted(ctx) {
+		// End Airdrop
+		goneTime := ctx.BlockTime().Sub(params.AirdropStart)
+		if goneTime > params.DurationUntilDecay+params.DurationOfDecay {
+			// airdrop time passed
+			k.EndAirdrop(ctx)
+		}
 	}
 }

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -28,6 +28,7 @@ func (k Keeper) EndAirdrop(ctx sdk.Context) error {
 		return err
 	}
 	k.clearInitialClaimables(ctx)
+	k.setAirdropCompleted(ctx, true)
 	return nil
 }
 
@@ -177,4 +178,25 @@ func (k Keeper) fundRemainingsToCommunity(ctx sdk.Context) error {
 	moduleAccAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
 	amt := k.GetModuleAccountBalance(ctx)
 	return k.distrKeeper.FundCommunityPool(ctx, sdk.NewCoins(amt), moduleAccAddr)
+}
+
+// GetAirdropCompleted returns a bool for whether EndAirdrop was already run
+func (k Keeper) GetAirdropCompleted(ctx sdk.Context) bool {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get([]byte(types.AirdropCompletedKey))
+	if bz[0] == byte(1) {
+		return true
+	}
+	return false
+}
+
+// setAirdropCompleted sets a bool to define if EndAirdrop was already run
+func (k Keeper) setAirdropCompleted(ctx sdk.Context, completed bool) {
+	store := ctx.KVStore(k.storeKey)
+	if completed {
+		store.Set([]byte(types.AirdropCompletedKey), []byte{byte(1)})
+	} else {
+		store.Set([]byte(types.AirdropCompletedKey), []byte{byte(0)})
+	}
+	return
 }

--- a/x/claim/types/keys.go
+++ b/x/claim/types/keys.go
@@ -21,4 +21,7 @@ const (
 
 	// ActionKey defines the store key to store user accomplished actions
 	ActionKey = "action"
+
+	// AirdropCompletedKey defines the store key for whether the airdrop is completed
+	AirdropCompletedKey = "completed"
 )


### PR DESCRIPTION
closes #137 

Currently, the claims module runs `EndAirdrop` every block after the airdrop completion time is over.  This PR adds an in-state bool storing whether the airdrop is completed, and only runs the check once it is completed.