### PR TITLE
Superfluid Misc: Improve grpc_query

### DIFF
--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -80,6 +80,17 @@ func (k Keeper) ConnectedIntermediaryAccount(goCtx context.Context, req *types.C
 	address := k.GetLockIdIntermediaryAccountConnection(ctx, req.LockId)
 	acc := k.GetIntermediaryAccount(ctx, address)
 
+	if len(acc.Denom) == 0 && acc.GaugeId == uint64(0) && len(acc.ValAddr) == 0 {
+		return &types.ConnectedIntermediaryAccountResponse{
+			Account: &types.SuperfluidIntermediaryAccountInfo{
+				Denom:   acc.Denom,
+				ValAddr: acc.ValAddr,
+				GaugeId: acc.GaugeId,
+				Address: "",
+			},
+		}, nil
+	}
+
 	return &types.ConnectedIntermediaryAccountResponse{
 		Account: &types.SuperfluidIntermediaryAccountInfo{
 			Denom:   acc.Denom,

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -318,7 +318,7 @@ func (k Keeper) TotalSuperfluidDelegations(goCtx context.Context, req *types.Tot
 
 		delegation, found := k.sk.GetDelegation(ctx, intermediaryAccount.GetAccAddress(), valAddr)
 		if !found {
-			return nil, stakingtypes.ErrNoDelegation
+			continue
 		}
 
 		syntheticOsmoAmt := delegation.Shares.Quo(val.DelegatorShares).MulInt(val.Tokens).RoundInt()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #[1080](https://github.com/osmosis-labs/osmosis/issues/1080)

## Description

This PR introduces the following improvements for grpc_query in the superfluid module.
- Fix bug where non-existent connected-intermediary-account would still return an address
- Fix bug for `total_supefluid_delegations`



______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

