### PR TITLE
Chain JSON Schema

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "git_repo": "https://github.com/osmosis-labs/osmosis",
+  "recommended_version": "v10.0.0",
+  "compatible_version": ["v10.0.0"],
+  "binaries": {
+    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-amd64",
+    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-arm64"
+  }
+}


### PR DESCRIPTION
Closes: Based on [#425](https://github.com/cosmos/chain-registry/issues/425)

## What is the purpose of the change

We shouldn't be manually updating the chain registry repo with a PR for every release we do.

This PR adds a chain JSON schema, which will soon have a bot that will automatically update the chain registry repo.

## Brief Changelog
 
Added a chain JSON schema that will have a bot to automatically update the cosmos chain registry.

The chain repo's schema file maintains

```
    "git_repo": "https://github.com/osmosis-labs/osmosis",
    "recommended_version": "v10.0.0",
    "compatible_versions": ["v10.0.0"],
    "binaries": {
      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-amd64",
      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-arm64"
```

In the future, perhaps we add more items.

## Testing and Verifying

**This change is a trivial rework / code cleanup without any test coverage.**

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / **no**)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / **no**)
  - How is the feature or change documented? (**not applicable**   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)