### PR TITLE
thought experiment: zeroconf osmosis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,6 @@
   "[proto3]": {
     "editor.defaultFormatter": "xaver.clang-format"
   },
-  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 120, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}"
+  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 120, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}",
+  "go.inferGopath": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,5 @@
   "[proto3]": {
     "editor.defaultFormatter": "xaver.clang-format"
   },
-  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 120, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}",
-  "go.inferGopath": false
+  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 120, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}"
 }

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -17,12 +17,7 @@ import (
 	"github.com/tendermint/tendermint/libs/cli"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 
-<<<<<<< HEAD
 	_ "github.com/osmosis-labs/osmosis/v7/networks/osmosis-1"
-=======
-	// import genesis state
-	_ "github.com/osmosis-labs/osmosis/v8/networks/osmosis-1"
->>>>>>> 9eeece98 (test)
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -17,7 +17,12 @@ import (
 	"github.com/tendermint/tendermint/libs/cli"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 
+<<<<<<< HEAD
 	_ "github.com/osmosis-labs/osmosis/v7/networks/osmosis-1"
+=======
+	// import genesis state
+	_ "github.com/osmosis-labs/osmosis/v8/networks/osmosis-1"
+>>>>>>> 9eeece98 (test)
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -44,7 +49,7 @@ type printInfo struct {
 	AppMessage json.RawMessage `json:"app_message" yaml:"app_message"`
 }
 
-func newPrintInfo(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage) printInfo {
+func newPrintInfo(moniker, chainID, nodeID, genTxsDir string) printInfo {
 	return printInfo{
 		Moniker:   moniker,
 		ChainID:   chainID,
@@ -133,11 +138,12 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			config.Moniker = args[0]
 
-			genFile := "genesis.json"
-			overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
+			config.Genesis = "genesis.json"
 
 			// this can be moved to another file for when we want to play with empty chains and the like.
 			/*
+				overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
+
 				if !overwrite && tmos.FileExists(genFile) {
 					return fmt.Errorf("genesis.json file already exists: %v", genFile)
 				}

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -15,9 +15,9 @@ import (
 
 	tmcfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
-	tmos "github.com/tendermint/tendermint/libs/os"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
-	"github.com/tendermint/tendermint/types"
+
+	_ "github.com/osmosis-labs/osmosis/v7/networks/osmosis-1"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -46,11 +46,10 @@ type printInfo struct {
 
 func newPrintInfo(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage) printInfo {
 	return printInfo{
-		Moniker:    moniker,
-		ChainID:    chainID,
-		NodeID:     nodeID,
-		GenTxsDir:  genTxsDir,
-		AppMessage: appMessage,
+		Moniker:   moniker,
+		ChainID:   chainID,
+		NodeID:    nodeID,
+		GenTxsDir: genTxsDir,
 	}
 }
 
@@ -75,13 +74,13 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			cdc := clientCtx.Codec
-
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			config := serverCtx.Config
 
+			// This is a slice of SEED nodes, not peers.  They must be configured in seed mode.
 			// An easy way to run a lightweight seed node is to use tenderseed: github.com/binaryholdings/tenderseed
-
+			// Another easy way to run a seed node is tinyseed: https://github.com/notional-labs/tinyseed
+			// Tinyseed is made for Akash!
 			seeds := []string{
 				"21d7539792ee2e0d650b199bf742c56ae0cf499e@162.55.132.230:2000",                             // Notional
 				"44ff091135ef2c69421eacfa136860472ac26e60@65.21.141.212:2000",                              // Notional
@@ -96,6 +95,9 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				"7c66126b64cd66bafd9ccfc721f068df451d31a3@osmosis-seed.sunshinevalidation.io:9393",         // Sunshine Validation
 			}
 			config.P2P.Seeds = strings.Join(seeds, ",")
+
+			// Override default settings in config.toml
+			config.P2P.Seeds = strings.Join(seeds[:], ",")
 			config.P2P.MaxNumInboundPeers = 320
 			config.P2P.MaxNumOutboundPeers = 40
 			config.Mempool.Size = 10000
@@ -131,37 +133,40 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			config.Moniker = args[0]
 
-			genFile := config.GenesisFile()
+			genFile := "genesis.json"
 			overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
 
-			if !overwrite && tmos.FileExists(genFile) {
-				return fmt.Errorf("genesis.json file already exists: %v", genFile)
-			}
-			appState, err := json.MarshalIndent(mbm.DefaultGenesis(cdc), "", " ")
-			if err != nil {
-				return errors.Wrap(err, "Failed to marshall default genesis state")
-			}
-
-			genDoc := &types.GenesisDoc{}
-			if _, err := os.Stat(genFile); err != nil {
-				if !os.IsNotExist(err) {
-					return err
+			// this can be moved to another file for when we want to play with empty chains and the like.
+			/*
+				if !overwrite && tmos.FileExists(genFile) {
+					return fmt.Errorf("genesis.json file already exists: %v", genFile)
 				}
-			} else {
-				genDoc, err = types.GenesisDocFromFile(genFile)
+				appState, err := json.MarshalIndent(mbm.DefaultGenesis(cdc), "", " ")
 				if err != nil {
-					return errors.Wrap(err, "Failed to read genesis doc from file")
+					return errors.Wrap(err, "Failed to marshall default genesis state")
 				}
-			}
 
-			genDoc.ChainID = chainID
-			genDoc.Validators = nil
-			genDoc.AppState = appState
-			if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
-				return errors.Wrap(err, "Failed to export genesis file")
-			}
+				genDoc := &types.GenesisDoc{}
+				if _, err := os.Stat(genFile); err != nil {
+					if !os.IsNotExist(err) {
+						return err
+					}
+				} else {
+					genDoc, err = types.GenesisDocFromFile(genFile)
+					if err != nil {
+						return errors.Wrap(err, "Failed to read genesis doc from file")
+					}
+				}
 
-			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
+				genDoc.ChainID = chainID
+				genDoc.Validators = nil
+				genDoc.AppState = appState
+				if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+					return errors.Wrap(err, "Failed to export genesis file")
+				}
+			*/
+
+			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "")
 
 			tmcfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
 

--- a/networks/osmosis-1/embed.go
+++ b/networks/osmosis-1/embed.go
@@ -1,4 +1,3 @@
-import "embed"
+package osmosis
 
 //go:embed genesis.json
-

--- a/networks/osmosis-1/embed.go
+++ b/networks/osmosis-1/embed.go
@@ -1,0 +1,4 @@
+import "embed"
+
+//go:embed genesis.json
+

--- a/networks/osmosis-1/embed.go
+++ b/networks/osmosis-1/embed.go
@@ -1,3 +1,5 @@
 package osmosis
 
+import _ "embed"
+
 //go:embed genesis.json


### PR DESCRIPTION
Basically, I wanted to put this idea out there to know if it is worth pursuing further.  It embeds the genesis.json file into osmosis. 

## What is the purpose of the change

> Add a description of the overall background and high level changes that this PR introduces

* let's do to genesis configuration what we did to seeds

....it's only ~~15~~, ~~30~~, 60? mins/dev/searchforfile/year right?

## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

This code is incomplete and I'll update this section going forward.

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)