### PR TITLE
Replace osmobuilder build tags to create releases

### DIFF
--- a/contrib/images/osmobuilder/Dockerfile
+++ b/contrib/images/osmobuilder/Dockerfile
@@ -31,7 +31,7 @@ RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 RUN go build \
     -mod=readonly \
     -tags "$BUILD_TAGS" \
-    -ldflags "-X github.com/osmosis-labs/osmosis/version.Name=$NAME -X github.com/osmosis-labs/osmosis/version.AppName=$APP_NAME -X github.com/osmosis-labs/osmosis/version.Version=$VERSION -X github.com/osmosis-labs/osmosis/version.Commit=$COMMIT -X github.com/osmosis-labs/osmosis/version.BuildTags='netgo,ledger,muslc' -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
+    -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name=$NAME -X github.com/cosmos/cosmos-sdk/version.AppName=$APP_NAME -X github.com/cosmos/cosmos-sdk/version.Version=$VERSION -X github.com/cosmos/cosmos-sdk/version.Commit=$COMMIT -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,ledger,muslc' -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
     -trimpath \
     -o /osmosis/build/ \
     ./...


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the `osmobuilder` reverting to the build tags to make the version command work https://github.com/cosmos/cosmos-sdk/blob/main/version/version.go

## Brief Changelog

- Update `osmobuilder` Dockerfile

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 