### PR TITLE
fix: gov support for superfluid

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -366,7 +366,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, appKeepers.keys[govtypes.StoreKey],
 		appKeepers.GetSubspace(govtypes.ModuleName), appKeepers.AccountKeeper, appKeepers.BankKeeper,
-		appKeepers.StakingKeeper, govRouter)
+		appKeepers.SuperfluidKeeper, govRouter)
 	appKeepers.GovKeeper = &govKeeper
 }
 

--- a/x/superfluid/keeper/keeper.go
+++ b/x/superfluid/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
@@ -29,6 +30,8 @@ type Keeper struct {
 
 	lms types.LockupMsgServer
 }
+
+var _ govtypes.StakingKeeper = (*Keeper)(nil)
 
 // NewKeeper returns an instance of Keeper.
 func NewKeeper(cdc codec.Codec, storeKey sdk.StoreKey, paramSpace paramtypes.Subspace, ak authkeeper.AccountKeeper, bk types.BankKeeper, sk types.StakingKeeper, dk types.DistrKeeper, ek types.EpochKeeper, lk types.LockupKeeper, gk types.GammKeeper, ik types.IncentivesKeeper, lms types.LockupMsgServer) *Keeper {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

@czarcas7ic and I ran into issues manually testing #1191 . We both reproduces this test case: https://github.com/osmosis-labs/osmosis/discussions/1543#discussioncomment-2786650

Upon further investigation, it was found that staking keeper was never replaced with superfluid keeper in the gov module so that the new logic could not be used for calculating tally and overriding validator votes by SF stakers.

We need to e2e test this case in a future PR: https://github.com/osmosis-labs/osmosis/issues/1556

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable