### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then exit and re-enter your shell.
 ```bash
 git clone https://github.com/osmosis-labs/osmosis
 cd osmosis
-git checkout v4.1.0
+git checkout v3.1.0
 make install
 which osmosisd
 ```


### PR DESCRIPTION
Closes: #569 

## Description

As stated in issue #569, utilizing v4.1.0 to start a full node from scratch will give the error "panic: unknown field "current_epoch_ended" in types.EpochInfo". You must instead start from v3.1.0 and once passed block 1314500, you can then upgrade to v4.1.0.


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

