### PR TITLE
Delete duplicate usage of setGauge at Incentives module InitGenesis

### DIFF
--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -85,12 +85,7 @@ func (k Keeper) SetGaugeWithRefKey(ctx sdk.Context, gauge *types.Gauge) error {
 			return err
 		}
 	}
-	store := ctx.KVStore(k.storeKey)
-	bz, err := proto.Marshal(gauge)
-	if err != nil {
-		return err
-	}
-	store.Set(gaugeStoreKey(gauge.Id), bz)
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Currently, the `SetGaugeWithRefKey` method which is getting called in initGenesis for the incentive module has duplicate code where setGauge would be done twice(at the beginning of the method, at the end of the method). 

This PR removes the duplicate instance of setting gauges.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

