### PR TITLE
fix: localosmosis to initialize state and mount it on a volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ $RECYCLE.BIN/
 /scripts/local/
 /x/incentives/keeper/osmosis_testing/
 tools-stamp
+/tests/localosmosis/.osmosisd/*

--- a/Makefile
+++ b/Makefile
@@ -276,8 +276,12 @@ localnet-build:
 localnet-start:
 	@docker-compose -f tests/localosmosis/docker-compose.yml up
 
-localnet-remove:
+localnet-remove: localnet-clear-state
 	@docker-compose -f tests/localosmosis/docker-compose.yml down
+
+localnet-clear-state:
+	PWD=$(shell pwd)
+	@docker run --user root -v ${PWD}/tests/localosmosis/.osmosisd:/root/osmosis ubuntu /bin/sh -c "rm -rf /root/osmosis/*"
 
 .PHONY: all build-linux install format lint \
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \

--- a/Makefile
+++ b/Makefile
@@ -276,10 +276,10 @@ localnet-build:
 localnet-start:
 	@docker-compose -f tests/localosmosis/docker-compose.yml up
 
-localnet-remove: localnet-clear-state
+localnet-stop:
 	@docker-compose -f tests/localosmosis/docker-compose.yml down
 
-localnet-clear-state:
+localnet-remove: localnet-stop
 	PWD=$(shell pwd)
 	@docker run --user root -v ${PWD}/tests/localosmosis/.osmosisd:/root/osmosis ubuntu /bin/sh -c "rm -rf /root/osmosis/*"
 

--- a/tests/localosmosis/Dockerfile
+++ b/tests/localosmosis/Dockerfile
@@ -1,9 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# --------------------------------------------------------
-# Build
-# --------------------------------------------------------
-
+# Build stage
 FROM golang:1.18.2-alpine3.15 as build
 
 RUN set -eux; apk add --no-cache ca-certificates build-base;
@@ -13,7 +10,6 @@ RUN apk add linux-headers
 
 WORKDIR /osmosis
 COPY . /osmosis
-
 
 # CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
 ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
@@ -26,26 +22,20 @@ RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build
 
-# --------------------------------------------------------
-# Runner
-# --------------------------------------------------------
-
+# Run stage
 FROM ubuntu
-
-COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
-COPY /tests/localosmosis/setup.sh /setup.sh
 
 ENV HOME /osmosis
 WORKDIR $HOME
-RUN apk update
-RUN apk add jq
-RUN apk add moreutils
-RUN rm -rf /var/cache/apk/*
-RUN chmod +x /setup.sh
-RUN /setup.sh
+
+COPY --from=build ${HOME}/build/osmosisd /bin/osmosisd
+COPY tests/localosmosis/setup.sh ${HOME}/setup.sh
+
+RUN apt-get update -y && apt-get install -y jq moreutils
+RUN chmod +x ${HOME}/setup.sh
+
 EXPOSE 26656
 EXPOSE 26657
 EXPOSE 1317
 
-ENTRYPOINT ["osmosisd"]
-CMD ["start"]
+ENTRYPOINT ${HOME}/setup.sh

--- a/tests/localosmosis/README.md
+++ b/tests/localosmosis/README.md
@@ -9,6 +9,9 @@ You can now quickly test your changes to Osmosis with just a few commands:
 
 3. Once complete, run `make localnet-start`
     - You will now be running a local network with your changes!
+    - The files in `tests/e2e/localosmosis/.osmosisd` that are produced
+    by this command can only be removed by running `make localnet-remove`
+    - That will reset the chain to genesis
 
 4. To add your validator wallet and 9 other preloaded wallets automatically, run `make localnet-keys`
     - These keys are added to your --keyring-backend test
@@ -17,6 +20,8 @@ You can now quickly test your changes to Osmosis with just a few commands:
         - Example: `osmosisd tx bank send lo-test2 osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks --keyring-backend test --chain-id localosmosis`
 
 5. To remove all block history and start from scratch, run `make localnet-remove`
+
+6. To stop the chain but keep the state, run `make localnet-stop`
 
 ## Accounts
 

--- a/tests/localosmosis/docker-compose.yml
+++ b/tests/localosmosis/docker-compose.yml
@@ -4,9 +4,10 @@ services:
   osmosisd:
     image: local:osmosis
     user: "root:root"
-    command:
-      - start
-      - --rpc.laddr=tcp://0.0.0.0:26657
+    volumes:
+      - ./.osmosisd/config:/osmosis/.osmosisd/config
+      - ./.osmosisd/data:/osmosis/.osmosisd/data
+      - ./.osmosisd/wasm:/osmosis/.osmosisd/wasm
     ports:
       - "26657:26657"
       - "1317:1317"

--- a/tests/localosmosis/setup.sh
+++ b/tests/localosmosis/setup.sh
@@ -42,5 +42,10 @@ cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["mint"]["params"]["mint
 cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["mint"]["params"]["epoch_identifier"]="day"' | sponge $HOME/.osmosisd/config/genesis.json
 # update gamm genesis
 cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["gamm"]["params"]["pool_creation_fee"][0]["denom"]="uosmo"' | sponge $HOME/.osmosisd/config/genesis.json
-# remove seeds
+# update txfee basedenom
+cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["txfees"]["basedenom"]="uosmo"' | sponge $HOME/.osmosisd/config/genesis.json
+remove seeds
+
 sed -i.bak -E 's#^(seeds[[:space:]]+=[[:space:]]+).*$#\1""#' ~/.osmosisd/config/config.toml
+
+osmosisd start

--- a/tests/localosmosis/setup.sh
+++ b/tests/localosmosis/setup.sh
@@ -48,4 +48,4 @@ remove seeds
 
 sed -i.bak -E 's#^(seeds[[:space:]]+=[[:space:]]+).*$#\1""#' ~/.osmosisd/config/config.toml
 
-osmosisd start
+osmosisd start --rpc.laddr=tcp://0.0.0.0:26657


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

There were several issues requiring the user to do some hacks to get localosmosis work with cosmwasm contracts.

This PR does the following:

- use apt-get in Dockerfile as apk is an alpine specific command
- run `setup.sh` on start up
    * if it is run as a Dockerfile "RUN" directive, it will not mount state on a volume for some reason. We want the state to be preserved

Add 


## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)