### PR TITLE
feat: Swap Fees Paid Contribute to Tx Fee for Sybil Resistant Fees

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -93,3 +93,24 @@ func (suite *KeeperTestHelper) PrepareBalancerPoolWithPoolAsset(assets []balance
 	suite.NoError(err)
 	return poolId
 }
+
+func (suite *KeeperTestHelper) PrepareBalancerPoolWithSwapFee() uint64 {
+	poolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+		SwapFee: sdk.MustNewDecFromStr("0.001"),
+		ExitFee: sdk.NewDec(0),
+	})
+
+	spotPrice, err := suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "foo", "bar")
+	suite.NoError(err)
+	suite.Equal(sdk.NewDec(2).String(), spotPrice.String())
+	spotPrice, err = suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "bar", "baz")
+	suite.NoError(err)
+	suite.Equal(sdk.NewDecWithPrec(15, 1).String(), spotPrice.String())
+	spotPrice, err = suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "baz", "foo")
+	suite.NoError(err)
+	s := sdk.NewDec(1).Quo(sdk.NewDec(3))
+	sp := s.MulInt(gammtypes.SigFigs).RoundInt().ToDec().QuoInt(gammtypes.SigFigs)
+	suite.Equal(sp.String(), spotPrice.String())
+
+	return poolId
+}

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -31,6 +31,15 @@ func (k Keeper) SwapExactAmountIn(
 	return k.swapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
 }
 
+func (k Keeper) GetSwapFeeFromPoolId(ctx sdk.Context, poolId uint64) (sdk.Dec, error) {
+	pool, err := k.getPoolForSwap(ctx, poolId)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	swapFee := pool.GetSwapFee(ctx)
+	return swapFee, nil
+}
+
 // swapExactAmountIn is an internal method for swapping an exact amount of tokens
 // as input to a pool, using the provided swapFee. This is intended to allow
 // different swap fees as determined by multi-hops, or when recovering from

--- a/x/gamm/keeper/swap_test.go
+++ b/x/gamm/keeper/swap_test.go
@@ -83,6 +83,7 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountIn() {
 		// Init suite for each test.
 		suite.SetupTest()
 		poolId := suite.PrepareBalancerPool()
+		poolIdWithSwap := suite.PrepareBalancerPoolWithSwapFee()
 		keeper := suite.App.GAMMKeeper
 
 		if test.expectPass {
@@ -99,6 +100,12 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountIn() {
 			// Ratio of the token out should be between the before spot price and after spot price.
 			tradeAvgPrice := test.param.tokenIn.Amount.ToDec().Quo(tokenOutAmount.ToDec())
 			suite.True(tradeAvgPrice.GT(spotPriceBefore) && tradeAvgPrice.LT(spotPriceAfter), "test: %v", test.name)
+
+			// swap fee should be 0.001 for pool id with swap
+			swapFee, err := keeper.GetSwapFeeFromPoolId(suite.Ctx, poolIdWithSwap)
+			suite.NoError(err, "test: %v", test.name)
+			// PrepareBalancerPoolWithSwapFee has "0.001" hard coded for the swap fee
+			suite.Equal(sdk.MustNewDecFromStr("0.001"), swapFee, "test: %v", test.name)
 		} else {
 			_, err := keeper.SwapExactAmountIn(suite.Ctx, suite.TestAccs[0], poolId, test.param.tokenIn, test.param.tokenOutDenom, test.param.tokenOutMinAmount)
 			suite.Error(err, "test: %v", test.name)

--- a/x/gamm/types/msg_sybil.go
+++ b/x/gamm/types/msg_sybil.go
@@ -1,0 +1,97 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// SybilResistantFee Swap Msg defines an interface for getting
+// - poolIds on a swap msg route
+// - token to apply the sybil resistant fees to
+type SybilResistantFee interface {
+	GetTokenDenomsOnPath() []string
+	GetPoolIdOnPath() []uint64
+	GetTokenToFee() sdk.Coin
+}
+
+var (
+	_ SybilResistantFee = MsgSwapExactAmountOut{}
+	_ SybilResistantFee = MsgSwapExactAmountIn{}
+)
+
+// MsgSwapExactAmountOut implements SybilResistantFee
+func (msg MsgSwapExactAmountOut) GetTokenDenomsOnPath() []string {
+	if msg.Routes == nil {
+		return []string{}
+	}
+
+	if len(msg.Routes) == 0 {
+		return []string{}
+	}
+
+	denoms := make([]string, 0, len(msg.Routes)+1)
+	for i := 0; i < len(msg.Routes); i++ {
+		denoms = append(denoms, msg.Routes[i].TokenInDenom)
+	}
+
+	denoms = append(denoms, msg.TokenOutDenom())
+
+	return denoms
+}
+
+func (msg MsgSwapExactAmountOut) GetTokenToFee() sdk.Coin {
+	if msg.TokenOut.Amount.LT(sdk.ZeroInt()) {
+		return sdk.Coin{}
+	}
+
+	if _, ok := sdk.NewIntFromString(msg.TokenOut.Denom); ok == true {
+		return sdk.Coin{}
+	}
+	return msg.TokenOut
+}
+
+func (msg MsgSwapExactAmountOut) GetPoolIdOnPath() []uint64 {
+	ids := make([]uint64, 0, len(msg.Routes))
+	for i := 0; i < len(msg.Routes); i++ {
+		ids = append(ids, msg.Routes[i].PoolId)
+	}
+	return ids
+}
+
+// MsgSwapExactAmountIn implements SybilResistantFee
+
+func (msg MsgSwapExactAmountIn) GetTokenDenomsOnPath() []string {
+	if msg.Routes == nil {
+		return []string{}
+	}
+
+	if len(msg.Routes) == 0 {
+		return []string{}
+	}
+
+	denoms := make([]string, 0, len(msg.Routes)+1)
+	denoms = append(denoms, msg.TokenInDenom())
+	for i := 0; i < len(msg.Routes); i++ {
+		denoms = append(denoms, msg.Routes[i].TokenOutDenom)
+	}
+	return denoms
+}
+
+func (msg MsgSwapExactAmountIn) GetTokenToFee() sdk.Coin {
+	if msg.TokenIn.Amount.LT(sdk.ZeroInt()) {
+		return sdk.Coin{}
+	}
+
+	if _, ok := sdk.NewIntFromString(msg.TokenIn.Denom); ok == true {
+		return sdk.Coin{}
+	}
+
+	return msg.TokenIn
+}
+
+func (msg MsgSwapExactAmountIn) GetPoolIdOnPath() []uint64 {
+	ids := make([]uint64, 0, len(msg.Routes))
+	for i := 0; i < len(msg.Routes); i++ {
+		ids = append(ids, msg.Routes[i].PoolId)
+	}
+	return ids
+}

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
@@ -9,6 +11,8 @@ import (
 
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
+	appParams "github.com/osmosis-labs/osmosis/v7/app/params"
+	gammtypes "github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v7/x/txfees/keeper"
 	txKeeper "github.com/osmosis-labs/osmosis/v7/x/txfees/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/txfees/types"
@@ -364,5 +368,128 @@ func (suite *KeeperTestSuite) TestIsSufficientFee() {
 			suite.Require().Error(err, "test: %s", test.name)
 		}
 	}
+}
 
+func (suite *KeeperTestSuite) TestGetMinBaseGasPriceForTxExactAmountIn() {
+	appParams.SetAddressPrefixes()
+	pk1 := ed25519.GenPrivKey().PubKey()
+	addr1 := sdk.AccAddress(pk1.Address()).String()
+	//	invalidAddr := sdk.AccAddress("invalid")
+
+	createMsg := func(after func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+		properMsg := gammtypes.MsgSwapExactAmountIn{
+			Sender: addr1,
+			Routes: []gammtypes.SwapAmountInRoute{{
+				PoolId:        1,
+				TokenOutDenom: "test1",
+			}, {
+				PoolId:        2,
+				TokenOutDenom: "test2",
+			}},
+			TokenIn:           sdk.NewCoin("test", sdk.NewInt(100)),
+			TokenOutMinAmount: sdk.NewInt(200),
+		}
+
+		return after(properMsg)
+	}
+
+	msg := createMsg(func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+		// Do nothing
+		return msg
+	})
+
+	suite.Require().Equal(msg.Route(), gammtypes.RouterKey)
+	suite.Require().Equal(msg.Type(), "swap_exact_amount_in")
+	signersSybilFee := msg.GetSigners()
+	suite.Require().Equal(len(signersSybilFee), 1)
+	suite.Require().Equal(signersSybilFee[0].String(), addr1)
+
+	createSybil := func(after func(s txKeeper.Sybil) txKeeper.Sybil) txKeeper.Sybil {
+		properSybil := txKeeper.Sybil{
+			GasPrice: sdk.MustNewDecFromStr("1"),
+			FeesPaid: sdk.NewCoin("test", sdk.NewInt(1)),
+		}
+
+		return after(properSybil)
+	}
+
+	sybilStruct := createSybil(func(s txKeeper.Sybil) txKeeper.Sybil {
+		// do nothing
+		return s
+	})
+
+	suite.Require().Equal(sdk.MustNewDecFromStr("1"), sybilStruct.GasPrice)
+	suite.Require().Equal(sdk.NewCoin("test", sdk.NewInt(1)), sybilStruct.FeesPaid)
+
+	baseDenom, err := suite.App.TxFeesKeeper.GetBaseDenom(suite.Ctx)
+	suite.Require().NoError(err, "base denom %v error %v for test get min gas price", baseDenom, err)
+	mempoolFeeOpts := types.NewDefaultMempoolFeeOptions()
+	mempoolFeeOpts.MinGasPriceForHighGasTx = sdk.MustNewDecFromStr("0.0025")
+
+	tests := []struct {
+		name           string
+		msg            gammtypes.MsgSwapExactAmountIn
+		txFee          sdk.Coin
+		expectGasPrice sdk.Dec
+		expectFeesPaid sdk.Coin
+		gasRequested   uint64
+		expectPass     bool
+	}{
+		{
+			name: "msg does not need sybil fees",
+			msg: createMsg(func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+				// Do nothing
+				return msg
+			}),
+			txFee:          sdk.NewCoin(baseDenom, sdk.NewInt(10000)),
+			expectGasPrice: suite.Ctx.MinGasPrices().AmountOf(baseDenom),
+			expectFeesPaid: sdk.NewCoin(baseDenom, sdk.ZeroInt()),
+			expectPass:     true,
+		},
+	}
+
+	for _, test := range tests {
+		suite.SetupTest(false)
+
+		// TxBuilder components reset for every test case
+		txBuilder := suite.clientCtx.TxConfig.NewTxBuilder()
+		priv0, _, addr0 := testdata.KeyTestPubAddr()
+		acc1 := suite.App.AccountKeeper.NewAccountWithAddress(suite.Ctx, addr0)
+		suite.App.AccountKeeper.SetAccount(suite.Ctx, acc1)
+		msgs := []sdk.Msg{&test.msg}
+		privs, accNums, accSeqs := []cryptotypes.PrivKey{priv0}, []uint64{0}, []uint64{0}
+		signerData := authsigning.SignerData{
+			ChainID:       suite.Ctx.ChainID(),
+			AccountNumber: accNums[0],
+			Sequence:      accSeqs[0],
+		}
+
+		gasLimit := test.gasRequested
+		sigV2, _ := clienttx.SignWithPrivKey(
+			1,
+			signerData,
+			txBuilder,
+			privs[0],
+			suite.clientCtx.TxConfig,
+			accSeqs[0],
+		)
+
+		// build transaction with swap extern amount out msg
+		tx := suite.BuildTx(txBuilder, msgs, sigV2, "", sdk.NewCoins(test.txFee), gasLimit)
+
+		// create mempool fee decorator
+		mfd := keeper.NewMempoolFeeDecorator(*suite.App.TxFeesKeeper, mempoolFeeOpts)
+
+		// get sybil fee struct
+		sybil, err := mfd.GetMinBaseGasPriceForTx(suite.Ctx, baseDenom, tx)
+
+		// check if sybil fee struct is as expected
+		if test.expectPass {
+			suite.Require().Equal(sybil.GasPrice, test.expectGasPrice)
+			suite.Require().Equal(sybil.FeesPaid, test.expectFeesPaid)
+			suite.Require().NoError(err, "test: %s", test.name)
+		} else {
+			suite.Require().Error(err, "test: %s", test.name)
+		}
+	}
 }

--- a/x/txfees/keeper/feetokens_test.go
+++ b/x/txfees/keeper/feetokens_test.go
@@ -1,9 +1,18 @@
 package keeper_test
 
 import (
+	"time"
+
+	"github.com/tendermint/tendermint/crypto/ed25519"
+
 	"github.com/osmosis-labs/osmosis/v7/x/txfees/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	balancertypes "github.com/osmosis-labs/osmosis/v7/x/gamm/pool-models/balancer"
+	gammtypes "github.com/osmosis-labs/osmosis/v7/x/gamm/types"
+
+	appParams "github.com/osmosis-labs/osmosis/v7/app/params"
 )
 
 func (suite *KeeperTestSuite) TestBaseDenom() {
@@ -217,5 +226,164 @@ func (suite *KeeperTestSuite) TestFeeTokenConversions() {
 		} else {
 			suite.Require().Error(err, "test: %s", tc.name)
 		}
+	}
+}
+
+var (
+	defaultExitFee            = sdk.MustNewDecFromStr("0.025")
+	defaultSwapFee            = sdk.MustNewDecFromStr("0.01")
+	defaultPoolId             = uint64(10)
+	defaultFutureGovernor     = ""
+	defaultCurBlockTime       = time.Unix(1618700000, 0)
+	defaultPoolAssetAmount    = sdk.NewInt(10000000000)
+	defaultPoolWeight         = sdk.NewInt(100)
+	defaultBalancerPoolParams = balancertypes.PoolParams{
+		SwapFee: defaultSwapFee,
+		ExitFee: defaultExitFee,
+	}
+	dummyPoolAssets = []balancertypes.PoolAsset{}
+)
+
+// In order to test the GetTotalSwapFee method for exact swaps in, we need to create both a
+// MsgSwapExactAmountIn and a pool for each denom pair in the list of Routes.  (still need to consider how to handle 3+ asset pools)
+// When the pool(s) are created, we cannot change their pool Id nor create a pool with a given pool ID
+// Therefore, we must reassign the values in the msg routes to reflect the pool id's that the method
+// we are testing checks the correct, newly created pools. Once the pools have been created, the check
+// should reflect that the number of hops on the route * defaultSwapFee, is the returned total swap fee
+func (suite *KeeperTestSuite) TestGetTotalSwapFeeForSwapInBalancerPool() {
+	// check tx must be true however SetupTest does not actually use its parameter
+	suite.SetupTest(true)
+	appParams.SetAddressPrefixes()
+	pk1 := ed25519.GenPrivKey().PubKey()
+	addr1 := sdk.AccAddress(pk1.Address()).String()
+
+	//suite.SetupTokenFactory()
+
+	// define a create msg function
+	createMsg := func(after func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+		properMsg := gammtypes.MsgSwapExactAmountIn{
+			Sender: addr1,
+			Routes: []gammtypes.SwapAmountInRoute{{
+				PoolId:        1,
+				TokenOutDenom: "test1",
+			}},
+			TokenIn:           sdk.NewCoin("test0", defaultPoolAssetAmount),
+			TokenOutMinAmount: defaultPoolAssetAmount,
+		}
+
+		return after(properMsg)
+	}
+
+	// create a msg
+	msg := createMsg(func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+		// do nothing
+		return msg
+	})
+
+	// verify msg was created correctly
+	suite.Require().Equal(msg.Route(), gammtypes.RouterKey)
+	suite.Require().Equal(msg.Type(), "swap_exact_amount_in")
+	signers := msg.GetSigners()
+	suite.Require().Equal(len(signers), 1)
+	suite.Require().Equal(signers[0].String(), addr1)
+
+	// define test cases
+	tests := []struct {
+		name               string
+		msg                gammtypes.MsgSwapExactAmountIn
+		expectPass         bool
+		expectTotalSwapFee sdk.Dec
+	}{
+		{
+			name: "Single denom pair",
+			msg: createMsg(func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+				// do nothing
+				return msg
+			}),
+			expectPass: true,
+			// expect zero because test denoms are not fee tokens
+			expectTotalSwapFee: sdk.ZeroDec(),
+		},
+		{
+			name: "Two denom pairs",
+			msg: createMsg(func(msg gammtypes.MsgSwapExactAmountIn) gammtypes.MsgSwapExactAmountIn {
+				// create 3 denoms on the route
+				msg.Routes = []gammtypes.SwapAmountInRoute{{
+					PoolId:        1,
+					TokenOutDenom: "test1",
+				}, {
+					PoolId:        2,
+					TokenOutDenom: "test2",
+				}, {
+					PoolId:        3,
+					TokenOutDenom: "test3",
+				},
+				}
+
+				return msg
+			}),
+			expectPass: true,
+			// expect zero because test denoms are not fee tokens
+			expectTotalSwapFee: sdk.ZeroDec(),
+		},
+	}
+
+	for _, test := range tests {
+		// check test cases
+		if test.expectPass {
+			// get pool ids from test msg
+			poolIds := test.msg.GetPoolIdOnPath()
+			suite.Require().NotEmpty(poolIds)
+
+			// get denomPath from test msg
+			denomPath := test.msg.GetTokenDenomsOnPath()
+			suite.Require().NotEmpty(denomPath)
+
+			// check denom path is longer than pool ids by 1
+			// *** if join/exit with swap msgs are added, denomPath length must be 2
+			suite.Require().Equal(len(poolIds)+1, len(denomPath), "test: %v", test.name)
+
+			// create pools for denom pairs and update pool ids to reflect returned pool ids from creation
+			for i := range poolIds {
+				// create pool assets
+				poolAssets := make([]balancertypes.PoolAsset, 2)
+
+				poolAssets[0] = balancertypes.PoolAsset{
+					Token:  sdk.NewCoin(denomPath[i], defaultPoolAssetAmount),
+					Weight: defaultPoolWeight,
+				}
+
+				poolAssets[1] = balancertypes.PoolAsset{
+					Token:  sdk.NewCoin(denomPath[i+1], defaultPoolAssetAmount),
+					Weight: defaultPoolWeight,
+				}
+
+				// Add coins for pool creation
+				fundCoins := sdk.Coins{sdk.NewCoin(denomPath[i], defaultPoolAssetAmount)}
+				fundCoins = fundCoins.Add(poolAssets[1].Token)
+				suite.FundAcc(suite.TestAccs[0], fundCoins)
+
+				// get a msg to create a new balancer pool
+				msg := balancertypes.NewMsgCreateBalancerPool(suite.TestAccs[0], balancertypes.PoolParams{
+					SwapFee: defaultSwapFee,
+					ExitFee: sdk.ZeroDec(),
+				}, poolAssets, "")
+
+				// use msg to create balancer pool for pool assets with a swap fee
+				poolId, err := suite.App.GAMMKeeper.CreatePool(suite.Ctx, msg)
+				suite.NoError(err)
+
+				// update msg's route to reflect to actual pool ID for the newly created pool
+				test.msg.Routes[i].PoolId = poolId
+			}
+			// now that all the pools on the route have been created, we can test getTotalSwapFee
+			swapFees, err := suite.App.TxFeesKeeper.GetTotalSwapFee(suite.Ctx, poolIds, denomPath)
+			suite.Require().NoError(err, "test: %v", test.name)
+			suite.Require().Equal(test.expectTotalSwapFee, swapFees, "test: %v", test.name)
+			suite.Require().NoError(msg.ValidateBasic(), "test: %v", test)
+		} else {
+			suite.Require().Error(msg.ValidateBasic(), "test: %v", test)
+		}
+
 	}
 }

--- a/x/txfees/keeper/sybil.go
+++ b/x/txfees/keeper/sybil.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Sybil struct {
+	GasPrice sdk.Dec
+	FeesPaid sdk.Coin
+}
+
+func NewSybil(gasPrice sdk.Dec, feesPaid sdk.Coin) (Sybil, error) {
+	// check amounts are non-negative
+	if gasPrice.LT(sdk.ZeroDec()) || feesPaid.IsLT(sdk.NewCoin(feesPaid.Denom, sdk.ZeroInt())) {
+		return Sybil{}, fmt.Errorf("Cannot create new sybil with gas price %v and fees %v", gasPrice, feesPaid.Amount)
+	}
+
+	return Sybil{
+		GasPrice: gasPrice,
+		FeesPaid: feesPaid,
+	}, nil
+}
+
+func (s *Sybil) AddToFeesPaid(feesPaid sdk.Coin) error {
+	// Check same denom
+	if feesPaid.Denom != s.FeesPaid.Denom {
+		return fmt.Errorf("Cannot add %s denom to sybil's %s fees paid denom", feesPaid.Denom, s.FeesPaid.Denom)
+	}
+	// Add tokens
+	s.FeesPaid = s.FeesPaid.Add(feesPaid)
+	return nil
+}

--- a/x/txfees/keeper/sybil_test.go
+++ b/x/txfees/keeper/sybil_test.go
@@ -1,0 +1,88 @@
+package keeper_test
+
+import (
+	txKeeper "github.com/osmosis-labs/osmosis/v7/x/txfees/keeper"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (suite *KeeperTestSuite) TestSybil() {
+	suite.SetupTest(false)
+
+	createSybil := func(after func(s txKeeper.Sybil) txKeeper.Sybil) txKeeper.Sybil {
+		properSybil := txKeeper.Sybil{
+			GasPrice: sdk.MustNewDecFromStr("0.01"),
+			FeesPaid: sdk.NewCoin("test", sdk.NewInt(1)),
+		}
+
+		return after(properSybil)
+	}
+
+	sybilStruct := createSybil(func(s txKeeper.Sybil) txKeeper.Sybil {
+		// do nothing
+		return s
+	})
+
+	suite.Require().Equal(sdk.MustNewDecFromStr("0.01"), sybilStruct.GasPrice)
+	suite.Require().Equal(sdk.NewCoin("test", sdk.NewInt(1)), sybilStruct.FeesPaid)
+
+	tests := []struct {
+		name       string
+		gasPrice   sdk.Dec
+		feesPaid   sdk.Coin
+		expectPass bool
+	}{
+		{
+			name:       "proper sybil",
+			gasPrice:   sdk.MustNewDecFromStr("0.01"),
+			feesPaid:   sdk.NewCoin("test", sdk.NewInt(100)),
+			expectPass: true,
+		},
+		{
+			name:       "sybil with zero fees paid",
+			gasPrice:   sdk.MustNewDecFromStr("0.01"),
+			feesPaid:   sdk.NewCoin("test", sdk.ZeroInt()),
+			expectPass: true,
+		},
+		{
+			name:       "sybil with zeo gas price",
+			gasPrice:   sdk.ZeroDec(),
+			feesPaid:   sdk.NewCoin("test", sdk.NewInt(100)),
+			expectPass: true,
+		},
+		{
+			name:       "sybil with zero gas price and zero fees paid",
+			gasPrice:   sdk.ZeroDec(),
+			feesPaid:   sdk.NewCoin("test", sdk.ZeroInt()),
+			expectPass: true,
+		},
+		{
+			name:       "sybil with negative gas price",
+			gasPrice:   sdk.MustNewDecFromStr("-100.0"),
+			feesPaid:   sdk.NewCoin("test", sdk.NewInt(100)),
+			expectPass: false,
+		},
+	}
+
+	for _, test := range tests {
+		sybil, err := txKeeper.NewSybil(test.gasPrice, test.feesPaid)
+
+		if test.expectPass {
+			suite.Require().NoError(err, "test: %v", test.name)
+			suite.Require().Equal(test.gasPrice, sybil.GasPrice, "test: %v", test.name)
+			suite.Require().Equal(test.feesPaid, sybil.FeesPaid, "test: %v", test.name)
+
+			// store original fees paid														= x
+			fp := sybil.FeesPaid
+			// check that feesPaid can be added to by adding 100 test coin using method	 	= x + 100
+			sybil.AddToFeesPaid(sdk.NewCoin("test", sdk.NewInt(100)))
+			// check that the difference is 100		 										= 100
+			diff := sybil.FeesPaid.Sub(fp)
+			suite.Require().Equal(diff, sdk.NewCoin("test", sdk.NewInt(100)))
+
+		} else {
+			suite.Require().Error(err, "test: %v", test.name)
+		}
+	}
+
+}

--- a/x/txfees/types/expected_keepers.go
+++ b/x/txfees/types/expected_keepers.go
@@ -23,6 +23,7 @@ type GammKeeper interface {
 		tokenOutDenom string,
 		tokenOutMinAmount sdk.Int,
 	) (tokenOutAmount sdk.Int, err error)
+	GetSwapFeeFromPoolId(ctx sdk.Context, poolId uint64) (sdk.Dec, error)
 }
 
 // AccountKeeper defines the contract needed for AccountKeeper related APIs.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1139   
[Previous PR](https://github.com/osmosis-labs/osmosis/pull/1675)

## What is the purpose of the change

Swap fees paid for a msg are added to Tx fee when determining if the fee is sufficient for the gas price
- If the tx fee attached for a swap message is not sufficient to pay for gas, the swap fees paid can make up the difference
- The attached tx fee is always deducted in its entirety if it exists
- If the gas price is zero, no tx fee needs to be attached
- If the message satisfies the SybilResistantFee interface, add the swap fees paid to the sybil struct
- For all tx, add tx fee to sybil fees paid (for non-applicable msgs, feed paid = 0)
- Compare sybil fees paid to gas price when determining if a fee is sufficient

## Brief Changelog

- Add `GetSwapFee(ctx sdk.Context, poolId uint64) (sdk.Dec, error)` to `swap.go` and to the `GammKeeper` in the `expected_keepers` for the `txfees` module
- Add interface `SybilResistantFee` in a new file `msg_sybil.go` in `gamm/types/` 
- Add implement `SybilResistantFee` in all msgs involving a swap, including multihops
- Add file `sybil.go` for sybil resistant fees struct and methods
- `AnteHandle` now treats `SybilResistantFee` msgs differently when checking a fee but other msgs use the same logic as before


## Testing and Verifying

`make test`, `make test-sim`, `make test-unit` and `make build` are all successful and specific tests are being written

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)