### PR TITLE
Make validateEpochIdentifier a function defined by x/epochs 

### DIFF
--- a/x/epochs/types/identifier.go
+++ b/x/epochs/types/identifier.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"fmt"
+)
+
+func ValidateEpochIdentifierInterface(i interface{}) error {
+	v, ok := i.(string)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+	ValidateEpochIdentifierString(v)
+
+	return nil
+}
+
+func ValidateEpochIdentifierString(s string) error {
+	if s == "" {
+		return fmt.Errorf("empty distribution epoch identifier: %+v", s)
+	}
+	return nil
+}

--- a/x/incentives/genesis_test.go
+++ b/x/incentives/genesis_test.go
@@ -53,6 +53,9 @@ func TestIncentivesInitGenesis(t *testing.T) {
 	app := simapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
+	validateGenesis := types.DefaultGenesis().Params.Validate()
+	require.NoError(t, validateGenesis)
+
 	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10000)}
 	startTime := time.Now()
 	distrTo := lockuptypes.QueryCondition{
@@ -86,4 +89,5 @@ func TestIncentivesInitGenesis(t *testing.T) {
 	gauges := app.IncentivesKeeper.GetGauges(ctx)
 	require.Len(t, gauges, 1)
 	require.Equal(t, gauges[0], gauge)
+
 }

--- a/x/incentives/types/params.go
+++ b/x/incentives/types/params.go
@@ -1,9 +1,8 @@
 package types
 
 import (
-	"fmt"
-
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 )
 
 // Parameter store keys
@@ -31,30 +30,15 @@ func DefaultParams() Params {
 
 // validate params
 func (p Params) Validate() error {
-	if err := validateDistrEpochIdentifier(p.DistrEpochIdentifier); err != nil {
+	if err := epochtypes.ValidateEpochIdentifierInterface(p.DistrEpochIdentifier); err != nil {
 		return err
 	}
-
 	return nil
-
 }
 
 // Implements params.ParamSet
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
-		paramtypes.NewParamSetPair(KeyDistrEpochIdentifier, &p.DistrEpochIdentifier, validateDistrEpochIdentifier),
+		paramtypes.NewParamSetPair(KeyDistrEpochIdentifier, &p.DistrEpochIdentifier, epochtypes.ValidateEpochIdentifierInterface),
 	}
-}
-
-func validateDistrEpochIdentifier(i interface{}) error {
-	v, ok := i.(string)
-	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-
-	if v == "" {
-		return fmt.Errorf("empty distribution epoch identifier: %+v", i)
-	}
-
-	return nil
 }

--- a/x/mint/genesis_test.go
+++ b/x/mint/genesis_test.go
@@ -1,0 +1,27 @@
+package mint_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simapp "github.com/osmosis-labs/osmosis/app"
+	"github.com/osmosis-labs/osmosis/x/mint/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestMintInitGenesis(t *testing.T) {
+	app := simapp.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	validateGenesis := types.ValidateGenesis(*types.DefaultGenesisState())
+	require.NoError(t, validateGenesis)
+
+	developerAccount := app.AccountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)
+	initialVestingCoins := app.BankKeeper.GetBalance(ctx, developerAccount, sdk.DefaultBondDenom)
+
+	expectedVestingCoins, ok := sdk.NewIntFromString("225000000000000")
+	require.True(t, ok)
+	require.Equal(t, expectedVestingCoins, initialVestingCoins.Amount)
+	require.Equal(t, int64(0), app.MintKeeper.GetLastHalvenEpochNum(ctx))
+}

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -72,7 +73,7 @@ func (p Params) Validate() error {
 	if err := validateGenesisEpochProvisions(p.GenesisEpochProvisions); err != nil {
 		return err
 	}
-	if err := validateEpochIdentifier(p.EpochIdentifier); err != nil {
+	if err := epochtypes.ValidateEpochIdentifierInterface(p.EpochIdentifier); err != nil {
 		return err
 	}
 	if err := validateReductionPeriodInEpochs(p.ReductionPeriodInEpochs); err != nil {
@@ -105,7 +106,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
 		paramtypes.NewParamSetPair(KeyMintDenom, &p.MintDenom, validateMintDenom),
 		paramtypes.NewParamSetPair(KeyGenesisEpochProvisions, &p.GenesisEpochProvisions, validateGenesisEpochProvisions),
-		paramtypes.NewParamSetPair(KeyEpochIdentifier, &p.EpochIdentifier, validateEpochIdentifier),
+		paramtypes.NewParamSetPair(KeyEpochIdentifier, &p.EpochIdentifier, epochtypes.ValidateEpochIdentifierInterface),
 		paramtypes.NewParamSetPair(KeyReductionPeriodInEpochs, &p.ReductionPeriodInEpochs, validateReductionPeriodInEpochs),
 		paramtypes.NewParamSetPair(KeyReductionFactor, &p.ReductionFactor, validateReductionFactor),
 		paramtypes.NewParamSetPair(KeyPoolAllocationRatio, &p.DistributionProportions, validateDistributionProportions),
@@ -138,19 +139,6 @@ func validateGenesisEpochProvisions(i interface{}) error {
 
 	if v.LT(sdk.ZeroDec()) {
 		return fmt.Errorf("genesis epoch provision must be non-negative")
-	}
-
-	return nil
-}
-
-func validateEpochIdentifier(i interface{}) error {
-	v, ok := i.(string)
-	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-
-	if v == "" {
-		return fmt.Errorf("empty distribution epoch identifier: %+v", i)
 	}
 
 	return nil


### PR DESCRIPTION
This PR is related to issue https://github.com/osmosis-labs/osmosis/issues/192.

This PR adds validateEpochIdentifier, a funciton for validating the epoch identifier so that it has valid epoch identifier, in the epoch module. Doing so would be necessary in the sense of scalability, as the function itself would be duplicated in every module which needs the process of validating the epoch identifier. 