### PR TITLE
Add initial pool liquidity validation to stableswap msg.ValidateBasic function

### DIFF
--- a/x/gamm/pool-models/stableswap/msgs.go
+++ b/x/gamm/pool-models/stableswap/msgs.go
@@ -43,7 +43,12 @@ func (msg MsgCreateStableswapPool) ValidateBasic() error {
 		return err
 	}
 
-	// TODO: Add validation for pool initial liquidity
+	// validation for pool initial liquidity
+	if len(msg.InitialPoolLiquidity) < 2 {
+		return types.ErrTooFewPoolAssets
+	} else if len(msg.InitialPoolLiquidity) > 2 {
+		return types.ErrTooManyPoolAssets
+	}
 
 	// validation for future owner
 	if err = types.ValidateFutureGovernor(msg.FuturePoolGovernor); err != nil {

--- a/x/gamm/pool-models/stableswap/msgs.go
+++ b/x/gamm/pool-models/stableswap/msgs.go
@@ -44,6 +44,7 @@ func (msg MsgCreateStableswapPool) ValidateBasic() error {
 	}
 
 	// validation for pool initial liquidity
+	// TO DO: expand this check to accommodate multi-asset pools for stableswap
 	if len(msg.InitialPoolLiquidity) < 2 {
 		return types.ErrTooFewPoolAssets
 	} else if len(msg.InitialPoolLiquidity) > 2 {

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -8,7 +8,7 @@ var (
 	ErrPoolAlreadyExist   = sdkerrors.Register(ModuleName, 2, "pool already exist")
 	ErrPoolLocked         = sdkerrors.Register(ModuleName, 3, "pool is locked")
 	ErrTooFewPoolAssets   = sdkerrors.Register(ModuleName, 4, "pool should have at least 2 assets, as they must be swapping between at least two assets")
-	ErrTooManyPoolAssets  = sdkerrors.Register(ModuleName, 5, "pool has too many assets (currently capped at 8 assets per pool)")
+	ErrTooManyPoolAssets  = sdkerrors.Register(ModuleName, 5, "pool has too many assets (currently capped at 8 assets per balancer pool and 2 per stableswap)")
 	ErrLimitMaxAmount     = sdkerrors.Register(ModuleName, 6, "calculated amount is larger than max amount")
 	ErrLimitMinAmount     = sdkerrors.Register(ModuleName, 7, "calculated amount is lesser than min amount")
 	ErrInvalidMathApprox  = sdkerrors.Register(ModuleName, 8, "invalid calculated result")


### PR DESCRIPTION
Closes: #1364 

## What is the purpose of the change

Add validation check to stableswap's `msg.ValidateBasic()` function linked to in issue #1364.


## Brief change log

 - Check if initial liquidity supplied to pool has exactly two assets (this will eventually need to be expanded to accommodate multi-asset stableswap pools)

## Testing and Verifying

We are currently missing a msgs_test.go file for this (and other functions related to creating pools) to be tested in. Created a new issue for this here: https://github.com/osmosis-labs/osmosis/issues/1384#issue-1222513046

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)

 