### PR TITLE
Add migration step to make x/wasm permissioned

### DIFF
--- a/app/genesis.go
+++ b/app/genesis.go
@@ -28,7 +28,7 @@ func NewDefaultGenesisState() GenesisState {
 			InstantiateDefaultPermission: wasmtypes.AccessTypeEverybody,
 			// DefaultMaxWasmCodeSize limit max bytes read to prevent gzip bombs
 			// It is 1200 KB in x/wasm, update it later via governance if really needed
-			MaxWasmCodeSize:              wasmtypes.DefaultMaxWasmCodeSize,
+			MaxWasmCodeSize: wasmtypes.DefaultMaxWasmCodeSize,
 		},
 	}
 	gen[wasm.ModuleName] = encCfg.Marshaler.MustMarshalJSON(&wasmGen)

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
@@ -15,12 +16,6 @@ import (
 // object provided to it during init.
 type GenesisState map[string]json.RawMessage
 
-const (
-	// DefaultMaxWasmCodeSize limit max bytes read to prevent gzip bombs
-	// 600 KB is copied from x/wasm, but you can customize here as desired
-	DefaultMaxWasmCodeSize = 600 * 1024 * 2
-)
-
 // NewDefaultGenesisState generates the default state for the application.
 func NewDefaultGenesisState() GenesisState {
 	encCfg := MakeEncodingConfig()
@@ -31,7 +26,9 @@ func NewDefaultGenesisState() GenesisState {
 		Params: wasmtypes.Params{
 			CodeUploadAccess:             wasmtypes.AllowNobody,
 			InstantiateDefaultPermission: wasmtypes.AccessTypeEverybody,
-			MaxWasmCodeSize:              DefaultMaxWasmCodeSize,
+			// DefaultMaxWasmCodeSize limit max bytes read to prevent gzip bombs
+			// It is 1200 KB in x/wasm, update it later via governance if really needed
+			MaxWasmCodeSize:              wasmtypes.DefaultMaxWasmCodeSize,
 		},
 	}
 	gen[wasm.ModuleName] = encCfg.Marshaler.MustMarshalJSON(&wasmGen)

--- a/app/upgrades/v7/upgrades.go
+++ b/app/upgrades/v7/upgrades.go
@@ -3,9 +3,10 @@ package v7
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
 func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator,
@@ -22,6 +23,13 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator,
 		if err != nil {
 			return newVM, err
 		}
+
+		// Since we provide custom DefaultGenesis (privileges StoreCode) in app/genesis.go rather than
+		// the wasm module, we need to set the params here when migrating (is it is not customized).
+
+		params := wasmKeeper.GetParams(ctx)
+		params.CodeUploadAccess = wasmtypes.AllowNobody
+		wasmKeeper.SetParams(ctx, params)
 
 		// override here
 		return newVM, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Builds on #822 

## Description

This ensures the permissioned parameters are set when doing a migration and not coming from genesis

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

