### PR TITLE
Add upgrade handler for v8

### DIFF
--- a/app/upgrades/README.md
+++ b/app/upgrades/README.md
@@ -8,5 +8,6 @@ This folder contains logic for every osmosis upgrade. (Both state migrations, an
 * v5 - Boron State migration
 * v6 - hard fork for IBC bug fix
 * v7 - Carbon State migration
+* v8 - Nitrogen State migration
 
 ## TODO: Make a fork-upgrade struct and a state-migration upgrade struct

--- a/app/upgrades/v8/constants.go
+++ b/app/upgrades/v8/constants.go
@@ -1,0 +1,4 @@
+package v8
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v7 upgrade.
+const UpgradeName = "v8"

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -1,0 +1,16 @@
+package v8
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR adds boilerplate for the v8 upgrade handler. Simplifies the logic for upgrade store handler updates. Intended as a precursor for #1301 

## Brief change log

- Adds boilerplate for the v8 upgrade handler. I don't think this necessitates an entry in the actual changelog.

## Testing and Verifying

This change should be tested in upcoming upgrade handler testing on testnets / in framework. It needs an end to end test to properly test changes to the store loaders.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? NA

 