### PR TITLE
Fix grpc query response for empty address in lockup

### DIFF
--- a/x/lockup/keeper/grpc_query.go
+++ b/x/lockup/keeper/grpc_query.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/x/lockup/types"
@@ -26,7 +27,7 @@ func (k Keeper) AccountUnlockableCoins(goCtx context.Context, req *types.Account
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -38,7 +39,7 @@ func (k Keeper) AccountUnlockingCoins(goCtx context.Context, req *types.AccountU
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -50,7 +51,7 @@ func (k Keeper) AccountLockedCoins(goCtx context.Context, req *types.AccountLock
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (k Keeper) AccountLockedPastTime(goCtx context.Context, req *types.AccountL
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -74,7 +75,7 @@ func (k Keeper) AccountUnlockedBeforeTime(goCtx context.Context, req *types.Acco
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -87,7 +88,7 @@ func (k Keeper) AccountLockedPastTimeDenom(goCtx context.Context, req *types.Acc
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (k Keeper) AccountLockedLongerDuration(goCtx context.Context, req *types.Ac
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func (k Keeper) AccountLockedLongerDurationDenom(goCtx context.Context, req *typ
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -132,7 +133,7 @@ func (k Keeper) AccountLockedPastTimeNotUnlockingOnly(goCtx context.Context, req
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (k Keeper) AccountLockedLongerDurationNotUnlockingOnly(goCtx context.Contex
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	owner, err := sdk.AccAddressFromBech32(req.Owner)
 	if req.Owner == "" {
-		owner = sdk.AccAddress{}
+		return nil, errors.New("empty address")
 	} else if err != nil {
 		return nil, err
 	}

--- a/x/lockup/keeper/grpc_query_test.go
+++ b/x/lockup/keeper/grpc_query_test.go
@@ -79,12 +79,11 @@ func (suite *KeeperTestSuite) TestAccountUnlockableCoins() {
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 
 	// empty address unlockable coins check
-	res, err := suite.app.LockupKeeper.AccountUnlockableCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockableCoinsRequest{Owner: ""})
-	suite.Require().NoError(err)
-	suite.Require().Equal(res.Coins, sdk.Coins{})
+	_, err := suite.app.LockupKeeper.AccountUnlockableCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockableCoinsRequest{Owner: ""})
+	suite.Require().Error(err)
 
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountUnlockableCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockableCoinsRequest{Owner: addr1.String()})
+	res, err := suite.app.LockupKeeper.AccountUnlockableCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockableCoinsRequest{Owner: addr1.String()})
 	suite.Require().NoError(err)
 	suite.Require().Equal(res.Coins, sdk.Coins{})
 
@@ -121,11 +120,11 @@ func (suite *KeeperTestSuite) TestAccountUnlockingCoins() {
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 
 	// empty address unlockable coins check
-	res, err := suite.app.LockupKeeper.AccountUnlockingCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockingCoinsRequest{Owner: ""})
-	suite.Require().NoError(err)
-	suite.Require().Equal(res.Coins, sdk.Coins{})
+	_, err := suite.app.LockupKeeper.AccountUnlockingCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockingCoinsRequest{Owner: ""})
+	suite.Require().Error(err)
+
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountUnlockingCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockingCoinsRequest{Owner: addr1.String()})
+	res, err := suite.app.LockupKeeper.AccountUnlockingCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockingCoinsRequest{Owner: addr1.String()})
 	suite.Require().NoError(err)
 	suite.Require().Equal(res.Coins, sdk.Coins{})
 
@@ -162,11 +161,11 @@ func (suite *KeeperTestSuite) TestAccountLockedCoins() {
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 
 	// empty address locked coins check
-	res, err := suite.app.LockupKeeper.AccountLockedCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedCoinsRequest{})
-	suite.Require().NoError(err)
-	suite.Require().Equal(res.Coins, sdk.Coins(nil))
+	_, err := suite.app.LockupKeeper.AccountLockedCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedCoinsRequest{})
+	suite.Require().Error(err)
+
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountLockedCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedCoinsRequest{Owner: addr1.String()})
+	res, err := suite.app.LockupKeeper.AccountLockedCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedCoinsRequest{Owner: addr1.String()})
 	suite.Require().NoError(err)
 	suite.Require().Equal(res.Coins, sdk.Coins(nil))
 
@@ -198,11 +197,11 @@ func (suite *KeeperTestSuite) TestAccountLockedPastTime() {
 	now := suite.ctx.BlockTime()
 
 	// empty address locks check
-	res, err := suite.app.LockupKeeper.AccountLockedPastTime(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeRequest{Owner: "", Timestamp: now})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	_, err := suite.app.LockupKeeper.AccountLockedPastTime(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeRequest{Owner: "", Timestamp: now})
+	suite.Require().Error(err)
+
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountLockedPastTime(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeRequest{Owner: addr1.String(), Timestamp: now})
+	res, err := suite.app.LockupKeeper.AccountLockedPastTime(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeRequest{Owner: addr1.String(), Timestamp: now})
 	suite.Require().NoError(err)
 	suite.Require().Len(res.Locks, 0)
 
@@ -233,12 +232,11 @@ func (suite *KeeperTestSuite) TestAccountLockedPastTimeNotUnlockingOnly() {
 	now := suite.ctx.BlockTime()
 
 	// empty address locks check
-	res, err := suite.app.LockupKeeper.AccountLockedPastTimeNotUnlockingOnly(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeNotUnlockingOnlyRequest{Owner: "", Timestamp: now})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	_, err := suite.app.LockupKeeper.AccountLockedPastTimeNotUnlockingOnly(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeNotUnlockingOnlyRequest{Owner: "", Timestamp: now})
+	suite.Require().Error(err)
 
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountLockedPastTimeNotUnlockingOnly(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeNotUnlockingOnlyRequest{Owner: addr1.String(), Timestamp: now})
+	res, err := suite.app.LockupKeeper.AccountLockedPastTimeNotUnlockingOnly(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeNotUnlockingOnlyRequest{Owner: addr1.String(), Timestamp: now})
 	suite.Require().NoError(err)
 	suite.Require().Len(res.Locks, 0)
 
@@ -266,11 +264,11 @@ func (suite *KeeperTestSuite) TestAccountUnlockedBeforeTime() {
 	now := suite.ctx.BlockTime()
 
 	// empty address unlockables check
-	res, err := suite.app.LockupKeeper.AccountUnlockedBeforeTime(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockedBeforeTimeRequest{Owner: "", Timestamp: now})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	_, err := suite.app.LockupKeeper.AccountUnlockedBeforeTime(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockedBeforeTimeRequest{Owner: "", Timestamp: now})
+	suite.Require().Error(err)
+
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountUnlockedBeforeTime(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockedBeforeTimeRequest{Owner: addr1.String(), Timestamp: now})
+	res, err := suite.app.LockupKeeper.AccountUnlockedBeforeTime(sdk.WrapSDKContext(suite.ctx), &types.AccountUnlockedBeforeTimeRequest{Owner: addr1.String(), Timestamp: now})
 	suite.Require().NoError(err)
 	suite.Require().Len(res.Locks, 0)
 
@@ -301,11 +299,11 @@ func (suite *KeeperTestSuite) TestAccountLockedPastTimeDenom() {
 	now := suite.ctx.BlockTime()
 
 	// empty address locks by denom check
-	res, err := suite.app.LockupKeeper.AccountLockedPastTimeDenom(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeDenomRequest{Owner: "", Denom: "stake", Timestamp: now})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	_, err := suite.app.LockupKeeper.AccountLockedPastTimeDenom(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeDenomRequest{Owner: "", Denom: "stake", Timestamp: now})
+	suite.Require().Error(err)
+
 	// initial check
-	res, err = suite.app.LockupKeeper.AccountLockedPastTimeDenom(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeDenomRequest{Owner: addr1.String(), Denom: "stake", Timestamp: now})
+	res, err := suite.app.LockupKeeper.AccountLockedPastTimeDenom(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedPastTimeDenomRequest{Owner: addr1.String(), Denom: "stake", Timestamp: now})
 	suite.Require().NoError(err)
 	suite.Require().Len(res.Locks, 0)
 
@@ -369,8 +367,8 @@ func (suite *KeeperTestSuite) TestAccountLockedLongerDuration() {
 
 	// empty address locks longer than duration check
 	res, err := suite.app.LockupKeeper.AccountLockedLongerDuration(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedLongerDurationRequest{Owner: "", Duration: time.Second})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	suite.Require().Error(err)
+
 	// initial check
 	res, err = suite.app.LockupKeeper.AccountLockedLongerDuration(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedLongerDurationRequest{Owner: addr1.String(), Duration: time.Second})
 	suite.Require().NoError(err)
@@ -403,8 +401,8 @@ func (suite *KeeperTestSuite) TestAccountLockedLongerDurationNotUnlockingOnly() 
 
 	// empty address locks longer than duration check
 	res, err := suite.app.LockupKeeper.AccountLockedLongerDurationNotUnlockingOnly(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedLongerDurationNotUnlockingOnlyRequest{Owner: "", Duration: time.Second})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	suite.Require().Error(err)
+
 	// initial check
 	res, err = suite.app.LockupKeeper.AccountLockedLongerDurationNotUnlockingOnly(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedLongerDurationNotUnlockingOnlyRequest{Owner: addr1.String(), Duration: time.Second})
 	suite.Require().NoError(err)
@@ -433,8 +431,8 @@ func (suite *KeeperTestSuite) TestAccountLockedLongerDurationDenom() {
 
 	// empty address locks longer than duration by denom check
 	res, err := suite.app.LockupKeeper.AccountLockedLongerDurationDenom(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedLongerDurationDenomRequest{Owner: "", Duration: time.Second, Denom: "stake"})
-	suite.Require().NoError(err)
-	suite.Require().Len(res.Locks, 0)
+	suite.Require().Error(err)
+
 	// initial check
 	res, err = suite.app.LockupKeeper.AccountLockedLongerDurationDenom(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedLongerDurationDenomRequest{Owner: addr1.String(), Duration: time.Second, Denom: "stake"})
 	suite.Require().NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/558

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Current querying methods in the lockup module, specifically in grpc_query.go, iterates over all unlocks when user queried with an empty address. (https://github.com/osmosis-labs/osmosis/blob/main/x/lockup/keeper/grpc_query.go#L37-L47).
This PR fixes it so that whenever a query of an lockup with an empty address has been attempted, the query returns an error.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

