### PR TITLE
Update Dockerfile to use distroless base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+docs/
+networks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [#869](https://github.com/osmosis-labs/osmosis/pull/869) Update Dockerfile to use distroless base image.
 - [#856](https://github.com/osmosis-labs/osmosis/pull/856) Make superfluid staking keeper in app.go a pointer receiver.
 - [#765](https://github.com/osmosis-labs/osmosis/pull/765) Fix a bug in `Makefile` regarding the location of localtestnet docker image.
 - [#795](https://github.com/osmosis-labs/osmosis/pull/795) Annotate app.go


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Addresses #816

## Description

This PR introduces a new Dockerfile to build and distribute the `osmosisd` binary.
The Dockerfile uses [multistage build](https://docs.docker.com/develop/develop-images/multistage-build/) process and serves `osmosisd` inside a [distroless base container image](https://github.com/GoogleContainerTools/distroless).

To test the Dockerfile against the latest tag (but any commit will do):

```bash
git clone https://github.com/osmosis-labs/osmosis
cd osmosis
git checkout v6.3.0
# Replace Dockerfile with the one above
docker build -t osmosis:v6.3.0 .
```

Then you can run the container as you normally would do with the binary:

```bash
docker run osmosis:v6.3.0 version 
# 6.3.0
```

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

