### PR TITLE
Arbitrage tx mempool filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Features
 
+- [#741](https://github.com/osmosis-labs/osmosis/pull/741) Allow node operators to set a second min gas price for arbitrage txs.
 - [#623](https://github.com/osmosis-labs/osmosis/pull/623) Use gosec for staticly linting for common non-determinism issues in SDK applications.
 
 ## Minor improvements & Bug Fixes

--- a/app/ante.go
+++ b/app/ante.go
@@ -53,18 +53,20 @@ func NewAnteHandler(
 	)
 }
 
+// TODO: Abstract this function better. We likely need a parse `osmosis-mempool` config section.
 func parseArbGasFromConfig(appOpts servertypes.AppOptions) sdk.Dec {
 	arbMinFeeInterface := appOpts.Get("osmosis-mempool.arbitrage-min-gas-fee")
 	arbMinFee := txfeeskeeper.DefaultArbMinGasFee
 	if arbMinFeeInterface != nil {
 		arbMinFeeStr, ok := arbMinFeeInterface.(string)
 		if !ok {
-			panic("Invalidly configured osmosis-mempool.arbitrage-min-gas-fee")
+			panic("invalidly configured osmosis-mempool.arbitrage-min-gas-fee")
 		}
 		var err error
+		// pre-pend 0 to allow the config to start with a decimal, e.g. ".01"
 		arbMinFee, err = sdk.NewDecFromStr("0" + arbMinFeeStr)
 		if err != nil {
-			panic(fmt.Errorf("Invalidly configured osmosis-mempool.arbitrage-min-gas-fee, err= %v", err))
+			panic(fmt.Errorf("invalidly configured osmosis-mempool.arbitrage-min-gas-fee, err= %v", err))
 		}
 	}
 	return arbMinFee

--- a/app/ante.go
+++ b/app/ante.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"fmt"
+
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -18,19 +21,24 @@ import (
 // Link to default ante handler used by cosmos sdk:
 // https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/x/auth/ante/ante.go#L41
 func NewAnteHandler(
+	appOpts servertypes.AppOptions,
 	ak ante.AccountKeeper, bankKeeper authtypes.BankKeeper,
 	txFeesKeeper *txfeeskeeper.Keeper, spotPriceCalculator txfeestypes.SpotPriceCalculator,
 	sigGasConsumer ante.SignatureVerificationGasConsumer,
 	signModeHandler signing.SignModeHandler,
 	channelKeeper channelkeeper.Keeper,
 ) sdk.AnteHandler {
+	mempoolFeeDecorator := txfeeskeeper.NewMempoolFeeDecorator(*txFeesKeeper)
+	// Optional if anyone else is using this repo. Primarily of impact for Osmosis.
+	// TODO: Abstract this better
+	mempoolFeeDecorator.SetArbMinGasFee(parseArbGasFromConfig(appOpts))
 	return sdk.ChainAnteDecorators(
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		ante.NewRejectExtensionOptionsDecorator(),
 		NewMempoolMaxGasPerTxDecorator(),
 		// Use Mempool Fee Decorator from our txfees module instead of default one from auth
 		// https://github.com/cosmos/cosmos-sdk/blob/master/x/auth/middleware/fee.go#L34
-		txfeeskeeper.NewMempoolFeeDecorator(*txFeesKeeper),
+		mempoolFeeDecorator,
 		ante.NewValidateBasicDecorator(),
 		ante.TxTimeoutHeightDecorator{},
 		ante.NewValidateMemoDecorator(ak),
@@ -43,6 +51,23 @@ func NewAnteHandler(
 		ante.NewIncrementSequenceDecorator(ak),
 		ibcante.NewAnteDecorator(channelKeeper),
 	)
+}
+
+func parseArbGasFromConfig(appOpts servertypes.AppOptions) sdk.Dec {
+	arbMinFeeInterface := appOpts.Get("osmosis-mempool.arbitrage-min-gas-fee")
+	arbMinFee := txfeeskeeper.DefaultArbMinGasFee
+	if arbMinFeeInterface != nil {
+		arbMinFeeStr, ok := arbMinFeeInterface.(string)
+		if !ok {
+			panic("Invalidly configured osmosis-mempool.arbitrage-min-gas-fee")
+		}
+		var err error
+		arbMinFee, err = sdk.NewDecFromStr("0" + arbMinFeeStr)
+		if err != nil {
+			panic(fmt.Errorf("Invalidly configured osmosis-mempool.arbitrage-min-gas-fee, err= %v", err))
+		}
+	}
+	return arbMinFee
 }
 
 // NewMempoolMaxGasPerTxDecorator will check if the transaction's gas

--- a/app/app.go
+++ b/app/app.go
@@ -436,6 +436,7 @@ func NewOsmosisApp(
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetAnteHandler(
 		NewAnteHandler(
+			appOpts,
 			app.AccountKeeper, app.BankKeeper,
 			app.TxFeesKeeper, app.GAMMKeeper,
 			ante.DefaultSigVerificationGasConsumer,

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -111,8 +111,8 @@ func initAppConfig() (string, interface{}) {
 
 [osmosis-mempool]
 # This is the minimum gas fee any arbitrage tx should have, denominated in uosmo per gas
-# Default value of ".01" then means that a tx with 1 million gas costs (.01 uosmo/gas) * 1_000_000 gas = .01 osmo
-arbitrage-min-gas-fee = ".01"
+# Default value of ".005" then means that a tx with 1 million gas costs (.005 uosmo/gas) * 1_000_000 gas = .005 osmo
+arbitrage-min-gas-fee = ".005"
 `
 
 	return OsmosisAppTemplate, OsmosisAppCfg

--- a/x/gamm/types/msg_lp.go
+++ b/x/gamm/types/msg_lp.go
@@ -7,7 +7,8 @@ const (
 	RemoveLiquidity
 )
 
-// SwapMsg defines a simple interface for getting the token denoms on a swap message route.
+// LiquidityChangeMsg defines a simple interface for determining if an LP msg
+// is removing or adding liquidity.
 type LiquidityChangeMsg interface {
 	LiquidityChangeType() LiquidityChangeType
 }

--- a/x/gamm/types/msg_lp.go
+++ b/x/gamm/types/msg_lp.go
@@ -1,0 +1,41 @@
+package types
+
+type LiquidityChangeType int
+
+const (
+	AddLiquidity LiquidityChangeType = iota
+	RemoveLiquidity
+)
+
+// SwapMsg defines a simple interface for getting the token denoms on a swap message route.
+type LiquidityChangeMsg interface {
+	LiquidityChangeType() LiquidityChangeType
+}
+
+var _ LiquidityChangeMsg = MsgExitPool{}
+var _ LiquidityChangeMsg = MsgExitSwapShareAmountIn{}
+var _ LiquidityChangeMsg = MsgExitSwapExternAmountOut{}
+
+var _ LiquidityChangeMsg = MsgJoinPool{}
+var _ LiquidityChangeMsg = MsgJoinSwapExternAmountIn{}
+var _ LiquidityChangeMsg = MsgJoinSwapShareAmountOut{}
+
+func (msg MsgExitPool) LiquidityChangeType() LiquidityChangeType {
+	return RemoveLiquidity
+}
+func (msg MsgExitSwapShareAmountIn) LiquidityChangeType() LiquidityChangeType {
+	return RemoveLiquidity
+}
+func (msg MsgExitSwapExternAmountOut) LiquidityChangeType() LiquidityChangeType {
+	return RemoveLiquidity
+}
+
+func (msg MsgJoinPool) LiquidityChangeType() LiquidityChangeType {
+	return AddLiquidity
+}
+func (msg MsgJoinSwapExternAmountIn) LiquidityChangeType() LiquidityChangeType {
+	return AddLiquidity
+}
+func (msg MsgJoinSwapShareAmountOut) LiquidityChangeType() LiquidityChangeType {
+	return AddLiquidity
+}

--- a/x/gamm/types/msg_swap.go
+++ b/x/gamm/types/msg_swap.go
@@ -1,0 +1,41 @@
+package types
+
+// SwapMsg defines a simple interface for getting the token denoms on a swap message route.
+type SwapMsgRoute interface {
+	TokenInDenom() string
+	TokenOutDenom() string
+	TokenDenomsOnPath() []string
+}
+
+var _ SwapMsgRoute = MsgSwapExactAmountOut{}
+var _ SwapMsgRoute = MsgSwapExactAmountIn{}
+
+func (msg MsgSwapExactAmountOut) TokenInDenom() string {
+	return msg.Routes[0].GetTokenInDenom()
+}
+func (msg MsgSwapExactAmountOut) TokenOutDenom() string {
+	return msg.TokenOut.Denom
+}
+func (msg MsgSwapExactAmountOut) TokenDenomsOnPath() []string {
+	denoms := make([]string, 0, len(msg.Routes)+1)
+	for i := 0; i < len(msg.Routes); i++ {
+		denoms = append(denoms, msg.Routes[i].TokenInDenom)
+	}
+	denoms = append(denoms, msg.TokenOutDenom())
+	return denoms
+}
+
+func (msg MsgSwapExactAmountIn) TokenInDenom() string {
+	return msg.TokenIn.Denom
+}
+func (msg MsgSwapExactAmountIn) TokenOutDenom() string {
+	return msg.Routes[0].GetTokenOutDenom()
+}
+func (msg MsgSwapExactAmountIn) TokenDenomsOnPath() []string {
+	denoms := make([]string, 0, len(msg.Routes)+1)
+	denoms = append(denoms, msg.TokenInDenom())
+	for i := 0; i < len(msg.Routes); i++ {
+		denoms = append(denoms, msg.Routes[i].TokenOutDenom)
+	}
+	return denoms
+}

--- a/x/gamm/types/msg_swap.go
+++ b/x/gamm/types/msg_swap.go
@@ -29,7 +29,8 @@ func (msg MsgSwapExactAmountIn) TokenInDenom() string {
 	return msg.TokenIn.Denom
 }
 func (msg MsgSwapExactAmountIn) TokenOutDenom() string {
-	return msg.Routes[0].GetTokenOutDenom()
+	lastRouteIndex := len(msg.Routes) - 1
+	return msg.Routes[lastRouteIndex].GetTokenOutDenom()
 }
 func (msg MsgSwapExactAmountIn) TokenDenomsOnPath() []string {
 	denoms := make([]string, 0, len(msg.Routes)+1)

--- a/x/txfees/README.md
+++ b/x/txfees/README.md
@@ -20,6 +20,14 @@ Currently the only supported metadata & spot price calculator is using a GAMM po
     * The simple alternative is only check fee equivalency at a txs entry into the mempool, which allows someone to manipulate price down to have many txs enter the chain at low cost.
     * Another alternative is to use TWAP instead of Spot Price once it is available on-chain
     * The former concern isn't very worrisome as long as some nodes have 0 min tx fees.
+* A separate min-gas-fee can be set on every node for arbitrage txs. Methods of detecting an arb tx atm
+  * does start token of a swap = final token of swap (definitionally correct)
+  * does it have multiple swap messages, with different tx ins. If so, we assume its an arb.
+    * This has false positives, but is intended to avoid the obvious solution of splitting an arb into multiple messages.
+  * We record all denoms seen across all swaps, and see if any duplicates. (TODO)
+  * Contains both JoinPool and ExitPool messages in one tx.
+    * Has some false positives.
+  * These false positives seem like they primarily will get hit during batching of many distinct operations, not really in one atomic action.
 
 ## New SDK messages
 

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -8,7 +8,10 @@ import (
 	"github.com/osmosis-labs/osmosis/x/txfees/types"
 )
 
-var DefaultArbMinGasFee sdk.Dec = sdk.NewDecWithPrec(1, 2) // .01uosmo/gas
+// DefaultArbMinGasFee if its not set in a config somewhere.
+// currently 0 uosmo/gas to preserve functionality with old node software
+// TODO: Bump after next minor version. (in 6.2+)
+var DefaultArbMinGasFee sdk.Dec = sdk.ZeroDec()
 
 // MempoolFeeDecorator will check if the transaction's fee is at least as large
 // as the local validator's minimum gasFee (defined in validator config).

--- a/x/txfees/keeper/txfee_filters/README.md
+++ b/x/txfees/keeper/txfee_filters/README.md
@@ -1,0 +1,5 @@
+# TXfee filters
+
+See https://github.com/osmosis-labs/osmosis/issues/738
+
+Want to move towards that, right now this is a stepping stone for that. We currently define a filter for recognizing if a tx is an arb transaction, and if so raising its gas price accordingly.

--- a/x/txfees/keeper/txfee_filters/arb_tx.go
+++ b/x/txfees/keeper/txfee_filters/arb_tx.go
@@ -1,0 +1,51 @@
+package txfee_filters
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gammtypes "github.com/osmosis-labs/osmosis/x/gamm/types"
+)
+
+// We check if a tx is an arbitrage for the mempool right now by seeing:
+// 1) does start token of a msg = final token of msg (definitionally correct)
+// 2) does it have multiple swap messages, with different tx ins. If so, we assume its an arb.
+//    - This has false positives, but is intended to avoid the obvious solution of splitting
+//      an arb into multiple messages.
+// 3) We record all denoms seen across all swaps, and see if any duplicates. (TODO)
+// 4) Contains both JoinPool and ExitPool messages in one tx.
+//    - Has some false positives, but they seem relatively contrived.
+// TODO: Move the first component to a future router module
+func IsArbTxLoose(tx sdk.Tx) bool {
+	msgs := tx.GetMsgs()
+
+	swapInDenom := ""
+	lpTypesSeen := make(map[gammtypes.LiquidityChangeType]bool, 2)
+
+	for _, m := range msgs {
+		// (4) Check that the tx doesn't have both JoinPool & ExitPool msgs
+		lpMsg, isLpMsg := m.(gammtypes.LiquidityChangeMsg)
+		if isLpMsg {
+			lpTypesSeen[lpMsg.LiquidityChangeType()] = true
+			if len(lpTypesSeen) > 1 {
+				return true
+			}
+		}
+
+		swapMsg, isSwapMsg := m.(gammtypes.SwapMsgRoute)
+		if !isSwapMsg {
+			continue
+		}
+
+		// (1) Check that swap denom in != swap denom out
+		if swapMsg.TokenInDenom() == swapMsg.TokenOutDenom() {
+			return true
+		}
+
+		// (2)
+		if swapInDenom != "" && swapMsg.TokenInDenom() != swapInDenom {
+			return true
+		}
+		swapInDenom = swapMsg.TokenInDenom()
+	}
+
+	return false
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #723 

## Description

This PR adds a mempool filter for arbitrage txs. When its hit, it charges a separate gas price, as specified in the full nodes application config.  This defaults to `0 uosmo` if not set in the app.toml, but the app.toml defaults to `.005uosmo/gas`.

The detection algorithm for arbitrage txs does have some false positives, and likely many false negatives. The false positives are described in the code comments, and I think are pretty miniscule. (Only thing I can see hitting it is a service that batches many users swap / LP positions together. Such a batching service seems like it can maintain connections to folks with lower fees though)

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

