### PR TITLE
x/claim: fix incorrect param in test

### DIFF
--- a/x/claim/genesis_test.go
+++ b/x/claim/genesis_test.go
@@ -20,7 +20,7 @@ var testGenesis = types.GenesisState{
 	ModuleAccountBalance: sdk.NewInt64Coin(types.DefaultClaimDenom, 750000000),
 	Params: types.Params{
 		AirdropStartTime:   now,
-		DurationUntilDecay: types.DefaultDurationOfDecay,
+		DurationUntilDecay: types.DefaultDurationUntilDecay,
 		DurationOfDecay:    types.DefaultDurationOfDecay,
 		ClaimDenom:         types.DefaultClaimDenom, // uosmo
 	},


### PR DESCRIPTION
This PR fixes bug in the test file that was in PR https://github.com/osmosis-labs/osmosis/pull/481, allocating the correct parameters to genesis_test.go in the claim module.
