### PR TITLE
Epoch hooks, panic recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1107](https://github.com/osmosis-labs/osmosis/pull/1107) Update to wasmvm v0.24.0, re-enabling building on M1 macs!
 
 ### Minor improvements & Bug Fixes
+
 * [#1308](https://github.com/osmosis-labs/osmosis/pull/1308) Make panics inside of epochs no longer chain halt by default.
 * [#1286](https://github.com/osmosis-labs/osmosis/pull/1286) Fix release build scripts.
 * [#1203](https://github.com/osmosis-labs/osmosis/pull/1203) cleanup Makefile and ci workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1107](https://github.com/osmosis-labs/osmosis/pull/1107) Update to wasmvm v0.24.0, re-enabling building on M1 macs!
 
 ### Minor improvements & Bug Fixes
+* [#1308](https://github.com/osmosis-labs/osmosis/pull/1308) Make panics inside of epochs no longer chain halt by default.
 * [#1286](https://github.com/osmosis-labs/osmosis/pull/1286) Fix release build scripts.
 * [#1203](https://github.com/osmosis-labs/osmosis/pull/1203) cleanup Makefile and ci workflows
 * [#1177](https://github.com/osmosis-labs/osmosis/pull/1177) upgrade to go 1.18

--- a/osmoutils/cache_ctx.go
+++ b/osmoutils/cache_ctx.go
@@ -3,6 +3,8 @@ package osmoutils
 import (
 	"errors"
 	"fmt"
+	"runtime"
+	"runtime/debug"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -14,8 +16,8 @@ import (
 func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err error) {
 	// Add a panic safeguard
 	defer func() {
-		if recovErr := recover(); recovErr != nil {
-			fmt.Println(recovErr)
+		if recoveryError := recover(); recoveryError != nil {
+			PrintPanicRecoveryError(ctx, recoveryError)
 			err = errors.New("panic occurred during execution")
 		}
 	}()
@@ -29,4 +31,24 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 		write()
 	}
 	return err
+}
+
+// This function error logs the recoveryError, along with the stacktrace, if it can be parsed.
+// If not emits them to stdout
+func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
+	errStackTrace := string(debug.Stack())
+	switch e := recoveryError.(type) {
+	case string:
+		ctx.Logger().Error("Recovering from panicrecovered (string) panic: " + e)
+	case runtime.Error:
+		ctx.Logger().Error("recovered (runtime.Error) panic: " + e.Error())
+	case error:
+		ctx.Logger().Error("recovered (error) panic: " + e.Error())
+	default:
+		ctx.Logger().Error("recovered (default) panic. Could not capture logs in ctx, see stdout")
+		fmt.Println("Recovering from panic ", recoveryError)
+		debug.PrintStack()
+		return
+	}
+	ctx.Logger().Error("stack trace: " + errStackTrace)
 }

--- a/osmoutils/cache_ctx.go
+++ b/osmoutils/cache_ctx.go
@@ -33,13 +33,13 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	return err
 }
 
-// This function error logs the recoveryError, along with the stacktrace, if it can be parsed.
-// If not emits them to stdout
+// PrintPanicRecoveryError error logs the recoveryError, along with the stacktrace, if it can be parsed.
+// If not emits them to stdout.
 func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
 	errStackTrace := string(debug.Stack())
 	switch e := recoveryError.(type) {
 	case string:
-		ctx.Logger().Error("Recovering from panicrecovered (string) panic: " + e)
+		ctx.Logger().Error("Recovering from (string) panic: " + e)
 	case runtime.Error:
 		ctx.Logger().Error("recovered (runtime.Error) panic: " + e.Error())
 	case error:

--- a/x/epochs/spec/05_hooks.md
+++ b/x/epochs/spec/05_hooks.md
@@ -17,3 +17,10 @@ order: 5
 On hook receiver function of other modules, they need to filter `epochIdentifier` and only do executions for only specific epochIdentifier.
 Filtering epochIdentifier could be in `Params` of other modules so that they can be modified by governance.
 Governance can change epoch from `week` to `day` as their need.
+
+## Panic isolation
+
+If a given epoch hook panics, its state update is reverted, but we keep proceeding through the remaining hooks.
+This allows more advanced epoch logic to be used, without concern over state machine halting, or halting subsequent modules.
+
+This does mean that if there is behavior you expect from a prior epoch hook, and that epoch hook reverted, your hook may also have an issue. So do keep in mind "what if a prior hook didn't get executed" in the safety checks you consider for a new epoch hook.

--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -1,6 +1,10 @@
 package types
 
 import (
+	fmt "fmt"
+	"runtime"
+	"runtime/debug"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -32,4 +36,31 @@ func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier strin
 	for i := range h {
 		h[i].BeforeEpochStart(ctx, epochIdentifier, epochNumber)
 	}
+}
+
+func panicCatchingEpochHook(
+	ctx sdk.Context,
+	hookFn func(ctx sdk.Context, epochIdentifier string, epochNumber int64),
+	epochIdentifier string,
+	epochNumber int64) {
+
+	defer func() {
+		if recovErr := recover(); recovErr != nil {
+			fmt.Println("Recovering from panic:", recovErr)
+			fmt.Println("Stack Trace:")
+			debug.PrintStack()
+			switch e := recovErr.(type) {
+			case string:
+				ctx.Logger().Error("Recovering from panicrecovered (string) panic:", e)
+			case runtime.Error:
+				fmt.Println("recovered (runtime.Error) panic:", e.Error())
+			case error:
+				fmt.Println("recovered (error) panic:", e.Error())
+			default:
+				fmt.Println("recovered (default) panic:", e)
+			}
+			fmt.Println(string(debug.Stack()))
+			return
+		}
+	}()
 }

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -26,7 +26,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
 }
 
-// dummy Epoch hook is a struct satisfying the epoch hook interface,
+// dummyEpochHook is a struct satisfying the epoch hook interface,
 // that maintains a counter for how many times its been succesfully called,
 // and a boolean for whether it should panic during its execution.
 type dummyEpochHook struct {

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -1,0 +1,96 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v7/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v7/x/epochs/types"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+
+	queryClient types.QueryClient
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (suite *KeeperTestSuite) SetupTest() {
+	suite.Setup()
+
+	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
+}
+
+// dummy Epoch hook is a struct satisfying the epoch hook interface,
+// that maintains a counter for how many times its been succesfully called,
+// and a boolean for whether it should panic during its execution.
+type dummyEpochHook struct {
+	successCounter int
+	shouldPanic    bool
+}
+
+func (hook *dummyEpochHook) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+	if hook.shouldPanic {
+		panic("dummyEpochHook is panicking")
+	}
+	hook.successCounter += 1
+}
+
+func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+	if hook.shouldPanic {
+		panic("dummyEpochHook is panicking")
+	}
+	hook.successCounter += 1
+}
+
+func (hook *dummyEpochHook) Clone() *dummyEpochHook {
+	newHook := dummyEpochHook{shouldPanic: hook.shouldPanic, successCounter: hook.successCounter}
+	return &newHook
+}
+
+var _ types.EpochHooks = &dummyEpochHook{}
+
+func (suite *KeeperTestSuite) TestHooksPanicRecovery() {
+	panicHook := dummyEpochHook{shouldPanic: true}
+	noPanicHook := dummyEpochHook{shouldPanic: false}
+	simpleHooks := []dummyEpochHook{panicHook, noPanicHook}
+
+	tests := []struct {
+		hooks                 []dummyEpochHook
+		expectedCounterValues []int
+	}{
+		{[]dummyEpochHook{noPanicHook}, []int{1}},
+		{simpleHooks, []int{0, 1}},
+	}
+
+	for tcIndex, tc := range tests {
+		for epochActionSelector := 0; epochActionSelector < 2; epochActionSelector++ {
+			suite.SetupTest()
+			hookRefs := []types.EpochHooks{}
+
+			for _, hook := range tc.hooks {
+				hookRefs = append(hookRefs, hook.Clone())
+			}
+
+			hooks := types.NewMultiEpochHooks(hookRefs...)
+			suite.NotPanics(func() {
+				if epochActionSelector == 0 {
+					hooks.BeforeEpochStart(suite.Ctx, "id", 0)
+				} else if epochActionSelector == 1 {
+					hooks.AfterEpochEnd(suite.Ctx, "id", 0)
+				}
+			})
+
+			for i := 0; i < len(hooks); i++ {
+				epochHook := hookRefs[i].(*dummyEpochHook)
+				suite.Require().Equal(tc.expectedCounterValues[i], epochHook.successCounter, "test case index %d", tcIndex)
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR aims to mitigate the risk of a panic within the epoch logic causing a chain halt (or even a halt of subsequent epoch actions). A subcomponent of #1305 

## Brief change log

  - Add panic recovery to the epoch hooks
  - Improve the panic recovery -> string printing mechanism

## Testing and Verifying

* This adds a test case to ensure that: Panics are actually caught in an `x/epochs/hooks_test.go`

We still need to test that this does not notably increase the epoch time. (Due to https://github.com/cosmos/cosmos-sdk/issues/10310 )

I want to understand that issue better, but it may be that the best way to test it is to get this cherry-picked on a v7 branch and just run it.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented?  **specification (`x/<module>/spec/`)**, this still needs to be done

 