### PR TITLE
chore: v7.x update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]()
 
-* [#1357] (https://github.com/osmosis-labs/osmosis/pull/1357) chore: upgrade sdk to v0.45.0x-osmo-v7.8.1
+## [v7.2.1](https://github.com/osmosis-labs/osmosis/releases/tag/v7.2.1)
+
+* [#1373](https://github.com/osmosis-labs/osmosis/pull/1373) fix: release build scripts
+* [#1357](https://github.com/osmosis-labs/osmosis/pull/1357) chore: upgrade sdk to v0.45.0x-osmo-v7.8.1
 * [#1262](https://github.com/osmosis-labs/osmosis/pull/1262) Add a `forceprune` command to the binaries, that prunes golevelDB data better.
 
 ## [v7.2.0](https://github.com/osmosis-labs/osmosis/releases/tag/v7.2.0)


### PR DESCRIPTION
Didnt update changelog on v7.x as well when I made the v7.2.1 release