### PR TITLE
chore: update v10.x sdk to v0.45.0x-osmo-v9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -270,8 +270,8 @@ require (
 replace (
 	// branch: v0.27.0.rc3-osmo, current tag: v0.27.0.rc3-osmo
 	github.com/CosmWasm/wasmd => github.com/osmosis-labs/wasmd v0.27.0-rc2.0.20220517191021-59051aa18d58
-	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk v0.45.0x-osmo-v7
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220611234148-f59c62f19567
+	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk v0.45.0x-osmo-v9
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220623193151-78093c5d2c13
 	// Use Osmosis fast iavl
 	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v7
 	// use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -1036,6 +1036,8 @@ github.com/osmosis-labs/bech32-ibc v0.3.0-rc1 h1:frHKHEdPfzoK2iMF2GeWKudLLzUXz+6
 github.com/osmosis-labs/bech32-ibc v0.3.0-rc1/go.mod h1:X5/FZHMPL+B3ufuVyY2/koxVjd4hIwyTLjYP1DZwppQ=
 github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220611234148-f59c62f19567 h1:8KQSVRLCp4Mp5c22Cec+XVs3pjMwDpyTYGQOtDAO1F8=
 github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220611234148-f59c62f19567/go.mod h1:pMiEr6WR7drhXAXK1FOdAKPazWCi7b+WOyWOF4O0OXY=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220623193151-78093c5d2c13 h1:RgNEnc1dzT1e1nFZ0u3jP19VQfOsBF74hcS8Wm9ADHg=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220623193151-78093c5d2c13/go.mod h1:pMiEr6WR7drhXAXK1FOdAKPazWCi7b+WOyWOF4O0OXY=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7 h1:6KcADC/WhL7yDmNQxUIJt2XmzNt4FfRmq9gRke45w74=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
 github.com/osmosis-labs/wasmd v0.27.0-rc2.0.20220517191021-59051aa18d58 h1:15l3Iss2oCGCeJRi2g3CuCnqmEjpAr3Le7cDnoN/LS0=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This change updates the SDK dependency. We now use `v0.45.0x-osmo-v9` SDK fork branch for tagging `v10.x` releases.

A decision was made to keep the same branch `v0.45.0x-osmo-v9` for both `osmosis/v9.x` and `osmosis/v10.x` because v10.x is a fork of v9.x.

This PR updates `go.mod` with the tag taken from [`v0.45.0x-osmo-v9`](https://github.com/osmosis-labs/cosmos-sdk/tree/v0.45.0x-osmo-v9)

`v0.45.0x-somo-v9` was created from [`v0.45.0x-osmo-v7-old`](https://github.com/osmosis-labs/cosmos-sdk/commits/v0.45.0x-osmo-v7-old), commit: https://github.com/osmosis-labs/cosmos-sdk/commit/6209434a1de9af5c6c0625509cb1cc64a6e2c3d2





## Testing and Verifying

This change is already covered by existing tests, such as *(please describe tests)*.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable