### PR TITLE
fix: slippage spelling for osmosis docs

### DIFF
--- a/docs/overview/osmosis-app/README.md
+++ b/docs/overview/osmosis-app/README.md
@@ -42,7 +42,7 @@ Once the transaction is completed a series if confirmations notifications will  
 
 ## Swapping Tokens
 
-Trading tokens is as easy as clicking on the Trade link and then selecting the pair you would like to trade.  Check out the [glossary](/overview/terminology.html) to learn about terms such as [slipage](/overview/terminology.html#slippage). 
+Trading tokens is as easy as clicking on the Trade link and then selecting the pair you would like to trade.  Check out the [glossary](/overview/terminology.html) to learn about terms such as [slippage](/overview/terminology.html#slippage). 
 ![](../../assets/swap.png)
 
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description

Fixes typo in osmosis usage documentation.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

No changelog entry is needed since this PR only fixes a typo in the documentation
