### PR TITLE
Upgrade IAVL and SDK with RAM improvements and bug fixes for v6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Minor improvements & Bug Fixes
 
--[#907](https://github.com/osmosis-labs/osmosis/pull/907) Upgrade IAVL and SDK with RAM improvements and bug fixes for v6.4
+-[#907](https://github.com/osmosis-labs/osmosis/pull/907) Upgrade IAVL and SDK with RAM improvements and bug fixes for v6.3.2
 
 ### SDK fork updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### SDK fork updates
 
-- [sdk-#114](https://github.com/osmosis-labs/cosmos-sdk/pull/114) [commit](https://github.com/osmosis-labs/cosmos-sdk/pull/114/commits/7ec05684856bf87b868f67d05459d64931ac599d) upgrading iavl with ram optimizations during migration and extra logs
+- [sdk-#114](https://github.com/osmosis-labs/cosmos-sdk/pull/114) upgrading iavl with ram optimizations during migration, and extra logs and fixes for "version X was already saved to a different hash" and "insufficient funds" bugs
 
 ### IAVL fork updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,22 +39,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v6.3.2](https://github.com/osmosis-labs/osmosis/releases/tag/v6.3.2)
+## [v6.4.0](https://github.com/osmosis-labs/osmosis/releases/tag/v6.4.0)
 
 ## Minor improvements & Bug Fixes
 
--[#907](https://github.com/osmosis-labs/osmosis/pull/907) Upgrade IAVL and SDK with RAM improvements and bug fixes for v6.3.2
+-[#907](https://github.com/osmosis-labs/osmosis/pull/907) Upgrade IAVL and SDK with RAM improvements and bug fixes for v6.4.0
 
 ### SDK fork updates
 
-- [sdk-#114](https://github.com/osmosis-labs/cosmos-sdk/pull/114) upgrading iavl with ram optimizations during migration and extra logs
+- [sdk-#114](https://github.com/osmosis-labs/cosmos-sdk/pull/114) [commit](https://github.com/osmosis-labs/cosmos-sdk/pull/114/commits/7ec05684856bf87b868f67d05459d64931ac599d) upgrading iavl with ram optimizations during migration and extra logs
 
 ### IAVL fork updates
 
 - [iavl-19](https://github.com/osmosis-labs/iavl/pull/19) force GC, no cache during migration, auto heap profile
 
 ## [v6.3.1](https://github.com/osmosis-labs/osmosis/releases/tag/v6.3.1)
-- [#859](https://github.com/osmosis-labs/osmosis/pull/859) min duration from days to hours, changed weekly to day
+- [#859](https://github.com/osmosis-labs/osmosis/pull/859) CLI, update default durations to be in better units.
 - [#Unknown](https://github.com/osmosis-labs/osmosis/commit/3bf63f1d3b7efee503106a008e84129489bdba8d) Switch to SDK branch with vesting by duration
 
 ## Minor improvements & Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v6.3.2](https://github.com/osmosis-labs/osmosis/releases/tag/v6.3.2)
+
+## Minor improvements & Bug Fixes
+
+-[#907](https://github.com/osmosis-labs/osmosis/pull/907) Upgrade IAVL and SDK with RAM improvements and bug fixes for v6.4
+
+### SDK fork updates
+
+- [sdk-#114](https://github.com/osmosis-labs/cosmos-sdk/pull/114) upgrading iavl with ram optimizations during migration and extra logs
+
+### IAVL fork updates
+
+- [iavl-19](https://github.com/osmosis-labs/iavl/pull/19) force GC, no cache during migration, auto heap profile
+
+## [v6.3.1](https://github.com/osmosis-labs/osmosis/releases/tag/v6.3.1)
+- [#859](https://github.com/osmosis-labs/osmosis/pull/859) min duration from days to hours, changed weekly to day
+- [#Unknown](https://github.com/osmosis-labs/osmosis/commit/3bf63f1d3b7efee503106a008e84129489bdba8d) Switch to SDK branch with vesting by duration
+
+## Minor improvements & Bug Fixes
+
+- [#795](https://github.com/osmosis-labs/osmosis/pull/795) Annotate app.go
+- [#791](https://github.com/osmosis-labs/osmosis/pull/791) Change to dependabot config to only upgrade patch version of tendermint
+- [#766](https://github.com/osmosis-labs/osmosis/pull/766) Consolidate code between InitGenesis and CreateGauge
+
 ## [v6.3.0](https://github.com/osmosis-labs/osmosis/releases/tag/v6.3.0)
 
 ## Features

--- a/go.mod
+++ b/go.mod
@@ -125,8 +125,8 @@ require github.com/dgraph-io/badger/v2 v2.2007.3 // indirect
 
 replace (
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk  v0.44.3x-osmo-v5
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220214220252-d69df1dbc317
-	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v1
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220220052304-a117f821a9b2
+	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v3
 	// Use osmosis-flavored IBCv2
 	github.com/cosmos/ibc-go/v2 => github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo
 	// Use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -704,8 +704,12 @@ github.com/osmosis-labs/bech32-ibc v0.2.0-rc2 h1:7xy1pLtNiF2KaRSkolayZf4z3OfCJsO
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc2/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220214220252-d69df1dbc317 h1:8x0W9mOmIlQK6YZ8yOMFhV8AKuDCzZOHL3PjGAmg3So=
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220214220252-d69df1dbc317/go.mod h1:XIvt5YKBsdq6wM84ixUlMkswPAgRFe+EA2PySK+8PzA=
+github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220220052304-a117f821a9b2 h1:0nwTKczrrNNXKZH9yaDtLWfgjrqtL8mwPO+m8T2sYno=
+github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220220052304-a117f821a9b2/go.mod h1:Tozvv3e+0o3SGzpRR0FhzhDBZK+7j95C7dvup6c5PU8=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v1 h1:orHUut98Miu2+bsFiNZJ29B3ogrbiBbQpti94L2w3Z4=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v1/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
+github.com/osmosis-labs/iavl v0.17.3-osmo-v3 h1:q2Qv3+DK52w5b68I96VApHI05jBu7HeQK/YDttKh/jY=
+github.com/osmosis-labs/iavl v0.17.3-osmo-v3/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo h1:XyYyDTjPIu7qX2nhQp9mboj7Pa9FEnjg1RXw73Ctv5U=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo/go.mod h1:XUmW7wmubCRhIEAGtMGS+5IjiSSmcAwihoN/yPGd6Kk=
 github.com/osmosis-labs/tendermint v0.34.12-0.20220109173307-59a781894ea7 h1:uMaGJbQ2g2pSK+7fWIlr+JJTape8hGHlSAMIiRPg2To=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

The main focus of this upgrade is stability improvements with the IAVL patch of v0.44.3x-osmo-v5.1. The big points are:

- Fixes the "version X was already saved to a different hash" and "insufficient funds" bugs nodes were sometimes seeing after crashes.
- Reduce the RAM overhead during the initial IAVL migration. Node operators should still have 32GB of RAM for all of their mainnet nodes.
- Improving the log messages during migrations

The bugs people were seeing for nodes being saved to a different hash, etc. happen after restoring the node post-crash during commit (the crash could be caused by something else). The bug on restart stems from the long-standing issue that SDK commits are actually not-atomic. This manifested in a failure to flush the latest height when an error during commit occurs, causing the state invalidities on restart. We mitigated the non-atomicity problem by flushing the metadata about the stores that successfully committed a new height. As a result, on restart, the SDK now knows which stores/modules are already on the newly committed height.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

