### PR TITLE
Try to add a check to prevent github secret call on PR's from fork

### DIFF
--- a/.github/workflows/add-issue-pr-to-project.yml
+++ b/.github/workflows/add-issue-pr-to-project.yml
@@ -12,7 +12,8 @@ jobs:
     name: Add issue to chain dev project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
-        with:
-          project-url: https://github.com/orgs/osmosis-labs/projects/1
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      if: github.event.pull_request.head.repo.full_name == github.repository
+        - uses: actions/add-to-project@main
+          with:
+            project-url: https://github.com/orgs/osmosis-labs/projects/1
+            github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## What is the purpose of the change

Attempt to fix erroneous CI errors on PR's from forks.
Solution taken from https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/14 , but not sure if I'm doing it right.

## Testing and Verifying

- Check if the job still run on this PR?
- See what happens on PRs from forks.
