### PR TITLE
Add docs label for any PR that edits a readme or spec folder

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,3 +40,21 @@
 "C:CLI":
   - client/**/*
   - x/*/client/**/*
+# Add "C:docs" label to documented related files and directories. 
+"C:docs":
+  - x/epochs/specs/*
+  - x/gamm/specs/*
+  - x/incentives/specs/*
+  - x/lockup/specs/*
+  - x/mint/specs/*
+  - x/pool-incentives/specs/*
+  - x/simulation/specs/*
+  - x/superfluid/specs/*
+  - x/tokenfactory/specs/*
+  - x/txfees/specs/*
+  - x/README.md
+  - README.md
+  - CHANGELOG.md
+  - bug.md
+  - issue.md
+  - proto-docs.md

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,19 +42,8 @@
   - x/*/client/**/*
 # Add "C:docs" label to documented related files and directories. 
 "C:docs":
-  - x/epochs/specs/*
-  - x/gamm/specs/*
-  - x/incentives/specs/*
-  - x/lockup/specs/*
-  - x/mint/specs/*
-  - x/pool-incentives/specs/*
-  - x/simulation/specs/*
-  - x/superfluid/specs/*
-  - x/tokenfactory/specs/*
-  - x/txfees/specs/*
-  - x/README.md
   - README.md
-  - CHANGELOG.md
-  - bug.md
-  - issue.md
-  - proto-docs.md
+  - x/**/*.md
+  - x/**/*/*.md
+  - tests/**/*.md
+  

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,6 +42,10 @@
   - x/*/client/**/*
 # Add "C:docs" label to documented related files and directories. 
 "C:docs":
+  - CHANGELOG.md
+  - bug.md
+  - issue.md
+  - proto-docs.md
   - README.md
   - x/**/*.md
   - x/**/*/*.md


### PR DESCRIPTION
Closes: #1833

## What is the purpose of the change
Add "C"docs" labels to the following:

```
  - x/epochs/specs/*
  - x/gamm/specs/*
  - x/incentives/specs/*
  - x/lockup/specs/*
  - x/mint/specs/*
  - x/pool-incentives/specs/*
  - x/simulation/specs/*
  - x/superfluid/specs/*
  - x/tokenfactory/specs/*
  - x/txfees/specs/*
  - x/README.md
  - README.md
  - CHANGELOG.md
  - bug.md
  - issue.md
  - proto-docs.md
```