### PR TITLE
Mergify: Make backports automatically assign PR author

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+defaults:
+  actions:
+    backport:
+      assignees:
+        - "{{ author }}"
+
 queue_rules:
   - name: default
     conditions:


### PR DESCRIPTION
This change has been made by @ValarDragon from https://mergify.com config editor.