### PR TITLE
Calculate SpotPrice with Ratios and SigFigs

### DIFF
--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -245,5 +245,7 @@ func (suite *KeeperTestSuite) TestQueryBalancerPoolSpotPrice() {
 		TokenOutDenom: "foo",
 	})
 	suite.NoError(err)
-	suite.Equal(sdk.NewDec(1).Quo(sdk.NewDec(3)).String(), res.SpotPrice)
+	s := sdk.NewDec(1).Quo(sdk.NewDec(3))
+	sp := s.Mul(types.SigFigs).RoundInt().ToDec().Quo(types.SigFigs)
+	suite.Equal(sp.String(), res.SpotPrice)
 }

--- a/x/gamm/keeper/keeper_test.go
+++ b/x/gamm/keeper/keeper_test.go
@@ -94,7 +94,9 @@ func (suite *KeeperTestSuite) prepareBalancerPool() uint64 {
 	suite.Equal(sdk.NewDecWithPrec(15, 1).String(), spotPrice.String())
 	spotPrice, err = suite.app.GAMMKeeper.CalculateSpotPrice(suite.ctx, poolId, "baz", "foo")
 	suite.NoError(err)
-	suite.Equal(sdk.NewDec(1).Quo(sdk.NewDec(3)).String(), spotPrice.String())
+	s := sdk.NewDec(1).Quo(sdk.NewDec(3))
+	sp := s.Mul(types.SigFigs).RoundInt().ToDec().Quo(types.SigFigs)
+	suite.Equal(sp.String(), spotPrice.String())
 
 	return poolId
 }

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -122,9 +122,11 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (sdk.Dec,
 		return sdk.Dec{}, errors.New("pool is misconfigured, got 0 weight")
 	}
 
-	weightRatio := base.Weight.ToDec().Quo(quote.Weight.ToDec())
+        // spot_price = (Base_supply / Weight_base) / (Quote_supply / Weight_quote)
+        // spot_price = (weight_quote / weight_base) * (base_supply / quote_supply)
+	invWeightRatio := quote.Weight.ToDec().Quo(base.Weight.ToDec())
 	supplyRatio := base.Token.Amount.ToDec().Quo(quote.Token.Amount.ToDec())
-	fullRatio := supplyRatio.Quo(weightRatio)
+	fullRatio := supplyRatio.Mul(invWeightRatio)
 	ratio := (fullRatio.Mul(types.SigFigs).RoundInt()).ToDec().Quo(types.SigFigs)
 	return ratio, nil
 }

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -122,8 +122,8 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (sdk.Dec,
 		return sdk.Dec{}, errors.New("pool is misconfigured, got 0 weight")
 	}
 
-        // spot_price = (Base_supply / Weight_base) / (Quote_supply / Weight_quote)
-        // spot_price = (weight_quote / weight_base) * (base_supply / quote_supply)
+	// spot_price = (Base_supply / Weight_base) / (Quote_supply / Weight_quote)
+	// spot_price = (weight_quote / weight_base) * (base_supply / quote_supply)
 	invWeightRatio := quote.Weight.ToDec().Quo(base.Weight.ToDec())
 	supplyRatio := base.Token.Amount.ToDec().Quo(quote.Token.Amount.ToDec())
 	fullRatio := supplyRatio.Mul(invWeightRatio)

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -28,16 +28,23 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 		{
 			name:                "1:2 ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
-			quoteDenomPoolInput: sdk.NewInt64Coin("foo", 200),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 200),
 			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("0.500000000002684355"),
+			expectedOutput:      sdk.MustNewDecFromStr("0.500000000000000000"),
 		},
 		{
 			name:                "2:1 ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
-			quoteDenomPoolInput: sdk.NewInt64Coin("foo", 100),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
 			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("1.999999999989262582"),
+			expectedOutput:      sdk.MustNewDecFromStr("2.000000000000000000"),
+		},
+		{
+			name:                "rounding after sigfig ratio",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
 		},
 	}
 

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -9,6 +9,8 @@ const (
 	MaxPoolAssets = 8
 
 	OneShareExponent = 18
+
+	SigFigsExponent = 8
 )
 
 var (
@@ -17,4 +19,7 @@ var (
 
 	// InitPoolSharesSupply is the amount of new shares to initialize a pool with.
 	InitPoolSharesSupply = OneShare.MulRaw(100)
+
+	// SigFigs is the amount of significant figures used to calculate SpotPrice
+	SigFigs = sdk.NewDec(10).Power(SigFigsExponent)
 )

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -9,7 +9,8 @@ const (
 	MaxPoolAssets = 8
 
 	OneShareExponent = 18
-
+	// Raise 10 to the power of SigFigsExponent to determine number of significant figures.
+	// i.e. SigFigExponent = 8 is 10^8 which is 100000000. This gives 8 significant figures.
 	SigFigsExponent = 8
 )
 

--- a/x/pool-incentives/keeper/keeper_test.go
+++ b/x/pool-incentives/keeper/keeper_test.go
@@ -96,7 +96,9 @@ func (suite *KeeperTestSuite) prepareBalancerPool() uint64 {
 	suite.Equal(sdk.NewDecWithPrec(15, 1).String(), spotPrice.String())
 	spotPrice, err = suite.app.GAMMKeeper.CalculateSpotPrice(suite.ctx, poolId, "baz", "foo")
 	suite.NoError(err)
-	suite.Equal(sdk.NewDec(1).Quo(sdk.NewDec(3)).String(), spotPrice.String())
+	s := sdk.NewDec(1).Quo(sdk.NewDec(3))
+	sp := s.Mul(gammtypes.SigFigs).RoundInt().ToDec().Quo(gammtypes.SigFigs)
+	suite.Equal(sp.String(), spotPrice.String())
 
 	return poolId
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1155 

## Description

* Calculates SpotPrice with ratios to prevent trailing digits from giving incorrect results
* Utilizes constant in x/gamm/types to determine how many significant figures we calculate SpotPrice to (other functions can also use this SigFigs constant now)
* Added a test to show a circumstance in which the 9th digit is greater than 5, and with 8 sigfigs set should remove the 9th digit however still round the 8th digit up
* Added comment to explain why this change was added