### PR TITLE
Fix broken query

### DIFF
--- a/x/superfluid/keeper/synthetic_lock_wrapper.go
+++ b/x/superfluid/keeper/synthetic_lock_wrapper.go
@@ -17,14 +17,18 @@ func unstakingSyntheticDenom(denom, valAddr string) string {
 }
 
 // quick fix for getting the validator addresss from a synthetic denom
-func ValidatorAddressFromSyntheticDenom(suffix string) (string, error) {
-	if strings.Contains(suffix, "superbonding") {
-		return strings.TrimLeft(suffix, "/superbonding/"), nil
+func ValidatorAddressFromSyntheticDenom(syntheticDenom string) (string, error) {
+	if strings.Contains(syntheticDenom, "superbonding") {
+		splitString := strings.Split(syntheticDenom, "/superbonding/")
+		lastComponent := splitString[len(splitString)-1]
+		return lastComponent, nil
 	}
-	if strings.Contains(suffix, "superunbonding") {
-		return strings.TrimLeft(suffix, "/superunbonding/"), nil
+	if strings.Contains(syntheticDenom, "superunbonding") {
+		splitString := strings.Split(syntheticDenom, "/superunbonding/")
+		lastComponent := splitString[len(splitString)-1]
+		return lastComponent, nil
 	}
-	return "", fmt.Errorf("%s is not a valid synthetic denom suffix", suffix)
+	return "", fmt.Errorf("%s is not a valid synthetic denom suffix", syntheticDenom)
 }
 
 type lockingStatus int64


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

smh, trimprefix does not work how we'd expect

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

