### PR TITLE
[Fix] Breaking superfluid docs image patch

### DIFF
--- a/x/superfluid/spec/README.md
+++ b/x/superfluid/spec/README.md
@@ -92,19 +92,15 @@ instant undelegations and immediately burn the OSMO. If less, we mint
 OSMO and update the amount delegated. A simplified diagram of this whole
 process is found below:
 
-`<br/>`{=html}
+<br/>
 
-```{=html}
 <p style="text-align:center;">
-```
 
-`<img src="https://raw.githubusercontent.com/osmosis-labs/osmosis/main/x/superfluid/spec/superfluiddiagram.png" height="300"/>`{=html}
+<img src="https://raw.githubusercontent.com/osmosis-labs/osmosis/main/x/superfluid/spec/superfluiddiagram.png" height="300"/>
 
-```{=html}
 </p>
-```
 
-`</br>`{=html}
+</br>
 
 This minting is safe because we strict constrain the permissions of Bank
 (the module that burns and mints OSMO) to do what it's designed to do.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently, there is a large chunk of the superfluid staking docs that are broken. Fixing this.

*(E.g.: This pull request improves documation of area A by adding ....*


## Brief Changelog

Fixed issues relating to a diagram not getting displayed in the superfluid docs


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

**This change is already covered by existing tests, such as porting the page to docs repo and building via yarn dev.**

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)