### PR TITLE
e2e: remove unused skipRunValidatorIndexes

### DIFF
--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -88,10 +88,6 @@ func (m *Manager) ExecCmd(t *testing.T, chainId string, validatorIndex int, comm
 				return false
 			}
 
-			if strings.Contains(errBuf.String(), "error") || strings.Contains(errBuf.String(), "Error") {
-				t.Log(errBuf.String())
-			}
-
 			if success != "" {
 				return strings.Contains(outBuf.String(), success) || strings.Contains(errBuf.String(), success)
 			}

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -88,6 +88,10 @@ func (m *Manager) ExecCmd(t *testing.T, chainId string, validatorIndex int, comm
 				return false
 			}
 
+			if strings.Contains(errBuf.String(), "error") || strings.Contains(errBuf.String(), "Error") {
+				t.Log(errBuf.String())
+			}
+
 			if success != "" {
 				return strings.Contains(outBuf.String(), success) || strings.Contains(errBuf.String(), success)
 			}

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -142,9 +142,6 @@ func (s *IntegrationTestSuite) voteProposal(c *chainConfig) {
 	s.T().Logf("voting yes on proposal for chain-id: %s", c.meta.Id)
 	cmd := []string{"osmosisd", "tx", "gov", "vote", propStr, "yes", "--from=val", fmt.Sprintf("--chain-id=%s", c.meta.Id), "-b=block", "--yes", "--keyring-backend=test"}
 	for i := range c.validators {
-		if _, ok := c.skipRunValidatorIndexes[i]; ok {
-			continue
-		}
 		_, _, err := s.containerManager.ExecCmd(s.T(), c.meta.Id, i, cmd, "code: 0")
 		s.Require().NoError(err)
 		validatorResource, exists := s.containerManager.GetValidatorResource(c.meta.Id, i)
@@ -267,10 +264,6 @@ func (s *IntegrationTestSuite) sendTx(c *chainConfig, validatorIndex int, amount
 
 func (s *IntegrationTestSuite) extractValidatorOperatorAddresses(config *chainConfig) {
 	for i, val := range config.validators {
-		if _, ok := config.skipRunValidatorIndexes[i]; ok {
-			s.T().Logf("skipping %s validator with index %d from running...", val.validator.Name, i)
-			continue
-		}
 		cmd := []string{"osmosisd", "debug", "addr", val.validator.PublicKey}
 		s.T().Logf("extracting validator operator addresses for chain-id: %s", config.meta.Id)
 		_, errBuf, err := s.containerManager.ExecCmd(s.T(), config.meta.Id, i, cmd, "")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This was originally meant to be used for initializing genesis and configs for state-sync nodes and be able to run them after the rest of the chain has started. However, a new design was chosen over this where we have the ability to initialize the configs for a single node, separate from the rest of the chain

As a result, this logic is not needed anymore

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable