### PR TITLE
chore: avoid using string comparison for unit testing errors

### DIFF
--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -1253,7 +1253,7 @@ func TestCalcJoinSingleAssetTokensIn(t *testing.T) {
 
 			if tc.expErr != nil {
 				require.Error(t, err)
-				require.Equal(t, tc.expErr, err)
+				require.ErrorAs(t, tc.expErr, &err)
 				require.Equal(t, sdk.ZeroInt(), totalNumShares)
 				require.Equal(t, sdk.Coins{}, totalNewLiquidity)
 				return

--- a/x/gamm/pool-models/balancer/balancer_pool.go
+++ b/x/gamm/pool-models/balancer/balancer_pool.go
@@ -224,7 +224,7 @@ func (pa Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	}
 
 	if len(pa.PoolAssets) == 0 {
-		return -1, PoolAsset{}, fmt.Errorf(errMsgFormatNoPoolAssetFound, denom)
+		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
 	}
 
 	i := sort.Search(len(pa.PoolAssets), func(i int) bool {
@@ -235,11 +235,11 @@ func (pa Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	})
 
 	if i < 0 || i >= len(pa.PoolAssets) {
-		return -1, PoolAsset{}, fmt.Errorf(errMsgFormatNoPoolAssetFound, denom)
+		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
 	}
 
 	if pa.PoolAssets[i].Token.Denom != denom {
-		return -1, PoolAsset{}, fmt.Errorf(errMsgFormatNoPoolAssetFound, denom)
+		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
 	}
 
 	return i, pa.PoolAssets[i], nil

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -4,16 +4,17 @@ import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 // x/gamm module sentinel errors.
 var (
-	ErrPoolNotFound       = sdkerrors.Register(ModuleName, 1, "pool not found")
-	ErrPoolAlreadyExist   = sdkerrors.Register(ModuleName, 2, "pool already exist")
-	ErrPoolLocked         = sdkerrors.Register(ModuleName, 3, "pool is locked")
-	ErrTooFewPoolAssets   = sdkerrors.Register(ModuleName, 4, "pool should have at least 2 assets, as they must be swapping between at least two assets")
-	ErrTooManyPoolAssets  = sdkerrors.Register(ModuleName, 5, "pool has too many assets (currently capped at 8 assets per balancer pool and 2 per stableswap)")
-	ErrLimitMaxAmount     = sdkerrors.Register(ModuleName, 6, "calculated amount is larger than max amount")
-	ErrLimitMinAmount     = sdkerrors.Register(ModuleName, 7, "calculated amount is lesser than min amount")
-	ErrInvalidMathApprox  = sdkerrors.Register(ModuleName, 8, "invalid calculated result")
-	ErrAlreadyInvalidPool = sdkerrors.Register(ModuleName, 9, "destruction on already invalid pool")
-	ErrInvalidPool        = sdkerrors.Register(ModuleName, 10, "attempting to create an invalid pool")
+	ErrPoolNotFound        = sdkerrors.Register(ModuleName, 1, "pool not found")
+	ErrPoolAlreadyExist    = sdkerrors.Register(ModuleName, 2, "pool already exist")
+	ErrPoolLocked          = sdkerrors.Register(ModuleName, 3, "pool is locked")
+	ErrTooFewPoolAssets    = sdkerrors.Register(ModuleName, 4, "pool should have at least 2 assets, as they must be swapping between at least two assets")
+	ErrTooManyPoolAssets   = sdkerrors.Register(ModuleName, 5, "pool has too many assets (currently capped at 8 assets per balancer pool and 2 per stableswap)")
+	ErrLimitMaxAmount      = sdkerrors.Register(ModuleName, 6, "calculated amount is larger than max amount")
+	ErrLimitMinAmount      = sdkerrors.Register(ModuleName, 7, "calculated amount is lesser than min amount")
+	ErrInvalidMathApprox   = sdkerrors.Register(ModuleName, 8, "invalid calculated result")
+	ErrAlreadyInvalidPool  = sdkerrors.Register(ModuleName, 9, "destruction on already invalid pool")
+	ErrInvalidPool         = sdkerrors.Register(ModuleName, 10, "attempting to create an invalid pool")
+	ErrDenomNotFoundInPool = sdkerrors.Register(ModuleName, 11, "denom does not exist in pool")
 
 	ErrEmptyRoutes              = sdkerrors.Register(ModuleName, 21, "routes not defined")
 	ErrEmptyPoolAssets          = sdkerrors.Register(ModuleName, 22, "PoolAssets not defined")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Brought up by @alexanderbez , we should not be using string comparison for comparing errors, even in tests.

This is a small refactor to rely on `errors.Is` and `require.ErrorsAs(...)`

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable