### PR TITLE
fix: release build scripts

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -11,7 +11,7 @@ set -ue
 # - DEBUG
 
 # Source builder's functions library
-. /usr/local/share/tendermint/buildlib.sh
+. /usr/local/share/osmosis/buildlib.sh
 
 # These variables are now available
 # - BASEDIR
@@ -31,7 +31,9 @@ for platform in ${TARGET_PLATFORMS} ; do
         LDFLAGS=-buildid=${VERSION} \
         VERSION=${VERSION} \
         COMMIT=${COMMIT} \
-        LEDGER_ENABLED=${LEDGER_ENABLED}
+        LEDGER_ENABLED=${LEDGER_ENABLED} \
+        LINK_STATICALLY=true \
+        BUILD_TAGS=muslc
     mv ./build/${APP}${OS_FILE_EXT} ${OUTDIR}/${APP}-${VERSION}-$(go env GOOS)-$(go env GOARCH)${OS_FILE_EXT}
 
     # This function restore the build environment variables to their

--- a/.build.sh
+++ b/.build.sh
@@ -24,7 +24,6 @@ for platform in ${TARGET_PLATFORMS} ; do
     # cases except when the target platform is 'windows'.
     setup_build_env_for_platform "${platform}"
 
-    make clean
     echo Building for $(go env GOOS)/$(go env GOARCH) >&2
     GOROOT_FINAL="$(go env GOROOT)" \
     make build \

--- a/.build.sh
+++ b/.build.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -ue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1107](https://github.com/osmosis-labs/osmosis/pull/1107) Update to wasmvm v0.24.0, re-enabling building on M1 macs!
 
 ### Minor improvements & Bug Fixes
+* [#1286](https://github.com/osmosis-labs/osmosis/pull/1286) Fix release build scripts.
 * [#1203](https://github.com/osmosis-labs/osmosis/pull/1203) cleanup Makefile and ci workflows
 * [#1177](https://github.com/osmosis-labs/osmosis/pull/1177) upgrade to go 1.18
 * [#1193](https://github.com/osmosis-labs/osmosis/pull/1193) Setup e2e tests on a single chain; add balances query test

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
   ldflags += -w -s
 endif
-ifeq ($(LEDGER_ENABLED),true)
+ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-L/lib/ -lwasmvm_muslc -Wl,-z,muldefs -static"
 endif
 ldflags += $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ build-reproducible: go.sum
 	--env COMMIT=$(COMMIT) \
 	--env LEDGER_ENABLED=$(LEDGER_ENABLED) \
 	--name latest-build osmolabs/rbuilder:latest
-	$(DOCKER) cp -a latest-build:/root/artifacts/ $(CURDIR)/
+	$(DOCKER) cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
 
 build-linux: go.sum
 	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 $(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
   ldflags += -w -s
 endif
 ifeq ($(LEDGER_ENABLED),true)
-	ldflags += -linkmode=external -extldflags "-L/home/roman/Downloads -lwasmvm_muslc -Wl,-z,muldefs -static"
+	ldflags += -linkmode=external -extldflags "-L/lib/ -lwasmvm_muslc -Wl,-z,muldefs -static"
 endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
@@ -97,8 +97,8 @@ $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/
 
 build-reproducible: go.sum
-	$(DOCKER) rm latest-build || true
-	$(DOCKER) run --volume=$(CURDIR):/sources:ro \
+		$(DOCKER) rm latest-build || true
+		$(DOCKER) run --volume=$(CURDIR):/sources:ro \
 		--env TARGET_PLATFORMS='linux/amd64' \
 		--env APP=osmosisd \
 		--env VERSION=$(VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(BUILDDIR)/:
 build-reproducible: go.sum
 	$(DOCKER) rm latest-build || true
 	$(DOCKER) run --volume=$(CURDIR):/sources:ro \
-        --env TARGET_PLATFORMS='linux/amd64 darwin/amd64 linux/arm64 windows/amd64' \
+        --env TARGET_PLATFORMS='linux/amd64' \
         --env APP=osmosisd \
         --env VERSION=$(VERSION) \
         --env COMMIT=$(COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ all: install lint test
 
 BUILD_TARGETS := build install
 
- build: BUILD_ARGS=-o $(BUILDDIR)/
+build: BUILD_ARGS=-o $(BUILDDIR)/
 
 $(BUILD_TARGETS): go.sum $(BUILDDIR)/
 	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
   ldflags += -w -s
 endif
 ifeq ($(LINK_STATICALLY),true)
-	ldflags += -linkmode=external -extldflags "-L/lib/ -lwasmvm_muslc -Wl,-z,muldefs -static"
+	ldflags += -linkmode=external -extldflags "-L/usr/local/lib/ -lwasmvm_muslc -Wl,-z,muldefs -static"
 endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))

--- a/Makefile
+++ b/Makefile
@@ -97,14 +97,14 @@ $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/
 
 build-reproducible: go.sum
-		$(DOCKER) rm latest-build || true
-		$(DOCKER) run --volume=$(CURDIR):/sources:ro \
-		--env TARGET_PLATFORMS='linux/amd64' \
-		--env APP=osmosisd \
-		--env VERSION=$(VERSION) \
-		--env COMMIT=$(COMMIT) \
-		--env LEDGER_ENABLED=$(LEDGER_ENABLED) \
-		--name latest-build osmolabs/rbuilder:latest
+	$(DOCKER) rm latest-build || true
+	$(DOCKER) run --volume=$(CURDIR):/sources:ro \
+	--env TARGET_PLATFORMS='linux/amd64' \
+	--env APP=osmosisd \
+	--env VERSION=$(VERSION) \
+	--env COMMIT=$(COMMIT) \
+	--env LEDGER_ENABLED=$(LEDGER_ENABLED) \
+	--name latest-build osmolabs/rbuilder:latest
 	$(DOCKER) cp -a latest-build:/root/artifacts/ $(CURDIR)/
 
 build-linux: go.sum

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
   ldflags += -w -s
 endif
 ifeq ($(LEDGER_ENABLED),true)
-	ldflags += -linkmode=external -extldflags "-L/lib/ -lwasmvm_muslc -Wl,-z,muldefs -static"
+	ldflags += -linkmode=external -extldflags "-L/home/roman/Downloads -lwasmvm_muslc -Wl,-z,muldefs -static"
 endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
@@ -98,14 +98,14 @@ $(BUILDDIR)/:
 
 build-reproducible: go.sum
 	$(DOCKER) rm latest-build || true
-	$(DOCKER) run --volume=$(CURDIR):/sources \
+	$(DOCKER) run --volume=$(CURDIR):/sources:ro \
 		--env TARGET_PLATFORMS='linux/amd64' \
 		--env APP=osmosisd \
 		--env VERSION=$(VERSION) \
 		--env COMMIT=$(COMMIT) \
 		--env LEDGER_ENABLED=$(LEDGER_ENABLED) \
 		--name latest-build osmolabs/rbuilder:latest
-	$(DOCKER) cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
+	$(DOCKER) cp -a latest-build:/root/artifacts/ $(CURDIR)/
 
 build-linux: go.sum
 	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 $(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ build-reproducible: go.sum
         --env VERSION=$(VERSION) \
         --env COMMIT=$(COMMIT) \
         --env LEDGER_ENABLED=$(LEDGER_ENABLED) \
-        --name latest-build cosmossdk/rbuilder:latest
+        --name latest-build osmolabs/rbuilder:latest
 	$(DOCKER) cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
 
 build-linux: go.sum

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -4,6 +4,6 @@ simd-env:
 	docker build --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) --tag cosmossdk/simd-env simd-env
 
 rbuilder:
-	docker build --tag cosmossdk/rbuilder rbuilder
+	docker build --tag osmolabs/rbuilder rbuilder
 
 .PHONY: all simd-env rbuilder

--- a/contrib/images/rbuilder/Dockerfile
+++ b/contrib/images/rbuilder/Dockerfile
@@ -1,16 +1,34 @@
-FROM golang:1.15.2-alpine3.12
+
+FROM golang:1.18-bullseye
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get --no-install-recommends -y install \
     pciutils build-essential git wget \
     lsb-release dpkg-dev curl bsdmainutils fakeroot
-RUN mkdir -p /usr/local/share/cosmos-sdk/
-COPY buildlib.sh /usr/local/share/cosmos-sdk/
+RUN mkdir -p /usr/local/share/tendermint/
+
+# Deploy the shell functions library.
+COPY buildlib.sh /usr/local/share/tendermint/
+
+# Create the 'builder' user.
 RUN useradd -ms /bin/bash -U builder
 ARG APP
 ARG DEBUG
-ENV APP ${APP:-cosmos-sdk}
-ENV DEBUG ${DEBUG} VERSION unknown COMMIT unknown LEDGER_ENABLE true
+ARG TARGET_PLATFORMS
+ENV APP ${APP:-app}
+ENV DEBUG ${DEBUG}
+ENV VERSION unknown
+ENV COMMIT unknown
+ENV LEDGER_ENABLE true
+ENV TARGET_PLATFORMS ${TARGET_PLATFORMS:-linux/amd64}
+ENV BUILD_SCRIPT ${BUILD_SCRIPT:-/sources/.build.sh}
+
+# Drop root privileges.
 USER builder:builder
 WORKDIR /sources
+
+# Mount the application's sources.
 VOLUME [ "/sources" ]
-ENTRYPOINT [ "/sources/build.sh" ]
+
+# Run the application's build.sh.
+ENTRYPOINT [ "/bin/bash", "-c", "${BUILD_SCRIPT}" ]

--- a/contrib/images/rbuilder/Dockerfile
+++ b/contrib/images/rbuilder/Dockerfile
@@ -10,11 +10,8 @@ RUN mkdir -p /usr/local/share/osmosis/
 # Deploy the shell functions library.
 COPY buildlib.sh /usr/local/share/osmosis/
 
-# From https://github.com/CosmWasm/wasmd/blob/master/Dockerfile
-# For more details see https://github.com/CosmWasm/wasmvm#builds-of-libwasmvm 
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d5f2cd7fd8513cafa9932d22eb350
-
+# Create the 'builder' user.
+RUN useradd -ms /bin/bash -U builder
 ARG APP
 ARG DEBUG
 ARG TARGET_PLATFORMS
@@ -26,10 +23,15 @@ ENV LEDGER_ENABLE true
 ENV TARGET_PLATFORMS ${TARGET_PLATFORMS:-linux/amd64}
 ENV BUILD_SCRIPT ${BUILD_SCRIPT:-/sources/.build.sh}
 
-WORKDIR /sources
+# From https://github.com/CosmWasm/wasmd/blob/master/Dockerfile
+# For more details see https://github.com/CosmWasm/wasmvm#builds-of-libwasmvm 
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a /usr/local/lib/libwasmvm_muslc.a
+RUN chown builder /usr/local/lib/libwasmvm_muslc.a 
+RUN sha256sum /usr/local/lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d5f2cd7fd8513cafa9932d22eb350
 
-# Mount the application's sources.
-VOLUME [ "/sources" ]
+# Drop root privileges.
+USER builder:builder
+WORKDIR /sources
 
 # Run the application's build.sh.
 ENTRYPOINT [ "/bin/bash", "-c", "${BUILD_SCRIPT}" ]

--- a/contrib/images/rbuilder/Dockerfile
+++ b/contrib/images/rbuilder/Dockerfile
@@ -5,13 +5,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get --no-install-recommends -y install \
     pciutils build-essential git wget \
     lsb-release dpkg-dev curl bsdmainutils fakeroot
-RUN mkdir -p /usr/local/share/tendermint/
+RUN mkdir -p /usr/local/share/osmosis/
 
 # Deploy the shell functions library.
-COPY buildlib.sh /usr/local/share/tendermint/
+COPY buildlib.sh /usr/local/share/osmosis/
 
-# Create the 'builder' user.
-RUN useradd -ms /bin/bash -U builder
+# From https://github.com/CosmWasm/wasmd/blob/master/Dockerfile
+# For more details see https://github.com/CosmWasm/wasmvm#builds-of-libwasmvm 
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d5f2cd7fd8513cafa9932d22eb350
+
 ARG APP
 ARG DEBUG
 ARG TARGET_PLATFORMS
@@ -23,8 +26,6 @@ ENV LEDGER_ENABLE true
 ENV TARGET_PLATFORMS ${TARGET_PLATFORMS:-linux/amd64}
 ENV BUILD_SCRIPT ${BUILD_SCRIPT:-/sources/.build.sh}
 
-# Drop root privileges.
-USER builder:builder
 WORKDIR /sources
 
 # Mount the application's sources.

--- a/contrib/images/rbuilder/README.md
+++ b/contrib/images/rbuilder/README.md
@@ -1,7 +1,7 @@
 # Reproducible Build System
 
 This image is meant to provide a minimal deterministic
-buildsystem for Cosmos SDK applications.
+build system for Cosmos SDK applications.
 
 # Requirements And Usage
 
@@ -11,6 +11,7 @@ in the root folder meant to drive the build process.
 The build's outputs are produced in the top-level `artifacts` directory.
 
 ## Building the Image Locally
+
 ```
 cd ./contrib/images
 
@@ -24,13 +25,18 @@ cd <osmosis root>
 make build-reproducible
 ```
 
-This spins up an rbuilder container with a volume installed to the
+This spins up an `rbuilder` container with a volume installed to the
 root of the repository. This way, the builder has access to the `.build.sh`file and is
 able to execute it.
 
-Currently, only `linux/amd64'` is supported. We can add support for other
-platforms by modifying TARGET_PLATFORMS environment variable. in `build-reproducible`
-Makefile step. Adding more support is blocked by our dependency on wasmvm.
-The support of some platforms are already added in new versions of wasmvm.
+## Wasmvm dependency
+
+Currently, only `linux/amd64` is supported. Adding more support is blocked by our dependency on wasmvm.
+
+The support of some platforms is already added in new versions of wasmvm.
 Follow the release log for more detaisl when updating our builder:
 https://github.com/CosmWasm/wasmvm/releases
+
+Once wasmvm is upgraded, more platforms may be built by changing
+`TARGET_PLATFORMS` environment variable in `build-reproducible`
+Makefile step. 

--- a/contrib/images/rbuilder/README.md
+++ b/contrib/images/rbuilder/README.md
@@ -1,7 +1,9 @@
 # Reproducible Build System
 
-This image is meant to provide a minimal deterministic
-build system for Cosmos SDK applications.
+This image and scripts are meant to provide a minimal deterministic
+build system for the Osmosis application.
+
+It was created by referencing Tendermint's [implementation](https://github.com/tendermint/images/blob/cf0d1a9f3731e30540bbfa36a36d13e4dcccf5eb/rbuilder/README.md)
 
 # Requirements And Usage
 

--- a/contrib/images/rbuilder/README.md
+++ b/contrib/images/rbuilder/README.md
@@ -1,0 +1,36 @@
+# Reproducible Build System
+
+This image is meant to provide a minimal deterministic
+buildsystem for Cosmos SDK applications.
+
+# Requirements And Usage
+
+The Osmosis repository must include a`.build.sh` executable file 
+in the root folder meant to drive the build process.
+
+The build's outputs are produced in the top-level `artifacts` directory.
+
+## Building the Image Locally
+```
+cd ./contrib/images
+
+make rbuilder
+```
+
+This creates the `rbuilder` image. To run a container of this image locally and build the binaries:
+```
+cd <osmosis root>
+
+make build-reproducible
+```
+
+This spins up an rbuilder container with a volume installed to the
+root of the repository. This way, the builder has access to the `.build.sh`file and is
+able to execute it.
+
+Currently, only `linux/amd64'` is supported. We can add support for other
+platforms by modifying TARGET_PLATFORMS environment variable. in `build-reproducible`
+Makefile step. Adding more support is blocked by our dependency on wasmvm.
+The support of some platforms are already added in new versions of wasmvm.
+Follow the release log for more detaisl when updating our builder:
+https://github.com/CosmWasm/wasmvm/releases


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1284

## What is the purpose of the change

This change fixes our `make build-reproducible` Makefile step to generate release binaries. As described in the issue #1284, our current binaries do not have cosm wasm dependencies correctly installed. Wasmvm binaries need to be statically linked.

On initial investigation, I observed that our `rbuilder` is broken when built locally. The version from docker hub that is used by default when local version is not available has not been updated in around a year and does not work with the `main` branch of our repository.

As a result, our `rbuilder` was fixed in this PR by referencing the updated version here: https://github.com/tendermint/images/tree/master/rbuilder

Additionally, it does not make sense to rely on the cosmoshub image (`cosmossdk/rbuilder:latest`). That is not built by our team.

I propose to push the final result of the `rbuilder` in this PR to our Dockerhub (i.e `osmolabs/rbuilder`) CC: @nikever 

## Brief change log
- fix `make build-reproducible` and all related scripts by referencing: https://github.com/tendermint/images/tree/master/rbuilder
- add logic for statically linking wasmvm
- fix permission errors related to cosm wasm library running in container as non-root

## PR Formatting


- Is PR targeted against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))  yes



## Testing and Verifying

Built the binary with `make built-reproducible` on main branch and successfully ran it without getting the error described in #1284:
```
./osmosisd-7.0.0-123-g33a436a2-linux-amd64 start
7:09PM INF starting ABCI with Tendermint
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? added a README in `contrib/images/README.md`
