### PR TITLE
Stableswap: Simple parts of LPing

### DIFF
--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -8,10 +8,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
 
+// CalcExitPool returns how many tokens should come out, when exiting k LP shares against a "standard" CFMM
 func CalcExitPool(ctx sdk.Context, pool types.PoolI, exitingShares sdk.Int, exitFee sdk.Dec) (sdk.Coins, error) {
 	totalShares := pool.GetTotalShares()
 	if exitingShares.GTE(totalShares) {
-		return sdk.Coins{}, errors.New(("too many shares out"))
+		return sdk.Coins{}, errors.New("too many shares out")
 	}
 
 	// refundedShares = exitingShares * (1 - exit fee)
@@ -38,10 +39,59 @@ func CalcExitPool(ctx sdk.Context, pool types.PoolI, exitingShares sdk.Int, exit
 			continue
 		}
 		if exitAmt.GTE(asset.Amount) {
-			return sdk.Coins{}, errors.New(("too many shares out"))
+			return sdk.Coins{}, errors.New("too many shares out")
 		}
 		exitedCoins = exitedCoins.Add(sdk.NewCoin(asset.Denom, exitAmt))
 	}
 
 	return exitedCoins, nil
+}
+
+// MaximalExactRatioJoin LP's the maximal amount of tokens in possible, and returns the number of shares that'd be
+// and how many coins would be left over.
+func MaximalExactRatioJoin(p types.PoolI, ctx sdk.Context, tokensIn sdk.Coins) (numShares sdk.Int, remCoins sdk.Coins, err error) {
+	coinShareRatios := make([]sdk.Dec, len(tokensIn))
+	minShareRatio := sdk.MaxSortableDec
+	maxShareRatio := sdk.ZeroDec()
+
+	poolLiquidity := p.GetTotalPoolLiquidity(ctx)
+	totalShares := p.GetTotalShares()
+
+	for i, coin := range tokensIn {
+		shareRatio := coin.Amount.ToDec().QuoInt(poolLiquidity.AmountOfNoDenomValidation(coin.Denom))
+		if shareRatio.LT(minShareRatio) {
+			minShareRatio = shareRatio
+		}
+		if shareRatio.GT(maxShareRatio) {
+			maxShareRatio = shareRatio
+		}
+		coinShareRatios[i] = shareRatio
+	}
+
+	if minShareRatio.Equal(sdk.MaxSortableDec) {
+		return numShares, remCoins, errors.New("unexpected error in MaximalExactRatioJoin")
+	}
+
+	remCoins = sdk.Coins{}
+	numShares = minShareRatio.MulInt(totalShares).TruncateInt()
+
+	// if we have multiple share values, calculate remainingCoins
+	if !minShareRatio.Equal(maxShareRatio) {
+		// we have to calculate remCoins
+		for i, coin := range tokensIn {
+			// if coinShareRatios[i] == minShareRatio, no remainder
+			if coinShareRatios[i].Equal(minShareRatio) {
+				continue
+			}
+
+			usedAmount := minShareRatio.MulInt(coin.Amount).Ceil().TruncateInt()
+			newAmt := coin.Amount.Sub(usedAmount)
+			// if newAmt is non-zero, add to RemCoins. (It could be zero due to rounding)
+			if !newAmt.IsZero() {
+				remCoins = remCoins.Add(sdk.Coin{Denom: coin.Denom, Amount: newAmt})
+			}
+		}
+	}
+
+	return numShares, remCoins, nil
 }

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -1,0 +1,47 @@
+package cfmm_common
+
+import (
+	"errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
+)
+
+func CalcExitPool(ctx sdk.Context, pool types.PoolI, exitingShares sdk.Int, exitFee sdk.Dec) (sdk.Coins, error) {
+	totalShares := pool.GetTotalShares()
+	if exitingShares.GTE(totalShares) {
+		return sdk.Coins{}, errors.New(("too many shares out"))
+	}
+
+	// refundedShares = exitingShares * (1 - exit fee)
+	// with 0 exit fee optimization
+	var refundedShares sdk.Dec
+	if !exitFee.IsZero() {
+		// exitingShares * (1 - exit fee)
+		// Todo: make a -1 constant
+		oneSubExitFee := sdk.OneDec().SubMut(exitFee)
+		refundedShares = oneSubExitFee.MulIntMut(exitingShares)
+	} else {
+		refundedShares = exitingShares.ToDec()
+	}
+
+	shareOutRatio := refundedShares.QuoInt(totalShares)
+	// exitedCoins = shareOutRatio * pool liquidity
+	exitedCoins := sdk.Coins{}
+	poolLiquidity := pool.GetTotalPoolLiquidity(ctx)
+
+	for _, asset := range poolLiquidity {
+		// round down here, due to not wanting to over-exit
+		exitAmt := shareOutRatio.MulInt(asset.Amount).TruncateInt()
+		if exitAmt.LTE(sdk.ZeroInt()) {
+			continue
+		}
+		if exitAmt.GTE(asset.Amount) {
+			return sdk.Coins{}, errors.New(("too many shares out"))
+		}
+		exitedCoins = exitedCoins.Add(sdk.NewCoin(asset.Denom, exitAmt))
+	}
+
+	return exitedCoins, nil
+}

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -95,3 +95,15 @@ func MaximalExactRatioJoin(p types.PoolI, ctx sdk.Context, tokensIn sdk.Coins) (
 
 	return numShares, remCoins, nil
 }
+
+// We binary search a number of LP shares, s.t. if we exited the pool with the updated liquidity,
+// and swapped all the tokens back to the input denom, we'd get the same amount. (under 0 swap fee)
+// We do the swap estimation, 'synthetically', so we ignore the slippage each swap would cause on other swaps.
+// This is because its important to not over-estimate, and error here is tolerable.
+func BinarySearchSingleAssetJoin(
+	poolWithTokenInAddedToLiquidity types.PoolI,
+	tokenIn sdk.Coin,
+	setPoolLPShares func(numShares sdk.Int) types.PoolI) (numLPShares sdk.Int, err error) {
+	// updatedPool :=
+	return sdk.Int{}, nil
+}

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -1,6 +1,8 @@
 package stableswap
 
 import (
+	"errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -229,4 +231,11 @@ func (pa *Pool) calcInAmtGivenOut(tokenOut sdk.Coin, tokenInDenom string, swapFe
 	cfmmIn := solveCfmm(tokenInSupply, tokenOutSupply, tokenOut.Amount.ToDec().Neg())
 	inAmt := pa.getDescaledPoolAmt(tokenInDenom, cfmmIn.NegMut())
 	return inAmt, nil
+}
+
+func (pa *Pool) calcSingleAssetJoinShares(tokenIn sdk.Coin, swapFee sdk.Dec) (sdk.Int, error) {
+	// paDeref := *pa
+	// paCopy := paDeref
+	// cfmm_common.BinarySearchSingleAssetJoin(paCopy, tokenIn, )
+	return sdk.Int{}, errors.New("Unimplemented")
 }

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -208,8 +208,7 @@ func (pa *Pool) calcOutAmtGivenIn(tokenIn sdk.Coin, tokenOutDenom string, swapFe
 	if err != nil {
 		return sdk.Dec{}, err
 	}
-	tokenInSupply := reserves[0].ToDec()
-	tokenOutSupply := reserves[1].ToDec()
+	tokenInSupply, tokenOutSupply := reserves[0], reserves[1]
 	// We are solving for the amount of token out, hence x = tokenOutSupply, y = tokenInSupply
 	cfmmOut := solveCfmm(tokenOutSupply, tokenInSupply, tokenIn.Amount.ToDec())
 	outAmt := pa.getDescaledPoolAmt(tokenOutDenom, cfmmOut)
@@ -222,8 +221,7 @@ func (pa *Pool) calcInAmtGivenOut(tokenOut sdk.Coin, tokenInDenom string, swapFe
 	if err != nil {
 		return sdk.Dec{}, err
 	}
-	tokenInSupply := reserves[0].ToDec()
-	tokenOutSupply := reserves[1].ToDec()
+	tokenInSupply, tokenOutSupply := reserves[0], reserves[1]
 	// We are solving for the amount of token in, cfmm(x,y) = cfmm(x + x_in, y - y_out)
 	// x = tokenInSupply, y = tokenOutSupply, yIn = -tokenOutAmount
 	cfmmIn := solveCfmm(tokenInSupply, tokenOutSupply, tokenOut.Amount.ToDec().Neg())

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -1,6 +1,8 @@
 package stableswap
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 var (
 	cubeRootTwo, _   = sdk.NewDec(2).ApproxRoot(3)

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -79,8 +79,8 @@ func (pa Pool) getPoolAmts(denoms ...string) ([]sdk.Int, error) {
 }
 
 // getScaledPoolAmts returns scaled amount of pool liquidity based on each asset's precisions
-func (pa Pool) getScaledPoolAmts(denoms ...string) ([]sdk.Int, error) {
-	result := make([]sdk.Int, len(denoms))
+func (pa Pool) getScaledPoolAmts(denoms ...string) ([]sdk.Dec, error) {
+	result := make([]sdk.Dec, len(denoms))
 	poolLiquidity := pa.PoolLiquidity
 	liquidityIndexes := pa.getLiquidityIndexMap()
 
@@ -89,10 +89,10 @@ func (pa Pool) getScaledPoolAmts(denoms ...string) ([]sdk.Int, error) {
 
 		amt := poolLiquidity.AmountOf(denom)
 		if amt.IsZero() {
-			return []sdk.Int{}, fmt.Errorf("denom %s does not exist in pool", denom)
+			return []sdk.Dec{}, fmt.Errorf("denom %s does not exist in pool", denom)
 		}
 		scalingFactor := pa.GetScalingFactorByLiquidityIndex(liquidityIndex)
-		result[i] = amt.QuoRaw(int64(scalingFactor))
+		result[i] = amt.ToDec().QuoInt64Mut(int64(scalingFactor))
 	}
 	return result, nil
 }
@@ -195,7 +195,7 @@ func (pa Pool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom
 	if err != nil {
 		return sdk.Dec{}, err
 	}
-	scaledSpotPrice := spotPrice(reserves[0].ToDec(), reserves[1].ToDec())
+	scaledSpotPrice := spotPrice(reserves[0], reserves[1])
 	spotPrice := pa.getDescaledPoolAmt(baseAssetDenom, scaledSpotPrice)
 
 	return spotPrice, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Component of: #1406 

## What is the purpose of the change

This PR abstracts the Balancer logic for exit pool, and JoinPoolNoSwap logic to internal code usable by both balancer and stableswap.

This PR then adds these functions to stableswap. What is missing from stableswap after this is then the logic for single asset LP'ing. I plan on doing that tomorrow, it will be more logically intense, so I was thinking of doing it in a separate PR to keep this one simple to review, if folks think that is a good plan. 

## Testing and Verifying

* Balancer changes are covered by existing tests.
* This lends some degree of confidence to their correctness within stableswap, as this code is reused.
* Stableswap needs similar tests. This should imo be done by abstracting the inverse relation tests to allow more pools as input. Cref #{TODO create an issue}

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? No
  - How is the feature or change documented? Needs documentation within stableswap spec

 