### PR TITLE
Tests: Join pool for non-even ratio

### DIFF
--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -301,6 +301,9 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 	// that has to be joined via single asset join
 	// ctx arg doesn't matter for balancer
 	numShares, remCoins, err := cfmm_common.MaximalExactRatioJoin(p, sdk.Context{}, tokensIn)
+	fmt.Println("================================================================")
+	fmt.Println(numShares.String())
+	fmt.Println(remCoins)
 	if err != nil {
 		return sdk.ZeroInt(), sdk.NewCoins(), err
 	}
@@ -310,6 +313,8 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 	for _, coin := range newLiquidity {
 		poolAsset := poolAssetsByDenom[coin.Denom]
 		poolAsset.Token.Amount = poolAssetsByDenom[coin.Denom].Token.Amount.Add(coin.Amount)
+		fmt.Println("++=")
+		fmt.Println(poolAsset.Token.Amount.String())
 		poolAssetsByDenom[coin.Denom] = poolAsset
 	}
 

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -301,9 +301,6 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 	// that has to be joined via single asset join
 	// ctx arg doesn't matter for balancer
 	numShares, remCoins, err := cfmm_common.MaximalExactRatioJoin(p, sdk.Context{}, tokensIn)
-	fmt.Println("================================================================")
-	fmt.Println(numShares.String())
-	fmt.Println(remCoins)
 	if err != nil {
 		return sdk.ZeroInt(), sdk.NewCoins(), err
 	}
@@ -313,8 +310,6 @@ func (p *Pool) CalcJoinPoolShares(_ sdk.Context, tokensIn sdk.Coins, swapFee sdk
 	for _, coin := range newLiquidity {
 		poolAsset := poolAssetsByDenom[coin.Denom]
 		poolAsset.Token.Amount = poolAssetsByDenom[coin.Denom].Token.Amount.Add(coin.Amount)
-		fmt.Println("++=")
-		fmt.Println(poolAsset.Token.Amount.String())
 		poolAssetsByDenom[coin.Denom] = poolAsset
 	}
 

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -786,23 +786,6 @@ func TestCalcJoinPoolShares(t *testing.T) {
 				sdk.NewInt64Coin("uatom", 100_000),
 			),
 		},
-		{
-			name:    "equal weights with 0.001 swap fee",
-			swapFee: sdk.MustNewDecFromStr("0.001"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
-			tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", 50_000)),
-			expectShares: sdk.NewInt(2498749968800),
-			expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", 50_000)),
-		},
 	}
 	testCases = append(testCases, calcSingleAssetJoinTestCases...)
 

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -800,7 +800,7 @@ func TestCalcJoinPoolShares(t *testing.T) {
 				sdk.NewInt64Coin("uatom", 50_000),
 			),
 
-			expectShares: sdk.NewInt(1250000000000 + 615624990000),
+			expectShares: sdk.NewInt(1250000000000 + 609374990000),
 			expectLiq: sdk.NewCoins(
 				sdk.NewInt64Coin("uosmo", 25_000),
 				sdk.NewInt64Coin("uatom", 50_000),

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -634,145 +634,103 @@ func TestCalcJoinPoolShares(t *testing.T) {
 	// See calcJoinSharesTestCase struct definition for explanation why the
 	// sharing is needed.
 	testCases := []calcJoinSharesTestCase{
-		//{
-		//	name:    "swap equal weights with zero swap fee",
-		//	swapFee: sdk.MustNewDecFromStr("0"),
-		//	poolAssets: []balancer.PoolAsset{
-		//		{
-		//			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-		//			Weight: sdk.NewInt(100),
-		//		},
-		//		{
-		//			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-		//			Weight: sdk.NewInt(100),
-		//		},
-		//	},
-		//	tokensIn: sdk.NewCoins(
-		//		sdk.NewInt64Coin("uosmo", 25_000),
-		//		sdk.NewInt64Coin("uatom", 25_000),
-		//	),
-		//	// Raises liquidity perfectly by 25_000 / 1_000_000_000_000.
-		//	// Initial number of pool shares = 100 * 10**18 = 10**20
-		//	// Expected increase = liquidity_increase_ratio * initial number of pool shares = (25_000 / 1_000_000_000_000) * 10**20 = 2500000000000.0 = 2.5 * 10**12
-		//	expectShares: sdk.NewInt(2.5e12),
-		//	expectLiq: sdk.NewCoins(
-		//		sdk.NewInt64Coin("uosmo", 25_000),
-		//		sdk.NewInt64Coin("uatom", 25_000),
-		//	),
-		//},
-		//{
-		//	name:    "swap equal weights with 0.001 swap fee",
-		//	swapFee: sdk.MustNewDecFromStr("0.001"),
-		//	poolAssets: []balancer.PoolAsset{
-		//		{
-		//			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-		//			Weight: sdk.NewInt(100),
-		//		},
-		//		{
-		//			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-		//			Weight: sdk.NewInt(100),
-		//		},
-		//	},
-		//	tokensIn: sdk.NewCoins(
-		//		sdk.NewInt64Coin("uosmo", 25_000),
-		//		sdk.NewInt64Coin("uatom", 25_000),
-		//	),
-		//	expectShares: sdk.NewInt(2500000000000),
-		//	expectLiq: sdk.NewCoins(
-		//		sdk.NewInt64Coin("uosmo", 25_000),
-		//		sdk.NewInt64Coin("uatom", 25_000),
-		//	),
-		//},
-		//{
-		//	// For uosmos and uatom
-		//	// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 25,000 uatom
-		//	// then we perfrom single asset deposit for the remaining 25,000 uatom with the equation below
-		//	// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
-		//	// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-		//	// 1_249_999_960_937 = 100 * 10^18 * (( 1 + (25000 * 1 / 1000000025000))^0.5 - 1) (without fee)
-		//	//
-		//	// where:
-		//	// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
-		//	//	A_t = amount of deposited asset = 25,000
-		//	//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
-		//	//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
-		//	// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
-		//	// Plugging all of this in, we get:
-		//	// 	Full Solution without fees: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+++%2825000+*+%281%29+%2F+1000000025000%29%29%5E0.5+-+1%29
-		//	// 	Simplified:  P_issued = 2_500_000_000_000 + 1_249_999_960_937
-		//
-		//	name:    "Multi-tokens In: unequal amounts, equal weights with 0 swap fee",
-		//	swapFee: sdk.ZeroDec(),
-		//	poolAssets: []balancer.PoolAsset{
-		//		{
-		//			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-		//			Weight: sdk.NewInt(100),
-		//		},
-		//		{
-		//			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-		//			Weight: sdk.NewInt(100),
-		//		},
-		//	},
-		//	tokensIn: sdk.NewCoins(
-		//		sdk.NewInt64Coin("uosmo", 25_000),
-		//		sdk.NewInt64Coin("uatom", 50_000),
-		//	),
-		//
-		//	expectShares: sdk.NewInt(2.5e12 + 1249999960937),
-		//	expectLiq: sdk.NewCoins(
-		//		sdk.NewInt64Coin("uosmo", 25_000),
-		//		sdk.NewInt64Coin("uatom", 50_000),
-		//	),
-		//},
-		// {
-		// 	// For uosmos and uatom
-		// 	// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 25,000 uatom
-		// 	// then we perfrom single asset deposit for the remaining 25,000 uatom with the equation below
-		// 	// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
-		// 	// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-		// 	// 1_243_750_000_000 = 100 * 10^18 *  (( 1 + (25000 * (1 - (1 - 0.5) * 0.01) / 1000000025000))^0.5 - 1)
-		// 	//
-		// 	// where:
-		// 	// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
-		// 	//	A_t = amount of deposited asset = 50,000
-		// 	//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
-		// 	//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
-		// 	// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
-		// 	// Plugging all of this in, we get:
-		// 	// 	Full solution with fees: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%282500*%281+-+%281-0.5%29+*+0.01%29%2F1000000000000%29%29%5E0.5+-+1%29
-		// 	// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
-
-		// 	name:    "Multi-tokens In: unequal amounts, equal weights with 0.01 swap fee",
-		// 	swapFee: sdk.MustNewDecFromStr("0.01"),
-		// 	poolAssets: []balancer.PoolAsset{
-		// 		{
-		// 			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-		// 			Weight: sdk.NewInt(100),
-		// 		},
-		// 		{
-		// 			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-		// 			Weight: sdk.NewInt(100),
-		// 		},
-		// 	},
-		// 	tokensIn: sdk.NewCoins(
-		// 		sdk.NewInt64Coin("uosmo", 25_000),
-		// 		sdk.NewInt64Coin("uatom", 50_000),
-		// 	),
-
-		// 	expectShares: sdk.NewInt(2.5e12 + 1243750000000),
-		// 	expectLiq: sdk.NewCoins(
-		// 		sdk.NewInt64Coin("uosmo", 25_000),
-		// 		sdk.NewInt64Coin("uatom", 50_000),
-		// 	),
-		// },
 		{
-			// For uosmo:
-			//
-			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 12,500 uatom
-			// then we perfrom single asset deposit for the remaining 37,500 uatom with the equation below
+			name:    "swap equal weights with zero swap fee",
+			swapFee: sdk.MustNewDecFromStr("0"),
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+			tokensIn: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 25_000),
+			),
+			// Raises liquidity perfectly by 25_000 / 1_000_000_000_000.
+			// Initial number of pool shares = 100 * 10**18 = 10**20
+			// Expected increase = liquidity_increase_ratio * initial number of pool shares = (25_000 / 1_000_000_000_000) * 10**20 = 2500000000000.0 = 2.5 * 10**12
+			expectShares: sdk.NewInt(2.5e12),
+			expectLiq: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 25_000),
+			),
+		},
+		{
+			name:    "swap equal weights with 0.001 swap fee",
+			swapFee: sdk.MustNewDecFromStr("0.001"),
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+			tokensIn: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 25_000),
+			),
+			expectShares: sdk.NewInt(2500000000000),
+			expectLiq: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 25_000),
+			),
+		},
+		{
+			// For uosmos and uatom
+			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 25,000 uatom
+			// then we perfrom single asset deposit for the remaining 25,000 uatom with the equation below
 			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
 			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-			// 1_243_750_000_000 = 100 * 10^18 *  (( 1 + (37500 * (1 - (1 - 0.5) * 0.01) / 1000000025000))^0.5 - 1)
+			// 1_249_999_960_937 = 100 * 10^18 * (( 1 + (25000 * 1 / 1000000025000))^0.5 - 1) (without fee)
+			//
+			// where:
+			// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
+			//	A_t = amount of deposited asset = 25,000
+			//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
+			//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
+			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
+			// Plugging all of this in, we get:
+			// 	Full Solution without fees: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+++%2825000+*+%281%29+%2F+1000000025000%29%29%5E0.5+-+1%29
+			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_249_999_960_937
+
+			name:    "Multi-tokens In: unequal amounts, equal weights with 0 swap fee",
+			swapFee: sdk.ZeroDec(),
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+			tokensIn: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 50_000),
+			),
+
+			expectShares: sdk.NewInt(2.5e12 + 1249999960937),
+			expectLiq: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 50_000),
+			),
+		},
+		{
+			// For uosmos and uatom
+			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 25,000 uatom
+			// then we perfrom single asset deposit for the remaining 25,000 uatom with the equation below
+			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
+			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
+			// 1_243_750_000_000 = 100 * 10^18 *  (( 1 + (25000 * (1 - (1 - 0.5) * 0.01) / 1000000025000))^0.5 - 1)
 			//
 			// where:
 			// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
@@ -782,6 +740,48 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
 			// Plugging all of this in, we get:
 			// 	Full solution with fees: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%282500*%281+-+%281-0.5%29+*+0.01%29%2F1000000000000%29%29%5E0.5+-+1%29
+			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
+
+			name:    "Multi-tokens In: unequal amounts, equal weights with 0.01 swap fee",
+			swapFee: sdk.MustNewDecFromStr("0.01"),
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+			tokensIn: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 50_000),
+			),
+
+			expectShares: sdk.NewInt(2.5e12 + 1243750000000),
+			expectLiq: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 50_000),
+			),
+		},
+		{
+			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 12,500 uatom
+			// then we perfrom single asset deposit for the remaining 37,500 uatom with the equation below
+			//
+			// For uatom:
+			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
+			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
+			// 615_624_990_000 = (100 * 10^18 + 1,250,000,000,000) *  (( 1 + (37,500 * (1 - (1 - 1/6) * 0.03) / 10,000,00,025,000))^1/6 - 1)
+			//
+			// where:
+			// 	P_supply = initial pool supply = 100 * 10^18 + 1_250_000_000_000 (from first join pool)
+			//	A_t = amount of deposited asset = 37,500
+			//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
+			//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
+			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
+			// Plugging all of this in, we get:
+			// 	Full solution with fees: https://www.wolframalpha.com/input?i=%28100+*10%5E18%2B+1250000000000%29*%28%281++%2B+%2837500*%281+-+%281-1%2F6%29+*+0.03%29%2F1000000012500%29%29%5E%281%2F6%29+-+1%29
 			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
 			name:    "Multi-tokens In: unequal amounts, with unequal weights with 0.03 swap fee",
 			swapFee: sdk.MustNewDecFromStr("0.03"),

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -744,6 +744,16 @@ func TestCalcSingleAssetInAndOut_InverseRelationship(t *testing.T) {
 }
 
 func TestCalcJoinPoolShares(t *testing.T) {
+	oneTrillionEvenPoolAssets := []balancer.PoolAsset{
+		{
+			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+			Weight: sdk.NewInt(100),
+		},
+		{
+			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+			Weight: sdk.NewInt(100),
+		},
+	}
 	// We append shared calcSingleAssetJoinTestCases with multi-asset and edge
 	// test cases.
 	//
@@ -751,18 +761,9 @@ func TestCalcJoinPoolShares(t *testing.T) {
 	// sharing is needed.
 	testCases := []calcJoinSharesTestCase{
 		{
-			name:    "swap equal weights with zero swap fee",
-			swapFee: sdk.MustNewDecFromStr("0"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
+			name:       "swap equal weights with zero swap fee",
+			swapFee:    sdk.MustNewDecFromStr("0"),
+			poolAssets: oneTrillionEvenPoolAssets,
 			tokensIn: sdk.NewCoins(
 				sdk.NewInt64Coin("uosmo", 25_000),
 				sdk.NewInt64Coin("uatom", 25_000),
@@ -777,18 +778,9 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			),
 		},
 		{
-			name:    "swap equal weights with 0.001 swap fee",
-			swapFee: sdk.MustNewDecFromStr("0.001"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
+			name:       "swap equal weights with 0.001 swap fee",
+			swapFee:    sdk.MustNewDecFromStr("0.001"),
+			poolAssets: oneTrillionEvenPoolAssets,
 			tokensIn: sdk.NewCoins(
 				sdk.NewInt64Coin("uosmo", 25_000),
 				sdk.NewInt64Coin("uatom", 25_000),
@@ -817,18 +809,9 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			// 	Full Solution without fees: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+++%2825000+*+%281%29+%2F+1000000025000%29%29%5E0.5+-+1%29
 			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_249_999_960_937
 
-			name:    "Multi-tokens In: unequal amounts, equal weights with 0 swap fee",
-			swapFee: sdk.ZeroDec(),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
+			name:       "Multi-tokens In: unequal amounts, equal weights with 0 swap fee",
+			swapFee:    sdk.ZeroDec(),
+			poolAssets: oneTrillionEvenPoolAssets,
 			tokensIn: sdk.NewCoins(
 				sdk.NewInt64Coin("uosmo", 25_000),
 				sdk.NewInt64Coin("uatom", 50_000),
@@ -850,32 +833,23 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			//
 			// where:
 			// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
-			//	A_t = amount of deposited asset = 50,000
+			//	A_t = amount of deposited asset = 25,000
 			//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
 			//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
 			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
 			// Plugging all of this in, we get:
-			// 	Full solution with fees: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%282500*%281+-+%281-0.5%29+*+0.01%29%2F1000000000000%29%29%5E0.5+-+1%29
+			// 	Full solution with fees: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%2825000*%281+-+%281-0.5%29+*+0.01%29%2F1000000000000%29%29%5E0.5+-+1%29
 			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
 
-			name:    "Multi-tokens In: unequal amounts, equal weights with 0.01 swap fee",
-			swapFee: sdk.MustNewDecFromStr("0.01"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
+			name:       "Multi-tokens In: unequal amounts, equal weights with 0.01 swap fee",
+			swapFee:    sdk.MustNewDecFromStr("0.01"),
+			poolAssets: oneTrillionEvenPoolAssets,
 			tokensIn: sdk.NewCoins(
 				sdk.NewInt64Coin("uosmo", 25_000),
 				sdk.NewInt64Coin("uatom", 50_000),
 			),
 
-			expectShares: sdk.NewInt(2.5e12 + 1243750000000),
+			expectShares: sdk.NewInt(2.5e12 + 1243749900000),
 			expectLiq: sdk.NewCoins(
 				sdk.NewInt64Coin("uosmo", 25_000),
 				sdk.NewInt64Coin("uatom", 50_000),

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -772,7 +772,7 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			// For uatom:
 			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
 			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-			// 615_624_990_000 = (100 * 10^18 + 1,250,000,000,000) *  (( 1 + (37,500 * (1 - (1 - 1/6) * 0.03) / 10,000,00,025,000))^1/6 - 1)
+			// 609,374,990,000 = (100 * 10^18 + 1,250,000,000,000) *  (( 1 + (37,500 * (1 - (1 - 1/6) * 0.03) / 10,000,00,025,000))^1/6 - 1)
 			//
 			// where:
 			// 	P_supply = initial pool supply = 100 * 10^18 + 1_250_000_000_000 (from first join pool)
@@ -781,8 +781,8 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
 			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
 			// Plugging all of this in, we get:
-			// 	Full solution with fees: https://www.wolframalpha.com/input?i=%28100+*10%5E18%2B+1250000000000%29*%28%281++%2B+%2837500*%281+-+%281-1%2F6%29+*+0.03%29%2F1000000012500%29%29%5E%281%2F6%29+-+1%29
-			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
+			// 	Full solution with fees: https://www.wolframalpha.com/input?i=%28100+*10%5E18+%2B+1250000000000%29*%28%281%2B++++%2837500*%281+-+%281-1%2F6%29+*+0.03%29%2F1000000012500%29%29%5E%281%2F6%29+-+1%29
+			// 	Simplified:  P_issued = 1,250,000,000,000 + 609,374,990,000
 			name:    "Multi-tokens In: unequal amounts, with unequal weights with 0.03 swap fee",
 			swapFee: sdk.MustNewDecFromStr("0.03"),
 			poolAssets: []balancer.PoolAsset{

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -634,135 +634,155 @@ func TestCalcJoinPoolShares(t *testing.T) {
 	// See calcJoinSharesTestCase struct definition for explanation why the
 	// sharing is needed.
 	testCases := []calcJoinSharesTestCase{
+		//{
+		//	name:    "swap equal weights with zero swap fee",
+		//	swapFee: sdk.MustNewDecFromStr("0"),
+		//	poolAssets: []balancer.PoolAsset{
+		//		{
+		//			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+		//			Weight: sdk.NewInt(100),
+		//		},
+		//		{
+		//			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+		//			Weight: sdk.NewInt(100),
+		//		},
+		//	},
+		//	tokensIn: sdk.NewCoins(
+		//		sdk.NewInt64Coin("uosmo", 25_000),
+		//		sdk.NewInt64Coin("uatom", 25_000),
+		//	),
+		//	// Raises liquidity perfectly by 25_000 / 1_000_000_000_000.
+		//	// Initial number of pool shares = 100 * 10**18 = 10**20
+		//	// Expected increase = liquidity_increase_ratio * initial number of pool shares = (25_000 / 1_000_000_000_000) * 10**20 = 2500000000000.0 = 2.5 * 10**12
+		//	expectShares: sdk.NewInt(2.5e12),
+		//	expectLiq: sdk.NewCoins(
+		//		sdk.NewInt64Coin("uosmo", 25_000),
+		//		sdk.NewInt64Coin("uatom", 25_000),
+		//	),
+		//},
+		//{
+		//	name:    "swap equal weights with 0.001 swap fee",
+		//	swapFee: sdk.MustNewDecFromStr("0.001"),
+		//	poolAssets: []balancer.PoolAsset{
+		//		{
+		//			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+		//			Weight: sdk.NewInt(100),
+		//		},
+		//		{
+		//			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+		//			Weight: sdk.NewInt(100),
+		//		},
+		//	},
+		//	tokensIn: sdk.NewCoins(
+		//		sdk.NewInt64Coin("uosmo", 25_000),
+		//		sdk.NewInt64Coin("uatom", 25_000),
+		//	),
+		//	expectShares: sdk.NewInt(2500000000000),
+		//	expectLiq: sdk.NewCoins(
+		//		sdk.NewInt64Coin("uosmo", 25_000),
+		//		sdk.NewInt64Coin("uatom", 25_000),
+		//	),
+		//},
+		//{
+		//	// For uosmos and uatom
+		//	// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 25,000 uatom
+		//	// then we perfrom single asset deposit for the remaining 25,000 uatom with the equation below
+		//	// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
+		//	// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
+		//	// 1_249_999_960_937 = 100 * 10^18 * (( 1 + (25000 * 1 / 1000000025000))^0.5 - 1) (without fee)
+		//	//
+		//	// where:
+		//	// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
+		//	//	A_t = amount of deposited asset = 25,000
+		//	//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
+		//	//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
+		//	// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
+		//	// Plugging all of this in, we get:
+		//	// 	Full Solution without fees: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+++%2825000+*+%281%29+%2F+1000000025000%29%29%5E0.5+-+1%29
+		//	// 	Simplified:  P_issued = 2_500_000_000_000 + 1_249_999_960_937
+		//
+		//	name:    "Multi-tokens In: unequal amounts, equal weights with 0 swap fee",
+		//	swapFee: sdk.ZeroDec(),
+		//	poolAssets: []balancer.PoolAsset{
+		//		{
+		//			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+		//			Weight: sdk.NewInt(100),
+		//		},
+		//		{
+		//			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+		//			Weight: sdk.NewInt(100),
+		//		},
+		//	},
+		//	tokensIn: sdk.NewCoins(
+		//		sdk.NewInt64Coin("uosmo", 25_000),
+		//		sdk.NewInt64Coin("uatom", 50_000),
+		//	),
+		//
+		//	expectShares: sdk.NewInt(2.5e12 + 1249999960937),
+		//	expectLiq: sdk.NewCoins(
+		//		sdk.NewInt64Coin("uosmo", 25_000),
+		//		sdk.NewInt64Coin("uatom", 50_000),
+		//	),
+		//},
+		// {
+		// 	// For uosmos and uatom
+		// 	// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 25,000 uatom
+		// 	// then we perfrom single asset deposit for the remaining 25,000 uatom with the equation below
+		// 	// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
+		// 	// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
+		// 	// 1_243_750_000_000 = 100 * 10^18 *  (( 1 + (25000 * (1 - (1 - 0.5) * 0.01) / 1000000025000))^0.5 - 1)
+		// 	//
+		// 	// where:
+		// 	// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
+		// 	//	A_t = amount of deposited asset = 50,000
+		// 	//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
+		// 	//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
+		// 	// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
+		// 	// Plugging all of this in, we get:
+		// 	// 	Full solution with fees: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%282500*%281+-+%281-0.5%29+*+0.01%29%2F1000000000000%29%29%5E0.5+-+1%29
+		// 	// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
+
+		// 	name:    "Multi-tokens In: unequal amounts, equal weights with 0.01 swap fee",
+		// 	swapFee: sdk.MustNewDecFromStr("0.01"),
+		// 	poolAssets: []balancer.PoolAsset{
+		// 		{
+		// 			Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+		// 			Weight: sdk.NewInt(100),
+		// 		},
+		// 		{
+		// 			Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+		// 			Weight: sdk.NewInt(100),
+		// 		},
+		// 	},
+		// 	tokensIn: sdk.NewCoins(
+		// 		sdk.NewInt64Coin("uosmo", 25_000),
+		// 		sdk.NewInt64Coin("uatom", 50_000),
+		// 	),
+
+		// 	expectShares: sdk.NewInt(2.5e12 + 1243750000000),
+		// 	expectLiq: sdk.NewCoins(
+		// 		sdk.NewInt64Coin("uosmo", 25_000),
+		// 		sdk.NewInt64Coin("uatom", 50_000),
+		// 	),
+		// },
 		{
-			name:    "swap equal weights with zero swap fee",
-			swapFee: sdk.MustNewDecFromStr("0"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
-			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 25_000),
-				sdk.NewInt64Coin("uatom", 25_000),
-			),
-			// Raises liquidity perfectly by 25_000 / 1_000_000_000_000.
-			// Initial number of pool shares = 100 * 10**18 = 10**20
-			// Expected increase = liquidity_increase_ratio * initial number of pool shares = (25_000 / 1_000_000_000_000) * 10**20 = 2500000000000.0 = 2.5 * 10**12
-			expectShares: sdk.NewInt(2.5e12),
-			expectLiq: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 25_000),
-				sdk.NewInt64Coin("uatom", 25_000),
-			),
-		},
-		{
-			name:    "swap equal weights with 0.001 swap fee",
-			swapFee: sdk.MustNewDecFromStr("0.001"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
-			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 25_000),
-				sdk.NewInt64Coin("uatom", 25_000),
-			),
-			expectShares: sdk.NewInt(2500000000000),
-			expectLiq: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 25_000),
-				sdk.NewInt64Coin("uatom", 25_000),
-			),
-		},
-		{
-			// For uosmos and uatom
+			// For uosmo:
+			//
+			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 12,500 uatom
+			// then we perfrom single asset deposit for the remaining 37,500 uatom with the equation below
 			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
 			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-			// 625_000_000_000 = 100 * 10^18 * (( 1 + (25000 * (1 - (1 - 0.5)) / 1000000000000))^0.5 - 1) (without fee)
-			// 621_874_980_000 = 100 * 10^18 *  (( 1 + (12500 * (1 - (1 - 0.5) * 0.01) / 1000000025000))^0.5 - 1)  (with fee)
+			// 1_243_750_000_000 = 100 * 10^18 *  (( 1 + (37500 * (1 - (1 - 0.5) * 0.01) / 1000000025000))^0.5 - 1)
 			//
 			// where:
 			// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
 			//	A_t = amount of deposited asset = 50,000
-			//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,000,000
+			//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,025,000
 			//	W_t = normalized weight of deposited asset in pool = 0.5 (equally weighted two-asset pool)
 			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
 			// Plugging all of this in, we get:
 			// 	Full solution with fees: https://www.wolframalpha.com/input?i=100+*10%5E18*%28%281+%2B+%282500*%281+-+%281-0.5%29+*+0.01%29%2F1000000000000%29%29%5E0.5+-+1%29
-			// 	Full Solution without fees: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+%2825000+*+%281+-+%281+-+0.5%29%29+%2F+1000000000000%29%29%5E0.5+-+1%29
-			// 	Simplified:  P_issued = 625_000_000_000 * 2 + 621_874_980_000 * 2
-
-			name:    "Multi-tokens In: unequal amounts, equal weights with 0.01 swap fee",
-			swapFee: sdk.MustNewDecFromStr("0.01"),
-			poolAssets: []balancer.PoolAsset{
-				{
-					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-				{
-					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
-					Weight: sdk.NewInt(100),
-				},
-			},
-			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 25_000),
-				sdk.NewInt64Coin("uatom", 50_000),
-			),
-
-			expectShares: sdk.NewInt((625_000_000_000 * 2) + (621_874_980_000 * 2)),
-			expectLiq: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 25_000),
-				sdk.NewInt64Coin("uatom", 50_000),
-			),
-		},
-		{
-			// For uosmo:
-			//
-			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
-			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-			//
-			// 1_722_250_000_000_000 = 100 * 10^18 * (( 1 + (50_000 * (1 - (1 - 0.83)) / 2_000_000_000))^0.83 - 1) (without swap Fee)
-			// 1_032_180_000_000_000 = 100 * 10^18 * (( 1 + (25_000 * (1 - (1 - 0.83) * 0.03) / 2_000_050_000))^0.83 - 1) (with swap fee)
-			//
-			// where:
-			// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
-			//	A_t = amount of deposited asset = 50,000
-			//	B_t = existing balance of deposited asset in the pool prior to deposit = 2_000_000_000
-			//	W_t = normalized weight of deposited asset in pool = 500 / 500 + 100 = 0.83
-			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
-			// Plugging all of this in, we get:
-			//  Full Solution without Swap Fee: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+%2850000+*+%281+-+%281+-+0.83%29%29+%2F+2000000000%29%29%5E0.83+-+1%29
-			// 	Full solution with Swap Fee: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+%2825000+*+%281+-+%281+-+0.83%29+*+0.03%29+%2F+2000050000%29%29%5E0.83+-+1%29
-			// 	Simplified:  P_issued = 1_722_250_000_000_000 + 1_032_180_000_000_000
-			//
-			//
-			// For uatom:
-			//
-			// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
-			// P_issued = P_supply * ((1 + (A_t * swapFeeRatio  / B_t))^W_t - 1)
-			//
-			// 139_445_000_000 = 100 * 10^18 * (( 1 + (50_000 * (1 - (1 - 0.167)) / 1_000_000_000_000))^0.167 - 1) (without swap Fee)
-			// 407_067_000_000 = 100 * 10^18 * (( 1 + (25_000 * (1 - (1 - 0.167) * 0.03) / 1_000_000_050_000))^0.167 - 1) (with swap fee)
-			//
-			// where:
-			// 	P_supply = initial pool supply = 100 * 10^18 (set at pool creation, same for all new pools)
-			//	A_t = amount of deposited asset = 50,000
-			//	B_t = existing balance of deposited asset in the pool prior to deposit = 1,000,000,000,000
-			//	W_t = normalized weight of deposited asset in pool = 100 / 500 + 100 = 0.167
-			// 	swapFeeRatio = (1 - (1 - W_t) * swapFee)
-			// Plugging all of this in, we get:
-			//  Full Solution without fee: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+%2850000+*+%281+-+%281+-+0.167%29%29+%2F+1000000000000%29%29%5E0.167+-+1%29
-			// 	Full solution with Fee: https://www.wolframalpha.com/input?i=100+*+10%5E18+*+%28%28+1+%2B+%2825000+*+%281+-+%281+-+0.167%29+*+0.03%29+%2F+1000000050000%29%29%5E0.167+-+1%29
-			// 	Simplified:  P_issued = 139_445_000_000 + 407_067_000_000
+			// 	Simplified:  P_issued = 2_500_000_000_000 + 1_243_750_000_000
 			name:    "Multi-tokens In: unequal amounts, with unequal weights with 0.03 swap fee",
 			swapFee: sdk.MustNewDecFromStr("0.03"),
 			poolAssets: []balancer.PoolAsset{
@@ -776,14 +796,14 @@ func TestCalcJoinPoolShares(t *testing.T) {
 				},
 			},
 			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 50_000),
-				sdk.NewInt64Coin("uatom", 100_000),
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 50_000),
 			),
 
-			expectShares: sdk.NewInt(1_722_250_000_000_000 + 1_032_180_000_000_000 + 139_445_000_000 + 407_067_000_000),
+			expectShares: sdk.NewInt(1250000000000 + 615624990000),
 			expectLiq: sdk.NewCoins(
-				sdk.NewInt64Coin("uosmo", 50_000),
-				sdk.NewInt64Coin("uatom", 100_000),
+				sdk.NewInt64Coin("uosmo", 25_000),
+				sdk.NewInt64Coin("uatom", 50_000),
 			),
 		},
 	}

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -317,7 +317,7 @@ var calcSingleAssetJoinTestCases = []calcJoinSharesTestCase{
 		// 156_736 * 3 / 4 = 117552
 		tokensIn:     sdk.NewCoins(sdk.NewInt64Coin("uosmo", (156_736*3)/4)),
 		expectShares: sdk.NewIntFromUint64(9_775_731_930_496_140_648),
-		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", (156_736*3) / 4)),
+		expectLiq:    sdk.NewCoins(sdk.NewInt64Coin("uosmo", (156_736*3)/4)),
 	},
 	{
 		// Expected output from Balancer paper (https://balancer.fi/whitepaper.pdf) using equation (25) on page 10:
@@ -882,7 +882,8 @@ func TestCalcJoinPoolShares(t *testing.T) {
 			),
 		},
 		{
-			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 12,500 uatom
+			// join pool is first done to the extent where the ratio can be preserved, which is 25,000 uosmo and 12,500 uatom.
+			// the minimal total share resulted here would be 1,250,000,000,000 =  2500 / 2,000,000,000,000 * 100,000,000,000,000,000,000
 			// then we perfrom single asset deposit for the remaining 37,500 uatom with the equation below
 			//
 			// For uatom:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Adds tests for join pool for non even ratio assets, so that the tests hit the side where even join is done to the maximal amount able to, and then do a single pool join for the remaining coins. 

All the results used within this test codes are hand derived, attached in comment the calculations done via wolfram


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)