### PR TITLE
Pool Incentives: Allow Zero Weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Allow zero-weight pool-incentive distribution records
 * Fix bug in incentives epoch distribution events, used to use raw address, now uses bech32 addr
 * Update peer ID of statesync-enabled node run by notional
 * Created a pull request template

--- a/x/pool-incentives/types/gov_test.go
+++ b/x/pool-incentives/types/gov_test.go
@@ -47,6 +47,18 @@ func TestUpdatePoolIncentivesProposalMarshalUnmarshal(t *testing.T) {
 				},
 			},
 		},
+		{ // zero-weight record
+			proposal: &types.UpdatePoolIncentivesProposal{
+				Title:       "title",
+				Description: "proposal to update pool incentives",
+				Records: []types.DistrRecord{
+					{
+						GaugeId: 1,
+						Weight:  sdk.NewInt(0),
+					},
+				},
+			},
+		},
 		{ // two records
 			proposal: &types.UpdatePoolIncentivesProposal{
 				Title:       "title",

--- a/x/pool-incentives/types/record.go
+++ b/x/pool-incentives/types/record.go
@@ -1,7 +1,7 @@
 package types
 
 func (r DistrRecord) ValidateBasic() error {
-	if !r.Weight.IsPositive() {
+	if r.Weight.IsNegative() {
 		return ErrDistrRecordNotPositiveWeight
 	}
 	return nil

--- a/x/pool-incentives/types/record_test.go
+++ b/x/pool-incentives/types/record_test.go
@@ -16,7 +16,7 @@ func TestDistrRecord(t *testing.T) {
 		Weight:  sdk.NewInt(0),
 	}
 
-	require.Error(t, zeroWeight.ValidateBasic())
+	require.NoError(t, zeroWeight.ValidateBasic())
 
 	negativeWeight := types.DistrRecord{
 		GaugeId: 1,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #546 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Validation check for pool-incentive gauge weight will only throw for negative values
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

