### PR TITLE
Fix docs navigation & update diagram's path

### DIFF
--- a/x/superfluid/spec/README.md
+++ b/x/superfluid/spec/README.md
@@ -1,10 +1,3 @@
-<!--
-order: 0
-title: "Superfluid Overview"
-parent:
-  title: "superfluid"
--->
-
 # Superfluid Staking
 
 ## Abstract
@@ -38,7 +31,7 @@ On epoch (start of every day), we read from the lockup module how much GAMM toke
 
 <br/>
 <p style="text-align:center;">
-<img src="/img/superfluiddiagram.png" height="300"/>
+<img src="https://raw.githubusercontent.com/osmosis-labs/osmosis/main/x/superfluid/spec/superfluiddiagram.png" height="300"/>
 </p>
 
 </br>


### PR DESCRIPTION
- [ ] Initial code is not needed, it breaks the docs site. 
- [ ] We also need absolute paths for images in order to render them in other sites.