### PR TITLE
add proposal flag: includes title, description, deposit. If this path…

### DIFF
--- a/x/pool-incentives/client/cli/parse.go
+++ b/x/pool-incentives/client/cli/parse.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"
+)
+
+type Proposal struct {
+	Title       string
+	Description string
+	Deposit     string
+}
+
+var ProposalFlags = []string {
+	cli.FlagTitle,
+	cli.FlagDescription,
+	cli.FlagDeposit,
+}
+
+func (p Proposal) validate() error {
+	if p.Title == "" {
+		return fmt.Errorf("proposal title is required")
+	}
+
+	if p.Description == "" {
+		return fmt.Errorf("proposal description is required")
+	}
+	return nil
+}
+
+func parseProposalFlags(fs *pflag.FlagSet) (*Proposal, error) {
+	proposal := &Proposal{}
+	proposalFile, _ := fs.GetString(cli.FlagProposal)
+
+	if proposalFile == "" {
+		proposal.Title, _ = fs.GetString(cli.FlagTitle)
+		proposal.Description, _ = fs.GetString(cli.FlagDescription)
+		proposal.Deposit, _ = fs.GetString(cli.FlagDeposit)
+		if err := proposal.validate(); err != nil {
+			return nil, err
+		}
+
+		return proposal, nil
+	}
+
+	for _, flag := range ProposalFlags {
+		if v, _ := fs.GetString(flag); v != "" {
+			return nil, fmt.Errorf("--%s flag provided alongside --proposal, which is a noop", flag)
+		}
+	}
+
+	contents, err := os.ReadFile(proposalFile)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(contents, proposal)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := proposal.validate(); err != nil {
+		return nil, err
+	}
+
+	return proposal, nil
+}

--- a/x/pool-incentives/client/cli/tx.go
+++ b/x/pool-incentives/client/cli/tx.go
@@ -71,28 +71,19 @@ func NewCmdSubmitUpdatePoolIncentivesProposal() *cobra.Command {
 				})
 			}
 
-			title, err := cmd.Flags().GetString(cli.FlagTitle)
-			if err != nil {
-				return err
-			}
-
-			description, err := cmd.Flags().GetString(cli.FlagDescription)
-			if err != nil {
-				return err
-			}
-
 			from := clientCtx.GetFromAddress()
 
-			depositStr, err := cmd.Flags().GetString(cli.FlagDeposit)
+			proposal, err := parseProposalFlags(cmd.Flags())
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse proposal: %w", err)
 			}
-			deposit, err := sdk.ParseCoinsNormalized(depositStr)
+			
+			deposit, err := sdk.ParseCoinsNormalized(proposal.Deposit)
 			if err != nil {
 				return err
 			}
 
-			content := types.NewUpdatePoolIncentivesProposal(title, description, records)
+			content := types.NewUpdatePoolIncentivesProposal(proposal.Title, proposal.Deposit, records)
 
 			msg, err := govtypes.NewMsgSubmitProposal(content, deposit, from)
 			if err != nil {
@@ -110,8 +101,7 @@ func NewCmdSubmitUpdatePoolIncentivesProposal() *cobra.Command {
 	cmd.Flags().String(cli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(cli.FlagDescription, "", "description of proposal")
 	cmd.Flags().String(cli.FlagDeposit, "", "deposit of proposal")
-	_ = cmd.MarkFlagRequired(cli.FlagTitle)
-	_ = cmd.MarkFlagRequired(cli.FlagDescription)
+	cmd.Flags().String(cli.FlagProposal, "", "Proposal file path (if this path is given, other proposal flags are ignored)")
 
 	return cmd
 }
@@ -153,28 +143,19 @@ func NewCmdSubmitReplacePoolIncentivesProposal() *cobra.Command {
 				})
 			}
 
-			title, err := cmd.Flags().GetString(cli.FlagTitle)
-			if err != nil {
-				return err
-			}
-
-			description, err := cmd.Flags().GetString(cli.FlagDescription)
-			if err != nil {
-				return err
-			}
-
 			from := clientCtx.GetFromAddress()
 
-			depositStr, err := cmd.Flags().GetString(cli.FlagDeposit)
+			proposal, err := parseProposalFlags(cmd.Flags())
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse proposal: %w", err)
 			}
-			deposit, err := sdk.ParseCoinsNormalized(depositStr)
+			
+			deposit, err := sdk.ParseCoinsNormalized(proposal.Deposit)
 			if err != nil {
 				return err
 			}
 
-			content := types.NewReplacePoolIncentivesProposal(title, description, records)
+			content := types.NewReplacePoolIncentivesProposal(proposal.Title, proposal.Description, records)
 
 			msg, err := govtypes.NewMsgSubmitProposal(content, deposit, from)
 			if err != nil {
@@ -192,8 +173,7 @@ func NewCmdSubmitReplacePoolIncentivesProposal() *cobra.Command {
 	cmd.Flags().String(cli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(cli.FlagDescription, "", "description of proposal")
 	cmd.Flags().String(cli.FlagDeposit, "", "deposit of proposal")
-	_ = cmd.MarkFlagRequired(cli.FlagTitle)
-	_ = cmd.MarkFlagRequired(cli.FlagDescription)
+	cmd.Flags().String(cli.FlagProposal, "", "Proposal file path (if this path is given, other proposal flags are ignored)")
 
 	return cmd
 }


### PR DESCRIPTION
add proposal flag: includes title, description, deposit. If this path is given, title and description flags are ignored

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

> Add a description of the overall background and high level changes that this PR introduces

*(E.g.: This pull request improves documation of area A by adding ....*


## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)