### PR TITLE
Move appKeepers struct to a different package

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -158,6 +158,7 @@ func NewOsmosisApp(
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 
 	app := &OsmosisApp{
+		AppKeepers:        keepers.AppKeepers{},
 		BaseApp:           bApp,
 		cdc:               cdc,
 		appCodec:          appCodec,

--- a/app/app.go
+++ b/app/app.go
@@ -42,6 +42,7 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/osmosis-labs/osmosis/v7/app/keepers"
 	appparams "github.com/osmosis-labs/osmosis/v7/app/params"
 	v4 "github.com/osmosis-labs/osmosis/v7/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/v7/app/upgrades/v5"
@@ -113,7 +114,7 @@ func GetWasmEnabledProposals() []wasm.ProposalType {
 // capabilities aren't needed for testing.
 type OsmosisApp struct {
 	*baseapp.BaseApp
-	appKeepers
+	keepers.AppKeepers
 
 	cdc               *codec.LegacyAmino
 	appCodec          codec.Codec
@@ -167,7 +168,7 @@ func NewOsmosisApp(
 	// Define what keys will be used in the cosmos-sdk key/value store.
 	// Cosmos-SDK modules each have a "key" that allows the application to reference what they've stored on the chain.
 	// Keys are in keys.go to kep app.go as brief as possible.
-	keys := sdk.NewKVStoreKeys(KVStoreKeys()...)
+	keys := sdk.NewKVStoreKeys(keepers.KVStoreKeys()...)
 
 	// Define transient store keys
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
@@ -192,9 +193,33 @@ func NewOsmosisApp(
 		panic(fmt.Sprintf("error while reading wasm config: %s", err))
 	}
 
-	app.InitSpecialKeepers(skipUpgradeHeights, homePath, invCheckPeriod)
+	app.InitSpecialKeepers(
+		appCodec,
+		bApp,
+		keys,
+		tkeys,
+		memKeys,
+		wasmDir,
+		cdc,
+		invCheckPeriod,
+		skipUpgradeHeights,
+		homePath,
+	)
 	app.setupUpgradeStoreLoaders()
-	app.InitNormalKeepers(wasmDir, wasmConfig, wasmEnabledProposals, wasmOpts)
+	app.InitNormalKeepers(
+		appCodec,
+		bApp,
+		keys,
+		maccPerms,
+		wasmDir,
+		wasmConfig,
+		wasmEnabledProposals,
+		wasmOpts,
+		&app.transferModule,
+		app.BlockedAddrs(),
+	)
+	app.transferModule = transfer.NewAppModule(*app.TransferKeeper)
+
 	app.SetupHooks()
 
 	/****  Module Options ****/

--- a/app/export.go
+++ b/app/export.go
@@ -152,7 +152,7 @@ func (app *OsmosisApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.
-	store := ctx.KVStore(app.keys[stakingtypes.StoreKey])
+	store := ctx.KVStore(app.GetKey(stakingtypes.StoreKey))
 	iter := sdk.KVStoreReversePrefixIterator(store, stakingtypes.ValidatorsKey)
 	counter := int16(0)
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -112,19 +112,6 @@ type AppKeepers struct {
 	memKeys map[string]*sdk.MemoryStoreKey
 }
 
-func (appKeepers *AppKeepers) GenerateKeys() {
-	// Define what keys will be used in the cosmos-sdk key/value store.
-	// Cosmos-SDK modules each have a "key" that allows the application to reference what they've stored on the chain.
-	// Keys are in keys.go to kep app.go as brief as possible.
-	appKeepers.keys = sdk.NewKVStoreKeys(KVStoreKeys()...)
-
-	// Define transient store keys
-	appKeepers.tkeys = sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
-
-	// MemKeys are for information that is stored only in RAM.
-	appKeepers.memKeys = sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
-}
-
 func (appKeepers *AppKeepers) InitNormalKeepers(
 	appCodec codec.Codec,
 	bApp *baseapp.BaseApp,
@@ -524,42 +511,4 @@ func KVStoreKeys() []string {
 		bech32ibctypes.StoreKey,
 		wasm.StoreKey,
 	}
-}
-
-func (appKeepers *AppKeepers) GetSubspace(moduleName string) paramstypes.Subspace {
-	subspace, _ := appKeepers.ParamsKeeper.GetSubspace(moduleName)
-	return subspace
-}
-
-func (appKeepers *AppKeepers) GetKVStoreKey() map[string]*sdk.KVStoreKey {
-	return appKeepers.keys
-}
-
-func (appKeepers *AppKeepers) GetTransientStoreKey() map[string]*sdk.TransientStoreKey {
-	return appKeepers.tkeys
-}
-
-func (appKeepers *AppKeepers) GetMemoryStoreKey() map[string]*sdk.MemoryStoreKey {
-	return appKeepers.memKeys
-}
-
-// GetKey returns the KVStoreKey for the provided store key.
-//
-// NOTE: This is solely to be used for testing purposes.
-func (appKeepers *AppKeepers) GetKey(storeKey string) *sdk.KVStoreKey {
-	return appKeepers.keys[storeKey]
-}
-
-// GetTKey returns the TransientStoreKey for the provided store key.
-//
-// NOTE: This is solely to be used for testing purposes.
-func (appKeepers *AppKeepers) GetTKey(storeKey string) *sdk.TransientStoreKey {
-	return appKeepers.tkeys[storeKey]
-}
-
-// GetMemKey returns the MemStoreKey for the provided mem key.
-//
-// NOTE: This is solely used for testing purposes.
-func (appKeepers *AppKeepers) GetMemKey(storeKey string) *sdk.MemoryStoreKey {
-	return appKeepers.memKeys[storeKey]
 }

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -467,6 +467,7 @@ func (appKeepers *AppKeepers) SetupHooks() {
 	appKeepers.EpochsKeeper.SetHooks(
 		epochstypes.NewMultiEpochHooks(
 			// insert epoch hooks receivers here
+			appKeepers.TxFeesKeeper.Hooks(),
 			appKeepers.SuperfluidKeeper.Hooks(),
 			appKeepers.IncentivesKeeper.Hooks(),
 			appKeepers.MintKeeper.Hooks(),

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,0 +1,58 @@
+package keepers
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+func (appKeepers *AppKeepers) GenerateKeys() {
+	// Define what keys will be used in the cosmos-sdk key/value store.
+	// Cosmos-SDK modules each have a "key" that allows the application to reference what they've stored on the chain.
+	// Keys are in keys.go to kep app.go as brief as possible.
+	appKeepers.keys = sdk.NewKVStoreKeys(KVStoreKeys()...)
+
+	// Define transient store keys
+	appKeepers.tkeys = sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
+
+	// MemKeys are for information that is stored only in RAM.
+	appKeepers.memKeys = sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
+}
+
+func (appKeepers *AppKeepers) GetSubspace(moduleName string) paramstypes.Subspace {
+	subspace, _ := appKeepers.ParamsKeeper.GetSubspace(moduleName)
+	return subspace
+}
+
+func (appKeepers *AppKeepers) GetKVStoreKey() map[string]*sdk.KVStoreKey {
+	return appKeepers.keys
+}
+
+func (appKeepers *AppKeepers) GetTransientStoreKey() map[string]*sdk.TransientStoreKey {
+	return appKeepers.tkeys
+}
+
+func (appKeepers *AppKeepers) GetMemoryStoreKey() map[string]*sdk.MemoryStoreKey {
+	return appKeepers.memKeys
+}
+
+// GetKey returns the KVStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (appKeepers *AppKeepers) GetKey(storeKey string) *sdk.KVStoreKey {
+	return appKeepers.keys[storeKey]
+}
+
+// GetTKey returns the TransientStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (appKeepers *AppKeepers) GetTKey(storeKey string) *sdk.TransientStoreKey {
+	return appKeepers.tkeys[storeKey]
+}
+
+// GetMemKey returns the MemStoreKey for the provided mem key.
+//
+// NOTE: This is solely used for testing purposes.
+func (appKeepers *AppKeepers) GetMemKey(storeKey string) *sdk.MemoryStoreKey {
+	return appKeepers.memKeys[storeKey]
+}

--- a/app/modules.go
+++ b/app/modules.go
@@ -162,7 +162,7 @@ func appModules(
 		authzmodule.NewAppModule(appCodec, *app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		ibc.NewAppModule(app.IBCKeeper),
 		params.NewAppModule(*app.ParamsKeeper),
-		app.transferModule,
+		app.TransferModule,
 		gamm.NewAppModule(appCodec, *app.GAMMKeeper, app.AccountKeeper, app.BankKeeper),
 		txfees.NewAppModule(appCodec, *app.TxFeesKeeper),
 		incentives.NewAppModule(appCodec, *app.IncentivesKeeper, app.AccountKeeper, app.BankKeeper, app.EpochsKeeper),
@@ -322,7 +322,7 @@ func simulationModules(
 			app.GAMMKeeper,
 			app.EpochsKeeper,
 		),
-		app.transferModule,
+		app.TransferModule,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/sylvia7788/contextcheck v1.0.4 // indirect
-	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 	github.com/tdakkota/asciicheck v0.1.1 // indirect
 	github.com/tendermint/btcd v0.1.1 // indirect
 	github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 // indirect


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1319 

## What is the purpose of the change

 - Move appKeepers struct to a different package

## Brief change log
 - Create new package called `keepers` at `app/keepers`,
 - Move logic from `app/keepers.go` to new module




## Testing and Verifying

 * This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable

 