### PR TITLE
Add SuperfluidUnbondLock test and cli

### DIFF
--- a/x/superfluid/client/cli/tx.go
+++ b/x/superfluid/client/cli/tx.go
@@ -28,6 +28,7 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(
 		NewSuperfluidDelegateCmd(),
 		NewSuperfluidUndelegateCmd(),
+		NewSuperfluidUnbondLockCmd(),
 		// NewSuperfluidRedelegateCmd(),
 		NewCmdSubmitSetSuperfluidAssetsProposal(),
 		NewCmdSubmitRemoveSuperfluidAssetsProposal(),
@@ -94,6 +95,38 @@ func NewSuperfluidUndelegateCmd() *cobra.Command {
 			}
 
 			msg := types.NewMsgSuperfluidUndelegate(
+				clientCtx.GetFromAddress(),
+				uint64(lockId),
+			)
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// NewSuperfluidUnbondLock broadcast MsgSuperfluidUndelegate and
+func NewSuperfluidUnbondLockCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unbond-lock [lock_id] [flags]",
+		Short: "unbond lock that has been superfluid staked",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			lockId, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgSuperfluidUnbondLock(
 				clientCtx.GetFromAddress(),
 				uint64(lockId),
 			)

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -445,6 +446,84 @@ func (suite *KeeperTestSuite) TestSuperfluidUndelegate() {
 				suite.Require().Error(err)
 			}
 		})
+	}
+}
+
+// TestSuperfluidUnbondLock tests the following.
+// 		1. test SuperfluidUnbondLock does not work before undelegation
+// 		2. test SuperfluidUnbondLock makes underlying lock start unlocking
+// 		3. test that syntehtic lockup being finished does not mean underlying lock is finished
+//      4. test after SuperfluidUnbondLock + lockup time, the underlying lock is finished
+func (suite *KeeperTestSuite) TestSuperfluidUnbondLock() {
+	suite.SetupTest()
+
+	poolId := suite.createGammPool([]string{appparams.BaseCoinUnit, "foo"})
+	suite.Require().Equal(poolId, uint64(1))
+
+	// Generate delegator addresses
+	delAddrs := CreateRandomAccounts(1)
+
+	// setup validators
+	valAddrs := suite.SetupValidators([]stakingtypes.BondStatus{stakingtypes.Bonded})
+
+	// setup superfluid delegations
+	intermediaryAccs, locks := suite.SetupSuperfluidDelegations(delAddrs, valAddrs, []superfluidDelegation{{0, 0, "gamm/pool/1", 1000000}})
+	suite.checkIntermediaryAccountDelegations(intermediaryAccs)
+
+	for _, lock := range locks {
+		startTime := time.Now()
+		suite.ctx = suite.ctx.WithBlockTime(startTime)
+		accAddr := suite.app.SuperfluidKeeper.GetLockIdIntermediaryAccountConnection(suite.ctx, lock.ID)
+		intermediaryAcc := suite.app.SuperfluidKeeper.GetIntermediaryAccount(suite.ctx, accAddr)
+		valAddr := intermediaryAcc.ValAddr
+
+		// first we test that SuperfluidUnbondLock would cause error before undelegating
+		err := suite.app.SuperfluidKeeper.SuperfluidUnbondLock(suite.ctx, lock.ID, lock.GetOwner())
+		suite.Require().Error(err)
+
+		// undelegation needs to happen prior to SuperfluidUnbondLock
+		err = suite.app.SuperfluidKeeper.SuperfluidUndelegate(suite.ctx, lock.Owner, lock.ID)
+		suite.Require().NoError(err)
+
+		// check that unbonding synth has been created correctly after undelegation
+		unbondingDuration := suite.app.StakingKeeper.GetParams(suite.ctx).UnbondingTime
+		synthLock, err := suite.app.LockupKeeper.GetSyntheticLockup(suite.ctx, lock.ID, keeper.UnstakingSyntheticDenom(lock.Coins[0].Denom, valAddr))
+		suite.Require().NoError(err)
+		suite.Require().Equal(synthLock.UnderlyingLockId, lock.ID)
+		suite.Require().Equal(synthLock.SynthDenom, keeper.UnstakingSyntheticDenom(lock.Coins[0].Denom, valAddr))
+		suite.Require().Equal(synthLock.EndTime, suite.ctx.BlockTime().Add(unbondingDuration))
+
+		// test SuperfluidUnbondLock
+		unbondLockStartTime := startTime.Add(time.Hour)
+		suite.ctx = suite.ctx.WithBlockTime(unbondLockStartTime)
+		err = suite.app.SuperfluidKeeper.SuperfluidUnbondLock(suite.ctx, lock.ID, lock.GetOwner())
+		suite.Require().NoError(err)
+
+		// check that SuperfluidUnbondLock makes underlying lock start unlocking
+		// we run WithdrawAllMaturedLocks to ensure that lock isn't getting finished immediately
+		suite.app.LockupKeeper.WithdrawAllMaturedLocks(suite.ctx)
+		updatedLock, err := suite.app.LockupKeeper.GetLockByID(suite.ctx, lock.ID)
+		suite.Require().NoError(err)
+		suite.Require().False(lock.IsUnlocking())
+		suite.Require().True(updatedLock.IsUnlocking())
+
+		// test that synth lock finish does not mean underlying lock is finished
+		suite.ctx = suite.ctx.WithBlockTime((startTime.Add(unbondingDuration)))
+		suite.app.LockupKeeper.DeleteAllMaturedSyntheticLocks(suite.ctx)
+		suite.app.LockupKeeper.WithdrawAllMaturedLocks(suite.ctx)
+		_, err = suite.app.LockupKeeper.GetSyntheticLockup(suite.ctx, lock.ID, keeper.UnstakingSyntheticDenom(lock.Coins[0].Denom, valAddr))
+		suite.Require().Error(err)
+		updatedLock, err = suite.app.LockupKeeper.GetLockByID(suite.ctx, lock.ID)
+		suite.Require().NoError(err)
+		suite.Require().True(updatedLock.IsUnlocking())
+
+		// test after SuperfluidUnbondLock + lockup unbonding duration, lock is finished and does not exist
+		suite.ctx = suite.ctx.WithBlockTime(unbondLockStartTime.Add(unbondingDuration))
+		suite.app.LockupKeeper.WithdrawAllMaturedLocks(suite.ctx)
+		updatedLock, err = suite.app.LockupKeeper.GetLockByID(suite.ctx, lock.ID)
+		fmt.Println(updatedLock)
+		suite.Require().Error(err)
+
 	}
 }
 

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -504,7 +504,6 @@ func (suite *KeeperTestSuite) TestSuperfluidUnbondLock() {
 		suite.app.LockupKeeper.WithdrawAllMaturedLocks(suite.ctx)
 		updatedLock, err := suite.app.LockupKeeper.GetLockByID(suite.ctx, lock.ID)
 		suite.Require().NoError(err)
-		suite.Require().False(lock.IsUnlocking())
 		suite.Require().True(updatedLock.IsUnlocking())
 
 		// test that synth lock finish does not mean underlying lock is finished

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -452,7 +452,7 @@ func (suite *KeeperTestSuite) TestSuperfluidUndelegate() {
 // TestSuperfluidUnbondLock tests the following.
 // 		1. test SuperfluidUnbondLock does not work before undelegation
 // 		2. test SuperfluidUnbondLock makes underlying lock start unlocking
-// 		3. test that syntehtic lockup being finished does not mean underlying lock is finished
+// 		3. test that synthetic lockup being finished does not mean underlying lock is finished
 //      4. test after SuperfluidUnbondLock + lockup time, the underlying lock is finished
 func (suite *KeeperTestSuite) TestSuperfluidUnbondLock() {
 	suite.SetupTest()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR adds go tests and cli for `SuperfluidUnbondLock`.
Testing for SuperfluidUnbondLock covers the following areas: 
1. test SuperfluidUnbondLock does not work before undelegation
2. test SuperfluidUnbondLock makes underlying lock start unlocking
3. test that synthetic lockup being finished does not mean underlying lock is finished
4. test after SuperfluidUnbondLock + lockup time, the underlying lock is finished


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

