### PR TITLE
Make our test for understanding token locking gas usage give more detail

### DIFF
--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -244,17 +244,27 @@ func (suite *KeeperTestSuite) TestLocksLongerThanDurationDenom() {
 func (suite *KeeperTestSuite) TestLockTokensAlot() {
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
-	skipLogsFor := 1000
-	for i := 0; i < skipLogsFor; i++ {
+	startAveragingAt := 1000
+	totalNumLocks := 2000
+	for i := 1; i < startAveragingAt; i++ {
 		suite.LockTokens(addr1, coins, time.Second)
 	}
-	for i := 0; i < 1000; i++ {
+	runningTotal := uint64(0)
+	maxGas := uint64(0)
+	for i := startAveragingAt; i < totalNumLocks; i++ {
 		alreadySpent := suite.ctx.GasMeter().GasConsumed()
 		suite.LockTokens(addr1, coins, time.Second)
 		newSpent := suite.ctx.GasMeter().GasConsumed()
 		spentNow := newSpent - alreadySpent
-		fmt.Println("sum up - consumed gas", i+skipLogsFor, spentNow)
+		runningTotal += spentNow
+		if spentNow > maxGas {
+			maxGas = spentNow
+		}
 	}
+	fmt.Println("test deets", "begin average at", startAveragingAt, "total locks created", totalNumLocks)
+	fmt.Println("average:", runningTotal/(uint64(totalNumLocks-startAveragingAt)))
+	fmt.Println("max gas / lock:", maxGas)
+
 	// panic(1)
 }
 

--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -261,8 +261,8 @@ func (suite *KeeperTestSuite) TestLockTokensAlot() {
 			maxGas = spentNow
 		}
 	}
-	fmt.Println("test deets", "begin average at", startAveragingAt, "total locks created", totalNumLocks)
-	fmt.Println("average:", runningTotal/(uint64(totalNumLocks-startAveragingAt)))
+	fmt.Println("test deets: total locks created %i, begin average at %i", totalNumLocks, startAveragingAt)
+	fmt.Println("average gas / lock:", runningTotal/(uint64(totalNumLocks-startAveragingAt)))
 	fmt.Println("max gas / lock:", maxGas)
 
 	// panic(1)


### PR DESCRIPTION
Increasing the number of locks we use to get stats for here is blocked on CacheKV store things, which I'm hoping to get tomorrow