### PR TITLE
GetRewardsEst grpc query constraints on end epoch

### DIFF
--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gogo/protobuf/proto"
 	"github.com/osmosis-labs/osmosis/x/incentives/types"
@@ -419,8 +420,7 @@ func (k Keeper) GetRewardsEst(ctx sdk.Context, addr sdk.AccAddress, locks []lock
 
 	// estimate rewards
 	estimatedRewards := sdk.Coins{}
-	params := k.GetParams(ctx)
-	epochInfo := k.ek.GetEpochInfo(ctx, params.DistrEpochIdentifier)
+	epochInfo := k.GetEpochInfo(ctx)
 
 	// no need to change storage while doing estimation and we use cached context
 	cacheCtx, _ := ctx.CacheContext()
@@ -443,4 +443,9 @@ func (k Keeper) GetRewardsEst(ctx sdk.Context, addr sdk.AccAddress, locks []lock
 	}
 
 	return estimatedRewards
+}
+
+func (k Keeper) GetEpochInfo(ctx sdk.Context) epochtypes.EpochInfo {
+	params := k.GetParams(ctx)
+	return k.ek.GetEpochInfo(ctx, params.DistrEpochIdentifier)
 }

--- a/x/incentives/keeper/grpc_query.go
+++ b/x/incentives/keeper/grpc_query.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/osmosis-labs/osmosis/x/incentives/types"
 	"google.golang.org/grpc/codes"
@@ -112,6 +113,10 @@ func (k Keeper) UpcomingGauges(goCtx context.Context, req *types.UpcomingGaugesR
 // RewardsEst returns rewards estimation at a future specific time
 func (k Keeper) RewardsEst(goCtx context.Context, req *types.RewardsEstRequest) (*types.RewardsEstResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	diff := req.EndEpoch - k.GetEpochInfo(ctx).CurrentEpoch
+	if diff > 100 {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "end epoch out of ranges")
+	}
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if err != nil {
 		return nil, err

--- a/x/incentives/keeper/grpc_query.go
+++ b/x/incentives/keeper/grpc_query.go
@@ -114,7 +114,7 @@ func (k Keeper) UpcomingGauges(goCtx context.Context, req *types.UpcomingGaugesR
 func (k Keeper) RewardsEst(goCtx context.Context, req *types.RewardsEstRequest) (*types.RewardsEstResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	diff := req.EndEpoch - k.GetEpochInfo(ctx).CurrentEpoch
-	if diff > 100 {
+	if diff > 365 {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "end epoch out of ranges")
 	}
 	owner, err := sdk.AccAddressFromBech32(req.Owner)


### PR DESCRIPTION
Took arbitrary number `100`, please suggest better number who knows better about this 