### PR TITLE
fix: e2e flakiness related to err checking containers

### DIFF
--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -25,8 +24,6 @@ type Manager struct {
 	hermesResource *dockertest.Resource
 	valResources   map[string][]*dockertest.Resource
 }
-
-var errRegex = regexp.MustCompile(`(E|e)rror`)
 
 // NewManager creates a new Manager instance and initializes
 // all Docker specific utilies. Returns an error if initialiation fails.
@@ -88,16 +85,6 @@ func (m *Manager) ExecCmd(t *testing.T, chainId string, validatorIndex int, comm
 				ErrorStream:  &errBuf,
 			})
 			if err != nil {
-				return false
-			}
-
-			errBufString := errBuf.String()
-
-			// Note that this does not match all errors.
-			// This only works if CLI outpurs "Error" or "error"
-			// to stderr.
-			if errRegex.MatchString(errBufString) {
-				t.Log(errBufString)
 				return false
 			}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

#1898 introduced flakiness. Apparently, Hermes sometimes produces errors to stderr when it functions correctly. Therefore, the added logic prevents IBC from functioning correctly.

For some reason, sometimes Hermes does not produce these logs so the CI passes.

This logic is not very useful so can be removed to fix CI. Test locally several times, and it works.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable