### PR TITLE
Edit linter: only enable errcheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.34.1
-          args: --timeout 10m
+          args: --timeout 10m --disable-all -E errcheck
           github-token: ${{ secrets.github_token }}
         if: "env.GIT_DIFF != ''"

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -34,12 +34,11 @@ func init() {
 }
 
 func RegisterDenoms() {
-	// err := sdk.RegisterDenom(HumanCoinUnit, sdk.OneDec())
-	// if err != nil {
-	// 	panic(err)
-	// }
-	sdk.RegisterDenom(HumanCoinUnit, sdk.OneDec())
-	err := sdk.RegisterDenom(BaseCoinUnit, sdk.NewDecWithPrec(1, OsmoExponent))
+	err := sdk.RegisterDenom(HumanCoinUnit, sdk.OneDec())
+	if err != nil {
+		panic(err)
+	}
+	err = sdk.RegisterDenom(BaseCoinUnit, sdk.NewDecWithPrec(1, OsmoExponent))
 	if err != nil {
 		panic(err)
 	}

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -34,11 +34,12 @@ func init() {
 }
 
 func RegisterDenoms() {
-	err := sdk.RegisterDenom(HumanCoinUnit, sdk.OneDec())
-	if err != nil {
-		panic(err)
-	}
-	err = sdk.RegisterDenom(BaseCoinUnit, sdk.NewDecWithPrec(1, OsmoExponent))
+	// err := sdk.RegisterDenom(HumanCoinUnit, sdk.OneDec())
+	// if err != nil {
+	// 	panic(err)
+	// }
+	sdk.RegisterDenom(HumanCoinUnit, sdk.OneDec())
+	err := sdk.RegisterDenom(BaseCoinUnit, sdk.NewDecWithPrec(1, OsmoExponent))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR edits linter so that it only has err check enabled on PRs and pushes to main