### PR TITLE
Consolidate code between InitGenesis and CreateGauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [97ac2a8](https://github.com/osmosis-labs/osmosis/commit/97ac2a86303fc8966a4c169107e0945775107e67) Fix InitGenesis bug for gauges
 - [#686](https://github.com/osmosis-labs/osmosis/pull/686) Add silence usage to cli to surpress unnecessary help logs
 - [#731](https://github.com/osmosis-labs/osmosis/pull/731) Add UpdateFeeToken proposal handler to app.go
+- [#644](https://github.com/osmosis-labs/osmosis/pull/766) Consolidate code between InitGenesis and CreateGauge
 
 ### SDK fork updates
 

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -58,7 +58,7 @@ func (k Keeper) setGauge(ctx sdk.Context, gauge *types.Gauge) error {
 	return nil
 }
 
-// Reduces codepaths between InitGenesis and CreateGauge
+// CreateGaugeRefKeys adds gauge references as needed. Used to consolidate codepaths for InitGenesis and CreateGauge
 func (k Keeper) CreateGaugeRefKeys(ctx sdk.Context, gauge *types.Gauge, CombinedKeys []byte, ActiveOrUpcomingGauge bool) error {
 	if err := k.addGaugeRefByKey(ctx, CombinedKeys, gauge.Id); err != nil {
 		return err

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -59,7 +59,7 @@ func (k Keeper) setGauge(ctx sdk.Context, gauge *types.Gauge) error {
 }
 
 // Reduces codepaths between InitGenesis and CreateGauge
-func (k Keeper) CreateUpcomingGaugeRefKeys(ctx sdk.Context, gauge *types.Gauge, CombinedKeys []byte, ActiveOrUpcomingGauge bool) error {
+func (k Keeper) CreateGaugeRefKeys(ctx sdk.Context, gauge *types.Gauge, CombinedKeys []byte, ActiveOrUpcomingGauge bool) error {
 	if err := k.addGaugeRefByKey(ctx, CombinedKeys, gauge.Id); err != nil {
 		return err
 	}
@@ -83,13 +83,13 @@ func (k Keeper) SetGaugeWithRefKey(ctx sdk.Context, gauge *types.Gauge) error {
 
 	if gauge.IsUpcomingGauge(curTime) {
 		CombinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, timeKey)
-		err = k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		err = k.CreateGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	} else if gauge.IsActiveGauge(curTime) {
 		CombinedKeys := combineKeys(types.KeyPrefixActiveGauges, timeKey)
-		err = k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		err = k.CreateGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	} else {
 		CombinedKeys := combineKeys(types.KeyPrefixFinishedGauges, timeKey)
-		err = k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		err = k.CreateGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	}
 
 	if err != nil {
@@ -144,7 +144,7 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 	CombinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, getTimeKey(gauge.StartTime))
 	ActiveOrUpcomingGauge := true
 
-	err = k.CreateUpcomingGaugeRefKeys(ctx, &gauge, CombinedKeys, ActiveOrUpcomingGauge)
+	err = k.CreateGaugeRefKeys(ctx, &gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	if err != nil {
 		return 0, err
 	}

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -83,14 +83,19 @@ func (k Keeper) SetGaugeWithRefKey(ctx sdk.Context, gauge *types.Gauge) error {
 
 	if gauge.IsUpcomingGauge(curTime) {
 		CombinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, timeKey)
-		k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		err = k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	} else if gauge.IsActiveGauge(curTime) {
 		CombinedKeys := combineKeys(types.KeyPrefixActiveGauges, timeKey)
-		k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		err = k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	} else {
 		CombinedKeys := combineKeys(types.KeyPrefixFinishedGauges, timeKey)
-		k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		err = k.CreateUpcomingGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
 	}
+
+	if err != nil {
+		return err
+	}
+
 	store := ctx.KVStore(k.storeKey)
 	bz, err := proto.Marshal(gauge)
 	if err != nil {
@@ -139,7 +144,10 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 	CombinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, getTimeKey(gauge.StartTime))
 	ActiveOrUpcomingGauge := true
 
-	k.CreateUpcomingGaugeRefKeys(ctx, &gauge, CombinedKeys, ActiveOrUpcomingGauge)
+	err = k.CreateUpcomingGaugeRefKeys(ctx, &gauge, CombinedKeys, ActiveOrUpcomingGauge)
+	if err != nil {
+		return 0, err
+	}
 	k.hooks.AfterCreateGauge(ctx, gauge.Id)
 	return gauge.Id, nil
 }

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -59,11 +59,11 @@ func (k Keeper) setGauge(ctx sdk.Context, gauge *types.Gauge) error {
 }
 
 // CreateGaugeRefKeys adds gauge references as needed. Used to consolidate codepaths for InitGenesis and CreateGauge
-func (k Keeper) CreateGaugeRefKeys(ctx sdk.Context, gauge *types.Gauge, CombinedKeys []byte, ActiveOrUpcomingGauge bool) error {
-	if err := k.addGaugeRefByKey(ctx, CombinedKeys, gauge.Id); err != nil {
+func (k Keeper) CreateGaugeRefKeys(ctx sdk.Context, gauge *types.Gauge, combinedKeys []byte, activeOrUpcomingGauge bool) error {
+	if err := k.addGaugeRefByKey(ctx, combinedKeys, gauge.Id); err != nil {
 		return err
 	}
-	if ActiveOrUpcomingGauge {
+	if activeOrUpcomingGauge {
 		if err := k.addGaugeIDForDenom(ctx, gauge.Id, gauge.DistributeTo.Denom); err != nil {
 			return err
 		}
@@ -79,17 +79,17 @@ func (k Keeper) SetGaugeWithRefKey(ctx sdk.Context, gauge *types.Gauge) error {
 
 	curTime := ctx.BlockTime()
 	timeKey := getTimeKey(gauge.StartTime)
-	ActiveOrUpcomingGauge := gauge.IsActiveGauge(curTime) || gauge.IsUpcomingGauge(curTime)
+	activeOrUpcomingGauge := gauge.IsActiveGauge(curTime) || gauge.IsUpcomingGauge(curTime)
 
 	if gauge.IsUpcomingGauge(curTime) {
-		CombinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, timeKey)
-		err = k.CreateGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		combinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, timeKey)
+		err = k.CreateGaugeRefKeys(ctx, gauge, combinedKeys, activeOrUpcomingGauge)
 	} else if gauge.IsActiveGauge(curTime) {
-		CombinedKeys := combineKeys(types.KeyPrefixActiveGauges, timeKey)
-		err = k.CreateGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		combinedKeys := combineKeys(types.KeyPrefixActiveGauges, timeKey)
+		err = k.CreateGaugeRefKeys(ctx, gauge, combinedKeys, activeOrUpcomingGauge)
 	} else {
-		CombinedKeys := combineKeys(types.KeyPrefixFinishedGauges, timeKey)
-		err = k.CreateGaugeRefKeys(ctx, gauge, CombinedKeys, ActiveOrUpcomingGauge)
+		combinedKeys := combineKeys(types.KeyPrefixFinishedGauges, timeKey)
+		err = k.CreateGaugeRefKeys(ctx, gauge, combinedKeys, activeOrUpcomingGauge)
 	}
 
 	if err != nil {
@@ -141,10 +141,10 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 	k.setLastGaugeID(ctx, gauge.Id)
 
 	// TODO: Do we need to be concerned with case where this should be ActiveGauges?
-	CombinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, getTimeKey(gauge.StartTime))
-	ActiveOrUpcomingGauge := true
+	combinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, getTimeKey(gauge.StartTime))
+	activeOrUpcomingGauge := true
 
-	err = k.CreateGaugeRefKeys(ctx, &gauge, CombinedKeys, ActiveOrUpcomingGauge)
+	err = k.CreateGaugeRefKeys(ctx, &gauge, combinedKeys, activeOrUpcomingGauge)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #644 

## Description

<!-- Previously, there were no shared code paths between `InitGenesis` and `CreateUpcomingGaugeRefKeys`.  This PR adds a separate function titled `CreateUpcomingGaugeRefKeys` that is used by both `InitGenesis` (i.e. the `k.SetGaugeWithRefKey(ctx, &gauge)` call) and `CreateGauge`, and also changes a small amount of logic in both functions.  In particular, there is now a flag `ActiveOrUpcomingGauge` that denotes whether a gauge is either upcoming or active.  This flag is passed into `CreateUpcomingGaugeRefKeys` and executes `k.addGaugeRefByKey` or `k.addGaugeIDForDenom` accordingly.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

