### PR TITLE
fix: Change usage of account keeper in lockup module, incentives module

### DIFF
--- a/app/keepers.go
+++ b/app/keepers.go
@@ -220,7 +220,6 @@ func (app *OsmosisApp) InitNormalKeepers() {
 	app.IncentivesKeeper = incentiveskeeper.NewKeeper(
 		appCodec, keys[incentivestypes.StoreKey],
 		app.GetSubspace(incentivestypes.ModuleName),
-		*app.AccountKeeper,
 		app.BankKeeper, app.LockupKeeper, app.EpochsKeeper)
 
 	mintKeeper := mintkeeper.NewKeeper(

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -211,8 +211,7 @@ func (app *OsmosisApp) InitNormalKeepers() {
 
 	app.LockupKeeper = lockupkeeper.NewKeeper(
 		appCodec, keys[lockuptypes.StoreKey],
-		// TODO: Visit why this needs to be deref'd
-		*app.AccountKeeper,
+		app.AccountKeeper,
 		app.BankKeeper)
 
 	app.EpochsKeeper = epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])

--- a/x/incentives/keeper/keeper.go
+++ b/x/incentives/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/osmosis-labs/osmosis/x/incentives/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -17,13 +16,12 @@ type Keeper struct {
 	storeKey   sdk.StoreKey
 	paramSpace paramtypes.Subspace
 	hooks      types.IncentiveHooks
-	ak         authkeeper.AccountKeeper
 	bk         types.BankKeeper
 	lk         types.LockupKeeper
 	ek         types.EpochKeeper
 }
 
-func NewKeeper(cdc codec.Codec, storeKey sdk.StoreKey, paramSpace paramtypes.Subspace, ak authkeeper.AccountKeeper, bk types.BankKeeper, lk types.LockupKeeper, ek types.EpochKeeper) *Keeper {
+func NewKeeper(cdc codec.Codec, storeKey sdk.StoreKey, paramSpace paramtypes.Subspace, bk types.BankKeeper, lk types.LockupKeeper, ek types.EpochKeeper) *Keeper {
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
 	}
@@ -32,7 +30,6 @@ func NewKeeper(cdc codec.Codec, storeKey sdk.StoreKey, paramSpace paramtypes.Sub
 		cdc:        cdc,
 		storeKey:   storeKey,
 		paramSpace: paramSpace,
-		ak:         ak,
 		bk:         bk,
 		lk:         lk,
 		ek:         ek,

--- a/x/lockup/keeper/keeper.go
+++ b/x/lockup/keeper/keeper.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	"github.com/osmosis-labs/osmosis/x/lockup/types"
 )
 
@@ -18,12 +17,12 @@ type Keeper struct {
 
 	hooks types.LockupHooks
 
-	ak authkeeper.AccountKeeper
+	ak types.AccountKeeper
 	bk types.BankKeeper
 }
 
 // NewKeeper returns an instance of Keeper
-func NewKeeper(cdc codec.Codec, storeKey sdk.StoreKey, ak authkeeper.AccountKeeper, bk types.BankKeeper) *Keeper {
+func NewKeeper(cdc codec.Codec, storeKey sdk.StoreKey, ak types.AccountKeeper, bk types.BankKeeper) *Keeper {
 	return &Keeper{
 		cdc:      cdc,
 		storeKey: storeKey,

--- a/x/lockup/types/expected_keepers.go
+++ b/x/lockup/types/expected_keepers.go
@@ -2,7 +2,12 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
+
+type AccountKeeper interface {
+	GetModuleAccount(ctx sdk.Context, moduleName string) authtypes.ModuleAccountI
+}
 
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#716](https://github.com/osmosis-labs/osmosis/issues/716)

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Currently keeper in the lockup module and the incentives module are using authkeeper as a struct, importing directly from the cosmos-sdk instead of using them with the usage of `expected_keeper.go`.

This PR suggests change in the lockup module so that it uses accountKeeper interface via expected_keeper. 

Additionally, it was found that accountKeeper was imported in incentives module without any usage. Thus, this PR also includes removing taking in accountKeeper as a parameter for the incentives module keeper, resulting in changes in `app.go` as well.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

