### PR TITLE
Reformat in-line comments in proto files

### DIFF
--- a/proto/osmosis/incentives/gauge.proto
+++ b/proto/osmosis/incentives/gauge.proto
@@ -10,30 +10,36 @@ import "osmosis/lockup/lock.proto";
 option go_package = "github.com/osmosis-labs/osmosis/v7/x/incentives/types";
 
 message Gauge {
-  uint64 id = 1;         // unique ID of a Gauge
-  bool is_perpetual = 2; // flag to show if it's perpetual or multi-epoch
-                         // distribution incentives by third party
+  // unique ID of a Gauge
+  uint64 id = 1;
+  // flag to show if it's perpetual or multi-epoch
+  // distribution incentives by third party
+  bool is_perpetual = 2;
   // Rewards are distributed to lockups that are are returned by at least one of
   // these queries
   osmosis.lockup.QueryCondition distribute_to = 3
       [ (gogoproto.nullable) = false ];
   // total amount of Coins that has been in the gauge.
+  // can distribute multiple coins
   repeated cosmos.base.v1beta1.Coin coins = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
-  ]; // can distribute multiple coins
+  ];
   // distribution start time
   google.protobuf.Timestamp start_time = 5 [
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = false,
     (gogoproto.moretags) = "yaml:\"start_time\""
   ];
-  uint64 num_epochs_paid_over = 6; // number of epochs distribution will be done
-  uint64 filled_epochs = 7;        // number of epochs distributed already
+  // number of epochs distribution will be done
+  uint64 num_epochs_paid_over = 6;
+  // number of epochs distributed already
+  uint64 filled_epochs = 7;
+  // already distributed coins
   repeated cosmos.base.v1beta1.Coin distributed_coins = 8 [
     (gogoproto.nullable) = false,
     (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
-  ]; // already distributed coins
+  ];
 }
 
 message LockableDurationsInfo {

--- a/proto/osmosis/incentives/tx.proto
+++ b/proto/osmosis/incentives/tx.proto
@@ -15,23 +15,27 @@ service Msg {
 }
 
 message MsgCreateGauge {
-  bool is_perpetual = 1; // flag to show if it's perpetual or multi-epoch
-                         // distribution incentives by third party
+  // flag to show if it's perpetual or multi-epoch
+  // distribution incentives by third party
+  bool is_perpetual = 1;
+
   string owner = 2 [ (gogoproto.moretags) = "yaml:\"owner\"" ];
-  osmosis.lockup.QueryCondition distribute_to = 3 [
-    (gogoproto.nullable) = false
-  ]; // distribute condition of a lock which meet one of these conditions
+  // distribute condition of a lock which meet one of these conditions
+  osmosis.lockup.QueryCondition distribute_to = 3
+      [ (gogoproto.nullable) = false ];
+  // can distribute multiple coins
   repeated cosmos.base.v1beta1.Coin coins = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
-  ]; // can distribute multiple coins
+  ];
   // distribution start time
   google.protobuf.Timestamp start_time = 5 [
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = false,
     (gogoproto.moretags) = "yaml:\"timestamp\""
   ];
-  uint64 num_epochs_paid_over = 6; // number of epochs distribution will be done
+  // number of epochs distribution will be done
+  uint64 num_epochs_paid_over = 6;
 }
 message MsgCreateGaugeResponse {}
 

--- a/proto/osmosis/lockup/lock.proto
+++ b/proto/osmosis/lockup/lock.proto
@@ -34,8 +34,10 @@ message PeriodLock {
 enum LockQueryType {
   option (gogoproto.goproto_enum_prefix) = false;
 
-  ByDuration = 0; // Queries for locks that are longer than a certain duration
-  ByTime = 1;     // Queries for lockups that started before a specific time
+  // Queries for locks that are longer than a certain duration
+  ByDuration = 0;
+  // Queries for lockups that started before a specific time
+  ByTime = 1;
 }
 
 message QueryCondition {

--- a/proto/osmosis/superfluid/genesis.proto
+++ b/proto/osmosis/superfluid/genesis.proto
@@ -16,6 +16,6 @@ message GenesisState {
       [ (gogoproto.nullable) = false ];
   repeated SuperfluidIntermediaryAccount intermediary_accounts = 4
       [ (gogoproto.nullable) = false ];
-  repeated LockIdIntermediaryAccountConnection intemediary_account_connections = 5
-      [ (gogoproto.nullable) = false ];
+  repeated LockIdIntermediaryAccountConnection intemediary_account_connections =
+      5 [ (gogoproto.nullable) = false ];
 }

--- a/proto/osmosis/superfluid/superfluid.proto
+++ b/proto/osmosis/superfluid/superfluid.proto
@@ -30,7 +30,8 @@ message SuperfluidAsset {
 message SuperfluidIntermediaryAccount {
   string denom = 1;
   string val_addr = 2;
-  uint64 gauge_id = 3; // perpetual gauge for rewards distribution
+  // perpetual gauge for rewards distribution
+  uint64 gauge_id = 3;
 }
 
 // The Osmo-Equivalent-Multiplier Record for epoch N refers to the osmo worth we
@@ -42,7 +43,8 @@ message SuperfluidIntermediaryAccount {
 // change.
 message OsmoEquivalentMultiplierRecord {
   int64 epoch_number = 1;
-  string denom = 2; // superfluid asset denom, can be LP token or native token
+  // superfluid asset denom, can be LP token or native token
+  string denom = 2;
   string multiplier = 3 [
     (gogoproto.moretags) = "yaml:\"multiplier\"",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",

--- a/x/incentives/types/gauge.pb.go
+++ b/x/incentives/types/gauge.pb.go
@@ -32,19 +32,25 @@ var _ = time.Kitchen
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Gauge struct {
-	Id          uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	IsPerpetual bool   `protobuf:"varint,2,opt,name=is_perpetual,json=isPerpetual,proto3" json:"is_perpetual,omitempty"`
+	// unique ID of a Gauge
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// flag to show if it's perpetual or multi-epoch
 	// distribution incentives by third party
+	IsPerpetual bool `protobuf:"varint,2,opt,name=is_perpetual,json=isPerpetual,proto3" json:"is_perpetual,omitempty"`
 	// Rewards are distributed to lockups that are are returned by at least one of
 	// these queries
 	DistributeTo types.QueryCondition `protobuf:"bytes,3,opt,name=distribute_to,json=distributeTo,proto3" json:"distribute_to"`
 	// total amount of Coins that has been in the gauge.
+	// can distribute multiple coins
 	Coins github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,4,rep,name=coins,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"coins"`
 	// distribution start time
-	StartTime         time.Time                                `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3,stdtime" json:"start_time" yaml:"start_time"`
-	NumEpochsPaidOver uint64                                   `protobuf:"varint,6,opt,name=num_epochs_paid_over,json=numEpochsPaidOver,proto3" json:"num_epochs_paid_over,omitempty"`
-	FilledEpochs      uint64                                   `protobuf:"varint,7,opt,name=filled_epochs,json=filledEpochs,proto3" json:"filled_epochs,omitempty"`
-	DistributedCoins  github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,8,rep,name=distributed_coins,json=distributedCoins,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"distributed_coins"`
+	StartTime time.Time `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3,stdtime" json:"start_time" yaml:"start_time"`
+	// number of epochs distribution will be done
+	NumEpochsPaidOver uint64 `protobuf:"varint,6,opt,name=num_epochs_paid_over,json=numEpochsPaidOver,proto3" json:"num_epochs_paid_over,omitempty"`
+	// number of epochs distributed already
+	FilledEpochs uint64 `protobuf:"varint,7,opt,name=filled_epochs,json=filledEpochs,proto3" json:"filled_epochs,omitempty"`
+	// already distributed coins
+	DistributedCoins github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,8,rep,name=distributed_coins,json=distributedCoins,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"distributed_coins"`
 }
 
 func (m *Gauge) Reset()         { *m = Gauge{} }

--- a/x/incentives/types/tx.pb.go
+++ b/x/incentives/types/tx.pb.go
@@ -36,14 +36,18 @@ var _ = time.Kitchen
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type MsgCreateGauge struct {
-	IsPerpetual bool `protobuf:"varint,1,opt,name=is_perpetual,json=isPerpetual,proto3" json:"is_perpetual,omitempty"`
+	// flag to show if it's perpetual or multi-epoch
 	// distribution incentives by third party
-	Owner        string                                   `protobuf:"bytes,2,opt,name=owner,proto3" json:"owner,omitempty" yaml:"owner"`
-	DistributeTo types.QueryCondition                     `protobuf:"bytes,3,opt,name=distribute_to,json=distributeTo,proto3" json:"distribute_to"`
-	Coins        github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,4,rep,name=coins,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"coins"`
+	IsPerpetual bool   `protobuf:"varint,1,opt,name=is_perpetual,json=isPerpetual,proto3" json:"is_perpetual,omitempty"`
+	Owner       string `protobuf:"bytes,2,opt,name=owner,proto3" json:"owner,omitempty" yaml:"owner"`
+	// distribute condition of a lock which meet one of these conditions
+	DistributeTo types.QueryCondition `protobuf:"bytes,3,opt,name=distribute_to,json=distributeTo,proto3" json:"distribute_to"`
+	// can distribute multiple coins
+	Coins github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,4,rep,name=coins,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"coins"`
 	// distribution start time
-	StartTime         time.Time `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3,stdtime" json:"start_time" yaml:"timestamp"`
-	NumEpochsPaidOver uint64    `protobuf:"varint,6,opt,name=num_epochs_paid_over,json=numEpochsPaidOver,proto3" json:"num_epochs_paid_over,omitempty"`
+	StartTime time.Time `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3,stdtime" json:"start_time" yaml:"timestamp"`
+	// number of epochs distribution will be done
+	NumEpochsPaidOver uint64 `protobuf:"varint,6,opt,name=num_epochs_paid_over,json=numEpochsPaidOver,proto3" json:"num_epochs_paid_over,omitempty"`
 }
 
 func (m *MsgCreateGauge) Reset()         { *m = MsgCreateGauge{} }

--- a/x/lockup/types/lock.pb.go
+++ b/x/lockup/types/lock.pb.go
@@ -33,8 +33,10 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type LockQueryType int32
 
 const (
+	// Queries for locks that are longer than a certain duration
 	ByDuration LockQueryType = 0
-	ByTime     LockQueryType = 1
+	// Queries for lockups that started before a specific time
+	ByTime LockQueryType = 1
 )
 
 var LockQueryType_name = map[int32]string{

--- a/x/superfluid/types/superfluid.pb.go
+++ b/x/superfluid/types/superfluid.pb.go
@@ -96,6 +96,7 @@ var xxx_messageInfo_SuperfluidAsset proto.InternalMessageInfo
 type SuperfluidIntermediaryAccount struct {
 	Denom   string `protobuf:"bytes,1,opt,name=denom,proto3" json:"denom,omitempty"`
 	ValAddr string `protobuf:"bytes,2,opt,name=val_addr,json=valAddr,proto3" json:"val_addr,omitempty"`
+	// perpetual gauge for rewards distribution
 	GaugeId uint64 `protobuf:"varint,3,opt,name=gauge_id,json=gaugeId,proto3" json:"gauge_id,omitempty"`
 }
 
@@ -161,9 +162,10 @@ func (m *SuperfluidIntermediaryAccount) GetGaugeId() uint64 {
 // price at the boundary.  For different types of assets in the future, it could
 // change.
 type OsmoEquivalentMultiplierRecord struct {
-	EpochNumber int64                                  `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
-	Denom       string                                 `protobuf:"bytes,2,opt,name=denom,proto3" json:"denom,omitempty"`
-	Multiplier  github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,3,opt,name=multiplier,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"multiplier" yaml:"multiplier"`
+	EpochNumber int64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
+	// superfluid asset denom, can be LP token or native token
+	Denom      string                                 `protobuf:"bytes,2,opt,name=denom,proto3" json:"denom,omitempty"`
+	Multiplier github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,3,opt,name=multiplier,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"multiplier" yaml:"multiplier"`
 }
 
 func (m *OsmoEquivalentMultiplierRecord) Reset()         { *m = OsmoEquivalentMultiplierRecord{} }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #863 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Moves inline comments in proto files to separate line(s) before so that they're properly shown in the generated `.pb.go` files. Should be a no-op in functionality. First PR so lmk if I missed something. What I did:
- Grepped for all `; //` in `*.proto` files and move those comments to separate lines
- Ran `make proto-all` to format proto files and generate docs

The `make` command made some local edits to `go.sum`, chose not to include them but lmk if I should check them in.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

