### PR TITLE
refactor FundCommunityPoolFromModule to use SDK

### DIFF
--- a/x/pool-incentives/keeper/distr.go
+++ b/x/pool-incentives/keeper/distr.go
@@ -10,16 +10,14 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// FundCommunityPoolFromModule allows the pool-incentives module to directly fund the community fund pool.
 func (k Keeper) FundCommunityPoolFromModule(ctx sdk.Context, asset sdk.Coin) error {
-	err := k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.communityPoolName, sdk.Coins{asset})
-	if err != nil {
-		return err
+	moduleAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
+	if moduleAddr == nil {
+		panic("Could not get distribution module from SDK")
 	}
 
-	feePool := k.distrKeeper.GetFeePool(ctx)
-	feePool.CommunityPool = feePool.CommunityPool.Add(sdk.NewDecCoinsFromCoins(asset)...)
-	k.distrKeeper.SetFeePool(ctx, feePool)
-	return nil
+	return k.distrKeeper.FundCommunityPool(ctx, sdk.Coins{asset}, moduleAddr)
 }
 
 // AllocateAsset allocates and distributes coin according a gauge’s proportional weight that is recorded in the record.

--- a/x/pool-incentives/types/expected_keepers.go
+++ b/x/pool-incentives/types/expected_keepers.go
@@ -41,4 +41,5 @@ type IncentivesKeeper interface {
 type DistrKeeper interface {
 	GetFeePool(ctx sdk.Context) (feePool distrtypes.FeePool)
 	SetFeePool(ctx sdk.Context, feePool distrtypes.FeePool)
+	FundCommunityPool(ctx sdk.Context, amount sdk.Coins, sender sdk.AccAddress) error
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1401 

## What is the purpose of the change

Dedupes funding logic by having `FundCommunityPoolFromModule` in the pool-incentives module call `FundCommunityPool` in the Cosmos SDK.


## Brief Changelog

  - Added `FundCommunityPool` to `DistrKeeper` interface
  - Refactored the `FundCommunityPoolFromModule` function


## Testing and Verifying

This change is already covered by existing tests, such as tests in `distr_test.go` that call `AllocateAsset`, which uses `FundCommunityPoolFromModule`.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? n/a, but added a brief inline comment