### PR TITLE
chore: unify docker proto container name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,8 +174,8 @@ docs:
 
 protoVer=v0.7
 protoImageName=tendermintdev/sdk-proto-gen:$(protoVer)
-containerProtoGen=osmosis-proto-gen-$(protoVer)
-containerProtoFmt=osmosis-proto-fmt-$(protoVer)
+containerProtoGen=cosmos-sdk-proto-gen-$(protoVer)
+containerProtoFmt=cosmos-sdk-proto-fmt-$(protoVer)
 
 proto-gen:
 	@echo "Generating Protobuf files"


### PR DESCRIPTION
Unify docker container name with the name used by Cosmos SDK.
The container is using the same docker image, so no need to duplicate hanging containers (each of them is few hundreds of MB).

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? rather no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)