### PR TITLE
Ensure gauges can only be created for assets that exist on-chain

### DIFF
--- a/proto/osmosis/lockup/lock.proto
+++ b/proto/osmosis/lockup/lock.proto
@@ -39,8 +39,10 @@ enum LockQueryType {
 }
 
 message QueryCondition {
-  LockQueryType lock_query_type = 1; // type of lock query, ByLockDuration | ByLockTime
-  string denom = 2; // What token denomination are we looking for lockups of
+  // type of lock query, ByLockDuration | ByLockTime
+  LockQueryType lock_query_type = 1;
+  // What token denomination are we looking for lockups of
+  string denom = 2;
   // valid when query condition is ByDuration
   google.protobuf.Duration duration = 3 [
     (gogoproto.stdduration) = true,

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -100,7 +100,7 @@ func (k Keeper) SetGaugeWithRefKey(ctx sdk.Context, gauge *types.Gauge) error {
 
 // CreateGauge create a gauge and send coins to the gauge
 func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddress, coins sdk.Coins, distrTo lockuptypes.QueryCondition, startTime time.Time, numEpochsPaidOver uint64) (uint64, error) {
-	
+
 	// Ensure that this gauge's duration is one of the allowed durations on chain
 	durations := k.GetLockableDurations(ctx)
 	if distrTo.LockQueryType == lockuptypes.ByDuration {
@@ -116,29 +116,9 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 		}
 	}
 
-	/* Questions:
-		1. Are the function inputs correct?
-		
-		2. How do we account for what happens if k.bk.HasSupply() fails or throws an error? - go stuff
-			general in go: https://earthly.dev/blog/golang-errors/
-
-		3. Is using "break" here a clean approach, or would it be better to bake this into the logic 
-		   of the whole function (i.e. wrap in an if statement)?
-		
-		4. How can I run existing tests against this and/or create my own for it?
-			setup state you want - we want table driven tests. automate most of the setup/post-condition testing bits.
-			
-			go test ./...
-
-			example: https://github.com/osmosis-labs/osmosis/blob/main/x/gamm/pool-models/balancer/balancer_pool_test.go#L151-L272
-
-		5. Why is the distrTo parameter type "lockuptypes.QueryCondition"? What does the "QueryCondition"
-		   part mean and where does it come from?
-	*/
-
 	// Ensure that the denom this gauge pays out to exists on-chain
-	if k.bk.HasSupply(ctx, distrTo.Denom) {
-		return 0, fmt.Errorf("denom does not exist: %d", distrTo.Denom)
+	if !k.bk.HasSupply(ctx, distrTo.Denom) {
+		return 0, fmt.Errorf("denom does not exist: %s", distrTo.Denom)
 	}
 
 	gauge := types.Gauge{

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -25,6 +25,23 @@ func (suite *KeeperTestSuite) TestInvalidDurationGaugeCreationValidation() {
 	suite.Require().NoError(err)
 }
 
+func (suite *KeeperTestSuite) TestNonExistentDenomGaugeCreation() {
+	suite.SetupTest()
+
+	addrNoSupply := sdk.AccAddress([]byte("Gauge_Creation_Addr_"))
+	addrs := suite.SetupManyLocks(1, defaultLiquidTokens, defaultLPTokens, defaultLockDuration)
+	distrTo := lockuptypes.QueryCondition{
+		LockQueryType: lockuptypes.ByDuration,
+		Denom:         defaultLPDenom,
+		Duration:      defaultLockDuration,
+	}
+	_, err := suite.app.IncentivesKeeper.CreateGauge(suite.ctx, false, addrNoSupply, defaultLiquidTokens, distrTo, time.Time{}, 1)
+	suite.Require().Error(err)
+
+	_, err = suite.app.IncentivesKeeper.CreateGauge(suite.ctx, false, addrs[0], defaultLiquidTokens, distrTo, time.Time{}, 1)
+	suite.Require().NoError(err)
+}
+
 // TODO: Make this test table driven
 // OR if it needs to be script based,
 // remove lots of boilerplate so this can actually be followed

--- a/x/incentives/keeper/suite_test.go
+++ b/x/incentives/keeper/suite_test.go
@@ -114,6 +114,12 @@ func (suite *KeeperTestSuite) setupNewGaugeWithDuration(isPerpetual bool, coins 
 		Denom:         "lptoken",
 		Duration:      duration,
 	}
+
+	// mints coins so supply exists on chain
+	mintCoins := sdk.Coins{sdk.NewInt64Coin(distrTo.Denom, 200)}
+	err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr, mintCoins)
+	suite.Require().NoError(err)
+
 	numEpochsPaidOver := uint64(2)
 	if isPerpetual {
 		numEpochsPaidOver = uint64(1)

--- a/x/incentives/types/expected_keepers.go
+++ b/x/incentives/types/expected_keepers.go
@@ -12,6 +12,8 @@ import (
 type BankKeeper interface {
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 
+	HasSupply(ctx sdk.Context, denom string) bool
+
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromModuleToManyAccounts(
 		ctx sdk.Context, senderModule string, recipientAddrs []sdk.AccAddress, amts []sdk.Coins,


### PR DESCRIPTION
Closes: #530 

## Description

Adds a check in the gauge creation process that prevents gauges from being created for denoms that do not exist on-chain.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

