### PR TITLE
Gauge test improvements

### DIFF
--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -8,22 +8,25 @@ import (
 	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
 )
 
+var defaultLPDenom string = "lptoken"
+var defaultLPTokens sdk.Coins = sdk.Coins{sdk.NewInt64Coin(defaultLPDenom, 10)}
+var defaultLiquidTokens sdk.Coins = sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
+var defaultLockDuration time.Duration = time.Second
+
 func (suite *KeeperTestSuite) TestInvalidDurationGaugeCreationValidation() {
 	suite.SetupTest()
 
-	addr := sdk.AccAddress([]byte("addr1---------------"))
-	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
-	suite.app.BankKeeper.SetBalances(suite.ctx, addr, coins)
+	addrs := suite.SetupManyLocks(1, defaultLiquidTokens, defaultLPTokens, defaultLockDuration)
 	distrTo := lockuptypes.QueryCondition{
 		LockQueryType: lockuptypes.ByDuration,
-		Denom:         "lptoken",
-		Duration:      time.Second / 2, // 0.5 second
+		Denom:         defaultLPDenom,
+		Duration:      defaultLockDuration / 2, // 0.5 second, invalid duration
 	}
-	_, err := suite.app.IncentivesKeeper.CreateGauge(suite.ctx, false, addr, coins, distrTo, time.Time{}, 1)
+	_, err := suite.app.IncentivesKeeper.CreateGauge(suite.ctx, false, addrs[0], defaultLiquidTokens, distrTo, time.Time{}, 1)
 	suite.Require().Error(err)
 
 	distrTo.Duration = time.Second
-	_, err = suite.app.IncentivesKeeper.CreateGauge(suite.ctx, false, addr, coins, distrTo, time.Time{}, 1)
+	_, err = suite.app.IncentivesKeeper.CreateGauge(suite.ctx, false, addrs[0], defaultLiquidTokens, distrTo, time.Time{}, 1)
 	suite.Require().NoError(err)
 }
 

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -8,10 +8,17 @@ import (
 	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
 )
 
-var defaultLPDenom string = "lptoken"
-var defaultLPTokens sdk.Coins = sdk.Coins{sdk.NewInt64Coin(defaultLPDenom, 10)}
-var defaultLiquidTokens sdk.Coins = sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
-var defaultLockDuration time.Duration = time.Second
+func (suite *KeeperTestSuite) TestDistribute() {
+	tests := []struct {
+		users           userLocks
+		gauge           []types.Gauge
+		expectedRewards []sdk.Coins
+	}{}
+	for _, _ = range tests {
+		suite.SetupTest()
+
+	}
+}
 
 func (suite *KeeperTestSuite) TestInvalidDurationGaugeCreationValidation() {
 	suite.SetupTest()

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -113,8 +113,8 @@ func (suite *KeeperTestSuite) TestNonPerpetualGaugeOperations() {
 	gauges := suite.app.IncentivesKeeper.GetNotFinishedGauges(suite.ctx)
 	suite.Require().Len(gauges, 0)
 
-	// setup lock and gauge
-	lockOwner, gaugeID, coins, startTime := suite.SetupLockAndGauge(false)
+	_ = suite.SetupManyLocks(5, sdk.Coins{}, sdk.Coins{sdk.NewInt64Coin("lptoken", 10)}, time.Second)
+	gaugeID, _, coins, startTime := suite.SetupNewGauge(false, sdk.Coins{sdk.NewInt64Coin("stake", 10)})
 
 	// check gauges
 	gauges = suite.app.IncentivesKeeper.GetNotFinishedGauges(suite.ctx)
@@ -125,10 +125,6 @@ func (suite *KeeperTestSuite) TestNonPerpetualGaugeOperations() {
 	suite.Require().Equal(gauges[0].FilledEpochs, uint64(0))
 	suite.Require().Equal(gauges[0].DistributedCoins, sdk.Coins(nil))
 	suite.Require().Equal(gauges[0].StartTime.Unix(), startTime.Unix())
-
-	// check rewards estimation
-	rewardsEst := suite.app.IncentivesKeeper.GetRewardsEst(suite.ctx, lockOwner, []lockuptypes.PeriodLock{}, 100)
-	suite.Require().Equal(coins.String(), rewardsEst.String())
 
 	// add to gauge
 	addCoins := sdk.Coins{sdk.NewInt64Coin("stake", 200)}
@@ -198,10 +194,6 @@ func (suite *KeeperTestSuite) TestNonPerpetualGaugeOperations() {
 	// check invalid gauge ID
 	_, err = suite.app.IncentivesKeeper.GetGaugeByID(suite.ctx, gaugeID+1000)
 	suite.Require().Error(err)
-
-	// check rewards estimation
-	rewardsEst = suite.app.IncentivesKeeper.GetRewardsEst(suite.ctx, lockOwner, []lockuptypes.PeriodLock{}, 100)
-	suite.Require().Equal(sdk.Coins{}, rewardsEst)
 }
 
 func (suite *KeeperTestSuite) TestPerpetualGaugeOperations() {

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -9,11 +9,28 @@ import (
 )
 
 func (suite *KeeperTestSuite) TestDistribute() {
+	twoLockupUser := userLocks{
+		lockDurations: []time.Duration{time.Second, 2 * time.Second},
+		lockAmounts:   []sdk.Coins{defaultLPTokens, defaultLPTokens},
+	}
+	defaultGauge := perpGaugeDesc{
+		lockDenom:    defaultLPDenom,
+		lockDuration: defaultLockDuration,
+		rewardAmount: sdk.Coins{sdk.NewInt64Coin(defaultRewardDenom, 3000)},
+	}
+	oneKRewardCoins := sdk.Coins{sdk.NewInt64Coin(defaultRewardDenom, 1000)}
+	twoKRewardCoins := oneKRewardCoins.Add(oneKRewardCoins...)
 	tests := []struct {
-		users           userLocks
-		gauge           []types.Gauge
+		users           []userLocks
+		gauge           perpGaugeDesc
 		expectedRewards []sdk.Coins
-	}{}
+	}{
+		{
+			users:           []userLocks{oneLockupUser, twoLockupUser},
+			gauge:           defaultGauge,
+			expectedRewards: []sdk.Coins{oneKRewardCoins, twoKRewardCoins},
+		},
+	}
 	for _, _ = range tests {
 		suite.SetupTest()
 

--- a/x/incentives/keeper/suite_test.go
+++ b/x/incentives/keeper/suite_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"fmt"
+	"math/rand"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -45,6 +47,18 @@ func (suite *KeeperTestSuite) SetupNewGauge(isPerpetual bool, coins sdk.Coins) (
 	}
 	gaugeID, gauge := suite.CreateGauge(isPerpetual, addr2, coins, distrTo, startTime2, numEpochsPaidOver)
 	return gaugeID, gauge, coins, startTime2
+}
+
+func (suite *KeeperTestSuite) SetupManyLocks(numLocks int, coinsPerLock sdk.Coins, lockDuration time.Duration) []sdk.AccAddress {
+	accts := make([]sdk.AccAddress, 0, numLocks)
+	randPrefix := make([]byte, 8)
+	_, _ = rand.Read(randPrefix)
+	for i := 0; i < numLocks; i++ {
+		lockOwner := sdk.AccAddress([]byte(fmt.Sprintf("addr%s%8d", string(randPrefix), i)))
+		accts = append(accts, lockOwner)
+		suite.LockTokens(lockOwner, coinsPerLock, lockDuration)
+	}
+	return accts
 }
 
 func (suite *KeeperTestSuite) SetupLockAndGauge(isPerpetual bool) (sdk.AccAddress, uint64, sdk.Coins, time.Time) {


### PR DESCRIPTION
This PR adds more scaffolding to writing tests for gauges. It also adds simpler tests for testing the distsribute function of a gauge, and removes some duplicate code between perpetual and non-perpetual gauge tests.

As I was reading this code, I noticed we have a lot more test cleanup to do, and better testing to be adding here. I'll start writing it into issues, but wanted to add this quick PR