### PR TITLE
Update errors.go: odd testing thing

### DIFF
--- a/x/epochs/types/errors.go
+++ b/x/epochs/types/errors.go
@@ -8,5 +8,5 @@ import (
 
 // x/epochs module sentinel errors
 var (
-	ErrSample = sdkerrors.Register(ModuleName, 1100, "sample error")
+	ErrSample = sdkerrors.Register(ModuleName, 69420, "sample error")
 )


### PR DESCRIPTION
## Description

We've got sdk.Error 1100 assigned to both claim module errors and epoch module errors. I don't know why the build system doens't throw an error for this when building the main branch, but it doesn't.  Hence, I've made error 69420 the error for epochs, because when you need a number, 69420 has got you covered. 


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

