### PR TITLE
Upgrade IAVL and SDK to v0.17.3-osmo-v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v6.4.1](https://github.com/osmosis-labs/osmosis/releases/tag/v6.4.1)
+
+## Minor improvements & Bug Fixes
+
+- [#1054](https://github.com/osmosis-labs/osmosis/pull/1054) Upgrade IAVL and SDK to v0.17.3-osmo-v4
+
+## IAVL Upgrades
+
+- [iavl-33](https://github.com/osmosis-labs/iavl/pull/33)
+
+## SDK Upgrades
+
+- [sdk-133](https://github.com/osmosis-labs/cosmos-sdk/pull/133)
+
 ## [v6.4.0](https://github.com/osmosis-labs/osmosis/releases/tag/v6.4.0)
 
 ## Minor improvements & Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## IAVL Upgrades
 
-- [iavl-33](https://github.com/osmosis-labs/iavl/pull/33)
+- [iavl-33](https://github.com/osmosis-labs/iavl/pull/33) revert #23 (sync access to fast node cache), fix bug related to old height export
 
 ## SDK Upgrades
 
-- [sdk-133](https://github.com/osmosis-labs/cosmos-sdk/pull/133)
+- [sdk-133](https://github.com/osmosis-labs/cosmos-sdk/pull/133) upgrade iavl to v0.17.3-osmo-v4 for v6.4.x
 
 ## [v6.4.0](https://github.com/osmosis-labs/osmosis/releases/tag/v6.4.0)
 

--- a/go.mod
+++ b/go.mod
@@ -125,8 +125,8 @@ require github.com/dgraph-io/badger/v2 v2.2007.3 // indirect
 
 replace (
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk  v0.44.3x-osmo-v5
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220220052304-a117f821a9b2
-	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v3
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220307181439-241339c0e282
+	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v4
 	// Use osmosis-flavored IBCv2
 	github.com/cosmos/ibc-go/v2 => github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo
 	// Use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -706,10 +706,14 @@ github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220214220252-d69df1dbc317 h1:
 github.com/osmosis-labs/cosmos-sdk v0.43.0-rc3.0.20220214220252-d69df1dbc317/go.mod h1:XIvt5YKBsdq6wM84ixUlMkswPAgRFe+EA2PySK+8PzA=
 github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220220052304-a117f821a9b2 h1:0nwTKczrrNNXKZH9yaDtLWfgjrqtL8mwPO+m8T2sYno=
 github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220220052304-a117f821a9b2/go.mod h1:Tozvv3e+0o3SGzpRR0FhzhDBZK+7j95C7dvup6c5PU8=
+github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220307181439-241339c0e282 h1:j2xz6nXi81MJ7yisuCBQvxqf5dgGO/BWPLJABDWNTmo=
+github.com/osmosis-labs/cosmos-sdk v0.44.4-0.20220307181439-241339c0e282/go.mod h1:6717hGNr8pzVmwwnVEN+4CsgeG3tV5iHB0WBQzZctcs=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v1 h1:orHUut98Miu2+bsFiNZJ29B3ogrbiBbQpti94L2w3Z4=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v1/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v3 h1:q2Qv3+DK52w5b68I96VApHI05jBu7HeQK/YDttKh/jY=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v3/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
+github.com/osmosis-labs/iavl v0.17.3-osmo-v4 h1:U1HA2WEMAYVPjeJlfClH10ajv6O0C1C1jk/SQxDPwyM=
+github.com/osmosis-labs/iavl v0.17.3-osmo-v4/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo h1:XyYyDTjPIu7qX2nhQp9mboj7Pa9FEnjg1RXw73Ctv5U=
 github.com/osmosis-labs/ibc-go/v2 v2.0.2-osmo/go.mod h1:XUmW7wmubCRhIEAGtMGS+5IjiSSmcAwihoN/yPGd6Kk=
 github.com/osmosis-labs/tendermint v0.34.12-0.20220109173307-59a781894ea7 h1:uMaGJbQ2g2pSK+7fWIlr+JJTape8hGHlSAMIiRPg2To=


### PR DESCRIPTION
With help from @p0mvn , bumping IAVL version to v0.17.3-osmo-v4 in order to prevent app hash errors when syncing from gen.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

