### PR TITLE
Write test for AddEpochInfo

### DIFF
--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -17,8 +17,6 @@ import (
 
 // This test is responsible for testing how epochs increment based off
 // of their initial conditions, and subsequent block height / times.
-//
-// TODO: Make a new test for init genesis logic
 func (suite KeeperTestSuite) TestEpochInfoBeginBlockChanges() {
 	block1Time := time.Unix(1656907200, 0).UTC()
 	const defaultIdentifier = "hourly"

--- a/x/epochs/keeper/epoch_test.go
+++ b/x/epochs/keeper/epoch_test.go
@@ -16,15 +16,17 @@ func (suite *KeeperTestSuite) TestAddEpochInfo() {
 		expErr         bool
 		expEpochInfo   types.EpochInfo
 	}{
-		"simple_add": {addedEpochInfo: types.EpochInfo{
-			Identifier:              defaultIdentifier,
-			StartTime:               time.Time{},
-			Duration:                defaultDuration,
-			CurrentEpoch:            0,
-			CurrentEpochStartHeight: 0,
-			CurrentEpochStartTime:   time.Time{},
-			EpochCountingStarted:    false,
-		}, expErr: false,
+		"simple_add": {
+			addedEpochInfo: types.EpochInfo{
+				Identifier:              defaultIdentifier,
+				StartTime:               time.Time{},
+				Duration:                defaultDuration,
+				CurrentEpoch:            0,
+				CurrentEpochStartHeight: 0,
+				CurrentEpochStartTime:   time.Time{},
+				EpochCountingStarted:    false,
+			},
+			expErr: false,
 			expEpochInfo: types.EpochInfo{
 				Identifier:              defaultIdentifier,
 				StartTime:               startBlockTime,
@@ -34,6 +36,18 @@ func (suite *KeeperTestSuite) TestAddEpochInfo() {
 				CurrentEpochStartTime:   time.Time{},
 				EpochCountingStarted:    false,
 			}},
+		"zero_duration": {
+			addedEpochInfo: types.EpochInfo{
+				Identifier:              defaultIdentifier,
+				StartTime:               time.Time{},
+				Duration:                time.Duration(0),
+				CurrentEpoch:            0,
+				CurrentEpochStartHeight: 0,
+				CurrentEpochStartTime:   time.Time{},
+				EpochCountingStarted:    false,
+			},
+			expErr: true,
+		},
 	}
 	for name, test := range tests {
 		suite.Run(name, func() {

--- a/x/epochs/keeper/epoch_test.go
+++ b/x/epochs/keeper/epoch_test.go
@@ -6,6 +6,60 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/epochs/types"
 )
 
+func (suite *KeeperTestSuite) TestAddEpochInfo() {
+	defaultIdentifier := "default_add_epoch_info_id"
+	defaultDuration := time.Hour
+	startBlockHeight := int64(100)
+	startBlockTime := time.Unix(1656907200, 0).UTC()
+	tests := map[string]struct {
+		addedEpochInfo types.EpochInfo
+		expErr         bool
+		expEpochInfo   types.EpochInfo
+	}{
+		"simple_add": {addedEpochInfo: types.EpochInfo{
+			Identifier:              defaultIdentifier,
+			StartTime:               time.Time{},
+			Duration:                defaultDuration,
+			CurrentEpoch:            0,
+			CurrentEpochStartHeight: 0,
+			CurrentEpochStartTime:   time.Time{},
+			EpochCountingStarted:    false,
+		}, expErr: false,
+			expEpochInfo: types.EpochInfo{
+				Identifier:              defaultIdentifier,
+				StartTime:               startBlockTime,
+				Duration:                defaultDuration,
+				CurrentEpoch:            0,
+				CurrentEpochStartHeight: startBlockHeight,
+				CurrentEpochStartTime:   time.Time{},
+				EpochCountingStarted:    false,
+			}},
+	}
+	for name, test := range tests {
+		suite.Run(name, func() {
+			suite.SetupTest()
+			suite.Ctx = suite.Ctx.WithBlockHeight(startBlockHeight).WithBlockTime(startBlockTime)
+			err := suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, test.addedEpochInfo)
+			if test.expErr != true {
+				suite.Require().NoError(err)
+				actualEpochInfo := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, test.addedEpochInfo.Identifier)
+				suite.Require().Equal(test.expEpochInfo, actualEpochInfo)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestDuplicateAddEpochInfo() {
+	identifier := "duplicate_add_epoch_info"
+	epochInfo := types.NewGenesisEpochInfo(identifier, time.Hour*24*30)
+	err := suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochInfo)
+	suite.Require().NoError(err)
+	err = suite.App.EpochsKeeper.AddEpochInfo(suite.Ctx, epochInfo)
+	suite.Require().Error(err)
+}
+
 func (suite *KeeperTestSuite) TestEpochLifeCycle() {
 	suite.SetupTest()
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1834 

## What is the purpose of the change

Adds a table driven test for AddEpochInfo functionality, and a unit test for its behavior on duplicates.

This is part of followup from #1893 

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?no
  - How is the feature or change documented? not applicable 