### PR TITLE
tests: add mainnet state to localosmosis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ localnet-build:
 	@docker build -t local:osmosis -f tests/localosmosis/Dockerfile .
 
 localnet-build-state-export:
-	@docker build -t local:osmosis/stateExport -f tests/localosmosis/Dockerfile-stateExport .
+	@docker build -t local:osmosis-se -f tests/localosmosis/Dockerfile-stateExport .
 
 localnet-start:
 	@docker-compose -f tests/localosmosis/docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -273,8 +273,14 @@ localnet-keys:
 localnet-build:
 	@docker build -t local:osmosis -f tests/localosmosis/Dockerfile .
 
+localnet-build-state-export:
+	@docker build -t local:osmosis/stateExport -f tests/localosmosis/Dockerfile-stateExport .
+
 localnet-start:
 	@docker-compose -f tests/localosmosis/docker-compose.yml up
+
+localnet-start-state-export:
+	@docker-compose -f tests/localosmosis/docker-compose-state-export.yml up
 
 localnet-remove:
 	@docker-compose -f tests/localosmosis/docker-compose.yml down

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ localnet-build:
 	@docker build -t local:osmosis -f tests/localosmosis/Dockerfile .
 
 localnet-build-state-export:
-	@docker build -t local:osmosis-se -f tests/localosmosis/Dockerfile-stateExport .
+	@docker build -t local:osmosis-se --build-arg ID=$(ID) -f tests/localosmosis/Dockerfile-stateExport .
 
 localnet-start:
 	@docker-compose -f tests/localosmosis/docker-compose.yml up
@@ -284,6 +284,9 @@ localnet-start-state-export:
 
 localnet-remove:
 	@docker-compose -f tests/localosmosis/docker-compose.yml down
+
+localnet-remove-state-export:
+	@docker-compose -f tests/localosmosis/docker-compose-state-export.yml down
 
 .PHONY: all build-linux install format lint \
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \

--- a/cmd/osmosisd/cmd/testnetify/testnetify.py
+++ b/cmd/osmosisd/cmd/testnetify/testnetify.py
@@ -52,9 +52,9 @@ op_address = "osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj"
 op_pubkey = "A2MR6q+pOpLtdxh0tHHe2JrEY2KOcvRogtLxHDHzJvOh"
 
 #feed address into osmosisd debug addr {address} to get bech32 validator op address (osmovaloper)
-bech32_op = subprocess.run([daemon_name,"debug", "addr", op_address], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+# bech32_op = subprocess.run([daemon_name,"debug", "addr", op_address], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 #osmovaloper
-bech32_valoper = bech32_op.stderr[bech32_op.stderr.find("Val: ") + 5: -1]
+# bech32_valoper = bech32_op.stderr[bech32_op.stderr.find("Val: ") + 5: -1]
 # osmovaloper12smx2wdlyttvyzvzg54y2vnqwq2qjatex7kgq4
 
 def sed_inplace(filename, pattern, repl):
@@ -99,8 +99,8 @@ print("Replacing 16A169951A878247DBE258FDDC71638F6606D156 with " + address)
 sed_inplace("testnet_genesis.json", "16A169951A878247DBE258FDDC71638F6606D156", address)
 
 #replace validator osmovaloper
-print("Replacing osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n with " + bech32_valoper)
-sed_inplace("testnet_genesis.json", "osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n", bech32_valoper)
+#print("Replacing osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n with " + bech32_valoper)
+#sed_inplace("testnet_genesis.json", "osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n", bech32_valoper)
 
 #replace actual account
 print("Replacing osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5 with " + op_address)
@@ -202,7 +202,8 @@ print("New validator power is " + new_power)
 val_power_list[val_power_index]['power'] = new_power
 #get index of val power in app state (osmovaloper) (bech32_valoper)
 last_val_power_list = read_test_gen['app_state']['staking']['last_validator_powers']
-last_val_power_index = [i for i, elem in enumerate(last_val_power_list) if bech32_valoper in elem['address']][0]
+#last_val_power_index = [i for i, elem in enumerate(last_val_power_list) if bech32_valoper in elem['address']][0]
+last_val_power_index = [i for i, elem in enumerate(last_val_power_list) if 'osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n' in elem['address']][0]
 val_power = int(read_test_gen['app_state']['staking']['last_validator_powers'][last_val_power_index]['power'])
 print("Current validator power in second location is " + str(val_power))
 new_val_power = str(val_power + 1000000000)

--- a/tests/localosmosis/Dockerfile-stateExport
+++ b/tests/localosmosis/Dockerfile-stateExport
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+# --------------------------------------------------------
+# Build
+# --------------------------------------------------------
+
+FROM golang:1.18.2-alpine3.15 as build
+
+RUN set -eux; apk add --no-cache ca-certificates build-base;
+RUN apk add git
+# Needed by github.com/zondax/hid
+RUN apk add linux-headers
+
+WORKDIR /osmosis
+COPY . /osmosis
+
+
+# CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
+
+# CosmWasm: copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
+RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
+
+RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build
+
+# --------------------------------------------------------
+# Runner
+# --------------------------------------------------------
+
+FROM alpine
+
+COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
+COPY /tests/localosmosis/statesync.sh /statesync.sh
+COPY /tests/localosmosis/testnetify.py /testnetify.py
+
+ENV HOME /osmosis
+WORKDIR $HOME
+RUN apk update
+RUN apk add jq
+RUN apk add moreutils
+RUN rm -rf /var/cache/apk/*
+# RUN apk add --no-cache python3 py3-pip
+RUN chmod +x /statesync.sh
+RUN /statesync.sh
+EXPOSE 26656
+EXPOSE 26657
+EXPOSE 1317
+
+ENTRYPOINT ["osmosisd"]
+CMD ["start", "--x-crisis-skip-assert-invariants"]

--- a/tests/localosmosis/Dockerfile-stateExport
+++ b/tests/localosmosis/Dockerfile-stateExport
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+ARG ID="localosmosis"
 
 # --------------------------------------------------------
 # Build
@@ -50,6 +51,8 @@ WORKDIR $HOME
 RUN apt-get update && apt-get install -y python3
 RUN chmod +x /osmosis/statesync.sh
 RUN /osmosis/statesync.sh
+RUN python3 /osmosis/testnetify.py --chain-id $ID
+RUN cp testnet_genesis.json .osmosisd/config/genesis.json
 EXPOSE 26656
 EXPOSE 26657
 EXPOSE 1317

--- a/tests/localosmosis/Dockerfile-stateExport
+++ b/tests/localosmosis/Dockerfile-stateExport
@@ -30,22 +30,26 @@ RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build
 # Runner
 # --------------------------------------------------------
 
-FROM alpine
+FROM ubuntu
 
 COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
-COPY /tests/localosmosis/statesync.sh /statesync.sh
-COPY /tests/localosmosis/testnetify.py /testnetify.py
-COPY /tests/localosmosis/testnet_genesis.json /testnet_genesis.json
+COPY /tests/localosmosis/statesync.sh /osmosis/statesync.sh
+COPY /tests/localosmosis/testnetify.py /osmosis/testnetify.py
+COPY /tests/localosmosis/testnet_genesis.json /osmosis/testnet_genesis.json
 
 ENV HOME /osmosis
 WORKDIR $HOME
-RUN apk update
-RUN apk add jq
-RUN apk add moreutils
-RUN rm -rf /var/cache/apk/*
+# RUN apk update
+# RUN apk add jq
+# RUN apk add moreutils
+# RUN rm -rf /var/cache/apk/*
 # RUN apk add --no-cache python3 py3-pip
-RUN chmod +x /statesync.sh
-RUN /statesync.sh
+# RUN apt-get update && apt-get install -y software-properties-common gcc && \
+#     add-apt-repository -y ppa:deadsnakes/ppa
+# RUN apt-get update && apt-get install -y python3.6 python3-distutils python3-pip python3-apt
+RUN apt-get install -y python3
+RUN chmod +x /osmosis/statesync.sh
+RUN /osmosis/statesync.sh
 EXPOSE 26656
 EXPOSE 26657
 EXPOSE 1317

--- a/tests/localosmosis/Dockerfile-stateExport
+++ b/tests/localosmosis/Dockerfile-stateExport
@@ -35,6 +35,7 @@ FROM alpine
 COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
 COPY /tests/localosmosis/statesync.sh /statesync.sh
 COPY /tests/localosmosis/testnetify.py /testnetify.py
+COPY /tests/localosmosis/testnet_genesis.json /testnet_genesis.json
 
 ENV HOME /osmosis
 WORKDIR $HOME

--- a/tests/localosmosis/Dockerfile-stateExport
+++ b/tests/localosmosis/Dockerfile-stateExport
@@ -47,7 +47,7 @@ WORKDIR $HOME
 # RUN apt-get update && apt-get install -y software-properties-common gcc && \
 #     add-apt-repository -y ppa:deadsnakes/ppa
 # RUN apt-get update && apt-get install -y python3.6 python3-distutils python3-pip python3-apt
-RUN apt-get install -y python3
+RUN apt-get update && apt-get install -y python3
 RUN chmod +x /osmosis/statesync.sh
 RUN /osmosis/statesync.sh
 EXPOSE 26656

--- a/tests/localosmosis/Dockerfile-stateExport
+++ b/tests/localosmosis/Dockerfile-stateExport
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG ID="localosmosis"
+
 
 # --------------------------------------------------------
 # Build
@@ -51,7 +51,8 @@ WORKDIR $HOME
 RUN apt-get update && apt-get install -y python3
 RUN chmod +x /osmosis/statesync.sh
 RUN /osmosis/statesync.sh
-RUN python3 /osmosis/testnetify.py --chain-id $ID
+ARG ID=localosmosis
+RUN python3 /osmosis/testnetify.py --chain-id=$ID
 RUN cp testnet_genesis.json .osmosisd/config/genesis.json
 EXPOSE 26656
 EXPOSE 26657

--- a/tests/localosmosis/README.md
+++ b/tests/localosmosis/README.md
@@ -33,7 +33,7 @@ curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
 systemctl stop osmosisd.service
 ```
 
-3. Take a state export snapshot with the following command:
+3. Take a state export snapshot with the following command (ensure you are on the same version that mainnet is currently on):
 ```
 cd $HOME
 osmosisd export 2> testnet_genesis.json
@@ -41,12 +41,20 @@ osmosisd export 2> testnet_genesis.json
 After a while, this will create a file called `testnet_genesis.json` which is a snapshot of the current mainnet state.
 
 
-4. Move `testnet_genesis.json` to the localosmosis folder within the osmosis repo
+4. Now, move to the version of Osmosis you intend to run your testnet on. In other words, if you are currently on v8.0.0 but want to run a testnet off main, switch to that branch now
 ```
-mv $HOME/testnet_genesis.json $HOME/osmosis/tests/localosmosis
+cd $HOME/osmosis
+git pull
+git checkout main
+make install
 ```
 
-5. Ensure you have docker and docker compose installed/running:
+5. Copy `testnet_genesis.json` to the localosmosis folder within the osmosis repo
+```
+cp -r $HOME/testnet_genesis.json $HOME/osmosis/tests/localosmosis
+```
+
+6. Ensure you have docker and docker compose installed/running:
 Docker
 ```
 sudo apt-get remove docker docker-engine docker.io
@@ -59,14 +67,14 @@ Docker Compose
 sudo apt install docker-compose -y
 ```
 
-6. Compile to local:osmosis/stateExport docker image
+7. Compile the local:osmosis-se docker image (~15 minutes, since this process modifies the testnet genesis you provided above).
 ```
 make localnet-build-state-export
 ```
 
-7. Start the docker image
+8. Start the local:osmosis-se docker image
 ```
-localnet-start-state-export
+make localnet-start-state-export
 ```
 
 

--- a/tests/localosmosis/README.md
+++ b/tests/localosmosis/README.md
@@ -32,12 +32,18 @@ Additionally, this process requires 64GB of RAM. If you do not have 64GB of RAM,
 curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
 ```
 
-2. Ensure your node is hitting blocks. Once it does, stop your Osmosis daemon
+2. Once the installer is done, ensure your node is hitting blocks.
+```
+source ~/.profile
+journalctl -u osmosisd.service -f
+```
+
+3. Stop your Osmosis daemon
 ```
 systemctl stop osmosisd.service
 ```
 
-3. Take a state export snapshot with the following command:
+4. Take a state export snapshot with the following command:
 ```
 cd $HOME
 osmosisd export 2> testnet_genesis.json
@@ -45,12 +51,12 @@ osmosisd export 2> testnet_genesis.json
 After a while, this will create a file called `testnet_genesis.json` which is a snapshot of the current mainnet state.
 
 
-4. Copy the `testnet_genesis.json` to the localosmosis folder within the osmosis repo
+5. Copy the `testnet_genesis.json` to the localosmosis folder within the osmosis repo
 ```
 cp -r $HOME/testnet_genesis.json $HOME/osmosis/tests/localosmosis
 ```
 
-5. Ensure you have docker and docker compose installed/running:
+6. Ensure you have docker and docker compose installed/running:
 Docker
 ```
 sudo apt-get remove docker docker-engine docker.io
@@ -63,32 +69,33 @@ Docker Compose
 sudo apt install docker-compose -y
 ```
 
-6. Compile the local:osmosis-se docker image (~15 minutes, since this process modifies the testnet genesis you provided above).
+7. Compile the local:osmosis-se docker image (~15 minutes, since this process modifies the testnet genesis you provided above).
 ```
 cd $HOME/osmosis
 make localnet-build-state-export
 ```
+docker build -t local:osmosis-se -f tests/localosmosis/Dockerfile-stateExport . --build-arg ID="testing"
 
-7. Start the local:osmosis-se docker image
+8. Start the local:osmosis-se docker image
 ```
 make localnet-start-state-export
 ```
 
 You will then go through the genesis intialization process. This will take ~20 minutes. You will then hit the first block (not block 1, but the block number after your snapshot was taken), and then you will just see a bunch of p2p error logs. This will happen for about 1 hour, and then you will finally hit blocks at a normal pace.
 
-8. On your host machine, add this specific wallet which holds a large amount of osmo funds
+9. On your host machine, add this specific wallet which holds a large amount of osmo funds
 ```
 echo "bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort" | osmosisd keys add wallet --recover --keyring-backend test
 ```
 
 You now are running a validator with a majority of the voting power with the same mainnet state as when you took the snapshot.
 
-9. On your host machine, you can now query the state export testnet like so:
+10. On your host machine, you can now query the state export testnet like so:
 ```
 osmosisd status
 ```
 
-10. Here is an example command to ensure complete understanding:
+11. Here is an example command to ensure complete understanding:
 ```
 
 ```

--- a/tests/localosmosis/README.md
+++ b/tests/localosmosis/README.md
@@ -21,9 +21,9 @@ You can now quickly test your changes to Osmosis with just a few commands:
 
 # LocalOsmosis with Mainnet State
 
-Running LocalOsmosis with mainnet state is resource intensive and can take a bit of time. It is recommmended to only use this method if you are testing a new feature that must be throughly tested before pushing to production.
+Running LocalOsmosis with mainnet state is resource intensive and can take a bit of time. It is recommended to only use this method if you are testing a new feature that must be thoroughly tested before pushing to production.
 
-A few things to note before getting started. The below method will only work if you are using the same version as mainnet. In other words, if mainnet is on v8.0.1 and you try to do this on a v9.0.0 tag, you will run into an error when initializing the genesis. (yes, it is possible to create a state exported testnet on a upcoming release, but that is out of the scope of this tutorial)
+A few things to note before getting started. The below method will only work if you are using the same version as mainnet. In other words, if mainnet is on v8.0.0 and you try to do this on a v9.0.0 tag or on main, you will run into an error when initializing the genesis. (yes, it is possible to create a state exported testnet on a upcoming release, but that is out of the scope of this tutorial)
 
 Additionally, this process requires 64GB of RAM. If you do not have 64GB of RAM, you will get an OOM error.
 
@@ -48,7 +48,7 @@ systemctl stop osmosisd.service
 cd $HOME
 osmosisd export 2> testnet_genesis.json
 ```
-After a while, this will create a file called `testnet_genesis.json` which is a snapshot of the current mainnet state.
+After a while (~15 minutes), this will create a file called `testnet_genesis.json` which is a snapshot of the current mainnet state.
 
 
 5. Copy the `testnet_genesis.json` to the localosmosis folder within the osmosis repo
@@ -69,19 +69,20 @@ Docker Compose
 sudo apt install docker-compose -y
 ```
 
-7. Compile the local:osmosis-se docker image (~15 minutes, since this process modifies the testnet genesis you provided above).
+7. Compile the local:osmosis-se docker image (~15 minutes, since this process modifies the testnet genesis you provided above). You may change the exported ID to whatever you want the chain-id to be. In this example, we will use the chain-id of localosmosis.
 ```
 cd $HOME/osmosis
+export ID=local
 make localnet-build-state-export
 ```
-docker build -t local:osmosis-se -f tests/localosmosis/Dockerfile-stateExport . --build-arg ID="testing"
+
 
 8. Start the local:osmosis-se docker image
 ```
 make localnet-start-state-export
 ```
 
-You will then go through the genesis intialization process. This will take ~20 minutes. You will then hit the first block (not block 1, but the block number after your snapshot was taken), and then you will just see a bunch of p2p error logs. This will happen for about 1 hour, and then you will finally hit blocks at a normal pace.
+You will then go through the genesis intialization process. This will take ~15 minutes. You will then hit the first block (not block 1, but the block number after your snapshot was taken), and then you will just see a bunch of p2p error logs with some KV store logs. **This will happen for about 1 hour**, and then you will finally hit blocks at a normal pace.
 
 9. On your host machine, add this specific wallet which holds a large amount of osmo funds
 ```
@@ -97,7 +98,12 @@ osmosisd status
 
 11. Here is an example command to ensure complete understanding:
 ```
+osmosisd tx bank send wallet osmo1nyphwl8p5yx6fxzevjwqunsfqpcxukmtk8t60m 10000000uosmo --chain-id testing1 --keyring-backend test
+```
 
+12. To stop the container and remove its data:
+```
+make localnet-remove-state-export
 ```
 
 Note: At some point, all the validators (except yours) will get jailed at the same block due to them being offline. When this happens, it make take a little bit of time to process. Once all validators are jailed, you will continue to hit blocks as you did before. If you are only running the validator for a short period of time (< 24 hours) you will not experience this.

--- a/tests/localosmosis/README.md
+++ b/tests/localosmosis/README.md
@@ -18,6 +18,58 @@ You can now quickly test your changes to Osmosis with just a few commands:
 
 5. To remove all block history and start from scratch, run `make localnet-remove`
 
+
+# LocalOsmosis with Mainnet State
+
+Running LocalOsmosis with mainnet state is resource intensive and can take a bit of time. It is recommmended to only use this method if you are testing a new feature that must be throughly tested before pushing to production.
+
+1. Set up a node on mainnet (easiest to use the https://get.osmosis.zone tool)
+```
+curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
+```
+
+2. Ensure your node is hitting blocks. Once it does, stop your Osmosis daemon
+```
+systemctl stop osmosisd.service
+```
+
+3. Take a state export snapshot with the following command:
+```
+cd $HOME
+osmosisd export 2> testnet_genesis.json
+```
+After a while, this will create a file called `testnet_genesis.json` which is a snapshot of the current mainnet state.
+
+
+4. Move `testnet_genesis.json` to the localosmosis folder within the osmosis repo
+```
+mv $HOME/testnet_genesis.json $HOME/osmosis/tests/localosmosis
+```
+
+5. Ensure you have docker and docker compose installed/running:
+Docker
+```
+sudo apt-get remove docker docker-engine docker.io
+sudo apt-get update
+sudo apt install docker.io -y
+```
+
+Docker Compose
+```
+sudo apt install docker-compose -y
+```
+
+6. Compile to local:osmosis/stateExport docker image
+```
+make localnet-build-state-export
+```
+
+7. Start the docker image
+```
+localnet-start-state-export
+```
+
+
 ## Accounts
 
 LocalOsmosis is pre-configured with one validator and 9 accounts with ION and OSMO balances.

--- a/tests/localosmosis/docker-compose-state-export.yml
+++ b/tests/localosmosis/docker-compose-state-export.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  osmosisd:
+    image: local:osmosis/stateExport
+    user: "root:root"
+    command:
+      - start
+      - --rpc.laddr=tcp://0.0.0.0:26657
+    ports:
+      - "26657:26657"
+      - "1317:1317"
+      - "9090:9090"
+      - "9091:9091"

--- a/tests/localosmosis/docker-compose-state-export.yml
+++ b/tests/localosmosis/docker-compose-state-export.yml
@@ -4,6 +4,9 @@ services:
   osmosisd:
     image: local:osmosis-se
     user: "root:root"
+    volumes:
+      - ./config:/osmosis/.osmosisd/config
+      - ./data:/osmosis/.osmosisd/data
     command:
       - start
       - --x-crisis-skip-assert-invariants

--- a/tests/localosmosis/docker-compose-state-export.yml
+++ b/tests/localosmosis/docker-compose-state-export.yml
@@ -2,10 +2,11 @@ version: "3"
 
 services:
   osmosisd:
-    image: local:osmosis/stateExport
+    image: local:osmosis-se
     user: "root:root"
     command:
       - start
+      - --x-crisis-skip-assert-invariants
       - --rpc.laddr=tcp://0.0.0.0:26657
     ports:
       - "26657:26657"

--- a/tests/localosmosis/docker-compose-state-export.yml
+++ b/tests/localosmosis/docker-compose-state-export.yml
@@ -4,9 +4,6 @@ services:
   osmosisd:
     image: local:osmosis-se
     user: "root:root"
-    volumes:
-      - ./config:/osmosis/.osmosisd/config
-      - ./data:/osmosis/.osmosisd/data
     command:
       - start
       - --x-crisis-skip-assert-invariants

--- a/tests/localosmosis/statesync.sh
+++ b/tests/localosmosis/statesync.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 # initialize osmosis
 osmosisd init --chain-id=localosmosis val
 # remove seeds
 sed -i.bak -E 's#^(seeds[[:space:]]+=[[:space:]]+).*$#\1""#' ~/.osmosisd/config/config.toml
-sed -i.bak -E 's#^(fast_sync[[:space:]]+=[[:space:]]+).*$#\1false#' ~/.chain-maind/config/config.toml
-python3 testnetify.py
+sed -i.bak -E 's#^(fast_sync[[:space:]]+=[[:space:]]+).*$#\1false#' ~/.osmosisd/config/config.toml
+python3 /osmosis/testnetify.py
 cp testnet_genesis.json .osmosisd/config/genesis.json

--- a/tests/localosmosis/statesync.sh
+++ b/tests/localosmosis/statesync.sh
@@ -5,5 +5,3 @@ osmosisd init --chain-id=localosmosis val
 # remove seeds
 sed -i.bak -E 's#^(seeds[[:space:]]+=[[:space:]]+).*$#\1""#' ~/.osmosisd/config/config.toml
 sed -i.bak -E 's#^(fast_sync[[:space:]]+=[[:space:]]+).*$#\1false#' ~/.osmosisd/config/config.toml
-python3 /osmosis/testnetify.py
-cp testnet_genesis.json .osmosisd/config/genesis.json

--- a/tests/localosmosis/statesync.sh
+++ b/tests/localosmosis/statesync.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# initialize osmosis
+osmosisd init --chain-id=localosmosis val
+# remove seeds
+sed -i.bak -E 's#^(seeds[[:space:]]+=[[:space:]]+).*$#\1""#' ~/.osmosisd/config/config.toml
+sed -i.bak -E 's#^(fast_sync[[:space:]]+=[[:space:]]+).*$#\1false#' ~/.chain-maind/config/config.toml
+python3 testnetify.py
+cp testnet_genesis.json .osmosisd/config/genesis.json

--- a/tests/localosmosis/testnetify.py
+++ b/tests/localosmosis/testnetify.py
@@ -2,7 +2,38 @@ import json
 import subprocess
 import re, shutil, tempfile
 from datetime import datetime
+import argparse
+import sys
+from sys import argv
 
+class CustomHelpFormatter(argparse.HelpFormatter):
+    def _format_action_invocation(self, action):
+        if not action.option_strings or action.nargs == 0:
+            return super()._format_action_invocation(action)
+        return ', '.join(action.option_strings)
+    def _split_lines(self, text, width):
+        if text.startswith('R|'):
+            return text[2:].splitlines()
+        # this is the RawTextHelpFormatter._split_lines
+        return argparse.HelpFormatter._split_lines(self, text, width)
+
+fmt = lambda prog: CustomHelpFormatter(prog,max_help_position=30)
+parser = argparse.ArgumentParser(description="Osmosis Installer",formatter_class=fmt)
+
+choice = parser.add_argument_group('Choices')
+
+choice.add_argument(
+    '-c',
+    '--chain-id',
+    type = str,
+    default="localosmosis",
+    help='R|Chain ID for newly created testnet \nDefault: localosmosis\n ',
+    dest="chainID")
+
+if not len(sys.argv) > 1:
+    parser.set_defaults(chainID="localosmosis")
+
+args = parser.parse_args()
 
 #get values from your priv_validator_key.json to later switch with high power validator
 
@@ -121,7 +152,10 @@ read_test_gen = json.loads(test_gen.read())
 #change chain-id
 print("Current chain-id is " + read_test_gen['chain_id'])
 #CAN MODIFY
-new_chain_id = "osmo-test-2"
+if args.chainID:
+    new_chain_id = args.chainID
+else:
+    new_chain_id = "localosmosis"
 read_test_gen['chain_id'] = new_chain_id
 print("New chain-id is " + read_test_gen['chain_id'])
 

--- a/tests/localosmosis/testnetify.py
+++ b/tests/localosmosis/testnetify.py
@@ -1,0 +1,313 @@
+import json
+import subprocess
+import re, shutil, tempfile
+from datetime import datetime
+
+
+#get values from your priv_validator_key.json to later switch with high power validator
+
+daemon_name = "osmosisd"
+
+#get bas64
+result = subprocess.run([daemon_name,"tendermint","show-validator"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+base64 = result.stdout.strip()
+##base64 = '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"3QVAkiUIkKR3B6kkbd+QqzWDdcExoggbZV5fwH4jKDs="}'
+
+#get validator cons pubkey
+val_pubkey = base64[base64.find('key":') +6 :-2]
+##val_pubkey = "3QVAkiUIkKR3B6kkbd+QqzWDdcExoggbZV5fwH4jKDs="
+
+#osmosisd debug pubkey {base64} to get address
+debug_pubkey = subprocess.run([daemon_name,"debug", "pubkey", base64], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+#address
+address = debug_pubkey.stderr[9: debug_pubkey.stderr.find("\n")]
+##based on show-valdiator
+##address = "214D831D6F49A75F9104BDC3F2E12A6CC1FC5669"
+
+#feed address into osmosisd debug addr {address} to get bech32 validator address (osmovaloper)
+bech32 = subprocess.run([daemon_name,"debug", "addr", address], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+#osmovaloper
+bech32_val = bech32.stderr[bech32.stderr.find("Val: ") + 5: -1]
+##operator address
+##bech32_val = "osmovaloper1y9xcx8t0fxn4lygyhhpl9cf2dnqlc4nf4pymm4"
+
+#pass osmovaloper address into osmosisd debug bech32-convert -p osmovalcons
+bech32_convert = subprocess.run([daemon_name,"debug", "bech32-convert", bech32_val, "-p", "osmovalcons"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+#osmovalcons
+final_address = bech32_convert.stderr[:bech32_convert.stderr.find("\n")]
+##osmovalcons is taken from show-validator
+##final_address = "osmovalcons1y9xcx8t0fxn4lygyhhpl9cf2dnqlc4nfpjh8h5"
+
+#own opp address
+#exchange the op_address and op_pubkey with own address and pubkey or use above mnemonic for following address
+#bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort
+#CAN MODIFY
+op_address = "osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj"
+
+#own pub key
+#op_base64_pre = subprocess.run(["osmosisd","query", "auth", "account", op_address], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+#op_pubkey = op_base64_pre.stdout[op_base64_pre.stdout.find("key: ")+5:op_base64_pre.stdout.find("sequence")-1]
+#CAN MODIFY
+op_pubkey = "A2MR6q+pOpLtdxh0tHHe2JrEY2KOcvRogtLxHDHzJvOh"
+
+#feed address into osmosisd debug addr {address} to get bech32 validator op address (osmovaloper)
+# bech32_op = subprocess.run([daemon_name,"debug", "addr", op_address], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+#osmovaloper
+# bech32_valoper = bech32_op.stderr[bech32_op.stderr.find("Val: ") + 5: -1]
+# osmovaloper12smx2wdlyttvyzvzg54y2vnqwq2qjatex7kgq4
+
+def sed_inplace(filename, pattern, repl):
+    '''
+    Perform the pure-Python equivalent of in-place `sed` substitution: e.g.,
+    `sed -i -e 's/'${pattern}'/'${repl}' "${filename}"`.
+    '''
+    # For efficiency, precompile the passed regular expression.
+    pattern_compiled = re.compile(pattern)
+
+    # For portability, NamedTemporaryFile() defaults to mode "w+b" (i.e., binary
+    # writing with updating)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+        with open(filename) as src_file:
+            for line in src_file:
+                tmp_file.write(pattern_compiled.sub(repl, line))
+
+    # Overwrite the original file with the munged temporary file in a
+    # manner preserving file attributes (e.g., permissions).
+    shutil.copystat(filename, tmp_file.name)
+    shutil.move(tmp_file.name, filename)
+
+
+#validator cons pubkey:     val_pubkey
+#osmovalcons:               final_address
+#validator hex address:     address
+#osmovaloper:               bech32_valoper
+#actual account:            op_address
+#accounts pubkey:           op_pubkey
+
+
+
+#replace validator cons pubkey (this did not work well due to random forward slashes, did other way later)
+#sed_inplace("testnet_genesis.json", "b77zCh/VsRgVvfGXuW4dB+Dhg4PrMWWBC5G2K/qFgiU=", val_pubkey)
+
+#replace validator osmovalcons
+print("Replacing osmovalcons1z6skn9g6s7py0klztr7acutr3anqd52k9x5p70 with " + final_address)
+sed_inplace("testnet_genesis.json", "osmovalcons1z6skn9g6s7py0klztr7acutr3anqd52k9x5p70", final_address)
+
+#replace validator hex address
+print("Replacing 16A169951A878247DBE258FDDC71638F6606D156 with " + address)
+sed_inplace("testnet_genesis.json", "16A169951A878247DBE258FDDC71638F6606D156", address)
+
+#replace validator osmovaloper
+#print("Replacing osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n with " + bech32_valoper)
+#sed_inplace("testnet_genesis.json", "osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n", bech32_valoper)
+
+#replace actual account
+print("Replacing osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5 with " + op_address)
+sed_inplace("testnet_genesis.json", "osmo1cyw4vw20el8e7ez8080md0r8psg25n0c6j07j5", op_address)
+
+#replace actual account pubkey
+print("Replacing AqlNb1FM8veQrT4/apR5B3hww8VApc0LTtZnXhq7FqG0 with " + op_pubkey)
+sed_inplace("testnet_genesis.json", "AqlNb1FM8veQrT4/apR5B3hww8VApc0LTtZnXhq7FqG0", op_pubkey)
+
+
+
+#open genesis json file with read write priv, load json
+test_gen = open("testnet_genesis.json", "r+")
+read_test_gen = json.loads(test_gen.read())
+#print(read_test_gen.keys())
+
+
+#change chain-id
+print("Current chain-id is " + read_test_gen['chain_id'])
+#CAN MODIFY
+new_chain_id = "osmo-test-2"
+read_test_gen['chain_id'] = new_chain_id
+print("New chain-id is " + read_test_gen['chain_id'])
+
+
+#validator pubkey must be replaced from b77zCh/VsRgVvfGXuW4dB+Dhg4PrMWWBC5G2K/qFgiU= in two locations
+#first under read_test_gen['app_state']['staking']['validators']
+#second under read_test_gen['validators']
+#i tried to do this using sed_inplace above but the multiple slashes broke it so did this instead
+
+#first val list index
+app_state_val_list = read_test_gen['app_state']['staking']['validators']
+val_index = [i for i, elem in enumerate(app_state_val_list) if 'Sentinel' in elem['description']['moniker']][0]
+#first val list update key
+#based on val
+app_state_val_list[val_index]['consensus_pubkey']['key'] = val_pubkey
+#also update delegator shares and tokens
+current_del_share = str(app_state_val_list[val_index]['delegator_shares'])
+print("Current delegator shares is " + current_del_share)
+app_state_val_list[val_index]['delegator_shares'] = str(int(float(app_state_val_list[val_index]['delegator_shares']) + 1000000000000000)) + ".000000000000000000"
+print("New delegator shares is " + app_state_val_list[val_index]['delegator_shares'])
+print("Current delegator tokens is " + app_state_val_list[val_index]['tokens'])
+app_state_val_list[val_index]['tokens'] = str(int(app_state_val_list[val_index]['tokens']) + 1000000000000000)
+print("New delegator tokens is " + app_state_val_list[val_index]['tokens'])
+
+#second val list index
+val_list_2 = read_test_gen['validators']
+val_list_2_index = [i for i, elem in enumerate(val_list_2) if 'Sentinel' in elem['name']][0]
+#second val list update key
+#based on val
+val_list_2[val_list_2_index]['pub_key']['value'] = val_pubkey
+
+
+#distribution module fix
+dist_address = "osmo1jv65s3grqf6v6jl3dp4t6c9t9rk99cd80yhvld"
+app_state_balances_list = read_test_gen['app_state']['bank']['balances']
+dist_index = [i for i, elem in enumerate(app_state_balances_list) if dist_address in elem['address']][0]
+dist_all = app_state_balances_list[dist_index]['coins']
+osmo_index = [i for i, elem in enumerate(dist_all) if 'uosmo' in elem['denom']][0]
+current_dist_osmo_bal = dist_all[osmo_index]['amount']
+dist_offset_amt = 2
+print("Current distribution account uosmo balance is " + current_dist_osmo_bal)
+new_dist_osmo_bal = str(int(current_dist_osmo_bal) - dist_offset_amt)
+print("New distribution account uosmo balance is " + new_dist_osmo_bal)
+dist_all[osmo_index]['amount'] = new_dist_osmo_bal
+
+
+#change self delegation amount on operator address
+
+#first location
+app_state_del_list = read_test_gen['app_state']['staking']['delegations']
+del_index = [i for i, elem in enumerate(app_state_del_list) if op_address in elem['delegator_address']][0]
+#first val list update share (add 1 BN)
+current_share = app_state_del_list[del_index]['shares']
+print("Current self delegation is " + str(current_share))
+new_share = str(int(float(current_share)) + 1000000000000000)+".000000000000000000"
+print("New self delegation is " + new_share)
+app_state_del_list[del_index]['shares'] = new_share
+
+#second location
+app_state_dist_list = read_test_gen['app_state']['distribution']['delegator_starting_infos']
+dist_index = [i for i, elem in enumerate(app_state_dist_list) if op_address in elem['delegator_address']][0]
+#second val list update stake (add 1 BN)
+current_stake = app_state_dist_list[dist_index]['starting_info']['stake']
+print("Current stake is " + str(current_stake))
+new_stake = str(int(float(current_stake)) + 1000000000000000)+".000000000000000000"
+print("New stake is " + new_stake)
+app_state_dist_list[dist_index]['starting_info']['stake'] = new_stake
+
+
+#get index of val power
+val_power_list = read_test_gen['validators']
+val_power_index = [i for i, elem in enumerate(val_power_list) if 'Sentinel' in elem['name']][0]
+#change val power (add 1 BN)
+current_power = int(val_power_list[val_power_index]['power'])
+print("Current validator power is " + str(current_power))
+new_power = str(current_power + 1000000000)
+print("New validator power is " + new_power)
+val_power_list[val_power_index]['power'] = new_power
+#get index of val power in app state (osmovaloper) (bech32_valoper)
+last_val_power_list = read_test_gen['app_state']['staking']['last_validator_powers']
+#last_val_power_index = [i for i, elem in enumerate(last_val_power_list) if bech32_valoper in elem['address']][0]
+last_val_power_index = [i for i, elem in enumerate(last_val_power_list) if 'osmovaloper1cyw4vw20el8e7ez8080md0r8psg25n0cq98a9n' in elem['address']][0]
+val_power = int(read_test_gen['app_state']['staking']['last_validator_powers'][last_val_power_index]['power'])
+print("Current validator power in second location is " + str(val_power))
+new_val_power = str(val_power + 1000000000)
+print("New validator power in second location is " + new_val_power)
+read_test_gen['app_state']['staking']['last_validator_powers'][last_val_power_index]['power'] = new_val_power
+
+
+#update last_total_power (last total bonded across all validators, add 1BN)
+last_total_power = int(read_test_gen['app_state']['staking']['last_total_power'])
+print("Current last total power is " + str(last_total_power))
+new_last_total_power = str(last_total_power + 1000000000)
+print("New last total power is " + new_last_total_power)
+read_test_gen['app_state']['staking']['last_total_power'] = new_last_total_power
+
+
+#update operator address amount (add 1 BN)
+#find wallet index in bank balance
+bank_balance_list = read_test_gen['app_state']['bank']['balances']
+op_amount_index = [i for i, elem in enumerate(bank_balance_list) if op_address in elem['address']][0]
+#get uosmo index from wallet
+op_wallet = read_test_gen['app_state']['bank']['balances'][op_amount_index]['coins']
+op_uosmo_index = [i for i, elem in enumerate(op_wallet) if 'uosmo' in elem['denom']][0]
+#update uosmo amount
+op_uosmo = int(op_wallet[op_uosmo_index]['amount'])
+print("Current operator address uosmo balance is " + str(op_uosmo))
+new_op_uosmo = str(op_uosmo + 1000000000000000)
+print("New operator address uosmo balance is " + new_op_uosmo)
+op_wallet[op_uosmo_index]['amount'] = new_op_uosmo
+
+
+#update total OSMO supply (add 2 BN)
+#supply list (ibc, ion, osmo)
+supply = read_test_gen['app_state']['bank']['supply']
+
+#get index of osmo supply
+osmo_index = [i for i, elem in enumerate(supply) if 'uosmo' in elem['denom']][0]
+
+#get osmo supply value
+osmo_supply = supply[osmo_index]['amount']
+print("Current OSMO supply is " + osmo_supply)
+
+#update osmo supply to new total osmo value (add 2 Billion OSMO)
+#subtract by however much module account is subtracted by
+osmo_supply_new = int(osmo_supply) + 2000000000000000 - dist_offset_amt
+print("New OSMO supply is " + str(osmo_supply_new))
+supply[osmo_index]['amount'] = str(osmo_supply_new)
+
+
+#update bonded_tokens_pool module balance osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09 (add 1BN)
+#get list of bank balances
+bank_bal_list = read_test_gen['app_state']['bank']['balances']
+#get index of module account
+module_acct_index = [i for i, elem in enumerate(bank_bal_list) if 'osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09' in elem['address']][0]
+#get current value
+module_denom_list = bank_bal_list[module_acct_index]['coins']
+osmo_bal_index = [i for i, elem in enumerate(module_denom_list) if 'uosmo' in elem['denom']][0]
+osmo_bal = bank_bal_list[module_acct_index]['coins'][osmo_bal_index]['amount']
+print("Current bonded tokens pool module account balance is " + osmo_bal)
+#increase by 1BN
+new_osmo_bal = int(osmo_bal) + 1000000000000000
+print("New bonded tokens pool module account balance is " + str(new_osmo_bal))
+bank_bal_list[module_acct_index]['coins'][osmo_bal_index]['amount'] = str(new_osmo_bal)
+
+
+#edit epoch params
+#change epoch duration to 21600s
+epochs_list = read_test_gen['app_state']['epochs']['epochs'][0]
+duration_current = epochs_list['duration']
+print("Current epoch duration is " + duration_current)
+#21600s for 6 hour epoch
+#CAN MODIFY
+new_duration = '21600s'
+print("New epoch duration is " + new_duration)
+epochs_list['duration'] = new_duration
+
+#change current_epoch_start_time
+start_time_current = epochs_list['current_epoch_start_time']
+print("Current epoch start time is " + start_time_current)
+#today = date.today()
+now = datetime.now()
+#date_format = now.strftime("%Y-%m-%d")
+date_format = now.strftime("%Y-%m-%d"+"T"+"%H:%M:")
+start_time_current_list = list(start_time_current)
+start_time_current_list[:17] = date_format
+start_time_new = ''.join(start_time_current_list)
+epochs_list['current_epoch_start_time'] = start_time_new
+print("New epoch start time is " + start_time_new)
+
+
+#edit gov params
+#change VotingPeriod
+current_voting_period = read_test_gen['app_state']['gov']['voting_params']['voting_period']
+print("Current voting period is " + current_voting_period)
+#180s for 3 minute voting period
+#CAN MODIFY
+new_voting_period = "180s"
+print("New voting period is " + new_voting_period)
+read_test_gen['app_state']['gov']['voting_params']['voting_period'] = new_voting_period
+
+
+print("Please wait while file writes over itself, this may take 60 seconds or more")
+#go back to begining of file, write over with new values
+test_gen.seek(0)
+json.dump(read_test_gen, test_gen)
+
+#delete remainder in case new data is shorter than old
+test_gen.truncate()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1598

## What is the purpose of the change

This PR includes the MVP to test contracts locally but with mainnet state. 

## Brief Changelog
 
  - Adds Makefile commands
    - localnet-build-state-export
    - - localnet-build-state-export
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

This change is already covered by existing tests (e2e test suite)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? not yet
  - How is the feature or change documented? not applicable