### PR TITLE
Whisky: Tweaks and hardware to eliminate the epoch lag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215174815-40427335a890
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db => github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215174815-40427335a890
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215190615-b6f6d47f0ffe
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db => github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1 h1:hophiDQD/blq/ejT/frDu/B9etQnWkgTjlOV7cXBONA=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4 h1:vcxXXGW6NBW9Ew4U5/GriN0DUJO0a2GQrCZARCk55Rk=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215174815-40427335a890 h1:2GIvhjtnm6a7n3ICkUc0DtZMoHoXYgsL1jgAcwy0Gv0=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215174815-40427335a890/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417 h1:otchJDd2SjFWfs7Tse3ULblGcVWqMJ50BE02XCaqXOo=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1 h1:hophiDQD/blq/ejT/frDu/B9etQnWkgTjlOV7cXBONA=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215174815-40427335a890 h1:2GIvhjtnm6a7n3ICkUc0DtZMoHoXYgsL1jgAcwy0Gv0=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215174815-40427335a890/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215190615-b6f6d47f0ffe h1:mBFo4w5HUCOsPtUW5CVz6bNm0hucMjVF0/Cq/9J2bXA=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211215190615-b6f6d47f0ffe/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417 h1:otchJDd2SjFWfs7Tse3ULblGcVWqMJ50BE02XCaqXOo=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=


### PR DESCRIPTION
# Whisky would change the requirements for running osmosis and should be carefully considered.  

## Description

This would change osmosis by:

* making nodes basically require 64gb RAM (mine stay steadyish at 40gb, so having 64gb would be best)
* solving nearly all relayer issues
* Nearly requiring that validators run their nodes on bare metal, preferably on-prem for cost reasons

## Here is a build that won't have an epoch lag:


$1250
https://newegg.io/05ba1f6

You could do it with 64GB of RAM, too, and then it would cost about $1000. 

But here are some facts:

* AWS keeps exploding
* Hetzner is the only place where you can get reliable metal but their disks are much slower from a write perspective (at **only** 180k iops vs the ss980pro above at 410k iops in fio 4kb rw tests)
* Osmo doesn't need to have an epoch lag **at all**
* We processed the upgrade in about 8 minutes. On a system that should have exactly the same performance characteristics as the one in the shopping list above, except that ours uses a higher core count cpu, has a gpu for cyber, and runs 15 validators.

To validators, I'd say:

This is a one-time cost, though there's an ongoing time cost to maintaining your own machines, and you do need to think about your network some.  In order to help, here is some info on how we're doing things:

https://whimsical.com/ibc-relaying-Y3L552gPH9vzThRGjqpgjW

I reckon that validators strongly concerned with user experience and the health of the network may wish to begin tracking our aggregate performance as validators by looking for validators who are significantly faster or slower than average.  

8 mins vs 2 hours

All I want to say here, is that the epoch time wait, is a choice-- or at least, now it is. 

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

