### PR TITLE
Move lock.go functions into iterator.go, lock_refs.go and store.go

### DIFF
--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -7,118 +7,17 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/gogo/protobuf/proto"
 	"github.com/osmosis-labs/osmosis/store"
 	"github.com/osmosis-labs/osmosis/x/lockup/types"
-	db "github.com/tendermint/tm-db"
 )
 
-func (k Keeper) getLocksFromIterator(ctx sdk.Context, iterator db.Iterator) []types.PeriodLock {
-	locks := []types.PeriodLock{}
-	defer iterator.Close()
-	for ; iterator.Valid(); iterator.Next() {
-		lockID := sdk.BigEndianToUint64(iterator.Value())
-		lock, err := k.GetLockByID(ctx, lockID)
-		if err != nil {
-			panic(err)
-		}
-		locks = append(locks, *lock)
-	}
-	return locks
-}
-
-func (k Keeper) beginUnlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]types.PeriodLock, sdk.Coins, error) {
-	// Note: this function is only used for an account
-	// and this has no conflicts with synthetic lockups
-
-	coins := sdk.Coins{}
-	locks := k.getLocksFromIterator(ctx, iterator)
-	for _, lock := range locks {
-		err := k.BeginUnlock(ctx, lock)
-		if err != nil {
-			return locks, coins, err
-		}
-		// sum up all coins begin unlocking
-		coins = coins.Add(lock.Coins...)
-	}
-	return locks, coins, nil
-}
+// TODO: Reorganize functions in this file
 
 // WithdrawAllMaturedLocks withdraws every lock thats in the process of unlocking, and has finished unlocking by
 // the current block time.
 func (k Keeper) WithdrawAllMaturedLocks(ctx sdk.Context) {
 	k.unlockFromIterator(ctx, k.LockIteratorBeforeTime(ctx, true, ctx.BlockTime()))
-}
-
-func (k Keeper) addLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types.PeriodLock) error {
-	refKeys, err := lockRefKeys(lock)
-	if err != nil {
-		return err
-	}
-	for _, refKey := range refKeys {
-		if err := k.addLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), lock.ID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (k Keeper) deleteLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types.PeriodLock) error {
-	refKeys, err := lockRefKeys(lock)
-	if err != nil {
-		return err
-	}
-	for _, refKey := range refKeys {
-		if err := k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), lock.ID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// XXX
-func (k Keeper) addSyntheticLockRefs(ctx sdk.Context, lockRefPrefix []byte, synthLock types.SyntheticLock) error {
-	refKeys, err := syntheticLockRefKeys(synthLock)
-	if err != nil {
-		return err
-	}
-	for _, refKey := range refKeys {
-		if err := k.addLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (k Keeper) deleteSyntheticLockRefs(ctx sdk.Context, lockRefPrefix []byte, synthLock types.SyntheticLock) error {
-	refKeys, err := syntheticLockRefKeys(synthLock)
-	if err != nil {
-		return err
-	}
-	for _, refKey := range refKeys {
-		if err := k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (k Keeper) unlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]types.PeriodLock, sdk.Coins) {
-	// Note: this function is only used for an account
-	// and this has no conflicts with synthetic lockups
-
-	coins := sdk.Coins{}
-	locks := k.getLocksFromIterator(ctx, iterator)
-	for _, lock := range locks {
-		err := k.Unlock(ctx, lock)
-		if err != nil {
-			panic(err)
-		}
-		// sum up all coins unlocked
-		coins = coins.Add(lock.Coins...)
-	}
-	return locks, coins
 }
 
 func (k Keeper) getCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
@@ -127,10 +26,6 @@ func (k Keeper) getCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
 		coins = coins.Add(lock.Coins...)
 	}
 	return coins
-}
-
-func (k Keeper) getCoinsFromIterator(ctx sdk.Context, iterator db.Iterator) sdk.Coins {
-	return k.getCoinsFromLocks(k.getLocksFromIterator(ctx, iterator))
 }
 
 func (k Keeper) accumulationStore(ctx sdk.Context, denom string) store.Tree {
@@ -150,156 +45,6 @@ func (k Keeper) GetModuleLockedCoins(ctx sdk.Context) sdk.Coins {
 	notUnlockingCoins := k.getCoinsFromIterator(ctx, k.LockIterator(ctx, false))
 	unlockingCoins := k.getCoinsFromIterator(ctx, k.LockIteratorAfterTime(ctx, true, ctx.BlockTime()))
 	return notUnlockingCoins.Add(unlockingCoins...)
-}
-
-// GetAccountUnlockableCoins Returns whole unlockable coins which are not withdrawn yet
-func (k Keeper) GetAccountUnlockableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
-	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, true, addr, ctx.BlockTime()))
-}
-
-// GetAccountUnlockingCoins Returns whole unlocking coins
-func (k Keeper) GetAccountUnlockingCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
-	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, ctx.BlockTime()))
-}
-
-// GetAccountLockedCoins Returns a locked coins that can't be withdrawn
-func (k Keeper) GetAccountLockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
-	// all account unlocking + not finished unlocking
-	notUnlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIterator(ctx, false, addr))
-	unlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, ctx.BlockTime()))
-	return notUnlockingCoins.Add(unlockingCoins...)
-}
-
-// GetAccountLockedPastTime Returns the total locks of an account whose unlock time is beyond timestamp
-func (k Keeper) GetAccountLockedPastTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
-	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, timestamp))
-	duration := time.Duration(0)
-	if timestamp.After(ctx.BlockTime()) {
-		duration = timestamp.Sub(ctx.BlockTime())
-	}
-	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-// GetAccountLockedPastTimeNotUnlockingOnly Returns the total locks of an account whose unlock time is beyond timestamp
-func (k Keeper) GetAccountLockedPastTimeNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
-	duration := time.Duration(0)
-	if timestamp.After(ctx.BlockTime()) {
-		duration = timestamp.Sub(ctx.BlockTime())
-	}
-	return k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
-}
-
-// GetAccountUnlockedBeforeTime Returns the total unlocks of an account whose unlock time is before timestamp
-func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
-	// unlockings finish before specific time + not started locks that can finish before the time if start now
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, true, addr, timestamp))
-	if timestamp.Before(ctx.BlockTime()) {
-		return unlockings
-	}
-	duration := timestamp.Sub(ctx.BlockTime())
-	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorShorterThanDuration(ctx, false, addr, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-// GetAccountLockedPastTimeDenom is equal to GetAccountLockedPastTime but denom specific
-func (k Keeper) GetAccountLockedPastTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, timestamp time.Time) []types.PeriodLock {
-	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTimeDenom(ctx, true, addr, denom, timestamp))
-	duration := time.Duration(0)
-	if timestamp.After(ctx.BlockTime()) {
-		duration = timestamp.Sub(ctx.BlockTime())
-	}
-	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, false, addr, denom, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-// GetAccountLockedDurationNotUnlockingOnly Returns account locked with specific duration within not unlockings
-func (k Keeper) GetAccountLockedDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
-	return k.getLocksFromIterator(ctx, k.AccountLockIteratorDurationDenom(ctx, false, addr, denom, duration))
-}
-
-// GetAccountLockedLongerDuration Returns account locked with duration longer than specified
-func (k Keeper) GetAccountLockedLongerDuration(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
-	// it does not matter started unlocking or not for duration query
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, true, addr, duration))
-	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-// GetAccountLockedLongerDurationNotUnlockingOnly Returns account locked with duration longer than specified
-func (k Keeper) GetAccountLockedLongerDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
-	return k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
-}
-
-// GetAccountLockedLongerDurationDenom Returns account locked with duration longer than specified with specific denom
-func (k Keeper) GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
-	// it does not matter started unlocking or not for duration query
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, true, addr, denom, duration))
-	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, false, addr, denom, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-// GetLocksPastTimeDenom Returns the locks whose unlock time is beyond timestamp
-func (k Keeper) GetLocksPastTimeDenom(ctx sdk.Context, denom string, timestamp time.Time) []types.PeriodLock {
-	// returns both unlocking started and not started assuming it started unlocking current time
-	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorAfterTimeDenom(ctx, true, denom, timestamp))
-	duration := time.Duration(0)
-	if timestamp.After(ctx.BlockTime()) {
-		duration = timestamp.Sub(ctx.BlockTime())
-	}
-	notUnlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, false, denom, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-func (k Keeper) GetLocksDenom(ctx sdk.Context, denom string) []types.PeriodLock {
-	return k.GetLocksLongerThanDurationDenom(ctx, denom, time.Duration(0))
-}
-
-// GetLockedDenom Returns the total amount of denom that are locked
-func (k Keeper) GetLockedDenom(ctx sdk.Context, denom string, duration time.Duration) sdk.Int {
-	totalAmtLocked := k.GetPeriodLocksAccumulation(ctx, types.QueryCondition{
-		LockQueryType: types.ByDuration,
-		Denom:         denom,
-		Duration:      duration,
-	})
-	return totalAmtLocked
-}
-
-// GetLocksLongerThanDurationDenom Returns the locks whose unlock duration is longer than duration
-func (k Keeper) GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []types.PeriodLock {
-	// returns both unlocking started and not started
-	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, true, denom, duration))
-	notUnlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, false, denom, duration))
-	return combineLocks(notUnlockings, unlockings)
-}
-
-// GetLockByID Returns lock from lockID
-func (k Keeper) GetLockByID(ctx sdk.Context, lockID uint64) (*types.PeriodLock, error) {
-	lock := types.PeriodLock{}
-	store := ctx.KVStore(k.storeKey)
-	lockKey := lockStoreKey(lockID)
-	if !store.Has(lockKey) {
-		return nil, sdkerrors.Wrap(types.ErrLockupNotFound, fmt.Sprintf("lock with ID %d does not exist", lockID))
-	}
-	bz := store.Get(lockKey)
-	err := proto.Unmarshal(bz, &lock)
-	return &lock, err
-}
-
-// GetPeriodLocks Returns the period locks on pool
-func (k Keeper) GetPeriodLocks(ctx sdk.Context) ([]types.PeriodLock, error) {
-	unlockings := k.getLocksFromIterator(ctx, k.LockIterator(ctx, true))
-	notUnlockings := k.getLocksFromIterator(ctx, k.LockIterator(ctx, false))
-	return combineLocks(notUnlockings, unlockings), nil
-}
-
-// GetAccountPeriodLocks Returns the period locks associated to an account
-func (k Keeper) GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []types.PeriodLock {
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIterator(ctx, true, addr))
-	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIterator(ctx, false, addr))
-	return combineLocks(notUnlockings, unlockings)
 }
 
 // GetPeriodLocksByDuration returns the total amount of query.Denom tokens locked for longer than
@@ -478,11 +223,6 @@ func (k Keeper) clearKeysByPrefix(ctx sdk.Context, prefix []byte) {
 	for ; iterator.Valid(); iterator.Next() {
 		store.Delete(iterator.Key())
 	}
-}
-
-func (k Keeper) ClearAllLockRefKeys(ctx sdk.Context) {
-	k.clearKeysByPrefix(ctx, types.KeyPrefixNotUnlocking)
-	k.clearKeysByPrefix(ctx, types.KeyPrefixUnlocking)
 }
 
 func (k Keeper) ClearAccumulationStores(ctx sdk.Context) {

--- a/x/lockup/keeper/lock_refs.go
+++ b/x/lockup/keeper/lock_refs.go
@@ -1,0 +1,64 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/x/lockup/types"
+)
+
+func (k Keeper) addLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types.PeriodLock) error {
+	refKeys, err := lockRefKeys(lock)
+	if err != nil {
+		return err
+	}
+	for _, refKey := range refKeys {
+		if err := k.addLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), lock.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k Keeper) deleteLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types.PeriodLock) error {
+	refKeys, err := lockRefKeys(lock)
+	if err != nil {
+		return err
+	}
+	for _, refKey := range refKeys {
+		if err := k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), lock.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// XXX
+func (k Keeper) addSyntheticLockRefs(ctx sdk.Context, lockRefPrefix []byte, synthLock types.SyntheticLock) error {
+	refKeys, err := syntheticLockRefKeys(synthLock)
+	if err != nil {
+		return err
+	}
+	for _, refKey := range refKeys {
+		if err := k.addLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k Keeper) deleteSyntheticLockRefs(ctx sdk.Context, lockRefPrefix []byte, synthLock types.SyntheticLock) error {
+	refKeys, err := syntheticLockRefKeys(synthLock)
+	if err != nil {
+		return err
+	}
+	for _, refKey := range refKeys {
+		if err := k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k Keeper) ClearAllLockRefKeys(ctx sdk.Context) {
+	k.clearKeysByPrefix(ctx, types.KeyPrefixNotUnlocking)
+	k.clearKeysByPrefix(ctx, types.KeyPrefixUnlocking)
+}

--- a/x/lockup/keeper/store.go
+++ b/x/lockup/keeper/store.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/gogo/protobuf/proto"
 	"github.com/osmosis-labs/osmosis/x/lockup/types"
 )
 
@@ -104,4 +106,154 @@ func (k Keeper) ClearAllAccumulationStores(ctx sdk.Context) {
 	for ; iter.Valid(); iter.Next() {
 		store.Delete(iter.Key())
 	}
+}
+
+// GetAccountUnlockableCoins Returns whole unlockable coins which are not withdrawn yet
+func (k Keeper) GetAccountUnlockableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, true, addr, ctx.BlockTime()))
+}
+
+// GetAccountUnlockingCoins Returns whole unlocking coins
+func (k Keeper) GetAccountUnlockingCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, ctx.BlockTime()))
+}
+
+// GetAccountLockedCoins Returns a locked coins that can't be withdrawn
+func (k Keeper) GetAccountLockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+	// all account unlocking + not finished unlocking
+	notUnlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIterator(ctx, false, addr))
+	unlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, ctx.BlockTime()))
+	return notUnlockingCoins.Add(unlockingCoins...)
+}
+
+// GetAccountLockedPastTime Returns the total locks of an account whose unlock time is beyond timestamp
+func (k Keeper) GetAccountLockedPastTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
+	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, timestamp))
+	duration := time.Duration(0)
+	if timestamp.After(ctx.BlockTime()) {
+		duration = timestamp.Sub(ctx.BlockTime())
+	}
+	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+// GetAccountLockedPastTimeNotUnlockingOnly Returns the total locks of an account whose unlock time is beyond timestamp
+func (k Keeper) GetAccountLockedPastTimeNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
+	duration := time.Duration(0)
+	if timestamp.After(ctx.BlockTime()) {
+		duration = timestamp.Sub(ctx.BlockTime())
+	}
+	return k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
+}
+
+// GetAccountUnlockedBeforeTime Returns the total unlocks of an account whose unlock time is before timestamp
+func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
+	// unlockings finish before specific time + not started locks that can finish before the time if start now
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, true, addr, timestamp))
+	if timestamp.Before(ctx.BlockTime()) {
+		return unlockings
+	}
+	duration := timestamp.Sub(ctx.BlockTime())
+	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorShorterThanDuration(ctx, false, addr, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+// GetAccountLockedPastTimeDenom is equal to GetAccountLockedPastTime but denom specific
+func (k Keeper) GetAccountLockedPastTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, timestamp time.Time) []types.PeriodLock {
+	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTimeDenom(ctx, true, addr, denom, timestamp))
+	duration := time.Duration(0)
+	if timestamp.After(ctx.BlockTime()) {
+		duration = timestamp.Sub(ctx.BlockTime())
+	}
+	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, false, addr, denom, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+// GetAccountLockedDurationNotUnlockingOnly Returns account locked with specific duration within not unlockings
+func (k Keeper) GetAccountLockedDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
+	return k.getLocksFromIterator(ctx, k.AccountLockIteratorDurationDenom(ctx, false, addr, denom, duration))
+}
+
+// GetAccountLockedLongerDuration Returns account locked with duration longer than specified
+func (k Keeper) GetAccountLockedLongerDuration(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
+	// it does not matter started unlocking or not for duration query
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, true, addr, duration))
+	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+// GetAccountLockedLongerDurationNotUnlockingOnly Returns account locked with duration longer than specified
+func (k Keeper) GetAccountLockedLongerDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
+	return k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
+}
+
+// GetAccountLockedLongerDurationDenom Returns account locked with duration longer than specified with specific denom
+func (k Keeper) GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
+	// it does not matter started unlocking or not for duration query
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, true, addr, denom, duration))
+	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, false, addr, denom, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+// GetLocksPastTimeDenom Returns the locks whose unlock time is beyond timestamp
+func (k Keeper) GetLocksPastTimeDenom(ctx sdk.Context, denom string, timestamp time.Time) []types.PeriodLock {
+	// returns both unlocking started and not started assuming it started unlocking current time
+	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorAfterTimeDenom(ctx, true, denom, timestamp))
+	duration := time.Duration(0)
+	if timestamp.After(ctx.BlockTime()) {
+		duration = timestamp.Sub(ctx.BlockTime())
+	}
+	notUnlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, false, denom, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+func (k Keeper) GetLocksDenom(ctx sdk.Context, denom string) []types.PeriodLock {
+	return k.GetLocksLongerThanDurationDenom(ctx, denom, time.Duration(0))
+}
+
+// GetLockedDenom Returns the total amount of denom that are locked
+func (k Keeper) GetLockedDenom(ctx sdk.Context, denom string, duration time.Duration) sdk.Int {
+	totalAmtLocked := k.GetPeriodLocksAccumulation(ctx, types.QueryCondition{
+		LockQueryType: types.ByDuration,
+		Denom:         denom,
+		Duration:      duration,
+	})
+	return totalAmtLocked
+}
+
+// GetLocksLongerThanDurationDenom Returns the locks whose unlock duration is longer than duration
+func (k Keeper) GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []types.PeriodLock {
+	// returns both unlocking started and not started
+	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, true, denom, duration))
+	notUnlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, false, denom, duration))
+	return combineLocks(notUnlockings, unlockings)
+}
+
+// GetLockByID Returns lock from lockID
+func (k Keeper) GetLockByID(ctx sdk.Context, lockID uint64) (*types.PeriodLock, error) {
+	lock := types.PeriodLock{}
+	store := ctx.KVStore(k.storeKey)
+	lockKey := lockStoreKey(lockID)
+	if !store.Has(lockKey) {
+		return nil, sdkerrors.Wrap(types.ErrLockupNotFound, fmt.Sprintf("lock with ID %d does not exist", lockID))
+	}
+	bz := store.Get(lockKey)
+	err := proto.Unmarshal(bz, &lock)
+	return &lock, err
+}
+
+// GetPeriodLocks Returns the period locks on pool
+func (k Keeper) GetPeriodLocks(ctx sdk.Context) ([]types.PeriodLock, error) {
+	unlockings := k.getLocksFromIterator(ctx, k.LockIterator(ctx, true))
+	notUnlockings := k.getLocksFromIterator(ctx, k.LockIterator(ctx, false))
+	return combineLocks(notUnlockings, unlockings), nil
+}
+
+// GetAccountPeriodLocks Returns the period locks associated to an account
+func (k Keeper) GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []types.PeriodLock {
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIterator(ctx, true, addr))
+	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIterator(ctx, false, addr))
+	return combineLocks(notUnlockings, unlockings)
 }

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -31,6 +31,7 @@ func (p SyntheticLock) IsUnlocking() bool {
 
 func SumLocksByDenom(locks []PeriodLock, denom string) sdk.Int {
 	sum := sdk.NewInt(0)
+	// validate the denom once, so we can avoid the expensive validate check in the hot loop.
 	err := sdk.ValidateDenom(denom)
 	if err != nil {
 		panic(fmt.Errorf("invalid denom used internally: %s, %v", denom, err))

--- a/x/lockup/types/types.go
+++ b/x/lockup/types/types.go
@@ -1,1 +1,0 @@
-package types


### PR DESCRIPTION
This makes the code more structured, and is a precursor to a subsequent commit
of trying to de-duplicate a lot of this logic to reduce API & bug surface

I'm making this a separate PR to make it easy to review method re-shuffles / refactor work, independently from changes into the logic.
