### PR TITLE
Add more directroies to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,5 +196,5 @@ $RECYCLE.BIN/
 /osmosisd
 /.idea/
 /artifacts/
-
-/scripts/local
+/.vscode/
+/scripts/local/


### PR DESCRIPTION
Kind of silly, but I find being able to make quick / hacky python scripts in the same code directory really useful. (Ease of access with IDE, and sometimes reading other parts of the codebase for variables)