### PR TITLE
Replace join, exit pool invariant test with quick check

### DIFF
--- a/x/gamm/pool-models/balancer/amm_joinpool_test.go
+++ b/x/gamm/pool-models/balancer/amm_joinpool_test.go
@@ -1100,15 +1100,16 @@ func (suite *KeeperTestSuite) TestRandomizedJoinPoolExitPoolInvariants() {
 	swapFeeDec := sdk.ZeroDec()
 	exitFeeDec := sdk.ZeroDec()
 
-	inverse := func(tokenDenomIn, tokenDenomOut, percentRatio int64) bool {
+	inverse := func(tokenDenomIn, tokenDenomOut, percentRatio uint64) bool {
 		percentRatio = percentRatio%100 + 1
+
 		// first create pool
 		poolAssetOut := balancer.PoolAsset{
-			Token:  sdk.NewInt64Coin(denomOut, tokenDenomOut),
+			Token:  sdk.NewCoin(denomOut, sdk.NewIntFromUint64(tokenDenomIn)),
 			Weight: sdk.NewInt(5),
 		}
 		poolAssetIn := balancer.PoolAsset{
-			Token:  sdk.NewInt64Coin(denomIn, tokenDenomIn),
+			Token:  sdk.NewCoin(denomIn, sdk.NewIntFromUint64(tokenDenomOut)),
 			Weight: sdk.NewInt(5),
 		}
 
@@ -1117,9 +1118,10 @@ func (suite *KeeperTestSuite) TestRandomizedJoinPoolExitPoolInvariants() {
 		originalCoins, originalShares := pool.GetTotalPoolLiquidity(sdk.Context{}), pool.GetTotalShares()
 
 		tokensIn := sdk.Coins{
-			sdk.NewCoin(denomIn, sdk.NewInt(tokenDenomIn).MulRaw(percentRatio).QuoRaw(100)),
-			sdk.NewCoin(denomOut, sdk.NewInt(tokenDenomOut).MulRaw(percentRatio).QuoRaw(100)),
+			sdk.NewCoin(denomIn, sdk.NewIntFromUint64(tokenDenomIn).MulRaw(int64(percentRatio)).QuoRaw(100)),
+			sdk.NewCoin(denomOut, sdk.NewIntFromUint64(tokenDenomOut).MulRaw(int64(percentRatio)).QuoRaw(100)),
 		}
+
 		numShares, err := pool.JoinPool(suite.Ctx, tokensIn, swapFeeDec)
 		suite.Require().NoError(err)
 
@@ -1129,6 +1131,7 @@ func (suite *KeeperTestSuite) TestRandomizedJoinPoolExitPoolInvariants() {
 		if originalCoins.IsAnyGT(pool.GetTotalPoolLiquidity(sdk.Context{})) || !originalShares.Equal(pool.GetTotalShares()) {
 			return false
 		}
+
 		return true
 	}
 	err := quick.Check(inverse, nil)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

This is an attempt to use quick check introduced in https://github.com/osmosis-labs/osmosis/issues/1818 to test invariants for joining pool and exit pool. Better ways to adopt and utilize quick.Config are to be revisited.

Further implementations of quick check to replace existing invariant methods are to be introduced as well, soon after we get this initial usage of quick check reviewed upon and merged. 


## Brief Changelog
- Replace join pool, exit pool invariant testing with quick check

## Testing and Verifying

Existing testings have been replaced.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)