### PR TITLE
AfterEpochEnd called with wrong epoch number

### DIFF
--- a/x/epochs/abci.go
+++ b/x/epochs/abci.go
@@ -31,9 +31,6 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 				epochInfo.CurrentEpochStartTime = epochInfo.StartTime
 				logger.Info(fmt.Sprintf("Starting new epoch with identifier %s epoch number %d", epochInfo.Identifier, epochInfo.CurrentEpoch))
 			} else {
-				epochInfo.CurrentEpoch += 1
-				epochInfo.CurrentEpochStartTime = epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration)
-				logger.Info(fmt.Sprintf("Starting epoch with identifier %s epoch number %d", epochInfo.Identifier, epochInfo.CurrentEpoch))
 				ctx.EventManager().EmitEvent(
 					sdk.NewEvent(
 						types.EventTypeEpochEnd,
@@ -41,6 +38,9 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 					),
 				)
 				k.AfterEpochEnd(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
+				epochInfo.CurrentEpoch += 1
+				epochInfo.CurrentEpochStartTime = epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration)
+				logger.Info(fmt.Sprintf("Starting epoch with identifier %s epoch number %d", epochInfo.Identifier, epochInfo.CurrentEpoch))
 			}
 			k.SetEpochInfo(ctx, epochInfo)
 			ctx.EventManager().EmitEvent(


### PR DESCRIPTION
This PR calls EpochEnd prior to increasing the CurrentEpoch by 1 [as discussed here](https://github.com/osmosis-labs/osmosis/issues/830)

Once approved, I will advise all integrators to test their systems off main before we push this to the next 7.x release (before we do this, I think we need to base main off 7.0.2, its still on 7.0.0 I believe)

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

