### PR TITLE
remove version from Proto schema go paths

### DIFF
--- a/proto/osmosis/epochs/genesis.proto
+++ b/proto/osmosis/epochs/genesis.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/epochs/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/epochs/types";
 
 message EpochInfo {
   string identifier = 1;

--- a/proto/osmosis/epochs/query.proto
+++ b/proto/osmosis/epochs/query.proto
@@ -6,7 +6,7 @@ import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "osmosis/epochs/genesis.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/epochs/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/epochs/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/osmosis/gamm/pool-models/balancer/balancerPool.proto
+++ b/proto/osmosis/gamm/pool-models/balancer/balancerPool.proto
@@ -10,7 +10,7 @@ import "google/protobuf/timestamp.proto";
 import "cosmos/auth/v1beta1/auth.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/pool-models/balancer";
 
 // Parameters for changing the weights in a balancer pool smoothly from
 // a start weight and end weight over a period of time.

--- a/proto/osmosis/gamm/pool-models/balancer/tx.proto
+++ b/proto/osmosis/gamm/pool-models/balancer/tx.proto
@@ -4,7 +4,7 @@ package osmosis.gamm.poolmodels.balancer.v1beta1;
 import "gogoproto/gogo.proto";
 import "osmosis/gamm/pool-models/balancer/balancerPool.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/pool-models/balancer";
 
 service Msg {
   rpc CreateBalancerPool(MsgCreateBalancerPool)

--- a/proto/osmosis/gamm/pool-models/stableswap/stableswap_pool.proto
+++ b/proto/osmosis/gamm/pool-models/stableswap/stableswap_pool.proto
@@ -10,7 +10,7 @@ import "google/protobuf/timestamp.proto";
 import "cosmos/auth/v1beta1/auth.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/stableswap";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/pool-models/stableswap";
 
 // PoolParams defined the parameters that will be managed by the pool
 // governance in the future. This params are not managed by the chain

--- a/proto/osmosis/gamm/pool-models/stableswap/tx.proto
+++ b/proto/osmosis/gamm/pool-models/stableswap/tx.proto
@@ -5,7 +5,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "gogoproto/gogo.proto";
 import "osmosis/gamm/pool-models/stableswap/stableswap_pool.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/stableswap";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/pool-models/stableswap";
 
 service Msg {
   rpc CreateStableswapPool(MsgCreateStableswapPool)

--- a/proto/osmosis/gamm/v1beta1/genesis.proto
+++ b/proto/osmosis/gamm/v1beta1/genesis.proto
@@ -15,7 +15,7 @@ message Params {
   ];
 }
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/types";
 
 // GenesisState defines the gamm module's genesis state.
 message GenesisState {

--- a/proto/osmosis/gamm/v1beta1/query.proto
+++ b/proto/osmosis/gamm/v1beta1/query.proto
@@ -10,7 +10,7 @@ import "google/api/annotations.proto";
 import "google/protobuf/any.proto";
 import "cosmos_proto/cosmos.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/types";
 
 service Query {
   rpc Pools(QueryPoolsRequest) returns (QueryPoolsResponse) {

--- a/proto/osmosis/gamm/v1beta1/tx.proto
+++ b/proto/osmosis/gamm/v1beta1/tx.proto
@@ -4,7 +4,7 @@ package osmosis.gamm.v1beta1;
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/gamm/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/gamm/types";
 
 service Msg {
   rpc JoinPool(MsgJoinPool) returns (MsgJoinPoolResponse);

--- a/proto/osmosis/incentives/gauge.proto
+++ b/proto/osmosis/incentives/gauge.proto
@@ -7,7 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "osmosis/lockup/lock.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/incentives/types";
 
 message Gauge {
   // unique ID of a Gauge

--- a/proto/osmosis/incentives/genesis.proto
+++ b/proto/osmosis/incentives/genesis.proto
@@ -6,7 +6,7 @@ import "google/protobuf/duration.proto";
 import "osmosis/incentives/params.proto";
 import "osmosis/incentives/gauge.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/incentives/types";
 
 // GenesisState defines the incentives module's genesis state.
 message GenesisState {

--- a/proto/osmosis/incentives/params.proto
+++ b/proto/osmosis/incentives/params.proto
@@ -3,7 +3,7 @@ package osmosis.incentives;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/incentives/types";
 
 // Params holds parameters for the incentives module
 message Params {

--- a/proto/osmosis/incentives/query.proto
+++ b/proto/osmosis/incentives/query.proto
@@ -9,7 +9,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "osmosis/incentives/gauge.proto";
 import "osmosis/lockup/lock.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/incentives/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/osmosis/incentives/tx.proto
+++ b/proto/osmosis/incentives/tx.proto
@@ -7,7 +7,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "osmosis/incentives/gauge.proto";
 import "osmosis/lockup/lock.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/incentives/types";
 
 service Msg {
   rpc CreateGauge(MsgCreateGauge) returns (MsgCreateGaugeResponse);

--- a/proto/osmosis/lockup/genesis.proto
+++ b/proto/osmosis/lockup/genesis.proto
@@ -4,7 +4,7 @@ package osmosis.lockup;
 import "gogoproto/gogo.proto";
 import "osmosis/lockup/lock.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/lockup/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/lockup/types";
 
 // GenesisState defines the lockup module's genesis state.
 message GenesisState {

--- a/proto/osmosis/lockup/lock.proto
+++ b/proto/osmosis/lockup/lock.proto
@@ -6,7 +6,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/lockup/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/lockup/types";
 
 // PeriodLock is a single unit of lock by period. It's a record of locked coin
 // at a specific time. It stores owner, duration, unlock time and the amount of

--- a/proto/osmosis/lockup/query.proto
+++ b/proto/osmosis/lockup/query.proto
@@ -8,7 +8,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "osmosis/lockup/lock.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/lockup/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/lockup/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/osmosis/lockup/tx.proto
+++ b/proto/osmosis/lockup/tx.proto
@@ -6,7 +6,7 @@ import "google/protobuf/duration.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "osmosis/lockup/lock.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/lockup/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/lockup/types";
 
 // Msg defines the Msg service.
 service Msg {

--- a/proto/osmosis/mint/v1beta1/genesis.proto
+++ b/proto/osmosis/mint/v1beta1/genesis.proto
@@ -4,7 +4,7 @@ package osmosis.mint.v1beta1;
 import "gogoproto/gogo.proto";
 import "osmosis/mint/v1beta1/mint.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/mint/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/mint/types";
 
 // GenesisState defines the mint module's genesis state.
 message GenesisState {

--- a/proto/osmosis/mint/v1beta1/mint.proto
+++ b/proto/osmosis/mint/v1beta1/mint.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package osmosis.mint.v1beta1;
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/mint/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/mint/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/proto/osmosis/mint/v1beta1/query.proto
+++ b/proto/osmosis/mint/v1beta1/query.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "osmosis/mint/v1beta1/mint.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/mint/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/mint/types";
 
 // Query provides defines the gRPC querier service.
 service Query {

--- a/proto/osmosis/pool-incentives/v1beta1/genesis.proto
+++ b/proto/osmosis/pool-incentives/v1beta1/genesis.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "osmosis/pool-incentives/v1beta1/incentives.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/pool-incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/pool-incentives/types";
 
 // GenesisState defines the pool incentives module's genesis state.
 message GenesisState {

--- a/proto/osmosis/pool-incentives/v1beta1/gov.proto
+++ b/proto/osmosis/pool-incentives/v1beta1/gov.proto
@@ -4,7 +4,7 @@ package osmosis.poolincentives.v1beta1;
 import "gogoproto/gogo.proto";
 import "osmosis/pool-incentives/v1beta1/incentives.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/pool-incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/pool-incentives/types";
 
 // ReplacePoolIncentivesProposal is a gov Content type for updating the pool
 // incentives. If a ReplacePoolIncentivesProposal passes, the proposal’s records

--- a/proto/osmosis/pool-incentives/v1beta1/incentives.proto
+++ b/proto/osmosis/pool-incentives/v1beta1/incentives.proto
@@ -4,7 +4,7 @@ package osmosis.poolincentives.v1beta1;
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/pool-incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/pool-incentives/types";
 
 message Params {
   option (gogoproto.goproto_stringer) = false;

--- a/proto/osmosis/pool-incentives/v1beta1/query.proto
+++ b/proto/osmosis/pool-incentives/v1beta1/query.proto
@@ -7,7 +7,7 @@ import "google/protobuf/duration.proto";
 import "osmosis/incentives/gauge.proto";
 import "osmosis/pool-incentives/v1beta1/incentives.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/pool-incentives/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/pool-incentives/types";
 
 service Query {
   // GaugeIds takes the pool id and returns the matching gauge ids and durations

--- a/proto/osmosis/store/v1beta1/tree.proto
+++ b/proto/osmosis/store/v1beta1/tree.proto
@@ -4,7 +4,7 @@ package osmosis.store.v1beta1;
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/store";
+option go_package = "github.com/osmosis-labs/osmosis/store";
 
 message Node { repeated Child children = 1; }
 

--- a/proto/osmosis/superfluid/genesis.proto
+++ b/proto/osmosis/superfluid/genesis.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "osmosis/superfluid/superfluid.proto";
 import "osmosis/superfluid/params.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/superfluid/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/superfluid/types";
 
 // GenesisState defines the module's genesis state.
 message GenesisState {

--- a/proto/osmosis/superfluid/gov.proto
+++ b/proto/osmosis/superfluid/gov.proto
@@ -4,7 +4,7 @@ package osmosis.superfluid.v1beta1;
 import "gogoproto/gogo.proto";
 import "osmosis/superfluid/superfluid.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/superfluid/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/superfluid/types";
 
 // SetSuperfluidAssetsProposal is a gov Content type to update the superfluid
 // assets

--- a/proto/osmosis/superfluid/params.proto
+++ b/proto/osmosis/superfluid/params.proto
@@ -4,7 +4,7 @@ package osmosis.superfluid;
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/superfluid/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/superfluid/types";
 
 // Params holds parameters for the superfluid module
 message Params {

--- a/proto/osmosis/superfluid/query.proto
+++ b/proto/osmosis/superfluid/query.proto
@@ -11,7 +11,7 @@ import "osmosis/superfluid/params.proto";
 import "osmosis/lockup/lock.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/superfluid/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/superfluid/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/osmosis/superfluid/superfluid.proto
+++ b/proto/osmosis/superfluid/superfluid.proto
@@ -6,7 +6,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/superfluid/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/superfluid/types";
 
 enum SuperfluidAssetType {
   option (gogoproto.goproto_enum_prefix) = false;

--- a/proto/osmosis/superfluid/tx.proto
+++ b/proto/osmosis/superfluid/tx.proto
@@ -6,7 +6,7 @@ import "google/protobuf/duration.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "osmosis/superfluid/superfluid.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/superfluid/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/superfluid/types";
 
 // Msg defines the Msg service.
 service Msg {

--- a/proto/osmosis/tokenfactory/v1beta1/authorityMetadata.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/authorityMetadata.proto
@@ -4,7 +4,7 @@ package osmosis.tokenfactory.v1beta1;
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/tokenfactory/types";
 
 // DenomAuthorityMetadata specifies metadata for addresses that have specific
 // capabilities over a token factory denom. Right now there is only one Admin

--- a/proto/osmosis/tokenfactory/v1beta1/genesis.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/genesis.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "osmosis/tokenfactory/v1beta1/authorityMetadata.proto";
 import "osmosis/tokenfactory/v1beta1/params.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/tokenfactory/types";
 
 // GenesisState defines the tokenfactory module's genesis state.
 message GenesisState {

--- a/proto/osmosis/tokenfactory/v1beta1/params.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/params.proto
@@ -6,7 +6,7 @@ import "osmosis/tokenfactory/v1beta1/authorityMetadata.proto";
 import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/tokenfactory/types";
 
 // Params holds parameters for the tokenfactory module
 message Params {

--- a/proto/osmosis/tokenfactory/v1beta1/query.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/query.proto
@@ -7,7 +7,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "osmosis/tokenfactory/v1beta1/authorityMetadata.proto";
 import "osmosis/tokenfactory/v1beta1/params.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/tokenfactory/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/osmosis/tokenfactory/v1beta1/tx.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/tx.proto
@@ -4,7 +4,7 @@ package osmosis.tokenfactory.v1beta1;
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/tokenfactory/types";
 
 // Msg defines the Msg service.
 service Msg {

--- a/proto/osmosis/txfees/v1beta1/feetoken.proto
+++ b/proto/osmosis/txfees/v1beta1/feetoken.proto
@@ -3,7 +3,7 @@ package osmosis.txfees.v1beta1;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/txfees/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/txfees/types";
 
 // FeeToken is a struct that specifies a coin denom, and pool ID pair.
 // This marks the token as eligible for use as a tx fee asset in Osmosis.

--- a/proto/osmosis/txfees/v1beta1/genesis.proto
+++ b/proto/osmosis/txfees/v1beta1/genesis.proto
@@ -4,7 +4,7 @@ package osmosis.txfees.v1beta1;
 import "gogoproto/gogo.proto";
 import "osmosis/txfees/v1beta1/feetoken.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/txfees/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/txfees/types";
 
 // GenesisState defines the txfees module's genesis state.
 message GenesisState {

--- a/proto/osmosis/txfees/v1beta1/gov.proto
+++ b/proto/osmosis/txfees/v1beta1/gov.proto
@@ -4,7 +4,7 @@ package osmosis.txfees.v1beta1;
 import "gogoproto/gogo.proto";
 import "osmosis/txfees/v1beta1/feetoken.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/txfees/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/txfees/types";
 
 // UpdateFeeTokenProposal is a gov Content type for adding a new whitelisted fee
 // token. It must specify a denom along with gamm pool ID to use as a spot price

--- a/proto/osmosis/txfees/v1beta1/query.proto
+++ b/proto/osmosis/txfees/v1beta1/query.proto
@@ -7,7 +7,7 @@ import "google/protobuf/duration.proto";
 
 import "osmosis/txfees/v1beta1/feetoken.proto";
 
-option go_package = "github.com/osmosis-labs/osmosis/v7/x/txfees/types";
+option go_package = "github.com/osmosis-labs/osmosis/x/txfees/types";
 
 service Query {
   // FeeTokens returns a list of all the whitelisted fee tokens and their

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -24,7 +24,7 @@ cd ..
 # move proto files to the right places
 #
 # Note: Proto files are suffixed with the current binary version.
-cp -r github.com/osmosis-labs/osmosis/v7/* ./
+cp -r github.com/osmosis-labs/osmosis/* ./
 rm -rf github.com
 
 go mod tidy -compat=1.18


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1657 

## What is the purpose of the change

Removes version from Proto schema go paths.

## Brief Changelog

- Removed `v7` suffix from from all Protobuf go package declarations
- Updated protocgen.sh to remove the v7 suffix

## Testing and Verifying

This change is a trivial rework.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable