### PR TITLE
refactor: e2e - allow disabling long running tests with environment variables

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -88,3 +88,44 @@ Example:
 ### To build the debug Osmosis image
 
     make docker-build-e2e-debug
+
+### Environment variables
+
+Some tests take a long time to run. Sometimes, we would like to disable them
+locally or in CI. The following are the environment variables to disable
+certain components of e2e testing.
+
+- `OSMOSIS_E2E_SKIP_UPGRADE` - when true, skips the upgrade tests.
+If OSMOSIS_E2E_SKIP_IBC is true, this must also be set to true because upgrade
+tests require IBC logic.
+
+- `OSMOSIS_E2E_SKIP_IBC` - when true, skips the IBC tests tests.
+
+- `OSMOSIS_E2E_SKIP_CLEANUP` - when true, avoids cleaning up the e2e Docker
+containers.
+
+#### VS Code Debug Configuration
+
+This debug configuration helps to run e2e tests locally and skip the desired tests.
+
+```json
+{
+    "name": "E2E IntegrationTestSuite",
+    "type": "go",
+    "request": "launch",
+    "mode": "test",
+    "program": "${workspaceFolder}/tests/e2e",
+    "args": [
+        "-test.timeout",
+        "30m",
+        "-test.run",
+        "IntegrationTestSuite",
+        "-test.v"
+    ],
+    "env": {
+        "OSMOSIS_E2E_SKIP_IBC": "true",
+        "OSMOSIS_E2E_SKIP_UPGRADE": "true",
+        "OSMOSIS_E2E_SKIP_CLEANUP": "true",
+    }
+}
+```

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -54,6 +54,12 @@ type chainConfig struct {
 }
 
 const (
+	// Environment variable name to skip the upgrade tests
+	skipUpgradeEnv = "OSMOSIS_E2E_SKIP_UPGRADE"
+	// Environment variable name to skip the IBC tests
+	skipIBCEnv = "OSMOSIS_E2E_SKIP_IBC"
+	// Environment variable name to skip cleaning up Docker resources in teardown.
+	skipCleanupEnv = "OSMOSIS_E2E_SKIP_CLEANUP"
 	// osmosis version being upgraded to (folder must exist here https://github.com/osmosis-labs/osmosis/tree/main/app/upgrades)
 	upgradeVersion = "v9"
 	// estimated number of blocks it takes to submit for a proposal
@@ -136,6 +142,8 @@ type IntegrationTestSuite struct {
 	initResource   *dockertest.Resource
 	valResources   map[string][]*dockertest.Resource
 	dockerImages   dockerconfig.ImageConfig
+	skipUpgrade    bool
+	skipIBC        bool
 }
 
 func TestIntegrationTestSuite(t *testing.T) {
@@ -156,36 +164,58 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	// 3. Run IBC relayer betweeen the two chains.
 	// 4. Execute various e2e tests, including IBC.
 	var (
-		skipUpgrade bool
-		err         error
+		err error
 	)
 
-	if str := os.Getenv("OSMOSIS_E2E_SKIP_UPGRADE"); len(str) > 0 {
-		skipUpgrade, err = strconv.ParseBool(str)
+	if str := os.Getenv(skipUpgradeEnv); len(str) > 0 {
+		s.skipUpgrade, err = strconv.ParseBool(str)
 		s.Require().NoError(err)
+
+		if s.skipUpgrade {
+			s.T().Log(fmt.Sprintf("%s was true, skipping upgrade tests", skipIBCEnv))
+		}
 	}
 
-	s.dockerImages = *dockerconfig.NewImageConfig(!skipUpgrade)
+	if str := os.Getenv(skipIBCEnv); len(str) > 0 {
+		s.skipIBC, err = strconv.ParseBool(str)
+		s.Require().NoError(err)
+
+		if s.skipIBC {
+			s.T().Log(fmt.Sprintf("%s was true, skipping IBC tests", skipIBCEnv))
+
+			if !s.skipUpgrade {
+				s.T().Fatal("If upgrade is enabled, IBC must be enabled as well.")
+			}
+		}
+	}
+
+	s.dockerImages = *dockerconfig.NewImageConfig(!s.skipUpgrade)
 
 	s.configureDockerResources(chain.ChainAID, chain.ChainBID)
 	s.configureChain(chain.ChainAID, validatorConfigsChainA, map[int]struct{}{
 		3: {}, // skip validator at index 3
 	})
-	s.configureChain(chain.ChainBID, validatorConfigsChainB, map[int]struct{}{})
+
+	// We don't need a second chain if IBC is disabled
+	if !s.skipIBC {
+		s.configureChain(chain.ChainBID, validatorConfigsChainB, map[int]struct{}{})
+	}
 
 	for i, chainConfig := range s.chainConfigs {
 		s.runValidators(chainConfig, s.dockerImages.OsmosisRepository, s.dockerImages.OsmosisTag, i*10)
 		s.extractValidatorOperatorAddresses(chainConfig)
 	}
 
-	// Run a relayer between every possible pair of chains.
-	for i := 0; i < len(s.chainConfigs); i++ {
-		for j := i + 1; j < len(s.chainConfigs); j++ {
-			s.runIBCRelayer(s.chainConfigs[i], s.chainConfigs[j])
+	if !s.skipIBC {
+		// Run a relayer between every possible pair of chains.
+		for i := 0; i < len(s.chainConfigs); i++ {
+			for j := i + 1; j < len(s.chainConfigs); j++ {
+				s.runIBCRelayer(s.chainConfigs[i], s.chainConfigs[j])
+			}
 		}
 	}
 
-	if !skipUpgrade {
+	if !s.skipUpgrade {
 		s.createPreUpgradeState()
 		s.upgrade()
 		s.runPostUpgradeTests()
@@ -198,6 +228,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 		s.Require().NoError(err)
 
 		if skipCleanup {
+			s.T().Log("skipping e2e resources clean up...")
 			return
 		}
 	}
@@ -414,6 +445,16 @@ func (s *IntegrationTestSuite) configureChain(chainId string, validatorConfigs [
 
 	votingPeriodDuration := time.Duration(int(newChainConfig.votingPeriod) * 1000000000)
 
+	// If upgrade is skipped, we can use the chain initialization logic from
+	// current branch directly. As a result, there is no need to run this
+	// via Docker.
+	if s.skipUpgrade {
+		initializedChain, err := chain.Init(chainId, tmpDir, validatorConfigs, votingPeriodDuration)
+		s.Require().NoError(err)
+		s.initializeChainConfig(&newChainConfig, initializedChain)
+		return
+	}
+
 	s.initResource, err = s.dkrPool.RunWithOptions(
 		&dockertest.RunOptions{
 			Name:       fmt.Sprintf("%s", chainId),
@@ -458,15 +499,19 @@ func (s *IntegrationTestSuite) configureChain(chainId string, validatorConfigs [
 	}
 	s.Require().NoError(s.dkrPool.Purge(s.initResource))
 
-	newChainConfig.meta.DataDir = initializedChain.ChainMeta.DataDir
-	newChainConfig.meta.Id = initializedChain.ChainMeta.Id
+	s.initializeChainConfig(&newChainConfig, &initializedChain)
+}
 
-	newChainConfig.validators = make([]*validatorConfig, 0, len(initializedChain.Validators))
+func (s *IntegrationTestSuite) initializeChainConfig(chainConfig *chainConfig, initializedChain *chain.Chain) {
+	chainConfig.meta.DataDir = initializedChain.ChainMeta.DataDir
+	chainConfig.meta.Id = initializedChain.ChainMeta.Id
+
+	chainConfig.validators = make([]*validatorConfig, 0, len(initializedChain.Validators))
 	for _, val := range initializedChain.Validators {
-		newChainConfig.validators = append(newChainConfig.validators, &validatorConfig{validator: *val})
+		chainConfig.validators = append(chainConfig.validators, &validatorConfig{validator: *val})
 	}
 
-	s.chainConfigs = append(s.chainConfigs, &newChainConfig)
+	s.chainConfigs = append(s.chainConfigs, chainConfig)
 }
 
 func (s *IntegrationTestSuite) configureDockerResources(chainIDOne, chainIDTwo string) {

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -369,7 +369,7 @@ func (s *IntegrationTestSuite) configureChain(chainId string, validatorConfigs [
 	// current branch directly. As a result, there is no need to run this
 	// via Docker.
 	if s.skipUpgrade {
-		initializedChain, err := chain.Init(chainId, tmpDir, validatorConfigs, votingPeriodDuration)
+		initializedChain, err := chain.Init(chainId, tmpDir, validatorConfigs, time.Duration(newChainConfig.votingPeriod))
 		s.Require().NoError(err)
 		s.initializeChainConfig(&newChainConfig, initializedChain)
 		return

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (s *IntegrationTestSuite) TestIBCTokenTransfer() {
+	if s.skipIBC {
+		s.T().Skip("Skipping IBC tests")
+	}
+
 	chainA := s.chainConfigs[0]
 	chainB := s.chainConfigs[1]
 	// compare coins of receiver pre and post IBC send
@@ -17,6 +21,11 @@ func (s *IntegrationTestSuite) TestIBCTokenTransfer() {
 }
 
 func (s *IntegrationTestSuite) TestSuperfluidVoting() {
+	if s.skipUpgrade {
+		// TODO: https://github.com/osmosis-labs/osmosis/issues/1843
+		s.T().Skip("Superfluid tests are broken when upgrade is skipped. To be fixed in #1843")
+	}
+
 	chainA := s.chainConfigs[0]
 	s.submitSuperfluidProposal(chainA, "gamm/pool/1")
 	s.depositProposal(chainA)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is a subset of the larger refactor in https://github.com/osmosis-labs/osmosis/pull/1591. Submitting this separately to ease the review process.

Here, we add the ability to disable long-running e2e test components with environment variables. This is useful for testing locally.
Additionally, we plan on enabling long-running e2e tests only on merge to main to speed up the CI in pull requests.

There is some boilerplate to utilize the newly introduced environment variables. This will be simplified in future PRs with the logic from #1591

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable