### PR TITLE
Make token factory handle empty genesis configurations better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,3 +43,4 @@ EXPOSE 26657
 EXPOSE 1317
 
 ENTRYPOINT ["osmosisd"]
+CMD [ "start" ]

--- a/x/tokenfactory/genesis.go
+++ b/x/tokenfactory/genesis.go
@@ -12,6 +12,9 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	k.CreateModuleAccount(ctx)
 
+	if genState.Params.DenomCreationFee == nil {
+		genState.Params.DenomCreationFee = sdk.NewCoins()
+	}
 	k.SetParams(ctx, genState.Params)
 
 	for _, genDenom := range genState.GetFactoryDenoms() {

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -15,8 +15,10 @@ func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, denomNonce stri
 	if err != nil {
 		return "", err
 	}
-	if err := k.distrKeeper.FundCommunityPool(ctx, creationFee, accAddr); err != nil {
-		return "", err
+	if len(creationFee) > 0 {
+		if err := k.distrKeeper.FundCommunityPool(ctx, creationFee, accAddr); err != nil {
+			return "", err
+		}
 	}
 
 	denom, err := types.GetTokenDenom(creatorAddr, denomNonce)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

A problem @czarcas7ic ran into was getting panics on token factory messages, when the genesis wasn't initialized.

## Brief Changelog

- Improve nil handling of token factory InitGenesis

## Testing and Verifying

- TODO

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no, still pre-release for token factory
  - How is the feature or change documented? not applicable, removes a thing to document tbh