### PR TITLE
feat: add height-gated AnteHandler message filter

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -1,18 +1,17 @@
 package app
 
 import (
+	wasm "github.com/CosmWasm/wasmd/x/wasm"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-
 	channelkeeper "github.com/cosmos/ibc-go/v2/modules/core/04-channel/keeper"
 	ibcante "github.com/cosmos/ibc-go/v2/modules/core/ante"
 
-	wasm "github.com/CosmWasm/wasmd/x/wasm"
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-
+	v8 "github.com/osmosis-labs/osmosis/v7/app/upgrades/v8"
 	txfeeskeeper "github.com/osmosis-labs/osmosis/v7/x/txfees/keeper"
 	txfeestypes "github.com/osmosis-labs/osmosis/v7/x/txfees/types"
 )
@@ -31,11 +30,13 @@ func NewAnteHandler(
 ) sdk.AnteHandler {
 	mempoolFeeOptions := txfeestypes.NewMempoolFeeOptions(appOpts)
 	mempoolFeeDecorator := txfeeskeeper.NewMempoolFeeDecorator(*txFeesKeeper, mempoolFeeOptions)
+
 	return sdk.ChainAnteDecorators(
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		wasmkeeper.NewLimitSimulationGasDecorator(wasmConfig.SimulationGasLimit),
 		wasmkeeper.NewCountTXDecorator(txCounterStoreKey),
 		ante.NewRejectExtensionOptionsDecorator(),
+		v8.MsgFilterDecorator{},
 		// Use Mempool Fee Decorator from our txfees module instead of default one from auth
 		// https://github.com/cosmos/cosmos-sdk/blob/master/x/auth/middleware/fee.go#L34
 		mempoolFeeDecorator,

--- a/app/upgrades/v8/msg_filter_ante.go
+++ b/app/upgrades/v8/msg_filter_ante.go
@@ -1,0 +1,36 @@
+package v8
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	superfluidtypes "github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
+)
+
+// MsgFilterDecorator defines an AnteHandler decorator for the v8 upgrade that
+// provide height-gated message filtering acceptance.
+type MsgFilterDecorator struct{}
+
+// AnteHandle performs an AnteHandler check that returns an error if the current
+// block height is less than the v8 upgrade height and contains messages that are
+// not supported until the upgrade height is reached.
+func (mfd MsgFilterDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	currHeight := ctx.BlockHeight()
+
+	if currHeight < UpgradeHeight && hasInvalidMsgs(tx.GetMsgs()) {
+		return ctx, fmt.Errorf("tx contains unsupported message types at height %d", currHeight)
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func hasInvalidMsgs(msgs []sdk.Msg) bool {
+	for _, msg := range msgs {
+		switch msg.(type) {
+		case *superfluidtypes.MsgUnPoolWhitelistedPool:
+			return true
+		}
+	}
+
+	return false
+}

--- a/app/upgrades/v8/msg_filter_ante_test.go
+++ b/app/upgrades/v8/msg_filter_ante_test.go
@@ -1,0 +1,77 @@
+package v8_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v7/app"
+	v8 "github.com/osmosis-labs/osmosis/v7/app/upgrades/v8"
+	superfluidtypes "github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
+)
+
+func noOpAnteDecorator() sdk.AnteHandler {
+	return func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	}
+}
+
+func TestMsgFilterDecorator(t *testing.T) {
+	handler := v8.MsgFilterDecorator{}
+	txCfg := app.MakeEncodingConfig().TxConfig
+
+	addr1 := sdk.AccAddress([]byte("addr1_______________"))
+	addr2 := sdk.AccAddress([]byte("addr2_______________"))
+
+	testCases := []struct {
+		name      string
+		ctx       sdk.Context
+		msgs      []sdk.Msg
+		expectErr bool
+	}{
+		{
+			name: "valid tx pre-upgrade",
+			ctx:  sdk.Context{}.WithBlockHeight(v8.UpgradeHeight - 1),
+			msgs: []sdk.Msg{
+				banktypes.NewMsgSend(addr1, addr2, sdk.NewCoins(sdk.NewInt64Coin("foo", 5))),
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid tx pre-upgrade",
+			ctx:  sdk.Context{}.WithBlockHeight(v8.UpgradeHeight - 1),
+			msgs: []sdk.Msg{
+				banktypes.NewMsgSend(addr1, addr2, sdk.NewCoins(sdk.NewInt64Coin("foo", 5))),
+				superfluidtypes.NewMsgUnPoolWhitelistedPool(addr1, 1, 1),
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid tx post-upgrade",
+			ctx:  sdk.Context{}.WithBlockHeight(v8.UpgradeHeight),
+			msgs: []sdk.Msg{
+				banktypes.NewMsgSend(addr1, addr2, sdk.NewCoins(sdk.NewInt64Coin("foo", 5))),
+				superfluidtypes.NewMsgUnPoolWhitelistedPool(addr1, 1, 1),
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			txBuilder := txCfg.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.msgs...))
+
+			_, err := handler.AnteHandle(tc.ctx, txBuilder.GetTx(), false, noOpAnteDecorator())
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x/superfluid/keeper/msg_server.go
+++ b/x/superfluid/keeper/msg_server.go
@@ -124,6 +124,5 @@ func (server msgServer) UnPoolWhitelistedPool(goCtx context.Context, msg *types.
 		),
 	})
 
-	x := &typesMsgUnPoolWhitelistedPool{}
 	return &types.MsgUnPoolWhitelistedPoolResponse{LockId: lockId}, nil
 }

--- a/x/superfluid/keeper/msg_server.go
+++ b/x/superfluid/keeper/msg_server.go
@@ -124,5 +124,6 @@ func (server msgServer) UnPoolWhitelistedPool(goCtx context.Context, msg *types.
 		),
 	})
 
+	x := &typesMsgUnPoolWhitelistedPool{}
 	return &types.MsgUnPoolWhitelistedPoolResponse{LockId: lockId}, nil
 }


### PR DESCRIPTION
Add an AnteHandler decorator that provides (height-gated) message filtering for the v8 upgrade.