### PR TITLE
Add v10 halting logic to v9 (cref #1741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v9.1.0
+
+Adds logic to make the binary automatically halt at the v10 upgrade height, in a cosmovisor compatible manner.
+
 ## v9.0.1
 
 ### Breaking Changes

--- a/app/app.go
+++ b/app/app.go
@@ -42,6 +42,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v9/app/keepers"
 	appparams "github.com/osmosis-labs/osmosis/v9/app/params"
 	"github.com/osmosis-labs/osmosis/v9/app/upgrades"
+	v10 "github.com/osmosis-labs/osmosis/v9/app/upgrades/v10"
 	v3 "github.com/osmosis-labs/osmosis/v9/app/upgrades/v3"
 	v4 "github.com/osmosis-labs/osmosis/v9/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/v9/app/upgrades/v5"
@@ -87,7 +88,7 @@ var (
 	_ App = (*OsmosisApp)(nil)
 
 	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade}
-	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork}
+	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork, v10.Fork}
 )
 
 // GetWasmEnabledProposals parses the WasmProposalsEnabled and

--- a/app/upgrades/v10/constants.go
+++ b/app/upgrades/v10/constants.go
@@ -1,9 +1,10 @@
+// This upgrades package just schedules an upgrade, to cause cosmovisor to automatically
+// trigger at the correct height, thus one can proceed using the v9 binary until halt height.
+// and their binary will automatically halt.
 package v10
 
 import (
 	"github.com/osmosis-labs/osmosis/v9/app/upgrades"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Last executed block on the v9 code was 4713064.
@@ -14,23 +15,6 @@ const ForkHeight = 4713065
 // UpgradeName defines the on-chain upgrade name for the Osmosis v9-fork for recovery.
 // This is not called v10, due to this bug that would require a state migration to fix:
 const UpgradeName = "v10"
-
-// RecoveryAddress that the irregular state change transfers to.
-// TODO: Include derivation of this
-var RecoveryAddress, recoveryAddressErr = sdk.AccAddressFromBech32("osmo1rdkpu0tfnp3vx7vg4gxhjr0gt9rtydtv4fsrd0")
-
-func init() {
-	if recoveryAddressErr != nil {
-		panic("recovery address decoding failure")
-	}
-}
-
-// Created synthetically via fork
-// var Upgrade = upgrades.Upgrade{
-// 	UpgradeName:          UpgradeName,
-// 	CreateUpgradeHandler: CreateUpgradeHandler,
-// 	StoreUpgrades:        store.StoreUpgrades{},
-// }
 
 var Fork = upgrades.Fork{
 	UpgradeName:    UpgradeName,

--- a/app/upgrades/v10/constants.go
+++ b/app/upgrades/v10/constants.go
@@ -1,0 +1,39 @@
+package v10
+
+import (
+	"github.com/osmosis-labs/osmosis/v9/app/upgrades"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Last executed block on the v9 code was 4713064.
+// Last committed block is assumed to be 4713064, as we have block proposals that were not precommitted upon
+// for 4713065.
+const ForkHeight = 4713065
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v9-fork for recovery.
+// This is not called v10, due to this bug that would require a state migration to fix:
+const UpgradeName = "v10"
+
+// RecoveryAddress that the irregular state change transfers to.
+// TODO: Include derivation of this
+var RecoveryAddress, recoveryAddressErr = sdk.AccAddressFromBech32("osmo1rdkpu0tfnp3vx7vg4gxhjr0gt9rtydtv4fsrd0")
+
+func init() {
+	if recoveryAddressErr != nil {
+		panic("recovery address decoding failure")
+	}
+}
+
+// Created synthetically via fork
+// var Upgrade = upgrades.Upgrade{
+// 	UpgradeName:          UpgradeName,
+// 	CreateUpgradeHandler: CreateUpgradeHandler,
+// 	StoreUpgrades:        store.StoreUpgrades{},
+// }
+
+var Fork = upgrades.Fork{
+	UpgradeName:    UpgradeName,
+	UpgradeHeight:  ForkHeight,
+	BeginForkLogic: RunForkLogic,
+}

--- a/app/upgrades/v10/fork.go
+++ b/app/upgrades/v10/fork.go
@@ -1,0 +1,26 @@
+package v10
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v9/app/keepers"
+)
+
+func RunForkLogic(ctx sdk.Context, appKeepers *keepers.AppKeepers) {
+	if ctx.BlockHeight() != ForkHeight {
+		panic(fmt.Sprintf("current height %d, expected it to be the fork height %d", ctx.BlockHeight(), ForkHeight))
+	}
+	plan := upgradetypes.Plan{
+		Name:   UpgradeName,
+		Height: ForkHeight,
+		Info:   "",
+	}
+	err := appKeepers.UpgradeKeeper.ScheduleUpgrade(ctx, plan)
+	if err != nil {
+		panic(err)
+	}
+	// Do not set upgrade handler, so the chain will halt.
+}

--- a/app/upgrades/v10/upgrades_test.go
+++ b/app/upgrades/v10/upgrades_test.go
@@ -1,0 +1,61 @@
+package v10_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v9/app/apptesting"
+	v10 "github.com/osmosis-labs/osmosis/v9/app/upgrades/v10"
+)
+
+type UpgradeTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+func (suite *UpgradeTestSuite) SetupTest() {
+	suite.Setup()
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+func (suite *UpgradeTestSuite) TestUpgradePayments() {
+	testCases := []struct {
+		msg         string
+		pre_update  func()
+		update      func()
+		post_update func()
+	}{
+		{
+			"Test that upgrade height panics",
+			func() {},
+			func() {
+				// run upgrade
+				// First run block N-1, begin new block takes ctx height + 1
+				suite.Ctx = suite.Ctx.WithBlockHeight(v10.ForkHeight - 2)
+				suite.BeginNewBlock(false)
+				balances := suite.App.AppKeepers.BankKeeper.GetAllBalances(suite.Ctx, v10.RecoveryAddress)
+				suite.Require().True(balances.Empty())
+
+				// run upgrade height, should panic
+				suite.Require().Panics(func() {
+					suite.BeginNewBlock(false)
+				})
+			},
+			func() {},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			suite.SetupTest() // reset
+
+			tc.pre_update()
+			tc.update()
+			tc.post_update()
+		})
+	}
+}

--- a/app/upgrades/v10/upgrades_test.go
+++ b/app/upgrades/v10/upgrades_test.go
@@ -22,30 +22,24 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(UpgradeTestSuite))
 }
 
-func (suite *UpgradeTestSuite) TestUpgradePayments() {
+func (suite *UpgradeTestSuite) TestUpgradePanics() {
 	testCases := []struct {
-		msg         string
-		pre_update  func()
-		update      func()
-		post_update func()
+		msg    string
+		update func()
 	}{
 		{
 			"Test that upgrade height panics",
-			func() {},
 			func() {
 				// run upgrade
 				// First run block N-1, begin new block takes ctx height + 1
 				suite.Ctx = suite.Ctx.WithBlockHeight(v10.ForkHeight - 2)
 				suite.BeginNewBlock(false)
-				balances := suite.App.AppKeepers.BankKeeper.GetAllBalances(suite.Ctx, v10.RecoveryAddress)
-				suite.Require().True(balances.Empty())
 
 				// run upgrade height, should panic
 				suite.Require().Panics(func() {
 					suite.BeginNewBlock(false)
 				})
 			},
-			func() {},
 		},
 	}
 
@@ -53,9 +47,7 @@ func (suite *UpgradeTestSuite) TestUpgradePayments() {
 		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
 			suite.SetupTest() // reset
 
-			tc.pre_update()
 			tc.update()
-			tc.post_update()
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -272,7 +272,7 @@ replace (
 	// branch: v0.27.0.rc3-osmo, current tag: v0.27.0.rc3-osmo
 	github.com/CosmWasm/wasmd => github.com/osmosis-labs/wasmd v0.27.0-rc2.0.20220517191021-59051aa18d58
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk v0.45.0x-osmo-v7
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220607221533-51108b6dcab2
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220610010940-bd421f8c0ff3
 	// Use Osmosis fast iavl
 	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v7
 	// use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/ory/dockertest/v3 v3.9.1 h1:v4dkG+dlu76goxMiTT2j8zV7s4oPPEppKT8K8p2f1
 github.com/ory/dockertest/v3 v3.9.1/go.mod h1:42Ir9hmvaAPm0Mgibk6mBPi7SFvTXxEcnztDYOJ//uM=
 github.com/osmosis-labs/bech32-ibc v0.3.0-rc1 h1:frHKHEdPfzoK2iMF2GeWKudLLzUXz+6GJcdZ/TMcs2k=
 github.com/osmosis-labs/bech32-ibc v0.3.0-rc1/go.mod h1:X5/FZHMPL+B3ufuVyY2/koxVjd4hIwyTLjYP1DZwppQ=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220607221533-51108b6dcab2 h1:ixv07gC37fLPBZWLyVcQFcif+f+mqUtScI0jNY9zBpU=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220607221533-51108b6dcab2/go.mod h1:pMiEr6WR7drhXAXK1FOdAKPazWCi7b+WOyWOF4O0OXY=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220610010940-bd421f8c0ff3 h1:zcKJqUC0Yyyv4uck9EuzwWfcUS9+jOp0PTqmN9RLju0=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220610010940-bd421f8c0ff3/go.mod h1:pMiEr6WR7drhXAXK1FOdAKPazWCi7b+WOyWOF4O0OXY=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7 h1:6KcADC/WhL7yDmNQxUIJt2XmzNt4FfRmq9gRke45w74=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
 github.com/osmosis-labs/wasmd v0.27.0-rc2.0.20220517191021-59051aa18d58 h1:15l3Iss2oCGCeJRi2g3CuCnqmEjpAr3Le7cDnoN/LS0=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

This PR introduces v10 halting logic to the v9 series. It makes a v9 state machine compatible version, that will halt at the upgrade height, and correctly signal cosmovisor to upgrade.

## Brief Changelog

- Add halt at v10 fork height logic

## Testing and Verifying

The test attempts running this block height, and it panics then. (as expected)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? Should be