### PR TITLE
Modify superfluid/gov to set OsmoEquivilentMultiplier

### DIFF
--- a/app/keepers.go
+++ b/app/keepers.go
@@ -317,7 +317,7 @@ func (app *OsmosisApp) InitNormalKeepers(
 		AddRoute(poolincentivestypes.RouterKey, poolincentives.NewPoolIncentivesProposalHandler(*app.PoolIncentivesKeeper)).
 		AddRoute(bech32ibctypes.RouterKey, bech32ibc.NewBech32IBCProposalHandler(*app.Bech32IBCKeeper)).
 		AddRoute(txfeestypes.RouterKey, txfees.NewUpdateFeeTokenProposalHandler(*app.TxFeesKeeper)).
-		AddRoute(superfluidtypes.RouterKey, superfluid.NewSuperfluidProposalHandler(*app.SuperfluidKeeper))
+		AddRoute(superfluidtypes.RouterKey, superfluid.NewSuperfluidProposalHandler(*app.SuperfluidKeeper, *app.EpochsKeeper))
 
 	// The gov proposal types can be individually enabled
 	if len(wasmEnabledProposals) != 0 {

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -25,7 +25,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64) 
 		// Exclusive of current epoch's rewards, inclusive of next epoch's rewards.
 		ctx.Logger().Info("Update all osmo equivalency multipliers")
 		for _, asset := range k.GetAllSuperfluidAssets(ctx) {
-			err := k.updateOsmoEquivalentMultipliers(ctx, asset, endedEpochNumber)
+			err := k.UpdateOsmoEquivalentMultipliers(ctx, asset, endedEpochNumber)
 			if err != nil {
 				// TODO: Revisit what we do here. (halt all distr, only skip this asset)
 				// Since at MVP of feature, we only have one pool of superfluid staking,
@@ -69,7 +69,7 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context) {
 	}
 }
 
-func (k Keeper) updateOsmoEquivalentMultipliers(ctx sdk.Context, asset types.SuperfluidAsset, endedEpochNumber int64) error {
+func (k Keeper) UpdateOsmoEquivalentMultipliers(ctx sdk.Context, asset types.SuperfluidAsset, endedEpochNumber int64) error {
 	if asset.AssetType == types.SuperfluidAssetTypeLPShare {
 		// LP_token_Osmo_equivalent = OSMO_amount_on_pool / LP_token_supply
 		poolId := gammtypes.MustGetPoolIdFromShareDenom(asset.Denom)

--- a/x/superfluid/keeper/gov/gov.go
+++ b/x/superfluid/keeper/gov/gov.go
@@ -3,14 +3,12 @@ package gov
 import (
 	"fmt"
 
-	epochskeeper "github.com/osmosis-labs/osmosis/v7/x/epochs/keeper"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 )
 
-func HandleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek epochskeeper.Keeper, p *types.SetSuperfluidAssetsProposal) error {
+func HandleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek types.EpochKeeper, p *types.SetSuperfluidAssetsProposal) error {
 	for _, asset := range p.Assets {
 		k.SetSuperfluidAsset(ctx, asset)
 

--- a/x/superfluid/keeper/gov/gov.go
+++ b/x/superfluid/keeper/gov/gov.go
@@ -11,17 +11,14 @@ import (
 
 func HandleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek types.EpochKeeper, p *types.SetSuperfluidAssetsProposal) error {
 	for _, asset := range p.Assets {
-		k.SetSuperfluidAsset(ctx, asset)
-
 		// initialize osmo equivalent multipliers
 		epochIdentifier := k.GetParams(ctx).RefreshEpochIdentifier
 		currentEpoch := ek.GetEpochInfo(ctx, epochIdentifier).CurrentEpoch
-
 		osmoutils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			k.SetSuperfluidAsset(ctx, asset)
 			err := k.UpdateOsmoEquivalentMultipliers(ctx, asset, currentEpoch)
 			return err
 		})
-
 		event := sdk.NewEvent(
 			types.TypeEvtSetSuperfluidAsset,
 			sdk.NewAttribute(types.AttributeDenom, asset.Denom),

--- a/x/superfluid/keeper/gov/gov.go
+++ b/x/superfluid/keeper/gov/gov.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/v7/osmoutils"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 )
@@ -15,10 +16,11 @@ func HandleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek type
 		// initialize osmo equivalent multipliers
 		epochIdentifier := k.GetParams(ctx).RefreshEpochIdentifier
 		currentEpoch := ek.GetEpochInfo(ctx, epochIdentifier).CurrentEpoch
-		err := k.UpdateOsmoEquivalentMultipliers(ctx, asset, currentEpoch)
-		if err != nil {
-			panic(err)
-		}
+
+		osmoutils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			err := k.UpdateOsmoEquivalentMultipliers(ctx, asset, currentEpoch)
+			return err
+		})
 
 		event := sdk.NewEvent(
 			types.TypeEvtSetSuperfluidAsset,

--- a/x/superfluid/keeper/gov/gov_test.go
+++ b/x/superfluid/keeper/gov/gov_test.go
@@ -14,13 +14,6 @@ import (
 )
 
 func (suite *KeeperTestSuite) createGammPool(denoms []string) uint64 {
-	// pools, err := suite.app.GAMMKeeper.GetPools(suite.ctx)
-	// suite.Require().NoError(err)
-
-	// for _, pool := range pools {
-	// 	suite.app.GAMMKeeper.DeletePool(suite.ctx, pool.GetId())
-	// }
-
 	coins := suite.app.GAMMKeeper.GetParams(suite.ctx).PoolCreationFee
 	poolAssets := []gammtypes.PoolAsset{}
 	for _, denom := range denoms {

--- a/x/superfluid/keeper/gov/gov_test.go
+++ b/x/superfluid/keeper/gov/gov_test.go
@@ -146,15 +146,6 @@ func (suite *KeeperTestSuite) TestHandleSetSuperfluidAssetsProposal() {
 				fmt.Println(resp)
 				suite.Require().NoError(err)
 				suite.Require().Equal(resp.Assets, action.expectedAssets)
-
-				superfluidAsset := suite.app.SuperfluidKeeper.GetAllSuperfluidAssets(suite.ctx)
-				fmt.Println("====superfluid asset")
-				fmt.Println(superfluidAsset)
-
-				osmoEquivilentMultiplers := suite.app.SuperfluidKeeper.GetAllOsmoEquivalentMultipliers(suite.ctx)
-				// a := suite.app.SuperfluidKeeper.GetOsmoEquivalentMultiplier(ctx, )
-				fmt.Println("=====osmo equivalent")
-				fmt.Println(osmoEquivilentMultiplers)
 			}
 		})
 	}

--- a/x/superfluid/keeper/gov/gov_test.go
+++ b/x/superfluid/keeper/gov/gov_test.go
@@ -1,21 +1,62 @@
 package gov_test
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer"
+	gammtypes "github.com/osmosis-labs/osmosis/v7/x/gamm/types"
+	minttypes "github.com/osmosis-labs/osmosis/v7/x/mint/types"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper/gov"
+
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
+func (suite *KeeperTestSuite) createGammPool(denoms []string) uint64 {
+	// pools, err := suite.app.GAMMKeeper.GetPools(suite.ctx)
+	// suite.Require().NoError(err)
+
+	// for _, pool := range pools {
+	// 	suite.app.GAMMKeeper.DeletePool(suite.ctx, pool.GetId())
+	// }
+
+	coins := suite.app.GAMMKeeper.GetParams(suite.ctx).PoolCreationFee
+	poolAssets := []gammtypes.PoolAsset{}
+	for _, denom := range denoms {
+		coins = coins.Add(sdk.NewInt64Coin(denom, 1000000000000000000))
+		poolAssets = append(poolAssets, gammtypes.PoolAsset{
+			Weight: sdk.NewInt(100),
+			Token:  sdk.NewCoin(denom, sdk.NewInt(1000000000000000000)),
+		})
+	}
+
+	acc1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address().Bytes())
+	err := suite.app.BankKeeper.MintCoins(suite.ctx, minttypes.ModuleName, coins)
+	suite.Require().NoError(err)
+	err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, minttypes.ModuleName, acc1, coins)
+	suite.Require().NoError(err)
+
+	poolId, err := suite.app.GAMMKeeper.CreateBalancerPool(
+		suite.ctx, acc1, balancer.PoolParams{
+			SwapFee: sdk.NewDecWithPrec(1, 2),
+			ExitFee: sdk.NewDecWithPrec(1, 2),
+		}, poolAssets, "")
+	suite.Require().NoError(err)
+
+	return poolId
+}
+
 func (suite *KeeperTestSuite) TestHandleSetSuperfluidAssetsProposal() {
+	nativeAsset := types.SuperfluidAsset{
+		Denom:     "stake",
+		AssetType: types.SuperfluidAssetTypeNative,
+	}
 	asset1 := types.SuperfluidAsset{
 		Denom:     "gamm/pool/1",
 		AssetType: types.SuperfluidAssetTypeLPShare,
 	}
 	asset2 := types.SuperfluidAsset{
-		Denom:     "nativetoken",
-		AssetType: types.SuperfluidAssetTypeNative,
-	}
-	asset3 := types.SuperfluidAsset{
 		Denom:     "nonexistanttoken",
 		AssetType: types.SuperfluidAssetTypeNative,
 	}
@@ -34,10 +75,10 @@ func (suite *KeeperTestSuite) TestHandleSetSuperfluidAssetsProposal() {
 			"happy path flow",
 			[]Action{
 				{
-					true, []types.SuperfluidAsset{asset1, asset2}, []types.SuperfluidAsset{asset1, asset2}, false,
+					true, []types.SuperfluidAsset{asset1}, []types.SuperfluidAsset{asset1}, false,
 				},
 				{
-					false, []types.SuperfluidAsset{asset2}, []types.SuperfluidAsset{asset1}, false,
+					false, []types.SuperfluidAsset{asset1}, []types.SuperfluidAsset{}, false,
 				},
 			},
 		},
@@ -45,10 +86,10 @@ func (suite *KeeperTestSuite) TestHandleSetSuperfluidAssetsProposal() {
 			"token does not exist",
 			[]Action{
 				{
-					true, []types.SuperfluidAsset{asset1, asset2}, []types.SuperfluidAsset{asset1, asset2}, false,
+					true, []types.SuperfluidAsset{asset1}, []types.SuperfluidAsset{asset1}, false,
 				},
 				{
-					false, []types.SuperfluidAsset{asset3}, []types.SuperfluidAsset{asset1, asset2}, true,
+					false, []types.SuperfluidAsset{asset2}, []types.SuperfluidAsset{asset1}, true,
 				},
 			},
 		},
@@ -66,23 +107,32 @@ func (suite *KeeperTestSuite) TestHandleSetSuperfluidAssetsProposal() {
 			suite.Require().Len(resp.Assets, 0)
 
 			for i, action := range tc.actions {
+
+				// here we set two different string arrays of denoms.
+				// The reason we do this is because native denom should be an asset within the pool,
+				// while we do not want native asset to be in gov proposals.
+				govDenoms := []string{}
+				poolDenoms := []string{nativeAsset.Denom}
+
+				for _, asset := range action.assets {
+					poolDenoms = append(poolDenoms, asset.Denom)
+					govDenoms = append(govDenoms, asset.Denom)
+				}
+
 				if action.isAdd {
+					suite.createGammPool(poolDenoms)
 					// set superfluid assets via proposal
-					err = gov.HandleSetSuperfluidAssetsProposal(suite.ctx, *suite.app.SuperfluidKeeper, &types.SetSuperfluidAssetsProposal{
+					err = gov.HandleSetSuperfluidAssetsProposal(suite.ctx, *suite.app.SuperfluidKeeper, *suite.app.EpochsKeeper, &types.SetSuperfluidAssetsProposal{
 						Title:       "title",
 						Description: "description",
 						Assets:      action.assets,
 					})
 				} else {
-					assetDenoms := []string{}
-					for _, asset := range action.assets {
-						assetDenoms = append(assetDenoms, asset.Denom)
-					}
 					// remove existing superfluid asset via proposal
 					err = gov.HandleRemoveSuperfluidAssetsProposal(suite.ctx, *suite.app.SuperfluidKeeper, &types.RemoveSuperfluidAssetsProposal{
 						Title:                 "title",
 						Description:           "description",
-						SuperfluidAssetDenoms: assetDenoms,
+						SuperfluidAssetDenoms: govDenoms,
 					})
 				}
 				if action.expectErr {
@@ -100,8 +150,18 @@ func (suite *KeeperTestSuite) TestHandleSetSuperfluidAssetsProposal() {
 
 				// check assets
 				resp, err = suite.app.SuperfluidKeeper.AllAssets(sdk.WrapSDKContext(suite.ctx), &types.AllAssetsRequest{})
+				fmt.Println(resp)
 				suite.Require().NoError(err)
 				suite.Require().Equal(resp.Assets, action.expectedAssets)
+
+				superfluidAsset := suite.app.SuperfluidKeeper.GetAllSuperfluidAssets(suite.ctx)
+				fmt.Println("====superfluid asset")
+				fmt.Println(superfluidAsset)
+
+				osmoEquivilentMultiplers := suite.app.SuperfluidKeeper.GetAllOsmoEquivalentMultipliers(suite.ctx)
+				// a := suite.app.SuperfluidKeeper.GetOsmoEquivalentMultiplier(ctx, )
+				fmt.Println("=====osmo equivalent")
+				fmt.Println(osmoEquivilentMultiplers)
 			}
 		})
 	}

--- a/x/superfluid/proposal_handler.go
+++ b/x/superfluid/proposal_handler.go
@@ -5,14 +5,12 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	epochskeeper "github.com/osmosis-labs/osmosis/v7/x/epochs/keeper"
-
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper/gov"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 )
 
-func NewSuperfluidProposalHandler(k keeper.Keeper, ek epochskeeper.Keeper) govtypes.Handler {
+func NewSuperfluidProposalHandler(k keeper.Keeper, ek types.EpochKeeper) govtypes.Handler {
 	return func(ctx sdk.Context, content govtypes.Content) error {
 		switch c := content.(type) {
 		case *types.SetSuperfluidAssetsProposal:
@@ -26,7 +24,7 @@ func NewSuperfluidProposalHandler(k keeper.Keeper, ek epochskeeper.Keeper) govty
 	}
 }
 
-func handleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek epochskeeper.Keeper, p *types.SetSuperfluidAssetsProposal) error {
+func handleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek types.EpochKeeper, p *types.SetSuperfluidAssetsProposal) error {
 	return gov.HandleSetSuperfluidAssetsProposal(ctx, k, ek, p)
 }
 

--- a/x/superfluid/proposal_handler.go
+++ b/x/superfluid/proposal_handler.go
@@ -5,16 +5,18 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
+	epochskeeper "github.com/osmosis-labs/osmosis/v7/x/epochs/keeper"
+
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper/gov"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 )
 
-func NewSuperfluidProposalHandler(k keeper.Keeper) govtypes.Handler {
+func NewSuperfluidProposalHandler(k keeper.Keeper, ek epochskeeper.Keeper) govtypes.Handler {
 	return func(ctx sdk.Context, content govtypes.Content) error {
 		switch c := content.(type) {
 		case *types.SetSuperfluidAssetsProposal:
-			return handleSetSuperfluidAssetsProposal(ctx, k, c)
+			return handleSetSuperfluidAssetsProposal(ctx, k, ek, c)
 		case *types.RemoveSuperfluidAssetsProposal:
 			return handleRemoveSuperfluidAssetsProposal(ctx, k, c)
 
@@ -24,8 +26,8 @@ func NewSuperfluidProposalHandler(k keeper.Keeper) govtypes.Handler {
 	}
 }
 
-func handleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, p *types.SetSuperfluidAssetsProposal) error {
-	return gov.HandleSetSuperfluidAssetsProposal(ctx, k, p)
+func handleSetSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, ek epochskeeper.Keeper, p *types.SetSuperfluidAssetsProposal) error {
+	return gov.HandleSetSuperfluidAssetsProposal(ctx, k, ek, p)
 }
 
 func handleRemoveSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, p *types.RemoveSuperfluidAssetsProposal) error {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Current gov proposal does not set OsmoEquivilentMultiplier, thus not being able to handle superfluid delegation upon first epoch after gov proposal has passed. 
This PR modifies superfluid/gov to set OsmoEquivilentMultiplier at its initial state

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

