### PR TITLE
Remove all (non-community pool) module accounts from derive-account-balances

### DIFF
--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtypes "github.com/tendermint/tendermint/types"
+	//import keeper: keeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 )
 
 const FlagSelectPoolIds = "breakdown-by-pool-ids"
@@ -314,6 +315,30 @@ Example:
 					Add(account.UnclaimedAirdrop...)
 				snapshotAccs[addr] = account
 			}
+
+			/*
+				Structure:
+				for _, account := range snapshotAccs {
+
+					acc := keeper.GetAccount(ctx, account.Address)
+
+					err := *authtypes.ModuleAccount(acc)
+					//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
+					if err != nil {
+						continue
+					}
+
+					//Repeat same casting/error check but w/o * in front of the cast, just to be comprehensive
+					err := authtypes.ModuleAccount(acc)
+					//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
+					if err != nil {
+						continue
+					}
+
+					//Else, remove account from list - how do we remove an item from a map in go?
+				}
+				//Make sure the length etc. is updated so the resulting json file generated next in the func doesn't error/generate garbage
+			*/
 
 			snapshot := DeriveSnapshot{
 				NumberAccounts: uint64(len(snapshotAccs)),

--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -12,6 +13,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/osmosis-labs/osmosis/app"
 	appparams "github.com/osmosis-labs/osmosis/app/params"
 	"github.com/osmosis-labs/osmosis/osmotestutils"
 	claimtypes "github.com/osmosis-labs/osmosis/x/claim/types"
@@ -19,6 +21,7 @@ import (
 	lockuptypes "github.com/osmosis-labs/osmosis/x/lockup/types"
 	"github.com/spf13/cobra"
 	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -315,24 +318,27 @@ Example:
 				snapshotAccs[addr] = account
 			}
 
-			queryClient := authtypes.NewQueryClient(clientCtx)
+			app := app.Setup(false)
+			ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, Time: time.Now().UTC()})
 
-			for addr, _ := range snapshotAccs {
+			for addr, account := range snapshotAccs {
 
-				acc, err := queryClient.Account(cmd.Context(), &authtypes.QueryAccountRequest{
-					Address: addr,
-				})
+				accAddr, err := sdk.AccAddressFromBech32(account.Address)
 				if err != nil {
 					return err
 				}
+				acc := app.AccountKeeper.GetAccount(ctx, accAddr)
 
-				moduleAccount, ok := acc.(*authtypes.ModuleAccount)
-				if !ok {
+				err = *authtypes.ModuleAccount(acc)
+				//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
+				if err != nil {
 					continue
 				}
 
-				moduleAccount, ok = acc.(authtypes.ModuleAccount)
-				if !ok {
+				//Repeat same casting/error check but w/o * in front of the cast, just to be comprehensive
+				err = authtypes.ModuleAccount(acc)
+				//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
+				if err != nil {
 					continue
 				}
 

--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -318,7 +318,7 @@ Example:
 
 			/*
 				Structure:
-				for _, account := range snapshotAccs {
+				for addr, account := range snapshotAccs {
 
 					acc := keeper.GetAccount(ctx, account.Address)
 
@@ -336,9 +336,34 @@ Example:
 					}
 
 					//Else, remove account from list - how do we remove an item from a map in go?
+					//ASSUMING THAT "addr" IS THE KEY
+					delete(snapshotAccs, addr)
 				}
 				//Make sure the length etc. is updated so the resulting json file generated next in the func doesn't error/generate garbage
 			*/
+
+			for addr, account := range snapshotAccs {
+
+				acc := keeper.accountKeeper.GetAccount(ctx, account.Address)
+
+				err := *authtypes.ModuleAccount(acc)
+				//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
+				if err != nil {
+					continue
+				}
+
+				//Repeat same casting/error check but w/o * in front of the cast, just to be comprehensive
+				err = authtypes.ModuleAccount(acc)
+				//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
+				if err != nil {
+					continue
+				}
+
+				//Else, remove account from list - how do we remove an item from a map in go?
+				//ASSUMING THAT "addr" IS THE KEY
+				delete(snapshotAccs, addr)
+			}
+			//Make sure the length etc. is updated so the resulting json file generated next in the func doesn't error/generate garbage
 
 			snapshot := DeriveSnapshot{
 				NumberAccounts: uint64(len(snapshotAccs)),

--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -321,6 +321,7 @@ Example:
 			app := app.Setup(false)
 			ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, Time: time.Now().UTC()})
 
+			// Remove module accounts from snapshots
 			for addr, account := range snapshotAccs {
 
 				accAddr, err := sdk.AccAddressFromBech32(account.Address)
@@ -329,22 +330,11 @@ Example:
 				}
 				acc := app.AccountKeeper.GetAccount(ctx, accAddr)
 
-				err = *authtypes.ModuleAccount(acc)
-				//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
-				if err != nil {
-					continue
+				if _, ok := acc.(*authtypes.ModuleAccount); ok {
+					//Else, remove account from list - how do we remove an item from a map in go?
+					//ASSUMING THAT "addr" IS THE KEY
+					delete(snapshotAccs, addr)
 				}
-
-				//Repeat same casting/error check but w/o * in front of the cast, just to be comprehensive
-				err = authtypes.ModuleAccount(acc)
-				//If there IS an error (meaning acc is NOT a module account), continue to next acc (i.e. don't remove)
-				if err != nil {
-					continue
-				}
-
-				//Else, remove account from list - how do we remove an item from a map in go?
-				//ASSUMING THAT "addr" IS THE KEY
-				delete(snapshotAccs, addr)
 			}
 
 			snapshot := DeriveSnapshot{


### PR DESCRIPTION
Closes: #479

## Description
Added logic at the end of the airdrop snapshot generation/export function that checks each account address in the snapshot to see if it's a module account and, if it is, removes it from the snapshot map before the JSON file is generated.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

