### PR TITLE
Use correct libwasm version in Dockerfile and backport docker Github Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: docker
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+' # ignore rc
+  
+env:
+  DOCKER_REPOSITORY: osmolabs/osmosis
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check out the repo
+        uses: actions/checkout@v2
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_REPOSITORY }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - 
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+      - 
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,13 @@ COPY . /osmosis
 
 # From https://github.com/CosmWasm/wasmd/blob/master/Dockerfile
 # For more details see https://github.com/CosmWasm/wasmvm#builds-of-libwasmvm 
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d5f2cd7fd8513cafa9932d22eb350
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta5/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep d16a2cab22c75dbe8af32265b9346c6266070bdcf9ed5aa9b7b39a7e32e25fe0
+
 RUN BUILD_TAGS=muslc make build
 
 ## Deploy image
-FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG} 
+FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG}
 
 COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,3 @@ EXPOSE 26657
 EXPOSE 1317
 
 ENTRYPOINT ["osmosisd"]
-CMD [ "start" ]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR:

- Use correct libwasm version (`v1.0.0-beta5`) in Dockerfile
- Ports the docker Github Action from main to `v8.x` branch (https://github.com/osmosis-labs/osmosis/blob/main/.github/workflows/docker.yml) 

## Brief Changelog

- Update Dockerfile
- Add Docker Github action

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

To check:

- Wasm version used in `v8`: https://github.com/osmosis-labs/osmosis/blob/v8.0.0/go.mod#L6
- Corresponding version of `libwasm`: https://github.com/CosmWasm/wasmd#compatibility
- Version used in the Dockerfile: https://github.com/nikever/osmosis/blob/fix/wasmd-version-in-dockerfile/Dockerfile#L13

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable  