### PR TITLE
[e2e] Add GitHub cache to docker build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - id: skip_check
+      -
+        id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
           cancel_others: "true" # workflow-runs from outdated commits will be cancelled.
@@ -23,7 +24,8 @@ jobs:
           skip_after_successful_duplicate: "true"
           paths: '["**/*.go", "**/*.mod", "**/*.sum"]'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-      - name: Skipping test
+      -
+        name: Skipping test
         run: echo Should I skip tests? ${{ steps.skip_check.outputs.should_skip }}
 
   go_test:
@@ -31,15 +33,19 @@ jobs:
     if: ${{ needs.should_run_test.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository code
         uses: actions/checkout@v2
-      - name: Setup Golang
+      -
+        name: Setup Golang
         uses: actions/setup-go@v2.1.4
         with:
           go-version: 1.18
-      - name: Display go version
+      -
+        name: Display go version
         run: go version
-      - name: Get data from build cache
+      -
+        name: Get data from build cache
         uses: actions/cache@v2
         with:
           # In order:
@@ -55,27 +61,35 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
-      - name: Run all tests
-        run: |
-          make test-cover
-      - name: Codecov
+      -
+        name: Run all tests
+        run: make test-cover
+      -
+        name: Codecov
         uses: codecov/codecov-action@v1.5.2
   
   e2e_test:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/setup-go@v2.2.0
+      -
+        name: Setup Go
+        uses: actions/setup-go@v2.2.0
         with:
           go-version: 1.18
-      - uses: actions/checkout@v2
-      - uses: technote-space/get-diff-action@v6.0.1
+      -
+        name: Check out repository code
+        uses: actions/checkout@v2
+      -
+        name: Get git diff
+        uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
             **/**.go
             go.mod
             go.sum
-      - name: Get data from build cache
+      -
+        name: Get data from build cache
         uses: actions/cache@v2
         with:
           # In order:
@@ -91,11 +105,20 @@ jobs:
           key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
-      - name: Build Docker Image
-        run: |
-          make docker-build-debug
+      -
+        name: Build e2e image
+        uses: docker/build-push-action@v3
+        with:
+          load: true
+          context: .
+          tags: osmosis:debug
+          # Use experimental Cache backend API: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+          BASE_IMG_TAG=debug
         if: env.GIT_DIFF
-      - name: Test E2E and Upgrade
-        run: |
-          make test-e2e
+      -
+        name: Test E2E and Upgrade
+        run: make test-e2e
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-          BASE_IMG_TAG=debug
+            BASE_IMG_TAG=debug
         if: env.GIT_DIFF
       -
         name: Test E2E and Upgrade

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests & Code Coverage
+name: Tests  & Code Coverage
 
 on:
   pull_request:
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "v[0-9]**"
+  workflow_dispatch:
 
 jobs:
   should_run_go_test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests  & Code Coverage
+name: Tests & Code Coverage
 
 on:
   pull_request:
@@ -107,6 +107,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Build e2e image
         uses: docker/build-push-action@v3
         with:
@@ -118,8 +124,6 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
-        if: env.GIT_DIFF
       -
-        name: Test E2E and Upgrade
+        name: Test e2e and Upgrade
         run: make test-e2e
-        if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,23 @@ jobs:
             go.mod
             go.sum
       -
+        name: Get data from build cache
+        uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,23 +90,6 @@ jobs:
             go.mod
             go.sum
       -
-        name: Get data from build cache
-        uses: actions/cache@v2
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          # * Build cache (Windows)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            ~\AppData\Local\go-build
-          key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1601 

## What is the purpose of the change

This PR adds experimental GitHub Cache backend API to the `e2e_test` job.

This results in the following speed-up in `Build e2e image` step:

- Build without cache (4m 4s): https://github.com/nikever/osmosis/runs/6622443417?check_suite_focus=true
- Build after the cache it's filled (3m 10s) https://github.com/nikever/osmosis/runs/6622514813?check_suite_focus=true

## Brief Changelog

- AddGitHub Cache backend API to the e2e workflows

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable