### PR TITLE
v5.x backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Features
 
+- [#623](https://github.com/osmosis-labs/osmosis/pull/623) Use gosec for staticly linting for common non-determinism issues in SDK applications.
+
 ## Minor improvements & Bug Fixes
 
+- [#655](https://github.com/osmosis-labs/osmosis/pull/655) Make the default genesis for pool-incentives work by default
+- [97ac2a8](https://github.com/osmosis-labs/osmosis/commit/97ac2a86303fc8966a4c169107e0945775107e67) Fix InitGenesis bug for gauges
 
 ## [v6.0.0](https://github.com/osmosis-labs/osmosis/releases/tag/v6.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,17 +41,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Remove docker github action (temporary)
-* Upgrade to Cosmos-sdk 0.44.3
-  * Includes Rosetta API
-* Upgrade to IBC-v2
-* Add [Authz module](https://github.com/cosmos/cosmos-sdk/tree/master/x/authz/spec)
-* Store block height in epochs module for debugging
-* Allow zero-weight pool-incentive distribution records
-* Fix bug in incentives epoch distribution events, used to use raw address, now uses bech32 addr
-* Update peer ID of statesync-enabled node run by notional
-* Created a pull request template
-* Update Notional Labs seed node in cmd/osmosisd/cmd/init.go
+## Features
+
+## Minor improvements & Bug Fixes
+
+
+## [v6.0.0](https://github.com/osmosis-labs/osmosis/releases/tag/v6.0.0)
+
+This upgrade fixes a bug in the v5.0.0 upgrade's app.go, which prevents new IBC channels from being created.
+This binary is compatible with v5.0.0 until block height `2464000`, estimated to be at 4PM UTC Monday December 20th.
+
+- [Patch](https://github.com/osmosis-labs/osmosis/commit/907001b08686ed980e0afa3d97a9c5e2f095b79f#diff-a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333) - Revert back to passing in the correct staking keeper into the IBC keeper constructor.
+- [Height gating change](https://github.com/osmosis-labs/ibc-go/pull/1) - Height gate the change in IBC, to make the v6.0.0 binary compatible until upgrade height.
+
+## [v5.0.0](https://github.com/osmosis-labs/osmosis/releases/tag/v5.0.0) - Boron upgrade
+
+The Osmosis Boron release is made!
+
+Notable features include:
+
+* Upgrading from SDK v0.42 to [SDK v0.44](https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/RELEASE_NOTES.md), bringing efficiency improvements, integrations and Rosetta support.
+* Bringing in the new modules [Bech32IBC](https://github.com/osmosis-labs/bech32-ibc/), [Authz](https://github.com/cosmos/cosmos-sdk/tree/master/x/authz/spec), [TxFees](https://github.com/osmosis-labs/osmosis/tree/main/x/txfees)
+* Upgrading to IBC v2, allowing for improved Ethereum Bridge and CosmWasm support
+* Implementing Osmosis chain governance's [Proposal 32](https://www.mintscan.io/osmosis/proposals/32)
+* Large suite of gas bugs fixed. (Including several that we have not seen on chain)
+* More queries exposed to aid node operators.
+* Blocking the OFAC banned Ethereum addresses.
+* Several (linear factor) epoch time improvements. (Most were present in v4.2.0)
+
+Upgrade instructions for node operators can be found [here](https://github.com/osmosis-labs/osmosis/blob/v5.x/networks/osmosis-1/upgrades/v5/guide.md)
+
+## Features
+
+* [\#637](https://github.com/osmosis-labs/osmosis/pull/637) Add [Bech32IBC](https://github.com/osmosis-labs/bech32-ibc/)
+* [\#610](https://github.com/osmosis-labs/osmosis/pull/610) Upgrade to Cosmos SDK v0.44.x
+  * Numerous large updates, such as making module accounts be 32 bytes, Rosetta support, etc.
+  * Adds & integrates the [Authz module](https://github.com/cosmos/cosmos-sdk/tree/master/x/authz/spec)
+   See: [SDK v0.43.0 Release Notes](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.43.0) For more details
+* [\#610](https://github.com/osmosis-labs/osmosis/pull/610) Upgrade to IBC-v2
+* [\#560](https://github.com/osmosis-labs/osmosis/pull/560) Implements Osmosis [prop32](https://www.mintscan.io/osmosis/proposals/32) -- clawing back the final 20% of unclaimed osmo and ion airdrop.
+* [\#394](https://github.com/osmosis-labs/osmosis/pull/394) Allow whitelisted tx fee tokens based on conversion rate to OSMO
+* [Commit db450f0](https://github.com/osmosis-labs/osmosis/commit/db450f0dce8c595211d920f9bca7ed0f3a136e43) Add blocking of OFAC banned Ethereum addresses
+
+## Minor improvements & Bug Fixes
+
+* {In the Osmosis-labs SDK fork}
+  * Increase default IAVL cache size to be in the hundred megabyte range
+  * Significantly improve CacheKVStore speed problems, reduced IBC upgrade time from 2hrs to 5min
+  * Add debug info to make it clear whats happening during upgrade
+* (From a series of commits) Fixes to the claims module to only do the reclaim logic once, not every block.
+* (From a series of commits) More logging to the claims module.
+* [\#563](https://github.com/osmosis-labs/osmosis/pull/563) Allow zero-weight pool-incentive distribution records
+* [\#562](https://github.com/osmosis-labs/osmosis/pull/562) Store block height in epochs module for easier debugging
+* [\#544](https://github.com/osmosis-labs/osmosis/pull/544) Update total liquidity tracking to be denom basis, lowering create pool and join pool gas.
+* [\#540](https://github.com/osmosis-labs/osmosis/pull/540) Fix git lfs links
+* [\#517](https://github.com/osmosis-labs/osmosis/pull/517) Linear time improvement for epoch time
+* [\#515](https://github.com/osmosis-labs/osmosis/pull/515) Add debug command for converting secp pubkeys
+* [\#510](https://github.com/osmosis-labs/osmosis/pull/510) Performance improvement for gauge distribution
+* [\#505](https://github.com/osmosis-labs/osmosis/pull/505) Fix bug in incentives epoch distribution events, used to use raw address, now uses bech32 addr
+* [\#464](https://github.com/osmosis-labs/osmosis/pull/464) Increase maximum outbound peers for validator nodes
+* [\#444](https://github.com/osmosis-labs/osmosis/pull/444) Add script for state sync
+* [\#409](https://github.com/osmosis-labs/osmosis/pull/409) Reduce epoch time growth rate for re-locking assets
+
 
 ## [v4.0.0]
 

--- a/app/app.go
+++ b/app/app.go
@@ -611,9 +611,11 @@ func NewOsmosisApp(
 	// CanWithdrawInvariant invariant.
 	// NOTE: staking module is required if HistoricalEntries param > 0
 	app.mm.SetOrderBeginBlockers(
+		// Upgrades should be run _very_ first
+		upgradetypes.ModuleName,
 		// Note: epochs' begin should be "real" start of epochs, we keep epochs beginblock at the beginning
 		epochstypes.ModuleName,
-		upgradetypes.ModuleName, minttypes.ModuleName, poolincentivestypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
+		minttypes.ModuleName, poolincentivestypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
 		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName, capabilitytypes.ModuleName,
 	)
 	app.mm.SetOrderEndBlockers(

--- a/app/app.go
+++ b/app/app.go
@@ -408,6 +408,7 @@ func NewOsmosisApp(
 			}
 
 			// Override txfees genesis here
+			ctx.Logger().Info("Setting txfees module genesis with actual v5 desired genesis")
 			txfees.InitGenesis(ctx, app.TxFeesKeeper, txfeestypes.GenesisState{
 				Basedenom: app.StakingKeeper.BondDenom(ctx),
 				Feetokens: []txfeestypes.FeeToken{},
@@ -416,6 +417,8 @@ func NewOsmosisApp(
 			// now update auth version back to v1, to run auth migration last
 			newVM[authtypes.ModuleName] = 1
 
+			ctx.Logger().Info("Now running migrations just for auth, to get auth migration to be last. " +
+				"(CC https://github.com/cosmos/cosmos-sdk/issues/10591)")
 			return app.mm.RunMigrations(ctx, app.configurator, newVM)
 		})
 

--- a/app/app.go
+++ b/app/app.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
@@ -769,6 +770,39 @@ func (app *OsmosisApp) BlockedAddrs() map[string]bool {
 	blockedAddrs := make(map[string]bool)
 	for acc := range maccPerms {
 		blockedAddrs[authtypes.NewModuleAddress(acc).String()] = !allowedReceivingModAcc[acc]
+	}
+
+	// We block all OFAC-blocked ETH addresses from receiving tokens as well
+	// The list is sourced from: https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml
+	ofacRawEthAddrs := []string{
+		"0x7F367cC41522cE07553e823bf3be79A889DEbe1B",
+		"0xd882cfc20f52f2599d84b8e8d58c7fb62cfe344b",
+		"0x901bb9583b24d97e995513c6778dc6888ab6870e",
+		"0xa7e5d5a720f06526557c513402f2e6b5fa20b008",
+		"0x8576acc5c05d6ce88f4e49bf65bdf0c62f91353c",
+		"0x1da5821544e25c636c1417ba96ade4cf6d2f9b5a",
+		"0x7Db418b5D567A4e0E8c59Ad71BE1FcE48f3E6107",
+		"0x72a5843cc08275C8171E582972Aa4fDa8C397B2A",
+		"0x7F19720A857F834887FC9A7bC0a0fBe7Fc7f8102",
+		"0x9f4cda013e354b8fc285bf4b9a60460cee7f7ea9",
+		"0x3cbded43efdaf0fc77b9c55f6fc9988fcc9b757d",
+		"0x2f389ce8bd8ff92de3402ffce4691d17fc4f6535",
+		"0x19aa5fe80d33a56d56c78e82ea5e50e5d80b4dff",
+		"0xe7aa314c77f4233c18c6cc84384a9247c0cf367b",
+		"0x308ed4b7b49797e1a98d3818bff6fe5385410370",
+		"0x2f389ce8bd8ff92de3402ffce4691d17fc4f6535",
+		"0x19aa5fe80d33a56d56c78e82ea5e50e5d80b4dff",
+		"0x67d40EE1A85bf4a4Bb7Ffae16De985e8427B6b45",
+		"0x6f1ca141a28907f78ebaa64fb83a9088b02a8352",
+		"0x6acdfba02d390b97ac2b2d42a63e85293bcc160e",
+		"0x48549a34ae37b12f6a30566245176994e17c6b4a",
+		"0x5512d943ed1f7c8a43f3435c85f7ab68b30121b0",
+		"0xc455f7fd3e0e12afd51fba5c106909934d8a0e4a",
+		"0xfec8a60023265364d066a1212fde3930f6ae8da7",
+	}
+	for _, addr := range ofacRawEthAddrs {
+		blockedAddrs[addr] = true
+		blockedAddrs[strings.ToLower(addr)] = true
 	}
 
 	return blockedAddrs

--- a/app/app.go
+++ b/app/app.go
@@ -167,7 +167,6 @@ var (
 		epochs.AppModuleBasic{},
 		claim.AppModuleBasic{},
 		bech32ibc.AppModuleBasic{},
-		bech32ics20.AppModuleBasic{},
 	)
 
 	// module account permissions
@@ -398,9 +397,10 @@ func NewOsmosisApp(
 			// then setting it back to 1, and then running migrations again.
 			fromVM[authtypes.ModuleName] = 2
 
-			// override versions for authz module as to not skip its InitGenesis
+			// override versions for authz & bech32ibctypes module as to not skip their InitGenesis
 			// for txfees module, we will override txfees ourselves.
 			delete(fromVM, authz.ModuleName)
+			delete(fromVM, bech32ibctypes.ModuleName)
 
 			newVM, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
 			if err != nil {

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -105,6 +105,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			appConfig.API.Enable = true
 			appConfig.StateSync.SnapshotInterval = 1500
 			appConfig.StateSync.SnapshotKeepRecent = 2
+			appConfig.MinGasPrices = "0uosmo"
 
 			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)
 			if chainID == "" {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/osmosis-labs/bech32-ibc v0.0.0-20211129140933-05a182d246f3
+	github.com/osmosis-labs/bech32-ibc v0.2.0-rc1
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/regen-network/cosmos-proto v0.3.1
@@ -119,7 +119,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211119062100-2f81f59f3aa1
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211208045127-38518812e1c0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db => github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211208045127-38518812e1c0
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db => github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1 h1:hophiDQD/blq/ejT/frDu/B9etQnWkgTjlOV7cXBONA=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211208045127-38518812e1c0 h1:dLIhe8W2jcmG7kpJEmNPWj9aOpikWoAvxnz+j94Os8s=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211208045127-38518812e1c0/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4 h1:vcxXXGW6NBW9Ew4U5/GriN0DUJO0a2GQrCZARCk55Rk=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417 h1:otchJDd2SjFWfs7Tse3ULblGcVWqMJ50BE02XCaqXOo=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/coinbase/rosetta-sdk-go v0.6.10/go.mod h1:J/JFMsfcePrjJZkwQFLh+hJErkA
 github.com/confio/ics23/go v0.6.6 h1:pkOy18YxxJ/r0XFDCnrl4Bjv6h4LkBSpLS6F38mrKL8=
 github.com/confio/ics23/go v0.6.6/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
-github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
+github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -602,8 +602,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -621,10 +621,10 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/osmosis-labs/bech32-ibc v0.0.0-20211129140933-05a182d246f3 h1:qPpkPrHrIro/9NiYGS+DJd2nUq2YK7oRmP/QXGKoC+c=
-github.com/osmosis-labs/bech32-ibc v0.0.0-20211129140933-05a182d246f3/go.mod h1:fwb95yj/poNCO8mfRfWQBclcEIX7hl27AqJc0DE2hRM=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211119062100-2f81f59f3aa1 h1:CxrbRUTLEWeNDQrZXJFIciPOO8YAsp4forPZcCHuMnY=
-github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211119062100-2f81f59f3aa1/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
+github.com/osmosis-labs/bech32-ibc v0.2.0-rc1 h1:hophiDQD/blq/ejT/frDu/B9etQnWkgTjlOV7cXBONA=
+github.com/osmosis-labs/bech32-ibc v0.2.0-rc1/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211208045127-38518812e1c0 h1:dLIhe8W2jcmG7kpJEmNPWj9aOpikWoAvxnz+j94Os8s=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211208045127-38518812e1c0/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417 h1:otchJDd2SjFWfs7Tse3ULblGcVWqMJ50BE02XCaqXOo=
 github.com/osmosis-labs/tm-db v0.6.5-0.20210911033928-ba9154613417/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=

--- a/x/claim/abci.go
+++ b/x/claim/abci.go
@@ -17,9 +17,12 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	goneTime := ctx.BlockTime().Sub(params.AirdropStartTime)
 	if goneTime > params.DurationUntilDecay+params.DurationOfDecay {
 		// airdrop time passed
-		err := k.EndAirdrop(ctx)
-		if err != nil {
-			panic(err)
+		if !k.GetModuleAccountBalance(ctx).IsZero() {
+			// airdrop not already ended
+			err := k.EndAirdrop(ctx)
+			if err != nil {
+				panic(err)
+			}
 		}
 	}
 }

--- a/x/claim/abci.go
+++ b/x/claim/abci.go
@@ -16,8 +16,12 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	// End Airdrop
 	goneTime := ctx.BlockTime().Sub(params.AirdropStartTime)
 	if goneTime > params.DurationUntilDecay+params.DurationOfDecay {
-		// airdrop time passed
-		if !k.GetModuleAccountBalance(ctx).IsZero() {
+		// airdrop time has passed
+
+		// now we sanity check that the airdrop claim hasn't already happened yet.
+		// This logic is hacky, but done so due to v5 deployment timelines.
+		minBalanceOsmo := sdk.NewCoin(params.ClaimDenom, sdk.NewInt(1_000_000_000_000))
+		if k.GetModuleAccountBalance(ctx).IsGTE(minBalanceOsmo) {
 			// airdrop not already ended
 			err := k.EndAirdrop(ctx)
 			if err != nil {

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -117,11 +117,11 @@ func (k Keeper) ClawbackAirdrop(ctx sdk.Context) error {
 func (k Keeper) clearInitialClaimables(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte(types.ClaimRecordsStorePrefix))
+	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		key := iterator.Key()
 		store.Delete(key)
 	}
-	iterator.Close()
 }
 
 // SetClaimables set claimable amount from balances object

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -101,7 +101,7 @@ func (k Keeper) ClawbackAirdrop(ctx sdk.Context) error {
 			osmoBal := k.bankKeeper.GetBalance(ctx, addr, "uosmo")
 			ionBal := k.bankKeeper.GetBalance(ctx, addr, "uion")
 			clawbackCoins := sdk.NewCoins(osmoBal, ionBal)
-			totalClawback.Add(clawbackCoins...)
+			totalClawback = totalClawback.Add(clawbackCoins...)
 			err = k.distrKeeper.FundCommunityPool(ctx, clawbackCoins, addr)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR brings with it every change from v5.x with cleaned git history into main. Please check its accuracy with the v5.x commit history. This PR should be merge committed, not squashed.

Backporting FeeTokens work, the v5.0.0 upgrade docs, and v6.x changes are relegated to separate PRs

Log of commits:

- [x] Correct changelog (First two commits)
- [x] Move upgrading to beginning of BeginBlock order (https://github.com/osmosis-labs/osmosis/commit/33da673f6ae22819a3d692540c122b36a38fe625)
- [x] ETH OFAC blocked addrs (https://github.com/osmosis-labs/osmosis/commit/db450f0dce8c595211d920f9bca7ed0f3a136e43)
- [x] One app.go update for bech32ibc (subsumes https://github.com/osmosis-labs/osmosis/commit/2d24772b9bbb4ea6715b7dd3228a9d85697eda8e & https://github.com/osmosis-labs/osmosis/commit/6f35ef703c9529b1903cfc3ff3ec8e5b69e9327e)
- [x] Update of claims module logic
  - Unity's commit, and my commit(s) are done separately. 
- [x] Claims init genesis bug
- [x] Claims logging bug (not in v5.x but discovered)
- [x] Upgrade logging updates (subsumes https://github.com/osmosis-labs/osmosis/commit/8ba7fb0f10f7adafd32dae696446776cf2ab6660, https://github.com/osmosis-labs/osmosis/commit/a4fc89208c3562045244928ae44a76fb6184f78d)
- [x] Final update of SDK version
- [ ] Separate PR for Feetokens whitelist.go (Initial commits b58357c0b8c21752c5f2f5edce6710d1bd4b3f44, https://github.com/osmosis-labs/osmosis/commit/e891bc898a8e17a8a07181f9a010a07c782a0fda. https://github.com/osmosis-labs/osmosis/commit/20e9675857f49cabd608fa2c9d3acf28386300c7, merged fixes: https://github.com/osmosis-labs/osmosis/commit/c287a25c2add958f14f4b703bad35c54a693a1ef, https://github.com/osmosis-labs/osmosis/commit/f47c64f531d06e5d94a86de8a3c3629220956749, https://github.com/osmosis-labs/osmosis/commit/bef6a9bd2b51fbd04eb62195d6e196dc29e157af, https://github.com/osmosis-labs/osmosis/commit/ba49793c66da9de4e883178ca9c6aaede88920bf)
  - Need to figure out a strategy here so Matt gets the proper git contribution credit.
- [ ] Separate PR for v5.0.0 upgrade guide
  - Need to figure out strategy so Unity and czar get contribution credit 
- Separate PR for v6 backports
  - [ ] v6 IBC-go update
  - [ ] v6 app.go update

< Needs to be continued>

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

