### PR TITLE
chore: add ability to tolerate 10^-6% inconsistencies in share calculation test

### DIFF
--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -38,8 +38,6 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 		if e.AdditiveTolerance.IsZero() {
 			if expected.Equal(actual) {
 				return 0
-			} else {
-				return comparisonSign
 			}
 		}
 

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -32,17 +32,17 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 		comparisonSign = -1
 	}
 
-	// if no error accepted, do a direct compare.
-	if e.AdditiveTolerance.IsZero() {
-		if expected.Equal(actual) {
-			return 0
-		} else {
-			return comparisonSign
-		}
-	}
-
 	// Check additive tolerance equations
 	if !e.AdditiveTolerance.IsNil() {
+		// if no error accepted, do a direct compare.
+		if e.AdditiveTolerance.IsZero() {
+			if expected.Equal(actual) {
+				return 0
+			} else {
+				return comparisonSign
+			}
+		}
+
 		if diff.GT(e.AdditiveTolerance) {
 			return comparisonSign
 		}

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
 
+const allowedErrRatio = "0.0000001"
+
 // This test sets up 2 asset pools, and then checks the spot price on them.
 // It uses the pools spot price method, rather than the Gamm keepers spot price method.
 func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
@@ -450,8 +452,8 @@ func TestRandomizedJoinPoolExitPoolInvariants(t *testing.T) {
 	}
 
 	const (
-	  denomOut = "denomOut"
-	  denomIn = "denomIn"
+		denomOut = "denomOut"
+		denomIn  = "denomIn"
 	)
 
 	now := time.Now().Unix()
@@ -545,4 +547,19 @@ func TestRandomizedJoinPoolExitPoolInvariants(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		testPoolInvariants()
 	}
+}
+
+func assertExpectedSharesErrRatio(t *testing.T, expectedShares, actualShares sdk.Int) {
+	allowedErrRatioDec, err := sdk.NewDecFromStr(allowedErrRatio)
+	require.NoError(t, err)
+
+	errTolerance := osmoutils.ErrTolerance{
+		MultiplicativeTolerance: allowedErrRatioDec,
+	}
+
+	require.Equal(
+		t,
+		0,
+		errTolerance.Compare(expectedShares, actualShares),
+		fmt.Sprintf("expectedShares: %d, actualShares: %d", expectedShares.Int64(), actualShares.Int64()))
 }

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
 
+// allowedErrRatio is the maximal multiplicative difference in either
+// direction (positive or negative) that we accept to tolerate in
+// unit tests for calcuating the number of shares to be returned by
+// joining a pool. The comparison is done between Wolfram estimates and our AMM logic.
 const allowedErrRatio = "0.0000001"
 
 // This test sets up 2 asset pools, and then checks the spot price on them.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

in #1721 the logic for tolerating rounding errors in share calculations was introduced. It is also useful for unit tests in concurrent PRs such as #1718 

Since #1721 is large and is likely to take time to review, I'm submitting the desired functionality separately

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable