### PR TITLE
chore: x/lockup documentation, minor module cleanup

### DIFF
--- a/x/lockup/client/cli/query.go
+++ b/x/lockup/client/cli/query.go
@@ -53,7 +53,9 @@ func GetQueryCmd() *cobra.Command {
 	return cmd
 }
 
-// GetCmdModuleBalance returns full balance of the module.
+// GetCmdModuleBalance returns full balance of the lockup module.
+// Lockup module is where coins of locks are held.
+// This includes locked balance and unlocked balance of the module.
 func GetCmdModuleBalance() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "module-balance",
@@ -89,7 +91,8 @@ $ %s query lockup module-balance
 	return cmd
 }
 
-// GetCmdModuleLockedAmount returns locked balance of the module.
+// GetCmdModuleLockedAmount returns locked balance of the module,
+// which are all the tokens not unlocking + tokens that are not finished unlocking.
 func GetCmdModuleLockedAmount() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "module-locked-amount",
@@ -125,7 +128,7 @@ $ %s query lockup module-locked-amount
 	return cmd
 }
 
-// GetCmdAccountUnlockableCoins returns unlockable coins which are not withdrawn yet.
+// GetCmdAccountUnlockableCoins returns unlockable coins which has finsihed unlocking.
 func GetCmdAccountUnlockableCoins() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-unlockable-coins <address>",
@@ -162,7 +165,7 @@ $ %s query lockup account-unlockable-coins <address>
 	return cmd
 }
 
-// GetCmdAccountUnlockingCoins returns unlocking coins.
+// GetCmdAccountUnlockingCoins returns unlocking coins of a specific account.
 func GetCmdAccountUnlockingCoins() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-unlocking-coins <address>",
@@ -199,7 +202,7 @@ $ %s query lockup account-unlocking-coins <address>
 	return cmd
 }
 
-// GetCmdAccountLockedCoins returns locked coins that can't be withdrawn.
+// GetCmdAccountLockedCoins returns locked coins that can't be withdrawn of a specific account.
 func GetCmdAccountLockedCoins() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-locked-coins <address>",
@@ -236,7 +239,7 @@ $ %s query lockup account-locked-coins <address>
 	return cmd
 }
 
-// GetCmdAccountLockedPastTime returns locked records of an account with unlock time beyond timestamp.
+// GetCmdAccountLockedPastTime returns locks of an account with unlock time beyond timestamp.
 func GetCmdAccountLockedPastTime() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-locked-pastime <address> <timestamp>",
@@ -279,7 +282,8 @@ $ %s query lockup account-locked-pastime <address> <timestamp>
 	return cmd
 }
 
-// GetCmdAccountLockedPastTimeNotUnlockingOnly returns locked records of an account with unlock time beyond timestamp within not unlocking queue.
+// GetCmdAccountLockedPastTimeNotUnlockingOnly returns locks of an account with unlock time beyond provided timestamp
+// amongst the locks that are in the unlocking queue.
 func GetCmdAccountLockedPastTimeNotUnlockingOnly() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-locked-pastime-not-unlocking <address> <timestamp>",
@@ -322,7 +326,7 @@ $ %s query lockup account-locked-pastime-not-unlocking <address> <timestamp>
 	return cmd
 }
 
-// GetCmdAccountUnlockedBeforeTime returns unlocked records with unlock time before timestamp.
+// GetCmdAccountUnlockedBeforeTime returns locks with unlock time before the provided timestamp.
 func GetCmdAccountUnlockedBeforeTime() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-locked-beforetime <address> <timestamp>",
@@ -365,7 +369,8 @@ $ %s query lockup account-locked-pastime <address> <timestamp>
 	return cmd
 }
 
-// GetCmdAccountLockedPastTimeDenom returns lock records by address, timestamp, denom.
+// GetCmdAccountLockedPastTimeDenom returns locks of an account whose unlock time is
+// beyond given timestamp, and locks with the specified denom.
 func GetCmdAccountLockedPastTimeDenom() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-locked-pastime-denom <address> <timestamp> <denom>",
@@ -410,7 +415,7 @@ $ %s query lockup account-locked-pastime-denom <address> <timestamp> <denom>
 	return cmd
 }
 
-// GetCmdLockedByID returns lock record by id.
+// GetCmdLockedByID returns lock by id.
 func GetCmdLockedByID() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lock-by-id <id>",
@@ -619,7 +624,8 @@ $ %s query lockup account-locked-longer-duration-not-unlocking <address> <durati
 	return cmd
 }
 
-// GetCmdAccountLockedLongerDurationDenom returns account's locked records for a denom with longer duration.
+// GetCmdAccountLockedLongerDurationDenom returns account's locks for a specific denom
+// with longer duration than the given duration.
 func GetCmdAccountLockedLongerDurationDenom() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-locked-longer-duration-denom <address> <duration> <denom>",
@@ -663,7 +669,7 @@ $ %s query lockup account-locked-pastime <address> <duration> <denom>
 	return cmd
 }
 
-// GetCmdTotalBondedByDenom returns total amount of locked asset.
+// GetCmdTotalBondedByDenom returns total amount of locked asset of a specific denom.
 func GetCmdTotalLockedByDenom() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "total-locked-of-denom <denom>",

--- a/x/lockup/client/cli/tx.go
+++ b/x/lockup/client/cli/tx.go
@@ -34,7 +34,7 @@ func GetTxCmd() *cobra.Command {
 	return cmd
 }
 
-// NewLockTokensCmd lock tokens into lockup pool from user's account.
+// NewLockTokensCmd creates a new lock with the specified duration and tokens from the user's account.
 func NewLockTokensCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lock-tokens [tokens]",
@@ -81,7 +81,7 @@ func NewLockTokensCmd() *cobra.Command {
 	return cmd
 }
 
-// NewBeginUnlockingCmd unlock all unlockable tokens from user's account.
+// NewBeginUnlockingCmd starts unlocking all unlockable locks from user's account.
 func NewBeginUnlockingCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "begin-unlock-tokens",
@@ -107,7 +107,7 @@ func NewBeginUnlockingCmd() *cobra.Command {
 	return cmd
 }
 
-// NewBeginUnlockByIDCmd unlock individual period lock by ID.
+// NewBeginUnlockByIDCmd unlocks individual period lock by ID.
 func NewBeginUnlockByIDCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "begin-unlock-by-id [id]",

--- a/x/lockup/keeper/grpc_query.go
+++ b/x/lockup/keeper/grpc_query.go
@@ -29,7 +29,8 @@ func (q Querier) ModuleBalance(goCtx context.Context, _ *types.ModuleBalanceRequ
 	return &types.ModuleBalanceResponse{Coins: q.Keeper.GetModuleBalance(ctx)}, nil
 }
 
-// ModuleLockedAmount Returns locked balance of the module.
+// ModuleLockedAmount returns locked balance of the module,
+// which are all the tokens not unlocking + tokens that are not finished unlocking.
 func (q Querier) ModuleLockedAmount(goCtx context.Context, _ *types.ModuleLockedAmountRequest) (*types.ModuleLockedAmountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	return &types.ModuleLockedAmountResponse{Coins: q.Keeper.GetModuleLockedCoins(ctx)}, nil
@@ -54,7 +55,7 @@ func (q Querier) AccountUnlockableCoins(goCtx context.Context, req *types.Accoun
 	return &types.AccountUnlockableCoinsResponse{Coins: q.Keeper.GetAccountUnlockableCoins(ctx, owner)}, nil
 }
 
-// AccountUnlockingCoins returns whole unlocking coins.
+// AccountUnlockingCoins returns the total amount of unlocking coins for a specific account.
 func (q Querier) AccountUnlockingCoins(goCtx context.Context, req *types.AccountUnlockingCoinsRequest) (*types.AccountUnlockingCoinsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -73,7 +74,7 @@ func (q Querier) AccountUnlockingCoins(goCtx context.Context, req *types.Account
 	return &types.AccountUnlockingCoinsResponse{Coins: q.Keeper.GetAccountUnlockingCoins(ctx, owner)}, nil
 }
 
-// AccountLockedCoins Returns a locked coins that can't be withdrawn.
+// AccountLockedCoins returns the total amount of locked coins that can't be withdrawn for a specific account.
 func (q Querier) AccountLockedCoins(goCtx context.Context, req *types.AccountLockedCoinsRequest) (*types.AccountLockedCoinsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -92,7 +93,7 @@ func (q Querier) AccountLockedCoins(goCtx context.Context, req *types.AccountLoc
 	return &types.AccountLockedCoinsResponse{Coins: q.Keeper.GetAccountLockedCoins(ctx, owner)}, nil
 }
 
-// AccountLockedPastTime Returns the total locks of an account whose unlock time is beyond timestamp.
+// AccountLockedPastTime returns the locks of an account whose unlock time is beyond provided timestamp.
 func (q Querier) AccountLockedPastTime(goCtx context.Context, req *types.AccountLockedPastTimeRequest) (*types.AccountLockedPastTimeResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -111,7 +112,7 @@ func (q Querier) AccountLockedPastTime(goCtx context.Context, req *types.Account
 	return &types.AccountLockedPastTimeResponse{Locks: q.Keeper.GetAccountLockedPastTime(ctx, owner, req.Timestamp)}, nil
 }
 
-// AccountUnlockedBeforeTime Returns the total unlocks of an account whose unlock time is before timestamp.
+// AccountUnlockedBeforeTime returns locks of an account of which unlock time is before the provided timestamp.
 func (q Querier) AccountUnlockedBeforeTime(goCtx context.Context, req *types.AccountUnlockedBeforeTimeRequest) (*types.AccountUnlockedBeforeTimeResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -130,7 +131,8 @@ func (q Querier) AccountUnlockedBeforeTime(goCtx context.Context, req *types.Acc
 	return &types.AccountUnlockedBeforeTimeResponse{Locks: q.Keeper.GetAccountUnlockedBeforeTime(ctx, owner, req.Timestamp)}, nil
 }
 
-// AccountLockedPastTimeDenom is equal to GetAccountLockedPastTime but denom specific.
+// AccountLockedPastTimeDenom returns the locks of an account whose unlock time is beyond provided timestamp, limited to locks with
+// the specified denom. Equivalent to `AccountLockedPastTime` but denom specific.
 func (q Querier) AccountLockedPastTimeDenom(goCtx context.Context, req *types.AccountLockedPastTimeDenomRequest) (*types.AccountLockedPastTimeDenomResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -149,7 +151,7 @@ func (q Querier) AccountLockedPastTimeDenom(goCtx context.Context, req *types.Ac
 	return &types.AccountLockedPastTimeDenomResponse{Locks: q.Keeper.GetAccountLockedPastTimeDenom(ctx, owner, req.Denom, req.Timestamp)}, nil
 }
 
-// LockedByID Returns lock by lock ID.
+// LockedByID returns lock by lock ID.
 func (q Querier) LockedByID(goCtx context.Context, req *types.LockedRequest) (*types.LockedResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -171,7 +173,7 @@ func (q Querier) SyntheticLockupsByLockupID(goCtx context.Context, req *types.Sy
 	return &types.SyntheticLockupsByLockupIDResponse{SyntheticLocks: synthLocks}, nil
 }
 
-// AccountLockedLongerDuration Returns account locked with duration longer than specified.
+// AccountLockedLongerDuration returns locks of an account with duration longer than specified.
 func (q Querier) AccountLockedLongerDuration(goCtx context.Context, req *types.AccountLockedLongerDurationRequest) (*types.AccountLockedLongerDurationResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -191,7 +193,7 @@ func (q Querier) AccountLockedLongerDuration(goCtx context.Context, req *types.A
 	return &types.AccountLockedLongerDurationResponse{Locks: locks}, nil
 }
 
-// AccountLockedLongerDurationDenom Returns account locked with duration longer than specified with specific denom.
+// AccountLockedLongerDurationDenom returns locks of an account with duration longer than specified with specific denom.
 func (q Querier) AccountLockedLongerDurationDenom(goCtx context.Context, req *types.AccountLockedLongerDurationDenomRequest) (*types.AccountLockedLongerDurationDenomResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -231,7 +233,8 @@ func (q Querier) AccountLockedDuration(goCtx context.Context, req *types.Account
 	return &types.AccountLockedDurationResponse{Locks: locks}, nil
 }
 
-// AccountLockedPastTimeNotUnlockingOnly Returns locked records of an account with unlock time beyond timestamp excluding tokens started unlocking.
+// AccountLockedPastTimeNotUnlockingOnly returns locks of an account with unlock time beyond
+// given timestamp excluding locks that has started unlocking.
 func (q Querier) AccountLockedPastTimeNotUnlockingOnly(goCtx context.Context, req *types.AccountLockedPastTimeNotUnlockingOnlyRequest) (*types.AccountLockedPastTimeNotUnlockingOnlyResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -250,7 +253,8 @@ func (q Querier) AccountLockedPastTimeNotUnlockingOnly(goCtx context.Context, re
 	return &types.AccountLockedPastTimeNotUnlockingOnlyResponse{Locks: q.Keeper.GetAccountLockedPastTimeNotUnlockingOnly(ctx, owner, req.Timestamp)}, nil
 }
 
-// AccountLockedLongerDurationNotUnlockingOnly Returns account locked records with longer duration excluding tokens started unlocking.
+// AccountLockedLongerDurationNotUnlockingOnly returns locks of an account with longer duration
+// than the specified duration, excluding tokens that has started unlocking.
 func (q Querier) AccountLockedLongerDurationNotUnlockingOnly(goCtx context.Context, req *types.AccountLockedLongerDurationNotUnlockingOnlyRequest) (*types.AccountLockedLongerDurationNotUnlockingOnlyResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -269,6 +273,7 @@ func (q Querier) AccountLockedLongerDurationNotUnlockingOnly(goCtx context.Conte
 	return &types.AccountLockedLongerDurationNotUnlockingOnlyResponse{Locks: q.Keeper.GetAccountLockedLongerDurationNotUnlockingOnly(ctx, owner, req.Duration)}, nil
 }
 
+// LockedDenom returns the total amount of denom locked throughout all locks.
 func (q Querier) LockedDenom(goCtx context.Context, req *types.LockedDenomRequest) (*types.LockedDenomResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")

--- a/x/lockup/keeper/invariants.go
+++ b/x/lockup/keeper/invariants.go
@@ -17,6 +17,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, keeper Keeper) {
 	ir.RegisterRoute(types.ModuleName, "accumulation-store-invariant", AccumulationStoreInvariant(keeper))
 }
 
+// SyntheticLockupInvariant ensures that synthetic lock's underlying lock id and the actual lock's id has the same id.
 func SyntheticLockupInvariant(keeper Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		synthlocks := keeper.GetAllSyntheticLockups(ctx)

--- a/x/lockup/keeper/iterator.go
+++ b/x/lockup/keeper/iterator.go
@@ -194,7 +194,7 @@ func (k Keeper) unlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]typ
 	coins := sdk.Coins{}
 	locks := k.getLocksFromIterator(ctx, iterator)
 	for _, lock := range locks {
-		err := k.Unlock(ctx, lock.ID)
+		err := k.UnlockMaturedLock(ctx, lock.ID)
 		if err != nil {
 			panic(err)
 		}

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -14,29 +14,14 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 )
 
-// TODO: Reorganize functions in this file
-
 // WithdrawAllMaturedLocks withdraws every lock thats in the process of unlocking, and has finished unlocking by
 // the current block time.
 func (k Keeper) WithdrawAllMaturedLocks(ctx sdk.Context) {
 	k.unlockFromIterator(ctx, k.LockIteratorBeforeTime(ctx, ctx.BlockTime()))
 }
 
-func (k Keeper) getCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
-	coins := sdk.Coins{}
-	for _, lock := range locks {
-		coins = coins.Add(lock.Coins...)
-	}
-	return coins
-}
-
-func (k Keeper) accumulationStore(ctx sdk.Context, denom string) store.Tree {
-	return store.NewTree(prefix.NewStore(ctx.KVStore(k.storeKey), accumulationStorePrefix(denom)), 10)
-}
-
-// GetModuleBalance Returns full balance of the module.
+// GetModuleBalance returns full balance of the module.
 func (k Keeper) GetModuleBalance(ctx sdk.Context) sdk.Coins {
-	// TODO: should add invariant test for module balance and lock items
 	acc := k.ak.GetModuleAccount(ctx, types.ModuleName)
 	return k.bk.GetAllBalances(ctx, acc.GetAddress())
 }
@@ -56,62 +41,14 @@ func (k Keeper) GetPeriodLocksAccumulation(ctx sdk.Context, query types.QueryCon
 	return k.accumulationStore(ctx, query.Denom).SubsetAccumulation(beginKey, nil)
 }
 
-// BeginUnlockAllNotUnlockings begins unlock for all not unlocking coins.
+// BeginUnlockAllNotUnlockings begins unlock for all not unlocking locks of the given account.
 func (k Keeper) BeginUnlockAllNotUnlockings(ctx sdk.Context, account sdk.AccAddress) ([]types.PeriodLock, error) {
 	locks, err := k.beginUnlockFromIterator(ctx, k.AccountLockIterator(ctx, false, account))
 	return locks, err
 }
 
-func (k Keeper) addTokenToLock(ctx sdk.Context, lock *types.PeriodLock, coin sdk.Coin) error {
-	lock.Coins = lock.Coins.Add(coin)
-
-	err := k.setLock(ctx, *lock)
-	if err != nil {
-		return err
-	}
-
-	// modifications to accumulation store
-	k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(lock.Duration), coin.Amount)
-	// modifications to accumulation store by synthlocks
-	// CONTRACT: lock will have synthetic lock only if it has a single coin
-	lockedCoin, err := lock.SingleCoin()
-	if err == nil {
-		for _, synthlock := range k.GetAllSyntheticLockupsByLockup(ctx, lock.ID) {
-			k.accumulationStore(ctx, synthlock.SynthDenom).Increase(accumulationKey(synthlock.Duration), sdk.NewCoins(coin).AmountOf(lockedCoin.Denom))
-		}
-	}
-
-	k.hooks.AfterAddTokensToLock(ctx, lock.OwnerAddress(), lock.GetID(), sdk.NewCoins(coin))
-
-	return nil
-}
-
-// removeTokensFromLock is called by lockup slash function - called by superfluid module only.
-func (k Keeper) removeTokensFromLock(ctx sdk.Context, lock *types.PeriodLock, coins sdk.Coins) error {
-	// TODO: Handle 100% slash eventually, not needed for osmosis codebase atm.
-	lock.Coins = lock.Coins.Sub(coins)
-
-	err := k.setLock(ctx, *lock)
-	if err != nil {
-		return err
-	}
-
-	// modifications to accumulation store
-	for _, coin := range coins {
-		k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
-	}
-
-	// increase synthetic lockup's accumulation store
-	synthLocks := k.GetAllSyntheticLockupsByLockup(ctx, lock.ID)
-
-	// Note: since synthetic lockup deletion is using native lockup's coins to reduce accumulation store
-	// all the synthetic lockups' accumulation should be decreased
-	for _, synthlock := range synthLocks {
-		k.accumulationStore(ctx, synthlock.SynthDenom).Decrease(accumulationKey(synthlock.Duration), coins[0].Amount)
-	}
-	return nil
-}
-
+// AddToExistingLock adds the given coin to the existing lock with the same owner and duration.
+// Returns an empty array of period lock when a lock with the given condition does not exist.
 func (k Keeper) AddToExistingLock(ctx sdk.Context, owner sdk.AccAddress, coin sdk.Coin, duration time.Duration) ([]types.PeriodLock, error) {
 	locks := k.GetAccountLockedDurationNotUnlockingOnly(ctx, owner, coin.Denom, duration)
 	// if existing lock with same duration and denom exists, just add there
@@ -125,8 +62,10 @@ func (k Keeper) AddToExistingLock(ctx sdk.Context, owner sdk.AccAddress, coin sd
 	return locks, nil
 }
 
-// AddTokensToLock locks more tokens into a lockup
-// This also saves the lock to the store.
+// AddTokensToLock locks additional tokens into an existing lock with the given ID.
+// Tokens locked are sent and kept in the module account.
+// This method alters the lock state in store, thus we do a sanity check to ensure
+// lock owner matches the given owner.
 func (k Keeper) AddTokensToLockByID(ctx sdk.Context, lockID uint64, owner sdk.AccAddress, coin sdk.Coin) (*types.PeriodLock, error) {
 	lock, err := k.GetLockByID(ctx, lockID)
 
@@ -154,36 +93,37 @@ func (k Keeper) AddTokensToLockByID(ctx sdk.Context, lockID uint64, owner sdk.Ac
 	return lock, nil
 }
 
-// SlashTokensFromLockByID send slashed tokens to community pool - called by superfluid module only.
-func (k Keeper) SlashTokensFromLockByID(ctx sdk.Context, lockID uint64, coins sdk.Coins) (*types.PeriodLock, error) {
-	lock, err := k.GetLockByID(ctx, lockID)
+// addTokenToLock adds token to lock and modifies the state of the lock and the accumulation store.
+func (k Keeper) addTokenToLock(ctx sdk.Context, lock *types.PeriodLock, coin sdk.Coin) error {
+	lock.Coins = lock.Coins.Add(coin)
+
+	err := k.setLock(ctx, *lock)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	modAddr := k.ak.GetModuleAddress(types.ModuleName)
-	err = k.dk.FundCommunityPool(ctx, coins, modAddr)
-	if err != nil {
-		return nil, err
+	// modifications to accumulation store
+	k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(lock.Duration), coin.Amount)
+
+	// CONTRACT: lock will have synthetic lock only if it has a single coin
+	// accumulation store for its synthetic denom is increased if exists.
+	lockedCoin, err := lock.SingleCoin()
+	if err == nil {
+		for _, synthlock := range k.GetAllSyntheticLockupsByLockup(ctx, lock.ID) {
+			k.accumulationStore(ctx, synthlock.SynthDenom).Increase(accumulationKey(synthlock.Duration), sdk.NewCoins(coin).AmountOf(lockedCoin.Denom))
+		}
 	}
 
-	err = k.removeTokensFromLock(ctx, lock, coins)
-	if err != nil {
-		return nil, err
-	}
+	k.hooks.AfterAddTokensToLock(ctx, lock.OwnerAddress(), lock.GetID(), sdk.NewCoins(coin))
 
-	if k.hooks == nil {
-		return lock, nil
-	}
-
-	k.hooks.OnTokenSlashed(ctx, lock.ID, coins)
-	return lock, nil
+	return nil
 }
 
-// LockTokens lock tokens from an account for specified duration.
+// CreateLock creates a new lock with the specified duration for the owner.
 func (k Keeper) CreateLock(ctx sdk.Context, owner sdk.AccAddress, coins sdk.Coins, duration time.Duration) (types.PeriodLock, error) {
 	ID := k.GetLastLockID(ctx) + 1
-	// unlock time is set at the beginning of unlocking time
+	// unlock time is initially set without a value, gets set as unlock start time + duration
+	// when unlocking starts.
 	lock := types.NewPeriodLock(ID, owner, duration, time.Time{}, coins)
 	err := k.Lock(ctx, lock)
 	if err != nil {
@@ -191,6 +131,115 @@ func (k Keeper) CreateLock(ctx sdk.Context, owner sdk.AccAddress, coins sdk.Coin
 	}
 	k.SetLastLockID(ctx, lock.ID)
 	return lock, nil
+}
+
+// Lock is a utility method to lock tokens into the module account. This method includes setting the
+// lock within the state machine and increasing the value of accumulation store.
+func (k Keeper) Lock(ctx sdk.Context, lock types.PeriodLock) error {
+	owner, err := sdk.AccAddressFromBech32(lock.Owner)
+	if err != nil {
+		return err
+	}
+	if err := k.bk.SendCoinsFromAccountToModule(ctx, owner, types.ModuleName, lock.Coins); err != nil {
+		return err
+	}
+
+	// store lock object into the store
+	store := ctx.KVStore(k.storeKey)
+	bz, err := proto.Marshal(&lock)
+	if err != nil {
+		return err
+	}
+	store.Set(lockStoreKey(lock.ID), bz)
+
+	// add lock refs into not unlocking queue
+	err = k.addLockRefs(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	// add to accumulation store
+	for _, coin := range lock.Coins {
+		k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(lock.Duration), coin.Amount)
+	}
+
+	k.hooks.OnTokenLocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+	return nil
+}
+
+// BeginUnlock is a utility to start unlocking coins from NotUnlocking queue.
+// Returns an error if the lock has a synthetic lock.
+func (k Keeper) BeginUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) error {
+	// prohibit BeginUnlock if synthetic locks are referring to this
+	// TODO: In the future, make synthetic locks only get partial restrictions on the main lock.
+	lock, err := k.GetLockByID(ctx, lockID)
+	if err != nil {
+		return err
+	}
+	if k.HasAnySyntheticLockups(ctx, lock.ID) {
+		return fmt.Errorf("cannot BeginUnlocking a lock with synthetic lockup")
+	}
+
+	return k.beginUnlock(ctx, *lock, coins)
+}
+
+// BeginForceUnlock begins force unlock of the given lock.
+// This method should be called by the superfluid module ONLY, as it does not check whether
+// the lock has a synthetic lock or not before unlocking.
+func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) error {
+	lock, err := k.GetLockByID(ctx, lockID)
+	if err != nil {
+		return err
+	}
+	return k.beginUnlock(ctx, *lock, coins)
+}
+
+// beginUnlock unlocks specified tokens from the given lock. Existing lock refs
+// of not unlocking queue are deleted and new lock refs are then added.
+// EndTime of the lock is set within this method.
+// Coins provided as the parameter does not require to have all the tokens in the lock,
+// as we allow partial unlockings of a lock.
+func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coins) error {
+	// sanity check
+	if !coins.IsAllLTE(lock.Coins) {
+		return fmt.Errorf("requested amount to unlock exceeds locked tokens")
+	}
+
+	// If the amount were unlocking is empty, or the entire coins amount, unlock the entire lock.
+	// Otherwise, split the lock into two locks, and fully unlock the newly created lock.
+	// (By virtue, the newly created lock we split into should have the unlock amount)
+	if len(coins) != 0 && !coins.IsEqual(lock.Coins) {
+		splitLock, err := k.splitLock(ctx, lock, coins)
+		if err != nil {
+			return err
+		}
+		lock = splitLock
+	}
+
+	// remove existing lock refs from not unlocking queue
+	err := k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
+	if err != nil {
+		return err
+	}
+
+	// store lock with the end time set to current block time + duration
+	lock.EndTime = ctx.BlockTime().Add(lock.Duration)
+	err = k.setLock(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	// add lock refs into unlocking queue
+	err = k.addLockRefs(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	if k.hooks != nil {
+		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+	}
+
+	return nil
 }
 
 func (k Keeper) clearKeysByPrefix(ctx sdk.Context, prefix []byte) {
@@ -205,6 +254,175 @@ func (k Keeper) clearKeysByPrefix(ctx sdk.Context, prefix []byte) {
 
 func (k Keeper) ClearAccumulationStores(ctx sdk.Context) {
 	k.clearKeysByPrefix(ctx, types.KeyPrefixLockAccumulation)
+}
+
+func (k Keeper) BeginForceUnlockWithEndTime(ctx sdk.Context, lockID uint64, endTime time.Time) error {
+	lock, err := k.GetLockByID(ctx, lockID)
+	if err != nil {
+		return err
+	}
+	return k.beginForceUnlockWithEndTime(ctx, *lock, endTime)
+}
+
+func (k Keeper) beginForceUnlockWithEndTime(ctx sdk.Context, lock types.PeriodLock, endTime time.Time) error {
+	// remove lock refs from not unlocking queue if exists
+	err := k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
+	if err != nil {
+		return err
+	}
+
+	// store lock with end time set
+	lock.EndTime = endTime
+	err = k.setLock(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	// add lock refs into unlocking queue
+	err = k.addLockRefs(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	if k.hooks != nil {
+		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+	}
+
+	return nil
+}
+
+// UnlockMaturedLock finishes unlocking by sending back the locked tokens from the module accounts
+// to the owner. This method requires lock to be matured, having passed the endtime of the lock.
+func (k Keeper) UnlockMaturedLock(ctx sdk.Context, lockID uint64) error {
+	lock, err := k.GetLockByID(ctx, lockID)
+	if err != nil {
+		return err
+	}
+
+	// validation for current time and unlock time
+	curTime := ctx.BlockTime()
+	if !lock.IsUnlocking() {
+		return fmt.Errorf("lock hasn't started unlocking yet")
+	}
+	if curTime.Before(lock.EndTime) {
+		return fmt.Errorf("lock is not unlockable yet: %s >= %s", curTime.String(), lock.EndTime.String())
+	}
+
+	return k.unlockMaturedLockInternalLogic(ctx, *lock)
+}
+
+// ForceUnlock ignores unlock duration and immediately unlocks the lock and refunds tokens to lock owner.
+func (k Keeper) ForceUnlock(ctx sdk.Context, lock types.PeriodLock) error {
+	// Steps:
+	// 1) Break associated synthetic locks. (Superfluid data)
+	// 2) If lock is bonded, move it to unlocking
+	// 3) Run logic to delete unlocking metadata, and send tokens to owner.
+
+	synthLocks := k.GetAllSyntheticLockupsByLockup(ctx, lock.ID)
+	err := k.DeleteAllSyntheticLocks(ctx, lock, synthLocks)
+	if err != nil {
+		return err
+	}
+
+	if !lock.IsUnlocking() {
+		err := k.BeginUnlock(ctx, lock.ID, nil)
+		if err != nil {
+			return err
+		}
+	}
+	// NOTE: This caused a bug! BeginUnlock changes the owner the lock.EndTime
+	// This shows the bad API design of not using lock.ID in every public function.
+	lockPtr, err := k.GetLockByID(ctx, lock.ID)
+	if err != nil {
+		return err
+	}
+	return k.unlockMaturedLockInternalLogic(ctx, *lockPtr)
+}
+
+// unlockMaturedLockInternalLogic handles internal logic for finishing unlocking matured locks.
+func (k Keeper) unlockMaturedLockInternalLogic(ctx sdk.Context, lock types.PeriodLock) error {
+	owner, err := sdk.AccAddressFromBech32(lock.Owner)
+	if err != nil {
+		return err
+	}
+
+	// send coins back to owner
+	if err := k.bk.SendCoinsFromModuleToAccount(ctx, types.ModuleName, owner, lock.Coins); err != nil {
+		return err
+	}
+
+	k.deleteLock(ctx, lock.ID)
+
+	// delete lock refs from the unlocking queue
+	err = k.deleteLockRefs(ctx, types.KeyPrefixUnlocking, lock)
+	if err != nil {
+		return err
+	}
+
+	// remove from accumulation store
+	for _, coin := range lock.Coins {
+		k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
+	}
+
+	k.hooks.OnTokenUnlocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+	return nil
+}
+
+// ExtendLockup changes the existing lock duration to the given lock duration.
+// Updating lock duration would fail on either of the following conditions.
+// 1. Only lock owner is able to change the duration of the lock.
+// 2. Locks that are unlokcing are not allowed to change duration.
+// 3. Locks that have synthetic lockup are not allowed to change.
+// 4. Provided duration should be greater than the original duration.
+func (k Keeper) ExtendLockup(ctx sdk.Context, lock types.PeriodLock, newDuration time.Duration) error {
+	if lock.IsUnlocking() {
+		return fmt.Errorf("cannot edit unlocking lockup for lock %d", lock.ID)
+	}
+
+	// check synthetic lockup exists
+	if k.HasAnySyntheticLockups(ctx, lock.ID) {
+		return fmt.Errorf("cannot edit lockup with synthetic lock %d", lock.ID)
+	}
+
+	oldLock := lock
+
+	if newDuration != 0 {
+		if newDuration <= lock.Duration {
+			return fmt.Errorf("new duration should be greater than the original")
+		}
+
+		// update accumulation store
+		for _, coin := range lock.Coins {
+			k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
+			k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(newDuration), coin.Amount)
+		}
+
+		lock.Duration = newDuration
+	}
+
+	// update lockup
+	err := k.deleteLockRefs(ctx, unlockingPrefix(oldLock.IsUnlocking()), oldLock)
+	if err != nil {
+		return err
+	}
+
+	err = k.addLockRefs(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	err = k.setLock(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	k.hooks.OnLockupExtend(ctx,
+		lock.GetID(),
+		oldLock.GetDuration(),
+		lock.GetDuration(),
+	)
+
+	return nil
 }
 
 // ResetAllLocks takes a set of locks, and initializes state to be storing
@@ -337,25 +555,62 @@ func (k Keeper) ResetAllSyntheticLocks(ctx sdk.Context, syntheticLocks []types.S
 	return nil
 }
 
-func (k Keeper) setSyntheticLockAndResetRefs(ctx sdk.Context, lock types.PeriodLock, synthLock types.SyntheticLock) error {
-	err := k.setSyntheticLockupObject(ctx, &synthLock)
+// SlashTokensFromLockByID sends slashed tokens directly from the lock to the community pool.
+// Called by the superfluid module ONLY.
+func (k Keeper) SlashTokensFromLockByID(ctx sdk.Context, lockID uint64, coins sdk.Coins) (*types.PeriodLock, error) {
+	lock, err := k.GetLockByID(ctx, lockID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// store synth lock refs
-	return k.addSyntheticLockRefs(ctx, lock, synthLock)
+	modAddr := k.ak.GetModuleAddress(types.ModuleName)
+	err = k.dk.FundCommunityPool(ctx, coins, modAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = k.removeTokensFromLock(ctx, lock, coins)
+	if err != nil {
+		return nil, err
+	}
+
+	if k.hooks == nil {
+		return lock, nil
+	}
+
+	k.hooks.OnTokenSlashed(ctx, lock.ID, coins)
+	return lock, nil
 }
 
-// setLockAndResetLockRefs sets the lock, and resets all of its lock references
-// This puts the lock into a 'clean' state, aside from the AccumulationStore.
-func (k Keeper) setLockAndResetLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
-	err := k.setLock(ctx, lock)
+func (k Keeper) accumulationStore(ctx sdk.Context, denom string) store.Tree {
+	return store.NewTree(prefix.NewStore(ctx.KVStore(k.storeKey), accumulationStorePrefix(denom)), 10)
+}
+
+// removeTokensFromLock is called by lockup slash function.
+// Called by the superfluid module ONLY.
+func (k Keeper) removeTokensFromLock(ctx sdk.Context, lock *types.PeriodLock, coins sdk.Coins) error {
+	// TODO: Handle 100% slash eventually, not needed for osmosis codebase atm.
+	lock.Coins = lock.Coins.Sub(coins)
+
+	err := k.setLock(ctx, *lock)
 	if err != nil {
 		return err
 	}
 
-	return k.addLockRefs(ctx, lock)
+	// modifications to accumulation store
+	for _, coin := range coins {
+		k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
+	}
+
+	// increase synthetic lockup's accumulation store
+	synthLocks := k.GetAllSyntheticLockupsByLockup(ctx, lock.ID)
+
+	// Note: since synthetic lockup deletion is using native lockup's coins to reduce accumulation store
+	// all the synthetic lockups' accumulation should be decreased
+	for _, synthlock := range synthLocks {
+		k.accumulationStore(ctx, synthlock.SynthDenom).Decrease(accumulationKey(synthlock.Duration), coins[0].Amount)
+	}
+	return nil
 }
 
 // setLock is a utility to store lock object into the store.
@@ -369,43 +624,32 @@ func (k Keeper) setLock(ctx sdk.Context, lock types.PeriodLock) error {
 	return nil
 }
 
+// setLockAndResetLockRefs sets the lock, and resets all of its lock references
+// This puts the lock into a 'clean' state, aside from the AccumulationStore.
+func (k Keeper) setLockAndResetLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
+	err := k.setLock(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	return k.addLockRefs(ctx, lock)
+}
+
+// setSyntheticLockAndResetRefs sets the synthetic lock object, and resets all of its lock references
+func (k Keeper) setSyntheticLockAndResetRefs(ctx sdk.Context, lock types.PeriodLock, synthLock types.SyntheticLock) error {
+	err := k.setSyntheticLockupObject(ctx, &synthLock)
+	if err != nil {
+		return err
+	}
+
+	// store synth lock refs
+	return k.addSyntheticLockRefs(ctx, lock, synthLock)
+}
+
 // deleteLock removes the lock object from the state.
 func (k Keeper) deleteLock(ctx sdk.Context, id uint64) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(lockStoreKey(id))
-}
-
-// Lock is a utility to lock coins into module account.
-func (k Keeper) Lock(ctx sdk.Context, lock types.PeriodLock) error {
-	owner, err := sdk.AccAddressFromBech32(lock.Owner)
-	if err != nil {
-		return err
-	}
-	if err := k.bk.SendCoinsFromAccountToModule(ctx, owner, types.ModuleName, lock.Coins); err != nil {
-		return err
-	}
-
-	// store lock object into the store
-	store := ctx.KVStore(k.storeKey)
-	bz, err := proto.Marshal(&lock)
-	if err != nil {
-		return err
-	}
-	store.Set(lockStoreKey(lock.ID), bz)
-
-	// add lock refs into not unlocking queue
-	err = k.addLockRefs(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	// add to accumulation store
-	for _, coin := range lock.Coins {
-		k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(lock.Duration), coin.Amount)
-	}
-
-	k.hooks.OnTokenLocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
-	return nil
 }
 
 // splitLock splits a lock with the given amount, and stores split new lock to the state.
@@ -427,251 +671,10 @@ func (k Keeper) splitLock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coin
 	return splitLock, err
 }
 
-// BeginUnlock is a utility to start unlocking coins from NotUnlocking queue.
-func (k Keeper) BeginUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) error {
-	// prohibit BeginUnlock if synthetic locks are referring to this
-	// TODO: In the future, make synthetic locks only get partial restrictions on the main lock.
-	lock, err := k.GetLockByID(ctx, lockID)
-	if err != nil {
-		return err
+func (k Keeper) getCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
+	coins := sdk.Coins{}
+	for _, lock := range locks {
+		coins = coins.Add(lock.Coins...)
 	}
-	if k.HasAnySyntheticLockups(ctx, lock.ID) {
-		return fmt.Errorf("cannot BeginUnlocking a lock with synthetic lockup")
-	}
-
-	return k.beginForceUnlock(ctx, *lock, coins)
-}
-
-func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) error {
-	lock, err := k.GetLockByID(ctx, lockID)
-	if err != nil {
-		return err
-	}
-	return k.beginForceUnlock(ctx, *lock, coins)
-}
-
-func (k Keeper) beginForceUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coins) error {
-	// sanity check
-	if !coins.IsAllLTE(lock.Coins) {
-		return fmt.Errorf("requested amount to unlock exceeds locked tokens")
-	}
-
-	// If the amount were unlocking is empty, or the entire coins amount, unlock the entire lock.
-	// Otherwise, split the lock into two locks, and fully unlock the newly created lock.
-	// (By virtue, the newly created lock we split into should have the unlock amount)
-	if len(coins) != 0 && !coins.IsEqual(lock.Coins) {
-		splitLock, err := k.splitLock(ctx, lock, coins)
-		if err != nil {
-			return err
-		}
-		lock = splitLock
-	}
-
-	// remove lock refs from not unlocking queue if exists
-	err := k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
-	if err != nil {
-		return err
-	}
-
-	// store lock with end time set
-	lock.EndTime = ctx.BlockTime().Add(lock.Duration)
-	err = k.setLock(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	// add lock refs into unlocking queue
-	err = k.addLockRefs(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	if k.hooks != nil {
-		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
-	}
-
-	return nil
-}
-
-func (k Keeper) BeginForceUnlockWithEndTime(ctx sdk.Context, lockID uint64, endTime time.Time) error {
-	lock, err := k.GetLockByID(ctx, lockID)
-	if err != nil {
-		return err
-	}
-	return k.beginForceUnlockWithEndTime(ctx, *lock, endTime)
-}
-
-func (k Keeper) beginForceUnlockWithEndTime(ctx sdk.Context, lock types.PeriodLock, endTime time.Time) error {
-	// remove lock refs from not unlocking queue if exists
-	err := k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
-	if err != nil {
-		return err
-	}
-
-	// store lock with end time set
-	lock.EndTime = endTime
-	err = k.setLock(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	// add lock refs into unlocking queue
-	err = k.addLockRefs(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	if k.hooks != nil {
-		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
-	}
-
-	return nil
-}
-
-// Unlock is a utility to unlock coins from module account.
-func (k Keeper) Unlock(ctx sdk.Context, lockID uint64) error {
-	lock, err := k.GetLockByID(ctx, lockID)
-	if err != nil {
-		return err
-	}
-
-	// validation for current time and unlock time
-	curTime := ctx.BlockTime()
-	if !lock.IsUnlocking() {
-		return fmt.Errorf("lock hasn't started unlocking yet")
-	}
-	if curTime.Before(lock.EndTime) {
-		return fmt.Errorf("lock is not unlockable yet: %s >= %s", curTime.String(), lock.EndTime.String())
-	}
-
-	return k.unlockInternalLogic(ctx, *lock)
-}
-
-// ForceUnlock ignores unlock duration and immediately unlocks the lock and refunds tokens to lock owner..
-func (k Keeper) ForceUnlock(ctx sdk.Context, lock types.PeriodLock) error {
-	// Steps:
-	// 1) Break associated synthetic locks. (Superfluid data)
-	// 2) If lock is bonded, move it to unlocking
-	// 3) Run logic to delete unlocking metadata, and send tokens to owner.
-
-	synthLocks := k.GetAllSyntheticLockupsByLockup(ctx, lock.ID)
-	err := k.BreakAllSyntheticLocks(ctx, lock, synthLocks)
-	if err != nil {
-		return err
-	}
-
-	if !lock.IsUnlocking() {
-		err := k.BeginUnlock(ctx, lock.ID, nil)
-		if err != nil {
-			return err
-		}
-	}
-	// NOTE: This caused a bug! BeginUnlock changes the owner the lock.EndTime
-	// This shows the bad API design of not using lock.ID in every public function.
-	lockPtr, err := k.GetLockByID(ctx, lock.ID)
-	if err != nil {
-		return err
-	}
-	return k.unlockInternalLogic(ctx, *lockPtr)
-}
-
-func (k Keeper) BreakAllSyntheticLocks(ctx sdk.Context, lock types.PeriodLock, synthLocks []types.SyntheticLock) error {
-	if len(synthLocks) == 0 {
-		return nil
-	}
-
-	// Synth locks have data set in two places, accumulation store & setSyntheticLockAndResetRefs
-	// see that [CreateSyntheticLock](https://github.com/osmosis-labs/osmosis/blob/v7.3.0/x/lockup/keeper/synthetic_lock.go#L105)
-	// only has 3 set locations:
-	// - k.setSyntheticLockupObject(ctx, &synthLock)
-	// - k.addSyntheticLockRefs(ctx, *lock, synthLock)
-	// - k.accumulationStore(ctx, synthLock.SynthDenom).Increase(accumulationKey(unlockDuration), coin.Amount)
-	// ALL of which are reverted in the method DeleteSyntheticLock, here:
-	// https://github.com/osmosis-labs/osmosis/blob/v7.3.0/x/lockup/keeper/synthetic_lock.go#L156
-	for _, synthLock := range synthLocks {
-		err := k.DeleteSyntheticLockup(ctx, lock.ID, synthLock.SynthDenom)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (k Keeper) unlockInternalLogic(ctx sdk.Context, lock types.PeriodLock) error {
-	owner, err := sdk.AccAddressFromBech32(lock.Owner)
-	if err != nil {
-		return err
-	}
-
-	// send coins back to owner
-	if err := k.bk.SendCoinsFromModuleToAccount(ctx, types.ModuleName, owner, lock.Coins); err != nil {
-		return err
-	}
-
-	k.deleteLock(ctx, lock.ID)
-
-	// delete lock refs from the unlocking queue
-	err = k.deleteLockRefs(ctx, types.KeyPrefixUnlocking, lock)
-	if err != nil {
-		return err
-	}
-
-	// remove from accumulation store
-	for _, coin := range lock.Coins {
-		k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
-	}
-
-	k.hooks.OnTokenUnlocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
-	return nil
-}
-
-func (k Keeper) ExtendLockup(ctx sdk.Context, lock types.PeriodLock, newDuration time.Duration) error {
-	if lock.IsUnlocking() {
-		return fmt.Errorf("cannot edit unlocking lockup for lock %d", lock.ID)
-	}
-
-	// check synthetic lockup exists
-	if k.HasAnySyntheticLockups(ctx, lock.ID) {
-		return fmt.Errorf("cannot edit lockup with synthetic lock %d", lock.ID)
-	}
-
-	oldLock := lock
-
-	if newDuration != 0 {
-		if newDuration <= lock.Duration {
-			return fmt.Errorf("new duration should be greater than the original")
-		}
-
-		// update accumulation store
-		for _, coin := range lock.Coins {
-			k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
-			k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(newDuration), coin.Amount)
-		}
-
-		lock.Duration = newDuration
-	}
-
-	// update lockup
-	err := k.deleteLockRefs(ctx, unlockingPrefix(oldLock.IsUnlocking()), oldLock)
-	if err != nil {
-		return err
-	}
-
-	err = k.addLockRefs(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	err = k.setLock(ctx, lock)
-	if err != nil {
-		return err
-	}
-
-	k.hooks.OnLockupExtend(ctx,
-		lock.GetID(),
-		oldLock.GetDuration(),
-		lock.GetDuration(),
-	)
-
-	return nil
+	return coins
 }

--- a/x/lockup/keeper/lock_refs.go
+++ b/x/lockup/keeper/lock_refs.go
@@ -6,6 +6,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// addLockRefs adds appropriate reference keys preceded by a prefix.
+// A prefix indicates whether the lock is unlocking or not.
 func (k Keeper) addLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
 	refKeys, err := durationLockRefKeys(lock)
 	if lock.IsUnlocking() {
@@ -23,6 +25,7 @@ func (k Keeper) addLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
 	return nil
 }
 
+// deleteLockRefs deletes all the lock references of the lock with the given lock prefix.
 func (k Keeper) deleteLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types.PeriodLock) error {
 	refKeys, err := lockRefKeys(lock)
 	if err != nil {
@@ -34,7 +37,7 @@ func (k Keeper) deleteLockRefs(ctx sdk.Context, lockRefPrefix []byte, lock types
 	return nil
 }
 
-// make references for.
+// addSyntheticLockRefs adds lock refs for the synthetic lock object.
 func (k Keeper) addSyntheticLockRefs(ctx sdk.Context, lock types.PeriodLock, synthLock types.SyntheticLock) error {
 	refKeys, err := syntheticLockRefKeys(lock, synthLock)
 	if err != nil {
@@ -49,6 +52,7 @@ func (k Keeper) addSyntheticLockRefs(ctx sdk.Context, lock types.PeriodLock, syn
 	return nil
 }
 
+// deleteSyntheticLockRefs deletes all lock refs for the synthetic lock object.
 func (k Keeper) deleteSyntheticLockRefs(ctx sdk.Context, lock types.PeriodLock, synthLock types.SyntheticLock) error {
 	refKeys, err := syntheticLockRefKeys(lock, synthLock)
 	if err != nil {
@@ -59,9 +63,4 @@ func (k Keeper) deleteSyntheticLockRefs(ctx sdk.Context, lock types.PeriodLock, 
 		k.deleteLockRefByKey(ctx, combineKeys(lockRefPrefix, refKey), synthLock.UnderlyingLockId)
 	}
 	return nil
-}
-
-func (k Keeper) ClearAllLockRefKeys(ctx sdk.Context) {
-	k.clearKeysByPrefix(ctx, types.KeyPrefixNotUnlocking)
-	k.clearKeysByPrefix(ctx, types.KeyPrefixUnlocking)
 }

--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -114,7 +114,7 @@ func (suite *KeeperTestSuite) TestUnlockPeriodLockByID() {
 	// unlock lock just now
 	lock, err := lockKeeper.GetLockByID(suite.Ctx, 1)
 	suite.Require().NoError(err)
-	err = lockKeeper.Unlock(suite.Ctx, lock.ID)
+	err = lockKeeper.UnlockMaturedLock(suite.Ctx, lock.ID)
 	suite.Require().Error(err)
 
 	// move start time to 1 second in the future.
@@ -123,7 +123,7 @@ func (suite *KeeperTestSuite) TestUnlockPeriodLockByID() {
 	// Try to finish unlocking a lock, before starting unlock.
 	lock, err = lockKeeper.GetLockByID(suite.Ctx, 1)
 	suite.Require().NoError(err)
-	err = lockKeeper.Unlock(suite.Ctx, lock.ID)
+	err = lockKeeper.UnlockMaturedLock(suite.Ctx, lock.ID)
 	suite.Require().Error(err)
 
 	// begin unlock
@@ -135,7 +135,7 @@ func (suite *KeeperTestSuite) TestUnlockPeriodLockByID() {
 	// unlock 1s after begin unlock
 	lock, err = lockKeeper.GetLockByID(suite.Ctx, 1)
 	suite.Require().NoError(err)
-	err = lockKeeper.Unlock(suite.Ctx.WithBlockTime(now.Add(time.Second*2)), lock.ID)
+	err = lockKeeper.UnlockMaturedLock(suite.Ctx.WithBlockTime(now.Add(time.Second*2)), lock.ID)
 	suite.Require().NoError(err)
 
 	// check locks
@@ -195,7 +195,7 @@ func (suite *KeeperTestSuite) TestUnlock() {
 	suite.Require().NoError(err)
 
 	// unlock with lock object
-	err = suite.App.LockupKeeper.Unlock(suite.Ctx.WithBlockTime(now.Add(time.Second)), lockPtr.ID)
+	err = suite.App.LockupKeeper.UnlockMaturedLock(suite.Ctx.WithBlockTime(now.Add(time.Second)), lockPtr.ID)
 	suite.Require().NoError(err)
 }
 
@@ -252,7 +252,7 @@ func (suite *KeeperTestSuite) TestPartialUnlock() {
 
 	// Finish unlocking partial unlock
 	partialUnlock := suite.App.LockupKeeper.GetAccountPeriodLocks(suite.Ctx, addr1)[1]
-	err = suite.App.LockupKeeper.Unlock(suite.Ctx.WithBlockTime(now.Add(time.Second)), partialUnlock.ID)
+	err = suite.App.LockupKeeper.UnlockMaturedLock(suite.Ctx.WithBlockTime(now.Add(time.Second)), partialUnlock.ID)
 	suite.Require().NoError(err)
 
 	// check unlocking coins

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -24,6 +24,11 @@ func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
 
 var _ types.MsgServer = msgServer{}
 
+// LockTokens locks tokens in either two ways.
+// 1. Add to an existing lock if a lock with the same owner and same duration exists.
+// 2. Create a new lock if not.
+// A sanity check to ensure given tokens is a single token is done in ValidateBaic.
+// That is, a lock with multiple tokens cannot be created.
 func (server msgServer) LockTokens(goCtx context.Context, msg *types.MsgLockTokens) (*types.MsgLockTokensResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -32,25 +37,27 @@ func (server msgServer) LockTokens(goCtx context.Context, msg *types.MsgLockToke
 		return nil, err
 	}
 
-	// if there is an existing lock
-	if len(msg.Coins) == 1 {
-		locks, err := server.keeper.AddToExistingLock(ctx, owner, msg.Coins[0], msg.Duration)
-		if err != nil {
-			return nil, err
-		}
-		if len(locks) > 0 {
-			ctx.EventManager().EmitEvents(sdk.Events{
-				sdk.NewEvent(
-					types.TypeEvtAddTokensToLock,
-					sdk.NewAttribute(types.AttributePeriodLockID, utils.Uint64ToString(locks[0].ID)),
-					sdk.NewAttribute(types.AttributePeriodLockOwner, msg.Owner),
-					sdk.NewAttribute(types.AttributePeriodLockAmount, msg.Coins.String()),
-				),
-			})
-			return &types.MsgLockTokensResponse{ID: locks[0].ID}, nil
-		}
+	// check if there's an existing lock from the same owner with the same duration.
+	// If so, simply add tokens to the existing lock.
+	locks, err := server.keeper.AddToExistingLock(ctx, owner, msg.Coins[0], msg.Duration)
+	if err != nil {
+		return nil, err
 	}
 
+	// return the lock id of the existing lock when successfully added to the existing lock.
+	if len(locks) > 0 {
+		ctx.EventManager().EmitEvents(sdk.Events{
+			sdk.NewEvent(
+				types.TypeEvtAddTokensToLock,
+				sdk.NewAttribute(types.AttributePeriodLockID, utils.Uint64ToString(locks[0].ID)),
+				sdk.NewAttribute(types.AttributePeriodLockOwner, msg.Owner),
+				sdk.NewAttribute(types.AttributePeriodLockAmount, msg.Coins.String()),
+			),
+		})
+		return &types.MsgLockTokensResponse{ID: locks[0].ID}, nil
+	}
+
+	// if the owner + duration combination is new, create a new lock.
 	lock, err := server.keeper.CreateLock(ctx, owner, msg.Coins, msg.Duration)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
@@ -70,6 +77,8 @@ func (server msgServer) LockTokens(goCtx context.Context, msg *types.MsgLockToke
 	return &types.MsgLockTokensResponse{ID: lock.ID}, nil
 }
 
+// BeginUnlocking begins unlocking of the specified lock.
+// The lock would enter the unlocking queue, with the endtime of the lock set as block time + duration.
 func (server msgServer) BeginUnlocking(goCtx context.Context, msg *types.MsgBeginUnlocking) (*types.MsgBeginUnlockingResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -99,6 +108,7 @@ func (server msgServer) BeginUnlocking(goCtx context.Context, msg *types.MsgBegi
 	return &types.MsgBeginUnlockingResponse{}, nil
 }
 
+// BeginUnlockingAll begins unlocking for all the locks that the account has by iterating all the not-unlocking locks the account holds.
 func (server msgServer) BeginUnlockingAll(goCtx context.Context, msg *types.MsgBeginUnlockingAll) (*types.MsgBeginUnlockingAllResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -140,6 +150,9 @@ func createBeginUnlockEvent(lock *types.PeriodLock) sdk.Event {
 	)
 }
 
+// ExtendLockup extends the duration of the existing lock.
+// ExtendLockup would fail if the original lock's duration is longer than the new duration,
+// OR if the lock is currently unlocking OR if the original lock has a synthetic lock.
 func (server msgServer) ExtendLockup(goCtx context.Context, msg *types.MsgExtendLockup) (*types.MsgExtendLockupResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/lockup/keeper/synthetic_lock.go
+++ b/x/lockup/keeper/synthetic_lock.go
@@ -5,41 +5,25 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 )
 
-func (k Keeper) setSyntheticLockupObject(ctx sdk.Context, synthLock *types.SyntheticLock) error {
-	store := ctx.KVStore(k.storeKey)
-	bz, err := proto.Marshal(synthLock)
-	if err != nil {
-		return err
-	}
-	store.Set(syntheticLockStoreKey(synthLock.UnderlyingLockId, synthLock.SynthDenom), bz)
-	if !synthLock.EndTime.Equal(time.Time{}) {
-		store.Set(syntheticLockTimeStoreKey(synthLock.UnderlyingLockId, synthLock.SynthDenom, synthLock.EndTime), bz)
-	}
-	return nil
-}
+// A synthetic lock object is a lock obejct used for the superfluid module.
+// Each synthetic lock object is stored in state using lock id and synthetic denom
+// as it's key, where a synthetic denom would be consisted of the original denom of the lock,
+// validator address, and the staking positiion of the lock.
+// Unlike the original lock objects, synthetic locks are mainly used to indicate the staking
+// position of the lock.
+// Synthetic use different accumulation store from the original lock objects.
+// Note that locks with synthetic objects cannot be directly deleted or cannot directly start
+// unlocking. locks with synthetic lock objects are to be unlocked via superfluid module.
+// The Endtime and the Duration fields of the synthetic locks do not need to have the same values
+// as the underlying lock objects.
 
-func (k Keeper) deleteSyntheticLockupObject(ctx sdk.Context, lockID uint64, synthdenom string) {
-	store := ctx.KVStore(k.storeKey)
-	synthLock, _ := k.GetSyntheticLockup(ctx, lockID, synthdenom)
-	if synthLock != nil && !synthLock.EndTime.Equal(time.Time{}) {
-		store.Delete(syntheticLockTimeStoreKey(lockID, synthdenom, synthLock.EndTime))
-	}
-	store.Delete(syntheticLockStoreKey(lockID, synthdenom))
-}
-
-func (k Keeper) GetUnderlyingLock(ctx sdk.Context, synthlock types.SyntheticLock) types.PeriodLock {
-	lock, err := k.GetLockByID(ctx, synthlock.UnderlyingLockId)
-	if err != nil {
-		panic(err) // Synthetic lock MUST have underlying lock
-	}
-	return *lock
-}
-
+// GetSyntheticLockup gets the synthetic lock object using lock ID and synthetic denom as key.
 func (k Keeper) GetSyntheticLockup(ctx sdk.Context, lockID uint64, synthdenom string) (*types.SyntheticLock, error) {
 	synthLock := types.SyntheticLock{}
 	store := ctx.KVStore(k.storeKey)
@@ -52,6 +36,7 @@ func (k Keeper) GetSyntheticLockup(ctx sdk.Context, lockID uint64, synthdenom st
 	return &synthLock, err
 }
 
+// GetAllSyntheticLockupsByLockup gets all the synthetic lockup object of the original lockup.
 func (k Keeper) GetAllSyntheticLockupsByLockup(ctx sdk.Context, lockID uint64) []types.SyntheticLock {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, combineKeys(types.KeyPrefixSyntheticLockup, sdk.Uint64ToBigEndian(lockID)))
@@ -69,6 +54,7 @@ func (k Keeper) GetAllSyntheticLockupsByLockup(ctx sdk.Context, lockID uint64) [
 	return synthLocks
 }
 
+// GetAllSyntheticLockupsByAddr gets all the synthetic lockups from all the locks owned by the given address.
 func (k Keeper) GetAllSyntheticLockupsByAddr(ctx sdk.Context, owner sdk.AccAddress) []types.SyntheticLock {
 	synthLocks := []types.SyntheticLock{}
 	locks := k.GetAccountPeriodLocks(ctx, owner)
@@ -78,6 +64,7 @@ func (k Keeper) GetAllSyntheticLockupsByAddr(ctx sdk.Context, owner sdk.AccAddre
 	return synthLocks
 }
 
+// HasAnySyntheticLockups returns true if the lock has a synthetic lock.
 func (k Keeper) HasAnySyntheticLockups(ctx sdk.Context, lockID uint64) bool {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, combineKeys(types.KeyPrefixSyntheticLockup, sdk.Uint64ToBigEndian(lockID)))
@@ -85,6 +72,7 @@ func (k Keeper) HasAnySyntheticLockups(ctx sdk.Context, lockID uint64) bool {
 	return iterator.Valid()
 }
 
+// GetAllSyntheticLockups gets all synthetic locks within the store.
 func (k Keeper) GetAllSyntheticLockups(ctx sdk.Context) []types.SyntheticLock {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixSyntheticLockup)
@@ -106,7 +94,7 @@ func (k Keeper) GetAllSyntheticLockups(ctx sdk.Context) []types.SyntheticLock {
 func (k Keeper) CreateSyntheticLockup(ctx sdk.Context, lockID uint64, synthDenom string, unlockDuration time.Duration, isUnlocking bool) error {
 	// Note: synthetic lockup is doing everything same as lockup except coin movement
 	// There is no relationship between unbonding and bonding synthetic lockup, it's managed separately
-	// Accumulation store works without caring about unlocking synthetic or not
+	// A separate accumulation store is incremented with the synth denom.
 
 	_, err := k.GetSyntheticLockup(ctx, lockID, synthDenom)
 	if err == nil {
@@ -153,7 +141,27 @@ func (k Keeper) CreateSyntheticLockup(ctx sdk.Context, lockID uint64, synthDenom
 	return nil
 }
 
+// DeleteAllSyntheticLocks iterates over given array of synthetic locks and deletes all individual synthetic locks.
+func (k Keeper) DeleteAllSyntheticLocks(ctx sdk.Context, lock types.PeriodLock, synthLocks []types.SyntheticLock) error {
+	if len(synthLocks) == 0 {
+		return nil
+	}
+
+	for _, synthLock := range synthLocks {
+		err := k.DeleteSyntheticLockup(ctx, lock.ID, synthLock.SynthDenom)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteSyntheticLockup delete synthetic lockup with lock id and synthdenom.
+// Synthetic lock has three relevant state entries.
+// - synthetic lock object itself
+// - synthetic lock refs
+// - accumulation store for the synthetic lock.
+// all of which are deleted within this method.
 func (k Keeper) DeleteSyntheticLockup(ctx sdk.Context, lockID uint64, synthdenom string) error {
 	synthLock, err := k.GetSyntheticLockup(ctx, lockID, synthdenom)
 	if err != nil {
@@ -185,6 +193,7 @@ func (k Keeper) DeleteSyntheticLockup(ctx sdk.Context, lockID uint64, synthdenom
 	return nil
 }
 
+// DeleteAllMaturedSyntheticLocks deletes all matured synthetic locks.
 func (k Keeper) DeleteAllMaturedSyntheticLocks(ctx sdk.Context) {
 	iterator := k.iteratorBeforeTime(ctx, combineKeys(types.KeyPrefixSyntheticLockTimestamp), ctx.BlockTime())
 	defer iterator.Close()
@@ -200,4 +209,34 @@ func (k Keeper) DeleteAllMaturedSyntheticLocks(ctx sdk.Context) {
 			panic(err)
 		}
 	}
+}
+
+func (k Keeper) GetUnderlyingLock(ctx sdk.Context, synthlock types.SyntheticLock) types.PeriodLock {
+	lock, err := k.GetLockByID(ctx, synthlock.UnderlyingLockId)
+	if err != nil {
+		panic(err) // Synthetic lock MUST have underlying lock
+	}
+	return *lock
+}
+
+func (k Keeper) setSyntheticLockupObject(ctx sdk.Context, synthLock *types.SyntheticLock) error {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := proto.Marshal(synthLock)
+	if err != nil {
+		return err
+	}
+	store.Set(syntheticLockStoreKey(synthLock.UnderlyingLockId, synthLock.SynthDenom), bz)
+	if !synthLock.EndTime.Equal(time.Time{}) {
+		store.Set(syntheticLockTimeStoreKey(synthLock.UnderlyingLockId, synthLock.SynthDenom, synthLock.EndTime), bz)
+	}
+	return nil
+}
+
+func (k Keeper) deleteSyntheticLockupObject(ctx sdk.Context, lockID uint64, synthdenom string) {
+	store := ctx.KVStore(k.storeKey)
+	synthLock, _ := k.GetSyntheticLockup(ctx, lockID, synthdenom)
+	if synthLock != nil && !synthLock.EndTime.Equal(time.Time{}) {
+		store.Delete(syntheticLockTimeStoreKey(lockID, synthdenom, synthLock.EndTime))
+	}
+	store.Delete(syntheticLockStoreKey(lockID, synthdenom))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Subcomponent of : #1838 

## What is the purpose of the change

This PR 
- adds documentations to each lockup methods
- changes order for methods in the `lock.go` file for readibility, 
- rename method name 
   - `Unlock` -> `UnlockMaturedLock`, as it was unclear if the unlock method was describing the initiative of unlocking or finishing of unlocking 
   - `BreakAllSynthethicLocks` -> `DeleteAllSyntheticLocks`, as BreakAllSyntheticLocks were basically iterating over locks to call `DeleteSyntheticLock` the change is better for naming consistency

This PR does not include any change or refactoring of the logic itself.

## Brief Changelog

Documentation additions, method renaming, file cleanup for x/lockup.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)