### PR TITLE
refactor MsgFilterDecorator to match abstractions of other ante decor…

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -30,13 +30,14 @@ func NewAnteHandler(
 ) sdk.AnteHandler {
 	mempoolFeeOptions := txfeestypes.NewMempoolFeeOptions(appOpts)
 	mempoolFeeDecorator := txfeeskeeper.NewMempoolFeeDecorator(*txFeesKeeper, mempoolFeeOptions)
+	msgFeeDecorator := v8.NewMsgFilterDecorator()
 
 	return sdk.ChainAnteDecorators(
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		wasmkeeper.NewLimitSimulationGasDecorator(wasmConfig.SimulationGasLimit),
 		wasmkeeper.NewCountTXDecorator(txCounterStoreKey),
 		ante.NewRejectExtensionOptionsDecorator(),
-		v8.MsgFilterDecorator{},
+		msgFeeDecorator,
 		// Use Mempool Fee Decorator from our txfees module instead of default one from auth
 		// https://github.com/cosmos/cosmos-sdk/blob/master/x/auth/middleware/fee.go#L34
 		mempoolFeeDecorator,

--- a/app/upgrades/v8/msg_filter_ante.go
+++ b/app/upgrades/v8/msg_filter_ante.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	superfluidtypes "github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 )
 
 // MsgFilterDecorator defines an AnteHandler decorator for the v8 upgrade that
 // provide height-gated message filtering acceptance.
 type MsgFilterDecorator struct{}
+
+func NewMsgFilterDecorator() MsgFilterDecorator {
+	return MsgFilterDecorator{}
+}
 
 // AnteHandle performs an AnteHandler check that returns an error if the current
 // block height is less than the v8 upgrade height and contains messages that are


### PR DESCRIPTION
Closes: #1487

## What is the purpose of the change

This change cleans up the implementation of the message filter ante, which previously broke multiple layers of abstraction and was inconsistent with implementations of other antes.

## Brief Changelog

- Add `NewMsgFilterDecorator()` function to `msg_filter_ante.go`
- Refactor related decorator code in `ante.go` and add relevant wiring

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)