### PR TITLE
fix: Change PowApprox to return one when exponent is 0 

### DIFF
--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -81,7 +81,7 @@ func Pow(base sdk.Dec, exp sdk.Dec) sdk.Dec {
 }
 
 // Contract: 0 < base <= 2
-// 0 < exp < 1.
+// 0 <= exp < 1.
 func PowApprox(base sdk.Dec, exp sdk.Dec, precision sdk.Dec) sdk.Dec {
 	if exp.IsZero() {
 		return sdk.OneDec()

--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -84,7 +84,7 @@ func Pow(base sdk.Dec, exp sdk.Dec) sdk.Dec {
 // 0 < exp < 1.
 func PowApprox(base sdk.Dec, exp sdk.Dec, precision sdk.Dec) sdk.Dec {
 	if exp.IsZero() {
-		return sdk.ZeroDec()
+		return sdk.OneDec()
 	}
 
 	// Common case optimization

--- a/osmomath/math_test.go
+++ b/osmomath/math_test.go
@@ -37,6 +37,21 @@ func TestPowApprox(t *testing.T) {
 		expectedDec.Sub(s).Abs().LTE(powPrecision),
 		"expected value & actual value's difference should less than precision",
 	)
+
+	base, err = sdk.NewDecFromStr("0.8")
+	require.NoError(t, err)
+	exp = sdk.ZeroDec()
+	require.NoError(t, err)
+
+	s = PowApprox(base, exp, powPrecision)
+	expectedDec = sdk.OneDec()
+	require.NoError(t, err)
+
+	require.True(
+		t,
+		expectedDec.Sub(s).Abs().LTE(powPrecision),
+		"expected value & actual value's difference should less than precision",
+	)
 }
 
 func TestPow(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1752 

## What is the purpose of the change
We were basically returning Zero Dec when the exponent was zero for `PowApprox` when in fact we should be returning one when any given exponent is zero.

Currently added a simple test case of testing when exponent is one but we should definitely revist osmomath as a while for better testing in a near future.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)