### PR TITLE
Make all keepers pointers, use multiple initialization methods

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -19,7 +19,7 @@ import (
 // https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/x/auth/ante/ante.go#L41
 func NewAnteHandler(
 	ak ante.AccountKeeper, bankKeeper authtypes.BankKeeper,
-	txFeesKeeper txfeeskeeper.Keeper, spotPriceCalculator txfeestypes.SpotPriceCalculator,
+	txFeesKeeper *txfeeskeeper.Keeper, spotPriceCalculator txfeestypes.SpotPriceCalculator,
 	sigGasConsumer ante.SignatureVerificationGasConsumer,
 	signModeHandler signing.SignModeHandler,
 	channelKeeper channelkeeper.Keeper,
@@ -30,7 +30,7 @@ func NewAnteHandler(
 		NewMempoolMaxGasPerTxDecorator(),
 		// Use Mempool Fee Decorator from our txfees module instead of default one from auth
 		// https://github.com/cosmos/cosmos-sdk/blob/master/x/auth/middleware/fee.go#L34
-		txfeeskeeper.NewMempoolFeeDecorator(txFeesKeeper),
+		txfeeskeeper.NewMempoolFeeDecorator(*txFeesKeeper),
 		ante.NewValidateBasicDecorator(),
 		ante.TxTimeoutHeightDecorator{},
 		ante.NewValidateMemoDecorator(ak),

--- a/app/app.go
+++ b/app/app.go
@@ -309,8 +309,9 @@ func NewOsmosisApp(
 	// we prefer to be more strict in what arguments the modules expect.
 	var skipGenesisInvariants = cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
 
-	// NOTE: Any module instantiated in the module manager that is later modified
-	// must be passed by reference here.
+	// NOTE: All module / keeper changes should happen prior to this module.NewManager line being called.
+	// However in the event any changes do need to happen after this call, ensure that that keeper
+	// is only passed in its keeper form (not de-ref'd anywhere)
 	app.mm = module.NewManager(
 		genutil.NewAppModule(
 			app.AccountKeeper, app.StakingKeeper, app.BaseApp.DeliverTx,

--- a/app/app.go
+++ b/app/app.go
@@ -312,6 +312,12 @@ func NewOsmosisApp(
 	// NOTE: All module / keeper changes should happen prior to this module.NewManager line being called.
 	// However in the event any changes do need to happen after this call, ensure that that keeper
 	// is only passed in its keeper form (not de-ref'd anywhere)
+	//
+	// Generally NewAppModule will require the keeper that module defines to be passed in as an exact struct,
+	// but should take in every other keeper as long as it matches a certain interface. (So no need to be de-ref'd)
+	//
+	// Any time a module requires a keeper de-ref'd thats not its native one,
+	// its code-smell and should probably change. We should get the staking keeper dependencies fixed.
 	app.mm = module.NewManager(
 		genutil.NewAppModule(
 			app.AccountKeeper, app.StakingKeeper, app.BaseApp.DeliverTx,

--- a/app/app.go
+++ b/app/app.go
@@ -16,11 +16,7 @@ import (
 	tmos "github.com/tendermint/tendermint/libs/os"
 	dbm "github.com/tendermint/tm-db"
 
-	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/02-client"
-	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
-
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -86,7 +82,6 @@ import (
 	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v2/modules/core"
 	ibcclientclient "github.com/cosmos/ibc-go/v2/modules/core/02-client/client"
-	porttypes "github.com/cosmos/ibc-go/v2/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
 	"github.com/gorilla/mux"
@@ -211,37 +206,40 @@ type OsmosisApp struct {
 	tkeys   map[string]*sdk.TransientStoreKey
 	memKeys map[string]*sdk.MemoryStoreKey
 
-	// keepers
-	AccountKeeper        authkeeper.AccountKeeper
-	BankKeeper           bankkeeper.Keeper
-	CapabilityKeeper     *capabilitykeeper.Keeper
-	StakingKeeper        stakingkeeper.Keeper
-	SlashingKeeper       slashingkeeper.Keeper
-	MintKeeper           mintkeeper.Keeper
-	DistrKeeper          distrkeeper.Keeper
-	GovKeeper            govkeeper.Keeper
-	CrisisKeeper         crisiskeeper.Keeper
-	UpgradeKeeper        upgradekeeper.Keeper
-	ParamsKeeper         paramskeeper.Keeper
-	IBCKeeper            *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-	EvidenceKeeper       evidencekeeper.Keeper
-	TransferKeeper       ibctransferkeeper.Keeper
-	AuthzKeeper          authzkeeper.Keeper
-	ClaimKeeper          *claimkeeper.Keeper
-	GAMMKeeper           gammkeeper.Keeper
-	IncentivesKeeper     incentiveskeeper.Keeper
-	LockupKeeper         lockupkeeper.Keeper
-	EpochsKeeper         epochskeeper.Keeper
-	PoolIncentivesKeeper poolincentiveskeeper.Keeper
-	TxFeesKeeper         txfeeskeeper.Keeper
-
-	Bech32IBCKeeper   bech32ibckeeper.Keeper
-	Bech32ICS20Keeper bech32ics20keeper.Keeper
+	// keepers, by order of initialization
+	// "Special" keepers
+	ParamsKeeper     *paramskeeper.Keeper
+	CapabilityKeeper *capabilitykeeper.Keeper
+	CrisisKeeper     *crisiskeeper.Keeper
+	UpgradeKeeper    *upgradekeeper.Keeper
 
 	// make scoped keepers public for test purposes
 	ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
 	ScopedTransferKeeper capabilitykeeper.ScopedKeeper
 
+	// "Normal" keepers
+	AccountKeeper        *authkeeper.AccountKeeper
+	BankKeeper           *bankkeeper.BaseKeeper
+	AuthzKeeper          *authzkeeper.Keeper
+	StakingKeeper        *stakingkeeper.Keeper
+	DistrKeeper          *distrkeeper.Keeper
+	SlashingKeeper       *slashingkeeper.Keeper
+	IBCKeeper            *ibckeeper.Keeper
+	TransferKeeper       *ibctransferkeeper.Keeper
+	Bech32IBCKeeper      *bech32ibckeeper.Keeper
+	Bech32ICS20Keeper    *bech32ics20keeper.Keeper
+	EvidenceKeeper       *evidencekeeper.Keeper
+	ClaimKeeper          *claimkeeper.Keeper
+	GAMMKeeper           *gammkeeper.Keeper
+	LockupKeeper         *lockupkeeper.Keeper
+	EpochsKeeper         *epochskeeper.Keeper
+	IncentivesKeeper     *incentiveskeeper.Keeper
+	MintKeeper           *mintkeeper.Keeper
+	PoolIncentivesKeeper *poolincentiveskeeper.Keeper
+	TxFeesKeeper         *txfeeskeeper.Keeper
+	GovKeeper            *govkeeper.Keeper
+
+	transferModule transfer.AppModule
 	// the module manager
 	mm *module.Manager
 
@@ -299,191 +297,10 @@ func NewOsmosisApp(
 		memKeys:           memKeys,
 	}
 
-	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
-
-	// set the BaseApp's parameter store
-	bApp.SetParamStore(app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()))
-
-	// add capability keeper and ScopeToModule for ibc module
-	app.CapabilityKeeper = capabilitykeeper.NewKeeper(appCodec, keys[capabilitytypes.StoreKey], memKeys[capabilitytypes.MemStoreKey])
-	scopedIBCKeeper := app.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
-	scopedTransferKeeper := app.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
-	app.CapabilityKeeper.Seal()
-
-	// add keepers
-	app.AccountKeeper = authkeeper.NewAccountKeeper(
-		appCodec, keys[authtypes.StoreKey], app.GetSubspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, maccPerms,
-	)
-	app.BankKeeper = bankkeeper.NewBaseKeeper(
-		appCodec,
-		keys[banktypes.StoreKey],
-		app.AccountKeeper,
-		app.GetSubspace(banktypes.ModuleName),
-		app.BlockedAddrs(),
-	)
-	app.AuthzKeeper = authzkeeper.NewKeeper(
-		keys[authzkeeper.StoreKey],
-		appCodec,
-		app.BaseApp.MsgServiceRouter(),
-	)
-	stakingKeeper := stakingkeeper.NewKeeper(
-		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
-	)
-
-	app.DistrKeeper = distrkeeper.NewKeeper(
-		appCodec, keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(),
-	)
-	app.SlashingKeeper = slashingkeeper.NewKeeper(
-		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
-	)
-	app.CrisisKeeper = crisiskeeper.NewKeeper(
-		app.GetSubspace(crisistypes.ModuleName), invCheckPeriod, app.BankKeeper, authtypes.FeeCollectorName,
-	)
-	app.UpgradeKeeper = upgradekeeper.NewKeeper(
-		skipUpgradeHeights,
-		keys[upgradetypes.StoreKey],
-		appCodec,
-		homePath,
-		app.BaseApp,
-	)
-
-	// Create IBC Keeper
-	app.IBCKeeper = ibckeeper.NewKeeper(
-		appCodec,
-		keys[ibchost.StoreKey],
-		app.GetSubspace(ibchost.ModuleName),
-		&stakingKeeper,
-		app.UpgradeKeeper,
-		scopedIBCKeeper)
-
-	// Create Transfer Keepers
-	app.TransferKeeper = ibctransferkeeper.NewKeeper(
-		appCodec, keys[ibctransfertypes.StoreKey], app.GetSubspace(ibctransfertypes.ModuleName),
-		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
-		app.AccountKeeper, app.BankKeeper, scopedTransferKeeper,
-	)
-	transferModule := transfer.NewAppModule(app.TransferKeeper)
-
-	// Create static IBC router, add transfer route, then set and seal it
-	ibcRouter := porttypes.NewRouter()
-	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferModule)
-	app.IBCKeeper.SetRouter(ibcRouter)
-
-	app.Bech32IBCKeeper = *bech32ibckeeper.NewKeeper(
-		app.IBCKeeper.ChannelKeeper, appCodec, keys[bech32ibctypes.StoreKey],
-		app.TransferKeeper,
-	)
-
-	app.Bech32ICS20Keeper = *bech32ics20keeper.NewKeeper(
-		app.IBCKeeper.ChannelKeeper,
-		app.BankKeeper, app.TransferKeeper,
-		app.Bech32IBCKeeper,
-		app.TransferKeeper,
-		appCodec,
-	)
-
-	// create evidence keeper with router
-	evidenceKeeper := evidencekeeper.NewKeeper(
-		appCodec, keys[evidencetypes.StoreKey], &stakingKeeper, app.SlashingKeeper,
-	)
-	// If evidence needs to be handled for the app, set routes in router here and seal
-	app.EvidenceKeeper = *evidenceKeeper
-
-	app.ClaimKeeper = claimkeeper.NewKeeper(appCodec, keys[claimtypes.StoreKey], app.AccountKeeper, app.BankKeeper, stakingKeeper, app.DistrKeeper)
-
+	app.InitSpecialKeepers(skipUpgradeHeights, homePath, invCheckPeriod)
+	app.InitNormalKeepers()
+	app.SetupHooks()
 	app.setupUpgrades()
-
-	// register the staking hooks
-	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-	app.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks(), app.ClaimKeeper.Hooks()),
-	)
-	gammKeeper := gammkeeper.NewKeeper(appCodec, keys[gammtypes.StoreKey], app.GetSubspace(gammtypes.ModuleName), app.AccountKeeper, app.BankKeeper, app.DistrKeeper)
-	lockupKeeper := lockupkeeper.NewKeeper(appCodec, keys[lockuptypes.StoreKey], app.AccountKeeper, app.BankKeeper)
-	epochsKeeper := epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])
-	incentivesKeeper := incentiveskeeper.NewKeeper(appCodec, keys[incentivestypes.StoreKey], app.GetSubspace(incentivestypes.ModuleName), app.AccountKeeper, app.BankKeeper, *lockupKeeper, epochsKeeper)
-	mintKeeper := mintkeeper.NewKeeper(
-		appCodec, keys[minttypes.StoreKey], app.GetSubspace(minttypes.ModuleName),
-		app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.EpochsKeeper,
-		authtypes.FeeCollectorName,
-	)
-
-	app.PoolIncentivesKeeper = poolincentiveskeeper.NewKeeper(
-		appCodec,
-		keys[poolincentivestypes.StoreKey],
-		app.GetSubspace(poolincentivestypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
-		incentivesKeeper,
-		app.DistrKeeper,
-		distrtypes.ModuleName,
-		authtypes.FeeCollectorName,
-	)
-	poolIncentivesHooks := app.PoolIncentivesKeeper.Hooks()
-
-	// register the proposal types
-	govRouter := govtypes.NewRouter()
-	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
-		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.DistrKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
-		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.UpgradeKeeper)).
-		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
-		AddRoute(poolincentivestypes.RouterKey, poolincentives.NewPoolIncentivesProposalHandler(app.PoolIncentivesKeeper)).
-		AddRoute(bech32ibctypes.RouterKey, bech32ibc.NewBech32IBCProposalHandler(app.Bech32IBCKeeper))
-
-	govKeeper := govkeeper.NewKeeper(
-		appCodec, keys[govtypes.StoreKey], app.GetSubspace(govtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, govRouter)
-
-	app.GAMMKeeper = *gammKeeper.SetHooks(
-		gammtypes.NewMultiGammHooks(
-			// insert gamm hooks receivers here
-			poolIncentivesHooks,
-			app.ClaimKeeper.Hooks(),
-		),
-	)
-
-	app.TxFeesKeeper = txfeeskeeper.NewKeeper(
-		appCodec,
-		keys[txfeestypes.StoreKey],
-		app.GAMMKeeper,
-	)
-
-	app.LockupKeeper = *lockupKeeper.SetHooks(
-		lockuptypes.NewMultiLockupHooks(
-		// insert lockup hooks receivers here
-		),
-	)
-
-	app.IncentivesKeeper = *incentivesKeeper.SetHooks(
-		incentivestypes.NewMultiIncentiveHooks(
-		// insert incentive hooks receivers here
-		),
-	)
-
-	app.MintKeeper = *mintKeeper.SetHooks(
-		minttypes.NewMultiMintHooks(
-			// insert mint hooks receivers here
-			poolIncentivesHooks,
-		),
-	)
-
-	app.EpochsKeeper = *epochsKeeper.SetHooks(
-		epochstypes.NewMultiEpochHooks(
-			// insert epoch hooks receivers here
-			app.IncentivesKeeper.Hooks(),
-			app.MintKeeper.Hooks(),
-		),
-	)
-
-	app.GovKeeper = *govKeeper.SetHooks(
-		govtypes.NewMultiGovHooks(
-			// insert governance hooks receivers here
-			app.ClaimKeeper.Hooks(),
-		),
-	)
 
 	/****  Module Options ****/
 
@@ -498,30 +315,30 @@ func NewOsmosisApp(
 			app.AccountKeeper, app.StakingKeeper, app.BaseApp.DeliverTx,
 			encodingConfig.TxConfig,
 		),
-		auth.NewAppModule(appCodec, app.AccountKeeper, nil),
-		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
-		bech32ics20.NewAppModule(appCodec, app.Bech32ICS20Keeper),
+		auth.NewAppModule(appCodec, *app.AccountKeeper, nil),
+		vesting.NewAppModule(*app.AccountKeeper, app.BankKeeper),
+		bech32ics20.NewAppModule(appCodec, *app.Bech32ICS20Keeper),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
-		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
-		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		upgrade.NewAppModule(app.UpgradeKeeper),
-		evidence.NewAppModule(app.EvidenceKeeper),
-		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
+		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants),
+		gov.NewAppModule(appCodec, *app.GovKeeper, app.AccountKeeper, app.BankKeeper),
+		mint.NewAppModule(appCodec, *app.MintKeeper, app.AccountKeeper),
+		slashing.NewAppModule(appCodec, *app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, *app.StakingKeeper),
+		distr.NewAppModule(appCodec, *app.DistrKeeper, app.AccountKeeper, app.BankKeeper, *app.StakingKeeper),
+		staking.NewAppModule(appCodec, *app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
+		upgrade.NewAppModule(*app.UpgradeKeeper),
+		evidence.NewAppModule(*app.EvidenceKeeper),
+		authzmodule.NewAppModule(appCodec, *app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		ibc.NewAppModule(app.IBCKeeper),
-		params.NewAppModule(app.ParamsKeeper),
-		transferModule,
+		params.NewAppModule(*app.ParamsKeeper),
+		app.transferModule,
 		claim.NewAppModule(appCodec, *app.ClaimKeeper),
-		gamm.NewAppModule(appCodec, app.GAMMKeeper, app.AccountKeeper, app.BankKeeper),
-		txfees.NewAppModule(appCodec, app.TxFeesKeeper),
-		incentives.NewAppModule(appCodec, app.IncentivesKeeper, app.AccountKeeper, app.BankKeeper, app.EpochsKeeper),
-		lockup.NewAppModule(appCodec, app.LockupKeeper, app.AccountKeeper, app.BankKeeper),
-		poolincentives.NewAppModule(appCodec, app.PoolIncentivesKeeper),
-		epochs.NewAppModule(appCodec, app.EpochsKeeper),
-		bech32ibc.NewAppModule(appCodec, app.Bech32IBCKeeper),
+		gamm.NewAppModule(appCodec, *app.GAMMKeeper, app.AccountKeeper, app.BankKeeper),
+		txfees.NewAppModule(appCodec, *app.TxFeesKeeper),
+		incentives.NewAppModule(appCodec, *app.IncentivesKeeper, app.AccountKeeper, app.BankKeeper, app.EpochsKeeper),
+		lockup.NewAppModule(appCodec, *app.LockupKeeper, app.AccountKeeper, app.BankKeeper),
+		poolincentives.NewAppModule(appCodec, *app.PoolIncentivesKeeper),
+		epochs.NewAppModule(appCodec, *app.EpochsKeeper),
+		bech32ibc.NewAppModule(appCodec, *app.Bech32IBCKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -565,7 +382,7 @@ func NewOsmosisApp(
 		authz.ModuleName,
 	)
 
-	app.mm.RegisterInvariants(&app.CrisisKeeper)
+	app.mm.RegisterInvariants(app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)
 	app.configurator = module.NewConfigurator(app.AppCodec(), app.MsgServiceRouter(), app.GRPCQueryRouter())
 	app.mm.RegisterServices(app.configurator)
@@ -575,25 +392,25 @@ func NewOsmosisApp(
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing
 	// transactions
 	app.sm = module.NewSimulationManager(
-		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts),
+		auth.NewAppModule(appCodec, *app.AccountKeeper, authsims.RandomGenesisAccounts),
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
-		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
-		gamm.NewAppModule(appCodec, app.GAMMKeeper, app.AccountKeeper, app.BankKeeper),
-		txfees.NewAppModule(appCodec, app.TxFeesKeeper),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
-		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		params.NewAppModule(app.ParamsKeeper),
-		evidence.NewAppModule(app.EvidenceKeeper),
+		authzmodule.NewAppModule(appCodec, *app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
+		gamm.NewAppModule(appCodec, *app.GAMMKeeper, app.AccountKeeper, app.BankKeeper),
+		txfees.NewAppModule(appCodec, *app.TxFeesKeeper),
+		gov.NewAppModule(appCodec, *app.GovKeeper, app.AccountKeeper, app.BankKeeper),
+		mint.NewAppModule(appCodec, *app.MintKeeper, app.AccountKeeper),
+		slashing.NewAppModule(appCodec, *app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, *app.StakingKeeper),
+		distr.NewAppModule(appCodec, *app.DistrKeeper, app.AccountKeeper, app.BankKeeper, *app.StakingKeeper),
+		staking.NewAppModule(appCodec, *app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
+		params.NewAppModule(*app.ParamsKeeper),
+		evidence.NewAppModule(*app.EvidenceKeeper),
 		ibc.NewAppModule(app.IBCKeeper),
-		incentives.NewAppModule(appCodec, app.IncentivesKeeper, app.AccountKeeper, app.BankKeeper, app.EpochsKeeper),
-		lockup.NewAppModule(appCodec, app.LockupKeeper, app.AccountKeeper, app.BankKeeper),
-		poolincentives.NewAppModule(appCodec, app.PoolIncentivesKeeper),
-		epochs.NewAppModule(appCodec, app.EpochsKeeper),
-		transferModule,
+		incentives.NewAppModule(appCodec, *app.IncentivesKeeper, app.AccountKeeper, app.BankKeeper, app.EpochsKeeper),
+		lockup.NewAppModule(appCodec, *app.LockupKeeper, app.AccountKeeper, app.BankKeeper),
+		poolincentives.NewAppModule(appCodec, *app.PoolIncentivesKeeper),
+		epochs.NewAppModule(appCodec, *app.EpochsKeeper),
+		app.transferModule,
 	)
 
 	app.sm.RegisterStoreDecoders()
@@ -612,7 +429,7 @@ func NewOsmosisApp(
 	app.SetAnteHandler(
 		NewAnteHandler(
 			app.AccountKeeper, app.BankKeeper,
-			app.TxFeesKeeper, app.GAMMKeeper,
+			*app.TxFeesKeeper, app.GAMMKeeper,
 			ante.DefaultSigVerificationGasConsumer,
 			encodingConfig.TxConfig.SignModeHandler(),
 			app.IBCKeeper.ChannelKeeper,
@@ -625,9 +442,6 @@ func NewOsmosisApp(
 			tmos.Exit(err.Error())
 		}
 	}
-
-	app.ScopedIBCKeeper = scopedIBCKeeper
-	app.ScopedTransferKeeper = scopedTransferKeeper
 
 	return app
 }
@@ -819,14 +633,14 @@ func (app *OsmosisApp) setupUpgrades() {
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v4.UpgradeName, v4.CreateUpgradeHandler(
 			app.mm, app.configurator,
-			&app.BankKeeper, &app.DistrKeeper, &app.GAMMKeeper))
+			*app.BankKeeper, app.DistrKeeper, app.GAMMKeeper))
 
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v5.UpgradeName,
 		v5.CreateUpgradeHandler(
 			app.mm, app.configurator,
-			&app.IBCKeeper.ConnectionKeeper, &app.TxFeesKeeper,
-			&app.GAMMKeeper, &app.StakingKeeper))
+			&app.IBCKeeper.ConnectionKeeper, app.TxFeesKeeper,
+			app.GAMMKeeper, app.StakingKeeper))
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -430,7 +430,7 @@ func NewOsmosisApp(
 	app.SetAnteHandler(
 		NewAnteHandler(
 			app.AccountKeeper, app.BankKeeper,
-			*app.TxFeesKeeper, app.GAMMKeeper,
+			app.TxFeesKeeper, app.GAMMKeeper,
 			ante.DefaultSigVerificationGasConsumer,
 			encodingConfig.TxConfig.SignModeHandler(),
 			app.IBCKeeper.ChannelKeeper,

--- a/app/export.go
+++ b/app/export.go
@@ -35,7 +35,7 @@ func (app *OsmosisApp) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
+	validators, err := staking.WriteValidators(ctx, *app.StakingKeeper)
 	return servertypes.ExportedApp{
 		AppState:        appState,
 		Validators:      validators,

--- a/app/forks.go
+++ b/app/forks.go
@@ -10,7 +10,7 @@ import (
 func BeginBlockForks(ctx sdk.Context, app *OsmosisApp) {
 	switch ctx.BlockHeight() {
 	case v3.UpgradeHeight:
-		v3.RunForkLogic(ctx, &app.GovKeeper, &app.StakingKeeper)
+		v3.RunForkLogic(ctx, app.GovKeeper, app.StakingKeeper)
 	case v6.UpgradeHeight:
 		v6.RunForkLogic(ctx)
 	default:

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -1,0 +1,326 @@
+package app
+
+import (
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	transfer "github.com/cosmos/ibc-go/v2/modules/apps/transfer"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v2/modules/apps/transfer/keeper"
+	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/02-client"
+	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	porttypes "github.com/cosmos/ibc-go/v2/modules/core/05-port/types"
+	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
+	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
+	"github.com/osmosis-labs/bech32-ibc/x/bech32ibc"
+	bech32ibckeeper "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/keeper"
+	bech32ibctypes "github.com/osmosis-labs/bech32-ibc/x/bech32ibc/types"
+	bech32ics20keeper "github.com/osmosis-labs/bech32-ibc/x/bech32ics20/keeper"
+	claimkeeper "github.com/osmosis-labs/osmosis/x/claim/keeper"
+	claimtypes "github.com/osmosis-labs/osmosis/x/claim/types"
+	epochskeeper "github.com/osmosis-labs/osmosis/x/epochs/keeper"
+	epochstypes "github.com/osmosis-labs/osmosis/x/epochs/types"
+	gammkeeper "github.com/osmosis-labs/osmosis/x/gamm/keeper"
+	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
+	incentiveskeeper "github.com/osmosis-labs/osmosis/x/incentives/keeper"
+	incentivestypes "github.com/osmosis-labs/osmosis/x/incentives/types"
+	lockupkeeper "github.com/osmosis-labs/osmosis/x/lockup/keeper"
+	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
+	mintkeeper "github.com/osmosis-labs/osmosis/x/mint/keeper"
+	minttypes "github.com/osmosis-labs/osmosis/x/mint/types"
+	poolincentives "github.com/osmosis-labs/osmosis/x/pool-incentives"
+	poolincentiveskeeper "github.com/osmosis-labs/osmosis/x/pool-incentives/keeper"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/x/pool-incentives/types"
+	txfeeskeeper "github.com/osmosis-labs/osmosis/x/txfees/keeper"
+	txfeestypes "github.com/osmosis-labs/osmosis/x/txfees/types"
+)
+
+func (app *OsmosisApp) InitSpecialKeepers(
+	skipUpgradeHeights map[int64]bool,
+	homePath string,
+	invCheckPeriod uint,
+) {
+	appCodec := app.appCodec
+	bApp := app.BaseApp
+	cdc := app.cdc
+	keys := app.keys
+	tkeys := app.tkeys
+	memKeys := app.memKeys
+
+	paramsKeeper := initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
+	app.ParamsKeeper = &paramsKeeper
+
+	// set the BaseApp's parameter store
+	bApp.SetParamStore(app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()))
+
+	// add capability keeper and ScopeToModule for ibc module
+	app.CapabilityKeeper = capabilitykeeper.NewKeeper(appCodec, keys[capabilitytypes.StoreKey], memKeys[capabilitytypes.MemStoreKey])
+	app.ScopedIBCKeeper = app.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
+	app.ScopedTransferKeeper = app.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
+	app.CapabilityKeeper.Seal()
+
+	// TODO: Make a SetInvCheckPeriod fn on CrisisKeeper.
+	// IMO, its bad design atm that it requires this in state machine initialization
+	crisisKeeper := crisiskeeper.NewKeeper(
+		app.GetSubspace(crisistypes.ModuleName), invCheckPeriod, app.BankKeeper, authtypes.FeeCollectorName,
+	)
+	app.CrisisKeeper = &crisisKeeper
+
+	upgradeKeeper := upgradekeeper.NewKeeper(
+		skipUpgradeHeights,
+		keys[upgradetypes.StoreKey],
+		appCodec,
+		homePath,
+		bApp,
+	)
+	app.UpgradeKeeper = &upgradeKeeper
+}
+
+func (app *OsmosisApp) InitNormalKeepers() {
+	appCodec := app.appCodec
+	bApp := app.BaseApp
+	keys := app.keys
+
+	// Add 'normal' keepers
+	accountKeeper := authkeeper.NewAccountKeeper(
+		appCodec,
+		keys[authtypes.StoreKey],
+		app.GetSubspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+	)
+	app.AccountKeeper = &accountKeeper
+	bankKeeper := bankkeeper.NewBaseKeeper(
+		appCodec,
+		keys[banktypes.StoreKey],
+		app.AccountKeeper,
+		app.GetSubspace(banktypes.ModuleName),
+		app.BlockedAddrs(),
+	)
+	app.BankKeeper = &bankKeeper
+
+	authzKeeper := authzkeeper.NewKeeper(
+		keys[authzkeeper.StoreKey],
+		appCodec,
+		bApp.MsgServiceRouter(),
+	)
+	app.AuthzKeeper = &authzKeeper
+
+	stakingKeeper := stakingkeeper.NewKeeper(
+		appCodec,
+		keys[stakingtypes.StoreKey],
+		app.AccountKeeper,
+		app.BankKeeper,
+		app.GetSubspace(stakingtypes.ModuleName),
+	)
+	app.StakingKeeper = &stakingKeeper
+
+	distrKeeper := distrkeeper.NewKeeper(
+		appCodec, keys[distrtypes.StoreKey],
+		app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
+		&stakingKeeper, authtypes.FeeCollectorName, app.BlockedAddrs(),
+	)
+	app.DistrKeeper = &distrKeeper
+
+	slashingKeeper := slashingkeeper.NewKeeper(
+		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
+	)
+	app.SlashingKeeper = &slashingKeeper
+
+	// Create IBC Keeper
+	app.IBCKeeper = ibckeeper.NewKeeper(
+		appCodec,
+		keys[ibchost.StoreKey],
+		app.GetSubspace(ibchost.ModuleName),
+		&stakingKeeper,
+		app.UpgradeKeeper,
+		app.ScopedIBCKeeper)
+
+	// Create Transfer Keepers
+	transferKeeper := ibctransferkeeper.NewKeeper(
+		appCodec, keys[ibctransfertypes.StoreKey], app.GetSubspace(ibctransfertypes.ModuleName),
+		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
+		app.AccountKeeper, app.BankKeeper, app.ScopedTransferKeeper,
+	)
+	app.TransferKeeper = &transferKeeper
+	app.transferModule = transfer.NewAppModule(*app.TransferKeeper)
+
+	// Create static IBC router, add transfer route, then set and seal it
+	ibcRouter := porttypes.NewRouter()
+	ibcRouter.AddRoute(ibctransfertypes.ModuleName, app.transferModule)
+	app.IBCKeeper.SetRouter(ibcRouter)
+
+	app.Bech32IBCKeeper = bech32ibckeeper.NewKeeper(
+		app.IBCKeeper.ChannelKeeper, appCodec, keys[bech32ibctypes.StoreKey],
+		app.TransferKeeper,
+	)
+
+	// TODO: Should we be passing this instead of bank in many places?
+	// Where do we want send coins to be cross-chain?
+	app.Bech32ICS20Keeper = bech32ics20keeper.NewKeeper(
+		app.IBCKeeper.ChannelKeeper,
+		app.BankKeeper, app.TransferKeeper,
+		app.Bech32IBCKeeper,
+		app.TransferKeeper,
+		appCodec,
+	)
+
+	// create evidence keeper with router
+	// If evidence needs to be handled for the app, set routes in router here and seal
+	app.EvidenceKeeper = evidencekeeper.NewKeeper(
+		appCodec, keys[evidencetypes.StoreKey], app.StakingKeeper, app.SlashingKeeper,
+	)
+
+	app.ClaimKeeper = claimkeeper.NewKeeper(
+		appCodec,
+		keys[claimtypes.StoreKey],
+		app.AccountKeeper,
+		app.BankKeeper, app.StakingKeeper, app.DistrKeeper)
+
+	gammKeeper := gammkeeper.NewKeeper(
+		appCodec, keys[gammtypes.StoreKey],
+		app.GetSubspace(gammtypes.ModuleName),
+		app.AccountKeeper, app.BankKeeper, app.DistrKeeper)
+	app.GAMMKeeper = &gammKeeper
+
+	app.LockupKeeper = lockupkeeper.NewKeeper(
+		appCodec, keys[lockuptypes.StoreKey],
+		// TODO: Visit why this needs to be deref'd
+		*app.AccountKeeper,
+		app.BankKeeper)
+
+	app.EpochsKeeper = epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])
+
+	app.IncentivesKeeper = incentiveskeeper.NewKeeper(
+		appCodec, keys[incentivestypes.StoreKey],
+		app.GetSubspace(incentivestypes.ModuleName),
+		*app.AccountKeeper,
+		app.BankKeeper, app.LockupKeeper, app.EpochsKeeper)
+
+	mintKeeper := mintkeeper.NewKeeper(
+		appCodec, keys[minttypes.StoreKey],
+		app.GetSubspace(minttypes.ModuleName),
+		app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.EpochsKeeper,
+		authtypes.FeeCollectorName,
+	)
+	app.MintKeeper = &mintKeeper
+
+	poolIncentivesKeeper := poolincentiveskeeper.NewKeeper(
+		appCodec,
+		keys[poolincentivestypes.StoreKey],
+		app.GetSubspace(poolincentivestypes.ModuleName),
+		app.AccountKeeper,
+		app.BankKeeper,
+		app.IncentivesKeeper,
+		app.DistrKeeper,
+		distrtypes.ModuleName,
+		authtypes.FeeCollectorName,
+	)
+	app.PoolIncentivesKeeper = &poolIncentivesKeeper
+
+	txFeesKeeper := txfeeskeeper.NewKeeper(
+		appCodec,
+		keys[txfeestypes.StoreKey],
+		app.GAMMKeeper,
+	)
+	app.TxFeesKeeper = &txFeesKeeper
+
+	// register the proposal types
+	// TODO: This appears to be missing tx fees proposal type
+	govRouter := govtypes.NewRouter()
+	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(*app.ParamsKeeper)).
+		AddRoute(distrtypes.RouterKey, distribution.NewCommunityPoolSpendProposalHandler(*app.DistrKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
+		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(*app.UpgradeKeeper)).
+		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
+		AddRoute(poolincentivestypes.RouterKey, poolincentives.NewPoolIncentivesProposalHandler(*app.PoolIncentivesKeeper)).
+		AddRoute(bech32ibctypes.RouterKey, bech32ibc.NewBech32IBCProposalHandler(*app.Bech32IBCKeeper))
+
+	govKeeper := govkeeper.NewKeeper(
+		appCodec, keys[govtypes.StoreKey],
+		app.GetSubspace(govtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
+		app.StakingKeeper, govRouter)
+	app.GovKeeper = &govKeeper
+}
+
+func (app *OsmosisApp) SetupHooks() {
+	// For every module that has hooks set on it,
+	// you must check InitNormalKeepers to ensure that its not passed by de-reference
+	// e.g. *app.StakingKeeper doesn't appear
+
+	// Recall that SetHooks is a mutative call.
+	app.StakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(
+			app.DistrKeeper.Hooks(),
+			app.SlashingKeeper.Hooks(),
+			app.ClaimKeeper.Hooks()),
+	)
+
+	app.GAMMKeeper.SetHooks(
+		gammtypes.NewMultiGammHooks(
+			// insert gamm hooks receivers here
+			app.PoolIncentivesKeeper.Hooks(),
+			app.ClaimKeeper.Hooks(),
+		),
+	)
+
+	app.LockupKeeper.SetHooks(
+		lockuptypes.NewMultiLockupHooks(
+		// insert lockup hooks receivers here
+		),
+	)
+
+	app.IncentivesKeeper.SetHooks(
+		incentivestypes.NewMultiIncentiveHooks(
+		// insert incentive hooks receivers here
+		),
+	)
+
+	app.MintKeeper.SetHooks(
+		minttypes.NewMultiMintHooks(
+			// insert mint hooks receivers here
+			app.PoolIncentivesKeeper.Hooks(),
+		),
+	)
+
+	app.EpochsKeeper.SetHooks(
+		epochstypes.NewMultiEpochHooks(
+			// insert epoch hooks receivers here
+			app.IncentivesKeeper.Hooks(),
+			app.MintKeeper.Hooks(),
+		),
+	)
+
+	app.GovKeeper.SetHooks(
+		govtypes.NewMultiGovHooks(
+			// insert governance hooks receivers here
+			app.ClaimKeeper.Hooks(),
+		),
+	)
+}

--- a/app/upgrades/v4/prop12.go
+++ b/app/upgrades/v4/prop12.go
@@ -10,7 +10,7 @@ import (
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 )
 
-func Prop12(ctx sdk.Context, bank *bankkeeper.Keeper, distr *distrkeeper.Keeper) {
+func Prop12(ctx sdk.Context, bank bankkeeper.Keeper, distr *distrkeeper.Keeper) {
 	payments := GetProp12Payments()
 
 	var total = int64(0)
@@ -25,7 +25,7 @@ func Prop12(ctx sdk.Context, bank *bankkeeper.Keeper, distr *distrkeeper.Keeper)
 			panic(err)
 		}
 		coins := sdk.NewCoins(sdk.NewInt64Coin("uosmo", amount))
-		if err := (*bank).SendCoinsFromModuleToAccount(ctx, "distribution", addr, coins); err != nil {
+		if err := bank.SendCoinsFromModuleToAccount(ctx, "distribution", addr, coins); err != nil {
 			panic(err)
 		}
 		total += amount

--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -13,7 +13,7 @@ import (
 )
 
 func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator,
-	bank *bankkeeper.Keeper,
+	bank bankkeeper.Keeper,
 	distr *distrkeeper.Keeper,
 	gamm *gammkeeper.Keeper) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/osmosis-labs/bech32-ibc v0.2.0-rc1
+	github.com/osmosis-labs/bech32-ibc v0.2.0-rc1.0.20211229033539-6398fe1c7f8c
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/regen-network/cosmos-proto v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,8 @@ github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnh
 github.com/ory/dockertest/v3 v3.6.2/go.mod h1:EFLcVUOl8qCwp9NyDAcCDtq/QviLtYswW/VbWzUnTNE=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1 h1:hophiDQD/blq/ejT/frDu/B9etQnWkgTjlOV7cXBONA=
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc1/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
+github.com/osmosis-labs/bech32-ibc v0.2.0-rc1.0.20211229033539-6398fe1c7f8c h1:6/DwxwJHJ9pjnfFnaIE1rhOK6x9l3+/S/SWU9Bexrcw=
+github.com/osmosis-labs/bech32-ibc v0.2.0-rc1.0.20211229033539-6398fe1c7f8c/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4 h1:vcxXXGW6NBW9Ew4U5/GriN0DUJO0a2GQrCZARCk55Rk=
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20211209072213-711e78b4f6b4/go.mod h1:S/sIkCqPuuvRrByglANXeN1eb1aA4lmKSjSG5E8SWsU=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo h1:XyYyDTjPIu7qX2nhQp9mboj7Pa9FEnjg1RXw73Ctv5U=

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -179,7 +179,7 @@ func (suite *KeeperTestSuite) TestDelegationAutoWithdrawAndDelegateMore() {
 	// set addr[0] as a validator
 	validator, err := stakingtypes.NewValidator(sdk.ValAddress(addrs[0]), pub1, stakingtypes.Description{})
 	suite.Require().NoError(err)
-	validator = stakingkeeper.TestingUpdateValidator(suite.app.StakingKeeper, suite.ctx, validator, true)
+	validator = stakingkeeper.TestingUpdateValidator(*suite.app.StakingKeeper, suite.ctx, validator, true)
 	suite.app.StakingKeeper.AfterValidatorCreated(suite.ctx, validator.GetOperator())
 
 	validator, _ = validator.AddTokensFromDel(sdk.TokensFromConsensusPower(1, sdk.DefaultPowerReduction))

--- a/x/epochs/abci_test.go
+++ b/x/epochs/abci_test.go
@@ -34,7 +34,7 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expInitialEpochStartTime:   now,
 			fn: func() {
 				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
@@ -45,7 +45,7 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expInitialEpochStartTime:   now,
 			fn: func() {
 				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
@@ -56,9 +56,9 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expInitialEpochStartTime:   now,
 			fn: func() {
 				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 31))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
@@ -70,9 +70,9 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expInitialEpochStartTime:   now,
 			fn: func() {
 				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
@@ -83,11 +83,11 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expInitialEpochStartTime:   now,
 			fn: func() {
 				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
@@ -98,11 +98,11 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expInitialEpochStartTime:   now,
 			fn: func() {
 				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
-				epochs.BeginBlocker(ctx, app.EpochsKeeper)
+				epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
@@ -122,7 +122,7 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 		ctx = ctx.WithBlockHeight(1).WithBlockTime(now)
 
 		// check init genesis
-		epochs.InitGenesis(ctx, app.EpochsKeeper, types.GenesisState{
+		epochs.InitGenesis(ctx, *app.EpochsKeeper, types.GenesisState{
 			Epochs: []types.EpochInfo{
 				{
 					Identifier:              "monthly",
@@ -165,7 +165,7 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 	initialBlockHeight := int64(1)
 	ctx = ctx.WithBlockHeight(initialBlockHeight).WithBlockTime(now)
 
-	epochs.InitGenesis(ctx, app.EpochsKeeper, types.GenesisState{
+	epochs.InitGenesis(ctx, *app.EpochsKeeper, types.GenesisState{
 		Epochs: []types.EpochInfo{
 			{
 				Identifier:              "monthly",
@@ -188,7 +188,7 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 
 	// after 1 week
 	ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(week))
-	epochs.BeginBlocker(ctx, app.EpochsKeeper)
+	epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 
 	// epoch not started yet
 	epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
@@ -199,7 +199,7 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 
 	// after 1 month
 	ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(month))
-	epochs.BeginBlocker(ctx, app.EpochsKeeper)
+	epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 
 	// epoch started
 	epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
@@ -235,17 +235,17 @@ func TestLegacyEpochSerialization(t *testing.T) {
 	ctx = ctx.WithBlockHeight(1).WithBlockTime(now)
 
 	// check init genesis
-	epochs.InitGenesis(ctx, app.EpochsKeeper, types.GenesisState{
+	epochs.InitGenesis(ctx, *app.EpochsKeeper, types.GenesisState{
 		Epochs: []types.EpochInfo{legacyEpochInfo},
 	})
 
 	// Do not increment epoch
 	ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-	epochs.BeginBlocker(ctx, app.EpochsKeeper)
+	epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 
 	// Increment epoch
 	ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-	epochs.BeginBlocker(ctx, app.EpochsKeeper)
+	epochs.BeginBlocker(ctx, *app.EpochsKeeper)
 	epochInfo := app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 
 	require.NotEqual(t, epochInfo.CurrentEpochStartHeight, int64(0))

--- a/x/epochs/genesis_test.go
+++ b/x/epochs/genesis_test.go
@@ -18,7 +18,7 @@ func TestEpochsExportGenesis(t *testing.T) {
 	chainStartTime := ctx.BlockTime()
 	chainStartHeight := ctx.BlockHeight()
 
-	genesis := epochs.ExportGenesis(ctx, app.EpochsKeeper)
+	genesis := epochs.ExportGenesis(ctx, *app.EpochsKeeper)
 	require.Len(t, genesis.Epochs, 2)
 
 	require.Equal(t, genesis.Epochs[0].Identifier, "day")
@@ -91,7 +91,7 @@ func TestEpochsInitGenesis(t *testing.T) {
 		},
 	}
 
-	epochs.InitGenesis(ctx, app.EpochsKeeper, genesisState)
+	epochs.InitGenesis(ctx, *app.EpochsKeeper, genesisState)
 	epochInfo := app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 	require.Equal(t, epochInfo.Identifier, "monthly")
 	require.Equal(t, epochInfo.StartTime.UTC().String(), now.UTC().String())

--- a/x/gamm/genesis_test.go
+++ b/x/gamm/genesis_test.go
@@ -39,7 +39,7 @@ func TestGammInitGenesis(t *testing.T) {
 	any, err := codectypes.NewAnyWithValue(&balancerPool)
 	require.NoError(t, err)
 
-	gamm.InitGenesis(ctx, app.GAMMKeeper, types.GenesisState{
+	gamm.InitGenesis(ctx, *app.GAMMKeeper, types.GenesisState{
 		Pools:          []*codectypes.Any{any},
 		NextPoolNumber: 2,
 		Params: types.Params{
@@ -102,7 +102,7 @@ func TestGammExportGenesis(t *testing.T) {
 	}}, "")
 	require.NoError(t, err)
 
-	genesis := gamm.ExportGenesis(ctx, app.GAMMKeeper)
+	genesis := gamm.ExportGenesis(ctx, *app.GAMMKeeper)
 	require.Equal(t, genesis.NextPoolNumber, uint64(3))
 	require.Len(t, genesis.Pools, 2)
 }
@@ -113,7 +113,7 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 
 	encodingConfig := osmoapp.MakeEncodingConfig()
 	appCodec := encodingConfig.Marshaler
-	am := gamm.NewAppModule(appCodec, app.GAMMKeeper, app.AccountKeeper, app.BankKeeper)
+	am := gamm.NewAppModule(appCodec, *app.GAMMKeeper, app.AccountKeeper, app.BankKeeper)
 	acc1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address().Bytes())
 	err := simapp.FundAccount(app.BankKeeper, ctx, acc1, sdk.NewCoins(
 		sdk.NewCoin("uosmo", sdk.NewInt(10000000000)),
@@ -137,7 +137,7 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 	genesis := am.ExportGenesis(ctx, appCodec)
 	assert.NotPanics(t, func() {
 		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-		am := gamm.NewAppModule(appCodec, app.GAMMKeeper, app.AccountKeeper, app.BankKeeper)
+		am := gamm.NewAppModule(appCodec, *app.GAMMKeeper, app.AccountKeeper, app.BankKeeper)
 		am.InitGenesis(ctx, appCodec, genesis)
 	})
 }

--- a/x/incentives/genesis_test.go
+++ b/x/incentives/genesis_test.go
@@ -18,7 +18,7 @@ func TestIncentivesExportGenesis(t *testing.T) {
 	app := osmoapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
-	genesis := incentives.ExportGenesis(ctx, app.IncentivesKeeper)
+	genesis := incentives.ExportGenesis(ctx, *app.IncentivesKeeper)
 	require.Equal(t, genesis.Params.DistrEpochIdentifier, "week")
 	require.Len(t, genesis.Gauges, 0)
 
@@ -35,7 +35,7 @@ func TestIncentivesExportGenesis(t *testing.T) {
 	gaugeID, err := app.IncentivesKeeper.CreateGauge(ctx, true, addr, coins, distrTo, startTime, 1)
 	require.NoError(t, err)
 
-	genesis = incentives.ExportGenesis(ctx, app.IncentivesKeeper)
+	genesis = incentives.ExportGenesis(ctx, *app.IncentivesKeeper)
 	require.Equal(t, genesis.Params.DistrEpochIdentifier, "week")
 	require.Len(t, genesis.Gauges, 1)
 
@@ -75,7 +75,7 @@ func TestIncentivesInitGenesis(t *testing.T) {
 		DistributedCoins:  sdk.Coins(nil),
 		StartTime:         startTime.UTC(),
 	}
-	incentives.InitGenesis(ctx, app.IncentivesKeeper, types.GenesisState{
+	incentives.InitGenesis(ctx, *app.IncentivesKeeper, types.GenesisState{
 		Params: types.Params{
 			DistrEpochIdentifier: "week",
 		},

--- a/x/lockup/genesis_test.go
+++ b/x/lockup/genesis_test.go
@@ -49,7 +49,7 @@ func TestInitGenesis(t *testing.T) {
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 	ctx = ctx.WithBlockTime(now.Add(time.Second))
 	genesis := testGenesis
-	lockup.InitGenesis(ctx, app.LockupKeeper, genesis)
+	lockup.InitGenesis(ctx, *app.LockupKeeper, genesis)
 
 	coins := app.LockupKeeper.GetAccountLockedCoins(ctx, acc1)
 	require.Equal(t, coins.String(), sdk.NewInt64Coin("foo", 25000000).String())
@@ -70,7 +70,7 @@ func TestExportGenesis(t *testing.T) {
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 	ctx = ctx.WithBlockTime(now.Add(time.Second))
 	genesis := testGenesis
-	lockup.InitGenesis(ctx, app.LockupKeeper, genesis)
+	lockup.InitGenesis(ctx, *app.LockupKeeper, genesis)
 
 	err := simapp.FundAccount(app.BankKeeper, ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestExportGenesis(t *testing.T) {
 	coins := app.LockupKeeper.GetAccountLockedCoins(ctx, acc2)
 	require.Equal(t, coins.String(), sdk.NewInt64Coin("foo", 10000000).String())
 
-	genesisExported := lockup.ExportGenesis(ctx, app.LockupKeeper)
+	genesisExported := lockup.ExportGenesis(ctx, *app.LockupKeeper)
 	require.Equal(t, genesisExported.LastLockId, uint64(11))
 	require.Equal(t, genesisExported.Locks, []types.PeriodLock{
 		{
@@ -121,7 +121,7 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 
 	encodingConfig := osmoapp.MakeEncodingConfig()
 	appCodec := encodingConfig.Marshaler
-	am := lockup.NewAppModule(appCodec, app.LockupKeeper, app.AccountKeeper, app.BankKeeper)
+	am := lockup.NewAppModule(appCodec, *app.LockupKeeper, app.AccountKeeper, app.BankKeeper)
 
 	err := simapp.FundAccount(app.BankKeeper, ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 		app := osmoapp.Setup(false)
 		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 		ctx = ctx.WithBlockTime(now.Add(time.Second))
-		am := lockup.NewAppModule(appCodec, app.LockupKeeper, app.AccountKeeper, app.BankKeeper)
+		am := lockup.NewAppModule(appCodec, *app.LockupKeeper, app.AccountKeeper, app.BankKeeper)
 		am.InitGenesis(ctx, appCodec, genesisExported)
 	})
 }

--- a/x/lockup/keeper/admin_keeper_test.go
+++ b/x/lockup/keeper/admin_keeper_test.go
@@ -26,7 +26,7 @@ func (suite *KeeperTestSuite) TestRelock() {
 	coins2 := sdk.Coins{sdk.NewInt64Coin("stake2", 10)}
 	err = simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr1, coins2)
 	suite.Require().NoError(err)
-	err = keeper.AdminKeeper{suite.app.LockupKeeper}.Relock(suite.ctx, lock.ID, coins2)
+	err = keeper.AdminKeeper{*suite.app.LockupKeeper}.Relock(suite.ctx, lock.ID, coins2)
 	suite.Require().NoError(err)
 
 	storedLock, err := suite.app.LockupKeeper.GetLockByID(suite.ctx, lock.ID)
@@ -50,7 +50,7 @@ func (suite *KeeperTestSuite) BreakLock() {
 	suite.Require().NoError(err)
 
 	// break lock
-	err = keeper.AdminKeeper{suite.app.LockupKeeper}.BreakLock(suite.ctx, lock.ID)
+	err = keeper.AdminKeeper{*suite.app.LockupKeeper}.BreakLock(suite.ctx, lock.ID)
 	suite.Require().NoError(err)
 
 	_, err = suite.app.LockupKeeper.GetLockByID(suite.ctx, lock.ID)

--- a/x/lockup/keeper/msg_server_test.go
+++ b/x/lockup/keeper/msg_server_test.go
@@ -23,7 +23,7 @@ func (suite *KeeperTestSuite) TestMsgLockTokens() {
 	suite.Require().NoError(err)
 
 	// creation of lock via LockTokens
-	msgServer := keeper.NewMsgServerImpl(suite.app.LockupKeeper)
+	msgServer := keeper.NewMsgServerImpl(*suite.app.LockupKeeper)
 	_, err = msgServer.LockTokens(sdk.WrapSDKContext(suite.ctx), types.NewMsgLockTokens(addr1, time.Second, coins))
 
 	// check locks

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -148,7 +148,7 @@ func (suite *KeeperTestSuite) TestDistrAssetToCommunityPoolWhenNoDeveloperReward
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin)
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	feePool := suite.app.DistrKeeper.GetFeePool(suite.ctx)
 	feeCollector := suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
@@ -169,7 +169,7 @@ func (suite *KeeperTestSuite) TestDistrAssetToCommunityPoolWhenNoDeveloperReward
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin)
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	feePool = suite.app.DistrKeeper.GetFeePool(suite.ctx)
 	suite.Equal(

--- a/x/mint/keeper/querier_test.go
+++ b/x/mint/keeper/querier_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewQuerier(t *testing.T) {
 	app, ctx := createTestApp(true)
 	legacyQuerierCdc := codec.NewAminoCodec(app.LegacyAmino())
-	querier := keep.NewQuerier(app.MintKeeper, legacyQuerierCdc.LegacyAmino)
+	querier := keep.NewQuerier(*app.MintKeeper, legacyQuerierCdc.LegacyAmino)
 
 	query := abci.RequestQuery{
 		Path: "",
@@ -37,7 +37,7 @@ func TestNewQuerier(t *testing.T) {
 func TestQueryParams(t *testing.T) {
 	app, ctx := createTestApp(true)
 	legacyQuerierCdc := codec.NewAminoCodec(app.LegacyAmino())
-	querier := keep.NewQuerier(app.MintKeeper, legacyQuerierCdc.LegacyAmino)
+	querier := keep.NewQuerier(*app.MintKeeper, legacyQuerierCdc.LegacyAmino)
 
 	var params types.Params
 
@@ -51,7 +51,7 @@ func TestQueryParams(t *testing.T) {
 func TestQueryEpochProvisions(t *testing.T) {
 	app, ctx := createTestApp(true)
 	legacyQuerierCdc := codec.NewAminoCodec(app.LegacyAmino())
-	querier := keep.NewQuerier(app.MintKeeper, legacyQuerierCdc.LegacyAmino)
+	querier := keep.NewQuerier(*app.MintKeeper, legacyQuerierCdc.LegacyAmino)
 
 	var epochProvisions sdk.Dec
 

--- a/x/pool-incentives/genesis_test.go
+++ b/x/pool-incentives/genesis_test.go
@@ -41,17 +41,17 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 
 	encodingConfig := simapp.MakeEncodingConfig()
 	appCodec := encodingConfig.Marshaler
-	am := pool_incentives.NewAppModule(appCodec, app.PoolIncentivesKeeper)
+	am := pool_incentives.NewAppModule(appCodec, *app.PoolIncentivesKeeper)
 
 	genesis := testGenesis
-	pool_incentives.InitGenesis(ctx, app.PoolIncentivesKeeper, &genesis)
+	pool_incentives.InitGenesis(ctx, *app.PoolIncentivesKeeper, &genesis)
 
 	genesisExported := am.ExportGenesis(ctx, appCodec)
 	assert.NotPanics(t, func() {
 		app := simapp.Setup(false)
 		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 		ctx = ctx.WithBlockTime(now.Add(time.Second))
-		am := pool_incentives.NewAppModule(appCodec, app.PoolIncentivesKeeper)
+		am := pool_incentives.NewAppModule(appCodec, *app.PoolIncentivesKeeper)
 		am.InitGenesis(ctx, appCodec, genesisExported)
 	})
 }
@@ -61,7 +61,7 @@ func TestInitGenesis(t *testing.T) {
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 	ctx = ctx.WithBlockTime(now.Add(time.Second))
 	genesis := testGenesis
-	pool_incentives.InitGenesis(ctx, app.PoolIncentivesKeeper, &genesis)
+	pool_incentives.InitGenesis(ctx, *app.PoolIncentivesKeeper, &genesis)
 
 	params := app.PoolIncentivesKeeper.GetParams(ctx)
 	require.Equal(t, params, genesis.Params)
@@ -78,7 +78,7 @@ func TestExportGenesis(t *testing.T) {
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 	ctx = ctx.WithBlockTime(now.Add(time.Second))
 	genesis := testGenesis
-	pool_incentives.InitGenesis(ctx, app.PoolIncentivesKeeper, &genesis)
+	pool_incentives.InitGenesis(ctx, *app.PoolIncentivesKeeper, &genesis)
 
 	durations := []time.Duration{
 		time.Second,
@@ -90,7 +90,7 @@ func TestExportGenesis(t *testing.T) {
 	savedDurations := app.PoolIncentivesKeeper.GetLockableDurations(ctx)
 	require.Equal(t, savedDurations, durations)
 
-	genesisExported := pool_incentives.ExportGenesis(ctx, app.PoolIncentivesKeeper)
+	genesisExported := pool_incentives.ExportGenesis(ctx, *app.PoolIncentivesKeeper)
 	require.Equal(t, genesisExported.Params, genesis.Params)
 	require.Equal(t, genesisExported.LockableDurations, durations)
 	require.Equal(t, genesisExported.DistrInfo, genesis.DistrInfo)

--- a/x/pool-incentives/keeper/distr_test.go
+++ b/x/pool-incentives/keeper/distr_test.go
@@ -30,7 +30,7 @@ func (suite *KeeperTestSuite) TestAllocateAssetToCommunityPoolWhenNoDistrRecords
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	feePool := suite.app.DistrKeeper.GetFeePool(suite.ctx)
 	suite.Equal("40000stake", suite.app.BankKeeper.GetBalance(suite.ctx, suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "stake").String())
@@ -45,7 +45,7 @@ func (suite *KeeperTestSuite) TestAllocateAssetToCommunityPoolWhenNoDistrRecords
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	feePool = suite.app.DistrKeeper.GetFeePool(suite.ctx)
 	suite.Equal("80000stake", suite.app.BankKeeper.GetBalance(suite.ctx, suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "stake").String())
@@ -106,7 +106,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	suite.Equal("40000stake", suite.app.BankKeeper.GetBalance(suite.ctx, suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "stake").String())
 
@@ -130,7 +130,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	// It has very small margin of error.
 	suite.Equal("60000stake", suite.app.BankKeeper.GetBalance(suite.ctx, suite.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "stake").String())
@@ -174,7 +174,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	// check community pool balance increase
 	feePoolNew := suite.app.DistrKeeper.GetFeePool(suite.ctx)
@@ -197,7 +197,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	err = mintKeeper.DistributeMintedCoin(suite.ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
-	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, suite.app.DistrKeeper)
+	distribution.BeginBlocker(suite.ctx, abci.RequestBeginBlock{}, *suite.app.DistrKeeper)
 
 	// check community pool balance increase
 	feePoolNew = suite.app.DistrKeeper.GetFeePool(suite.ctx)

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -143,7 +143,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			tc.txFee,
 		), []legacytx.StdSignature{}, "")
 
-		mfd := keeper.NewMempoolFeeDecorator(suite.app.TxFeesKeeper)
+		mfd := keeper.NewMempoolFeeDecorator(*suite.app.TxFeesKeeper)
 		antehandler := sdk.ChainAnteDecorators(mfd)
 		_, err := antehandler(suite.ctx, tx, false)
 		if tc.expectPass {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is an alternate design to #696 , I actually like this better. It doesn't involve sweeping breaking changes across the app tests. I think we get the benefits of split up methods, and pointers unless necessary to not use them, without sacrificing usability elsewhere. I think we can get the abstraction we want in a keepers module still, by making a method to go from app -> AppKeepers struct, but not force its use throughout. (This is also really low priority imo)

We are refactoring initializing keepers into five steps, using pointer refs to keepers the whole way through:
* Initializing keepers with special SDK tie-ins", e.g. UpgradeKeeper, ParamsKeeper, CrisisKeeper, CapabilityKeeper.
* Setup upgrade keeper store loaders for new modules
* Initialize all other keepers
* Setup all the hooks
* Setup upgrade migrations

Then we have all other prior logic for setting module managers. The module managers should likely have code deduplicated in a future PR.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

