### PR TITLE
Disable Stableswap

### DIFF
--- a/x/gamm/keeper/msg_server.go
+++ b/x/gamm/keeper/msg_server.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer"
-	"github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
 
@@ -27,16 +26,16 @@ func NewBalancerMsgServerImpl(keeper *Keeper) balancer.MsgServer {
 	}
 }
 
-func NewStableswapMsgServerImpl(keeper *Keeper) stableswap.MsgServer {
-	return &msgServer{
-		keeper: keeper,
-	}
-}
+// func NewStableswapMsgServerImpl(keeper *Keeper) stableswap.MsgServer {
+// 	return &msgServer{
+// 		keeper: keeper,
+// 	}
+// }
 
 var (
-	_ types.MsgServer      = msgServer{}
-	_ balancer.MsgServer   = msgServer{}
-	_ stableswap.MsgServer = msgServer{}
+	_ types.MsgServer    = msgServer{}
+	_ balancer.MsgServer = msgServer{}
+	// _ stableswap.MsgServer = msgServer{}
 )
 
 func (server msgServer) CreateBalancerPool(goCtx context.Context, msg *balancer.MsgCreateBalancerPool) (*balancer.MsgCreateBalancerPoolResponse, error) {
@@ -44,13 +43,13 @@ func (server msgServer) CreateBalancerPool(goCtx context.Context, msg *balancer.
 	return &balancer.MsgCreateBalancerPoolResponse{PoolID: poolId}, err
 }
 
-func (server msgServer) CreateStableswapPool(goCtx context.Context, msg *stableswap.MsgCreateStableswapPool) (*stableswap.MsgCreateStableswapPoolResponse, error) {
-	poolId, err := server.CreatePool(goCtx, msg)
-	if err != nil {
-		return nil, err
-	}
-	return &stableswap.MsgCreateStableswapPoolResponse{PoolID: poolId}, nil
-}
+// func (server msgServer) CreateStableswapPool(goCtx context.Context, msg *stableswap.MsgCreateStableswapPool) (*stableswap.MsgCreateStableswapPoolResponse, error) {
+// 	poolId, err := server.CreatePool(goCtx, msg)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return &stableswap.MsgCreateStableswapPoolResponse{PoolID: poolId}, nil
+// }
 
 func (server msgServer) CreatePool(goCtx context.Context, msg types.CreatePoolMsg) (poolId uint64, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/gamm/module.go
+++ b/x/gamm/module.go
@@ -22,7 +22,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/client/cli"
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer"
-	"github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/simulation"
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
@@ -44,7 +43,7 @@ func (AppModuleBasic) Name() string { return types.ModuleName }
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	types.RegisterLegacyAminoCodec(cdc)
 	balancer.RegisterLegacyAminoCodec(cdc)
-	stableswap.RegisterLegacyAminoCodec(cdc)
+	// stableswap.RegisterLegacyAminoCodec(cdc)
 }
 
 // DefaultGenesis returns default genesis state as raw bytes for the gamm
@@ -83,7 +82,7 @@ func (b AppModuleBasic) GetQueryCmd() *cobra.Command {
 func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
 	balancer.RegisterInterfaces(registry)
-	stableswap.RegisterInterfaces(registry)
+	// stableswap.RegisterInterfaces(registry)
 }
 
 type AppModule struct {
@@ -100,7 +99,7 @@ type AppModule struct {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(&am.keeper))
 	balancer.RegisterMsgServer(cfg.MsgServer(), keeper.NewBalancerMsgServerImpl(&am.keeper))
-	stableswap.RegisterMsgServer(cfg.MsgServer(), keeper.NewStableswapMsgServerImpl(&am.keeper))
+	// stableswap.RegisterMsgServer(cfg.MsgServer(), keeper.NewStableswapMsgServerImpl(&am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQuerier(am.keeper))
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1503 

## What is the purpose of the change

The upcoming V9 upgrade should be including the gamm generalization, but not stable swap implementations. 
This PR removes(comments out) stable swap inplementation and existing stableswap calls, which was to my surprise only present in `msg_sever.go` and `module.go`. 




## Brief Changelog
  - Remove stableswap implementation from gamm module
## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)