### PR TITLE
second e2e chain with expanded test

### DIFF
--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -10,7 +10,6 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	tmrand "github.com/tendermint/tendermint/libs/rand"
 
 	osmosisApp "github.com/osmosis-labs/osmosis/v7/app"
 	"github.com/osmosis-labs/osmosis/v7/app/params"
@@ -48,14 +47,14 @@ type chain struct {
 	validators []*validator
 }
 
-func newChain() (*chain, error) {
+func newChain(name string) (*chain, error) {
 	tmpDir, err := ioutil.TempDir("", "osmosis-e2e-testnet-")
 	if err != nil {
 		return nil, err
 	}
 
 	return &chain{
-		id:      "chain-" + tmrand.NewRand().Str(6),
+		id:      name,
 		dataDir: tmpDir,
 	}, nil
 }

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -43,12 +43,12 @@ const (
 )
 
 var (
-	initBalanceStrA    = fmt.Sprintf("%d%s,%d%s", osmoBalanceA, osmoDenom, stakeBalanceA, stakeDenom)
-	initBalanceStrB    = fmt.Sprintf("%d%s,%d%s", osmoBalanceB, osmoDenom, stakeBalanceB, stakeDenom)
-	stakeAmountIntA, _ = sdk.NewIntFromString(fmt.Sprintf("%d", stakeAmountA))
-	stakeAmountCoinA   = sdk.NewCoin(stakeDenom, stakeAmountIntA)
-	stakeAmountIntB, _ = sdk.NewIntFromString(fmt.Sprintf("%d", stakeAmountB))
-	stakeAmountCoinB   = sdk.NewCoin(stakeDenom, stakeAmountIntB)
+	initBalanceStrA  = fmt.Sprintf("%d%s,%d%s", osmoBalanceA, osmoDenom, stakeBalanceA, stakeDenom)
+	initBalanceStrB  = fmt.Sprintf("%d%s,%d%s", osmoBalanceB, osmoDenom, stakeBalanceB, stakeDenom)
+	stakeAmountIntA  = sdk.NewInt(stakeAmountA)
+	stakeAmountCoinA = sdk.NewCoin(stakeDenom, stakeAmountIntA)
+	stakeAmountIntB  = sdk.NewInt(stakeAmountB)
+	stakeAmountCoinB = sdk.NewCoin(stakeDenom, stakeAmountIntB)
 )
 
 type IntegrationTestSuite struct {
@@ -87,7 +87,8 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	// The boostrapping phase is as follows:
 	//
 	// 1. Initialize Osmosis validator nodes.
-	// 2. Create and initialize Osmosis validator genesis files (one chain)
+	// 2. Create and initialize Osmosis validator genesis files (both chains)
+	// 3. Start both networks.
 
 	s.T().Logf("starting e2e infrastructure for chain A; chain-id: %s; datadir: %s", s.chainA.id, s.chainA.dataDir)
 	s.initNodes(s.chainA)

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -196,10 +196,7 @@ func (s *IntegrationTestSuite) initGenesis(c *chain) {
 	genTxs := make([]json.RawMessage, len(c.validators))
 	for i, val := range c.validators {
 		stakeAmountCoin := stakeAmountCoinA
-		if c.id == chainAName {
-			stakeAmountCoin = stakeAmountCoinA
-
-		} else {
+		if c.id != chainAName {
 			stakeAmountCoin = stakeAmountCoinB
 		}
 		createValmsg, err := val.buildCreateValidatorMsg(stakeAmountCoin)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -18,14 +18,14 @@ func (s *IntegrationTestSuite) TestQueryBalances() {
 		expectedBalancesB = []uint64{osmoBalanceB, stakeBalanceB - stakeAmountB}
 	)
 
-	chainAAPIEndpointA := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
-	balancesA, err := queryBalances(chainAAPIEndpointA, s.chainA.validators[0].keyInfo.GetAddress().String())
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
+	balancesA, err := queryBalances(chainAAPIEndpoint, s.chainA.validators[0].keyInfo.GetAddress().String())
 	s.Require().NoError(err)
 	s.Require().NotNil(balancesA)
 	s.Require().Equal(2, len(balancesA))
 
-	chainAAPIEndpointB := fmt.Sprintf("http://%s", s.valResources[s.chainB.id][0].GetHostPort("1317/tcp"))
-	balancesB, err := queryBalances(chainAAPIEndpointB, s.chainB.validators[0].keyInfo.GetAddress().String())
+	chainBAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainB.id][0].GetHostPort("1317/tcp"))
+	balancesB, err := queryBalances(chainBAPIEndpoint, s.chainB.validators[0].keyInfo.GetAddress().String())
 	s.Require().NoError(err)
 	s.Require().NotNil(balancesB)
 	s.Require().Equal(2, len(balancesB))

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -13,26 +13,42 @@ import (
 
 func (s *IntegrationTestSuite) TestQueryBalances() {
 	var (
-		expectedDenoms   = []string{osmoDenom, stakeDenom}
-		expectedBalances = []uint64{osmoBalance, stakeBalance - stakeAmount}
+		expectedDenoms    = []string{osmoDenom, stakeDenom}
+		expectedBalancesA = []uint64{osmoBalanceA, stakeBalanceA - stakeAmountA}
+		expectedBalancesB = []uint64{osmoBalanceB, stakeBalanceB - stakeAmountB}
 	)
 
-	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chain.id][0].GetHostPort("1317/tcp"))
-	balances, err := queryBalances(chainAAPIEndpoint, s.chain.validators[0].keyInfo.GetAddress().String())
+	chainAAPIEndpointA := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
+	balancesA, err := queryBalances(chainAAPIEndpointA, s.chainA.validators[0].keyInfo.GetAddress().String())
 	s.Require().NoError(err)
-	s.Require().NotNil(balances)
-	s.Require().Equal(2, len(balances))
+	s.Require().NotNil(balancesA)
+	s.Require().Equal(2, len(balancesA))
 
-	actualDenoms := make([]string, 0, 2)
-	actualBalances := make([]uint64, 0, 2)
+	chainAAPIEndpointB := fmt.Sprintf("http://%s", s.valResources[s.chainB.id][0].GetHostPort("1317/tcp"))
+	balancesB, err := queryBalances(chainAAPIEndpointB, s.chainB.validators[0].keyInfo.GetAddress().String())
+	s.Require().NoError(err)
+	s.Require().NotNil(balancesB)
+	s.Require().Equal(2, len(balancesB))
 
-	for _, balance := range balances {
-		actualDenoms = append(actualDenoms, balance.GetDenom())
-		actualBalances = append(actualBalances, balance.Amount.Uint64())
+	actualDenomsA := make([]string, 0, 2)
+	actualBalancesA := make([]uint64, 0, 2)
+	actualDenomsB := make([]string, 0, 2)
+	actualBalancesB := make([]uint64, 0, 2)
+
+	for _, balanceA := range balancesA {
+		actualDenomsA = append(actualDenomsA, balanceA.GetDenom())
+		actualBalancesA = append(actualBalancesA, balanceA.Amount.Uint64())
 	}
 
-	s.Require().ElementsMatch(expectedDenoms, actualDenoms)
-	s.Require().ElementsMatch(expectedBalances, actualBalances)
+	for _, balanceB := range balancesB {
+		actualDenomsB = append(actualDenomsB, balanceB.GetDenom())
+		actualBalancesB = append(actualBalancesB, balanceB.Amount.Uint64())
+	}
+
+	s.Require().ElementsMatch(expectedDenoms, actualDenomsA)
+	s.Require().ElementsMatch(expectedBalancesA, actualBalancesA)
+	s.Require().ElementsMatch(expectedDenoms, actualDenomsB)
+	s.Require().ElementsMatch(expectedBalancesB, actualBalancesB)
 }
 
 func queryBalances(endpoint, addr string) (sdk.Coins, error) {


### PR DESCRIPTION
Closes: #1200 

## Description

1. Added a second chain
2. Created a constant for human readable chain names
3. Used different values for chainB's osmo/stake balance to ensure the balance query is tracking the correct chain
4. Included chainB in the QueryBalances test

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

