### PR TITLE
fix(stableswap): Return correct number of shares when joining stableswap pool

### DIFF
--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -399,6 +399,7 @@ func (pa *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swap
 			return sdk.ZeroInt(), sdk.NewCoins(), err
 		}
 		pa.updatePoolForJoin(sdk.NewCoins(coin), newShare)
+		numShares = numShares.Add(newShare)
 	}
 
 	return numShares, tokensIn, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The `joinPoolSharesInternal` method was not taking into account the newShares from single-sided LP joins. I wanted to make sure another Osmosis bug didn't happen related to LP share calculation.

## Brief Changelog

  - Fix LP share calculation for stableswap pools.


## Testing and Verifying

*(Please pick one of the following options)*

This change fixes code that doesn't have test coverage yet.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable  /  not documented)