### PR TITLE
Added section to Contributing.md detailing our desired pre-release code auditing process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,51 @@ For v6.x, and v4.x, most PRs to them should go to main and get a "backport" labe
 
 ### How to build proto files. (rm -rf vendor/ && make build-reproducible once docker is installed)
 
-You can do rm -rf vendor and make build-reproducible to redownload all dependencies - this should pull the latest docker image of Osmosis. You should also make sure to do make proto-all to auto-generate your protobuf files. Makes ure you have docker installed. 
+You can do rm -rf vendor and make build-reproducible to redownload all dependencies - this should pull the latest docker image of Osmosis. You should also make sure to do make proto-all to auto-generate your protobuf files. Makes ure you have docker installed.
 
-If you get something like `W0503 22:16:30.068560 158 services.go:38] No HttpRule found for method: Msg.CreateBalancerPool` feel free to ignore that. 
+If you get something like `W0503 22:16:30.068560 158 services.go:38] No HttpRule found for method: Msg.CreateBalancerPool` feel free to ignore that.
 
-Make sure to also do make all to run all the linting tests before you commit and push, as well as `gofmt`-ing the file you've modified or added to make sure everything still abides by the standards. 
+Make sure to also do make all to run all the linting tests before you commit and push, as well as `gofmt`-ing the file you've modified or added to make sure everything still abides by the standards.
+
+## Major Release
+
+There are several steps that go into a major release
+
+* Run the (existing binary creation tool)[].
+
+* Make a PR to main, with a cosmovisor config, generated in tandem with the binaries from tool.
+    * Should be its own PR, as it may get denied for Fork upgrades.
+
+* Make a PR to main to update the import paths and go.mod for the new major release
+
+* Should also make a commit into every open PR to main to do the same find/replace. (Unless this will cause conflicts)
+
+* Do a PR if that commit has conflicts
+
+* (Eventually) Make a PR that adds a version handler for the next upgrade
+    * Add v10 upgrade boilerplate #1649
+
+* Update chain JSON schema's recommended versions
+
+### Pre-release auditing process
+
+For every module with notable changes, we assign someone who was not a primary author of those changes to review the entire module.
+
+Deliverables of review are:
+
+* PR's with in-line code comments for things they had to figure out (or questions) 
+
+* tests / test comments needed to convince themselves of correctness 
+
+* spec updates
+
+* Small refactors that helped in understanding / making code conform to consistency stds / improve code signal-to-noise ratio welcome
+
+* (As with all PRs, should not be a monolithic PR that gets PR'd, even though that may be the natural way its first formed)
+
+We will find a tool that lets us statically figure out every message that had something in its code path that changed, and until a tool is found, we must do this manually.
+
+We test in testnet & e2e testnet behaviors about every message that has changed
+
+We communicate with various integrators if they'd like release-blocking QA testing for major releases
+    * Chainapsis has communicated wanting a series of osmosis-frontend functionalities to be checked for correctness on a testnet as a release blocking item

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "git_repo": "https://github.com/osmosis-labs/osmosis",
+    "recommended_version": "v10.0.0",
+    "compatible_version": ["v10.0.0"],
+    "binaries": {
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-amd64",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-arm64"
+    }
+}


### PR DESCRIPTION
Closes: #1830 

## What is the purpose of the change

This PR adds a section to the contributing.md labeled "Major release" detailing our desired pre-release code auditing and actual release workflow processes.

## Brief Changelog

Added a section to the contributing.md labeled "Major release" detailing:

The [actual release workflow](https://github.com/osmosis-labs/osmosis/issues/1663)
The pre-release internal auditing process we've discussed as per notes on #1830 

## Testing and Verifying

*(Please pick one of the following options)*

**This change is a trivial rework / code cleanup without any test coverage.**

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / **no**)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / **no**)
  - How is the feature or change documented? (not applicable  /   specification (`x/<module>/spec/`)  /  **[Osmosis docs repo]**(https://github.com/osmosis-labs/docs)   /   not documented)

This change will be synced up with a future PR that creates an action syncing contributing.md docs on the docs repo with this one.