### PR TITLE
Include bash script for making testnet off of state export and WIP golang code

### DIFF
--- a/cmd/osmosisd/cmd/testnetify/cmd.go
+++ b/cmd/osmosisd/cmd/testnetify/cmd.go
@@ -1,0 +1,67 @@
+package testnetify
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	"github.com/osmosis-labs/osmosis/app"
+	"github.com/spf13/cobra"
+)
+
+// get cmd to convert any bech32 address to an osmo prefix
+func StateExportToTestnetGenesis() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "testnetify [state_export_path] -p [testnet_params]",
+		Short: "Convert state export to be a testnet",
+		Long: `Fill this out plz
+	`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			testnetParams, err := loadTestnetParams(cmd)
+			if err != nil {
+				return err
+			}
+
+			state_export_path := args[0]
+			file, err := ioutil.ReadFile(state_export_path)
+			if err != nil {
+				// failed to read file
+				return err
+			}
+			var genesis app.GenesisState
+			err = json.Unmarshal([]byte(file), &genesis)
+			if err != nil {
+				return err
+			}
+
+			replaceValidatorDetails(genesis, testnetParams)
+			updateChainId(genesis)
+			clearIBC(genesis)
+
+			cmd.Println("Writing new genesis to: ", testnetParams.OutputExportFilepath)
+			err = writeGenesis(genesis, testnetParams.OutputExportFilepath)
+			if err != nil {
+				// failed to read file
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP(flagTestnetParams, "p", "params", "Testnet params json")
+
+	return cmd
+}
+
+func writeGenesis(genesis app.GenesisState, path string) error {
+	file, err := os.OpenFile(path, os.O_CREATE, os.ModePerm)
+	if err != nil {
+		// failed to read file
+		return err
+	}
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+	encoder.Encode(genesis)
+	return nil
+}

--- a/cmd/osmosisd/cmd/testnetify/find_replace.go
+++ b/cmd/osmosisd/cmd/testnetify/find_replace.go
@@ -1,0 +1,25 @@
+package testnetify
+
+import (
+	"bytes"
+
+	"github.com/osmosis-labs/osmosis/app"
+)
+
+func replaceConsAddrHex(genesis app.GenesisState, fromAddr string, replaceAddr string) {
+	// TODO: When optimizing, do single in-place mutation
+	replaceAllInGenesis(genesis, fromAddr, replaceAddr)
+}
+
+// TODO: Make it possible to only replace all in certain genesis keys
+// no reason to pay for iterating over bank every time :)
+func replaceAllInGenesis(genesis app.GenesisState, find string, replace string) {
+	// To help in debugging
+	findBz := []byte(find)
+	replaceBz := []byte(replace)
+	for k := range genesis {
+		value := genesis[k]
+		value = bytes.ReplaceAll(value, findBz, replaceBz)
+		genesis[k] = value
+	}
+}

--- a/cmd/osmosisd/cmd/testnetify/script.sh
+++ b/cmd/osmosisd/cmd/testnetify/script.sh
@@ -1,0 +1,63 @@
+# run sed
+
+export EXPORTED_GENESIS=testnet_genesis.json
+
+# Replace Sentinel addrs/pubkeys
+
+# replace validator cons pubkey
+sed -i '' 's%b77zCh/VsRgVvfGXuW4dB+Dhg4PrMWWBC5G2K/qFgiU=%2OpBuqaXvXQ+lSxAoT1S7Jfyr56KiakTzvuFiuJK+X4=%g' $EXPORTED_GENESIS
+# This is a PITA to get:
+# take pubkey, do osmosisd debug pubkey {base64}
+# take address out of it, feed into osmosisd debug addr {addr}
+# pass that into osmosisd debug bech32-convert -p osmovalcons
+sed -i '' 's%osmovalcons1z6skn9g6s7py0klztr7acutr3anqd52k9x5p70%osmovalcons13duwg7rhwsnucwgxhq35edete63v0r5rqp90es%g' $EXPORTED_GENESIS
+# replace validator hex addr
+sed -i '' 's%16A169951A878247DBE258FDDC71638F6606D156%8B78E478777427CC3906B8234CB72BCEA2C78E83%g' $EXPORTED_GENESIS
+# replace operator address
+sed -i '' 's%osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n%osmovaloper1qye772qje88p7ggtzrvl9nxvty6dkuusvpqhac%g' $EXPORTED_GENESIS
+# replace the actual account
+sed -i '' 's%osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5%osmo1qye772qje88p7ggtzrvl9nxvty6dkuuskkg52l%g' $EXPORTED_GENESIS
+# replace that accounts pubkey, obtained via auth. New pubkey obtained via new debug command
+sed -i '' 's%AqlNb1FM8veQrT4/apR5B3hww8VApc0LTtZnXhq7FqG0%A9zC0Sa0VCK/lVLi1Kv0C1c0MQp47d+yjFqb6dAUza0a%g' $EXPORTED_GENESIS
+
+# now time to replace the amounts
+# manually increase share amounts for 
+#          "delegator_address": "osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5",
+# before: 5000000000.000000000000000000 (5000 osmo)
+# after: 100005000000000.000000000000000000 (100M + 5k osmo = 100,005,000)
+# there are two such locations
+
+# Then correspondingly up the total tokens bonded to the validator
+#           "tokens": "4844955522615", (add 100M to this)
+sed -i '' 's%4844955522615%104844955522615%g' $EXPORTED_GENESIS
+sed -i '' 's%"power": "4844955"%"power": "104844955"%g' $EXPORTED_GENESIS
+# Update last_total_power (which is last total bonded across validators)
+sed -i '' 's%36834775%136834775%g' $EXPORTED_GENESIS
+
+# edit operator address, old: 2125267 (2.1 osmo), new: 100000002125267 (100M + 2.1)
+sed -i '' 's%2125267%100000002125267%g' $EXPORTED_GENESIS
+
+# Update total osmo supply, old 371848992476804, new 571M
+sed -i '' 's%371848992476804%571848992476804%g' $EXPORTED_GENESIS
+
+# Fix bonded tokens pool balance, old 36834819673258
+sed -i '' 's%36834819673258%1036834819673258%g' $EXPORTED_GENESIS
+
+### Fix gov params
+
+# deposit
+sed -i '' 's%"voting_period": "259200s"%"voting_period": "60s"%g' $EXPORTED_GENESIS
+
+# epoch length
+    #   "epochs": [
+    #     {
+    #       "current_epoch": "77",
+    #       "current_epoch_ended": false,
+    #       "current_epoch_start_time": "2021-09-03T17:12:52.752325457Z",
+    #       "duration": "86400s",
+    #       "epoch_counting_started": true,
+    #       "identifier": "day",
+    #       "start_time": "2021-06-18T17:00:00Z"
+    #     },
+# replace that duration with jq
+cat $EXPORTED_GENESIS | jq '.app_state["epochs"]["epochs"][0]["duration"]="1800s"' > tmp_genesis.json && mv tmp_genesis.json $EXPORTED_GENESIS

--- a/cmd/osmosisd/cmd/testnetify/state_export_to_testnet.go
+++ b/cmd/osmosisd/cmd/testnetify/state_export_to_testnet.go
@@ -1,0 +1,122 @@
+package testnetify
+
+import (
+	"github.com/osmosis-labs/osmosis/app"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagTestnetParams = "empty"
+	valConsBech32     = "osmovalcons"
+)
+
+// TODO: Add params for min num validators for consensus
+type TestnetParams struct {
+	ValidatorConsensusPubkeys []string
+	ValidatorOperatorPubkeys  []string
+	OutputExportFilepath      string
+}
+
+type ValidatorDetails struct {
+	// e.g. 16A169951A878247DBE258FDDC71638F6606D156
+	// Only appears once
+	ConsAddressHex string
+	// e.g. b77zCh/VsRgVvfGXuW4dB+Dhg4PrMWWBC5G2K/qFgiU=
+	ConsPubkeyRaw string
+	// e.g. osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n
+	OperatorAddress string
+}
+
+func defaultTestnetParams() TestnetParams {
+	/* priv_validator_key.json file
+	{
+		"address": "8B78E478777427CC3906B8234CB72BCEA2C78E83",
+		"pub_key": {
+			"type": "tendermint/PubKeyEd25519",
+			"value": "2OpBuqaXvXQ+lSxAoT1S7Jfyr56KiakTzvuFiuJK+X4="
+		},
+		"priv_key": {
+			"type": "tendermint/PrivKeyEd25519",
+			"value": "3OLLoEfdT+ZrLqpRCvytpXrhgKfeEBBoeaoXe1p3/mjY6kG6ppe9dD6VLEChPVLsl/KvnoqJqRPO+4WK4kr5fg=="
+		}
+	}
+	*/
+	consensusPubkey := "2OpBuqaXvXQ+lSxAoT1S7Jfyr56KiakTzvuFiuJK+X4="
+	// mnemonic kitchen comic flower drip sick prize account cheese truth income weekend nominee segment punch call satisfy captain earth ethics wasp clump tunnel orchard advance
+	operatorPubkey := "osmopub1addwnpepq0wv95fxk32z90u42t3df2l5pdtngvg20rkalv5vt2d7n5q5ekk35d8hh20"
+	operatorValOper := "osmovaloper1qye772qje88p7ggtzrvl9nxvty6dkuusvpqhac"
+	operatorValOper += ""
+	return TestnetParams{
+		ValidatorConsensusPubkeys: []string{consensusPubkey},
+		ValidatorOperatorPubkeys:  []string{operatorPubkey},
+		OutputExportFilepath:      "new_testnet_genesis.json",
+	}
+}
+
+func (params TestnetParams) NewValidatorDetails() []ValidatorDetails {
+	numValidators := len(params.ValidatorConsensusPubkeys)
+	outputDeets := make([]ValidatorDetails, 0, numValidators)
+	for i := 0; i < numValidators; i++ {
+		deets := ValidatorDetails{
+			ConsPubkeyRaw:   params.ValidatorConsensusPubkeys[i],
+			OperatorAddress: params.ValidatorConsensusPubkeys[i],
+		}
+		outputDeets = append(outputDeets, deets)
+	}
+	return outputDeets
+}
+
+func replaceValidatorDetails(genesis app.GenesisState, params TestnetParams) {
+	oldValidatorDetails := getValidatorDetailsToReplace(genesis, params)
+	newValidatorDetails := params.NewValidatorDetails()
+	numValidators := len(oldValidatorDetails)
+	for i := 0; i < numValidators; i++ {
+		oldDeets := oldValidatorDetails[i]
+		newDeets := newValidatorDetails[i]
+
+		// TODO: Use more module-focused find replaces
+		replaceConsAddrHex(genesis, oldDeets.ConsAddressHex, newDeets.ConsAddressHex)
+		replaceAllInGenesis(genesis, oldDeets.ConsPubkeyRaw, newDeets.ConsPubkeyRaw)
+		replaceAllInGenesis(genesis, oldDeets.OperatorAddress, newDeets.OperatorAddress)
+	}
+}
+
+func getValidatorDetailsToReplace(genesis app.GenesisState, params TestnetParams) []ValidatorDetails {
+	// TODO: Don't hardcode to sentinel, instead all validators from chain
+	// and get top N validators
+	// consAddr only has 1 instance
+	validatorConsAddr := "16A169951A878247DBE258FDDC71638F6606D156"
+	// Only has 2 instances
+	validatorConsPubkey := "b77zCh/VsRgVvfGXuW4dB+Dhg4PrMWWBC5G2K/qFgiU="
+	// Sometimes appears in slashing
+	// validatorConsBech32Addr := "osmosvalcons1z6skn9g6s7py0klztr7acutr3anqd52kuhdukh"
+	validatorOperBech32Addr := "osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n"
+
+	SentinelValidatorDetails := ValidatorDetails{
+		ConsAddressHex:  validatorConsAddr,
+		ConsPubkeyRaw:   validatorConsPubkey,
+		OperatorAddress: validatorOperBech32Addr,
+	}
+	return []ValidatorDetails{
+		SentinelValidatorDetails,
+	}
+}
+
+func updateChainId(genesis app.GenesisState) {
+	// TODO: Implement
+}
+
+func clearIBC(genesis app.GenesisState) {
+	// TODO: Implement
+}
+
+func loadTestnetParams(cmd *cobra.Command) (TestnetParams, error) {
+	testnetParamPath, err := cmd.Flags().GetString(flagTestnetParams)
+	if err != nil {
+		return TestnetParams{}, err
+	}
+	if testnetParamPath == "empty" {
+		return defaultTestnetParams(), nil
+	}
+	panic("TODO: Go read testnet params from a file")
+}

--- a/go.mod
+++ b/go.mod
@@ -25,10 +25,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.12
-
 replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
 
-replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829064313-2c87644925da
+replace github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.12
+
+replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210908215742-545f8d2e916b

--- a/go.sum
+++ b/go.sum
@@ -400,10 +400,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829035621-cec66b14cc50 h1:Mh2KucRLDHaFcLEhEnz+XNfJsalDIlqFSIWjF7G7HOs=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829035621-cec66b14cc50/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829064313-2c87644925da h1:kg60BcOfzv5k/2xJuLhpqPzx+/mQ2KRceRIPSvnduxk=
-github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210829064313-2c87644925da/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210908215742-545f8d2e916b h1:yA+NmA0YaotPaXq6t7lnDGarIyxhucIUCWKBO2q+gNY=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210908215742-545f8d2e916b/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/scripts/upgrades/4/test_script.sh
+++ b/scripts/upgrades/4/test_script.sh
@@ -1,0 +1,41 @@
+# Download a genesis.json for testing. The node that you this on will be your "validator"
+# It should be on version v4.x
+
+osmosisd init --chain-id=testing testing --home=$HOME/.osmosisd
+osmosisd keys add validator --keyring-backend=test --home=$HOME/.osmosisd
+osmosisd add-genesis-account $(osmosisd keys show validator -a --keyring-backend=test --home=$HOME/.osmosisd) 1000000000uosmo,1000000000valtoken --home=$HOME/.osmosisd
+sed -i -e "s/stake/uosmo/g" $HOME/.osmosisd/config/genesis.json
+osmosisd gentx validator 500000000uosmo --commission-rate="0.0" --keyring-backend=test --home=$HOME/.osmosisd --chain-id=testing
+osmosisd collect-gentxs --home=$HOME/.osmosisd
+
+cat $HOME/.osmosisd/config/genesis.json | jq '.initial_height="711800"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"]["denom"]="valtoken"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"]["amount"]="100"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="120s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["staking"]["params"]["min_commission_rate"]="0.050000000000000000"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+
+# Now setup a second full node, and peer it with this v3.0.0-rc0 node.
+
+# start the chain on both machines
+osmosisd start
+# Create proposals
+
+osmosisd tx gov submit-proposal --title="existing passing prop" --description="passing prop"  --from=validator --deposit=1000valtoken --chain-id=testing --keyring-backend=test --broadcast-mode=block  --type="Text"
+osmosisd tx gov vote 1 yes --from=validator --keyring-backend=test --chain-id=testing --yes
+osmosisd tx gov submit-proposal --title="prop with enough osmo deposit" --description="prop w/ enough deposit"  --from=validator --deposit=500000000uosmo --chain-id=testing --keyring-backend=test --broadcast-mode=block  --type="Text"
+# Check that we have proposal 1 passed, and proposal 2 in deposit period
+osmosisd q gov proposals
+# CHeck that validator commission is under min_commission_rate
+osmosisd q staking validators
+# Wait for upgrade block.
+# Upgrade happened
+# your full node should have crashed with consensus failure
+
+# Now we test post-upgrade behavior is as intended
+
+# Everything in deposit stayed in deposit
+osmosisd q gov proposals
+# Check that commissions was bumped to min_commission_rate
+osmosisd q staking validators
+# pushes 2 into voting period
+osmosisd tx gov deposit 2 1valtoken --from=validator --keyring-backend=test --chain-id=testing --yes


### PR DESCRIPTION
I'm dreaming of a tool with this golang code, where I can get a state export off of mainnet, and then quickly spin up a testnet off a modification of the state export according to my own config. The config could be like "I want to replace the top 4 validators with my keys, bump their stake amount each by 100x, replace certain governance params as follows, use {this} as faucet address"

Then that new genesis file would be created from a script like this, and will be of huge importance for benchmarking, daily build testing, and upgrade testing. (We could then make upgrades a super quikc process, we just define some txs we do from our faucet acct, and some expected state queries before and after!)

The main feature of this PR really is the started code in the golang, but the shell script for whats an MVP of what we need to emulate.