### PR TITLE
fix: stableswap joinPoolSharesInternal

### DIFF
--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -378,7 +378,11 @@ func (pa *Pool) calcSingleAssetJoinShares(tokenIn sdk.Coin, swapFee sdk.Dec) (sd
 func (pa *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
 	if len(tokensIn) == 1 {
 		numShares, err = pa.calcSingleAssetJoinShares(tokensIn[0], swapFee)
+		if err != nil {
+			return sdk.ZeroInt(), sdk.NewCoins(), err
+		}
 		newLiquidity = tokensIn
+		pa.updatePoolForJoin(tokensIn, numShares)
 		return numShares, newLiquidity, err
 	} else if len(tokensIn) != pa.NumAssets() {
 		return sdk.ZeroInt(), sdk.NewCoins(), errors.New(

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -381,6 +381,7 @@ func (pa *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swap
 		if err != nil {
 			return sdk.ZeroInt(), sdk.NewCoins(), err
 		}
+
 		newLiquidity = tokensIn
 		pa.updatePoolForJoin(tokensIn, numShares)
 		return numShares, newLiquidity, err

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -384,6 +384,7 @@ func (pa *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swap
 
 		newLiquidity = tokensIn
 		pa.updatePoolForJoin(tokensIn, numShares)
+
 		return numShares, newLiquidity, err
 	} else if len(tokensIn) != pa.NumAssets() {
 		return sdk.ZeroInt(), sdk.NewCoins(), errors.New(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

 Stable swap `joinPoolSharesInternal` doesn't `updatePoolForJoin` for the case of single asset join  


## Brief Changelog

I change `joinPoolSharesInternal` so that it `updatePoolForJoin` for the case of single asset join

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes?  no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not documented