### PR TITLE
Make staking keeper passing more idiomatic

### DIFF
--- a/app/keepers.go
+++ b/app/keepers.go
@@ -144,12 +144,12 @@ func (app *OsmosisApp) InitNormalKeepers() {
 	distrKeeper := distrkeeper.NewKeeper(
 		appCodec, keys[distrtypes.StoreKey],
 		app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, authtypes.FeeCollectorName, app.BlockedAddrs(),
+		app.StakingKeeper, authtypes.FeeCollectorName, app.BlockedAddrs(),
 	)
 	app.DistrKeeper = &distrKeeper
 
 	slashingKeeper := slashingkeeper.NewKeeper(
-		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
+		appCodec, keys[slashingtypes.StoreKey], app.StakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
 	)
 	app.SlashingKeeper = &slashingKeeper
 
@@ -158,7 +158,7 @@ func (app *OsmosisApp) InitNormalKeepers() {
 		appCodec,
 		keys[ibchost.StoreKey],
 		app.GetSubspace(ibchost.ModuleName),
-		&stakingKeeper,
+		app.StakingKeeper,
 		app.UpgradeKeeper,
 		app.ScopedIBCKeeper)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The whole point of the keepers.go refactor was to make the keeper on the app a pointer =)
See line 142, `app.StakingKeeper = &stakingKeeper`. This just makes this section cleaner


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`) - N/A
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md` - N/A
- [x] Re-reviewed `Files changed` in the Github PR explorer

