### PR TITLE
Add deserialization test for gamm

### DIFF
--- a/x/gamm/pool-models/balancer/marshal_test.go
+++ b/x/gamm/pool-models/balancer/marshal_test.go
@@ -1,9 +1,11 @@
 package balancer
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -50,4 +52,37 @@ func TestPoolJson(t *testing.T) {
 	var a BalancerPool
 	require.NoError(t, json.Unmarshal(bz, &a))
 	require.Equal(t, pacc.String(), a.String())
+}
+
+func TestPoolProtoMarshal(t *testing.T) {
+
+	// hex of serialzied poolI from v6.x
+	decodedByteArray, err := hex.DecodeString("0a3f6f736d6f316b727033387a7a63337a7a356173396e64716b79736b686b7a76367839653330636b63713567346c637375357770776371793073613364656132100a1a260a113235303030303030303030303030303030121132353030303030303030303030303030302a110a0c67616d6d2f706f6f6c2f3130120130321e0a0e0a05746573743112053130303030120c313037333734313832343030321e0a0e0a05746573743212053530303030120c3231343734383336343830303a0c333232313232353437323030")
+	require.NoError(t, err)
+
+	pool2 := BalancerPool{}
+	err = proto.Unmarshal(decodedByteArray, &pool2)
+	require.NoError(t, err)
+
+	require.Equal(t, pool2.Id, uint64(10))
+	require.Equal(t, pool2.PoolParams.SwapFee, defaultSwapFee)
+	require.Equal(t, pool2.PoolParams.ExitFee, defaultExitFee)
+	require.Equal(t, pool2.FuturePoolGovernor, "")
+	require.Equal(t, pool2.TotalShares, sdk.Coin{Denom: "gamm/pool/10", Amount: sdk.ZeroInt()})
+	require.Equal(t, pool2.PoolAssets, []types.PoolAsset{
+		{
+			Token: sdk.Coin{
+				Denom:  "test1",
+				Amount: sdk.NewInt(10000),
+			},
+			Weight: sdk.NewInt(107374182400),
+		},
+		{
+			Token: sdk.Coin{
+				Denom:  "test2",
+				Amount: sdk.NewInt(50000),
+			},
+			Weight: sdk.NewInt(214748364800),
+		},
+	})
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Migration from structs in types has taken to `pool-models`. We want to ensure that this doesn't break serialization. This PR introduces test case that deserializes hex serialization from v6.x, to ensure that nothing breaks from main 


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

