### PR TITLE
Mint test modifications

### DIFF
--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -85,9 +85,16 @@ func (suite *KeeperTestSuite) TestDistrAssetToDeveloperRewardsAddrWhenNotEmpty()
 	suite.NoError(err)
 
 	feePool := suite.app.DistrKeeper.GetFeePool(suite.ctx)
-	suite.Equal("40000stake", suite.app.BankKeeper.GetBalance(suite.ctx, suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "stake").String())
-	suite.Equal("10000.000000000000000000stake", feePool.CommunityPool.String())
-	suite.Equal("20000stake", suite.app.BankKeeper.GetBalance(suite.ctx, devRewardsReceiver, "stake").String())
+	feeCollector := suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+	suite.Equal(
+		mintCoins[0].Amount.ToDec().Mul(params.DistributionProportions.Staking).TruncateInt(),
+		suite.app.BankKeeper.GetAllBalances(suite.ctx, feeCollector).AmountOf("stake"))
+	suite.Equal(
+		mintCoins[0].Amount.ToDec().Mul(params.DistributionProportions.CommunityPool),
+		feePool.CommunityPool.AmountOf("stake"))
+	suite.Equal(
+		mintCoins[0].Amount.ToDec().Mul(params.DistributionProportions.DeveloperRewards).TruncateInt(),
+		suite.app.BankKeeper.GetBalance(suite.ctx, devRewardsReceiver, "stake").Amount)
 }
 
 func (suite *KeeperTestSuite) TestDistrAssetToCommunityPoolWhenNoDeveloperRewardsAddr() {

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -57,7 +57,7 @@ func DefaultParams() Params {
 			Staking:          sdk.NewDecWithPrec(4, 1), // 0.4
 			PoolIncentives:   sdk.NewDecWithPrec(3, 1), // 0.3
 			DeveloperRewards: sdk.NewDecWithPrec(2, 1), // 0.2
-			CommunityPool:    sdk.NewDecWithPrec(1, 1), // 0.5
+			CommunityPool:    sdk.NewDecWithPrec(1, 1), // 0.1
 		},
 		DeveloperRewardsReceiver:             "",
 		MintingRewardsDistributionStartEpoch: 0,


### PR DESCRIPTION
closes #214

* Adjust the tests in x/mint to not use magic numbers for their expected values
* Make a single test for checking that when the developer address is left blank, funds go to the community pool.