### PR TITLE
Hotfix - Fix event attribute in incentives module

### DIFF
--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -381,7 +381,7 @@ func (k Keeper) doDistributionSends(ctx sdk.Context, denom string, distrs distri
 			sdk.NewEvent(
 				types.TypeEvtDistribution,
 				sdk.NewAttribute(types.AttributeLockedDenom, denom),
-				sdk.NewAttribute(types.AttributeReceiver, string(distrs.idToDecodedAddr[id])),
+				sdk.NewAttribute(types.AttributeReceiver, distrs.idToDecodedAddr[id].String()),
 				sdk.NewAttribute(types.AttributeAmount, distrs.idToDistrCoins[id].String()),
 			),
 		})


### PR DESCRIPTION
This PR fixes the bug in the current event emitted in the incentive module.
Converting address to string without using the String() method ignores the process of going through bech32 encoding, consequently emitting events with the wrong address attribute, making it impossible to query based on the incentive events.