### PR TITLE
e2e: fix image choice when upgrade logic is disabled

### DIFF
--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -52,6 +52,7 @@ func NewImageConfig(isUpgrade, isFork bool) ImageConfig {
 		// the need for Docker.
 		config.OsmosisRepository = CurrentBranchOsmoRepository
 		config.OsmosisTag = CurrentBranchOsmoTag
+		return config
 	}
 
 	// If upgrade is tested, we need to utilize InitRepository and InitTag


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Due to a missing return, the image would get overwritten by incorrect value when running e2e with upgrade tests disabled. This short change fixes it

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable