### PR TITLE
Speedup distribution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,4 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
 
-replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.5-0.20210613202848-b45039095bc3
+replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.5-0.20210616143906-49caecfe0a60

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/osmosis-labs/cosmos-sdk v0.42.5-0.20210613202848-b45039095bc3 h1:UpwrTsXpHKaFyLiDEiJoLTWjsB57bkd35KcpVjkrrL0=
 github.com/osmosis-labs/cosmos-sdk v0.42.5-0.20210613202848-b45039095bc3/go.mod h1:3JyT+Ud7QRTO1/ikncNqVhaF526ZKNqh2HGMqXn+QHE=
+github.com/osmosis-labs/cosmos-sdk v0.42.5-0.20210616143906-49caecfe0a60 h1:giqRZBXkTehX1oOjtC8gKfQ0E4XVyjkecZVpYdNEhk8=
+github.com/osmosis-labs/cosmos-sdk v0.42.5-0.20210616143906-49caecfe0a60/go.mod h1:3JyT+Ud7QRTO1/ikncNqVhaF526ZKNqh2HGMqXn+QHE=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -37,7 +37,7 @@ func TestFullAppSimulation(t *testing.T) {
 	// -Enabled=true -NumBlocks=1000 -BlockSize=200 \
 	// -Period=1 -Commit=true -Seed=57 -v -timeout 24h
 	sdkSimapp.FlagEnabledValue = true
-	sdkSimapp.FlagNumBlocksValue = 20
+	sdkSimapp.FlagNumBlocksValue = 100
 	sdkSimapp.FlagBlockSizeValue = 25
 	sdkSimapp.FlagCommitValue = true
 	sdkSimapp.FlagVerboseValue = true
@@ -117,9 +117,9 @@ func interBlockCacheOpt() func(*baseapp.BaseApp) {
 // // TODO: Make another test for the fuzzer itself, which just has noOp txs
 // // and doesn't depend on the application.
 func TestAppStateDeterminism(t *testing.T) {
-	// if !sdkSimapp.FlagEnabledValue {
-	// 	t.Skip("skipping application simulation")
-	// }
+	if !sdkSimapp.FlagEnabledValue {
+		t.Skip("skipping application simulation")
+	}
 
 	config := sdkSimapp.NewConfigFromFlags()
 	config.InitialBlockHeight = 1

--- a/x/incentives/keeper/bench_test.go
+++ b/x/incentives/keeper/bench_test.go
@@ -143,13 +143,17 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 	b.StartTimer()
 	// distribute coins from gauges to lockup owners
 	for i := 0; i < numDistrs; i++ {
-		for _, gaugeId := range gaugeIds {
-			gauge, _ := app.IncentivesKeeper.GetGaugeByID(ctx, gaugeId)
-			_, err := app.IncentivesKeeper.Distribute(ctx, *gauge)
-			if err != nil {
-				fmt.Printf("Distribute, %v\n", err)
-				b.FailNow()
-			}
+		// for _, gaugeId := range gaugeIds {
+		// 	gauge, _ := app.IncentivesKeeper.GetGaugeByID(ctx, gaugeId)
+		// 	_, err := app.IncentivesKeeper.Distribute(ctx, *gauge)
+		// 	if err != nil {
+		// 		fmt.Printf("Distribute, %v\n", err)
+		// 		b.FailNow()
+		// 	}
+		// }
+		_, err := app.IncentivesKeeper.DistributeAllGauges(ctx)
+		if err != nil {
+			b.FailNow()
 		}
 	}
 	b.ReportAllocs()

--- a/x/incentives/keeper/bench_test.go
+++ b/x/incentives/keeper/bench_test.go
@@ -77,7 +77,7 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 		addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 		coins := sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000000)}
 		for j := 0; j < numDenoms; j++ {
-			coins = coins.Add(sdk.NewInt64Coin(fmt.Sprintf("token%d", j), r.Int63n(100000000)))
+			coins = coins.Add(sdk.NewInt64Coin(fmt.Sprintf("token%d", j), 100000000))
 		}
 		app.BankKeeper.SetBalances(ctx, addr, coins)
 		app.AccountKeeper.SetAccount(ctx, authtypes.NewBaseAccount(addr, nil, 0, 0))
@@ -120,7 +120,7 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 
 	// setup lockups
 	for i := 0; i < numLockups; i++ {
-		addr := addrs[r.Int()%numAccts]
+		addr := addrs[i%numAccts]
 		simCoins := app.BankKeeper.SpendableCoins(ctx, addr)
 		duration := time.Second
 		_, err := app.LockupKeeper.LockTokens(ctx, addr, simCoins, duration)
@@ -152,6 +152,7 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 			}
 		}
 	}
+	b.ReportAllocs()
 }
 
 func BenchmarkDistributionLogicTiny(b *testing.B) {
@@ -159,7 +160,13 @@ func BenchmarkDistributionLogicTiny(b *testing.B) {
 }
 
 func BenchmarkDistributionLogicSmall(b *testing.B) {
-	benchmarkDistributionLogic(10, 1, 10, 1000, 100, b)
+	numAccts := 100
+	numDenoms := 8
+	numGauges := 30
+	numLockups := 2000
+	numDistrs := 1
+
+	benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numDistrs, b)
 }
 
 func BenchmarkDistributionLogicMedium(b *testing.B) {

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -319,6 +319,9 @@ func (k Keeper) payRewardToLock(ctx sdk.Context, lock lockuptypes.PeriodLock, re
 	if err != nil {
 		return err
 	}
+	if reward.Empty() {
+		return nil
+	}
 	err = k.bk.SendCoinsFromModuleToAccount(ctx, types.ModuleName, owner, reward)
 	return err
 }
@@ -466,12 +469,12 @@ func (k Keeper) distributeAllGaugesForDenom(
 		// 	k.FinishDistribution(ctx, gauge)
 		// }
 	}
-	if !sumGaugeRewards.IsEqual(totalDistrCoins) {
-		panic(fmt.Sprintf("basic %v, %v, %v, \n filtered gauges %v,\n locks %v\n", sumGaugeRewards, totalDistrCoins, totalDistrCoins.Sub(sumGaugeRewards),
-			filteredGauges, locks))
-	} else {
-		fmt.Println("Working correctly")
-	}
+	// if !sumGaugeRewards.IsEqual(totalDistrCoins) {
+	// 	panic(fmt.Sprintf("basic %v, %v, %v, \n filtered gauges %v,\n locks %v\n", sumGaugeRewards, totalDistrCoins, totalDistrCoins.Sub(sumGaugeRewards),
+	// 		filteredGauges, locks))
+	// } else {
+	// 	fmt.Println("Working correctly")
+	// }
 	return totalDistrCoins, nil
 }
 

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -256,6 +256,17 @@ func (k Keeper) FilteredLocksDistributionEst(ctx sdk.Context, gauge types.Gauge,
 
 // Distribute coins from gauge according to its conditions
 func (k Keeper) DistributeAllGauges(ctx sdk.Context) {
+	// Plan:
+	// We need to get a map for denom -> active gauges
+	// and a map for denom -> locks
+	// Both exist.
+	// Now we need to get list
+	// k.getAllGaugeIDsByDenom()
+	denoms := []string{}
+	for _, denom := range denoms {
+		gaugeIDs := k.getAllGaugeIDsByDenom(ctx, denom)
+		locks := k.GetLocksToDistribution()
+	}
 	// distribute due to epoch event
 	gauges := k.GetActiveGauges(ctx)
 	for _, gauge := range gauges {

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -255,6 +255,19 @@ func (k Keeper) FilteredLocksDistributionEst(ctx sdk.Context, gauge types.Gauge,
 }
 
 // Distribute coins from gauge according to its conditions
+func (k Keeper) DistributeAllGauges(ctx sdk.Context) {
+	// distribute due to epoch event
+	gauges := k.GetActiveGauges(ctx)
+	for _, gauge := range gauges {
+		k.Distribute(ctx, gauge)
+		// filled epoch is increased in this step and we compare with +1
+		if !gauge.IsPerpetual && gauge.NumEpochsPaidOver <= gauge.FilledEpochs+1 {
+			k.FinishDistribution(ctx, gauge)
+		}
+	}
+}
+
+// Distribute coins from gauge according to its conditions
 func (k Keeper) Distribute(ctx sdk.Context, gauge types.Gauge) (sdk.Coins, error) {
 	totalDistrCoins := sdk.NewCoins()
 	locks := k.GetLocksToDistribution(ctx, gauge.DistributeTo)

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -329,7 +329,7 @@ func (suite *KeeperTestSuite) TestPerpetualGaugeOperations() {
 	suite.Require().NoError(err)
 	distrCoins, err = suite.app.IncentivesKeeper.Distribute(suite.ctx, *gauge)
 	suite.Require().NoError(err)
-	suite.Require().Equal(distrCoins, sdk.Coins{})
+	suite.Require().True(distrCoins.Empty())
 
 	// add to gauge
 	addCoins := sdk.Coins{sdk.NewInt64Coin("stake", 200)}

--- a/x/incentives/keeper/grpc_query_test.go
+++ b/x/incentives/keeper/grpc_query_test.go
@@ -252,7 +252,7 @@ func (suite *KeeperTestSuite) TestGRPCDistributedCoins() {
 	// distribute coins to stakers
 	distrCoins, err := suite.app.IncentivesKeeper.Distribute(suite.ctx, *gauge)
 	suite.Require().NoError(err)
-	suite.Require().Equal(distrCoins, sdk.Coins{sdk.NewInt64Coin("stake", 4)})
+	suite.Require().Equal(sdk.Coins{sdk.NewInt64Coin("stake", 4)}, distrCoins)
 
 	// check gauge changes after distribution
 	gauge, err = suite.app.IncentivesKeeper.GetGaugeByID(suite.ctx, gaugeID)

--- a/x/incentives/keeper/hooks.go
+++ b/x/incentives/keeper/hooks.go
@@ -19,15 +19,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			}
 		}
 
-		// distribute due to epoch event
-		gauges = k.GetActiveGauges(ctx)
-		for _, gauge := range gauges {
-			k.Distribute(ctx, gauge)
-			// filled epoch is increased in this step and we compare with +1
-			if !gauge.IsPerpetual && gauge.NumEpochsPaidOver <= gauge.FilledEpochs+1 {
-				k.FinishDistribution(ctx, gauge)
-			}
-		}
+		k.DistributeAllGauges(ctx)
 	}
 }
 

--- a/x/incentives/keeper/hooks.go
+++ b/x/incentives/keeper/hooks.go
@@ -20,6 +20,15 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		}
 
 		k.DistributeAllGauges(ctx)
+
+		// Finish distribution
+		gauges = k.GetActiveGauges(ctx)
+		for _, gauge := range gauges {
+			// filled epoch is increased in this step and we compare with +1
+			if !gauge.IsPerpetual && gauge.NumEpochsPaidOver <= gauge.FilledEpochs+1 {
+				k.FinishDistribution(ctx, gauge)
+			}
+		}
 	}
 }
 

--- a/x/incentives/keeper/hooks.go
+++ b/x/incentives/keeper/hooks.go
@@ -19,7 +19,10 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			}
 		}
 
-		k.DistributeAllGauges(ctx)
+		_, err := k.DistributeAllGauges(ctx)
+		if err != nil {
+			panic(err)
+		}
 
 		// Finish distribution
 		gauges = k.GetActiveGauges(ctx)

--- a/x/incentives/keeper/setup_test.go
+++ b/x/incentives/keeper/setup_test.go
@@ -1,0 +1,59 @@
+package keeper_test
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/x/incentives/types"
+	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
+)
+
+func (suite *KeeperTestSuite) CreateGauge(isPerpetual bool, addr sdk.AccAddress, coins sdk.Coins, distrTo lockuptypes.QueryCondition, startTime time.Time, numEpoch uint64) (uint64, *types.Gauge) {
+	suite.app.BankKeeper.SetBalances(suite.ctx, addr, coins)
+	gaugeID, err := suite.app.IncentivesKeeper.CreateGauge(suite.ctx, isPerpetual, addr, coins, distrTo, startTime, numEpoch)
+	suite.Require().NoError(err)
+	gauge, err := suite.app.IncentivesKeeper.GetGaugeByID(suite.ctx, gaugeID)
+	suite.Require().NoError(err)
+	return gaugeID, gauge
+}
+
+func (suite *KeeperTestSuite) AddToGauge(coins sdk.Coins, gaugeID uint64) uint64 {
+	addr := sdk.AccAddress([]byte("addrx---------------"))
+	suite.app.BankKeeper.SetBalances(suite.ctx, addr, coins)
+	err := suite.app.IncentivesKeeper.AddToGaugeRewards(suite.ctx, addr, coins, gaugeID)
+	suite.Require().NoError(err)
+	return gaugeID
+}
+
+func (suite *KeeperTestSuite) LockTokens(addr sdk.AccAddress, coins sdk.Coins, duration time.Duration) {
+	suite.app.BankKeeper.SetBalances(suite.ctx, addr, coins)
+	_, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr, coins, duration)
+	suite.Require().NoError(err)
+}
+
+func (suite *KeeperTestSuite) SetupNewGauge(isPerpetual bool, coins sdk.Coins) (uint64, *types.Gauge, sdk.Coins, time.Time) {
+	addr2 := sdk.AccAddress([]byte("addr1---------------"))
+	startTime2 := time.Now()
+	distrTo := lockuptypes.QueryCondition{
+		LockQueryType: lockuptypes.ByDuration,
+		Denom:         "lptoken",
+		Duration:      time.Second,
+	}
+	numEpochsPaidOver := uint64(2)
+	if isPerpetual {
+		numEpochsPaidOver = uint64(1)
+	}
+	gaugeID, gauge := suite.CreateGauge(isPerpetual, addr2, coins, distrTo, startTime2, numEpochsPaidOver)
+	return gaugeID, gauge, coins, startTime2
+}
+
+func (suite *KeeperTestSuite) SetupLockAndGauge(isPerpetual bool) (sdk.AccAddress, uint64, sdk.Coins, time.Time) {
+	// create a gauge and locks
+	lockOwner := sdk.AccAddress([]byte("addr1---------------"))
+	suite.LockTokens(lockOwner, sdk.Coins{sdk.NewInt64Coin("lptoken", 1000)}, time.Second)
+
+	// create gauge
+	gaugeID, _, gaugeCoins, startTime := suite.SetupNewGauge(isPerpetual, sdk.Coins{sdk.NewInt64Coin("stake", 1000)})
+
+	return lockOwner, gaugeID, gaugeCoins, startTime
+}

--- a/x/incentives/types/expected_keepers.go
+++ b/x/incentives/types/expected_keepers.go
@@ -4,6 +4,7 @@ import (
 	time "time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankExported "github.com/cosmos/cosmos-sdk/x/bank/exported"
 	epochstypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
 )
@@ -11,6 +12,7 @@ import (
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	GetSupply(ctx sdk.Context) bankExported.SupplyI
 
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error

--- a/x/incentives/types/gauge.go
+++ b/x/incentives/types/gauge.go
@@ -21,17 +21,17 @@ func NewGauge(id uint64, isPerpetual bool, distrTo lockuptypes.QueryCondition, c
 }
 
 func (gauge Gauge) IsUpcomingGauge(curTime time.Time) bool {
-	if curTime.After(gauge.StartTime) {
+	if gauge.StartTime.After(curTime) {
 		return true
 	}
 	return false
 }
 
 func (gauge Gauge) IsActiveGauge(curTime time.Time) bool {
-	if curTime.Before(gauge.StartTime) && (gauge.IsPerpetual || gauge.FilledEpochs < gauge.NumEpochsPaidOver) {
-		return true
+	if gauge.StartTime.Before(curTime) {
+		return false
 	}
-	return false
+	return gauge.IsPerpetual || gauge.FilledEpochs < gauge.NumEpochsPaidOver
 }
 
 func (gauge Gauge) IsFinishedGauge(curTime time.Time) bool {

--- a/x/incentives/types/keys.go
+++ b/x/incentives/types/keys.go
@@ -49,6 +49,9 @@ var (
 	// KeyEpochBeginBlock defines key for storing begin block of current epoch
 	KeyEpochBeginBlock = []byte{0x09}
 
+	// KeyPrefixDenomList defines prefix key for storing all denoms
+	KeyPrefixDenomList = []byte{0x0A}
+
 	LockableDurationsKey = []byte("lockable_durations")
 )
 

--- a/x/lockup/spec/README.md
+++ b/x/lockup/spec/README.md
@@ -9,3 +9,4 @@ parent:
 
 ## Abstract
 
+The purpose of the lockup module is to 


### PR DESCRIPTION
Close #310, potentially removes the need for #289

Converts distribution speed from `O(sum_{denom} #lockups_for_denom * #num_gauges_for_denom)` to instead be `O-tilde(#lockups_for_denom + #num_gauges_for_denom)`