### PR TITLE
Testnet Scripts [WIP - DNM]

### DIFF
--- a/scripts/testnets/clean/start.sh
+++ b/scripts/testnets/clean/start.sh
@@ -1,0 +1,75 @@
+##### Spins up and starts a single validator Osmosis testnet
+
+#### Parameters
+export CHAIN_ID="osmosis-clean-testnet-X"
+export VERSION="v4.2.0"
+
+#### Initial node setup
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get install curl build-essential jq git wget liblz4-tool aria2 make -y
+
+curl https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash
+
+export GOROOT=/root/.go
+export PATH=$GOROOT/bin:$PATH
+export GOPATH=/root/go
+export PATH=$GOPATH/bin:$PATH
+
+cd /root/
+
+rm /root/osmosis/ -rf 
+git clone https://github.com/osmosis-labs/osmosis
+cd osmosis
+git checkout $VERSION
+make install
+
+rm /root/.osmosisd/ -rf
+
+osmosisd config chain-id $CHAIN_ID
+osmosisd init "testnet-validator" --chain-id=$CHAIN_ID
+
+
+#### This section is for setting up local keys and genesis state
+## TODO Should probably be separated out into another script
+
+
+#TODO Should be replaced with dynamically generated where seed is written to a local file
+echo "oven thank broccoli giant neither swamp betray moment birth lady wage student bicycle craft permit avoid burden tortoise oxygen file fix penalty two onion" | osmosisd keys add validator --recover --keyring-backend=test
+echo "catch spider raise grass flush audit result off auction stone best day soap stay organ canoe test spoon edit relief want warrior siren act" | osmosisd keys add faucet --recover --keyring-backend=test
+echo "name salt burden assume awkward copy morning any kangaroo crucial width brother organ casual brief scorpion actress lady hover figure idea another employ another" | osmosisd keys add clawback --recover --keyring-backend=test
+
+echo "travel renew first fiction trick fly disease advance hunt famous absurd region" | osmosisd keys add keplr1 --recover --keyring-backend=test
+
+osmosisd add-genesis-account validator 2000000000000uosmo --keyring-backend=test
+osmosisd add-genesis-account faucet 2000000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
+osmosisd add-genesis-account clawback 2000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
+# osmosisd add-genesis-account keplr1 2000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
+
+osmosisd gentx validator 1000000000000uosmo --chain-id=$CHAIN_ID --commission-rate=0.05 --commission-max-change-rate=0.01 --commission-max-rate=1.0 --keyring-backend=test
+osmosisd collect-gentxs
+
+#TODO most of this should be done with jq instead of sed, for better readability
+sed -i 's%osmo15qgrux35vf87hfx77efk6hw3lcc5slv0awc3qh%osmo1h5rcx73zj474nrkkcyf28tud47k8thy59pt529%g' /root/.osmosisd/config/genesis.json
+sed -i 's%stake%uosmo%g' /root/.osmosisd/config/genesis.json
+sed -i 's%"voting_period": "172800s"%"voting_period": "60s"%g' /root/.osmosisd/config/genesis.json
+sed -i 's%"distr_epoch_identifier": "week"%"distr_epoch_identifier": "day"%g' /root/.osmosisd/config/genesis.json
+sed -i 's%"epoch_identifier": "week"%"epoch_identifier": "day"%g' /root/.osmosisd/config/genesis.json
+sed -i 's%"duration": "86400s"%"duration": "120s"%g' /root/.osmosisd/config/genesis.json
+sed -i 's%"duration_until_decay": "3600s"%"duration_until_decay": "30s"%g' /root/.osmosisd/config/genesis.json
+sed -i 's%"duration_of_decay": "18000s"%"duration_of_decay": "600s"%g' /root/.osmosisd/config/genesis.json
+
+#state that was specific for v4 -> v5, should be removed for future setups
+jq '.app_state.claim.module_account_balance.amount = "393880785"' /root/.osmosisd/config/genesis.json > /root/.osmosisd/config/genesis_2.json
+jq '.app_state.claim.claim_records[0] = {"address": "osmo1h5rcx73zj474nrkkcyf28tud47k8thy59pt529","initial_claimable_amount": [{"denom": "uosmo","amount": "393880785"}],"action_completed": [false,false,false,false]}' /root/.osmosisd/config/genesis_2.json > /root/.osmosisd/config/genesis_3.json
+
+jq '.app_state.poolincentives.distr_info = {"total_weight": "1000","records": [{"gauge_id": "0","weight": "1000"}]}' /root/.osmosisd/config/genesis_3.json > /root/.osmosisd/config/genesis.json
+
+sed -i 's%minimum-gas-prices = ""%minimum-gas-prices = "0.01uosmo"%g' /root/.osmosisd/config/app.toml
+
+
+
+osmosisd unsafe-reset-all
+osmosisd start
+
+

--- a/scripts/testnets/clean/start.sh
+++ b/scripts/testnets/clean/start.sh
@@ -2,7 +2,7 @@
 
 #### Parameters
 export CHAIN_ID="osmosis-clean-testnet-X"
-export VERSION="v4.2.0"
+export VERSION="v5.0.0"
 
 #### Initial node setup
 sudo apt-get update
@@ -45,6 +45,8 @@ osmosisd add-genesis-account validator 2000000000000uosmo --keyring-backend=test
 osmosisd add-genesis-account faucet 2000000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
 osmosisd add-genesis-account clawback 2000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
 # osmosisd add-genesis-account keplr1 2000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
+
+osmosisd prepare-genesis mainnet $CHAIN_ID
 
 osmosisd gentx validator 1000000000000uosmo --chain-id=$CHAIN_ID --commission-rate=0.05 --commission-max-change-rate=0.01 --commission-max-rate=1.0 --keyring-backend=test
 osmosisd collect-gentxs

--- a/scripts/testnets/clean/start.sh
+++ b/scripts/testnets/clean/start.sh
@@ -4,10 +4,14 @@
 export CHAIN_ID="osmosis-clean-testnet-X"
 export VERSION="v5.0.0"
 
+#Constants
+export GENESIS="/root/.osmosisd/config/genesis.json"
+export TMP_GENESIS="/root/.osmosisd/config/genesis.json.tmp"
+
 #### Initial node setup
 sudo apt-get update
 sudo apt-get upgrade -y
-sudo apt-get install curl build-essential jq git wget liblz4-tool aria2 make -y
+sudo apt-get install curl build-essential jq git wget make -y
 
 curl https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash
 
@@ -37,39 +41,16 @@ osmosisd init "testnet-validator" --chain-id=$CHAIN_ID
 #TODO Should be replaced with dynamically generated where seed is written to a local file
 echo "oven thank broccoli giant neither swamp betray moment birth lady wage student bicycle craft permit avoid burden tortoise oxygen file fix penalty two onion" | osmosisd keys add validator --recover --keyring-backend=test
 echo "catch spider raise grass flush audit result off auction stone best day soap stay organ canoe test spoon edit relief want warrior siren act" | osmosisd keys add faucet --recover --keyring-backend=test
-echo "name salt burden assume awkward copy morning any kangaroo crucial width brother organ casual brief scorpion actress lady hover figure idea another employ another" | osmosisd keys add clawback --recover --keyring-backend=test
-
-echo "travel renew first fiction trick fly disease advance hunt famous absurd region" | osmosisd keys add keplr1 --recover --keyring-backend=test
 
 osmosisd add-genesis-account validator 2000000000000uosmo --keyring-backend=test
-osmosisd add-genesis-account faucet 2000000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
-osmosisd add-genesis-account clawback 2000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
-# osmosisd add-genesis-account keplr1 2000000000uosmo,2000000000uion,2000000000000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 --keyring-backend=test
+osmosisd add-genesis-account faucet 2000000000000uosmo,2000000000uion --keyring-backend=test
 
-osmosisd prepare-genesis mainnet $CHAIN_ID
+jq '.app_state.poolincentives.distr_info = {"total_weight": "1000","records": [{"gauge_id": "0","weight": "1000"}]}' $GENESIS > $TMP_GENESIS && mv $TMP_GENESIS $GENESIS
 
 osmosisd gentx validator 1000000000000uosmo --chain-id=$CHAIN_ID --commission-rate=0.05 --commission-max-change-rate=0.01 --commission-max-rate=1.0 --keyring-backend=test
 osmosisd collect-gentxs
 
-#TODO most of this should be done with jq instead of sed, for better readability
-sed -i 's%osmo15qgrux35vf87hfx77efk6hw3lcc5slv0awc3qh%osmo1h5rcx73zj474nrkkcyf28tud47k8thy59pt529%g' /root/.osmosisd/config/genesis.json
-sed -i 's%stake%uosmo%g' /root/.osmosisd/config/genesis.json
-sed -i 's%"voting_period": "172800s"%"voting_period": "60s"%g' /root/.osmosisd/config/genesis.json
-sed -i 's%"distr_epoch_identifier": "week"%"distr_epoch_identifier": "day"%g' /root/.osmosisd/config/genesis.json
-sed -i 's%"epoch_identifier": "week"%"epoch_identifier": "day"%g' /root/.osmosisd/config/genesis.json
-sed -i 's%"duration": "86400s"%"duration": "120s"%g' /root/.osmosisd/config/genesis.json
-sed -i 's%"duration_until_decay": "3600s"%"duration_until_decay": "30s"%g' /root/.osmosisd/config/genesis.json
-sed -i 's%"duration_of_decay": "18000s"%"duration_of_decay": "600s"%g' /root/.osmosisd/config/genesis.json
-
-#state that was specific for v4 -> v5, should be removed for future setups
-jq '.app_state.claim.module_account_balance.amount = "393880785"' /root/.osmosisd/config/genesis.json > /root/.osmosisd/config/genesis_2.json
-jq '.app_state.claim.claim_records[0] = {"address": "osmo1h5rcx73zj474nrkkcyf28tud47k8thy59pt529","initial_claimable_amount": [{"denom": "uosmo","amount": "393880785"}],"action_completed": [false,false,false,false]}' /root/.osmosisd/config/genesis_2.json > /root/.osmosisd/config/genesis_3.json
-
-jq '.app_state.poolincentives.distr_info = {"total_weight": "1000","records": [{"gauge_id": "0","weight": "1000"}]}' /root/.osmosisd/config/genesis_3.json > /root/.osmosisd/config/genesis.json
-
-sed -i 's%minimum-gas-prices = ""%minimum-gas-prices = "0.01uosmo"%g' /root/.osmosisd/config/app.toml
-
-
+sed -i 's%stake%uosmo%g' $GENESIS
 
 osmosisd unsafe-reset-all
 osmosisd start

--- a/scripts/testnets/clean/upgrade.sh
+++ b/scripts/testnets/clean/upgrade.sh
@@ -1,0 +1,13 @@
+#Pool creation and upgrade for testing v4 -> v5
+#TODO should be replaced with a parameterized script to just upgrade to a specific new branch / upgrade handler
+
+yes | osmosisd tx gov submit-proposal software-upgrade v5 --upgrade-height=25 --from=validator --keyring-backend=test --title="v5 upgrade" --description="v5 upgrade" --fees=2000uosmo
+yes | osmosisd tx gov deposit 1 10000000uosmo --from=faucet --keyring-backend=test --fees=2000uosmo
+sleep 7
+yes | osmosisd tx gov vote 1 yes --from=validator --keyring-backend=test --fees=2000uosmo
+sleep 7
+yes | osmosisd tx gamm create-pool --pool-file="pool1.json" --from=faucet --keyring-backend=test --gas=400000 --fees=4000uosmo
+
+cd osmosis
+git checkout v5.x
+make install

--- a/scripts/testnets/mainnet/export.sh
+++ b/scripts/testnets/mainnet/export.sh
@@ -1,0 +1,42 @@
+# Generates a state export from Osmosis mainnet (through Chainlayer) with a modified chain-id, and uploads to transfer.sh
+
+export CHAIN_ID="osmosis-mainnet-testnet-X"
+export VERSION="v4.2.0"
+
+
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get install curl build-essential jq git wget liblz4-tool aria2 -y
+
+curl https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash
+
+export GOROOT=/root/.go
+export PATH=$GOROOT/bin:$PATH
+export GOPATH=/root/go
+export PATH=$GOPATH/bin:$PATH
+ 
+git clone https://github.com/osmosis-labs/osmosis
+cd osmosis
+git checkout $VERSION
+make install
+
+osmosisd init "testnet-validator" --chain-id=$CHAIN_ID
+
+cd ~/.osmosisd/
+FILENAME=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.network=="pruned")|select (.mirror=="SanFrancisco")|.filename'`
+
+#Switch which of these sections is commented out if disk space is insufficeient
+
+#single threaded / half space
+# wget -O - https://getsfo.quicksync.io/$FILENAME | lz4 -d | tar -xvf -
+
+#multi threaded / double space
+aria2c -x5 https://getsfo.quicksync.io/$FILENAME
+lz4 -d $FILENAME | tar xf -
+rm $FILENAME
+#/multi threaded
+
+
+cd ~
+osmosisd export > genesis.json
+curl --upload-file ./genesis.txt https://transfer.sh/genesis.json

--- a/scripts/testnets/mainnet/modify.sh
+++ b/scripts/testnets/mainnet/modify.sh
@@ -1,0 +1,137 @@
+#### Modify a mainnet export based genesis file to have a single local >66% validator, and a faucet
+
+###FIXME incomplete / WIP, needs to be finished based on original testnetify script which uses sed
+
+#Parameters
+export VALIDATOR_NAME="Validating Chaos" #Moniker of validtor to be replaced
+export VALIDATOR_ADDRESS=""
+
+#Constants
+export GENESIS=".osmosisd/config/genesis.json"
+export TMP_GENESIS=".osmosisd/config/genesis.json.tmp"
+export PRIV_VAL=".osmosisd/config/priv_validator_key.json"
+
+
+
+#collect indices and keys for existing validator to replace
+VALIDATOR_INDEX=$(jq --arg VALIDATOR_NAME "$VALIDATOR_NAME" '.validators | map (.name==$VALIDATOR_NAME) | index(true)' $GENESIS)
+echo $VALIDATOR_INDEX
+NEW_VALIDATOR_POWER=$(jq --arg VALIDATOR_INDEX "$VALIDATOR_INDEX" '.validators[$VALIDATOR_INDEX | tonumber].power | tonumber + 2000000000' $GENESIS)
+#read as int, add 2billion to it
+echo $NEW_VALIDATOR_POWER
+
+jq --arg VALIDATOR_INDEX "$VALIDATOR_INDEX" '.validators[$VALIDATOR_INDEX | tonumber]' $GENESIS
+
+STAKING_VALIDATOR_INDEX=$(jq --arg VALIDATOR_NAME "$VALIDATOR_NAME" '.app_state.staking.validators | map (.description.moniker==$VALIDATOR_NAME) | index(true)' $GENESIS)
+echo $STAKING_VALIDATOR_INDEX
+jq --arg STAKING_VALIDATOR_INDEX "$STAKING_VALIDATOR_INDEX" '.app_state.staking.validators[$STAKING_VALIDATOR_INDEX | tonumber]' $GENESIS
+
+VALOPER_ADDRESS=$(jq -r --arg STAKING_VALIDATOR_INDEX "$STAKING_VALIDATOR_INDEX" '.app_state.staking.validators[$STAKING_VALIDATOR_INDEX | tonumber].operator_address' $GENESIS)
+echo $VALOPER_ADDRESS
+
+VALIDATOR_ADDRESS=$(osmosisd debug bech32-convert $VALOPER_ADDRESS --prefix="osmo" 2>&1 >/dev/null)
+echo $VALIDATOR_ADDRESS
+
+DELEGATOR_INDEX=$(jq --arg VALIDATOR_ADDRESS "$VALIDATOR_ADDRESS" '.app_state.staking.delegations | map (.delegator_address==$VALIDATOR_ADDRESS) | index(true)' $GENESIS)
+echo $DELEGATOR_INDEX
+jq --arg DELEGATOR_INDEX "$DELEGATOR_INDEX" '.app_state.staking.delegations[$DELEGATOR_INDEX | tonumber]' $GENESIS
+
+STARTING_INFO_INDEX=$(jq --arg VALIDATOR_ADDRESS "$VALIDATOR_ADDRESS" '.app_state.distribution.delegator_starting_infos | map (.delegator_address==$VALIDATOR_ADDRESS) | index(true)' $GENESIS)
+echo $STARTING_INFO_INDEX
+jq --arg STARTING_INFO_INDEX "$STARTING_INFO_INDEX" '.app_state.distribution.delegator_starting_infos[$STARTING_INFO_INDEX | tonumber]' $GENESIS
+
+#collect newly generated validator addresses/keys
+NEW_VALIDATOR_ADDRESS=$(jq '.address' $PRIV_VAL)
+echo $NEW_VALIDATOR_ADDRESS
+NEW_VALIDATOR_PUBKEY=$(jq '.pub_key.value' $PRIV_VAL)
+echo $NEW_VALIDATOR_PUBKEY
+
+NEW_VALIDATOR_PUBOPER=$(osmosisd debug addr $NEW_VALIDATOR_ADDRESS 2>&1 >/dev/null | tail -c 51)
+echo $NEW_VALIDATOR_PUBOPER
+NEW_VALIDATOR_CONS=$(osmosisd debug bech32-convert $NEW_VALIDATOR_PUBOPER -p osmovalcons)
+echo $NEW_VALIDATOR_CONS
+
+
+#modify validator values
+jq\
+    --arg VALIDATOR_INDEX "$VALIDATOR_INDEX"\
+    --arg NEW_VALIDATOR_ADDRESS "$NEW_VALIDATOR_ADDRESS"\
+    --arg VALIDATOR_NAME "$VALIDATOR_NAME"\
+    --arg NEW_VALIDATOR_POWER "$NEW_VALIDATOR_POWER"\
+    --arg NEW_VALIDATOR_PUBKEY "$NEW_VALIDATOR_CONS"\
+    '.validators[$VALIDATOR_INDEX | tonumber] = {"address": NEW_VALIDATOR_ADDRESS, "name": $VALIDATOR_NAME,"power": $NEW_VALIDATOR_POWER,"pub_key": {"type": "tendermint/PubKeyEd25519","value": $NEW_VALIDATOR_PUBKEY}}'\
+    $GENESIS > $TMP_GENESIS
+
+jq --arg VALIDATOR_INDEX "$VALIDATOR_INDEX" '.validators[$VALIDATOR_INDEX | tonumber' $TMP_GENESIS
+
+#TODO should separate out standard validator replacement stuff, from state specific changes / setup
+
+#modify bank values
+
+#modify params (voting period, epochs, claim decay)
+
+
+
+## Copy of testnetify script for quick reverence, remove before actual finalization for usage
+
+# export EXPORTED_GENESIS=testnet_genesis.json
+
+# # Replace Sentinel addrs/pubkeys
+
+# # replace validator cons pubkey
+# sed -i '' 's%b77zCh/VsRgVvfGXuW4dB+Dhg4PrMWWBC5G2K/qFgiU=%2OpBuqaXvXQ+lSxAoT1S7Jfyr56KiakTzvuFiuJK+X4=%g' $EXPORTED_GENESIS
+# # This is a PITA to get:
+# # take pubkey, do osmosisd debug pubkey {base64}
+# # take address out of it, feed into osmosisd debug addr {addr}
+# # pass that into osmosisd debug bech32-convert -p osmovalcons
+# sed -i '' 's%osmovalcons1z6skn9g6s7py0klztr7acutr3anqd52k9x5p70%osmovalcons13duwg7rhwsnucwgxhq35edete63v0r5rqp90es%g' $EXPORTED_GENESIS
+# # replace validator hex addr
+# sed -i '' 's%16A169951A878247DBE258FDDC71638F6606D156%8B78E478777427CC3906B8234CB72BCEA2C78E83%g' $EXPORTED_GENESIS
+# # replace operator address
+# sed -i '' 's%osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n%osmovaloper1qye772qje88p7ggtzrvl9nxvty6dkuusvpqhac%g' $EXPORTED_GENESIS
+# # replace the actual account
+# sed -i '' 's%osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5%osmo1qye772qje88p7ggtzrvl9nxvty6dkuuskkg52l%g' $EXPORTED_GENESIS
+# # replace that accounts pubkey, obtained via auth. New pubkey obtained via new debug command
+# sed -i '' 's%AqlNb1FM8veQrT4/apR5B3hww8VApc0LTtZnXhq7FqG0%A9zC0Sa0VCK/lVLi1Kv0C1c0MQp47d+yjFqb6dAUza0a%g' $EXPORTED_GENESIS
+
+# # now time to replace the amounts
+# # manually increase share amounts for 
+# #          "delegator_address": "osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5",
+# # before: 5000000000.000000000000000000 (5000 osmo)
+# # after: 100005000000000.000000000000000000 (100M + 5k osmo = 100,005,000)
+# # there are two such locations
+
+# # Then correspondingly up the total tokens bonded to the validator
+# #           "tokens": "5979280136171", (add 100M to this)
+# sed -i '' 's%5979280136171%105979280136171%g' $EXPORTED_GENESIS
+# sed -i '' 's%"power": "5979280"%"power": "105979280"%g' $EXPORTED_GENESIS
+# # Update last_total_power (which is last total bonded across validators)
+# sed -i '' 's%57368851%157368851%g' $EXPORTED_GENESIS
+
+# # edit operator address, old: 2125267 (2.1 osmo), new: 100000002125267 (100M + 2.1)
+# sed -i '' 's%2125267%100000002125267%g' $EXPORTED_GENESIS
+
+# # Update total osmo supply, old 413150362339859, new 613M
+# sed -i '' 's%413150362339859%613150362339859%g' $EXPORTED_GENESIS
+
+# # Fix bonded_tokens_pool balance, old 57368900009013
+# sed -i '' 's%57368900009013%157368900009013%g' $EXPORTED_GENESIS
+
+# ### Fix gov params
+
+# # deposit
+# sed -i '' 's%"voting_period": "259200s"%"voting_period": "120s"%g' $EXPORTED_GENESIS
+
+# # epoch length
+#     #   "epochs": [
+#     #     {
+#     #       "current_epoch": "77",
+#     #       "current_epoch_ended": false,
+#     #       "current_epoch_start_time": "2021-09-03T17:12:52.752325457Z",
+#     #       "duration": "86400s",
+#     #       "epoch_counting_started": true,
+#     #       "identifier": "day",
+#     #       "start_time": "2021-06-18T17:00:00Z"
+#     #     },
+# # replace that duration with jq
+# cat $EXPORTED_GENESIS | jq '.app_state["epochs"]["epochs"][0]["duration"]="1800s"' > tmp_genesis.json && mv tmp_genesis.json $EXPORTED_GENESIS

--- a/scripts/testnets/mainnet/setup.sh
+++ b/scripts/testnets/mainnet/setup.sh
@@ -1,0 +1,49 @@
+#### Script for taking a modified mainnet export and starting up a node
+# FIXME incomplete / WIP , not functional
+
+#Parameters
+export MAIN_GENESIS_URL="https://transfer.sh/o9B26h/genesis.json"
+export CHAIN_ID="osmosis-testnet-main-4"
+export VERSION="v4.2.0"
+
+
+#TODO replace these with generate and write to file
+export VALIDATOR_SEED="oven thank broccoli giant neither swamp betray moment birth lady wage student bicycle craft permit avoid burden tortoise oxygen file fix penalty two onion"
+export FAUCET_SEED="catch spider raise grass flush audit result off auction stone best day soap stay organ canoe test spoon edit relief want warrior siren act"
+
+
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get install curl build-essential jq git wget liblz4-tool aria2 make -y
+
+curl https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash
+
+export GOROOT=/root/.go
+export PATH=$GOROOT/bin:$PATH
+export GOPATH=/root/go
+export PATH=$GOPATH/bin:$PATH
+
+cd /root/
+
+rm /root/osmosis/ -rf 
+git clone https://github.com/osmosis-labs/osmosis
+cd osmosis
+git checkout $VERSION
+make install
+
+rm /root/.osmosisd/ -rf
+
+osmosisd config chain-id $CHAIN_ID
+osmosisd init "testnet-validator" --chain-id=$CHAIN_ID
+
+rm /root/.osmosisd/config/genesis.json
+
+curl -o /root/.osmosisd/config/genesis.json $MAIN_GENESIS_URL
+
+##TODO following section should be part of modification script, not setup
+
+echo $VALIDATOR_SEED | osmosisd keys add validator --recover --keyring-backend=test
+echo $FAUCET_SEED | osmosisd keys add faucet --recover --keyring-backend=test
+
+osmosisd add-genesis-account validator 1000000000000uosmo,1000000000uion --keyring-backend=test
+osmossid add-genesis-account faucet 1000000000000uosmo,1000000000uion --keyring-backend=test

--- a/scripts/testnets/mainnet/upgrade.sh
+++ b/scripts/testnets/mainnet/upgrade.sh
@@ -1,0 +1,19 @@
+#FIXME incomplete / WIP
+# should be replaced with parameterized upgrade script based on branch / upgrade handler to be tested
+# should dynamically get usable upgrade height from state export / live chain
+# should use existing local validator key, created in modify/setup, rather than hardcoded seed
+
+echo "kitchen comic flower drip sick prize account cheese truth income weekend nominee segment punch call satisfy captain earth ethics wasp clump tunnel orchard advance" | osmosisd keys add validator --recover --keyring-backend=test
+yes | osmosisd tx gov submit-proposal software-upgrade v5 --upgrade-height=2292611\
+    --from=validator\
+    --keyring-backend=test\
+    --title="Boron v5 upgrade"\
+    --description="v5 upgrade - #changelog"\
+    --upgrade-info="na"\
+    --fees=100000uosmo\
+yes | osmosisd tx gov deposit 89 500000000uosmo\
+    --from=validator --keyring-backend=test --fees=100000uosmo
+sleep 7
+yes | osmosisd tx gov vote 89 yes\
+    --from=validator --keyring-backend=test --fees=100000uosmo
+


### PR DESCRIPTION
Ref #656

Partially usable testnet automation scripts, used in testing v4 -> v5 upgrade.

Clean/start.sh and Mainnet/export.sh are usable, but need cleanup. The rest are WIP and should only be used as reference for building better scripts.

