### PR TITLE
add pool incentives query cli

### DIFF
--- a/x/pool-incentives/client/cli/query.go
+++ b/x/pool-incentives/client/cli/query.go
@@ -25,6 +25,10 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 
 	cmd.AddCommand(
 		GetCmdGaugeIds(),
+		GetCmdDistrInfo(),
+		GetCmdParams(),
+		GetCmdLockableDurations(),
+		GetCmdIncentivizedPools(),
 	)
 
 	return cmd
@@ -73,7 +77,7 @@ $ %s query pool-incentives gauge-ids 1
 	return cmd
 }
 
-// GetCmdDistrInfo takes the pool id and returns the matching gauge ids and durations
+// GetCmdDistrInfo takes the pool id and returns the matching gauge ids and weights
 func GetCmdDistrInfo() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "distr-info",


### PR DESCRIPTION
This PR adds the cli commands in the pool-incentives module to add the following queries.
- Distribution Info(Guage Ids and weights)
- Module params
- Lockable durations
- Incentivized pools
