### PR TITLE
Make dependabot ignore non-patch IBC-go versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,7 @@ updates:
   ignore:
     - dependency-name: "github.com/tendermint/tendermint"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  ignore:
+    - dependency-name: "github.com/cosmos/ibc-go"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Make dependabot ignore non-patch ibc-go changes, as minor changes are state breaking, and need more deliberation.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? Not applicable