### PR TITLE
e2e: ExecCmd debug log on error

### DIFF
--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -106,7 +106,7 @@ func (m *Manager) ExecCmd(t *testing.T, chainId string, validatorIndex int, comm
 			}
 
 			if success != "" {
-				return strings.Contains(outBuf.String(), success) || strings.Contains(errBuf.String(), success)
+				return strings.Contains(outBuf.String(), success) || strings.Contains(errBufString, success)
 			}
 
 			return true

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -109,15 +109,11 @@ func (m *Manager) ExecCmd(t *testing.T, chainId string, validatorIndex int, comm
 				return strings.Contains(outBuf.String(), success) || strings.Contains(errBuf.String(), success)
 			}
 
-			if success != "" {
-				return strings.Contains(outBuf.String(), success) || strings.Contains(errBuf.String(), success)
-			}
-
 			return true
 		},
 		time.Minute,
 		time.Second,
-		"tx returned a non-zero code; stdout: %s, stderr: %s", outBuf.String(), errBuf.String(),
+		"tx returned a non-zero code",
 	)
 
 	return outBuf, errBuf, nil

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,8 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 )
+
+var errRegex = regexp.MustCompile(`(E|e)rror`)
 
 // Manager is a wrapper around all Docker instances, and the Docker API.
 // It provides utilities to run and interact with all Docker containers used within e2e testing.
@@ -86,6 +89,24 @@ func (m *Manager) ExecCmd(t *testing.T, chainId string, validatorIndex int, comm
 			})
 			if err != nil {
 				return false
+			}
+
+			errBufString := errBuf.String()
+			// Note that this does not match all errors.
+			// This only works if CLI outpurs "Error" or "error"
+			// to stderr.
+			if errRegex.MatchString(errBufString) {
+				t.Log("Potential error in stderr:")
+				t.Log(errBufString)
+				// N.B: We should not be returning false here
+				// because some applications such as Hermes might log
+				// "error" to stderr when they function correctly,
+				// causing test flakiness. This log is needed only for
+				// debugging purposes.
+			}
+
+			if success != "" {
+				return strings.Contains(outBuf.String(), success) || strings.Contains(errBuf.String(), success)
 			}
 
 			if success != "" {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This change was originally introduced in #1898. However, in #1898 if "error" was found, the system would fail on the following line:
https://github.com/osmosis-labs/osmosis/blob/8f31b5afdbc9dfdbfbc20045dcb7f7004ae72b53/tests/e2e/containers/containers.go#L101

That started causing issues because some applications such as Hermes log "error" to stderr in the normal mode of operation.  So the change was reverted in #1902

This log proved to be incredibly helpful, making me manually change every PR for debugging. So, a modified version is introduced here. This version does not fail but only logs when "error is encountered. 

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable