### PR TITLE
test: extract getPoolAssetsByDenom function from CalcJoinPoolShares and unit test

### DIFF
--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -761,6 +761,90 @@ func TestRandomizedJoinPoolExitPoolInvariants(t *testing.T) {
 	}
 }
 
+// TestGetPoolAssetsByDenom tests if `GetPoolAssetsByDenom` succesfully creates a map of denom to pool asset
+// given pool asset as parameter
+func TestGetPoolAssetsByDenom(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		poolAssets                []balancer.PoolAsset
+		expectedPoolAssetsByDenom map[string]balancer.PoolAsset
+
+		err error
+	}{
+		{
+			name:                      "zero pool assets",
+			poolAssets:                []balancer.PoolAsset{},
+			expectedPoolAssetsByDenom: make(map[string]balancer.PoolAsset),
+		},
+		{
+			name: "one pool asset",
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+			expectedPoolAssetsByDenom: map[string]balancer.PoolAsset{
+				"uosmo": {
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+		},
+		{
+			name: "two pool assets",
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("atom", 123),
+					Weight: sdk.NewInt(400),
+				},
+			},
+			expectedPoolAssetsByDenom: map[string]balancer.PoolAsset{
+				"uosmo": {
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				"atom": {
+					Token:  sdk.NewInt64Coin("atom", 123),
+					Weight: sdk.NewInt(400),
+				},
+			},
+		},
+		{
+			name: "duplicate pool assets",
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 123),
+					Weight: sdk.NewInt(400),
+				},
+			},
+			err: fmt.Errorf(balancer.ErrMsgFormatRepeatingPoolAssetsNotAllowed, "uosmo"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualPoolAssetsByDenom, err := balancer.GetPoolAssetsByDenom(tc.poolAssets)
+
+			require.Equal(t, tc.err, err)
+
+			if tc.err != nil {
+				return
+			}
+
+			require.Equal(t, tc.expectedPoolAssetsByDenom, actualPoolAssetsByDenom)
+		})
+	}
+}
+
 func assertExpectedSharesErrRatio(t *testing.T, expectedShares, actualShares sdk.Int) {
 	allowedErrRatioDec, err := sdk.NewDecFromStr(allowedErrRatio)
 	require.NoError(t, err)

--- a/x/gamm/pool-models/balancer/export_test.go
+++ b/x/gamm/pool-models/balancer/export_test.go
@@ -2,9 +2,15 @@ package balancer
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
+const (
+	ErrMsgFormatRepeatingPoolAssetsNotAllowed = errMsgFormatRepeatingPoolAssetsNotAllowed
+)
+
 var (
 	CalcPoolSharesOutGivenSingleAssetIn = calcPoolSharesOutGivenSingleAssetIn
 	CalcSingleAssetInGivenPoolSharesOut = calcSingleAssetInGivenPoolSharesOut
+
+	GetPoolAssetsByDenom = getPoolAssetsByDenom
 )
 
 func (p *Pool) CalcSingleAssetJoin(tokenIn sdk.Coin, swapFee sdk.Dec, tokenInPoolAsset PoolAsset, totalShares sdk.Int) (numShares sdk.Int, err error) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

`CalcJoinPoolShares` has a lot of logic and is hard to test. This PR abstracts away some functionality behind a new `getPoolAssetsByDenom` function and unit tests it.

Originally introduced in #1721. Moving it in its own PR to ease the review process

## Brief Changelog


## Testing and Verifying

This change added tests and can be verified as follows:

- `go test -timeout 30s -run ^TestGetPoolAssetsByDenom$ github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable