### PR TITLE
refactor: e2e setup to be more extensible for state sync

### DIFF
--- a/tests/e2e/docker/image_config.go
+++ b/tests/e2e/docker/image_config.go
@@ -1,0 +1,64 @@
+package docker
+
+// ImageConfig contains all images and their respective tags
+// needed for running e2e tests.
+type ImageConfig struct {
+	InitRepository string
+	InitTag        string
+
+	OsmosisRepository string
+	OsmosisTag        string
+
+	RelayerRepository string
+	RelayerTag        string
+}
+
+const (
+	// Local osmosis repo/version.
+	// It is used when skipping upgrade by setting OSMOSIS_E2E_SKIP_UPGRADE to true).
+	// This image should be pre-built with `make docker-build-debug` either in CI or locally.
+	LocalOsmoRepository = "osmosis"
+	LocalOsmoTag        = "debug"
+	// Local osmosis repo/version for osmosis initialization.
+	// It is used when skipping upgrade by setting OSMOSIS_E2E_SKIP_UPGRADE to true).
+	// This image should be pre-built with `make docker-build-e2e-chain-init` either in CI or locally.
+	localInitRepository = "osmosis-e2e-chain-init"
+	localInitTag        = "debug"
+	// Pre-upgrade osmosis repo/tag to pull.
+	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
+	// for this functionality to be used.
+	previousVersionOsmoRepository = "osmolabs/osmosis-dev"
+	previousVersionOsmoTag        = "v8.0.0-debug"
+	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
+	previousVersionInitRepository = "osmolabs/osmosis-init"
+	previousVersionInitTag        = "v8.0.0"
+	// Hermes repo/version for relayer
+	relayerRepository = "osmolabs/hermes"
+	relayerTag        = "0.13.0"
+)
+
+// Returns ImageConfig needed for running e2e test.
+// If isUpgrade is true, returns images for running the upgrade
+// Otherwise, returns images for running non-upgrade e2e tests.
+func NewImageConfig(isUpgrade bool) *ImageConfig {
+	config := &ImageConfig{
+		RelayerRepository: relayerRepository,
+		RelayerTag:        relayerTag,
+	}
+
+	if isUpgrade {
+		config.InitRepository = previousVersionInitRepository
+		config.InitTag = previousVersionInitTag
+
+		config.OsmosisRepository = previousVersionOsmoRepository
+		config.OsmosisTag = previousVersionOsmoTag
+	} else {
+		config.InitRepository = localInitRepository
+		config.InitTag = localInitTag
+
+		config.OsmosisRepository = LocalOsmoRepository
+		config.OsmosisTag = LocalOsmoTag
+	}
+
+	return config
+}

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -217,7 +217,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 func (s *IntegrationTestSuite) runValidators(chainConfig *chainConfig, dockerRepository, dockerTag string, portOffset int) {
 	chain := chainConfig.chain
 	s.T().Logf("starting %s validator containers...", chain.ChainMeta.Id)
-	s.valResources[chain.ChainMeta.Id] = make([]*dockertest.Resource, len(chain.Validators))
+	s.valResources[chain.ChainMeta.Id] = make([]*dockertest.Resource, len(chain.Validators)-len(chainConfig.skipRunValidatorIndexes))
 	pwd, err := os.Getwd()
 	s.Require().NoError(err)
 	for i, val := range chain.Validators {

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -225,6 +225,7 @@ func (s *IntegrationTestSuite) runValidators(chainConfig *chainConfig, dockerRep
 		// This is needed for testing functionality like
 		// state-sunc where we might want to start some validators during tests.
 		if _, ok := chainConfig.skipRunValidatorIndexes[i]; ok {
+			s.T().Logf("skipping %s validator with index %d from running...", val.Name, i)
 			continue
 		}
 

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -518,6 +518,10 @@ func (s *IntegrationTestSuite) upgrade() {
 	for _, chainConfig := range s.chainConfigs {
 		curChain := chainConfig.chain
 		for valIdx := range curChain.Validators {
+			if _, ok := chainConfig.skipRunValidatorIndexes[valIdx]; ok {
+				continue
+			}
+
 			var opts docker.RemoveContainerOptions
 			opts.ID = s.valResources[curChain.ChainMeta.Id][valIdx].Container.ID
 			opts.Force = true

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -478,7 +478,7 @@ func (s *IntegrationTestSuite) upgrade() {
 		chainConfig.propHeight = currentHeight + int(chainConfig.votingPeriod) + int(propSubmitBlocks) + int(propBufferBlocks)
 		s.submitProposal(chainConfig.chain, chainConfig.propHeight)
 		s.depositProposal(chainConfig.chain)
-		s.voteProposal(chainConfig.chain)
+		s.voteProposal(chainConfig)
 	}
 
 	// wait till all chains halt at upgrade height

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -486,6 +486,10 @@ func (s *IntegrationTestSuite) upgrade() {
 		curChain := chainConfig.chain
 
 		for i := range chainConfig.chain.Validators {
+			if _, ok := chainConfig.skipRunValidatorIndexes[i]; ok {
+				continue
+			}
+
 			// use counter to ensure no new blocks are being created
 			counter := 0
 			s.T().Logf("waiting to reach upgrade height on %s validator container: %s", s.valResources[curChain.ChainMeta.Id][i].Container.Name[1:], s.valResources[curChain.ChainMeta.Id][i].Container.ID)

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -84,6 +84,13 @@ var (
 			SnapshotInterval:   1500,
 			SnapshotKeepRecent: 2,
 		},
+		{
+			Pruning:            "everything",
+			PruningKeepRecent:  "0",
+			PruningInterval:    "0",
+			SnapshotInterval:   0,
+			SnapshotKeepRecent: 0,
+		},
 	}
 	validatorConfigsChainB = []*chain.ValidatorConfig{
 		{

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -5,9 +5,14 @@ import (
 )
 
 func (s *IntegrationTestSuite) TestIBCTokenTransfer() {
-	s.Run("send_uosmo_to_chainB", func() {
-		// compare coins of reciever pre and post IBC send
-		// diff should only be the amount sent
-		s.sendIBC(s.chains[0], s.chains[1], s.chains[1].Validators[0].PublicAddress, chain.OsmoToken)
-	})
+	chainA := s.chainConfigs[0].chain
+	chainB := s.chainConfigs[1].chain
+
+	// compare coins of reciever pre and post IBC send
+	// diff should only be the amount sent
+	s.sendIBC(chainA, chainB, chainB.Validators[0].PublicAddress, chain.OsmoToken)
+}
+
+func (s *IntegrationTestSuite) TestStateSync() {
+
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -12,7 +12,3 @@ func (s *IntegrationTestSuite) TestIBCTokenTransfer() {
 	// diff should only be the amount sent
 	s.sendIBC(chainA, chainB, chainB.Validators[0].PublicAddress, chain.OsmoToken)
 }
-
-func (s *IntegrationTestSuite) TestStateSync() {
-
-}

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/util"
 )
 
-func (s *IntegrationTestSuite) connectIBCChains() {
-	s.T().Logf("connecting %s and %s chains via IBC", s.chains[0].ChainMeta.Id, s.chains[1].ChainMeta.Id)
+func (s *IntegrationTestSuite) connectIBCChains(chainA *chain.Chain, chainB *chain.Chain) {
+	s.T().Logf("connecting %s and %s chains via IBC", chainA.ChainMeta.Id, chainB.ChainMeta.Id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -33,8 +33,8 @@ func (s *IntegrationTestSuite) connectIBCChains() {
 			"hermes",
 			"create",
 			"channel",
-			s.chains[0].ChainMeta.Id,
-			s.chains[1].ChainMeta.Id,
+			chainA.ChainMeta.Id,
+			chainB.ChainMeta.Id,
 			"--port-a=transfer",
 			"--port-b=transfer",
 		},
@@ -63,7 +63,7 @@ func (s *IntegrationTestSuite) connectIBCChains() {
 		"failed to connect chains via IBC: %s", errBuf.String(),
 	)
 
-	s.T().Logf("connected %s and %s chains via IBC", s.chains[0].ChainMeta.Id, s.chains[1].ChainMeta.Id)
+	s.T().Logf("connected %s and %s chains via IBC", chainA.ChainMeta.Id, chainB.ChainMeta.Id)
 }
 
 func (s *IntegrationTestSuite) sendIBC(srcChain *chain.Chain, dstChain *chain.Chain, recipient string, token sdk.Coin) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR refactors e2e test setup to have an abstraction `chainConfig` that has information about which validators should not be run during initialization. This is a first step toward testing state-sync as we want to postpone running some nodes so that we can test nodes "catching up".

Additionally, this PR extracts a separate package `docker` for managing and storing all information related to docker images.

## Brief Changelog

- create a `chainConfig` struct to encapsulate all configurations related to chains in a single abstraction
   * remove global variables `propHeightA`, `propHeightB`, `votingPeriodA`, `votingPeriodB`. Instead, these are part of the `chainConfig` struct
   * `skipRunValidatorIndexes` - this is needed to skip certain validators from being run during setup so that we can test state-sync post-initialization and upgrade
- remove code duplication for every chain. Instead, always loop over `chainConfig`s so that if we add more chains later, the setup would work out of the box

## Testing and Verifying

- tested running both with and without upgrade

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable