### PR TITLE
Configure CI to not double run docker/builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Compile Osmosis across arch's
+name: Compile Osmosis
 
 # Controls when the action will run.
 #  This workflow runr on pushes to master & every Pull Requests. (Or when manually triggered)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,15 @@
-# This is a basic workflow that is manually triggered
+name: Compile Osmosis across arch's
 
-name: compile osmosis
-
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
-on: [push, pull_request, workflow_dispatch]
+# Controls when the action will run.
+#  This workflow runr on pushes to master & every Pull Requests. (Or when manually triggered)
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 # This workflow makes x86_64 binaries for mac, windows, and linux.
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,12 @@
 name: docker
 
-# todo: fix later
-on: [push,pull_request]
-
+# Controls when the action will run.
+# This workflow runs on pushes to master & every Pull Requests. 
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We were double running every build on prior PRs

cc @faddat 