### PR TITLE
fixed typo bug in osmosisdnode/Dockerfile

### DIFF
--- a/networks/local/osmosisdnode/Dockerfile
+++ b/networks/local/osmosisdnode/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install curl jq file
 
-VOLUME [ /omsosisd ]
-WORKDIR /omsosisd
+VOLUME [ /osmosisd ]
+WORKDIR /osmosisd
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
 CMD ["start"]


### PR DESCRIPTION
This bug prevents the localnet-start target of Makefile from creating necessary files needed for launch of a local testnet in the proper directory. The reason is that the `build` directory is mounted on `/osmosisd`, but the output directory is set to `.` (current directory) which in the docker file is specified as `WORKDIR /omsosisd`; therefore by the time testnet command finishes and docker exits the output files will be lost.