### PR TITLE
fix parse

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -94,6 +94,9 @@ func Execute(rootCmd *cobra.Command) error {
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	authclient.Codec = encodingConfig.Marshaler
 
+	cfg := sdk.GetConfig()
+	cfg.Seal()
+
 	debugCmd := debug.Cmd()
 	debugCmd.AddCommand(ConvertBech32Cmd())
 


### PR DESCRIPTION
This applies the same patch that was previously applied to fix the `keys parse` command