### PR TITLE
Accumulation store reset on lockup migration

### DIFF
--- a/app/upgrades/v7/upgrades.go
+++ b/app/upgrades/v7/upgrades.go
@@ -39,9 +39,8 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator,
 		wasmKeeper.SetParams(ctx, params)
 
 		// Merge similar duration lockups
-		lockupkeeper.MergeLockupsForSimilarDurations(
-			ctx, *lockupKeeper, accountKeeper,
-			lockupkeeper.BaselineDurations, lockupkeeper.HourDuration,
+		lockupkeeper.MigrateLockups(
+			ctx, *lockupKeeper,
 		)
 
 		// Set the supply offset from the developer vesting account

--- a/x/gamm/keeper/pool_test.go
+++ b/x/gamm/keeper/pool_test.go
@@ -203,7 +203,7 @@ func (suite *KeeperTestSuite) TestCleanupPoolWithLockup() {
 	}, "")
 	suite.NoError(err)
 
-	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, acc1, sdk.Coins{sdk.NewCoin(types.GetPoolShareDenom(poolId), types.InitPoolSharesSupply)}, time.Hour)
+	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, acc1, time.Hour, sdk.Coins{sdk.NewCoin(types.GetPoolShareDenom(poolId), types.InitPoolSharesSupply)})
 	suite.NoError(err)
 
 	for _, lock := range suite.app.LockupKeeper.GetLocksDenom(suite.ctx, types.GetPoolShareDenom(poolId)) {

--- a/x/incentives/keeper/bench_test.go
+++ b/x/incentives/keeper/bench_test.go
@@ -132,7 +132,7 @@ func benchmarkDistributionLogic(numAccts, numDenoms, numGauges, numLockups, numD
 			lockSecs = r.Intn(1 * 60 * 60 * 8)
 		}
 		duration := time.Duration(lockSecs) * time.Second
-		_, err := app.LockupKeeper.LockTokens(ctx, addr, simCoins, duration)
+		_, err := app.LockupKeeper.LockTokens(ctx, addr, duration, simCoins)
 		if err != nil {
 			fmt.Printf("Lock tokens, %v\n", err)
 			b.FailNow()

--- a/x/incentives/keeper/suite_test.go
+++ b/x/incentives/keeper/suite_test.go
@@ -62,7 +62,7 @@ func (suite *KeeperTestSuite) SetupUserLocks(users []userLocks) (accs []sdk.AccA
 		accs[i] = suite.setupAddr(i, "", totalLockAmt)
 		for j := 0; j < len(user.lockAmounts); j++ {
 			_, err := suite.app.LockupKeeper.LockTokens(
-				suite.ctx, accs[i], user.lockAmounts[j], user.lockDurations[j])
+				suite.ctx, accs[i], user.lockDurations[j], user.lockAmounts[j])
 			suite.Require().NoError(err)
 		}
 	}
@@ -101,7 +101,7 @@ func (suite *KeeperTestSuite) AddToGauge(coins sdk.Coins, gaugeID uint64) uint64
 func (suite *KeeperTestSuite) LockTokens(addr sdk.AccAddress, coins sdk.Coins, duration time.Duration) {
 	err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr, coins)
 	suite.Require().NoError(err)
-	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr, coins, duration)
+	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr, duration, coins)
 	suite.Require().NoError(err)
 }
 
@@ -142,7 +142,7 @@ func (suite *KeeperTestSuite) SetupManyLocks(numLocks int, liquidBalance sdk.Coi
 	bal := liquidBalance.Add(coinsPerLock...)
 	for i := 0; i < numLocks; i++ {
 		addr := suite.setupAddr(i, string(randPrefix), bal)
-		_, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr, coinsPerLock, lockDuration)
+		_, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr, lockDuration, coinsPerLock)
 		suite.Require().NoError(err)
 		addrs = append(addrs, addr)
 	}

--- a/x/lockup/genesis_test.go
+++ b/x/lockup/genesis_test.go
@@ -74,7 +74,7 @@ func TestExportGenesis(t *testing.T) {
 
 	err := simapp.FundAccount(app.BankKeeper, ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
-	_, err = app.LockupKeeper.LockTokens(ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)}, time.Second*5)
+	_, err = app.LockupKeeper.LockTokens(ctx, acc2, time.Second*5, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
 
 	coins := app.LockupKeeper.GetAccountLockedCoins(ctx, acc2)
@@ -125,7 +125,7 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 
 	err := simapp.FundAccount(app.BankKeeper, ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
-	_, err = app.LockupKeeper.LockTokens(ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)}, time.Second*5)
+	_, err = app.LockupKeeper.LockTokens(ctx, acc2, time.Second*5, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
 
 	genesisExported := am.ExportGenesis(ctx, appCodec)

--- a/x/lockup/keeper/admin_keeper.go
+++ b/x/lockup/keeper/admin_keeper.go
@@ -58,18 +58,7 @@ func (ak AdminKeeper) BreakLock(ctx sdk.Context, lockID uint64) error {
 		return err
 	}
 
-	ak.deleteLock(ctx, lockID)
+	err = ak.deleteLock(ctx, *lock)
 
-	refKeys, err := lockRefKeys(*lock)
-	if err != nil {
-		return err
-	}
-
-	for _, refKey := range refKeys {
-		err = ak.deleteLockRefByKey(ctx, refKey, lockID)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return err
 }

--- a/x/lockup/keeper/admin_keeper_test.go
+++ b/x/lockup/keeper/admin_keeper_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/v7/x/lockup/keeper"
-	"github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 )
 
 func (suite *KeeperTestSuite) TestRelock() {
@@ -14,12 +13,11 @@ func (suite *KeeperTestSuite) TestRelock() {
 
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
-	lock := types.NewPeriodLock(1, addr1, time.Second, suite.ctx.BlockTime().Add(time.Second), coins)
 
 	// lock with balance
 	err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr1, coins)
 	suite.Require().NoError(err)
-	err = suite.app.LockupKeeper.Lock(suite.ctx, lock)
+	lock, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr1, time.Second, coins)
 	suite.Require().NoError(err)
 
 	// lock with balance with same id
@@ -40,13 +38,12 @@ func (suite *KeeperTestSuite) BreakLock() {
 
 	addr1 := sdk.AccAddress([]byte("addr1---------------"))
 	coins := sdk.Coins{sdk.NewInt64Coin("stake", 10)}
-	lock := types.NewPeriodLock(1, addr1, time.Second, suite.ctx.BlockTime().Add(time.Second), coins)
 
 	// lock with balance
 	err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr1, coins)
 	suite.Require().NoError(err)
 
-	err = suite.app.LockupKeeper.Lock(suite.ctx, lock)
+	lock, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr1, time.Second, coins)
 	suite.Require().NoError(err)
 
 	// break lock

--- a/x/lockup/keeper/gas_test.go
+++ b/x/lockup/keeper/gas_test.go
@@ -19,7 +19,7 @@ func (suite *KeeperTestSuite) measureLockGas(addr sdk.AccAddress, coins sdk.Coin
 	suite.Require().NoError(err)
 	// start measuring gas
 	alreadySpent := suite.ctx.GasMeter().GasConsumed()
-	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr, coins, dur)
+	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr, dur, coins)
 	suite.Require().NoError(err)
 	newSpent := suite.ctx.GasMeter().GasConsumed()
 	spentNow := newSpent - alreadySpent

--- a/x/lockup/keeper/grpc_query_test.go
+++ b/x/lockup/keeper/grpc_query_test.go
@@ -11,7 +11,7 @@ import (
 func (suite *KeeperTestSuite) LockTokens(addr sdk.AccAddress, coins sdk.Coins, duration time.Duration) {
 	err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr, coins)
 	suite.Require().NoError(err)
-	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr, coins, duration)
+	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr, duration, coins)
 	suite.Require().NoError(err)
 }
 

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -358,13 +358,7 @@ func (k Keeper) createLock(ctx sdk.Context, addr sdk.AccAddress, duration time.D
 
 	// unlock time is set at the beginning of unlocking time
 	lock := types.NewPeriodLock(id, addr, duration, time.Time{}, coins)
-	k.setLock(ctx, lock)
-
-	// add lock refs into not unlocking queue
-	err := k.addLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
-	if err != nil {
-		return types.PeriodLock{}, err
-	}
+	k.setLockAndResetLockRefs(ctx, lock)
 
 	return lock, nil
 }

--- a/x/lockup/keeper/migration_test.go
+++ b/x/lockup/keeper/migration_test.go
@@ -45,9 +45,8 @@ func (suite *KeeperTestSuite) TestLockupMergeMigration() {
 	}
 
 	suite.Require().NotPanics(func() {
-		keeper.MergeLockupsForSimilarDurations(
-			suite.ctx, *suite.app.LockupKeeper, suite.app.AccountKeeper,
-			keeper.BaselineDurations, keeper.HourDuration,
+		keeper.MigrateLockups(
+			suite.ctx, *suite.app.LockupKeeper,
 		)
 	})
 

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -67,7 +67,7 @@ func (server msgServer) LockTokens(goCtx context.Context, msg *types.MsgLockToke
 		}
 	}
 
-	lock, err := server.keeper.LockTokens(ctx, owner, msg.Coins, msg.Duration)
+	lock, err := server.keeper.LockTokens(ctx, owner, msg.Duration, msg.Coins)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}

--- a/x/lockup/keeper/msg_server_test.go
+++ b/x/lockup/keeper/msg_server_test.go
@@ -19,7 +19,7 @@ func (suite *KeeperTestSuite) TestMsgLockTokens() {
 
 	err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, addr1, coins)
 	suite.Require().NoError(err)
-	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr1, coins, time.Second)
+	_, err = suite.app.LockupKeeper.LockTokens(suite.ctx, addr1, time.Second, coins)
 	suite.Require().NoError(err)
 
 	// creation of lock via LockTokens

--- a/x/lockup/keeper/store.go
+++ b/x/lockup/keeper/store.go
@@ -30,6 +30,12 @@ func (k Keeper) SetLastLockID(ctx sdk.Context, ID uint64) {
 	store.Set(types.KeyLastLockID, sdk.Uint64ToBigEndian(ID))
 }
 
+func (k Keeper) NextLockID(ctx sdk.Context) uint64 {
+	id := k.GetLastLockID(ctx) + 1
+	k.SetLastLockID(ctx, id)
+	return id
+}
+
 // lockStoreKey returns action store key from ID
 func lockStoreKey(ID uint64) []byte {
 	return combineKeys(types.KeyPrefixPeriodLock, sdk.Uint64ToBigEndian(ID))

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -50,7 +50,7 @@ func (suite *KeeperTestSuite) LockTokens(addr sdk.AccAddress, coins sdk.Coins, d
 	err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, minttypes.ModuleName, addr, coins)
 	suite.Require().NoError(err)
 	suite.Require().NoError(err)
-	lock, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr, coins, duration)
+	lock, err := suite.app.LockupKeeper.LockTokens(suite.ctx, addr, duration, coins)
 	suite.Require().NoError(err)
 	return lock
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

changes made other than the main migration script:
- remove Lock() as an exported method for locking tokens
- use LockTokens() for single entry point for locking tokens
- add createLock() that creates a lock with next lock ID
- createLock() and deleteLock() now add/deletes lockrefs in it 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

