### PR TITLE
Fix Epoch Time Drift

### DIFF
--- a/x/epochs/abci.go
+++ b/x/epochs/abci.go
@@ -29,11 +29,13 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 			epochStart = true
 			epochInfo.CurrentEpoch = epochInfo.CurrentEpoch + 1
 		}
-
 		if epochStart {
 			epochInfo.CurrentEpochEnded = false
-			epochInfo.CurrentEpochStartTime = ctx.BlockTime()
-
+			if epochInfo.CurrentEpochStartTime.Equal(time.Time{}) { //genesis state, initialize
+				epochInfo.CurrentEpochStartTime = epochInfo.StartTime
+			} else {
+				epochInfo.CurrentEpochStartTime = epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration)
+			}
 			k.SetEpochInfo(ctx, epochInfo)
 			k.BeforeEpochStart(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
 			ctx.EventManager().EmitEvent(

--- a/x/epochs/abci_test.go
+++ b/x/epochs/abci_test.go
@@ -26,7 +26,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 		fn                       func()
 	}{
 		{
-			expCurrentEpochStartTime: now,
+			expCurrentEpochStartTime: time.Time{},
 			expCurrentEpoch:          0,
 			expCurrentEpochEnded:     true,
 			fn: func() {
@@ -34,7 +34,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 			},
 		},
 		{
-			expCurrentEpochStartTime: now.Add(time.Second),
+			expCurrentEpochStartTime: now,
 			expCurrentEpoch:          1,
 			expCurrentEpochEnded:     false,
 			fn: func() {
@@ -44,7 +44,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 			},
 		},
 		{
-			expCurrentEpochStartTime: now.Add(time.Second),
+			expCurrentEpochStartTime: now,
 			expCurrentEpoch:          1,
 			expCurrentEpochEnded:     false,
 			fn: func() {
@@ -55,7 +55,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 			},
 		},
 		{
-			expCurrentEpochStartTime: now.Add(time.Second),
+			expCurrentEpochStartTime: now,
 			expCurrentEpoch:          1,
 			expCurrentEpochEnded:     false,
 			fn: func() {
@@ -68,7 +68,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 			},
 		},
 		{
-			expCurrentEpochStartTime: now.Add(time.Second),
+			expCurrentEpochStartTime: now,
 			expCurrentEpoch:          1,
 			expCurrentEpochEnded:     true,
 			fn: func() {
@@ -135,7 +135,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 				{
 					Identifier:            "monthly",
 					StartTime:             time.Time{},
-					Duration:              time.Hour * 24,
+					Duration:              time.Hour * 24 * 31,
 					CurrentEpoch:          0,
 					CurrentEpochStartTime: time.Time{},
 					EpochCountingStarted:  true,
@@ -148,7 +148,7 @@ func TestEpochInfoChangesBeginEndBlockersAndInitGenesis(t *testing.T) {
 
 		require.Equal(t, epochInfo.Identifier, "monthly")
 		require.Equal(t, epochInfo.StartTime.UTC().String(), now.UTC().String())
-		require.Equal(t, epochInfo.Duration, time.Hour*24)
+		require.Equal(t, epochInfo.Duration, time.Hour*24*31)
 		require.Equal(t, epochInfo.CurrentEpoch, test.expCurrentEpoch)
 		require.Equal(t, epochInfo.CurrentEpochStartTime.UTC().String(), test.expCurrentEpochStartTime.UTC().String())
 		require.Equal(t, epochInfo.EpochCountingStarted, true)

--- a/x/epochs/genesis.go
+++ b/x/epochs/genesis.go
@@ -18,11 +18,6 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 			epoch.StartTime = ctx.BlockTime()
 		}
 
-		// when epoch counting started and current_epoch_start_time is not set, set it
-		if epoch.EpochCountingStarted && epoch.CurrentEpochStartTime.Equal(time.Time{}) {
-			epoch.CurrentEpochStartTime = ctx.BlockTime()
-		}
-
 		k.SetEpochInfo(ctx, epoch)
 	}
 }

--- a/x/epochs/genesis_test.go
+++ b/x/epochs/genesis_test.go
@@ -51,7 +51,32 @@ func TestEpochsInitGenesis(t *testing.T) {
 	ctx = ctx.WithBlockHeight(1)
 	ctx = ctx.WithBlockTime(now)
 
-	epochs.InitGenesis(ctx, app.EpochsKeeper, types.GenesisState{
+	//test genesisState validation
+	genesisState := types.GenesisState{
+		Epochs: []types.EpochInfo{
+			{
+				Identifier:            "monthly",
+				StartTime:             time.Time{},
+				Duration:              time.Hour * 24,
+				CurrentEpoch:          0,
+				CurrentEpochStartTime: time.Time{},
+				EpochCountingStarted:  true,
+				CurrentEpochEnded:     true,
+			},
+			{
+				Identifier:            "monthly",
+				StartTime:             time.Time{},
+				Duration:              time.Hour * 24,
+				CurrentEpoch:          0,
+				CurrentEpochStartTime: time.Time{},
+				EpochCountingStarted:  true,
+				CurrentEpochEnded:     true,
+			},
+		},
+	}
+	require.EqualError(t, genesisState.Validate(), "epoch identifier should be unique")
+
+	genesisState = types.GenesisState{
 		Epochs: []types.EpochInfo{
 			{
 				Identifier:            "monthly",
@@ -63,8 +88,9 @@ func TestEpochsInitGenesis(t *testing.T) {
 				CurrentEpochEnded:     true,
 			},
 		},
-	})
+	}
 
+	epochs.InitGenesis(ctx, app.EpochsKeeper, genesisState)
 	epochInfo := app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 	require.Equal(t, epochInfo.Identifier, "monthly")
 	require.Equal(t, epochInfo.StartTime.UTC().String(), now.UTC().String())

--- a/x/epochs/genesis_test.go
+++ b/x/epochs/genesis_test.go
@@ -96,7 +96,7 @@ func TestEpochsInitGenesis(t *testing.T) {
 	require.Equal(t, epochInfo.StartTime.UTC().String(), now.UTC().String())
 	require.Equal(t, epochInfo.Duration, time.Hour*24)
 	require.Equal(t, epochInfo.CurrentEpoch, int64(0))
-	require.Equal(t, epochInfo.CurrentEpochStartTime.UTC().String(), ctx.BlockTime().UTC().String())
+	require.Equal(t, epochInfo.CurrentEpochStartTime.UTC().String(), time.Time{}.String())
 	require.Equal(t, epochInfo.EpochCountingStarted, true)
 	require.Equal(t, epochInfo.CurrentEpochEnded, true)
 }

--- a/x/epochs/types/genesis.go
+++ b/x/epochs/types/genesis.go
@@ -41,13 +41,18 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// TODO: Epochs identifiers should be unique
+	epochIdentifiers := map[string]bool{}
 	for _, epoch := range gs.Epochs {
 		if epoch.Identifier == "" {
 			return errors.New("epoch identifier should NOT be empty")
 		}
+		if epochIdentifiers[epoch.Identifier] {
+			return errors.New("epoch identifier should be unique")
+		}
 		if epoch.Duration == 0 {
 			return errors.New("epoch duration should NOT be 0")
 		}
+		epochIdentifiers[epoch.Identifier] = true
 	}
 	return nil
 }


### PR DESCRIPTION
This PR is related to issue https://github.com/osmosis-labs/osmosis/issues/149.

This PR fixes the current problem of time drift in the epoch module by modifying the logic in abci.go. With the modified logic, `CurrentEpochStartTime` is no longer set as the current time, but follows the actual epoch duration. 

In addition to the logic changes in abci.go, additional changes have been made to genesis.go, as the logic of initializing the `CurrentEpochStartTime` should be happening in abci.go to distinguish the initial start of the epoch.