### PR TITLE
test: improve TestCalculateAmountOutAndIn with swap fee tests

### DIFF
--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -82,7 +82,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 	}
 }
 
-func TestCalculateAmountOutAndIn_InverseRelationship_ZeroSwapFee(t *testing.T) {
+func TestCalculateAmountOutAndIn_InverseRelationship(t *testing.T) {
 	type testcase struct {
 		denomOut         string
 		initialPoolOut   int64
@@ -94,6 +94,7 @@ func TestCalculateAmountOutAndIn_InverseRelationship_ZeroSwapFee(t *testing.T) {
 		initialWeightIn int64
 	}
 
+	// For every test case in testcases, apply a swap fee in swapFeeCases.
 	testcases := []testcase{
 		{
 			denomOut:         "uosmo",
@@ -137,52 +138,63 @@ func TestCalculateAmountOutAndIn_InverseRelationship_ZeroSwapFee(t *testing.T) {
 		},
 	}
 
-	getTestCaseName := func(tc testcase) string {
-		return fmt.Sprintf("tokenOutInitial: %d, tokenInInitial: %d, initialOut: %d",
+	swapFeeCases := []string{"0", "0.001", "0.1", "0.5", "0.99"}
+
+	getTestCaseName := func(tc testcase, swapFeeCase string) string {
+		return fmt.Sprintf("tokenOutInitial: %d, tokenInInitial: %d, initialOut: %d, swapFee: %s",
 			tc.initialPoolOut,
 			tc.initialPoolIn,
 			tc.initialCalcOut,
+			swapFeeCase,
 		)
 	}
 
 	for _, tc := range testcases {
-		t.Run(getTestCaseName(tc), func(t *testing.T) {
-			ctx := createTestContext(t)
+		for _, swapFee := range swapFeeCases {
+			t.Run(getTestCaseName(tc, swapFee), func(t *testing.T) {
+				ctx := createTestContext(t)
 
-			poolAssetOut := balancer.PoolAsset{
-				Token:  sdk.NewInt64Coin(tc.denomOut, tc.initialPoolOut),
-				Weight: sdk.NewInt(tc.initialWeightOut),
-			}
+				poolAssetOut := balancer.PoolAsset{
+					Token:  sdk.NewInt64Coin(tc.denomOut, tc.initialPoolOut),
+					Weight: sdk.NewInt(tc.initialWeightOut),
+				}
 
-			poolAssetIn := balancer.PoolAsset{
-				Token:  sdk.NewInt64Coin(tc.denomIn, tc.initialPoolIn),
-				Weight: sdk.NewInt(tc.initialWeightIn),
-			}
+				poolAssetIn := balancer.PoolAsset{
+					Token:  sdk.NewInt64Coin(tc.denomIn, tc.initialPoolIn),
+					Weight: sdk.NewInt(tc.initialWeightIn),
+				}
 
-			pool := createTestPool(t, []balancer.PoolAsset{
-				poolAssetOut,
-				poolAssetIn,
-			},
-				"0",
-				"0",
-			)
-			require.NotNil(t, pool)
+				swapFeeDec, err := sdk.NewDecFromStr(swapFee)
+				require.NoError(t, err)
 
-			initialOut := sdk.NewInt64Coin(poolAssetOut.Token.Denom, tc.initialCalcOut)
-			initialOutCoins := sdk.NewCoins(initialOut)
+				exitFeeDec, err := sdk.NewDecFromStr("0")
+				require.NoError(t, err)
 
-			actualTokenIn, err := pool.CalcInAmtGivenOut(ctx, initialOutCoins, poolAssetIn.Token.Denom, sdk.ZeroDec())
-			require.NoError(t, err)
+				pool := createTestPool(t, []balancer.PoolAsset{
+					poolAssetOut,
+					poolAssetIn,
+				},
+					swapFeeDec,
+					exitFeeDec,
+				)
+				require.NotNil(t, pool)
 
-			inverseTokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewInt64Coin(poolAssetIn.Token.Denom, actualTokenIn.Amount.TruncateInt64())), poolAssetOut.Token.Denom, sdk.ZeroDec())
-			require.NoError(t, err)
+				initialOut := sdk.NewInt64Coin(poolAssetOut.Token.Denom, tc.initialCalcOut)
+				initialOutCoins := sdk.NewCoins(initialOut)
 
-			require.Equal(t, initialOut.Denom, inverseTokenOut.Denom)
+				actualTokenIn, err := pool.CalcInAmtGivenOut(ctx, initialOutCoins, poolAssetIn.Token.Denom, swapFeeDec)
+				require.NoError(t, err)
 
-			expected := initialOut.Amount.ToDec()
-			actual := inverseTokenOut.Amount.RoundInt().ToDec() // must round to be able to compare with expected.
+				inverseTokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewInt64Coin(poolAssetIn.Token.Denom, actualTokenIn.Amount.TruncateInt64())), poolAssetOut.Token.Denom, swapFeeDec)
+				require.NoError(t, err)
 
-			require.Equal(t, expected, actual)
-		})
+				require.Equal(t, initialOut.Denom, inverseTokenOut.Denom)
+
+				expected := initialOut.Amount.ToDec()
+				actual := inverseTokenOut.Amount.RoundInt().ToDec() // must round to be able to compare with expected.
+
+				require.Equal(t, expected, actual)
+			})
+		}
 	}
 }

--- a/x/gamm/pool-models/balancer/util_test.go
+++ b/x/gamm/pool-models/balancer/util_test.go
@@ -15,16 +15,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
 
-func createTestPool(t *testing.T, poolAssets []balancer.PoolAsset, swapFee, exitFee string) types.PoolI {
-	swapFeeDec, err := sdk.NewDecFromStr(swapFee)
-	require.NoError(t, err)
-
-	exitFeeDec, err := sdk.NewDecFromStr(exitFee)
-	require.NoError(t, err)
-
+func createTestPool(t *testing.T, poolAssets []balancer.PoolAsset, swapFee, exitFee sdk.Dec) types.PoolI {
 	pool, err := balancer.NewBalancerPool(1, balancer.PoolParams{
-		SwapFee: swapFeeDec,
-		ExitFee: exitFeeDec,
+		SwapFee: swapFee,
+		ExitFee: exitFee,
 	}, poolAssets, "", time.Now())
 
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1288

## What is the purpose of the change

This PR is focused on improving code and logic test coverage in the balancer pool. Specifically, it adds inverse tests for `CalcInAmtGivenOut` and `CalcOutAmtGivenIn` **with non-zero swap fees**.

## Brief change log
- add non-zero swap fee unit tests for `TestCalculateAmountOutAndIn_InverseRelationship` 

## Testing and Verifying

This change added tests and can be verified as follows:
  - *Added unit test `TestCalculateAmountOutAndIn_InverseRelationship`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable

 