### PR TITLE
Add some helpers for testing to its own package in app

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -33,7 +33,8 @@ func SetupValidator(suite SuiteI, bondStatus stakingtypes.BondStatus) sdk.ValAdd
 	bondDenom := suite.GetApp().StakingKeeper.GetParams(suite.GetCtx()).BondDenom
 	selfBond := sdk.NewCoins(sdk.Coin{Amount: sdk.NewInt(100), Denom: bondDenom})
 
-	simapp.FundAccount(suite.GetApp().BankKeeper, suite.GetCtx(), sdk.AccAddress(valAddr), selfBond)
+	err := simapp.FundAccount(suite.GetApp().BankKeeper, suite.GetCtx(), sdk.AccAddress(valAddr), selfBond)
+	suite.GetSuite().Require().NoError(err)
 	sh := teststaking.NewHelper(suite.GetSuite().T(), suite.GetCtx(), *suite.GetApp().StakingKeeper)
 	msg := sh.CreateValidatorMsg(valAddr, valPub, selfBond[0].Amount)
 	sh.Handle(msg, true)

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -1,0 +1,100 @@
+package apptesting
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/simapp"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/osmosis-labs/osmosis/v7/app"
+	"github.com/stretchr/testify/suite"
+)
+
+// TODO: Consider an embedded struct here rather than an interface
+type SuiteI interface {
+	GetSuite() *suite.Suite
+	GetCtx() sdk.Context
+	SetCtx(sdk.Context)
+	GetApp() *app.OsmosisApp
+}
+
+func SetupValidator(suite SuiteI, bondStatus stakingtypes.BondStatus) sdk.ValAddress {
+	valPub := secp256k1.GenPrivKey().PubKey()
+	valAddr := sdk.ValAddress(valPub.Address())
+	bondDenom := suite.GetApp().StakingKeeper.GetParams(suite.GetCtx()).BondDenom
+	selfBond := sdk.NewCoins(sdk.Coin{Amount: sdk.NewInt(100), Denom: bondDenom})
+
+	simapp.FundAccount(suite.GetApp().BankKeeper, suite.GetCtx(), sdk.AccAddress(valAddr), selfBond)
+	sh := teststaking.NewHelper(suite.GetSuite().T(), suite.GetCtx(), *suite.GetApp().StakingKeeper)
+	msg := sh.CreateValidatorMsg(valAddr, valPub, selfBond[0].Amount)
+	sh.Handle(msg, true)
+	val, found := suite.GetApp().StakingKeeper.GetValidator(suite.GetCtx(), valAddr)
+	suite.GetSuite().Require().True(found)
+	val = val.UpdateStatus(bondStatus)
+	suite.GetApp().StakingKeeper.SetValidator(suite.GetCtx(), val)
+
+	consAddr, err := val.GetConsAddr()
+	suite.GetSuite().Require().NoError(err)
+	signingInfo := slashingtypes.NewValidatorSigningInfo(
+		consAddr,
+		suite.GetCtx().BlockHeight(),
+		0,
+		time.Unix(0, 0),
+		false,
+		0,
+	)
+	suite.GetApp().SlashingKeeper.SetValidatorSigningInfo(suite.GetCtx(), consAddr, signingInfo)
+
+	return valAddr
+}
+
+func BeginNewBlock(suite SuiteI, executeNextEpoch bool) {
+	valAddr := []byte(":^) at this distribution workaround")
+	validators := suite.GetApp().StakingKeeper.GetAllValidators(suite.GetCtx())
+	if len(validators) >= 1 {
+		valAddrFancy, err := validators[0].GetConsAddr()
+		suite.GetSuite().Require().NoError(err)
+		valAddr = valAddrFancy.Bytes()
+	} else {
+		valAddrFancy := SetupValidator(suite, stakingtypes.Bonded)
+		validator, _ := suite.GetApp().StakingKeeper.GetValidator(suite.GetCtx(), valAddrFancy)
+		valAddr2, _ := validator.GetConsAddr()
+		valAddr = valAddr2.Bytes()
+	}
+
+	epochIdentifier := suite.GetApp().SuperfluidKeeper.GetEpochIdentifier(suite.GetCtx())
+	epoch := suite.GetApp().EpochsKeeper.GetEpochInfo(suite.GetCtx(), epochIdentifier)
+	newBlockTime := suite.GetCtx().BlockTime().Add(5 * time.Second)
+	if executeNextEpoch {
+		endEpochTime := epoch.CurrentEpochStartTime.Add(epoch.Duration)
+		newBlockTime = endEpochTime.Add(time.Second)
+	}
+	// fmt.Println(executeNextEpoch, suite.ctx.BlockTime(), newBlockTime)
+	header := tmproto.Header{Height: suite.GetCtx().BlockHeight() + 1, Time: newBlockTime}
+	newCtx := suite.GetCtx().WithBlockTime(newBlockTime).WithBlockHeight(suite.GetCtx().BlockHeight() + 1)
+	suite.SetCtx(newCtx)
+	lastCommitInfo := abci.LastCommitInfo{
+		Votes: []abci.VoteInfo{{
+			Validator:       abci.Validator{Address: valAddr, Power: 1000},
+			SignedLastBlock: true},
+		},
+	}
+	reqBeginBlock := abci.RequestBeginBlock{Header: header, LastCommitInfo: lastCommitInfo}
+
+	fmt.Println("beginning block ", suite.GetCtx().BlockHeight())
+	suite.GetApp().BeginBlocker(suite.GetCtx(), reqBeginBlock)
+}
+
+func EndBlock(suite SuiteI) {
+	reqEndBlock := abci.RequestEndBlock{Height: suite.GetCtx().BlockHeight()}
+	suite.GetApp().EndBlocker(suite.GetCtx(), reqEndBlock)
+}

--- a/x/superfluid/keeper/hooks_test.go
+++ b/x/superfluid/keeper/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/osmosis-labs/osmosis/v7/app/apptesting"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
@@ -44,7 +45,7 @@ func (suite *KeeperTestSuite) TestSuperfluidAfterEpochEnd() {
 			suite.Require().NoError(err)
 
 			// run epoch actions
-			suite.BeginNewBlock(true)
+			apptesting.BeginNewBlock(suite, true)
 
 			// check lptoken twap value set
 			newEpochTwap := suite.app.SuperfluidKeeper.GetOsmoEquivalentMultiplier(suite.ctx, "gamm/pool/1")
@@ -58,6 +59,7 @@ func (suite *KeeperTestSuite) TestSuperfluidAfterEpochEnd() {
 				suite.Require().True(found)
 				suite.Require().Equal(sdk.NewDec(5000), delegation.Shares)
 				// TODO: Check reward distribution
+				// suite.Require().NotEqual(sdk.Coins{}, )
 			}
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds some helpers for testing various functions in a re-usable way in app.go

I think this should probably be paired with more custom functions / integrations in modules, to get a more composable testing framework. This at least does a first step with setting up validators, and epochs across modules.

I am torn on whether it should be suiteI, or an embeddable struct though. I'm leaning towards making it an embeddable struct.


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

