### PR TITLE
Make the upgrade logic delete the old accumulation stores

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -323,7 +323,7 @@ func NewOsmosisApp(
 			app.DistrKeeper.SetParams(ctx, distrParams)
 
 			// configure upgrade for gamm module's pool creation fee param add
-			app.GAMMKeeper.SetParams(ctx, gammtypes.NewParams(sdk.Coins{sdk.NewInt64Coin("uosmo", 0)})) // 0 OSMO
+			app.GAMMKeeper.SetParams(ctx, gammtypes.NewParams(sdk.Coins{sdk.NewInt64Coin("uosmo", 1)})) // 1 uOSMO
 		})
 
 	// Create IBC Keeper

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -339,7 +339,7 @@ func (k Keeper) LockTokens(ctx sdk.Context, owner sdk.AccAddress, coins sdk.Coin
 	return lock, nil
 }
 
-func (k Keeper) clearLockRefKeysByPrefix(ctx sdk.Context, prefix []byte) {
+func (k Keeper) clearKeysByPrefix(ctx sdk.Context, prefix []byte) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, prefix)
 	defer iterator.Close()
@@ -350,8 +350,12 @@ func (k Keeper) clearLockRefKeysByPrefix(ctx sdk.Context, prefix []byte) {
 }
 
 func (k Keeper) ClearAllLockRefKeys(ctx sdk.Context) {
-	k.clearLockRefKeysByPrefix(ctx, types.KeyPrefixNotUnlocking)
-	k.clearLockRefKeysByPrefix(ctx, types.KeyPrefixUnlocking)
+	k.clearKeysByPrefix(ctx, types.KeyPrefixNotUnlocking)
+	k.clearKeysByPrefix(ctx, types.KeyPrefixUnlocking)
+}
+
+func (k Keeper) ClearAccumulationStores(ctx sdk.Context) {
+	k.clearKeysByPrefix(ctx, types.KeyPrefixLockAccumulation)
 }
 
 // ResetLock reset lock to lock's previous state on InitGenesis

--- a/x/lockup/keeper/upgrade_test.go
+++ b/x/lockup/keeper/upgrade_test.go
@@ -60,7 +60,7 @@ func (suite *KeeperTestSuite) TestUpgradeStoreManagement() {
 				suite.app.EndBlocker(suite.ctx, types.RequestEndBlock{suite.ctx.BlockHeight()})
 
 				// run upgrades
-				plan := upgradetypes.Plan{Name: "v2", Height: 5}
+				plan := upgradetypes.Plan{Name: "v4", Height: 5}
 				suite.app.UpgradeKeeper.ScheduleUpgrade(suite.ctx, plan)
 				plan, exists := suite.app.UpgradeKeeper.GetUpgradePlan(suite.ctx)
 				suite.Require().True(exists)


### PR DESCRIPTION
This makes the `v4` upgrade logic delete the old accumulation store (so they then get created correctly during the upgrade), and deletes the min commission update logic that got included in the v3 fork.