### PR TITLE
test: upgrade testing automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker-build-debug
-          make docker-build-e2e-chain-init
         if: env.GIT_DIFF
       - name: Test E2E
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker-build-debug
+        if: env.GIT_DIFF
       - name: Test E2E
         run: |
           make test-e2e
+        if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,6 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker-build-debug
-        if: env.GIT_DIFF
       - name: Test E2E
         run: |
           make test-e2e
-        if: env.GIT_DIFF

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d
 RUN BUILD_TAGS=muslc make build
 
 ## Deploy image
-FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG} 
+FROM ubuntu
 
 COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
 

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ benchmark:
 	@go test -mod=readonly -bench=. $(PACKAGES_UNIT)
 
 docker-build-debug:
-	@docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f Dockerfile .
+	@docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f tests/e2e/Dockerfile .
 
 docker-build-e2e-chain-init:
 	@docker build -t osmosis-e2e-chain-init:debug -f tests/e2e/chain_init/chain-init.Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ test-sim:
 	@VERSION=$(VERSION) go test -mod=readonly $(PACKAGES_SIM)
 
 test-e2e:
-	@VERSION=$(VERSION) go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+	@VERSION=$(VERSION) go test -mod=readonly -timeout=25m -v github.com/osmosis-labs/osmosis/v7/tests/e2e
 
 benchmark:
 	@go test -mod=readonly -bench=. $(PACKAGES_UNIT)

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -15,7 +15,7 @@ RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d
 RUN BUILD_TAGS=muslc make build
 
 ## Deploy image
-FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG}
+FROM ubuntu
 
 COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
 

--- a/tests/e2e/chain/config.go
+++ b/tests/e2e/chain/config.go
@@ -13,6 +13,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/spf13/viper"
 	tmconfig "github.com/tendermint/tendermint/config"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -27,6 +28,7 @@ const (
 	IbcDenom      = "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
 	MinGasPrice   = "0.000"
 	IbcSendAmount = 3300000000
+	VotingPeriod  = 180000000000
 	// chainA
 	ChainAID      = "osmo-test-a"
 	OsmoBalanceA  = 200000000000
@@ -157,6 +159,21 @@ func initGenesis(c *internalChain) error {
 		return err
 	}
 	appGenState[banktypes.ModuleName] = bz
+
+	var govGenState govtypes.GenesisState
+	if err := util.Cdc.UnmarshalJSON(appGenState[govtypes.ModuleName], &govGenState); err != nil {
+		return err
+	}
+
+	govGenState.VotingParams = govtypes.VotingParams{
+		VotingPeriod: VotingPeriod,
+	}
+
+	gz, err := util.Cdc.MarshalJSON(&govGenState)
+	if err != nil {
+		return err
+	}
+	appGenState[govtypes.ModuleName] = gz
 
 	var genUtilGenState genutiltypes.GenesisState
 	if err := util.Cdc.UnmarshalJSON(appGenState[genutiltypes.ModuleName], &genUtilGenState); err != nil {

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -109,8 +109,11 @@ func (s *IntegrationTestSuite) runValidators(c *chain.Chain, portOffset int) {
 			Mounts: []string{
 				fmt.Sprintf("%s/:/osmosis/.osmosisd", val.ConfigDir),
 			},
-			Repository: "osmosis",
-			Tag:        "debug",
+			Repository: "osmolabs/osmosis-dev",
+			Tag:        "v7.0.4-debug",
+			Cmd: []string{
+				"start",
+			},
 		}
 
 		// expose the first validator for debugging and communication
@@ -267,8 +270,8 @@ func (s *IntegrationTestSuite) configureChain(chainId string) {
 	s.initResource, err = s.dkrPool.RunWithOptions(
 		&dockertest.RunOptions{
 			Name:       fmt.Sprintf("%s", chainId),
-			Repository: "osmosis-e2e-chain-init",
-			Tag:        "debug",
+			Repository: "osmolabs/osmosis-init",
+			Tag:        "v7.2.1",
 			NetworkID:  s.dkrNet.Network.ID,
 			Cmd: []string{
 				fmt.Sprintf("--data-dir=%s", tmpDir),

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -334,14 +334,13 @@ func noRestart(config *docker.HostConfig) {
 func (s *IntegrationTestSuite) initUpgrade() {
 	for x := range s.chains {
 		c := s.chains[x]
-		err := os.Chmod(c.Validators[0].ConfigDir, 0777)
-		if err != nil {
-			fmt.Println(err)
-		}
-		_, err2 := util.CopyFile(
+		_, err := util.CopyFile(
 			filepath.Join("./scripts/", "osmosis_upgrade.sh"),
 			filepath.Join(c.Validators[0].ConfigDir, "osmosis_upgrade.sh"),
 		)
+		s.Require().NoError(err)
+		cmd := fmt.Sprintf("chmod +x %s/osmosis_upgrade.sh", c.Validators[0].ConfigDir)
+		_, err2 := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
 		s.Require().NoError(err2)
 		s.T().Logf("submitting upgrade proposal for chain-id: %s", c.ChainMeta.Id)
 		cmdStr := fmt.Sprintf("docker exec %v bash -c 'chmod +x ~/.osmosisd/osmosis_upgrade.sh && ~/.osmosisd/osmosis_upgrade.sh \"%s\"'", s.valResources[c.ChainMeta.Id][0].Container.ID, c.ChainMeta.Id)

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -334,11 +334,15 @@ func noRestart(config *docker.HostConfig) {
 func (s *IntegrationTestSuite) initUpgrade() {
 	for x := range s.chains {
 		c := s.chains[x]
-		_, err := util.CopyFile(
+		err := os.Chmod(c.Validators[0].ConfigDir, 0777)
+		if err != nil {
+			fmt.Println(err)
+		}
+		_, err2 := util.CopyFile(
 			filepath.Join("./scripts/", "osmosis_upgrade.sh"),
 			filepath.Join(c.Validators[0].ConfigDir, "osmosis_upgrade.sh"),
 		)
-		s.Require().NoError(err)
+		s.Require().NoError(err2)
 		s.T().Logf("submitting upgrade proposal for chain-id: %s", c.ChainMeta.Id)
 		cmdStr := fmt.Sprintf("docker exec %v bash -c 'chmod +x ~/.osmosisd/osmosis_upgrade.sh && ~/.osmosisd/osmosis_upgrade.sh \"%s\"'", s.valResources[c.ChainMeta.Id][0].Container.ID, c.ChainMeta.Id)
 		exec.Command("/bin/sh", "-c", cmdStr).Output()

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -336,14 +336,6 @@ func noRestart(config *docker.HostConfig) {
 func (s *IntegrationTestSuite) initUpgrade() {
 	for x := range s.chains {
 		c := s.chains[x]
-		// _, err := util.CopyFile(
-		// 	filepath.Join("./scripts/", "osmosis_upgrade.sh"),
-		// 	filepath.Join(c.Validators[0].ConfigDir, "osmosis_upgrade.sh"),
-		// )
-		// s.Require().NoError(err)
-		// cmdStr1 := fmt.Sprintf("cp ./scripts/osmosis_upgrade.sh %s/", c.Validators[0].ConfigDir)
-		// _, err := exec.Command("/bin/sh", "-c", cmdStr1).Output()
-		// s.Require().NoError(err)
 		s.T().Logf("submitting upgrade proposal for chain-id: %s", c.ChainMeta.Id)
 		cmdStr := fmt.Sprintf("docker exec %v bash -c 'chmod +x /scripts/osmosis_upgrade.sh && /scripts/osmosis_upgrade.sh \"%s\"'", s.valResources[c.ChainMeta.Id][0].Container.ID, c.ChainMeta.Id)
 		exec.Command("/bin/sh", "-c", cmdStr).Output()

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -334,10 +334,13 @@ func noRestart(config *docker.HostConfig) {
 func (s *IntegrationTestSuite) initUpgrade() {
 	for x := range s.chains {
 		c := s.chains[x]
-		_, err := util.CopyFile(
-			filepath.Join("./scripts/", "osmosis_upgrade.sh"),
-			filepath.Join(c.Validators[0].ConfigDir, "osmosis_upgrade.sh"),
-		)
+		// _, err := util.CopyFile(
+		// 	filepath.Join("./scripts/", "osmosis_upgrade.sh"),
+		// 	filepath.Join(c.Validators[0].ConfigDir, "osmosis_upgrade.sh"),
+		// )
+		// s.Require().NoError(err)
+		cmdStr1 := fmt.Sprintf("cp ./scripts/osmosis_upgrade.sh %s/", c.Validators[0].ConfigDir)
+		_, err := exec.Command("/bin/sh", "-c", cmdStr1).Output()
 		s.Require().NoError(err)
 		s.T().Logf("submitting upgrade proposal for chain-id: %s", c.ChainMeta.Id)
 		cmdStr := fmt.Sprintf("docker exec %v bash -c 'chmod +x ~/.osmosisd/osmosis_upgrade.sh && ~/.osmosisd/osmosis_upgrade.sh \"%s\"'", s.valResources[c.ChainMeta.Id][0].Container.ID, c.ChainMeta.Id)

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -339,9 +339,6 @@ func (s *IntegrationTestSuite) initUpgrade() {
 			filepath.Join(c.Validators[0].ConfigDir, "osmosis_upgrade.sh"),
 		)
 		s.Require().NoError(err)
-		cmd := fmt.Sprintf("chmod +x %s/osmosis_upgrade.sh", c.Validators[0].ConfigDir)
-		_, err2 := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
-		s.Require().NoError(err2)
 		s.T().Logf("submitting upgrade proposal for chain-id: %s", c.ChainMeta.Id)
 		cmdStr := fmt.Sprintf("docker exec %v bash -c 'chmod +x ~/.osmosisd/osmosis_upgrade.sh && ~/.osmosisd/osmosis_upgrade.sh \"%s\"'", s.valResources[c.ChainMeta.Id][0].Container.ID, c.ChainMeta.Id)
 		exec.Command("/bin/sh", "-c", cmdStr).Output()

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -58,9 +58,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.configureDockerResources(chain.ChainAID, chain.ChainBID)
 
 	s.configureChain(chain.ChainAID)
-	s.Require().NoError(s.dkrPool.Purge(s.initResource))
 	s.configureChain(chain.ChainBID)
-	s.Require().NoError(s.dkrPool.Purge(s.initResource))
 
 	s.runValidators(s.chains[0], 0)
 	s.runValidators(s.chains[1], 10)
@@ -110,7 +108,7 @@ func (s *IntegrationTestSuite) runValidators(c *chain.Chain, portOffset int) {
 				fmt.Sprintf("%s/:/osmosis/.osmosisd", val.ConfigDir),
 			},
 			Repository: "osmolabs/osmosis-dev",
-			Tag:        "v7.0.4-debug",
+			Tag:        "v7.2.1-debug",
 			Cmd: []string{
 				"start",
 			},
@@ -309,7 +307,7 @@ func (s *IntegrationTestSuite) configureChain(chainId string) {
 		}
 	}
 	s.chains = append(s.chains, &newChain)
-
+	s.Require().NoError(s.dkrPool.Purge(s.initResource))
 }
 
 func (s *IntegrationTestSuite) configureDockerResources(chainIDOne, chainIDTwo string) {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,23 +1,56 @@
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	"github.com/ory/dockertest/v3"
-
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/chain"
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/util"
 )
+
+func (s *IntegrationTestSuite) TestAIBCTokenTransfer() {
+	var ibcStakeDenom string
+
+	s.Run("send_uosmo_to_chainB", func() {
+		recipient := s.chains[1].Validators[0].PublicAddress
+		token := sdk.NewInt64Coin(chain.OsmoDenom, chain.IbcSendAmount) // 3,300uosmo
+		s.sendIBC(s.chains[0].ChainMeta.Id, s.chains[1].ChainMeta.Id, recipient, token)
+
+		chainBAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chains[1].ChainMeta.Id][0].GetHostPort("1317/tcp"))
+
+		// require the recipient account receives the IBC tokens (IBC packets ACKd)
+		var (
+			balances sdk.Coins
+			err      error
+		)
+		s.Require().Eventually(
+			func() bool {
+				balances, err = queryBalances(chainBAPIEndpoint, recipient)
+				s.Require().NoError(err)
+
+				return balances.Len() == 3
+			},
+			time.Minute,
+			5*time.Second,
+		)
+
+		for _, c := range balances {
+			if strings.Contains(c.Denom, "ibc/") {
+				ibcStakeDenom = c.Denom
+				s.Require().Equal(token.Amount.Int64(), c.Amount.Int64())
+				break
+			}
+		}
+
+		s.Require().NotEmpty(ibcStakeDenom)
+	})
+}
 
 func (s *IntegrationTestSuite) TestBQueryBalances() {
 	var (
@@ -99,116 +132,4 @@ func queryBalances(endpoint, addr string) (sdk.Coins, error) {
 	}
 
 	return balancesResp.GetBalances(), nil
-}
-
-func (s *IntegrationTestSuite) TestAIBCTokenTransfer() {
-	var ibcStakeDenom string
-
-	s.Run("send_uosmo_to_chainB", func() {
-		recipient := s.chains[1].Validators[0].PublicAddress
-		token := sdk.NewInt64Coin(chain.OsmoDenom, chain.IbcSendAmount) // 3,300uosmo
-		s.sendIBC(s.chains[0].ChainMeta.Id, s.chains[1].ChainMeta.Id, recipient, token)
-
-		chainBAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chains[1].ChainMeta.Id][0].GetHostPort("1317/tcp"))
-
-		// require the recipient account receives the IBC tokens (IBC packets ACKd)
-		var (
-			balances sdk.Coins
-			err      error
-		)
-		s.Require().Eventually(
-			func() bool {
-				balances, err = queryBalances(chainBAPIEndpoint, recipient)
-				s.Require().NoError(err)
-
-				return balances.Len() == 3
-			},
-			time.Minute,
-			5*time.Second,
-		)
-
-		for _, c := range balances {
-			if strings.Contains(c.Denom, "ibc/") {
-				ibcStakeDenom = c.Denom
-				s.Require().Equal(token.Amount.Int64(), c.Amount.Int64())
-				break
-			}
-		}
-
-		s.Require().NotEmpty(ibcStakeDenom)
-	})
-}
-
-func (s *IntegrationTestSuite) TestCInitUpgrade() {
-	_, err := util.CopyFile(
-		filepath.Join("./scripts/", "osmosis_upgrade.sh"),
-		filepath.Join(s.chains[0].Validators[0].ConfigDir, "osmosis_upgrade.sh"),
-	)
-	s.Require().NoError(err)
-
-	cmdStr := fmt.Sprintf("docker exec %v bash -c 'chmod +x ~/.osmosisd/osmosis_upgrade.sh && ~/.osmosisd/osmosis_upgrade.sh'", s.valResources[s.chains[0].ChainMeta.Id][0].Container.ID)
-	out, _ := exec.Command("/bin/sh", "-c", cmdStr).Output()
-	fmt.Printf("%s", out)
-
-	type status struct {
-		LatestHeight string `json:"latest_block_height"`
-	}
-
-	type syncInfo struct {
-		SyncInfo status `json:"SyncInfo"`
-	}
-
-	s.Require().Eventually(
-		func() bool {
-			cmdStr := fmt.Sprintf("docker exec %v bash -c 'osmosisd status'", s.valResources[s.chains[0].ChainMeta.Id][0].Container.ID)
-			out, err := exec.Command("/bin/sh", "-c", cmdStr).CombinedOutput()
-			s.Require().NoError(err)
-			var syncInfo syncInfo
-			json.Unmarshal(out, &syncInfo)
-			if syncInfo.SyncInfo.LatestHeight != "75" {
-				fmt.Printf("current block height is %v, waiting for block 75\n", syncInfo.SyncInfo.LatestHeight)
-			}
-			return syncInfo.SyncInfo.LatestHeight == "75"
-		},
-		2*time.Minute,
-		5*time.Second,
-	)
-	for x := range s.chains {
-		c := s.chains[x]
-		for i := range c.Validators {
-			s.Require().NoError(s.dkrPool.RemoveContainerByName(s.valResources[c.ChainMeta.Id][i].Container.Name))
-		}
-	}
-}
-
-func (s *IntegrationTestSuite) TestDUpgrade() {
-	// s.T().Logf("starting e2e infrastructure for chain-id: %s", chainId)
-	// tmpDir, err := ioutil.TempDir("", "osmosis-e2e-testnet-")
-
-	// s.T().Logf("temp directory for chain-id %v: %v", chainId, tmpDir)
-	//s.Require().NoError(err)
-	for x := range s.chains {
-		c := s.chains[x]
-		for i, val := range c.Validators {
-			runOpts := &dockertest.RunOptions{
-				Name:       val.Name,
-				Repository: "osmosis",
-				Tag:        "debug",
-				NetworkID:  s.dkrNet.Network.ID,
-				User:       "root:root",
-				Mounts: []string{
-					fmt.Sprintf("%s/:/osmosis/.osmosisd", val.ConfigDir),
-				},
-			}
-			// _, err := s.dkrPool.RunWithOptions(runOpts, noRestart)
-			// s.Require().NoError(err)
-
-			// s.T().Logf("started Osmosis %s validator container: %s", s.chains[0].ChainMeta.Id, s.valResources[s.chains[0].ChainMeta.Id][0].Container.ID)
-			resource, err := s.dkrPool.RunWithOptions(runOpts, noRestart)
-			s.Require().NoError(err)
-
-			s.valResources[c.ChainMeta.Id][i] = resource
-			s.T().Logf("started Osmosis %s validator container: %s", c.ChainMeta.Id, resource.Container.ID)
-		}
-	}
 }

--- a/tests/e2e/scripts/osmosis_upgrade.sh
+++ b/tests/e2e/scripts/osmosis_upgrade.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+osmosisd tx gov submit-proposal software-upgrade v8 --title "v8 upgrade" --description "v8 upgrade proposal" --upgrade-height 75 --upgrade-info "" --chain-id osmo-test-a --from val -b block --yes --keyring-backend test
+osmosisd tx gov deposit 1 10000000stake --from val --chain-id osmo-test-a -b block --yes --keyring-backend test
+osmosisd tx gov vote 1 yes --from val --chain-id osmo-test-a -b block --yes --keyring-backend test

--- a/tests/e2e/scripts/osmosis_upgrade.sh
+++ b/tests/e2e/scripts/osmosis_upgrade.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-osmosisd tx gov submit-proposal software-upgrade v8 --title "v8 upgrade" --description "v8 upgrade proposal" --upgrade-height 75 --upgrade-info "" --chain-id $1 --from val -b block --yes --keyring-backend test
-osmosisd tx gov deposit 1 10000000stake --from val --chain-id $1 -b block --yes --keyring-backend test
-osmosisd tx gov vote 1 yes --from val --chain-id $1 -b block --yes --keyring-backend test

--- a/tests/e2e/scripts/osmosis_upgrade.sh
+++ b/tests/e2e/scripts/osmosis_upgrade.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-osmosisd tx gov submit-proposal software-upgrade v8 --title "v8 upgrade" --description "v8 upgrade proposal" --upgrade-height 75 --upgrade-info "" --chain-id osmo-test-a --from val -b block --yes --keyring-backend test
-osmosisd tx gov deposit 1 10000000stake --from val --chain-id osmo-test-a -b block --yes --keyring-backend test
-osmosisd tx gov vote 1 yes --from val --chain-id osmo-test-a -b block --yes --keyring-backend test
+osmosisd tx gov submit-proposal software-upgrade v8 --title "v8 upgrade" --description "v8 upgrade proposal" --upgrade-height 75 --upgrade-info "" --chain-id $1 --from val -b block --yes --keyring-backend test
+osmosisd tx gov deposit 1 10000000stake --from val --chain-id $1 -b block --yes --keyring-backend test
+osmosisd tx gov vote 1 yes --from val --chain-id $1 -b block --yes --keyring-backend test


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1333 , #1235

## What is the purpose of the change

This pull request follows the methodology laid out in #1333 to complete the minimum viable product needed for #1235 

## Process
  - Modified the v7 init docker image to reduce the vote time to 30 seconds
  - Checks out a v7 init docker image from dockerhub and initializes the genesis and config files
  - Checks out a v7 osmosis image from dockerhub and utilizes the initialized genesis and config to spin up two separate chains, along with a hermes image that connects the two chains via IBC
  - Submits a v8 upgrade prop, funds, and votes for it on both chains
  - Ensures upgrade height is reached and then no longer hits blocks
  - Stops all containers and replaces them with the locally compiled v8 image
  - Ensures blocks are hit on both chains
  - Proceeds with remaining tests

## Testing and Verifying

This change is already covered by existing e2e test suite. This was tested locally and through github CI

[Here is an example of the test output](https://github.com/osmosis-labs/osmosis/runs/6265997089?check_suite_focus=true#step:6:125)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? none

## Notes / Next Steps

From here, we can create an environment variable that allows us to skip upgrade testing and instead only compile locally and go though the chain tests. This will save us time instead of having to go through the upgrade process for every commit. 

Another important note, I [removed the locally compile osmosis-init-image step](https://github.com/osmosis-labs/osmosis/commit/f142e1af7363daa2ec01184c617f2256384fd4b1) here since it is not needed at the moment. When we introduce the environment variable addressed above, we will need to re-add this to compile the v8 init image instead of compiling with the v7 init image from docker hub. We should split these into two separate make tests so that way we are only compiling the docker images we absolutely need. The full upgrade testing takes only 8 minutes though.

Another note, I need to backport the config changes to v7.x that changes the gov voting period

Last note, we need to [change the test.yml](https://github.com/osmosis-labs/osmosis/commit/2305866480bc45383fd520f4b08b0f04230bbacf) because if you can make a commit that does not pass the e2e-test at first, but if you do a second commit that does not trigger this `enc.GIT_DIFF` and it will skip the test despite actually not passing it. cc @daniel-farina if you know how to go about fixing this