### PR TITLE
hack: replace superfluid intermediary account hash(denom + old acc) with hash(denom + new acc) for init genesis

### DIFF
--- a/x/superfluid/genesis.go
+++ b/x/superfluid/genesis.go
@@ -1,6 +1,8 @@
 package superfluid
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
@@ -21,7 +23,22 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 		k.SetOsmoEquivalentMultiplier(ctx, multiplierRecord.EpochNumber, multiplierRecord.Denom, multiplierRecord.Multiplier)
 	}
 
+	accountsToReplace := make(map[string]types.SuperfluidIntermediaryAccount)
+
 	for _, intermediaryAcc := range genState.IntermediaryAccounts {
+		if string(intermediaryAcc.ValAddr) == "osmovaloper12smx2wdlyttvyzvzg54y2vnqwq2qjatex7kgq4" {
+			// This the account we are replacing
+			oldAcc := types.SuperfluidIntermediaryAccount{
+				Denom:   intermediaryAcc.Denom,
+				ValAddr: "osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n",
+				GaugeId: intermediaryAcc.GaugeId,
+			}
+
+			// Key is the old account address and value is the new account
+			accountsToReplace[oldAcc.GetAccAddress().String()] = intermediaryAcc
+			fmt.Printf("for old account %v caching new acc %v\n", oldAcc, intermediaryAcc)
+		}
+
 		k.SetIntermediaryAccount(ctx, intermediaryAcc)
 	}
 
@@ -32,6 +49,17 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 			panic(err)
 		}
 		intermediaryAcc := k.GetIntermediaryAccount(ctx, acc)
+
+		// We state exported an old address that was created from hash(denom + old address)
+		// So we want to replace it with a new address that replaced old
+		if intermediaryAcc.Empty() {
+			toReplace, ok := accountsToReplace[acc.String()]
+			if !ok {
+				panic(fmt.Sprintf("did not find %s in accountsToReplace", acc.String()))
+			}
+			intermediaryAcc = toReplace
+		}
+
 		if intermediaryAcc.Denom == "" {
 			panic("connection to invalid intermediary account found")
 		}

--- a/x/superfluid/keeper/intermediary_account.go
+++ b/x/superfluid/keeper/intermediary_account.go
@@ -36,7 +36,7 @@ func (k Keeper) GetIntermediaryAccount(ctx sdk.Context, address sdk.AccAddress) 
 
 	acc := types.SuperfluidIntermediaryAccount{}
 	if address == nil {
-		return acc
+		panic("address was nil")
 	}
 
 	bz := prefixStore.Get(address)
@@ -132,6 +132,7 @@ func (k Keeper) GetAllLockIdIntermediaryAccountConnections(ctx sdk.Context) []ty
 	prefixStore := prefix.NewStore(store, types.KeyPrefixLockIntermediaryAccAddr)
 
 	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
 
 	connections := []types.LockIdIntermediaryAccountConnection{}
 	for ; iterator.Valid(); iterator.Next() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

DO NOT MERGE

Superfluid intermediary account address = hash(denom + validator address) ([link](https://github.com/osmosis-labs/osmosis/blob/2d8d32c5e28779bc059768ce47f4463e88e6d6c1/x/superfluid/types/superfluid.go#L38))

To spin up a testnet, we export genesis and replace a validator address to the one we have control of in the following script:
https://github.com/osmosis-labs/osmosis/blob/84e7726a4de52539b0fe3c0c5fc68b8d84131835/cmd/osmosisd/cmd/testnetify/testnetify.py#L102

However, since Superfluid intermediary account address = hash(denom + validator address), that does not get replaces since this address is a hash of 2 values where one gets changed.

As a result, we need a way to programmatically replace Superfluid intermediary account with a new version so that we can initialize genesis from genesis that had validator addresses replaced.

This is only a temporary solution to be able to spin up a testnet. We should think of a better way to change Superfluid intermediary account addresses in the future via testnetify script.


## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)