### PR TITLE
WIP: AppKeepers struct concept

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -16,11 +16,7 @@ import (
 	tmos "github.com/tendermint/tendermint/libs/os"
 	dbm "github.com/tendermint/tm-db"
 
-	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/02-client"
-	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
-
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -39,93 +35,70 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
-	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
 	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/capability"
-	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	distrclient "github.com/cosmos/cosmos-sdk/x/distribution/client"
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/evidence"
-	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
-	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
-	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	transfer "github.com/cosmos/ibc-go/v2/modules/apps/transfer"
-	ibctransferkeeper "github.com/cosmos/ibc-go/v2/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v2/modules/core"
 	ibcclientclient "github.com/cosmos/ibc-go/v2/modules/core/02-client/client"
-	porttypes "github.com/cosmos/ibc-go/v2/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
-	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
 	"github.com/gorilla/mux"
 
+	"github.com/osmosis-labs/osmosis/app/keepers"
 	appparams "github.com/osmosis-labs/osmosis/app/params"
 	v4 "github.com/osmosis-labs/osmosis/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/app/upgrades/v5"
 	_ "github.com/osmosis-labs/osmosis/client/docs/statik"
 	"github.com/osmosis-labs/osmosis/x/claim"
-	claimkeeper "github.com/osmosis-labs/osmosis/x/claim/keeper"
 	claimtypes "github.com/osmosis-labs/osmosis/x/claim/types"
 	"github.com/osmosis-labs/osmosis/x/epochs"
-	epochskeeper "github.com/osmosis-labs/osmosis/x/epochs/keeper"
 	epochstypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 	"github.com/osmosis-labs/osmosis/x/gamm"
-	gammkeeper "github.com/osmosis-labs/osmosis/x/gamm/keeper"
 	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/x/incentives"
-	incentiveskeeper "github.com/osmosis-labs/osmosis/x/incentives/keeper"
 	incentivestypes "github.com/osmosis-labs/osmosis/x/incentives/types"
 	"github.com/osmosis-labs/osmosis/x/lockup"
-	lockupkeeper "github.com/osmosis-labs/osmosis/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
 	"github.com/osmosis-labs/osmosis/x/mint"
-	mintkeeper "github.com/osmosis-labs/osmosis/x/mint/keeper"
 	minttypes "github.com/osmosis-labs/osmosis/x/mint/types"
 	poolincentives "github.com/osmosis-labs/osmosis/x/pool-incentives"
 	poolincentivesclient "github.com/osmosis-labs/osmosis/x/pool-incentives/client"
-	poolincentiveskeeper "github.com/osmosis-labs/osmosis/x/pool-incentives/keeper"
 	poolincentivestypes "github.com/osmosis-labs/osmosis/x/pool-incentives/types"
 	"github.com/osmosis-labs/osmosis/x/txfees"
-	txfeeskeeper "github.com/osmosis-labs/osmosis/x/txfees/keeper"
 	txfeestypes "github.com/osmosis-labs/osmosis/x/txfees/types"
 
 	"github.com/osmosis-labs/bech32-ibc/x/bech32ibc"
-	bech32ibckeeper "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/keeper"
 	bech32ibctypes "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/types"
 	"github.com/osmosis-labs/bech32-ibc/x/bech32ics20"
-	bech32ics20keeper "github.com/osmosis-labs/bech32-ibc/x/bech32ics20/keeper"
 )
 
 const appName = "OsmosisApp"
@@ -169,24 +142,6 @@ var (
 		bech32ibc.AppModuleBasic{},
 	)
 
-	// module account permissions
-	maccPerms = map[string][]string{
-		authtypes.FeeCollectorName:               nil,
-		distrtypes.ModuleName:                    nil,
-		minttypes.ModuleName:                     {authtypes.Minter, authtypes.Burner},
-		minttypes.DeveloperVestingModuleAcctName: nil,
-		stakingtypes.BondedPoolName:              {authtypes.Burner, authtypes.Staking},
-		stakingtypes.NotBondedPoolName:           {authtypes.Burner, authtypes.Staking},
-		govtypes.ModuleName:                      {authtypes.Burner},
-		ibctransfertypes.ModuleName:              {authtypes.Minter, authtypes.Burner},
-		claimtypes.ModuleName:                    {authtypes.Minter, authtypes.Burner},
-		gammtypes.ModuleName:                     {authtypes.Minter, authtypes.Burner},
-		incentivestypes.ModuleName:               {authtypes.Minter, authtypes.Burner},
-		lockuptypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
-		poolincentivestypes.ModuleName:           nil,
-		txfeestypes.ModuleName:                   nil,
-	}
-
 	// module accounts that are allowed to receive tokens
 	allowedReceivingModAcc = map[string]bool{
 		distrtypes.ModuleName: true,
@@ -212,35 +167,7 @@ type OsmosisApp struct {
 	memKeys map[string]*sdk.MemoryStoreKey
 
 	// keepers
-	AccountKeeper        authkeeper.AccountKeeper
-	BankKeeper           bankkeeper.Keeper
-	CapabilityKeeper     *capabilitykeeper.Keeper
-	StakingKeeper        stakingkeeper.Keeper
-	SlashingKeeper       slashingkeeper.Keeper
-	MintKeeper           mintkeeper.Keeper
-	DistrKeeper          distrkeeper.Keeper
-	GovKeeper            govkeeper.Keeper
-	CrisisKeeper         crisiskeeper.Keeper
-	UpgradeKeeper        upgradekeeper.Keeper
-	ParamsKeeper         paramskeeper.Keeper
-	IBCKeeper            *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-	EvidenceKeeper       evidencekeeper.Keeper
-	TransferKeeper       ibctransferkeeper.Keeper
-	AuthzKeeper          authzkeeper.Keeper
-	ClaimKeeper          *claimkeeper.Keeper
-	GAMMKeeper           gammkeeper.Keeper
-	IncentivesKeeper     incentiveskeeper.Keeper
-	LockupKeeper         lockupkeeper.Keeper
-	EpochsKeeper         epochskeeper.Keeper
-	PoolIncentivesKeeper poolincentiveskeeper.Keeper
-	TxFeesKeeper         txfeeskeeper.Keeper
-
-	Bech32IBCKeeper   bech32ibckeeper.Keeper
-	Bech32ICS20Keeper bech32ics20keeper.Keeper
-
-	// make scoped keepers public for test purposes
-	ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
-	ScopedTransferKeeper capabilitykeeper.ScopedKeeper
+	keepers keepers.AppKeepers
 
 	// the module manager
 	mm *module.Manager
@@ -276,17 +203,9 @@ func NewOsmosisApp(
 	bApp.SetVersion(version.Version)
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 
-	keys := sdk.NewKVStoreKeys(
-		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
-		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
-		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
-		evidencetypes.StoreKey, ibctransfertypes.StoreKey, capabilitytypes.StoreKey,
-		gammtypes.StoreKey, lockuptypes.StoreKey, claimtypes.StoreKey, incentivestypes.StoreKey,
-		epochstypes.StoreKey, poolincentivestypes.StoreKey, authzkeeper.StoreKey, txfeestypes.StoreKey,
-		bech32ibctypes.StoreKey,
-	)
-	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
-	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
+	keys := keepers.AllKVStoreKeys()
+	tkeys := keepers.AllTStoreKeys()
+	memKeys := keepers.AllMemStoreKeys()
 
 	app := &OsmosisApp{
 		BaseApp:           bApp,
@@ -294,196 +213,19 @@ func NewOsmosisApp(
 		appCodec:          appCodec,
 		interfaceRegistry: interfaceRegistry,
 		invCheckPeriod:    invCheckPeriod,
+		keepers:           keepers.NewBlankKeepers(),
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
 	}
 
-	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
-
-	// set the BaseApp's parameter store
-	bApp.SetParamStore(app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()))
-
-	// add capability keeper and ScopeToModule for ibc module
-	app.CapabilityKeeper = capabilitykeeper.NewKeeper(appCodec, keys[capabilitytypes.StoreKey], memKeys[capabilitytypes.MemStoreKey])
-	scopedIBCKeeper := app.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
-	scopedTransferKeeper := app.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
-	app.CapabilityKeeper.Seal()
-
-	// add keepers
-	app.AccountKeeper = authkeeper.NewAccountKeeper(
-		appCodec, keys[authtypes.StoreKey], app.GetSubspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, maccPerms,
-	)
-	app.BankKeeper = bankkeeper.NewBaseKeeper(
-		appCodec,
-		keys[banktypes.StoreKey],
-		app.AccountKeeper,
-		app.GetSubspace(banktypes.ModuleName),
-		app.BlockedAddrs(),
-	)
-	app.AuthzKeeper = authzkeeper.NewKeeper(
-		keys[authzkeeper.StoreKey],
-		appCodec,
-		app.BaseApp.MsgServiceRouter(),
-	)
-	stakingKeeper := stakingkeeper.NewKeeper(
-		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
-	)
-
-	app.DistrKeeper = distrkeeper.NewKeeper(
-		appCodec, keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(),
-	)
-	app.SlashingKeeper = slashingkeeper.NewKeeper(
-		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
-	)
-	app.CrisisKeeper = crisiskeeper.NewKeeper(
-		app.GetSubspace(crisistypes.ModuleName), invCheckPeriod, app.BankKeeper, authtypes.FeeCollectorName,
-	)
-	app.UpgradeKeeper = upgradekeeper.NewKeeper(
-		skipUpgradeHeights,
-		keys[upgradetypes.StoreKey],
-		appCodec,
-		homePath,
-		app.BaseApp,
-	)
-
-	// Create IBC Keeper
-	app.IBCKeeper = ibckeeper.NewKeeper(
-		appCodec,
-		keys[ibchost.StoreKey],
-		app.GetSubspace(ibchost.ModuleName),
-		&stakingKeeper,
-		app.UpgradeKeeper,
-		scopedIBCKeeper)
-
-	// Create Transfer Keepers
-	app.TransferKeeper = ibctransferkeeper.NewKeeper(
-		appCodec, keys[ibctransfertypes.StoreKey], app.GetSubspace(ibctransfertypes.ModuleName),
-		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
-		app.AccountKeeper, app.BankKeeper, scopedTransferKeeper,
-	)
-	transferModule := transfer.NewAppModule(app.TransferKeeper)
-
-	// Create static IBC router, add transfer route, then set and seal it
-	ibcRouter := porttypes.NewRouter()
-	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferModule)
-	app.IBCKeeper.SetRouter(ibcRouter)
-
-	app.Bech32IBCKeeper = *bech32ibckeeper.NewKeeper(
-		app.IBCKeeper.ChannelKeeper, appCodec, keys[bech32ibctypes.StoreKey],
-		app.TransferKeeper,
-	)
-
-	app.Bech32ICS20Keeper = *bech32ics20keeper.NewKeeper(
-		app.IBCKeeper.ChannelKeeper,
-		app.BankKeeper, app.TransferKeeper,
-		app.Bech32IBCKeeper,
-		app.TransferKeeper,
-		appCodec,
-	)
-
-	// create evidence keeper with router
-	evidenceKeeper := evidencekeeper.NewKeeper(
-		appCodec, keys[evidencetypes.StoreKey], &stakingKeeper, app.SlashingKeeper,
-	)
-	// If evidence needs to be handled for the app, set routes in router here and seal
-	app.EvidenceKeeper = *evidenceKeeper
-
-	app.ClaimKeeper = claimkeeper.NewKeeper(appCodec, keys[claimtypes.StoreKey], app.AccountKeeper, app.BankKeeper, stakingKeeper, app.DistrKeeper)
+	keepers.InitSpecialKeepers(&app.keepers,
+		app.BaseApp, encodingConfig, cdc, skipUpgradeHeights, homePath, invCheckPeriod)
 
 	app.setupUpgrades()
 
-	// register the staking hooks
-	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-	app.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks(), app.ClaimKeeper.Hooks()),
-	)
-	gammKeeper := gammkeeper.NewKeeper(appCodec, keys[gammtypes.StoreKey], app.GetSubspace(gammtypes.ModuleName), app.AccountKeeper, app.BankKeeper, app.DistrKeeper)
-	lockupKeeper := lockupkeeper.NewKeeper(appCodec, keys[lockuptypes.StoreKey], app.AccountKeeper, app.BankKeeper)
-	epochsKeeper := epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])
-	incentivesKeeper := incentiveskeeper.NewKeeper(appCodec, keys[incentivestypes.StoreKey], app.GetSubspace(incentivestypes.ModuleName), app.AccountKeeper, app.BankKeeper, *lockupKeeper, epochsKeeper)
-	mintKeeper := mintkeeper.NewKeeper(
-		appCodec, keys[minttypes.StoreKey], app.GetSubspace(minttypes.ModuleName),
-		app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.EpochsKeeper,
-		authtypes.FeeCollectorName,
-	)
-
-	app.PoolIncentivesKeeper = poolincentiveskeeper.NewKeeper(
-		appCodec,
-		keys[poolincentivestypes.StoreKey],
-		app.GetSubspace(poolincentivestypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
-		incentivesKeeper,
-		app.DistrKeeper,
-		distrtypes.ModuleName,
-		authtypes.FeeCollectorName,
-	)
-	poolIncentivesHooks := app.PoolIncentivesKeeper.Hooks()
-
-	// register the proposal types
-	govRouter := govtypes.NewRouter()
-	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
-		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.DistrKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
-		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.UpgradeKeeper)).
-		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
-		AddRoute(poolincentivestypes.RouterKey, poolincentives.NewPoolIncentivesProposalHandler(app.PoolIncentivesKeeper)).
-		AddRoute(bech32ibctypes.RouterKey, bech32ibc.NewBech32IBCProposalHandler(app.Bech32IBCKeeper))
-
-	govKeeper := govkeeper.NewKeeper(
-		appCodec, keys[govtypes.StoreKey], app.GetSubspace(govtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, govRouter)
-
-	app.GAMMKeeper = *gammKeeper.SetHooks(
-		gammtypes.NewMultiGammHooks(
-			// insert gamm hooks receivers here
-			poolIncentivesHooks,
-			app.ClaimKeeper.Hooks(),
-		),
-	)
-
-	app.TxFeesKeeper = txfeeskeeper.NewKeeper(
-		appCodec,
-		keys[txfeestypes.StoreKey],
-		app.GAMMKeeper,
-	)
-
-	app.LockupKeeper = *lockupKeeper.SetHooks(
-		lockuptypes.NewMultiLockupHooks(
-		// insert lockup hooks receivers here
-		),
-	)
-
-	app.IncentivesKeeper = *incentivesKeeper.SetHooks(
-		incentivestypes.NewMultiIncentiveHooks(
-		// insert incentive hooks receivers here
-		),
-	)
-
-	app.MintKeeper = *mintKeeper.SetHooks(
-		minttypes.NewMultiMintHooks(
-			// insert mint hooks receivers here
-			poolIncentivesHooks,
-		),
-	)
-
-	app.EpochsKeeper = *epochsKeeper.SetHooks(
-		epochstypes.NewMultiEpochHooks(
-			// insert epoch hooks receivers here
-			app.IncentivesKeeper.Hooks(),
-			app.MintKeeper.Hooks(),
-		),
-	)
-
-	app.GovKeeper = *govKeeper.SetHooks(
-		govtypes.NewMultiGovHooks(
-			// insert governance hooks receivers here
-			app.ClaimKeeper.Hooks(),
-		),
-	)
+	keepers.InitNormalKeepers(&app.keepers, app.BaseApp, encodingConfig, cdc, app.BlockedAddrs())
+	keepers.SetupHooks(&app.keepers)
 
 	/****  Module Options ****/
 
@@ -495,11 +237,12 @@ func NewOsmosisApp(
 	// must be passed by reference here.
 	app.mm = module.NewManager(
 		genutil.NewAppModule(
-			app.AccountKeeper, app.StakingKeeper, app.BaseApp.DeliverTx,
+			app.keepers.AccountKeeper, app.keepers.StakingKeeper, app.BaseApp.DeliverTx,
 			encodingConfig.TxConfig,
 		),
-		auth.NewAppModule(appCodec, app.AccountKeeper, nil),
-		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
+		auth.NewAppModule(appCodec, *app.keepers.AccountKeeper, nil),
+		vesting.NewAppModule(*app.keepers.AccountKeeper, app.keepers.BankKeeper),
+		// TODO: This is where I left off in changes
 		bech32ics20.NewAppModule(appCodec, app.Bech32ICS20Keeper),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
 		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants),
@@ -674,7 +417,7 @@ func (app *OsmosisApp) LoadHeight(height int64) error {
 // ModuleAccountAddrs returns all the app's module account addresses.
 func (app *OsmosisApp) ModuleAccountAddrs() map[string]bool {
 	modAccAddrs := make(map[string]bool)
-	for acc := range maccPerms {
+	for acc := range keepers.MaccPerms {
 		modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true
 	}
 
@@ -685,7 +428,7 @@ func (app *OsmosisApp) ModuleAccountAddrs() map[string]bool {
 // allowed to receive external tokens.
 func (app *OsmosisApp) BlockedAddrs() map[string]bool {
 	blockedAddrs := make(map[string]bool)
-	for acc := range maccPerms {
+	for acc := range keepers.MaccPerms {
 		blockedAddrs[authtypes.NewModuleAddress(acc).String()] = !allowedReceivingModAcc[acc]
 	}
 
@@ -858,7 +601,7 @@ func RegisterSwaggerAPI(ctx client.Context, rtr *mux.Router) {
 // GetMaccPerms returns a copy of the module account permissions
 func GetMaccPerms() map[string][]string {
 	dupMaccPerms := make(map[string][]string)
-	for k, v := range maccPerms {
+	for k, v := range keepers.MaccPerms {
 		dupMaccPerms[k] = v
 	}
 	return dupMaccPerms

--- a/app/keepers/maccperms.go
+++ b/app/keepers/maccperms.go
@@ -1,0 +1,38 @@
+package keepers
+
+import (
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	claimtypes "github.com/osmosis-labs/osmosis/x/claim/types"
+	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
+	incentivestypes "github.com/osmosis-labs/osmosis/x/incentives/types"
+	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
+	minttypes "github.com/osmosis-labs/osmosis/x/mint/types"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/x/pool-incentives/types"
+	txfeestypes "github.com/osmosis-labs/osmosis/x/txfees/types"
+)
+
+var (
+	// module account permissions
+	// TODO: Delete this on next upgrade, all of these module permissions should be set in their apps.
+	// Or at minimum, we should make a test for consistency here.
+	MaccPerms = map[string][]string{
+		authtypes.FeeCollectorName:               nil,
+		distrtypes.ModuleName:                    nil,
+		minttypes.ModuleName:                     {authtypes.Minter, authtypes.Burner},
+		minttypes.DeveloperVestingModuleAcctName: nil,
+		stakingtypes.BondedPoolName:              {authtypes.Burner, authtypes.Staking},
+		stakingtypes.NotBondedPoolName:           {authtypes.Burner, authtypes.Staking},
+		govtypes.ModuleName:                      {authtypes.Burner},
+		ibctransfertypes.ModuleName:              {authtypes.Minter, authtypes.Burner},
+		claimtypes.ModuleName:                    {authtypes.Minter, authtypes.Burner},
+		gammtypes.ModuleName:                     {authtypes.Minter, authtypes.Burner},
+		incentivestypes.ModuleName:               {authtypes.Minter, authtypes.Burner},
+		lockuptypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
+		poolincentivestypes.ModuleName:           nil,
+		txfeestypes.ModuleName:                   nil,
+	}
+)

--- a/app/keepers/storekeys.go
+++ b/app/keepers/storekeys.go
@@ -1,0 +1,49 @@
+package keepers
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
+	bech32ibctypes "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/types"
+	claimtypes "github.com/osmosis-labs/osmosis/x/claim/types"
+	epochstypes "github.com/osmosis-labs/osmosis/x/epochs/types"
+	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
+	incentivestypes "github.com/osmosis-labs/osmosis/x/incentives/types"
+	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
+	minttypes "github.com/osmosis-labs/osmosis/x/mint/types"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/x/pool-incentives/types"
+	txfeestypes "github.com/osmosis-labs/osmosis/x/txfees/types"
+)
+
+// TODO: Figure out a test to ensure every keeper has its store key set
+func AllKVStoreKeys() map[string]*sdk.KVStoreKey {
+	keys := sdk.NewKVStoreKeys(
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
+		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
+		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
+		evidencetypes.StoreKey, ibctransfertypes.StoreKey, capabilitytypes.StoreKey,
+		gammtypes.StoreKey, lockuptypes.StoreKey, claimtypes.StoreKey, incentivestypes.StoreKey,
+		epochstypes.StoreKey, poolincentivestypes.StoreKey, authzkeeper.StoreKey, txfeestypes.StoreKey,
+		bech32ibctypes.StoreKey,
+	)
+	return keys
+}
+
+func AllTStoreKeys() map[string]*sdk.TransientStoreKey {
+	return sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
+}
+
+func AllMemStoreKeys() map[string]*sdk.MemoryStoreKey {
+	return sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
+}

--- a/app/keepers/struct.go
+++ b/app/keepers/struct.go
@@ -1,0 +1,424 @@
+package keepers
+
+import (
+	// TODO: Find a coherent way to organize these imports
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/cosmos/ibc-go/v2/modules/apps/transfer"
+
+	ibctransferkeeper "github.com/cosmos/ibc-go/v2/modules/apps/transfer/keeper"
+	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	porttypes "github.com/cosmos/ibc-go/v2/modules/core/05-port/types"
+	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
+	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
+
+	appparams "github.com/osmosis-labs/osmosis/app/params"
+	_ "github.com/osmosis-labs/osmosis/client/docs/statik"
+	claimkeeper "github.com/osmosis-labs/osmosis/x/claim/keeper"
+	claimtypes "github.com/osmosis-labs/osmosis/x/claim/types"
+	epochskeeper "github.com/osmosis-labs/osmosis/x/epochs/keeper"
+	epochstypes "github.com/osmosis-labs/osmosis/x/epochs/types"
+	gammkeeper "github.com/osmosis-labs/osmosis/x/gamm/keeper"
+	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
+	incentiveskeeper "github.com/osmosis-labs/osmosis/x/incentives/keeper"
+	incentivestypes "github.com/osmosis-labs/osmosis/x/incentives/types"
+	lockupkeeper "github.com/osmosis-labs/osmosis/x/lockup/keeper"
+	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
+	mintkeeper "github.com/osmosis-labs/osmosis/x/mint/keeper"
+	minttypes "github.com/osmosis-labs/osmosis/x/mint/types"
+	poolincentives "github.com/osmosis-labs/osmosis/x/pool-incentives"
+	poolincentiveskeeper "github.com/osmosis-labs/osmosis/x/pool-incentives/keeper"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/x/pool-incentives/types"
+	txfeeskeeper "github.com/osmosis-labs/osmosis/x/txfees/keeper"
+	txfeestypes "github.com/osmosis-labs/osmosis/x/txfees/types"
+
+	"github.com/osmosis-labs/bech32-ibc/x/bech32ibc"
+	bech32ibckeeper "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/keeper"
+	bech32ibctypes "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/types"
+	bech32ics20keeper "github.com/osmosis-labs/bech32-ibc/x/bech32ics20/keeper"
+
+	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/02-client"
+	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+)
+
+// AppKeepers is a struct of a pointer to every keeper in Osmosis.
+type AppKeepers struct {
+	// keepers, by order of initialization
+	// "Special" keepers
+	ParamsKeeper     *paramskeeper.Keeper
+	CapabilityKeeper *capabilitykeeper.Keeper
+	CrisisKeeper     *crisiskeeper.Keeper
+	UpgradeKeeper    *upgradekeeper.Keeper
+
+	// make scoped keepers public for test purposes
+	ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
+	ScopedTransferKeeper capabilitykeeper.ScopedKeeper
+
+	// "Normal" keepers
+	AccountKeeper        *authkeeper.AccountKeeper
+	BankKeeper           *bankkeeper.BaseKeeper
+	AuthzKeeper          *authzkeeper.Keeper
+	StakingKeeper        *stakingkeeper.Keeper
+	DistrKeeper          *distrkeeper.Keeper
+	SlashingKeeper       *slashingkeeper.Keeper
+	IBCKeeper            *ibckeeper.Keeper
+	TransferKeeper       *ibctransferkeeper.Keeper
+	Bech32IBCKeeper      *bech32ibckeeper.Keeper
+	Bech32ICS20Keeper    *bech32ics20keeper.Keeper
+	EvidenceKeeper       *evidencekeeper.Keeper
+	ClaimKeeper          *claimkeeper.Keeper
+	GAMMKeeper           *gammkeeper.Keeper
+	LockupKeeper         *lockupkeeper.Keeper
+	EpochsKeeper         *epochskeeper.Keeper
+	IncentivesKeeper     *incentiveskeeper.Keeper
+	MintKeeper           *mintkeeper.Keeper
+	PoolIncentivesKeeper *poolincentiveskeeper.Keeper
+	TxFeesKeeper         *txfeeskeeper.Keeper
+	GovKeeper            *govkeeper.Keeper
+}
+
+// GetSubspace returns a param subspace for a given module name.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (keepers AppKeepers) GetSubspace(moduleName string) paramstypes.Subspace {
+	subspace, ok := keepers.ParamsKeeper.GetSubspace(moduleName)
+	if !ok {
+		panic("We did not register a subspace that was expected")
+	}
+	return subspace
+}
+
+func InitEmptyKeepers() AppKeepers {
+	return AppKeepers{}
+}
+
+func InitSpecialKeepers(
+	keepers *AppKeepers,
+	bApp *baseapp.BaseApp,
+	encodingConfig appparams.EncodingConfig,
+	legacyAmino *codec.LegacyAmino,
+	skipUpgradeHeights map[int64]bool,
+	homePath string,
+	invCheckPeriod uint,
+) {
+	appCodec := encodingConfig.Marshaler
+	cdc := encodingConfig.Amino
+	keys := AllKVStoreKeys()
+	tkeys := AllTStoreKeys()
+	memKeys := AllMemStoreKeys()
+
+	paramsKeeper := initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
+	keepers.ParamsKeeper = &paramsKeeper
+
+	// set the BaseApp's parameter store
+	bApp.SetParamStore(keepers.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()))
+
+	// add capability keeper and ScopeToModule for ibc module
+	keepers.CapabilityKeeper = capabilitykeeper.NewKeeper(appCodec, keys[capabilitytypes.StoreKey], memKeys[capabilitytypes.MemStoreKey])
+	keepers.ScopedIBCKeeper = keepers.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
+	keepers.ScopedTransferKeeper = keepers.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
+	keepers.CapabilityKeeper.Seal()
+
+	// TODO: Make a SetInvCheckPeriod fn on CrisisKeeper.
+	// IMO, its bad design atm that it requires this in state machine initialization
+	crisisKeeper := crisiskeeper.NewKeeper(
+		keepers.GetSubspace(crisistypes.ModuleName), invCheckPeriod, keepers.BankKeeper, authtypes.FeeCollectorName,
+	)
+	keepers.CrisisKeeper = &crisisKeeper
+
+	upgradeKeeper := upgradekeeper.NewKeeper(
+		skipUpgradeHeights,
+		keys[upgradetypes.StoreKey],
+		appCodec,
+		homePath,
+		bApp,
+	)
+	keepers.UpgradeKeeper = &upgradeKeeper
+}
+
+func InitNormalKeepers(
+	keepers *AppKeepers,
+	bApp *baseapp.BaseApp,
+	encodingConfig appparams.EncodingConfig,
+	legacyAmino *codec.LegacyAmino,
+	// TODO: We should move BlockedAddrs to be a method on the bank keeper that can get configured independently
+	blockedAddrs map[string]bool) {
+
+	appCodec := encodingConfig.Marshaler
+	keys := AllKVStoreKeys()
+	// tkeys := AllTStoreKeys()
+	// memKeys := AllMemStoreKeys()
+
+	// Add 'normal' keepers
+	accountKeeper := authkeeper.NewAccountKeeper(
+		appCodec,
+		keys[authtypes.StoreKey],
+		keepers.GetSubspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount,
+		MaccPerms,
+	)
+	keepers.AccountKeeper = &accountKeeper
+	bankKeeper := bankkeeper.NewBaseKeeper(
+		appCodec,
+		keys[banktypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.GetSubspace(banktypes.ModuleName),
+		blockedAddrs,
+	)
+	keepers.BankKeeper = &bankKeeper
+
+	authzKeeper := authzkeeper.NewKeeper(
+		keys[authzkeeper.StoreKey],
+		appCodec,
+		bApp.MsgServiceRouter(),
+	)
+	keepers.AuthzKeeper = &authzKeeper
+
+	stakingKeeper := stakingkeeper.NewKeeper(
+		appCodec,
+		keys[stakingtypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.GetSubspace(stakingtypes.ModuleName),
+	)
+	keepers.StakingKeeper = &stakingKeeper
+
+	distrKeeper := distrkeeper.NewKeeper(
+		appCodec, keys[distrtypes.StoreKey],
+		keepers.GetSubspace(distrtypes.ModuleName), keepers.AccountKeeper, keepers.BankKeeper,
+		&stakingKeeper, authtypes.FeeCollectorName, blockedAddrs,
+	)
+	keepers.DistrKeeper = &distrKeeper
+
+	slashingKeeper := slashingkeeper.NewKeeper(
+		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, keepers.GetSubspace(slashingtypes.ModuleName),
+	)
+	keepers.SlashingKeeper = &slashingKeeper
+
+	// Create IBC Keeper
+	keepers.IBCKeeper = ibckeeper.NewKeeper(
+		appCodec,
+		keys[ibchost.StoreKey],
+		keepers.GetSubspace(ibchost.ModuleName),
+		&stakingKeeper,
+		keepers.UpgradeKeeper,
+		keepers.ScopedIBCKeeper)
+
+	// Create Transfer Keepers
+	transferKeeper := ibctransferkeeper.NewKeeper(
+		appCodec, keys[ibctransfertypes.StoreKey], keepers.GetSubspace(ibctransfertypes.ModuleName),
+		keepers.IBCKeeper.ChannelKeeper, &keepers.IBCKeeper.PortKeeper,
+		keepers.AccountKeeper, keepers.BankKeeper, keepers.ScopedTransferKeeper,
+	)
+	keepers.TransferKeeper = &transferKeeper
+	transferModule := transfer.NewAppModule(*keepers.TransferKeeper)
+
+	// Create static IBC router, add transfer route, then set and seal it
+	ibcRouter := porttypes.NewRouter()
+	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferModule)
+	keepers.IBCKeeper.SetRouter(ibcRouter)
+
+	keepers.Bech32IBCKeeper = bech32ibckeeper.NewKeeper(
+		keepers.IBCKeeper.ChannelKeeper, appCodec, keys[bech32ibctypes.StoreKey],
+		keepers.TransferKeeper,
+	)
+
+	// TODO: Should we be passing this instead of bank in many places?
+	// Where do we want send coins to be cross-chain?
+	keepers.Bech32ICS20Keeper = bech32ics20keeper.NewKeeper(
+		keepers.IBCKeeper.ChannelKeeper,
+		keepers.BankKeeper, keepers.TransferKeeper,
+		keepers.Bech32IBCKeeper,
+		keepers.TransferKeeper,
+		appCodec,
+	)
+
+	// create evidence keeper with router
+	// If evidence needs to be handled for the app, set routes in router here and seal
+	keepers.EvidenceKeeper = evidencekeeper.NewKeeper(
+		appCodec, keys[evidencetypes.StoreKey], keepers.StakingKeeper, keepers.SlashingKeeper,
+	)
+
+	keepers.ClaimKeeper = claimkeeper.NewKeeper(
+		appCodec,
+		keys[claimtypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper, keepers.StakingKeeper, keepers.DistrKeeper)
+
+	gammKeeper := gammkeeper.NewKeeper(
+		appCodec, keys[gammtypes.StoreKey],
+		keepers.GetSubspace(gammtypes.ModuleName),
+		keepers.AccountKeeper, keepers.BankKeeper, keepers.DistrKeeper)
+	keepers.GAMMKeeper = &gammKeeper
+
+	keepers.LockupKeeper = lockupkeeper.NewKeeper(
+		appCodec, keys[lockuptypes.StoreKey],
+		// TODO: Visit why this needs to be deref'd
+		*keepers.AccountKeeper,
+		keepers.BankKeeper)
+
+	keepers.EpochsKeeper = epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])
+
+	keepers.IncentivesKeeper = incentiveskeeper.NewKeeper(
+		appCodec, keys[incentivestypes.StoreKey],
+		keepers.GetSubspace(incentivestypes.ModuleName),
+		*keepers.AccountKeeper,
+		keepers.BankKeeper, keepers.LockupKeeper, keepers.EpochsKeeper)
+
+	mintKeeper := mintkeeper.NewKeeper(
+		appCodec, keys[minttypes.StoreKey],
+		keepers.GetSubspace(minttypes.ModuleName),
+		keepers.AccountKeeper, keepers.BankKeeper, keepers.DistrKeeper, keepers.EpochsKeeper,
+		authtypes.FeeCollectorName,
+	)
+	keepers.MintKeeper = &mintKeeper
+
+	poolIncentivesKeeper := poolincentiveskeeper.NewKeeper(
+		appCodec,
+		keys[poolincentivestypes.StoreKey],
+		keepers.GetSubspace(poolincentivestypes.ModuleName),
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.IncentivesKeeper,
+		keepers.DistrKeeper,
+		distrtypes.ModuleName,
+		authtypes.FeeCollectorName,
+	)
+	keepers.PoolIncentivesKeeper = &poolIncentivesKeeper
+
+	txFeesKeeper := txfeeskeeper.NewKeeper(
+		appCodec,
+		keys[txfeestypes.StoreKey],
+		keepers.GAMMKeeper,
+	)
+	keepers.TxFeesKeeper = &txFeesKeeper
+
+	// register the proposal types
+	// TODO: This appears to be missing tx fees proposal type
+	govRouter := govtypes.NewRouter()
+	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(*keepers.ParamsKeeper)).
+		AddRoute(distrtypes.RouterKey, distribution.NewCommunityPoolSpendProposalHandler(*keepers.DistrKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(keepers.IBCKeeper.ClientKeeper)).
+		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(*keepers.UpgradeKeeper)).
+		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(keepers.IBCKeeper.ClientKeeper)).
+		AddRoute(poolincentivestypes.RouterKey, poolincentives.NewPoolIncentivesProposalHandler(*keepers.PoolIncentivesKeeper)).
+		AddRoute(bech32ibctypes.RouterKey, bech32ibc.NewBech32IBCProposalHandler(*keepers.Bech32IBCKeeper))
+
+	govKeeper := govkeeper.NewKeeper(
+		appCodec, keys[govtypes.StoreKey],
+		keepers.GetSubspace(govtypes.ModuleName), keepers.AccountKeeper, keepers.BankKeeper,
+		keepers.StakingKeeper, govRouter)
+	keepers.GovKeeper = &govKeeper
+}
+
+func SetupHooks(keepers *AppKeepers) {
+	// For every module that has hooks set on it,
+	// you must check InitNormalKeepers to ensure that its not passed by de-reference
+	// e.g. *keepers.StakingKeeper doesn't appear
+
+	// Recall that SetHooks is a mutative call.
+	keepers.StakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(
+			keepers.DistrKeeper.Hooks(),
+			keepers.SlashingKeeper.Hooks(),
+			keepers.ClaimKeeper.Hooks()),
+	)
+
+	keepers.GAMMKeeper.SetHooks(
+		gammtypes.NewMultiGammHooks(
+			// insert gamm hooks receivers here
+			keepers.PoolIncentivesKeeper.Hooks(),
+			keepers.ClaimKeeper.Hooks(),
+		),
+	)
+
+	keepers.LockupKeeper.SetHooks(
+		lockuptypes.NewMultiLockupHooks(
+		// insert lockup hooks receivers here
+		),
+	)
+
+	keepers.IncentivesKeeper.SetHooks(
+		incentivestypes.NewMultiIncentiveHooks(
+		// insert incentive hooks receivers here
+		),
+	)
+
+	keepers.MintKeeper.SetHooks(
+		minttypes.NewMultiMintHooks(
+			// insert mint hooks receivers here
+			keepers.PoolIncentivesKeeper.Hooks(),
+		),
+	)
+
+	keepers.EpochsKeeper.SetHooks(
+		epochstypes.NewMultiEpochHooks(
+			// insert epoch hooks receivers here
+			keepers.IncentivesKeeper.Hooks(),
+			keepers.MintKeeper.Hooks(),
+		),
+	)
+
+	keepers.GovKeeper.SetHooks(
+		govtypes.NewMultiGovHooks(
+			// insert governance hooks receivers here
+			keepers.ClaimKeeper.Hooks(),
+		),
+	)
+}
+
+func NewBlankKeepers() AppKeepers {
+	return AppKeepers{}
+}
+
+// initParamsKeeper init params keeper and its subspaces
+// TODO: Figure out why this doesn't include every module.
+func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey sdk.StoreKey) paramskeeper.Keeper {
+	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
+
+	paramsKeeper.Subspace(authtypes.ModuleName)
+	paramsKeeper.Subspace(banktypes.ModuleName)
+	paramsKeeper.Subspace(stakingtypes.ModuleName)
+	paramsKeeper.Subspace(minttypes.ModuleName)
+	paramsKeeper.Subspace(distrtypes.ModuleName)
+	paramsKeeper.Subspace(slashingtypes.ModuleName)
+	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govtypes.ParamKeyTable())
+	paramsKeeper.Subspace(crisistypes.ModuleName)
+	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
+	paramsKeeper.Subspace(ibchost.ModuleName)
+	paramsKeeper.Subspace(incentivestypes.ModuleName)
+	paramsKeeper.Subspace(poolincentivestypes.ModuleName)
+	paramsKeeper.Subspace(gammtypes.ModuleName)
+
+	return paramsKeeper
+}

--- a/app/upgrades/v4/prop12.go
+++ b/app/upgrades/v4/prop12.go
@@ -10,7 +10,7 @@ import (
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 )
 
-func Prop12(ctx sdk.Context, bank *bankkeeper.Keeper, distr *distrkeeper.Keeper) {
+func Prop12(ctx sdk.Context, bank *bankkeeper.BaseKeeper, distr *distrkeeper.Keeper) {
 	payments := GetProp12Payments()
 
 	var total = int64(0)

--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -4,18 +4,14 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
-	gammkeeper "github.com/osmosis-labs/osmosis/x/gamm/keeper"
+	"github.com/osmosis-labs/osmosis/app/keepers"
 
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
 )
 
 func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator,
-	bank *bankkeeper.Keeper,
-	distr *distrkeeper.Keeper,
-	gamm *gammkeeper.Keeper) upgradetypes.UpgradeHandler {
+	keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		// // Upgrade all of the lock storages
 		// locks, err := app.LockupKeeper.GetLegacyPeriodLocks(ctx)
@@ -32,9 +28,9 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator,
 		// }
 
 		// configure upgrade for gamm module's pool creation fee param add
-		gamm.SetParams(ctx, gammtypes.NewParams(sdk.Coins{sdk.NewInt64Coin("uosmo", 1)})) // 1 uOSMO
+		keepers.GAMMKeeper.SetParams(ctx, gammtypes.NewParams(sdk.Coins{sdk.NewInt64Coin("uosmo", 1)})) // 1 uOSMO
 		// execute prop12. See implementation in
-		Prop12(ctx, bank, distr)
+		Prop12(ctx, keepers.BankKeeper, keepers.DistrKeeper)
 		return vm, nil
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

Makes a separate AppKeepers struct, to avoid issues like the v6 upgrade from occuring. We store all Keepers as pointers, and separate out hook setting from them.

Moreover, by having the keepers be a separate struct, we can have upgrades take in AppKeepers directly without circular dependencies.

The main reason for a second struct in a different module is the upgrades module. Otherwise we could keep everything in the app.go, with this new method structure & local variable separation.

Thoughts on this approach / if its worth continuing as a separate module / struct, versus just separating initialization methods in app.go?

This is going to break many tests / require aliasing, which I'm now thinking may not be worth the more convenient upgrade logic.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

