### PR TITLE
Fix: txfees module

### DIFF
--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -23,15 +23,34 @@ func (k Keeper) ConvertToBaseToken(ctx sdk.Context, inputFee sdk.Coin) (sdk.Coin
 		return sdk.Coin{}, err
 	}
 
-	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, feeToken.Denom, baseDenom)
+	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
+
 	if err != nil {
 		return sdk.Coin{}, err
 	}
 
-	return sdk.NewCoin(baseDenom, spotPrice.MulInt(inputFee.Amount).Ceil().RoundInt()), nil
+	return sdk.NewCoin(baseDenom, spotPrice.MulInt(inputFee.Amount).RoundInt()), nil
 }
 
-// GetFeeToken returns the fee token record for a specific denom.
+func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (sdk.Dec, error) {
+	baseDenom, err := k.GetBaseDenom(ctx)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+
+	feeToken, err := k.GetFeeToken(ctx, inputDenom)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+
+	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	return spotPrice, nil
+}
+
+// GetFeeToken returns the fee token record for a specific denom
 func (k Keeper) GetBaseDenom(ctx sdk.Context) (denom string, err error) {
 	store := ctx.KVStore(k.storeKey)
 

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -24,30 +24,11 @@ func (k Keeper) ConvertToBaseToken(ctx sdk.Context, inputFee sdk.Coin) (sdk.Coin
 	}
 
 	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
-
 	if err != nil {
 		return sdk.Coin{}, err
 	}
 
 	return sdk.NewCoin(baseDenom, spotPrice.MulInt(inputFee.Amount).RoundInt()), nil
-}
-
-func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (sdk.Dec, error) {
-	baseDenom, err := k.GetBaseDenom(ctx)
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-
-	feeToken, err := k.GetFeeToken(ctx, inputDenom)
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-
-	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-	return spotPrice, nil
 }
 
 // GetFeeToken returns the fee token record for a specific denom

--- a/x/txfees/keeper/feetokens_test.go
+++ b/x/txfees/keeper/feetokens_test.go
@@ -173,10 +173,11 @@ func (suite *KeeperTestSuite) TestFeeTokenConversions() {
 			expectedConvertable: true,
 		},
 		{
-			name:                "unequal value",
-			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
-			feeTokenPoolInput:   sdk.NewInt64Coin("foo", 200),
-			inputFee:            sdk.NewInt64Coin("foo", 10),
+			name:               "unequal value",
+			baseDenomPoolInput: sdk.NewInt64Coin(baseDenom, 100),
+			feeTokenPoolInput:  sdk.NewInt64Coin("foo", 200),
+			inputFee:           sdk.NewInt64Coin("foo", 10),
+			// expected to get 5.000000000005368710 baseDenom without rounding
 			expectedOutput:      sdk.NewInt64Coin(baseDenom, 5),
 			expectedConvertable: true,
 		},

--- a/x/txfees/keeper/feetokens_test.go
+++ b/x/txfees/keeper/feetokens_test.go
@@ -177,7 +177,7 @@ func (suite *KeeperTestSuite) TestFeeTokenConversions() {
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			feeTokenPoolInput:   sdk.NewInt64Coin("foo", 200),
 			inputFee:            sdk.NewInt64Coin("foo", 10),
-			expectedOutput:      sdk.NewInt64Coin(baseDenom, 20),
+			expectedOutput:      sdk.NewInt64Coin(baseDenom, 5),
 			expectedConvertable: true,
 		},
 		{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR handles a possible bug in the txfees module. 
The current test cases could be the most intuitive example, where we created a pool with 100 base denom and 200 foo tokens. If we're using 10 foo tokens as the input fee, we should expect it to be converted to 5 base denom, not 20 base denom. 

This PR also includes deleting ceil for the calculated spot price. Using the same example above that was used for the test case, the user would be required 5.000000000005368710 base tokens, but this would be ceiled and would be required as 6 basetokens.


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

