### PR TITLE
Make CI only run on pushes to main / release branches. Comment out less useful CLI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,12 @@ name: Tests & Code Coverage
 
 on:
   pull_request:
-  push:
     branches:
       - "**"
+  push:
+    branches:
+      - "main"
+      - "v[0-9]**"
 
 jobs:
   should_run_go_test:

--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -152,45 +152,47 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
 			false, &sdk.TxResponse{}, 0,
 		},
-		{
-			"future governor time",
-			fmt.Sprintf(`
-			{
-			  "%s": "1node0token,3stake",
-			  "%s": "100node0token,100stake",
-			  "%s": "0.001",
-			  "%s": "0.001",
-			  "%s": "2h"
-			}
-			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
-			false, &sdk.TxResponse{}, 0,
-		},
-		{
-			"future governor token + time",
-			fmt.Sprintf(`
-			{
-			  "%s": "1node0token,3stake",
-			  "%s": "100node0token,100stake",
-			  "%s": "0.001",
-			  "%s": "0.001",
-			  "%s": "token,1000h"
-			}
-			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
-			false, &sdk.TxResponse{}, 0,
-		},
-		{
-			"invalid future governor",
-			fmt.Sprintf(`
-			{
-			  "%s": "1node0token,3stake",
-			  "%s": "100node0token,100stake",
-			  "%s": "0.001",
-			  "%s": "0.001",
-			  "%s": "validdenom,invalidtime"
-			}
-			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
-			true, &sdk.TxResponse{}, 7,
-		},
+		// Due to CI time concerns, we leave these CLI tests commented out, and instead guaranteed via
+		// the logic tests.
+		// {
+		// 	"future governor time",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "2h"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	false, &sdk.TxResponse{}, 0,
+		// },
+		// {
+		// 	"future governor token + time",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "token,1000h"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	false, &sdk.TxResponse{}, 0,
+		// },
+		// {
+		// 	"invalid future governor",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "validdenom,invalidtime"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	true, &sdk.TxResponse{}, 7,
+		// },
 		{
 			"not valid json",
 			"bad json",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

I'm losing a ton of time due to waiting for CI. This PR de-duplicates the on-push / pull-request CI contention.

Now we only have CI run on pushes to main and release branches. (With sub-optimal release branch matching)

Also comments out some of the less useless gamm tests. Were trying to eliminate these anyway, cref https://github.com/cosmos/cosmos-sdk/pull/11877

## Testing and Verifying

Tests still run on this PR, and they remain running on main.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? CI out of scope of changelog
  - How is the feature or change documented? not applicable