### PR TITLE
docs/usage fixes

### DIFF
--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -189,7 +189,7 @@ osmosisd tx gamm join-pool [flags]
 #### Example
 Join pool 1 with 1 OSMO and the respective amount of ATOM, using myKeyringWallet.
 ```sh
-osmosisd tx gamm join-pool --pool-id 1 --max-amounts-in 1000000uosmo --share-amount-out 1000000 --from myKeyringWallet
+osmosisd tx gamm join-pool --pool-id 2 --max-amounts-in 1000000uosmo --max-amounts-in 1000000uion --share-amount-out 1000000 --from myKeyringWallet
 ```
 
 

--- a/x/gamm/client/cli/flags.go
+++ b/x/gamm/client/cli/flags.go
@@ -81,8 +81,8 @@ func FlagSetJoinPool() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
 	fs.Uint64(FlagPoolId, 0, "The id of pool")
-	fs.String(FlagShareAmountOut, "", "TODO: add description")
-	fs.StringArray(FlagMaxAmountsIn, []string{""}, "TODO: add description")
+	fs.String(FlagShareAmountOut, "", "Minimum amount of Gamm tokens to receive")
+	fs.StringArray(FlagMaxAmountsIn, []string{""}, "Maximum amount of each denom to send into the pool (specify multiple denoms with: --max-amounts-in=1uosmo --max-amounts-in=1uion)")
 
 	return fs
 }


### PR DESCRIPTION
Closes: #500 

Existing doc lines for `join-swap-extern-amount-in` and `join-swap-share-amount-out` match what worked for me, so only `join-pool` and the usage lines for `--max-amounts-in` and `--share-amount-out` needed fixing.