### PR TITLE
Randomized testing for Join-Exit

### DIFF
--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
@@ -451,14 +452,18 @@ func TestRandomizedPoolInvariants(t *testing.T) {
 	const denomOut = "denomOut"
 	const denomIn = "denomIn"
 
+	now := time.Now().Unix()
+	rng := rand.NewSource(now)
+	fmt.Printf("Using random source of %d\n", now)
+
 	// generate test case with randomized initial assets and join/exit ratio
 	newCase := func() (tc *testCase) {
 		tc = new(testCase)
-		tc.initialTokensDenomIn = rand.Int63n(1_000_000)
-		tc.initialTokensDenomOut = rand.Int63n(1_000_000)
+		tc.initialTokensDenomIn = rng.Int63() % 1_000_000
+		tc.initialTokensDenomOut = rng.Int63() % 1_000_000
 
 		// 1%~100% of initial assets
-		tc.percentRatio = rand.Int63n(100) + 1
+		tc.percentRatio = rng.Int63()%100 + 1
 
 		return tc
 	}

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -505,30 +505,19 @@ func TestRandomizedPoolInvariants(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// two coins are equal within rounding error margin of 1
-	equalWithinErrorMargin := func(a, b sdk.Coins) bool {
-		diff, _ := a.SafeSub(b)
-		for _, coin := range diff {
-			amount := coin.Amount.Int64()
-			if amount < -1 || amount > 1 {
-				return false
-			}
-		}
-		return true
-	}
-
 	invariantJoinExitInversePreserve := func(
 		beforeCoins, afterCoins sdk.Coins,
 		beforeShares, afterShares sdk.Int,
 	) {
 		// test token amount has been preserved
 		require.True(t,
-			equalWithinErrorMargin(beforeCoins, afterCoins),
+			!beforeCoins.IsAnyGT(afterCoins),
 			"Coins has not been preserved before and after join-exit\nbefore:\t%s\nafter:\t%s",
 			beforeCoins, afterCoins,
 		)
 		// test share amount has been preserved
-		require.True(t, beforeShares.Equal(afterShares),
+		require.True(t,
+			beforeShares.Equal(afterShares),
 			"Shares has not been preserved before and after join-exit\nbefore:\t%s\nafter:\t%s",
 			beforeShares, afterShares,
 		)

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -439,7 +439,7 @@ func TestCalcJoinPoolShares(t *testing.T) {
 	}
 }
 
-func TestRandomizedPoolInvariants(t *testing.T) {
+func TestRandomizedJoinPoolExitPoolInvariants(t *testing.T) {
 	type testCase struct {
 		initialTokensDenomIn  int64
 		initialTokensDenomOut int64

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -456,7 +456,7 @@ func TestRandomizedJoinPoolExitPoolInvariants(t *testing.T) {
 
 	now := time.Now().Unix()
 	rng := rand.NewSource(now)
-	fmt.Printf("Using random source of %d\n", now)
+	t.Logf("Using random source of %d\n", now)
 
 	// generate test case with randomized initial assets and join/exit ratio
 	newCase := func() (tc *testCase) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Added randomized testing for balancer pool `JoinPool` and `ExitPool`. The added test generates pool with randomized initial assets, and randomized ratio of assets to join/exit. It then performs the sequential JoinPool ExitPool operations, and check if the number of remaining assets and total number of shares are preserved.

## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)