### PR TITLE
min duration from days to hours, changed weekly to day

### DIFF
--- a/x/epochs/client/cli/query.go
+++ b/x/epochs/client/cli/query.go
@@ -75,7 +75,7 @@ func GetCmdCurrentEpoch() *cobra.Command {
 			fmt.Sprintf(`Query current epoch by specified identifier.
 
 Example:
-$ %s query epochs current-epoch weekly
+$ %s query epochs current-epoch day
 `,
 				version.AppName,
 			),

--- a/x/lockup/client/cli/flags.go
+++ b/x/lockup/client/cli/flags.go
@@ -14,13 +14,13 @@ const (
 func FlagSetLockTokens() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.String(FlagDuration, "86400s", "The duration token to be locked. e.g. 86400s, 604800s, 1209600s")
+	fs.String(FlagDuration, "24h", "The duration token to be locked. e.g. 24h, 168h, 336h")
 	return fs
 }
 
 func FlagSetMinDuration() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.String(FlagMinDuration, "86400s", "The minimum duration of token bonded. e.g. 86400s, 604800s, 1209600s")
+	fs.String(FlagMinDuration, "336h", "The minimum duration of token bonded. e.g. 24h, 168h, 336h")
 	return fs
 }

--- a/x/lockup/client/cli/flags.go
+++ b/x/lockup/client/cli/flags.go
@@ -14,13 +14,13 @@ const (
 func FlagSetLockTokens() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.String(FlagDuration, "86400s", "The duration token to be locked. e.g. 1h, 1m, 1s, 0.1s")
+	fs.String(FlagDuration, "86400s", "The duration token to be locked. e.g. 86400s, 604800s, 1209600s")
 	return fs
 }
 
 func FlagSetMinDuration() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.String(FlagMinDuration, "1d", "The minimum duration of token bonded. e.g. 1d, 7d, 14d")
+	fs.String(FlagMinDuration, "86400s", "The minimum duration of token bonded. e.g. 86400s, 604800s, 1209600s")
 	return fs
 }


### PR DESCRIPTION
Fixes two queries

`osmosisd query lockup total-locked-of-denom gamm/pool/1`
Wont work since it tries to use `1d` as default min duration. Changed default to 86400s.

`osmosisd query epochs current-epoch -h`
Shows weekly as a potential input but its week not weekly. While I was at it I just changed default to day since it is most used.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

