### PR TITLE
Bump osmosis-SDK fork version: Add debug command for converting secp pubkeys 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,6 @@ replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alp
 
 replace github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.12
 
-replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210915013958-01114e89a579
+replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20211008194120-d0e63ff7691b
 
 replace github.com/tendermint/tm-db => github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210915013958-01114e89a579 h1:wF1dMC97AEdUE4kKCEK4ep1mTnpaPEN6G8IUcL2vu2E=
 github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20210915013958-01114e89a579/go.mod h1:QByRyM6mubdL7o30ZuJTFWT2cwjmT+GT19XSYwyS7pc=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20211008194120-d0e63ff7691b h1:kt2khOeVohgBMYoSq1ZCjkzQXstQMH2Fsdn+3zaDHNs=
+github.com/osmosis-labs/cosmos-sdk v0.42.10-0.20211008194120-d0e63ff7691b/go.mod h1:QByRyM6mubdL7o30ZuJTFWT2cwjmT+GT19XSYwyS7pc=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417 h1:otchJDd2SjFWfs7Tse3ULblGcVWqMJ50BE02XCaqXOo=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=


### PR DESCRIPTION
Bumps the Osmosis SDK import version, to make it possible to convert pubkey outputs from querying, into bech32 usable for multisigs.