### PR TITLE
Makefile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [#765](https://github.com/osmosis-labs/osmosis/pull/765) Fix a bug in `Makefile` regarding the location of localtestnet docker image.
+
 ## Features
 
 - [#741](https://github.com/osmosis-labs/osmosis/pull/741) Allow node operators to set a second min gas price for arbitrage txs.

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ format:
 ###############################################################################
 
 build-docker-osmosisdnode:
-	$(MAKE) -C networks/local
+	$(MAKE) -C contrib/localtestnet
 
 # Run a 4-node testnet locally
 localnet-start: build-linux build-docker-osmosisdnode # localnet-stop


### PR DESCRIPTION
localtestnet docker image directory was incorrect

## Description

Fixes a minor bug in `Makefile`.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
      n/a: only a bug fix
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

