### PR TITLE
Improve Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Minor improvements & Bug Fixes
 
 * [#1061](https://github.com/osmosis-labs/osmosis/pull/1061) upgrade iavl to v0.17.3-osmo-v5 with concurrent map write fix
+* [#1071](https://github.com/osmosis-labs/osmosis/pull/1071) improve Dockerfile
 
 ### SDK fork updates
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This repository improves our Dockerfile by:

- Using `base-debian11:nonroot` over `base-debian11` to avoid running container as root
- Uses the `/osmosis` folder as `$HOME` directory for the container
- Statically links `libwasmvm_muslc.a` as in https://github.com/CosmWasm/wasmd/blob/master/Dockerfile

Usage:

```bash
docker run --rm -it -v $HOME/.osmosisd/:/osmosis/ osmolabs/osmosis:v7.0.4 <subcommand>
```

Example:
```bash
docker run --rm -it -v $HOME/.osmosisd/:/osmosis/ osmolabs/osmosis:v7.0.4 init my-moniker
```

You can create an alias to simplify the command:

```bash
alias osmosisd="docker run --rm -it -v $HOME/.osmosisd/:/osmosis/ osmolabs/osmosis:v7.0.4"
```

and then simply:
```
osmosisd init my-moniker 
```
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

