### PR TITLE
Fix spotprice sigfig rounding for small spot prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+* [#1699](https://github.com/osmosis-labs/osmosis/pull/1699) Fixes bug in sig fig rounding on spot price queries for small values
+
 #### golang API breaks
 
 * [#1671](https://github.com/osmosis-labs/osmosis/pull/1671) Remove methods that constitute AppModuleSimulation APIs for several modules' AppModules, which implemented no-ops

--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -45,7 +45,7 @@ func (suite *KeeperTestHelper) PrepareBalancerPool() uint64 {
 	spotPrice, err = suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "baz", "foo")
 	suite.NoError(err)
 	s := sdk.NewDec(1).Quo(sdk.NewDec(3))
-	sp := s.Mul(gammtypes.SigFigs).RoundInt().ToDec().Quo(gammtypes.SigFigs)
+	sp := s.MulInt(gammtypes.SigFigs).RoundInt().ToDec().QuoInt(gammtypes.SigFigs)
 	suite.Equal(sp.String(), spotPrice.String())
 
 	return poolId

--- a/osmomath/sigfig_round.go
+++ b/osmomath/sigfig_round.go
@@ -6,7 +6,7 @@ var pointOne = sdk.OneDec().QuoInt64(10)
 
 func SigFigRound(d sdk.Dec, tenToSigFig sdk.Int) sdk.Dec {
 	// for d > .1, we do round(d * 10^sigfig) / 10^sigfig
-	// for k, where 10^k*d > 1 && 10^{k-1}*d < .1, we do:
+	// for k, where 10^k*d > .1 && 10^{k-1}*d < .1, we do:
 	// (round(10^k * d * 10^sigfig) / (10^sigfig * 10^k)
 	// take note of floor div, vs normal div
 	k := uint64(0)
@@ -17,10 +17,8 @@ func SigFigRound(d sdk.Dec, tenToSigFig sdk.Int) sdk.Dec {
 	// d * 10^k * 10^sigfig
 	dkSigFig := dTimesK.MulInt(tenToSigFig)
 	numerator := dkSigFig.RoundInt().ToDec()
-	denominator := tenToSigFig
-	if k != 0 {
-		tenToK := sdk.NewInt(10).ToDec().Power(k)
-		denominator = denominator.Mul(tenToK.TruncateInt())
-	}
+
+	tenToK := sdk.NewInt(10).ToDec().Power(k)
+	denominator := tenToSigFig.Mul(tenToK.TruncateInt())
 	return numerator.QuoInt(denominator)
 }

--- a/osmomath/sigfig_round.go
+++ b/osmomath/sigfig_round.go
@@ -2,14 +2,16 @@ package osmomath
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
+var pointOne = sdk.OneDec().QuoInt64(10)
+
 func SigFigRound(d sdk.Dec, tenToSigFig sdk.Int) sdk.Dec {
-	// for d > 1, we do round(d * 10^sigfig) / 10^sigfig
-	// for k, where 10^k*d > 1 && 10^{k-1}*d < 1, we do:
+	// for d > .1, we do round(d * 10^sigfig) / 10^sigfig
+	// for k, where 10^k*d > 1 && 10^{k-1}*d < .1, we do:
 	// (round(10^k * d * 10^sigfig) / (10^sigfig * 10^k)
 	// take note of floor div, vs normal div
 	k := uint64(0)
 	dTimesK := d
-	for ; dTimesK.LT(sdk.OneDec()); k += 1 {
+	for ; dTimesK.LT(pointOne); k += 1 {
 		dTimesK.MulInt64Mut(10)
 	}
 	// d * 10^k * 10^sigfig

--- a/osmomath/sigfig_round.go
+++ b/osmomath/sigfig_round.go
@@ -1,0 +1,24 @@
+package osmomath
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+func SigFigRound(d sdk.Dec, tenToSigFig sdk.Int) sdk.Dec {
+	// for d > 1, we do round(d * 10^sigfig) / 10^sigfig
+	// for k, where 10^k*d > 1 && 10^{k-1}*d < 1, we do:
+	// (round(10^k * d * 10^sigfig) / (10^sigfig * 10^k)
+	// take note of floor div, vs normal div
+	k := uint64(0)
+	dTimesK := d
+	for ; dTimesK.LT(sdk.OneDec()); k += 1 {
+		dTimesK.MulInt64Mut(10)
+	}
+	// d * 10^k * 10^sigfig
+	dkSigFig := dTimesK.MulInt(tenToSigFig)
+	numerator := dkSigFig.RoundInt().ToDec()
+	denominator := tenToSigFig
+	if k != 0 {
+		tenToK := sdk.NewInt(10).ToDec().Power(k)
+		denominator = denominator.Mul(tenToK.TruncateInt())
+	}
+	return numerator.QuoInt(denominator)
+}

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -195,7 +195,8 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (sdk.Dec,
 	invWeightRatio := quote.Weight.ToDec().Quo(base.Weight.ToDec())
 	supplyRatio := base.Token.Amount.ToDec().Quo(quote.Token.Amount.ToDec())
 	fullRatio := supplyRatio.Mul(invWeightRatio)
-	ratio := (fullRatio.Mul(types.SigFigs).RoundInt()).ToDec().Quo(types.SigFigs)
+	// we want to round this to `SigFigs` of precision
+	ratio := osmomath.SigFigRound(fullRatio, types.SigFigs)
 	return ratio, nil
 }
 

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -53,6 +53,20 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 			expectError:         false,
 			expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
 		},
+		{
+			name:                "check number of sig figs",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100000),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("0.001000000000000000"),
+		},
+		{
+			name:                "check number of sig figs high sizes",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("0.000000000001840877"),
+		},
 	}
 
 	for _, tc := range tests {

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -56,9 +56,9 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 		{
 			name:                "check number of sig figs",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
-			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100000),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
 			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("0.001000000000000000"),
+			expectedOutput:      sdk.MustNewDecFromStr("0.333333330000000000"),
 		},
 		{
 			name:                "check number of sig figs high sizes",

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -22,5 +22,5 @@ var (
 	InitPoolSharesSupply = OneShare.MulRaw(100)
 
 	// SigFigs is the amount of significant figures used to calculate SpotPrice
-	SigFigs = sdk.NewDec(10).Power(SigFigsExponent)
+	SigFigs = sdk.NewDec(10).Power(SigFigsExponent).TruncateInt()
 )


### PR DESCRIPTION
## What is the purpose of the change

Fixes query bug on mainnet, for pools with an asset with `10**18` precision. We passed all spot prices through 8 sig fig rounding, however our sig fig rounding was incorrect for inputs with value less than 1.

This fixes a bug with spot price being called on values less than 1.

## Brief Changelog

- Fixes SpotPrice rounding on extremely small inputs

## Testing and Verifying

This change added a new test for a large input from mainnet, that was returning 0.
I also checked that spot price is not called anywhere in the state machine, except in the cosmwasm bindings.
We will have to ensure that no contract gets uploaded with spot price calls in the v9.x release series, which was also the general plan since contracts should depend on TWAP not spot price.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? Correct code to the spec