### PR TITLE
Add default params to pool-incentives genesis

### DIFF
--- a/x/pool-incentives/types/genesis.go
+++ b/x/pool-incentives/types/genesis.go
@@ -27,7 +27,10 @@ func DefaultGenesisState() *GenesisState {
 			time.Hour * 3,
 			time.Hour * 7,
 		},
-		DistrInfo: nil,
+		DistrInfo: &DistrInfo{
+			TotalWeight: sdk.ZeroInt(),
+			Records:     []DistrRecord{},
+		},
 	}
 }
 

--- a/x/pool-incentives/types/genesis.go
+++ b/x/pool-incentives/types/genesis.go
@@ -29,7 +29,7 @@ func DefaultGenesisState() *GenesisState {
 		},
 		DistrInfo: &DistrInfo{
 			TotalWeight: sdk.ZeroInt(),
-			Records:     []DistrRecord{},
+			Records:     nil,
 		},
 	}
 }

--- a/x/pool-incentives/types/genesis_test.go
+++ b/x/pool-incentives/types/genesis_test.go
@@ -22,14 +22,20 @@ func TestGenesisStateMarshalUnmarshal(t *testing.T) {
 			state: &types.GenesisState{
 				Params:            types.DefaultParams(),
 				LockableDurations: []time.Duration(nil),
-				DistrInfo:         nil,
+				DistrInfo: &types.DistrInfo{
+					TotalWeight: sdk.ZeroInt(),
+					Records:     nil,
+				},
 			},
 		},
 		{ // empty array distribution info
 			state: &types.GenesisState{
 				Params:            types.DefaultParams(),
 				LockableDurations: []time.Duration(nil),
-				DistrInfo:         &types.DistrInfo{},
+				DistrInfo: &types.DistrInfo{
+					TotalWeight: sdk.ZeroInt(),
+					Records:     nil,
+				},
 			},
 		},
 		{ // one record distribution info
@@ -51,7 +57,10 @@ func TestGenesisStateMarshalUnmarshal(t *testing.T) {
 			state: &types.GenesisState{
 				Params:            types.Params{},
 				LockableDurations: []time.Duration(nil),
-				DistrInfo:         nil,
+				DistrInfo: &types.DistrInfo{
+					TotalWeight: sdk.ZeroInt(),
+					Records:     nil,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Due to added validation on genesis on validating whether distr_info in pool-incentives module is non-negative, the default genesis file currently omits error when starting from the initial state.

This PR adds default genesis for distr_info so that it does not omit error when starting chain from the initial state.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

