### PR TITLE
Update osmosis-bindings to use the repo at osmosis-labs rather than confio

### DIFF
--- a/app/wasm/bindings/query.go
+++ b/app/wasm/bindings/query.go
@@ -5,7 +5,7 @@ import (
 )
 
 // OsmosisQuery contains osmosis custom queries.
-// See https://github.com/confio/osmosis-bindings/blob/main/packages/bindings/src/query.rs
+// See https://github.com/osmosis-labs/osmosis-bindings/blob/main/packages/bindings/src/query.rs
 type OsmosisQuery struct {
 	/// Given a subdenom minted by a contract via `OsmosisMsg::MintTokens`,
 	/// returns the full denom as used by `BankMsg::Send`.

--- a/app/wasm/testdata/download_releases.sh
+++ b/app/wasm/testdata/download_releases.sh
@@ -16,7 +16,7 @@ for contract in hackatom reflect; do
 done
 
 tag="$1"
-url="https://github.com/confio/osmosis-bindings/releases/download/$tag/osmo_reflect.wasm"
+url="https://github.com/osmosis-labs/osmosis-bindings/releases/download/$tag/osmo_reflect.wasm"
 echo "Downloading $url ..."
 wget -O "osmo_reflect.wasm" "$url"
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1542 

## What is the purpose of the change

Update osmosis-bindings to use the repo at osmosis-labs rather than confio 


## Brief Changelog

- Change the relevant url entries in `app/wasm/bindings/query.go` and `app/wasm/testdata/download_releases.sh`

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)