### PR TITLE
test: ensure tokenIn exists in pool for calcSingleAssetJoin

### DIFF
--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -2,7 +2,7 @@ package balancer
 
 import (
 	"errors"
-	fmt "fmt"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -236,6 +236,11 @@ func calcPoolSharesOutGivenSingleAssetIn(
 
 // calcPoolOutGivenSingleIn - balance pAo.
 func (p *Pool) calcSingleAssetJoin(tokenIn sdk.Coin, swapFee sdk.Dec, tokenInPoolAsset PoolAsset, totalShares sdk.Int) (numShares sdk.Int, err error) {
+	_, err = p.GetPoolAsset(tokenIn.Denom)
+	if err != nil {
+		return sdk.ZeroInt(), err
+	}
+
 	totalWeight := p.GetTotalWeight()
 	if totalWeight.IsZero() {
 		return sdk.ZeroInt(), errors.New("pool misconfigured, total weight = 0")

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -3,6 +3,7 @@ package balancer_test
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,16 +26,21 @@ type calcJoinSharesTestCase struct {
 	swapFee      sdk.Dec
 	poolAssets   []balancer.PoolAsset
 	tokensIn     sdk.Coins
-	expectErr    bool
 	expectShares sdk.Int
 	expectLiq    sdk.Coins
+	expErr       error
 }
 
-// allowedErrRatio is the maximal multiplicative difference in either
-// direction (positive or negative) that we accept to tolerate in
-// unit tests for calcuating the number of shares to be returned by
-// joining a pool. The comparison is done between Wolfram estimates and our AMM logic.
-const allowedErrRatio = "0.0000001"
+const (
+	// allowedErrRatio is the maximal multiplicative difference in either
+	// direction (positive or negative) that we accept to tolerate in
+	// unit tests for calcuating the number of shares to be returned by
+	// joining a pool. The comparison is done between Wolfram estimates and our AMM logic.
+	allowedErrRatio = "0.0000001"
+	// doesNotExistDenom denom name assummed to be used in test cases where the provided
+	// denom does not exist in pool
+	doesNotExistDenom = "doesnotexist"
+)
 
 // see calcJoinSharesTestCase struct definition.
 var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
@@ -280,6 +286,23 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", 50_000)),
 		expectShares: sdk.NewInt(819_444_430_000),
 		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 50_000)),
+	},
+	{
+		name:    "tokenIn asset does not exist in pool",
+		swapFee: sdk.MustNewDecFromStr("0"),
+		poolAssets: []balancer.PoolAsset{
+			{
+				Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+				Weight: sdk.NewInt(100),
+			},
+			{
+				Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+				Weight: sdk.NewInt(100),
+			},
+		},
+		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin(doesNotExistDenom, 50_000)),
+		expectShares: sdk.ZeroInt(),
+		expErr:       fmt.Errorf(balancer.ErrMsgFormatNoPoolAssetFound, doesNotExistDenom),
 	},
 }
 
@@ -616,8 +639,9 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			pool := createTestPool(t, tc.swapFee, sdk.MustNewDecFromStr("0"), tc.poolAssets...)
 
 			shares, liquidity, err := pool.CalcJoinPoolShares(sdk.Context{}, tc.tokensIn, tc.swapFee)
-			if tc.expectErr {
+			if tc.expErr != nil {
 				require.Error(t, err)
+				require.Equal(t, tc.expErr, err)
 				require.Equal(t, sdk.ZeroInt(), shares)
 				require.Equal(t, sdk.NewCoins(), liquidity)
 			} else {
@@ -640,14 +664,28 @@ func TestCalcSingleAssetJoin(t *testing.T) {
 
 			tokenIn := tc.tokensIn[0]
 
+			poolAssetInDenom := tokenIn.Denom
+			// when testing a case with tokenIn that does not exist in pool, we just want
+			// to provide any pool asset.
+			if tc.expErr != nil && strings.Contains(tc.expErr.Error(), doesNotExistDenom) {
+				poolAssetInDenom = tc.poolAssets[0].Token.Denom
+			}
+
 			// find pool asset in pool
 			// must be in pool since weights get scaled in Balancer pool
 			// constructor
-			poolAssetIn, err := balancerPool.GetPoolAsset(tokenIn.Denom)
+			poolAssetIn, err := balancerPool.GetPoolAsset(poolAssetInDenom)
 			require.NoError(t, err)
 
 			shares, err := balancerPool.CalcSingleAssetJoin(tokenIn, tc.swapFee, poolAssetIn, pool.GetTotalShares())
-			// It is impossible to set up a test case with error here so we omit it.
+
+			if tc.expErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.expErr, err)
+				require.Equal(t, sdk.ZeroInt(), shares)
+				return
+			}
+
 			require.NoError(t, err)
 			assertExpectedSharesErrRatio(t, tc.expectShares, shares)
 		})

--- a/x/gamm/pool-models/balancer/balancer_pool.go
+++ b/x/gamm/pool-models/balancer/balancer_pool.go
@@ -13,6 +13,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 )
 
+const (
+	errMsgFormatNoPoolAssetFound = "can't find the PoolAsset (%s)"
+)
+
 var (
 	_ types.PoolI                  = &Pool{}
 	_ types.PoolAmountOutExtension = &Pool{}
@@ -220,7 +224,7 @@ func (pa Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	}
 
 	if len(pa.PoolAssets) == 0 {
-		return -1, PoolAsset{}, fmt.Errorf("can't find the PoolAsset (%s)", denom)
+		return -1, PoolAsset{}, fmt.Errorf(errMsgFormatNoPoolAssetFound, denom)
 	}
 
 	i := sort.Search(len(pa.PoolAssets), func(i int) bool {
@@ -231,11 +235,11 @@ func (pa Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	})
 
 	if i < 0 || i >= len(pa.PoolAssets) {
-		return -1, PoolAsset{}, fmt.Errorf("can't find the PoolAsset (%s)", denom)
+		return -1, PoolAsset{}, fmt.Errorf(errMsgFormatNoPoolAssetFound, denom)
 	}
 
 	if pa.PoolAssets[i].Token.Denom != denom {
-		return -1, PoolAsset{}, fmt.Errorf("can't find the PoolAsset (%s)", denom)
+		return -1, PoolAsset{}, fmt.Errorf(errMsgFormatNoPoolAssetFound, denom)
 	}
 
 	return i, pa.PoolAssets[i], nil

--- a/x/gamm/pool-models/balancer/export_test.go
+++ b/x/gamm/pool-models/balancer/export_test.go
@@ -4,6 +4,7 @@ import sdk "github.com/cosmos/cosmos-sdk/types"
 
 const (
 	ErrMsgFormatRepeatingPoolAssetsNotAllowed = errMsgFormatRepeatingPoolAssetsNotAllowed
+	ErrMsgFormatNoPoolAssetFound              = errMsgFormatNoPoolAssetFound
 )
 
 var (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This improvement was suggested by @AlpinYukseloglu in #1721. Moving it to a separate PR for ease of review.

In short, we would like to make sure that the `tokenIn` belongs to the pool and error out if not. Currently, it would panic.

Added a unit test to cover this logic as well

## Testing and Verifying

This change added tests and can be verified as follows:
- `go test -timeout 30s -run ^TestCalcJoinPoolShares$ github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer`
- `go test -timeout 30s -run ^TestCalcSingleAssetJoin$ github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)