### PR TITLE
make proto gen scripts compatible with vendor

### DIFF
--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -4,8 +4,20 @@ set -eo pipefail
 
 mkdir -p ./tmp-swagger-gen
 
+# move the vendor folder to a temp dir so that go list works properly
+temp_dir="f29ea6aa861dc4b083e8e48f67cce"
+if [ -d vendor ]; then
+  mv ./vendor ./$temp_dir
+fi
+
 # Get the path of the cosmos-sdk repo from go/pkg/mod
 cosmos_sdk_dir=$(go list -f '{{ .Dir }}' -m github.com/cosmos/cosmos-sdk)
+
+# move the vendor folder back to ./vendor
+if [ -d $temp_dir ]; then
+  mv ./$temp_dir ./vendor
+fi
+
 proto_dirs=$(find ./proto $cosmos_sdk_dir/proto -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   # generate swagger files (filter query files)

--- a/scripts/generate-proto.sh
+++ b/scripts/generate-proto.sh
@@ -2,9 +2,22 @@
 
 set -eo pipefail
 
+# move the vendor folder to a temp dir so that go list works properly
+temp_dir="f29ea6aa861dc4b083e8e48f67cce"
+if [ -d vendor ]; then
+  mv ./vendor ./$temp_dir
+fi
+
 # Get the path of the cosmos-sdk repo from go/pkg/mod
 cosmos_sdk_dir=$(go list -f '{{ .Dir }}' -m github.com/cosmos/cosmos-sdk)
-proto_dirs=$(find . -path ./third_party -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+
+# move the vendor folder back to ./vendor
+if [ -d $temp_dir ]; then
+  mv ./$temp_dir ./vendor
+fi
+
+proto_dirs=$(find . \( -path ./third_party -o -path ./vendor \) -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+
 for dir in $proto_dirs; do
   # generate protobuf bind
   protoc \

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -7,9 +7,22 @@ go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos 2>/dev/null
 # get cosmos sdk from github
 go get github.com/cosmos/cosmos-sdk 2>/dev/null
 
+# move the vendor folder to a temp dir so that go list works properly
+temp_dir="f29ea6aa861dc4b083e8e48f67cce"
+if [ -d vendor ]; then
+  mv ./vendor ./$temp_dir
+fi
+
 # Get the path of the cosmos-sdk repo from go/pkg/mod
 cosmos_sdk_dir=$(go list -f '{{ .Dir }}' -m github.com/cosmos/cosmos-sdk)
-proto_dirs=$(find . -path ./third_party -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+
+# move the vendor folder back to ./vendor
+if [ -d $temp_dir ]; then
+  mv ./$temp_dir ./vendor
+fi
+
+proto_dirs=$(find . \( -path ./third_party -o -path ./vendor \) -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+
 for dir in $proto_dirs; do
   # generate protobuf bind
   buf protoc \


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
Closes: #504

So these 3 scripts for generating protobuf ( [generate-proto.sh](https://github.com/osmosis-labs/osmosis/blob/main/scripts/generate-proto.sh),
[generate-docs.sh](https://github.com/osmosis-labs/osmosis/blob/main/scripts/generate-docs.sh), [protocgen.sh](https://github.com/osmosis-labs/osmosis/blob/main/scripts/protocgen.sh) ) use [go list](https://github.com/osmosis-labs/osmosis/blob/039f686ed40008228db65352ad09d1f38a8f88cb/scripts/protocgen.sh#L11) to get the `cosmos-sdk` dependency in go/pkg/mod. But `go list` doesn't work properly if we have a vendor folder, so I move the vendor folder to a temp folder to run `go list` and then move it back right after running `go list`.

 