### PR TITLE
add github issue templates for bug report and feature request, to facilitate project management

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+*E.g. when doing ..., ... unexpectedly happened*
+
+
+**Reproduce Steps**
+
+*Steps to reproduce the behavior:*
+
+1. Go to '...'
+2. Run '...'
+4. See error '...'
+
+**Business Impact and Suggested Priority**
+
+*E.g. it impacts our validator because ...*
+
+
+**Expected behavior**
+
+*E.g. I expected it to work as ...*
+
+**Screenshots**
+
+*If applicable, add screenshots to help explain your problem.*
+
+
+**Version**
+
+*Which Osmosis version are you running? e.g. v6.0.0, v7.0.2*
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: enhancement
+assignees: ''
+
+---
+
+Please open the feature request issue in osmosis-labs/feature-requests repo [here](https://github.com/osmosis-labs/feature-requests/issues).


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/1339

## What is the purpose of the change

This PR adds github issue templates for bug report and feature request, to facilitate project management and prioritization

## Brief change log

- added template "bug_report.md"
- added template "feature_request.md" to redirect to https://github.com/osmosis-labs/feature-requests/issues

## Testing and Verifying

Tested in my local repo. Here's the workflow and screenshots

1) click "New issue" as usual

![image](https://user-images.githubusercontent.com/66541548/165224414-794ba4ca-94d0-4ced-ad04-18c45ce108f9.png)

2) with this PR, github will start to show 2 templates to choose from

![image](https://user-images.githubusercontent.com/66541548/165224279-f0c8c973-905e-4499-b03c-fe6109a2258d.png)

3) choose "Bug report", the bug report template will show up as prepopulated

![image](https://user-images.githubusercontent.com/66541548/165224335-ad07e483-961c-4d0f-9823-564090609a29.png)


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)
 