### PR TITLE
fix: Only apply v8 fork logic on osmosis-1

### DIFF
--- a/app/upgrades/v8/forks.go
+++ b/app/upgrades/v8/forks.go
@@ -9,6 +9,12 @@ import (
 // RunForkLogic executes height-gated on-chain fork logic for the Osmosis v8
 // upgrade.
 func RunForkLogic(ctx sdk.Context, appKeepers *keepers.AppKeepers) {
+	// Only proceed with v8 for mainnet, testnets need not adjust their pool incentives or unbonding.
+	// https://github.com/osmosis-labs/osmosis/issues/1609
+	if ctx.ChainID() != "osmosis-1" {
+		return
+	}
+
 	for i := 0; i < 100; i++ {
 		ctx.Logger().Info("I am upgrading to v8")
 	}


### PR DESCRIPTION
Closes: #1609

## What is the purpose of the change

The v8 fork contained parameter changes that were only applicable on the `"osmosis-1"` chainID.

## Brief Changelog

Limiting the `RunForkLogic` to osmosis-1

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
