### PR TITLE
upgrade zondax/hid to remove build message warning on macos 12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.1.1-0.20210918184747-d757024714a1 // indirect
-	github.com/zondax/hid v0.9.0 // indirect
+	github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266 // indirect
 	gitlab.com/bosi/decorder v0.2.1 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1420,6 +1420,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
+github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266 h1:O9XLFXGkVswDFmH9LaYpqu+r/AAFWqr0DL6V00KEVFg=
+github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 gitlab.com/bosi/decorder v0.2.1 h1:ehqZe8hI4w7O4b1vgsDZw1YU1PE7iJXrQWFMsocbQ1w=
 gitlab.com/bosi/decorder v0.2.1/go.mod h1:6C/nhLSbF6qZbYD8bRmISBwc6vcWdNsiIBkRvjJFrH0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis/issues/1267

NOTE! I‘m using the proposed PR template for this PR, to demonstrate how it can work

## What is the purpose of the change

Upgrade zondax/hid to remove build warnings and noise on mac

## Brief change log

- upgrade zondax/hid from 0.9.0 to 0.9.1, by referencing [this fix](https://github.com/cosmos/cosmos-sdk/pull/11307) from Cosmos SDK

Please reference the before v.s. after screenshots to see the warnings are gone and build messages are much cleaner. Note that the screenshot diffs are already based on https://github.com/osmosis-labs/osmosis/pull/1266 which removed massive keyring warnings already

Screenshot before this change:

![image](https://user-images.githubusercontent.com/66541548/163692909-6bf149dd-5889-4594-a0bc-1c9a01b85b7d.png)

Screenshot after upgrading the lib:

![image](https://user-images.githubusercontent.com/66541548/163693047-7e95d8ea-7fe5-4b7e-8c60-f210d4f007b9.png)

## PR Formatting

- Is PR targeted against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))  (yes)


## Testing and Verifying

I tested locally, `make test` passed.

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)
