### PR TITLE
Remove linear # of bech32 encodes introduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,15 @@ Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+* Fix bug in incentives epoch distribution events, used to use raw address, now uses bech32 addr
 
 ## [v4.0.0]
 

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -333,6 +333,7 @@ func (k Keeper) debugDistribute(ctx sdk.Context, gauge types.Gauge) (sdk.Coins, 
 type distributionInfo struct {
 	nextID            int
 	lockOwnerAddrToID map[string]int
+	idToBech32Addr    []string
 	idToDecodedAddr   []sdk.AccAddress
 	idToDistrCoins    []sdk.Coins
 }
@@ -341,6 +342,7 @@ func newDistributionInfo() distributionInfo {
 	return distributionInfo{
 		nextID:            0,
 		lockOwnerAddrToID: make(map[string]int),
+		idToBech32Addr:    []string{},
 		idToDecodedAddr:   []sdk.AccAddress{},
 		idToDistrCoins:    []sdk.Coins{},
 	}
@@ -358,6 +360,7 @@ func (d *distributionInfo) addLockRewards(lock lockuptypes.PeriodLock, rewards s
 		if err != nil {
 			return err
 		}
+		d.idToBech32Addr = append(d.idToBech32Addr, lock.Owner)
 		d.idToDecodedAddr = append(d.idToDecodedAddr, decodedOwnerAddr)
 		d.idToDistrCoins = append(d.idToDistrCoins, rewards)
 	}
@@ -381,7 +384,7 @@ func (k Keeper) doDistributionSends(ctx sdk.Context, denom string, distrs distri
 			sdk.NewEvent(
 				types.TypeEvtDistribution,
 				sdk.NewAttribute(types.AttributeLockedDenom, denom),
-				sdk.NewAttribute(types.AttributeReceiver, distrs.idToDecodedAddr[id].String()),
+				sdk.NewAttribute(types.AttributeReceiver, distrs.idToBech32Addr[id]),
 				sdk.NewAttribute(types.AttributeAmount, distrs.idToDistrCoins[id].String()),
 			),
 		})


### PR DESCRIPTION
Removes computational overhead introduced in #501, for fixing printed format of bech32 addresses