### PR TITLE
Fix second source of (minor) over-LP shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 * [1700](https://github.com/osmosis-labs/osmosis/pull/1700) Upgrade sdk fork with missing snapshot manager fix.
+* [1716](https://github.com/osmosis-labs/osmosis/pull/1716) Fix secondary over-LP shares bug with uneven swap amounts in `CalcJoinPoolShares`.
 
 ## [v9.0.0 - Nitrogen](https://github.com/osmosis-labs/osmosis/releases/tag/v9.0.0)
 

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -257,6 +257,7 @@ func (p *Pool) JoinPool(_ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (
 	return numShares, nil
 }
 
+// CalcJoinPoolShares
 func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
 	poolAssets := p.GetAllPoolAssets()
 	poolAssetsByDenom := make(map[string]PoolAsset)
@@ -293,21 +294,22 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 		poolAssetsByDenom[coin.Denom] = poolAsset
 	}
 
+	newTotalShares := totalShares.Add(numShares)
+
 	// If there are coins that couldn't be perfectly joined, do single asset joins
 	// for each of them.
 	if !remCoins.Empty() {
 		for _, coin := range remCoins {
-			newShares, err := p.calcSingleAssetJoin(coin, swapFee, poolAssetsByDenom[coin.Denom], totalShares)
+			newShares, err := p.calcSingleAssetJoin(coin, swapFee, poolAssetsByDenom[coin.Denom], newTotalShares)
 			if err != nil {
 				return sdk.ZeroInt(), sdk.NewCoins(), err
 			}
 
 			newLiquidity = newLiquidity.Add(coin)
+			newTotalShares = newTotalShares.Add(newShares)
 			numShares = numShares.Add(newShares)
 		}
 	}
-
-	totalShares = totalShares.Add(numShares)
 
 	return numShares, newLiquidity, nil
 }

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -293,8 +293,6 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 		poolAssetsByDenom[coin.Denom] = poolAsset
 	}
 
-	totalShares = totalShares.Add(numShares)
-
 	// If there are coins that couldn't be perfectly joined, do single asset joins
 	// for each of them.
 	if !remCoins.Empty() {
@@ -308,6 +306,8 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 			numShares = numShares.Add(newShares)
 		}
 	}
+
+	totalShares = totalShares.Add(numShares)
 
 	return numShares, newLiquidity, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Another bug, spotted by samczun. Not caught in tests, because it occurs on uneven swap amounts.

For uneven swap amounts, we tend to have tokens remaining after doing an equal ratio swap. For each of the tokens, we do a single asset pool join.

The logic was broken in providing the correct number fo shares for single asset joins. This PR fixes it.

This change added tests and can be verified as follows:

- Breaking down logic for handling uneven swap amounts and unit testing each function separately: https://github.com/osmosis-labs/osmosis/pull/1721
- Test cases for `CalcJoinPoolShares` with uneven swap amounts: https://github.com/osmosis-labs/osmosis/pull/1713

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable