### PR TITLE
Make creation of a bonded lock not create unused time keys

### DIFF
--- a/x/lockup/genesis_test.go
+++ b/x/lockup/genesis_test.go
@@ -91,11 +91,11 @@ func TestExportGenesis(t *testing.T) {
 			Coins:    sdk.Coins{sdk.NewInt64Coin("foo", 10000000)},
 		},
 		{
-			ID:       2,
-			Owner:    acc1.String(),
-			Duration: time.Hour,
+			ID:       11,
+			Owner:    acc2.String(),
+			Duration: time.Second * 5,
 			EndTime:  time.Time{},
-			Coins:    sdk.Coins{sdk.NewInt64Coin("foo", 15000000)},
+			Coins:    sdk.Coins{sdk.NewInt64Coin("foo", 5000000)},
 		},
 		{
 			ID:       3,
@@ -105,11 +105,11 @@ func TestExportGenesis(t *testing.T) {
 			Coins:    sdk.Coins{sdk.NewInt64Coin("foo", 5000000)},
 		},
 		{
-			ID:       11,
-			Owner:    acc2.String(),
-			Duration: time.Second * 5,
+			ID:       2,
+			Owner:    acc1.String(),
+			Duration: time.Hour,
 			EndTime:  time.Time{},
-			Coins:    sdk.Coins{sdk.NewInt64Coin("foo", 5000000)},
+			Coins:    sdk.Coins{sdk.NewInt64Coin("foo", 15000000)},
 		},
 	})
 }

--- a/x/lockup/keeper/admin_keeper.go
+++ b/x/lockup/keeper/admin_keeper.go
@@ -66,10 +66,7 @@ func (ak AdminKeeper) BreakLock(ctx sdk.Context, lockID uint64) error {
 	}
 
 	for _, refKey := range refKeys {
-		err = ak.deleteLockRefByKey(ctx, refKey, lockID)
-		if err != nil {
-			return err
-		}
+		ak.deleteLockRefByKey(ctx, refKey, lockID)
 	}
 	return nil
 }

--- a/x/lockup/keeper/export_test.go
+++ b/x/lockup/keeper/export_test.go
@@ -9,8 +9,8 @@ func (k Keeper) AddLockRefByKey(ctx sdk.Context, key []byte, lockID uint64) erro
 	return k.addLockRefByKey(ctx, key, lockID)
 }
 
-func (k Keeper) DeleteLockRefByKey(ctx sdk.Context, key []byte, lockID uint64) error {
-	return k.deleteLockRefByKey(ctx, key, lockID)
+func (k Keeper) DeleteLockRefByKey(ctx sdk.Context, key []byte, lockID uint64) {
+	k.deleteLockRefByKey(ctx, key, lockID)
 }
 
 func (k Keeper) GetLockRefs(ctx sdk.Context, key []byte) []uint64 {

--- a/x/lockup/keeper/grpc_query_test.go
+++ b/x/lockup/keeper/grpc_query_test.go
@@ -178,7 +178,7 @@ func (suite *KeeperTestSuite) TestAccountLockedCoins() {
 	// check = unlockTime - 1s
 	res, err = suite.app.LockupKeeper.AccountLockedCoins(sdk.WrapSDKContext(suite.ctx), &types.AccountLockedCoinsRequest{Owner: addr1.String()})
 	suite.Require().NoError(err)
-	suite.Require().Equal(res.Coins, coins)
+	suite.Require().Equal(coins, res.Coins)
 
 	// check after 1 second = unlockTime
 	now := suite.ctx.BlockTime()

--- a/x/lockup/keeper/iterator.go
+++ b/x/lockup/keeper/iterator.go
@@ -78,7 +78,7 @@ func (k Keeper) LockIteratorBeforeTime(ctx sdk.Context, isUnlocking bool, time t
 // LockIterator returns the iterator used for getting all locks
 func (k Keeper) LockIterator(ctx sdk.Context, isUnlocking bool) sdk.Iterator {
 	unlockingPrefix := unlockingPrefix(isUnlocking)
-	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixLockTimestamp))
+	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixLockDuration))
 }
 
 // LockIteratorAfterTimeDenom returns the iterator to get locked coins by denom
@@ -120,7 +120,7 @@ func (k Keeper) AccountLockIteratorBeforeTime(ctx sdk.Context, isUnlocking bool,
 // AccountLockIterator returns the iterator used for getting all locks by account
 func (k Keeper) AccountLockIterator(ctx sdk.Context, isUnlocking bool, addr sdk.AccAddress) sdk.Iterator {
 	unlockingPrefix := unlockingPrefix(isUnlocking)
-	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountLockTimestamp, addr))
+	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountLockDuration, addr))
 }
 
 // AccountLockIteratorAfterTimeDenom returns the iterator to get locked coins by account and denom

--- a/x/lockup/keeper/iterator.go
+++ b/x/lockup/keeper/iterator.go
@@ -64,14 +64,14 @@ func (k Keeper) iterator(ctx sdk.Context, prefix []byte) sdk.Iterator {
 }
 
 // LockIteratorAfterTime returns the iterator to get locked coins
-func (k Keeper) LockIteratorAfterTime(ctx sdk.Context, isUnlocking bool, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) LockIteratorAfterTime(ctx sdk.Context, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorAfterTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixLockTimestamp), time)
 }
 
 // LockIteratorBeforeTime returns the iterator to get unlockable coins
-func (k Keeper) LockIteratorBeforeTime(ctx sdk.Context, isUnlocking bool, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) LockIteratorBeforeTime(ctx sdk.Context, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorBeforeTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixLockTimestamp), time)
 }
 
@@ -82,14 +82,14 @@ func (k Keeper) LockIterator(ctx sdk.Context, isUnlocking bool) sdk.Iterator {
 }
 
 // LockIteratorAfterTimeDenom returns the iterator to get locked coins by denom
-func (k Keeper) LockIteratorAfterTimeDenom(ctx sdk.Context, isUnlocking bool, denom string, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) LockIteratorAfterTimeDenom(ctx sdk.Context, denom string, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorAfterTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixDenomLockTimestamp, []byte(denom)), time)
 }
 
 // LockIteratorBeforeTimeDenom returns the iterator to get unlockable coins by denom
-func (k Keeper) LockIteratorBeforeTimeDenom(ctx sdk.Context, isUnlocking bool, denom string, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) LockIteratorBeforeTimeDenom(ctx sdk.Context, denom string, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorBeforeTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixDenomLockTimestamp, []byte(denom)), time)
 }
 
@@ -106,14 +106,14 @@ func (k Keeper) LockIteratorDenom(ctx sdk.Context, isUnlocking bool, denom strin
 }
 
 // AccountLockIteratorAfterTime returns the iterator to get locked coins by account
-func (k Keeper) AccountLockIteratorAfterTime(ctx sdk.Context, isUnlocking bool, addr sdk.AccAddress, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) AccountLockIteratorAfterTime(ctx sdk.Context, addr sdk.AccAddress, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorAfterTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountLockTimestamp, addr), time)
 }
 
 // AccountLockIteratorBeforeTime returns the iterator to get unlockable coins by account
-func (k Keeper) AccountLockIteratorBeforeTime(ctx sdk.Context, isUnlocking bool, addr sdk.AccAddress, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) AccountLockIteratorBeforeTime(ctx sdk.Context, addr sdk.AccAddress, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorBeforeTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountLockTimestamp, addr), time)
 }
 
@@ -124,14 +124,14 @@ func (k Keeper) AccountLockIterator(ctx sdk.Context, isUnlocking bool, addr sdk.
 }
 
 // AccountLockIteratorAfterTimeDenom returns the iterator to get locked coins by account and denom
-func (k Keeper) AccountLockIteratorAfterTimeDenom(ctx sdk.Context, isUnlocking bool, addr sdk.AccAddress, denom string, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) AccountLockIteratorAfterTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorAfterTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountDenomLockTimestamp, addr, []byte(denom)), time)
 }
 
 // AccountLockIteratorBeforeTimeDenom returns the iterator to get unlockable coins by account and denom
-func (k Keeper) AccountLockIteratorBeforeTimeDenom(ctx sdk.Context, isUnlocking bool, addr sdk.AccAddress, denom string, time time.Time) sdk.Iterator {
-	unlockingPrefix := unlockingPrefix(isUnlocking)
+func (k Keeper) AccountLockIteratorBeforeTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, time time.Time) sdk.Iterator {
+	unlockingPrefix := unlockingPrefix(true)
 	return k.iteratorBeforeTime(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountDenomLockTimestamp, addr, []byte(denom)), time)
 }
 

--- a/x/lockup/keeper/iterator.go
+++ b/x/lockup/keeper/iterator.go
@@ -102,7 +102,7 @@ func (k Keeper) LockIteratorLongerThanDurationDenom(ctx sdk.Context, isUnlocking
 // LockIteratorDenom returns the iterator used for getting all locks by denom
 func (k Keeper) LockIteratorDenom(ctx sdk.Context, isUnlocking bool, denom string) sdk.Iterator {
 	unlockingPrefix := unlockingPrefix(isUnlocking)
-	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixDenomLockTimestamp, []byte(denom)))
+	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixDenomLockDuration, []byte(denom)))
 }
 
 // AccountLockIteratorAfterTime returns the iterator to get locked coins by account
@@ -138,7 +138,7 @@ func (k Keeper) AccountLockIteratorBeforeTimeDenom(ctx sdk.Context, addr sdk.Acc
 // AccountLockIteratorDenom returns the iterator used for getting all locks by account and denom
 func (k Keeper) AccountLockIteratorDenom(ctx sdk.Context, isUnlocking bool, addr sdk.AccAddress, denom string) sdk.Iterator {
 	unlockingPrefix := unlockingPrefix(isUnlocking)
-	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountDenomLockTimestamp, addr, []byte(denom)))
+	return k.iterator(ctx, combineKeys(unlockingPrefix, types.KeyPrefixAccountDenomLockDuration, addr, []byte(denom)))
 }
 
 // AccountLockIteratorLongerDuration returns iterator used for getting all locks by account longer than duration

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -17,7 +17,7 @@ import (
 // WithdrawAllMaturedLocks withdraws every lock thats in the process of unlocking, and has finished unlocking by
 // the current block time.
 func (k Keeper) WithdrawAllMaturedLocks(ctx sdk.Context) {
-	k.unlockFromIterator(ctx, k.LockIteratorBeforeTime(ctx, true, ctx.BlockTime()))
+	k.unlockFromIterator(ctx, k.LockIteratorBeforeTime(ctx, ctx.BlockTime()))
 }
 
 func (k Keeper) getCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
@@ -43,7 +43,7 @@ func (k Keeper) GetModuleBalance(ctx sdk.Context) sdk.Coins {
 func (k Keeper) GetModuleLockedCoins(ctx sdk.Context) sdk.Coins {
 	// all not unlocking + not finished unlocking
 	notUnlockingCoins := k.getCoinsFromIterator(ctx, k.LockIterator(ctx, false))
-	unlockingCoins := k.getCoinsFromIterator(ctx, k.LockIteratorAfterTime(ctx, true, ctx.BlockTime()))
+	unlockingCoins := k.getCoinsFromIterator(ctx, k.LockIteratorAfterTime(ctx, ctx.BlockTime()))
 	return notUnlockingCoins.Add(unlockingCoins...)
 }
 

--- a/x/lockup/keeper/lock_refs.go
+++ b/x/lockup/keeper/lock_refs.go
@@ -25,9 +25,7 @@ func (k Keeper) deleteLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types
 		return err
 	}
 	for _, refKey := range refKeys {
-		if err := k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), lock.ID); err != nil {
-			return err
-		}
+		k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), lock.ID)
 	}
 	return nil
 }
@@ -54,9 +52,7 @@ func (k Keeper) deleteSyntheticLockRefs(ctx sdk.Context, lock types.PeriodLock, 
 	}
 	lockRefPrefix := unlockingPrefix(synthLock.IsUnlocking())
 	for _, refKey := range refKeys {
-		if err := k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId); err != nil {
-			return err
-		}
+		k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId)
 	}
 	return nil
 }

--- a/x/lockup/keeper/lock_refs.go
+++ b/x/lockup/keeper/lock_refs.go
@@ -6,7 +6,10 @@ import (
 )
 
 func (k Keeper) addLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
-	refKeys, err := lockRefKeys(lock)
+	refKeys, err := durationLockRefKeys(lock)
+	if lock.IsUnlocking() {
+		refKeys, err = lockRefKeys(lock)
+	}
 	if err != nil {
 		return err
 	}

--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -491,6 +491,7 @@ func (suite *KeeperTestSuite) TestEndblockerWithdrawAllMaturedLockups() {
 	// lock coins for 5 second, 1 seconds, and 3 seconds in that order
 	times := []time.Duration{time.Second * 5, time.Second, time.Second * 3}
 	sortedTimes := []time.Duration{time.Second, time.Second * 3, time.Second * 5}
+	sortedTimesIndex := []uint64{2, 3, 1}
 	unbondBlockTimes := make([]time.Time, len(times))
 
 	// setup locks for 5 second, 1 second, and 3 seconds, and begin unbonding them.
@@ -519,7 +520,7 @@ func (suite *KeeperTestSuite) TestEndblockerWithdrawAllMaturedLockups() {
 		suite.Require().Len(locks, len(times))
 		suite.Require().Equal(unlockedCoins, totalCoins)
 		for i := 0; i < len(times); i++ {
-			suite.Require().Equal(locks[i].ID, uint64(i+1))
+			suite.Require().Equal(sortedTimesIndex[i], locks[i].ID)
 		}
 
 		// check locks, these should now be sorted by unbonding completion time

--- a/x/lockup/keeper/store.go
+++ b/x/lockup/keeper/store.go
@@ -109,26 +109,26 @@ func (k Keeper) ClearAllAccumulationStores(ctx sdk.Context) {
 
 // GetAccountUnlockableCoins Returns whole unlockable coins which are not withdrawn yet
 func (k Keeper) GetAccountUnlockableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
-	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, true, addr, ctx.BlockTime()))
+	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, addr, ctx.BlockTime()))
 }
 
 // GetAccountUnlockingCoins Returns whole unlocking coins
 func (k Keeper) GetAccountUnlockingCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
-	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, ctx.BlockTime()))
+	return k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, addr, ctx.BlockTime()))
 }
 
 // GetAccountLockedCoins Returns a locked coins that can't be withdrawn
 func (k Keeper) GetAccountLockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
 	// all account unlocking + not finished unlocking
 	notUnlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIterator(ctx, false, addr))
-	unlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, ctx.BlockTime()))
+	unlockingCoins := k.getCoinsFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, addr, ctx.BlockTime()))
 	return notUnlockingCoins.Add(unlockingCoins...)
 }
 
 // GetAccountLockedPastTime Returns the total locks of an account whose unlock time is beyond timestamp
 func (k Keeper) GetAccountLockedPastTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
 	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, true, addr, timestamp))
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, addr, timestamp))
 	duration := time.Duration(0)
 	if timestamp.After(ctx.BlockTime()) {
 		duration = timestamp.Sub(ctx.BlockTime())
@@ -149,7 +149,7 @@ func (k Keeper) GetAccountLockedPastTimeNotUnlockingOnly(ctx sdk.Context, addr s
 // GetAccountUnlockedBeforeTime Returns the total unlocks of an account whose unlock time is before timestamp
 func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
 	// unlockings finish before specific time + not started locks that can finish before the time if start now
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, true, addr, timestamp))
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, addr, timestamp))
 	if timestamp.Before(ctx.BlockTime()) {
 		return unlockings
 	}
@@ -161,7 +161,7 @@ func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddres
 // GetAccountLockedPastTimeDenom is equal to GetAccountLockedPastTime but denom specific
 func (k Keeper) GetAccountLockedPastTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, timestamp time.Time) []types.PeriodLock {
 	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
-	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTimeDenom(ctx, true, addr, denom, timestamp))
+	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTimeDenom(ctx, addr, denom, timestamp))
 	duration := time.Duration(0)
 	if timestamp.After(ctx.BlockTime()) {
 		duration = timestamp.Sub(ctx.BlockTime())
@@ -204,7 +204,7 @@ func (k Keeper) GetAccountLockedLongerDurationDenomNotUnlockingOnly(ctx sdk.Cont
 // GetLocksPastTimeDenom Returns the locks whose unlock time is beyond timestamp
 func (k Keeper) GetLocksPastTimeDenom(ctx sdk.Context, denom string, timestamp time.Time) []types.PeriodLock {
 	// returns both unlocking started and not started assuming it started unlocking current time
-	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorAfterTimeDenom(ctx, true, denom, timestamp))
+	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorAfterTimeDenom(ctx, denom, timestamp))
 	duration := time.Duration(0)
 	if timestamp.After(ctx.BlockTime()) {
 		duration = timestamp.Sub(ctx.BlockTime())

--- a/x/lockup/keeper/store.go
+++ b/x/lockup/keeper/store.go
@@ -77,11 +77,10 @@ func (k Keeper) addLockRefByKey(ctx sdk.Context, key []byte, lockID uint64) erro
 }
 
 // deleteLockRefByKey removes lock ID from an array associated to provided key
-func (k Keeper) deleteLockRefByKey(ctx sdk.Context, key []byte, lockID uint64) error {
+func (k Keeper) deleteLockRefByKey(ctx sdk.Context, key []byte, lockID uint64) {
 	store := ctx.KVStore(k.storeKey)
 	lockIDKey := sdk.Uint64ToBigEndian(lockID)
 	store.Delete(combineKeys(key, lockIDKey))
-	return nil
 }
 
 func accumulationStorePrefix(denom string) (res []byte) {

--- a/x/lockup/keeper/store_test.go
+++ b/x/lockup/keeper/store_test.go
@@ -17,8 +17,7 @@ func (suite *KeeperTestSuite) TestLockReferencesManagement() {
 	lockIDs2 := suite.app.LockupKeeper.GetLockRefs(suite.ctx, key2)
 	suite.Require().Equal(len(lockIDs2), 3)
 
-	err := suite.app.LockupKeeper.DeleteLockRefByKey(suite.ctx, key2, 1)
-	suite.Require().NoError(err)
+	suite.app.LockupKeeper.DeleteLockRefByKey(suite.ctx, key2, 1)
 	lockIDs2 = suite.app.LockupKeeper.GetLockRefs(suite.ctx, key2)
 	suite.Require().Equal(len(lockIDs2), 2)
 }

--- a/x/lockup/keeper/utils.go
+++ b/x/lockup/keeper/utils.go
@@ -43,10 +43,28 @@ func getDurationKey(duration time.Duration) []byte {
 	return combineKeys(types.KeyPrefixDuration, key)
 }
 
-func lockRefKeys(lock types.PeriodLock) ([][]byte, error) {
+func durationLockRefKeys(lock types.PeriodLock) ([][]byte, error) {
 	refKeys := [][]byte{}
-	timeKey := getTimeKey(lock.EndTime)
 	durationKey := getDurationKey(lock.Duration)
+	owner, err := sdk.AccAddressFromBech32(lock.Owner)
+	if err != nil {
+		return nil, err
+	}
+
+	refKeys = append(refKeys, combineKeys(types.KeyPrefixLockDuration, durationKey))
+	refKeys = append(refKeys, combineKeys(types.KeyPrefixAccountLockDuration, owner, durationKey))
+
+	for _, coin := range lock.Coins {
+		denomBz := []byte(coin.Denom)
+		refKeys = append(refKeys, combineKeys(types.KeyPrefixDenomLockDuration, denomBz, durationKey))
+		refKeys = append(refKeys, combineKeys(types.KeyPrefixAccountDenomLockDuration, owner, denomBz, durationKey))
+	}
+	return refKeys, nil
+}
+
+func lockRefKeys(lock types.PeriodLock) ([][]byte, error) {
+	refKeys, _ := durationLockRefKeys(lock)
+	timeKey := getTimeKey(lock.EndTime)
 
 	owner, err := sdk.AccAddressFromBech32(lock.Owner)
 	if err != nil {
@@ -54,16 +72,12 @@ func lockRefKeys(lock types.PeriodLock) ([][]byte, error) {
 	}
 
 	refKeys = append(refKeys, combineKeys(types.KeyPrefixLockTimestamp, timeKey))
-	refKeys = append(refKeys, combineKeys(types.KeyPrefixLockDuration, durationKey))
 	refKeys = append(refKeys, combineKeys(types.KeyPrefixAccountLockTimestamp, owner, timeKey))
-	refKeys = append(refKeys, combineKeys(types.KeyPrefixAccountLockDuration, owner, durationKey))
 
 	for _, coin := range lock.Coins {
 		denomBz := []byte(coin.Denom)
 		refKeys = append(refKeys, combineKeys(types.KeyPrefixDenomLockTimestamp, denomBz, timeKey))
-		refKeys = append(refKeys, combineKeys(types.KeyPrefixDenomLockDuration, denomBz, durationKey))
 		refKeys = append(refKeys, combineKeys(types.KeyPrefixAccountDenomLockTimestamp, owner, denomBz, timeKey))
-		refKeys = append(refKeys, combineKeys(types.KeyPrefixAccountDenomLockDuration, owner, denomBz, durationKey))
 	}
 	return refKeys, nil
 }

--- a/x/lockup/spec/02_state.md
+++ b/x/lockup/spec/02_state.md
@@ -40,14 +40,17 @@ There are two big queues to store the lock references. (`a_prefix_key`)
 
 Regardless the lock has started unlocking or not, it stores below references. (`b_prefix_key`)
 
+1. `{KeyPrefixLockDuration}{Duration}`
+2. `{KeyPrefixAccountLockDuration}{Owner}{Duration}`
+3. `{KeyPrefixDenomLockDuration}{Denom}{Duration}`
+4. `{KeyPrefixAccountDenomLockDuration}{Owner}{Denom}{Duration}`
+
+If the lock is unlocking, it also stores the below referneces.
+
 1. `{KeyPrefixLockTimestamp}{LockEndTime}`
-2. `{KeyPrefixLockDuration}{Duration}`
-3. `{KeyPrefixAccountLockTimestamp}{Owner}{LockEndTime}`
-4. `{KeyPrefixAccountLockDuration}{Owner}{Duration}`
-5. `{KeyPrefixDenomLockTimestamp}{Denom}{LockEndTime}`
-6. `{KeyPrefixDenomLockDuration}{Denom}{Duration}`
-7. `{KeyPrefixAccountDenomLockTimestamp}{Owner}{Denom}{LockEndTime}`
-8. `{KeyPrefixAccountDenomLockDuration}{Owner}{Denom}{Duration}`
+2. `{KeyPrefixAccountLockTimestamp}{Owner}{LockEndTime}`
+3. `{KeyPrefixDenomLockTimestamp}{Denom}{LockEndTime}`
+4. `{KeyPrefixAccountDenomLockTimestamp}{Owner}{Denom}{LockEndTime}`
 
 For end time keys, they are converted to sortable string by using `sdk.FormatTimeBytes` function.
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Cref #447 

Basically for a long time, we've known that we've been adding extra keys to bonding locks that are useless. This removes the creation of those useless ref keys, helping reduce the write load of our migration.

We are still deleting all refkeys, even if they don't exist. This is because we shouldn't keep any ref keys in state that aren't valid.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

