### PR TITLE
Fix epochs modules tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1825](https://github.com/osmosis-labs/osmosis/pull/1825) Fixes Interchain Accounts (host side) by adding it to AppModuleBasics
 * [#1699](https://github.com/osmosis-labs/osmosis/pull/1699) Fixes bug in sig fig rounding on spot price queries for small values
 
-#### golang API breaks
+#### Golang API breaks
 
 * [#1893](https://github.com/osmosis-labs/osmosis/pull/1893) Change `EpochsKeeper.SetEpochInfo` to `AddEpochInfo`, which has more safety checks with it. (Makes it suitable to be called within upgrades)
 * [#1671](https://github.com/osmosis-labs/osmosis/pull/1671) Remove methods that constitute AppModuleSimulation APIs for several modules' AppModules, which implemented no-ops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### golang API breaks
 
+* [#1893](https://github.com/osmosis-labs/osmosis/pull/1893) Change `EpochsKeeper.SetEpochInfo` to `AddEpochInfo`, which has more safety checks with it. (Makes it suitable to be called within upgrades)
 * [#1671](https://github.com/osmosis-labs/osmosis/pull/1671) Remove methods that constitute AppModuleSimulation APIs for several modules' AppModules, which implemented no-ops
 * [#1671](https://github.com/osmosis-labs/osmosis/pull/1671) Add hourly epochs to `x/epochs` DefaultGenesis.
 * [#1665](https://github.com/osmosis-labs/osmosis/pull/1665) Delete app/App interface, instead use simapp.App

--- a/go.mod
+++ b/go.mod
@@ -25,13 +25,12 @@ require (
 	github.com/stretchr/testify v1.7.5
 	github.com/tendermint/tendermint v0.34.19
 	github.com/tendermint/tm-db v0.6.8-0.20220506192307-f628bb5dc95b
+	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
 	google.golang.org/grpc v1.46.2
 	gopkg.in/yaml.v2 v2.4.0
 	mvdan.cc/gofumpt v0.3.1
 )
-
-require golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 
 require (
 	4d63.com/gochecknoglobals v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	mvdan.cc/gofumpt v0.3.1
 )
 
+require golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
+
 require (
 	4d63.com/gochecknoglobals v0.1.0 // indirect
 	filippo.io/edwards25519 v1.0.0-beta.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1484,6 +1484,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d h1:vtUKgx8dahOomfFzLREU8nSv25YHnTgLBn4rDnWZdU0=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e h1:qyrTQ++p1afMkO4DPEeLGq/3oTsdlvdH4vqZUBWzUKM=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+// SortSlice sorts a slice of type T elements that implement constraints.Ordered.
 func SortSlice[T constraints.Ordered](s []T) {
 	sort.Slice(s, func(i, j int) bool {
 		return s[i] < s[j]

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -1,0 +1,13 @@
+package osmoutils
+
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
+
+func SortSlice[T constraints.Ordered](s []T) {
+	sort.Slice(s, func(i, j int) bool {
+		return s[i] < s[j]
+	})
+}

--- a/x/epochs/keeper/abci.go
+++ b/x/epochs/keeper/abci.go
@@ -17,7 +17,6 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 		logger := k.Logger(ctx)
 
 		// If blocktime < initial epoch start time, return
-		fmt.Printf("Identifier %s, blocktime %s, start time %s\n", epochInfo.Identifier, ctx.BlockTime(), epochInfo.StartTime)
 		if ctx.BlockTime().Before(epochInfo.StartTime) {
 			return
 		}

--- a/x/epochs/keeper/abci.go
+++ b/x/epochs/keeper/abci.go
@@ -17,6 +17,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 		logger := k.Logger(ctx)
 
 		// If blocktime < initial epoch start time, return
+		fmt.Printf("Identifier %s, blocktime %s, start time %s\n", epochInfo.Identifier, ctx.BlockTime(), epochInfo.StartTime)
 		if ctx.BlockTime().Before(epochInfo.StartTime) {
 			return
 		}
@@ -57,7 +58,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 				sdk.NewAttribute(types.AttributeEpochStartTime, fmt.Sprintf("%d", epochInfo.CurrentEpochStartTime.Unix())),
 			),
 		)
-		k.SetEpochInfo(ctx, epochInfo)
+		k.setEpochInfo(ctx, epochInfo)
 		k.BeforeEpochStart(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
 
 		return false

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -67,6 +67,20 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Second), 3: block1Time.Add(2 * time.Second), 4: block1Time.Add(time.Hour).Add(eps)},
 			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Hour), CurrentEpochStartHeight: 4},
 		},
+		"Distinct identifier and duration still works": {
+			initialEpochInfo:     types.EpochInfo{Identifier: "hello", Duration: time.Minute, StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Second), 3: block1Time.Add(time.Minute).Add(eps)},
+			expEpochInfo:         types.EpochInfo{Identifier: "hello", Duration: time.Minute, StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Minute), CurrentEpochStartHeight: 3},
+		},
+		"StartTime in future won't get ticked on first block": {
+			initialEpochInfo: types.EpochInfo{StartTime: block1Time.Add(time.Second), CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			// currentEpochStartHeight is 1 because thats when the timer was created on-chain
+			expEpochInfo: types.EpochInfo{StartTime: block1Time.Add(time.Second), CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}, CurrentEpochStartHeight: 1},
+		},
+		"StartTime in past will get ticked on first block": {
+			initialEpochInfo: types.EpochInfo{StartTime: block1Time.Add(-time.Second), CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			expEpochInfo:     types.EpochInfo{StartTime: block1Time.Add(-time.Second), CurrentEpoch: 1, CurrentEpochStartTime: block1Time.Add(-time.Second), CurrentEpochStartHeight: 1},
+		},
 	}
 	for name, test := range tests {
 		suite.Run(name, func() {

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -23,6 +23,7 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 	block1Time := time.Unix(1656907200, 0).UTC()
 	const defaultIdentifier = "hourly"
 	const defaultDuration = time.Hour
+	// eps is short for epsilon - in this case a negligible amount of time.
 	const eps = time.Nanosecond
 
 	tests := map[string]struct {

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 	defaultDuration := time.Hour
 	eps := time.Nanosecond
 
-	// TODO: Refactor these tests to be well typed / make sense
 	tests := map[string]struct {
 		// if identifier, duration is not set, we make it defaultIdentifier and defaultDuration.
 		// EpochCountingStarted, if unspecified, is inferred by CurrentEpoch == 0
@@ -83,11 +81,8 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 			heights := maps.Keys(test.blockHeightTimePairs)
 			osmoutils.SortSlice(heights)
 			for _, h := range heights {
-				fmt.Println(h)
 				// for each height in order, run begin block
 				suite.Ctx = suite.Ctx.WithBlockHeight(int64(h)).WithBlockTime(test.blockHeightTimePairs[h])
-				fmt.Println(test.blockHeightTimePairs[h])
-
 				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
 			}
 			expEpoch := initializeBlankEpochInfoFields(test.expEpochInfo, initialEpoch.Identifier, initialEpoch.Duration)

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -37,17 +37,17 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 			initialEpochInfo: types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
 			expEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
-		"First block run sets start time, subsequent blocks within interval do not affect": {
+		"First block run sets start time, subsequent blocks within timer interval do not cause timer tick": {
 			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
 			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Second), 3: block1Time.Add(time.Minute), 4: block1Time.Add(30 * time.Minute)},
 			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
-		"Second block at exactly interval later does not tick": {
+		"Second block at exactly timer interval later does not tick": {
 			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
 			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(defaultDuration)},
 			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
-		"Second block at interval + epsilon later does tick": {
+		"Second block at timer interval + epsilon later does tick": {
 			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
 			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(defaultDuration).Add(eps)},
 			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Hour), CurrentEpochStartHeight: 2},

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -45,12 +45,12 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 		},
 		"Second block at exactly interval later does not tick": {
 			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
-			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Hour)},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(defaultDuration)},
 			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
 		"Second block at interval + epsilon later does tick": {
 			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
-			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Hour).Add(eps)},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(defaultDuration).Add(eps)},
 			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Hour), CurrentEpochStartHeight: 2},
 		},
 		"Downtime recovery (many intervals), first block causes 1 tick and sets current start time 1 interval ahead": {
@@ -92,7 +92,7 @@ func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 	}
 }
 
-// set identifier, duration and epochCountingStarted if blank in epoch
+// initializeBlankEpochInfoFields set identifier, duration and epochCountingStarted if blank in epoch
 func initializeBlankEpochInfoFields(epoch types.EpochInfo, identifier string, duration time.Duration) types.EpochInfo {
 	if epoch.Identifier == "" {
 		epoch.Identifier = identifier

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -21,10 +21,9 @@ import (
 // TODO: Make a new test for init genesis logic
 func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 	block1Time := time.Unix(1656907200, 0).UTC()
-	// We run all tests with the same identifier and same duration
-	defaultIdentifier := "hourly"
-	defaultDuration := time.Hour
-	eps := time.Nanosecond
+	const defaultIdentifier = "hourly"
+	const defaultDuration = time.Hour
+	const eps = time.Nanosecond
 
 	tests := map[string]struct {
 		// if identifier, duration is not set, we make it defaultIdentifier and defaultDuration.

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,146 +11,102 @@ import (
 	simapp "github.com/osmosis-labs/osmosis/v7/app"
 	"github.com/osmosis-labs/osmosis/v7/x/epochs/types"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"golang.org/x/exp/maps"
+
+	"github.com/osmosis-labs/osmosis/v7/osmoutils"
 )
 
-func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
-	var app *simapp.OsmosisApp
-	var ctx sdk.Context
-	var epochInfo types.EpochInfo
+// This test is responsible for testing how epochs increment based off
+// of their initial conditions, and subsequent block height / times.
+//
+// TODO: Make a new test for init genesis logic
+func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
+	block1Time := time.Unix(1656907200, 0).UTC()
+	// We run all tests with the same identifier and same duration
+	defaultIdentifier := "hourly"
+	defaultDuration := time.Hour
+	eps := time.Nanosecond
 
-	now := time.Now()
-
-	tests := []struct {
-		expCurrentEpochStartTime   time.Time
-		expCurrentEpochStartHeight int64
-		expCurrentEpoch            int64
-		expInitialEpochStartTime   time.Time
-		fn                         func()
+	// TODO: Refactor these tests to be well typed / make sense
+	tests := map[string]struct {
+		// if identifier, duration is not set, we make it defaultIdentifier and defaultDuration.
+		// EpochCountingStarted, if unspecified, is inferred by CurrentEpoch == 0
+		// StartTime is inferred to be block1Time if left blank.
+		initialEpochInfo     types.EpochInfo
+		blockHeightTimePairs map[int]time.Time
+		expEpochInfo         types.EpochInfo
 	}{
-		{
-			// Only advance 2 seconds, do not increment epoch
-			expCurrentEpochStartHeight: 2,
-			expCurrentEpochStartTime:   now,
-			expCurrentEpoch:            1,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-			},
+		"First block running at exactly start time sets epoch tick": {
+			initialEpochInfo: types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			expEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
-		{
-			expCurrentEpochStartHeight: 2,
-			expCurrentEpochStartTime:   now,
-			expCurrentEpoch:            1,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-			},
+		"First block run sets start time, subsequent blocks within interval do not affect": {
+			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Second), 3: block1Time.Add(time.Minute), 4: block1Time.Add(30 * time.Minute)},
+			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
-		{
-			expCurrentEpochStartHeight: 2,
-			expCurrentEpochStartTime:   now,
-			expCurrentEpoch:            1,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 31))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-			},
+		"Second block at exactly interval later does not tick": {
+			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Hour)},
+			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time, CurrentEpochStartHeight: 1},
 		},
-		// Test that incrementing _exactly_ 1 month increments the epoch count.
-		{
-			expCurrentEpochStartHeight: 3,
-			expCurrentEpochStartTime:   now.Add(time.Hour * 24 * 31),
-			expCurrentEpoch:            2,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-			},
+		"Second block at interval + epsilon later does tick": {
+			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Hour).Add(eps)},
+			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Hour), CurrentEpochStartHeight: 2},
 		},
-		{
-			expCurrentEpochStartHeight: 3,
-			expCurrentEpochStartTime:   now.Add(time.Hour * 24 * 31),
-			expCurrentEpoch:            2,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-			},
+		"Downtime recovery (many intervals), first block causes 1 tick and sets current start time 1 interval ahead": {
+			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(24 * time.Hour)},
+			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Hour), CurrentEpochStartHeight: 2},
 		},
-		{
-			expCurrentEpochStartHeight: 3,
-			expCurrentEpochStartTime:   now.Add(time.Hour * 24 * 31),
-			expCurrentEpoch:            2,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				numBlocksSinceStart, _ := app.EpochsKeeper.NumBlocksSinceEpochStart(ctx, "monthly")
-				require.Equal(t, int64(0), numBlocksSinceStart)
-				ctx = ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
-				app.EpochsKeeper.BeginBlocker(ctx)
-				epochInfo = app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-				numBlocksSinceStart, _ = app.EpochsKeeper.NumBlocksSinceEpochStart(ctx, "monthly")
-				require.Equal(t, int64(1), numBlocksSinceStart)
-			},
+		"Downtime recovery (many intervals), second block is at tick 2, w/ start time 2 intervals ahead": {
+			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 0, CurrentEpochStartTime: time.Time{}},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(24 * time.Hour), 3: block1Time.Add(24 * time.Hour).Add(eps)},
+			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 3, CurrentEpochStartTime: block1Time.Add(2 * time.Hour), CurrentEpochStartHeight: 3},
+		},
+		"Many blocks between first and second tick": {
+			initialEpochInfo:     types.EpochInfo{StartTime: block1Time, CurrentEpoch: 1, CurrentEpochStartTime: block1Time},
+			blockHeightTimePairs: map[int]time.Time{2: block1Time.Add(time.Second), 3: block1Time.Add(2 * time.Second), 4: block1Time.Add(time.Hour).Add(eps)},
+			expEpochInfo:         types.EpochInfo{StartTime: block1Time, CurrentEpoch: 2, CurrentEpochStartTime: block1Time.Add(time.Hour), CurrentEpochStartHeight: 4},
 		},
 	}
+	for name, test := range tests {
+		suite.Run(name, func() {
+			suite.SetupTest()
+			suite.Ctx = suite.Ctx.WithBlockHeight(1).WithBlockTime(block1Time)
+			initialEpoch := initializeBlankEpochInfoFields(test.initialEpochInfo, defaultIdentifier, defaultDuration)
+			suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, initialEpoch)
+			suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
 
-	for _, test := range tests {
-		app = simapp.Setup(false)
-		ctx = app.BaseApp.NewContext(false, tmproto.Header{})
+			// get sorted heights
+			heights := maps.Keys(test.blockHeightTimePairs)
+			osmoutils.SortSlice(heights)
+			for _, h := range heights {
+				fmt.Println(h)
+				// for each height in order, run begin block
+				suite.Ctx = suite.Ctx.WithBlockHeight(int64(h)).WithBlockTime(test.blockHeightTimePairs[h])
+				fmt.Println(test.blockHeightTimePairs[h])
 
-		// On init genesis, default epochs information is set
-		// To check init genesis again, should make it fresh status
-		epochInfos := app.EpochsKeeper.AllEpochInfos(ctx)
-		for _, epochInfo := range epochInfos {
-			app.EpochsKeeper.DeleteEpochInfo(ctx, epochInfo.Identifier)
-		}
-
-		ctx = ctx.WithBlockHeight(1).WithBlockTime(now)
-		// check init genesis
-		app.EpochsKeeper.InitGenesis(ctx, types.GenesisState{
-			Epochs: []types.EpochInfo{
-				{
-					Identifier:              "monthly",
-					StartTime:               time.Time{},
-					Duration:                time.Hour * 24 * 31,
-					CurrentEpoch:            0,
-					CurrentEpochStartHeight: ctx.BlockHeight(),
-					CurrentEpochStartTime:   time.Time{},
-					EpochCountingStarted:    false,
-				},
-			},
+				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
+			}
+			expEpoch := initializeBlankEpochInfoFields(test.expEpochInfo, initialEpoch.Identifier, initialEpoch.Duration)
+			actEpoch := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, initialEpoch.Identifier)
+			suite.Require().Equal(expEpoch, actEpoch)
 		})
-
-		test.fn()
-
-		require.Equal(t, epochInfo.Identifier, "monthly")
-		require.Equal(t, epochInfo.StartTime.UTC().String(), test.expInitialEpochStartTime.UTC().String())
-		require.Equal(t, epochInfo.Duration, time.Hour*24*31)
-		require.Equal(t, epochInfo.CurrentEpoch, test.expCurrentEpoch)
-		require.Equal(t, epochInfo.CurrentEpochStartHeight, test.expCurrentEpochStartHeight)
-		require.Equal(t, epochInfo.CurrentEpochStartTime.UTC().String(), test.expCurrentEpochStartTime.UTC().String())
-		require.Equal(t, epochInfo.EpochCountingStarted, true)
 	}
+}
+
+// set identifier, duration and epochCountingStarted if blank in epoch
+func initializeBlankEpochInfoFields(epoch types.EpochInfo, identifier string, duration time.Duration) types.EpochInfo {
+	if epoch.Identifier == "" {
+		epoch.Identifier = identifier
+	}
+	if epoch.Duration == time.Duration(0) {
+		epoch.Duration = duration
+	}
+	epoch.EpochCountingStarted = (epoch.CurrentEpoch != 0)
+	return epoch
 }
 
 func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
@@ -211,46 +168,4 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 	require.Equal(t, epochInfo.CurrentEpochStartHeight, ctx.BlockHeight())
 	require.Equal(t, epochInfo.CurrentEpochStartTime.UTC().String(), now.Add(month).UTC().String())
 	require.Equal(t, epochInfo.EpochCountingStarted, true)
-}
-
-// This test ensures legacy EpochInfo messages will not throw errors via InitGenesis and BeginBlocker
-func TestLegacyEpochSerialization(t *testing.T) {
-	// Legacy Epoch Info message - without CurrentEpochStartHeight property
-	legacyEpochInfo := types.EpochInfo{
-		Identifier:            "monthly",
-		StartTime:             time.Time{},
-		Duration:              time.Hour * 24 * 31,
-		CurrentEpoch:          0,
-		CurrentEpochStartTime: time.Time{},
-		EpochCountingStarted:  false,
-	}
-
-	now := time.Now()
-	app := simapp.Setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-
-	// On init genesis, default epochs information is set
-	// To check init genesis again, should make it fresh status
-	epochInfos := app.EpochsKeeper.AllEpochInfos(ctx)
-	for _, epochInfo := range epochInfos {
-		app.EpochsKeeper.DeleteEpochInfo(ctx, epochInfo.Identifier)
-	}
-
-	ctx = ctx.WithBlockHeight(1).WithBlockTime(now)
-
-	// check init genesis
-	app.EpochsKeeper.InitGenesis(ctx, types.GenesisState{
-		Epochs: []types.EpochInfo{legacyEpochInfo},
-	})
-
-	// Do not increment epoch
-	ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-	app.EpochsKeeper.BeginBlocker(ctx)
-
-	// Increment epoch
-	ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-	app.EpochsKeeper.BeginBlocker(ctx)
-	epochInfo := app.EpochsKeeper.GetEpochInfo(ctx, "monthly")
-
-	require.NotEqual(t, epochInfo.CurrentEpochStartHeight, int64(0))
 }

--- a/x/epochs/keeper/epoch.go
+++ b/x/epochs/keeper/epoch.go
@@ -2,8 +2,10 @@ package keeper
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
+
 	"github.com/osmosis-labs/osmosis/v7/x/epochs/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,8 +26,23 @@ func (k Keeper) GetEpochInfo(ctx sdk.Context, identifier string) types.EpochInfo
 	return epoch
 }
 
-// SetEpochInfo set epoch info.
-func (k Keeper) SetEpochInfo(ctx sdk.Context, epoch types.EpochInfo) {
+// setEpochInfo set epoch info.
+func (k Keeper) AddEpochInfo(ctx sdk.Context, epoch types.EpochInfo) error {
+	err := epoch.Validate()
+	if err != nil {
+		return err
+	}
+	// Initialize empty epoch values via Cosmos SDK
+	if epoch.StartTime.Equal(time.Time{}) {
+		epoch.StartTime = ctx.BlockTime()
+	}
+	epoch.CurrentEpochStartHeight = ctx.BlockHeight()
+	k.setEpochInfo(ctx, epoch)
+	return nil
+}
+
+// setEpochInfo set epoch info.
+func (k Keeper) setEpochInfo(ctx sdk.Context, epoch types.EpochInfo) {
 	store := ctx.KVStore(k.storeKey)
 	value, err := proto.Marshal(&epoch)
 	if err != nil {

--- a/x/epochs/keeper/epoch.go
+++ b/x/epochs/keeper/epoch.go
@@ -26,13 +26,18 @@ func (k Keeper) GetEpochInfo(ctx sdk.Context, identifier string) types.EpochInfo
 	return epoch
 }
 
-// setEpochInfo set epoch info.
+// AddEpochInfo adds a new epoch info.
 func (k Keeper) AddEpochInfo(ctx sdk.Context, epoch types.EpochInfo) error {
 	err := epoch.Validate()
 	if err != nil {
 		return err
 	}
-	// Initialize empty epoch values via Cosmos SDK
+	// Check if identifier already exists
+	if (k.GetEpochInfo(ctx, epoch.Identifier) != types.EpochInfo{}) {
+		return fmt.Errorf("epoch with identifier %s already exists", epoch.Identifier)
+	}
+
+	// Initialize empty and default epoch values
 	if epoch.StartTime.Equal(time.Time{}) {
 		epoch.StartTime = ctx.BlockTime()
 	}

--- a/x/epochs/keeper/epoch.go
+++ b/x/epochs/keeper/epoch.go
@@ -26,7 +26,9 @@ func (k Keeper) GetEpochInfo(ctx sdk.Context, identifier string) types.EpochInfo
 	return epoch
 }
 
-// AddEpochInfo adds a new epoch info.
+// AddEpochInfo adds a new epoch info. Will return an error if the epoch fails validation,
+// or re-uses an existing identifier.
+// This method also sets the start time if left unset, and sets the epoch start height.
 func (k Keeper) AddEpochInfo(ctx sdk.Context, epoch types.EpochInfo) error {
 	err := epoch.Validate()
 	if err != nil {

--- a/x/epochs/keeper/epoch_test.go
+++ b/x/epochs/keeper/epoch_test.go
@@ -10,9 +10,13 @@ func (suite *KeeperTestSuite) TestEpochLifeCycle() {
 	suite.SetupTest()
 
 	epochInfo := types.NewGenesisEpochInfo("monthly", time.Hour*24*30)
-	suite.App.EpochsKeeper.SetEpochInfo(suite.Ctx, epochInfo)
+	suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochInfo)
 	epochInfoSaved := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
-	suite.Require().Equal(epochInfo, epochInfoSaved)
+	// setup expected epoch info
+	expectedEpochInfo := epochInfo
+	expectedEpochInfo.StartTime = suite.Ctx.BlockTime()
+	expectedEpochInfo.CurrentEpochStartHeight = suite.Ctx.BlockHeight()
+	suite.Require().Equal(expectedEpochInfo, epochInfoSaved)
 
 	allEpochs := suite.App.EpochsKeeper.AllEpochInfos(suite.Ctx)
 	suite.Require().Len(allEpochs, 4)

--- a/x/epochs/keeper/genesis.go
+++ b/x/epochs/keeper/genesis.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"time"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v7/x/epochs/types"
@@ -11,14 +9,10 @@ import (
 func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	// set epoch info from genesis
 	for _, epoch := range genState.Epochs {
-		// Initialize empty epoch values via Cosmos SDK
-		if epoch.StartTime.Equal(time.Time{}) {
-			epoch.StartTime = ctx.BlockTime()
+		err := k.AddEpochInfo(ctx, epoch)
+		if err != nil {
+			panic(err)
 		}
-
-		epoch.CurrentEpochStartHeight = ctx.BlockHeight()
-
-		k.SetEpochInfo(ctx, epoch)
 	}
 }
 

--- a/x/epochs/keeper/keeper_test.go
+++ b/x/epochs/keeper/keeper_test.go
@@ -19,11 +19,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
 }
 
-func (suite *KeeperTestSuite) SetupCleanGenesisTest() {
-	suite.Setup()
-	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
-}
-
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }

--- a/x/epochs/keeper/keeper_test.go
+++ b/x/epochs/keeper/keeper_test.go
@@ -19,6 +19,11 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
 }
 
+func (suite *KeeperTestSuite) SetupCleanGenesisTest() {
+	suite.Setup()
+	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
+}
+
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }

--- a/x/superfluid/keeper/keeper.go
+++ b/x/superfluid/keeper/keeper.go
@@ -3,8 +3,9 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/superfluid/keeper/keeper_test.go
+++ b/x/superfluid/keeper/keeper_test.go
@@ -43,10 +43,12 @@ func (suite *KeeperTestSuite) SetupTest() {
 		unbondingDuration,
 	})
 
-	// TODO: Revisit if this is needed, it was added due to another bug in testing that is now fixed.
-	epochIdentifier := suite.App.SuperfluidKeeper.GetEpochIdentifier(suite.Ctx)
-	suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochtypes.EpochInfo{
-		Identifier:              epochIdentifier,
+	superfluidEpochIdentifer := "superfluid_epoch"
+	incentiveKeeperParams := suite.App.IncentivesKeeper.GetParams(suite.Ctx)
+	incentiveKeeperParams.DistrEpochIdentifier = superfluidEpochIdentifer
+	suite.App.IncentivesKeeper.SetParams(suite.Ctx, incentiveKeeperParams)
+	err := suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochtypes.EpochInfo{
+		Identifier:              superfluidEpochIdentifer,
 		StartTime:               startTime,
 		Duration:                time.Hour,
 		CurrentEpochStartTime:   startTime,
@@ -54,9 +56,10 @@ func (suite *KeeperTestSuite) SetupTest() {
 		CurrentEpoch:            1,
 		EpochCountingStarted:    true,
 	})
+	suite.Require().NoError(err)
 
 	mintParams := suite.App.MintKeeper.GetParams(suite.Ctx)
-	mintParams.EpochIdentifier = epochIdentifier
+	mintParams.EpochIdentifier = superfluidEpochIdentifer
 	mintParams.DistributionProportions = minttypes.DistributionProportions{
 		Staking:          sdk.OneDec(),
 		PoolIncentives:   sdk.ZeroDec(),

--- a/x/superfluid/keeper/keeper_test.go
+++ b/x/superfluid/keeper/keeper_test.go
@@ -45,7 +45,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 	// TODO: Revisit if this is needed, it was added due to another bug in testing that is now fixed.
 	epochIdentifier := suite.App.SuperfluidKeeper.GetEpochIdentifier(suite.Ctx)
-	suite.App.EpochsKeeper.SetEpochInfo(suite.Ctx, epochtypes.EpochInfo{
+	suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochtypes.EpochInfo{
 		Identifier:              epochIdentifier,
 		StartTime:               startTime,
 		Duration:                time.Hour,

--- a/x/superfluid/keeper/twap_price_test.go
+++ b/x/superfluid/keeper/twap_price_test.go
@@ -33,7 +33,7 @@ func (suite *KeeperTestSuite) TestOsmoEquivalentMultiplierSetGetDeleteFlow() {
 	suite.Require().Equal(multipliers, expectedMultipliers)
 
 	epochIdentifier := suite.App.SuperfluidKeeper.GetEpochIdentifier(suite.Ctx)
-	suite.App.EpochsKeeper.SetEpochInfo(suite.Ctx, epochstypes.EpochInfo{
+	suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochstypes.EpochInfo{
 		Identifier:   epochIdentifier,
 		CurrentEpoch: 2,
 	})

--- a/x/superfluid/keeper/twap_price_test.go
+++ b/x/superfluid/keeper/twap_price_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	epochstypes "github.com/osmosis-labs/osmosis/v7/x/epochs/types"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -31,12 +30,6 @@ func (suite *KeeperTestSuite) TestOsmoEquivalentMultiplierSetGetDeleteFlow() {
 	}
 	multipliers = suite.App.SuperfluidKeeper.GetAllOsmoEquivalentMultipliers(suite.Ctx)
 	suite.Require().Equal(multipliers, expectedMultipliers)
-
-	epochIdentifier := suite.App.SuperfluidKeeper.GetEpochIdentifier(suite.Ctx)
-	suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochstypes.EpochInfo{
-		Identifier:   epochIdentifier,
-		CurrentEpoch: 2,
-	})
 
 	// test last epoch price
 	multiplier = suite.App.SuperfluidKeeper.GetOsmoEquivalentMultiplier(suite.Ctx, "gamm/pool/1")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: #1834 

## What is the purpose of the change

Update the epochs modules tests to be readable, make sense & cover more relevant cases.

As part of this, we remove the prior `SetEpochInfo` API, and solely use a safer `AddEpochInfo` api, that includes relevant entries if they're left blank, and errors if its an invalid configuration

## Brief Changelog

  - Remove epochskeeper.SetEpochInfo API, in favor of epochskeeper.AddEpochInfo

## Testing and Verifying

This change added tests and can be verified as follows:

  - Added unit test that validates expected epoch behavior on begin block
    - Open to any other test cases we can think of for edge cases / etc.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable