### PR TITLE
Superfluid slashing code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,8 +126,8 @@ require (
 )
 
 replace (
-	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk v0.45.0x-osmo-v7
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220124045025-f4329814320d
+	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk dev/update_slashing_hooks
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220220010512-689410c34e4e
 	// Use osmosis fork of ibc-go
 	github.com/cosmos/ibc-go/v2 => github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo
 	// use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -793,6 +793,10 @@ github.com/osmosis-labs/bech32-ibc v0.2.0-rc2 h1:7xy1pLtNiF2KaRSkolayZf4z3OfCJsO
 github.com/osmosis-labs/bech32-ibc v0.2.0-rc2/go.mod h1:0JCaioRNOVUiw7c3MngmKACnumaQ2sjPenXCnwxCttI=
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220124045025-f4329814320d h1:rV2K3AcMG66cBPp0GSOy1E+VAq977bbEHhtJdl2p/40=
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220124045025-f4329814320d/go.mod h1:ThWFGTvQHB9AVuKLxAIw+RWJy0EB2CF3Xg2+JNd2jzg=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220219221222-608ef3c78884 h1:nmhuAMbue08Ahj6c8d0V+41m2CtKVGZw1pJ4AxzwI9w=
+github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220219221222-608ef3c78884/go.mod h1:ThWFGTvQHB9AVuKLxAIw+RWJy0EB2CF3Xg2+JNd2jzg=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220220010512-689410c34e4e h1:ccLG7X2jj1lGDLHKR5Qm0rVJQUlGIykJGAoxtwh2+ZY=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220220010512-689410c34e4e/go.mod h1:ThWFGTvQHB9AVuKLxAIw+RWJy0EB2CF3Xg2+JNd2jzg=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo h1:XyYyDTjPIu7qX2nhQp9mboj7Pa9FEnjg1RXw73Ctv5U=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo/go.mod h1:XUmW7wmubCRhIEAGtMGS+5IjiSSmcAwihoN/yPGd6Kk=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=

--- a/x/claim/keeper/hooks.go
+++ b/x/claim/keeper/hooks.go
@@ -101,7 +101,8 @@ func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, 
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	h.k.AfterDelegationModified(ctx, delAddr, valAddr)
 }
-func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {}
+func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, _ int64, _ sdk.Dec, _ sdk.Dec) {
+}
 func (h Hooks) BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation stakingtypes.UnbondingDelegation,
 	infractionHeight int64, slashFactor sdk.Dec) {
 }

--- a/x/lockup/keeper/lock_refs.go
+++ b/x/lockup/keeper/lock_refs.go
@@ -31,7 +31,9 @@ func (k Keeper) deleteLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types
 	return nil
 }
 
-// XXX
+// TODO: This is messed up that this works. It shouldn't.
+// You should _have_ to get the synthetic lockup.
+// We can make a wrapper that then gets the underlying locks easily.
 func (k Keeper) addSyntheticLockRefs(ctx sdk.Context, lockRefPrefix []byte, synthLock types.SyntheticLock) error {
 	refKeys, err := syntheticLockRefKeys(synthLock)
 	if err != nil {

--- a/x/superfluid/keeper/hooks.go
+++ b/x/superfluid/keeper/hooks.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	epochstypes "github.com/osmosis-labs/osmosis/v7/x/epochs/types"
 )
 
@@ -82,21 +81,9 @@ func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, 
 }
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 }
-func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashFactor sdk.Dec) {
+func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec, effectiveSlashFactor sdk.Dec) {
 	if slashFactor == sdk.ZeroDec() {
 		return
 	}
-	h.k.SlashLockupsForValidatorSlash(ctx, valAddr, slashFactor)
-}
-func (h Hooks) BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation stakingtypes.UnbondingDelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-	if slashFactor == sdk.ZeroDec() {
-		return
-	}
-	h.k.SlashLockupsForUnbondingDelegationSlash(ctx, unbondingDelegation.DelegatorAddress, unbondingDelegation.ValidatorAddress, slashFactor)
-}
-
-// Not used right now, as we don't allow superfluid redelegations
-func (h Hooks) BeforeSlashingRedelegation(ctx sdk.Context, srcValidator stakingtypes.Validator, redelegation stakingtypes.Redelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
+	h.k.SlashLockupsForValidatorSlash(ctx, valAddr, infractionHeight, slashFactor)
 }

--- a/x/superfluid/keeper/hooks_test.go
+++ b/x/superfluid/keeper/hooks_test.go
@@ -287,14 +287,14 @@ func (suite *KeeperTestSuite) TestBeforeSlashingUnbondingDelegationHook() {
 			for _, lockId := range tc.expSlashedLockIds {
 				gotLock, err := suite.app.LockupKeeper.GetLockByID(suite.ctx, lockId)
 				suite.Require().NoError(err)
-				suite.Require().Equal(gotLock.Coins.AmountOf("gamm/pool/1").String(), sdk.NewInt(950000).String())
+				suite.Require().Equal(sdk.NewInt(950000).String(), gotLock.Coins.AmountOf("gamm/pool/1").String())
 			}
 
 			// check unslashed lockups
 			for _, lockId := range tc.expUnslashedLockIds {
 				gotLock, err := suite.app.LockupKeeper.GetLockByID(suite.ctx, lockId)
 				suite.Require().NoError(err)
-				suite.Require().Equal(gotLock.Coins.AmountOf("gamm/pool/1").String(), sdk.NewInt(1000000).String())
+				suite.Require().Equal(sdk.NewInt(1000000).String(), gotLock.Coins.AmountOf("gamm/pool/1").String())
 			}
 		})
 	}

--- a/x/superfluid/keeper/intermediary_account.go
+++ b/x/superfluid/keeper/intermediary_account.go
@@ -49,6 +49,18 @@ func (k Keeper) GetIntermediaryAccount(ctx sdk.Context, address sdk.AccAddress) 
 	return acc
 }
 
+func (k Keeper) GetIntermediaryAccountsForVal(ctx sdk.Context, valAddr sdk.ValAddress) []types.SuperfluidIntermediaryAccount {
+	accs := k.GetAllIntermediaryAccounts(ctx)
+	valAccs := []types.SuperfluidIntermediaryAccount{}
+	for _, acc := range accs {
+		if acc.ValAddr != valAddr.String() { // only apply for slashed validator
+			continue
+		}
+		valAccs = append(valAccs, acc)
+	}
+	return valAccs
+}
+
 func (k Keeper) GetOrCreateIntermediaryAccount(ctx sdk.Context, denom, valAddr string) (types.SuperfluidIntermediaryAccount, error) {
 	accountAddr := types.GetSuperfluidIntermediaryAccountAddr(denom, valAddr)
 	storeAccount := k.GetIntermediaryAccount(ctx, accountAddr)

--- a/x/superfluid/keeper/slash.go
+++ b/x/superfluid/keeper/slash.go
@@ -6,87 +6,68 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/v7/osmoutils"
 	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
-	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 )
 
-func (k Keeper) SlashLockupsForUnbondingDelegationSlash(ctx sdk.Context, delAddrStr string, valAddrStr string, slashFactor sdk.Dec) {
-	delAddr, err := sdk.AccAddressFromBech32(delAddrStr)
-	if err != nil {
-		panic(err)
-	}
-
-	// TODO: What?? The intermediary accounts aren't serialized by delAddr??
-	// Lets replace with the following pseudocode
-	// locks := lk.GetAllSyntheticLockupsByAddr(delAddr)
-	// for _, lock := range locks {
-	// 	denom, val := parse_denom(lock.suffix)
-	//  // No need for infraction height checks, as this delegator is already confirmed as needing a slash.
-	// 	if val == relevant_val {
-	// 	   do_slash(lock)
-	// 	}
-	//  }
-	acc := k.GetIntermediaryAccount(ctx, delAddr)
-	// if delAddr is not intermediary account, pass
-	if acc.Denom == "" {
-		return
-	}
-
-	// Get lockups longer or equal to SuperfluidUnbondDuration
-	params := k.GetParams(ctx)
-	locks := k.lk.GetLocksLongerThanDurationDenom(ctx, acc.Denom+unstakingSuffix(acc.ValAddr), params.UnbondingDuration)
-	for _, lock := range locks {
-		// slashing only applies to synthetic lockup amount
-		synthLock, err := k.lk.GetSyntheticLockup(ctx, lock.ID, unstakingSuffix(acc.ValAddr))
-		if err != nil {
-			k.Logger(ctx).Error(err.Error())
-			continue
-		}
-
-		// Only single token lock is allowed here
-		slashAmt := synthLock.Coins[0].Amount.ToDec().Mul(slashFactor).TruncateInt()
-		osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
-			_, err = k.lk.SlashTokensFromLockByID(cacheCtx, lock.ID, sdk.Coins{sdk.NewCoin(lock.Coins[0].Denom, slashAmt)})
-			return err
-		})
-	}
-}
-
+// SlashLockupsForValidatorSlash should be called before the validator at valAddr is slashed.
+// This function is responsible for inspecting every intermediate account to valAddr.
+// For each intermediate account IA, it slashes every constituent delegation behind IA.
+// Furthermore, if the infraction height is sufficiently old, slashes unbondings
 // Note: Based on sdk.staking.Slash function review, slashed tokens are burnt not sent to community pool
-func (k Keeper) SlashLockupsForValidatorSlash(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
-	accs := k.GetAllIntermediaryAccounts(ctx)
-	valAccs := []types.SuperfluidIntermediaryAccount{}
+// we ignore that, and send the underliyng tokens to the community pool anyway.
+func (k Keeper) SlashLockupsForValidatorSlash(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec) {
+	// Important note: The SDK slashing for historical heights is wrong.
+	// It defines a "slash amount" off of the live staked amount.
+	// Then it charges all the unbondings & redelegations at the slash factor.
+	// It then creates a new slash factor for the amount remaining to be charged from the slash amount,
+	// across all the live accounts.
+	// This is the "effectiveSlashFactor".
+	//
+	// The SDK's design is wack / wrong in our view, and this was a pre Cosmos Hub
+	// launch hack that never got remedied.
+	// We are not concerned about maximal consistency with the SDK, and instead charge slashFactor to
+	// both unbonding and live delegations. Rather than slashFactor to unbonding delegations,
+	// and effectiveSlashFactor to new delegations.
+	accs := k.GetIntermediaryAccountsForVal(ctx, valAddr)
+
+	// for every intermediary account, we first slash the live tokens comprosing delegated to it,
+	// and then all of its unbonding delegations.
+	// We do these slashes as burns.
+	// TODO: Make it go to community pool.
 	for _, acc := range accs {
-		if acc.ValAddr != valAddr.String() { // only apply for slashed validator
-			continue
-		}
-		valAccs = append(valAccs, acc)
-	}
-
-	for _, acc := range valAccs {
-		// mint OSMO token based on TWAP of locked denom to denom module account
 		// Get total delegation from synthetic lockups
-		queryCondition := lockuptypes.QueryCondition{
-			LockQueryType: lockuptypes.ByDuration,
-			Denom:         acc.Denom + stakingSuffix(acc.ValAddr),
-			Duration:      time.Hour * 24 * 14,
-		}
+		syntheticDenom := acc.Denom + stakingSuffix(acc.ValAddr)
+		nativeDenom := lockuptypes.NativeDenom(syntheticDenom)
 
-		// (1 - amt/delegatedTokens) describes slash factor
-		locks := k.lk.GetLocksLongerThanDurationDenom(ctx, queryCondition.Denom, queryCondition.Duration)
+		locks := k.lk.GetLocksLongerThanDurationDenom(ctx, nativeDenom, time.Second)
 		for _, lock := range locks {
 			// slashing only applies to synthetic lockup amount
 			synthLock, err := k.lk.GetSyntheticLockup(ctx, lock.ID, stakingSuffix(acc.ValAddr))
+			// synth lock doesn't exist for bonding
 			if err != nil {
-				k.Logger(ctx).Error(err.Error())
-				continue
+				synthLock, err = k.lk.GetSyntheticLockup(ctx, lock.ID, unstakingSuffix(acc.ValAddr))
+				// synth lock doesn't exist for unbonding
+				// => no superlfuid staking on this lock ID, so continue
+				if err != nil {
+					continue
+				}
 			}
 
-			// Only single token lock is allowed here
-			slashAmt := synthLock.Coins[0].Amount.ToDec().Mul(fraction).TruncateInt()
-			osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
-				_, err := k.lk.SlashTokensFromLockByID(cacheCtx, lock.ID, sdk.Coins{sdk.NewCoin(lock.Coins[0].Denom, slashAmt)})
-				return err
-			})
+			// slash the lock whether its bonding or unbonding.
+			// this overslashes unbondings that started unbonding before the slash infraction,
+			// but this seems to be an acceptable trade-off based upon choices taken in the SDK.
+			k.slashSynthLock(ctx, synthLock, slashFactor)
 		}
 	}
+}
+
+func (k Keeper) slashSynthLock(ctx sdk.Context, synthLock *lockuptypes.SyntheticLock, slashFactor sdk.Dec) {
+	// Only single token lock is allowed here
+	lock, _ := k.lk.GetLockByID(ctx, synthLock.UnderlyingLockId)
+	slashAmt := synthLock.Coins[0].Amount.ToDec().Mul(slashFactor).TruncateInt()
+	slashCoins := sdk.NewCoins(sdk.NewCoin(lock.Coins[0].Denom, slashAmt))
+	osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
+		// These tokens get moved to the community pool.
+		_, err := k.lk.SlashTokensFromLockByID(cacheCtx, lock.ID, slashCoins)
+		return err
+	})
 }

--- a/x/superfluid/keeper/slash_test.go
+++ b/x/superfluid/keeper/slash_test.go
@@ -150,14 +150,13 @@ func (suite *KeeperTestSuite) TestSlashLockupsForUnbondingDelegationSlash() {
 			}
 
 			// slash unbonding lockups for all intermediary accounts
-			for _, acc := range intermediaryAccs {
-				suite.NotPanics(func() {
-					suite.app.SuperfluidKeeper.SlashLockupsForUnbondingDelegationSlash(
-						suite.ctx,
-						acc.GetAccAddress().String(),
-						acc.ValAddr,
-						sdk.NewDecWithPrec(5, 2))
-				})
+			slashFactor := sdk.NewDecWithPrec(5, 2)
+			for i := 0; i < len(valAddrs); i++ {
+				suite.app.SuperfluidKeeper.SlashLockupsForValidatorSlash(
+					suite.ctx,
+					valAddrs[i],
+					suite.ctx.BlockHeight(),
+					slashFactor)
 			}
 
 			// check check unbonding lockup changes

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -39,7 +39,9 @@ func (k Keeper) RefreshIntermediaryDelegationAmounts(ctx sdk.Context) {
 		bondDenom := k.sk.BondDenom(ctx)
 
 		balance := k.bk.GetBalance(ctx, mAddr, bondDenom)
-		if balance.Amount.IsPositive() { // if free balance is available on intermediary account burn it
+		// if free balance is available on intermediary account burn it
+		// TODO: Why??? What is the flow undelegate that would leave it in the intermediary delegation object?
+		if balance.Amount.IsPositive() {
 			err := k.bk.SendCoinsFromAccountToModule(ctx, mAddr, stakingtypes.NotBondedPoolName, sdk.Coins{balance})
 			if err != nil {
 				panic(err)

--- a/x/superfluid/spec/08_hooks.md
+++ b/x/superfluid/spec/08_hooks.md
@@ -12,8 +12,8 @@ On AfterEpochEnd, we iterate through all existing intermediary accounts and with
 
 ## OnTokenLocked
 
-When a token is locked, we first check if the corresponding lock is currently in the state of superfluid delegation. If it is, we run the logic to add delegation via intermediary account. 
+When a token is locked, we first check if the corresponding lock is currently in the state of superfluid delegation. If it is, we run the logic to add delegation via intermediary account.
 
-## OnStartUnlock 
+## OnStartUnlock
 
 On Unlocking of a lock, we check if the corresponding lock has been superfluid staked. If it has, we run `SuperfluidUndelegate` for undelegation of the superfluid delegation.

--- a/x/superfluid/spec/11_slashing.md
+++ b/x/superfluid/spec/11_slashing.md
@@ -1,0 +1,44 @@
+<!--
+order: 11
+-->
+
+# Slashing
+
+We first get a hook from the staking module, marking that a validator is about to be slashed at a slashFactor of `f`, for an infraction at height `h`.
+
+The staking module handles slashing every delegation to that validator, which will handle slashing the delegation from every intermediary account.
+However, it is up to the superfluid module to then:
+
+* Slash every constituent superfluid staking position for this validator.
+* Slash every unbonding superfluid staking position to this validator.
+
+We do this by:
+
+* Collect all intermediate accounts to this validator
+* For each IA, iterate over every lock to the underlying native denom.
+* If the lock has a synthetic lockup, it gets slashed.
+* The slash works by calculating the amount of tokens to slash.
+* It removes these from the underlying lock and the synthetic lock.
+* These coins are moved to the community pool.
+
+## Slashing nuances
+
+* Slashed tokens go to the community pool, rather than being burned as in staking.
+* We slash every unbonding, rather than just unbondings that started after the infraction height.
+* We can "overslash" relative to the staking module. (For a slash factor of 5%, the staking module can often burn <5% of active delegation, but superfluid will always slash 5%)
+
+We slash every unbonding, purely because lockup module tracks things by unbonding start time, whereas staking/slashing tracks things by height we begin unbonding at.
+Thus we get a problem that we cannot convert between these cleanly.
+Really there should be a storage of all historical block height <> block times for everything in the unbonding period, but this is not considered a near-term problem.
+
+### Correcting overslashing
+
+The overslashing possibility stems from a problem in the SDKs slashing module, that really is a bug there, and superfluid is doing the correct thing.
+<https://github.com/cosmos/cosmos-sdk/issues/1440>
+
+Basically, slashes to unbondings and redelegations can lower the amount that gets slashed from live delegations in the staking module today.
+
+It turns out this edge case, where superfluid's intermediate account can have more delegation than expected from its underlying collateral, is already safely handled by the Superfluid refreshing logic.
+
+The refreshing logic checks the total amount of tokens in locks to this denom (Reading from the lockup accumulation store), calculates how many osmo thats worth at the epochs new osmo worth for that asset, and then uses that.
+Thus this safely handles this edge case, as it uses the new 'live' lockup amount.

--- a/x/superfluid/types/expected_keepers.go
+++ b/x/superfluid/types/expected_keepers.go
@@ -59,6 +59,7 @@ type StakingKeeper interface {
 	Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, sharesAmount sdk.Dec) (time.Time, error)
 	GetDelegation(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (delegation stakingtypes.Delegation, found bool)
 	GetUnbondingDelegation(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (ubd types.UnbondingDelegation, found bool)
+	GetParams(ctx sdk.Context) stakingtypes.Params
 }
 
 // DistrKeeper expected distribution keeper


### PR DESCRIPTION
Makes superfluid slashing work. It now starts from a slash validator hook for a validator.
The superfluid module is then responsible for slashing every intermediate account's underlying delegation,
and the undelegations to that validator.

It does this, by getting all synthetic lockups for the underlying denom the IA represents.
It then slashes each of those synthetic lockups.

THought this was already PR'd earlier 😓 
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

