### PR TITLE
Switch to SDK branch that lowers epoch time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ $RECYCLE.BIN/
 /artifacts/
 /.vscode/
 /scripts/local/
+/x/incentives/keeper/osmosis_testing/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,21 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## [v2.0.0](https://github.com/osmosis/osmosis-labs/releases/tag/v2.0.0) - 2021-06-28
+## [Upcoming]
 
-* Update the cosmos-sdk version we modify to v0.42.6
-* Fix a bug in the min commission rate code that allows validators to be created with commission rates less than the minimum.
-* Automatically upgrade any validator with less than the minimum comission rate to the minimum at upgrade time.
+* Significantly speedup epoch times
 * Fix bug in the lockup module code that caused it to take a linear amount of gas.
 * Make unbonding tokens from the lockup module get automatically claimed when unbonding is done.
 * Add events for all tx types in the gamm module.
 * Make queries to bank total chain balance account for developer vesting correctly.
+* Add ability for nodes to query 
+
+## [v3.2.0](https://github.com/osmosis/osmosis-labs/releases/tag/v2.0.0) - 2021-06-28
+
+* Update the cosmos-sdk version we modify to v0.42.9
+* Fix a bug in the min commission rate code that allows validators to be created with commission rates less than the minimum.
+* Automatically upgrade any validator with less than the minimum comission rate to the minimum at upgrade time.
+* Unbrick on-chain governance, by fixing the deposit parameter to use `uosmo` instead of `osmo`.
 
 ## [v1.0.2](https://github.com/osmosis/osmosis-labs/releases/tag/v1.0.2) - 2021-06-18
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -30,4 +32,40 @@ func Setup(isCheckTx bool) *OsmosisApp {
 	}
 
 	return app
+}
+
+// SetupTestingAppWithLevelDb initializes a new OsmosisApp intended for testing,
+// with LevelDB as a db
+func SetupTestingAppWithLevelDb(isCheckTx bool) (app *OsmosisApp, cleanupFn func()) {
+	dir := "osmosis_testing"
+	db, err := sdk.NewLevelDB("osmosis_leveldb_testing", dir)
+	if err != nil {
+		panic(err)
+	}
+	app = NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, MakeEncodingConfig(), simapp.EmptyAppOptions{})
+	if !isCheckTx {
+		genesisState := NewDefaultGenesisState()
+		stateBytes, err := json.MarshalIndent(genesisState, "", " ")
+		if err != nil {
+			panic(err)
+		}
+
+		app.InitChain(
+			abci.RequestInitChain{
+				Validators:      []abci.ValidatorUpdate{},
+				ConsensusParams: simapp.DefaultConsensusParams,
+				AppStateBytes:   stateBytes,
+			},
+		)
+	}
+
+	cleanupFn = func() {
+		db.Close()
+		err = os.RemoveAll(dir)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return
 }

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,4 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
 
-replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210819201800-7d5063b74305
+replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210828064312-0ff691be3463

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,4 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
 
-replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210828064312-0ff691be3463
+replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829064313-2c87644925da

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210819201800-7d5063b74305 h1:u/c19T1LAimpBOcmJEIcTn3qEILiMsZ4XqxhtDmnGvE=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210819201800-7d5063b74305/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210828064312-0ff691be3463 h1:64oVksl7AaIifdYkFCQDXEKAQ6gkOBCtBilzryLQykw=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210828064312-0ff691be3463/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,10 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210828064312-0ff691be3463 h1:64oVksl7AaIifdYkFCQDXEKAQ6gkOBCtBilzryLQykw=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210828064312-0ff691be3463/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829035621-cec66b14cc50 h1:Mh2KucRLDHaFcLEhEnz+XNfJsalDIlqFSIWjF7G7HOs=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829035621-cec66b14cc50/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829064313-2c87644925da h1:kg60BcOfzv5k/2xJuLhpqPzx+/mQ2KRceRIPSvnduxk=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829064313-2c87644925da/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/x/incentives/keeper/bench_test.go
+++ b/x/incentives/keeper/bench_test.go
@@ -66,7 +66,8 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 	b.StopTimer()
 
 	blockStartTime := time.Now().UTC()
-	app := app.Setup(false)
+	app, cleanupFn := app.SetupTestingAppWithLevelDb(false)
+	defer cleanupFn()
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: blockStartTime})
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/x/incentives/keeper/bench_test.go
+++ b/x/incentives/keeper/bench_test.go
@@ -87,6 +87,7 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 
 	distrEpoch := app.EpochsKeeper.GetEpochInfo(ctx, app.IncentivesKeeper.GetParams(ctx).DistrEpochIdentifier)
 	durationOptions := app.IncentivesKeeper.GetLockableDurations(ctx)
+	fmt.Println(durationOptions)
 	// setup gauges
 	gaugeIds := []uint64{}
 	for i := 0; i < numGauges; i++ {
@@ -119,17 +120,23 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 	futureSecs := r.Intn(1 * 60 * 60 * 24 * 7)
 	ctx = ctx.WithBlockTime(ctx.BlockTime().Add(time.Duration(futureSecs) * time.Second))
 
+	lockSecs := r.Intn(1 * 60 * 60 * 8)
 	// setup lockups
 	for i := 0; i < numLockups; i++ {
-		addr := addrs[r.Int()%numAccts]
+		addr := addrs[i%numAccts]
 		simCoins := app.BankKeeper.SpendableCoins(ctx, addr)
-		duration := time.Second
+
+		if i%10 == 0 {
+			lockSecs = r.Intn(1 * 60 * 60 * 8)
+		}
+		duration := time.Duration(lockSecs) * time.Second
 		_, err := app.LockupKeeper.LockTokens(ctx, addr, simCoins, duration)
 		if err != nil {
 			fmt.Printf("Lock tokens, %v\n", err)
 			b.FailNow()
 		}
 	}
+	fmt.Println("created all lockups")
 
 	// begin distribution for all gauges
 	for _, gaugeId := range gaugeIds {
@@ -174,7 +181,13 @@ func BenchmarkDistributionLogicMedium(b *testing.B) {
 }
 
 func BenchmarkDistributionLogicLarge(b *testing.B) {
-	benchmarkDistributionLogic(100, 10, 100, 100, 5000, b)
+	numAccts := 50000
+	numDenoms := 10
+	numGauges := 60
+	numLockups := 100000
+	numDistrs := 1
+
+	benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numDistrs, b)
 }
 
 func BenchmarkDistributionLogicHuge(b *testing.B) {

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -290,7 +290,7 @@ func (k Keeper) Distribute(ctx sdk.Context, gauge types.Gauge) (sdk.Coins, error
 		distrCoins := sdk.Coins{}
 		for _, coin := range remainCoins {
 			// distribution amount = gauge_size * denom_lock_amount / (total_denom_lock_amount * remain_epochs)
-			denomLockAmt := lock.Coins.AmountOf(gauge.DistributeTo.Denom)
+			denomLockAmt := lock.Coins.AmountOfNoDenomValidation(gauge.DistributeTo.Denom)
 			amt := coin.Amount.Mul(denomLockAmt).Quo(lockSum.Mul(sdk.NewInt(int64(remainEpochs))))
 			if amt.IsPositive() {
 				distrCoins = distrCoins.Add(sdk.NewCoin(coin.Denom, amt))

--- a/x/lockup/keeper/keeper_test.go
+++ b/x/lockup/keeper/keeper_test.go
@@ -16,11 +16,21 @@ type KeeperTestSuite struct {
 	ctx     sdk.Context
 	querier sdk.Querier
 	app     *app.OsmosisApp
+	cleanup func()
 }
 
 func (suite *KeeperTestSuite) SetupTest() {
 	suite.app = app.Setup(false)
 	suite.ctx = suite.app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+}
+
+func (suite *KeeperTestSuite) SetupTestWithLevelDb() {
+	suite.app, suite.cleanup = app.SetupTestingAppWithLevelDb(false)
+	suite.ctx = suite.app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+}
+
+func (suite *KeeperTestSuite) Cleanup() {
+	suite.cleanup()
 }
 
 func TestKeeperTestSuite(t *testing.T) {

--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -242,10 +242,12 @@ func (suite *KeeperTestSuite) TestLocksLongerThanDurationDenom() {
 }
 
 func (suite *KeeperTestSuite) TestLockTokensAlot() {
+	suite.SetupTest()
+
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
 	startAveragingAt := 1000
-	totalNumLocks := 2000
+	totalNumLocks := 5000
 	for i := 1; i < startAveragingAt; i++ {
 		suite.LockTokens(addr1, coins, time.Second)
 	}


### PR DESCRIPTION
This switches us to the SDK branch that fixes the N^2 issues within the CacheKV store (https://github.com/osmosis-labs/cosmos-sdk/pull/24 )

It also adds some scaffolding so that we can test with LevelDB backends, which at some point ended up being necessary due to a memDB bug and makes benchmarks more accurate due to avoiding some weird oddities with the memDB.

(I'm not sure if the memDB bug still gets triggered if we make some insanely high loads, but it definitely seemed like a bug on google's sides, as I traced it back when it applied to a perfectly normal set operation that caused google's BTree to infinitely hang)

Before:
```
BenchmarkDistributionLogicMedium-16            4         270370131 ns/op        96074306 B/op    1334220 allocs/op
```
After:
```
BenchmarkDistributionLogicMedium-16          285           3644674 ns/op         1192226 B/op      20120 allocs/op
```

Speedup:
```
>>> old = 270370131
>>> new = 3644674
>>> 100 * (old - new) / old
98.6519686969416
```
~99% speedup of the benchmark!

We should backport this to v3.2.0, and check if this empirically improves the epoch time performance moreso than prior WIP v3.2.0 branch.

Also interestingly, now bech32 encoding / decoding work takes 10% of the compute time after this change.