### PR TITLE
Refactor some keeper methods, to expose primitives needed for multihop routing

### DIFF
--- a/x/gamm/keeper/multihop.go
+++ b/x/gamm/keeper/multihop.go
@@ -74,7 +74,7 @@ func (k Keeper) createMultihopExpectedSwapOuts(ctx sdk.Context, routes []types.S
 	for i := len(routes) - 1; i >= 0; i-- {
 		route := routes[i]
 
-		pool, err := k.GetPool(ctx, route.PoolId)
+		pool, err := k.getPoolForSwap(ctx, route.PoolId)
 		if err != nil {
 			return nil, err
 		}

--- a/x/gamm/keeper/pool.go
+++ b/x/gamm/keeper/pool.go
@@ -49,7 +49,7 @@ func (k Keeper) getPoolForSwap(ctx sdk.Context, poolId uint64) (types.PoolI, err
 	}
 
 	if !pool.IsActive(ctx.BlockTime()) {
-		return &balancer.Pool{}, sdkerrors.Wrapf(types.ErrPoolLocked, "join swap on inactive pool")
+		return &balancer.Pool{}, sdkerrors.Wrapf(types.ErrPoolLocked, "swap on inactive pool")
 	}
 	return pool, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Makes internal methods with swap fee exposed. Needed for:
- Getting compound swap fee estimates (needed for mempool work)
- Enabling different multihop swap fees
- (Future) work on raised swapfees during chain liveness failures.

This PR also fixes getPoolForSwap usage
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

