### PR TITLE
test: add more calcSingleAssetJoinTestCases with varying ratio of tokenInAmount to existing liquidity

### DIFF
--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -281,6 +281,38 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 		expectShares: sdk.NewInt(819_444_430_000),
 		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 50_000)),
 	},
+
+	{
+		// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
+		// P_issued = P_supply * ((1 + (A_t / B_t))^W_t - 1)
+		//
+		// 9_775_731_930_496_140_648 = 100 * 10^18 * (( 1 + (117552 / 156_736))^0.167 - 1)
+		//
+		// where:
+		// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
+		//	A_t = amount of deposited asset = 117552
+		//	B_t = existing balance of deposited asset in the pool prior to deposit = 156_736
+		//	W_t = normalized weight of deposited asset in pool = 200 / (200 + 1000) approx = 0.167
+		// Plugging all of this in, we get:
+		// 	Full solution: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%28117552*%281+-+%281-%28200+%2F+%28200+%2B+1000%29%29%29+*+0%29%2F156736%29%29%5E%28200+%2F+%28200+%2B+1000%29%29+-+1%29
+		// 	Simplified:  P_issued = 9_775_731_930_496_140_648
+		name:    "single asset - tokenIn is large relative to liquidity, token in weight is smaller than the other token, with zero swap fee",
+		swapFee: sdk.MustNewDecFromStr("0"),
+		poolAssets: []balancer.PoolAsset{
+			{
+				Token:  sdk.NewInt64Coin("uosmo", 156_736),
+				Weight: sdk.NewInt(200),
+			},
+			{
+				Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+				Weight: sdk.NewInt(1000),
+			},
+		},
+		// 156_736 / 4 * 3 = 117552
+		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
+		expectShares: sdk.NewIntFromUint64(9_775_731_930_496_140_648),
+		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
+	},
 }
 
 // This test sets up 2 asset pools, and then checks the spot price on them.
@@ -858,5 +890,5 @@ func assertExpectedSharesErrRatio(t *testing.T, expectedShares, actualShares sdk
 		t,
 		0,
 		errTolerance.Compare(expectedShares, actualShares),
-		fmt.Sprintf("expectedShares: %d, actualShares: %d", expectedShares.Int64(), actualShares.Int64()))
+		fmt.Sprintf("expectedShares: %s, actualShares: %s", expectedShares.String(), actualShares.String()))
 }

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -314,10 +314,10 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 				Weight: sdk.NewInt(1000),
 			},
 		},
-		// 156_736 / 4 * 3 = 117552
-		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
+		// 156_736 * 3 / 4 = 117552
+		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", (156_736*3)/4)),
 		expectShares: sdk.NewIntFromUint64(9_775_731_930_496_140_648),
-		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
+		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", (156_736*3) / 4)),
 	},
 	{
 		// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -281,7 +281,6 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 		expectShares: sdk.NewInt(819_444_430_000),
 		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 50_000)),
 	},
-
 	{
 		// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
 		// P_issued = P_supply * ((1 + (A_t / B_t))^W_t - 1)
@@ -311,6 +310,37 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 		// 156_736 / 4 * 3 = 117552
 		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
 		expectShares: sdk.NewIntFromUint64(9_775_731_930_496_140_648),
+		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
+	},
+	{
+		// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
+		// P_issued = P_supply * ((1 + (A_t / B_t))^W_t - 1)
+		//
+		// 9_644_655_900_000_000_000 = 100 * 10^18 * (( 1 + (117552 * (1 - (1 - 0.167) * 0.02) / 156_736))^0.167 - 1)
+		//
+		// where:
+		// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
+		//	A_t = amount of deposited asset = 50,000
+		//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,000,000
+		//	W_t = normalized weight of deposited asset in pool = 200 / (200 + 1000) approx = 0.167
+		// Plugging all of this in, we get:
+		// 	Full solution: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%2850000*%281+-+%281-%28200+%2F+%28200+%2B+1000%29%29%29+*+0.02%29%2F1000000000000%29%29%5E%28200+%2F+%28200+%2B+1000%29%29+-+1%29
+		// 	Simplified:  P_issued = 9_644_655_900_000_000_000
+		name:    "single asset - tokenIn is large relative to liquidity, token in weight is smaller than the other token, with non-zero swap fee",
+		swapFee: sdk.MustNewDecFromStr("0.02"),
+		poolAssets: []balancer.PoolAsset{
+			{
+				Token:  sdk.NewInt64Coin("uosmo", 156_736),
+				Weight: sdk.NewInt(200),
+			},
+			{
+				Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+				Weight: sdk.NewInt(1000),
+			},
+		},
+		// 156_736 / 4 * 3 = 117552
+		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
+		expectShares: sdk.NewIntFromUint64(9_644_655_900_000_000_000),
 		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 156_736/4*3)),
 	},
 }

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -384,7 +384,8 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 		// Currently, our Pow approximation function does not work correctly when one tries
 		// to add liquidity that is larger than the existing liquidity.
 		// The ratio of tokenIn / existing liquidity that is larger than or equal to 1 causes a panic.
-		// We deem this as temporarily acceptable.
+		// This has been deemed as acceptable since it causes code complexity to fix
+		// & only affects UX in an edge case (user has to split up single asset joins)
 		name:    "single asset - (exactly 1 == tokenIn / liquidity ratio - failure), token in weight is smaller than the other token, with zero swap fee",
 		swapFee: sdk.MustNewDecFromStr("0"),
 		poolAssets: []balancer.PoolAsset{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1740

## What is the purpose of the change

We consistently use 50000 as tokenIn amount in `calcSingleAssetJoinTestCases` unit tests which isn't the best practice

Add the following:
   * TokensIn is large relative to liquidity
      * with swap fee
      * no swap fee
   * TokensIn is greater than the pool liquidity
       * This is currently not possible because there is a panic in Pow function when we have tokenInAmount >= existing liquidity
       * Instead, tested the panic boundary

## Testing and Verifying

This change added tests and can be verified as follows:

- `go test -timeout 30s -run ^TestCalcJoinPoolShares$ github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable