### PR TITLE
misc test improvements

### DIFF
--- a/osmotestutils/cli_helpers.go
+++ b/osmotestutils/cli_helpers.go
@@ -1,0 +1,14 @@
+package osmotestutils
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func DefaultFeeString(cfg network.Config) string {
+	feeCoins := sdk.NewCoins(sdk.NewCoin(cfg.BondDenom, sdk.NewInt(10)))
+	return fmt.Sprintf("--%s=%s", flags.FlagFees, feeCoins.String())
+}

--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -16,6 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
 	"github.com/osmosis-labs/osmosis/app"
+	"github.com/osmosis-labs/osmosis/osmotestutils"
 	"github.com/osmosis-labs/osmosis/x/gamm/client/cli"
 	gammtestutil "github.com/osmosis-labs/osmosis/x/gamm/client/testutil"
 	"github.com/osmosis-labs/osmosis/x/gamm/types"
@@ -78,7 +79,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 200000000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 
@@ -324,7 +325,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				// common args
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+				osmotestutils.DefaultFeeString(s.cfg),
 				fmt.Sprintf("--%s=%s", flags.FlagGas, fmt.Sprint(300000)),
 			}
 
@@ -357,7 +358,7 @@ func (s IntegrationTestSuite) TestNewJoinPoolCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 
@@ -495,7 +496,7 @@ func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 
@@ -559,7 +560,7 @@ func (s IntegrationTestSuite) TestNewJoinSwapExternAmountInCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(20000))), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 
@@ -667,7 +668,7 @@ func (s IntegrationTestSuite) TestNewJoinSwapShareAmountOutCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(20000))), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 
@@ -1118,7 +1119,7 @@ func (s IntegrationTestSuite) TestNewSwapExactAmountInCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 

--- a/x/gamm/keeper/invariants.go
+++ b/x/gamm/keeper/invariants.go
@@ -43,7 +43,7 @@ func PoolAccountInvariant(keeper Keeper, bk types.BankKeeper) sdk.Invariant {
 		pools, err := keeper.GetPools(ctx)
 		if err != nil {
 			return sdk.FormatInvariant(types.ModuleName, poolBalanceInvariantName,
-				fmt.Sprintf("\tgamm pool retrieval failed")), true
+				"\tgamm pool retrieval failed"), true
 		}
 
 		for _, pool := range pools {
@@ -57,7 +57,7 @@ func PoolAccountInvariant(keeper Keeper, bk types.BankKeeper) sdk.Invariant {
 		}
 
 		return sdk.FormatInvariant(types.ModuleName, poolBalanceInvariantName,
-			fmt.Sprintf("\tgamm all pool asset coins and account coins match\n")), false
+			"\tgamm all pool asset coins and account coins match\n"), false
 	}
 }
 
@@ -68,7 +68,7 @@ func PoolTotalWeightInvariant(keeper Keeper, bk types.BankKeeper) sdk.Invariant 
 		pools, err := keeper.GetPools(ctx)
 		if err != nil {
 			return sdk.FormatInvariant(types.ModuleName, "pool-total-weight",
-				fmt.Sprintf("\tgamm pool retrieval failed")), true
+				"\tgamm pool retrieval failed"), true
 		}
 
 		for _, pool := range pools {
@@ -84,7 +84,7 @@ func PoolTotalWeightInvariant(keeper Keeper, bk types.BankKeeper) sdk.Invariant 
 		}
 
 		return sdk.FormatInvariant(types.ModuleName, "pool-total-weight",
-			fmt.Sprintf("\tgamm all pool calculated and stored total weight match\n")), false
+			"\tgamm all pool calculated and stored total weight match\n"), false
 	}
 }
 
@@ -130,7 +130,7 @@ func PoolProductConstantInvariant(keeper Keeper) sdk.Invariant {
 		newpools, err := keeper.GetPools(ctx)
 		if err != nil {
 			return sdk.FormatInvariant(types.ModuleName, "pool-product-constant",
-				fmt.Sprintf("\tgamm pool retrieval failed")), true
+				"\tgamm pool retrieval failed"), true
 		}
 
 		for _, pool := range newpools {
@@ -150,6 +150,6 @@ func PoolProductConstantInvariant(keeper Keeper) sdk.Invariant {
 		}
 
 		return sdk.FormatInvariant(types.ModuleName, "pool-product-constant",
-			fmt.Sprintf("\tgamm all pool product constant preserved\n")), false
+			"\tgamm all pool product constant preserved\n"), false
 	}
 }

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -28,6 +28,12 @@ var (
 		Token:  sdk.NewCoin("bar", sdk.NewInt(10000)),
 	}
 	defaultPoolAssets []types.PoolAsset = []types.PoolAsset{defaultFooAsset, defaultBarAsset}
+	defaultAcctFunds  sdk.Coins         = sdk.NewCoins(
+		sdk.NewCoin("uosmo", sdk.NewInt(10000000000)),
+		sdk.NewCoin("foo", sdk.NewInt(10000000)),
+		sdk.NewCoin("bar", sdk.NewInt(10000000)),
+		sdk.NewCoin("baz", sdk.NewInt(10000000)),
+	)
 )
 
 func (suite *KeeperTestSuite) TestCreatePool() {
@@ -196,12 +202,7 @@ func (suite *KeeperTestSuite) TestCreatePool() {
 
 		// Mint some assets to the accounts.
 		for _, acc := range []sdk.AccAddress{acc1, acc2, acc3} {
-			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, sdk.NewCoins(
-				sdk.NewCoin("uosmo", sdk.NewInt(10000000000)),
-				sdk.NewCoin("foo", sdk.NewInt(10000000)),
-				sdk.NewCoin("bar", sdk.NewInt(10000000)),
-				sdk.NewCoin("baz", sdk.NewInt(10000000)),
-			))
+			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, defaultAcctFunds)
 			if err != nil {
 				panic(err)
 			}
@@ -280,12 +281,7 @@ func (suite *KeeperTestSuite) TestJoinPool() {
 
 		// Mint some assets to the accounts.
 		for _, acc := range []sdk.AccAddress{acc1, acc2, acc3} {
-			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, sdk.NewCoins(
-				sdk.NewCoin("uosmo", sdk.NewInt(10000000000)),
-				sdk.NewCoin("foo", sdk.NewInt(10000000)),
-				sdk.NewCoin("bar", sdk.NewInt(10000000)),
-				sdk.NewCoin("baz", sdk.NewInt(10000000)),
-			))
+			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, defaultAcctFunds)
 			if err != nil {
 				panic(err)
 			}
@@ -377,12 +373,7 @@ func (suite *KeeperTestSuite) TestExitPool() {
 
 		// Mint some assets to the accounts.
 		for _, acc := range []sdk.AccAddress{acc1, acc2, acc3} {
-			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, sdk.NewCoins(
-				sdk.NewCoin("uosmo", sdk.NewInt(10000000000)),
-				sdk.NewCoin("foo", sdk.NewInt(10000000)),
-				sdk.NewCoin("bar", sdk.NewInt(10000000)),
-				sdk.NewCoin("baz", sdk.NewInt(10000000)),
-			))
+			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, defaultAcctFunds)
 			if err != nil {
 				panic(err)
 			}
@@ -415,12 +406,7 @@ func (suite *KeeperTestSuite) TestActivePool() {
 
 		// Mint some assets to the accounts.
 		for _, acc := range []sdk.AccAddress{acc1, acc2, acc3} {
-			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, sdk.NewCoins(
-				sdk.NewCoin("uosmo", sdk.NewInt(10000000000)),
-				sdk.NewCoin("foo", sdk.NewInt(10000000)),
-				sdk.NewCoin("bar", sdk.NewInt(10000000)),
-				sdk.NewCoin("baz", sdk.NewInt(10000000)),
-			))
+			err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, acc, defaultAcctFunds)
 			if err != nil {
 				panic(err)
 			}

--- a/x/lockup/client/cli/cli_test.go
+++ b/x/lockup/client/cli/cli_test.go
@@ -17,6 +17,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
 	"github.com/osmosis-labs/osmosis/app"
+	"github.com/osmosis-labs/osmosis/osmotestutils"
 	"github.com/osmosis-labs/osmosis/x/lockup/client/cli"
 	lockuptestutil "github.com/osmosis-labs/osmosis/x/lockup/client/testutil"
 	"github.com/osmosis-labs/osmosis/x/lockup/types"
@@ -152,7 +153,7 @@ func (s *IntegrationTestSuite) TestBeginUnlockingCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(20000))), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 
@@ -220,7 +221,7 @@ func (s *IntegrationTestSuite) TestNewBeginUnlockPeriodLockCmd() {
 		newAddr,
 		sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(20000))), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+		osmotestutils.DefaultFeeString(s.cfg),
 	)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
This PR contains the following misc test improvements:
* x/gamm: Deduplicate the FundAccounts coins constant
* x/gamm: Fix staticcheck being angry about unnecessary fmt.Sprintf's
* x/lockup: Fix noise from FundAccount in gas_test
* osmotestutils: Add GetFeeString function
* Replace complex fee cli line with simple osmotestutils call

## Description

This osmotestutils should accrue more improvements to testing here. The latency of trying to get improvements into the SDK, then back onto our own repo is far too high.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

