### PR TITLE
Make `make lint` work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ benchmark:
 ###############################################################################
 
 lint:
-	golangci-lint run
+	golangci-lint run --disable-all -E errcheck
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
 
 format:

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -541,7 +541,7 @@ func (k Keeper) GetRewardsEst(ctx sdk.Context, addr sdk.AccAddress, locks []lock
 	}
 	gauges := []types.Gauge{}
 	// initialize gauges to active and upcomings if not set
-	for s, _ := range denomSet {
+	for s := range denomSet {
 		gaugeIDs := k.getAllGaugeIDsByDenom(ctx, s)
 		// Each gauge only rewards locks to one denom, so no duplicates
 		for _, id := range gaugeIDs {

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -417,7 +417,7 @@ func (k Keeper) ResetAllLocks(ctx sdk.Context, locks []types.PeriodLock) error {
 	for _, denom := range denoms {
 		curDurationMap := accumulationStoreEntries[denom]
 		durations := make([]time.Duration, 0, len(curDurationMap))
-		for duration, _ := range curDurationMap {
+		for duration := range curDurationMap {
 			durations = append(durations, duration)
 		}
 		sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })

--- a/x/lockup/keeper/msg_server_test.go
+++ b/x/lockup/keeper/msg_server_test.go
@@ -16,8 +16,9 @@ func (suite *KeeperTestSuite) TestMsgLockTokens() {
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
 
-	suite.app.BankKeeper.SetBalances(suite.ctx, addr1, coins)
-	_, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr1, coins, time.Second)
+	err := suite.app.BankKeeper.SetBalances(suite.ctx, addr1, coins)
+	suite.Require().NoError(err)
+	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr1, coins, time.Second)
 	suite.Require().NoError(err)
 
 	// creation of lock via LockTokens
@@ -39,7 +40,8 @@ func (suite *KeeperTestSuite) TestMsgLockTokens() {
 
 	// add more tokens to lock via LockTokens
 	addCoins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
-	suite.app.BankKeeper.SetBalances(suite.ctx, addr1, addCoins)
+	err = suite.app.BankKeeper.SetBalances(suite.ctx, addr1, addCoins)
+	suite.Require().NoError(err)
 
 	_, err = msgServer.LockTokens(sdk.WrapSDKContext(suite.ctx), types.NewMsgLockTokens(addr1, locks[0].Duration, addCoins))
 	suite.Require().NoError(err)


### PR DESCRIPTION
Makes make lint match whats in CI.

Also fixes two errors that got added in parallel to #491 being merged
