### PR TITLE
Make Add new issues to project only run on PRs that are not from a fork

### DIFF
--- a/.github/workflows/add-issue-pr-to-project.yml
+++ b/.github/workflows/add-issue-pr-to-project.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to chain dev project
+    if: ${{ github.event.pull_request.head.repo.full_name == 'osmosis-labs/osmosis' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main


### PR DESCRIPTION
Closes: #1529 

## What is the purpose of the change

Making `Add new issues to project` only run on PRs that are not from a fork. Its currently erroring on every PR from a fork.

This should help folks working on forks to not have constant errors on their PRs

## Brief Changelog

Added in a Github actions rule that checks whether or not someone is running `Add new issues to project` from a fork
If they are, do not run the action.

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

Opening a PR on a fork of osmosis

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / **no**)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / **no**)
  - How is the feature or change documented? (**not applicable**   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)