### PR TITLE
Re-use code in superfluid TotalDelegationByDelegator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,7 @@ linters:
 #    - gosec <- triggers too much for this round and should be re-enabled later
 #    - gosimple <- later
     - govet
-    #   - ifshort <- seems to be of questionable value
+    #   - ifshort <- questionable value, unclear if globally helping readability.
     - importas
     - ineffassign
     #    - ireturn <- disabled because we want to return interfaces

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -439,48 +439,17 @@ func (q Querier) TotalDelegationByDelegator(goCtx context.Context, req *types.Qu
 		return nil, err
 	}
 
-	res := types.QueryTotalDelegationByDelegatorResponse{
-		SuperfluidDelegationRecords: []types.SuperfluidDelegationRecord{},
-		DelegationResponse:          []stakingtypes.DelegationResponse{},
-		TotalDelegatedCoins:         sdk.NewCoins(),
-		TotalEquivalentStakedAmount: sdk.NewCoin(appparams.BaseCoinUnit, sdk.ZeroInt()),
+	superfluidDelegationResp, err := q.SuperfluidDelegationsByDelegator(goCtx, &types.SuperfluidDelegationsByDelegatorRequest{
+		DelegatorAddress: req.DelegatorAddress})
+	if err != nil {
+		return nil, err
 	}
 
-	syntheticLocks := q.Keeper.lk.GetAllSyntheticLockupsByAddr(ctx, delAddr)
-
-	for _, syntheticLock := range syntheticLocks {
-		// don't include unbonding delegations
-		if strings.Contains(syntheticLock.SynthDenom, "superunbonding") {
-			continue
-		}
-
-		periodLock, err := q.Keeper.lk.GetLockByID(ctx, syntheticLock.UnderlyingLockId)
-		if err != nil {
-			return nil, err
-		}
-
-		baseDenom := periodLock.Coins.GetDenomByIndex(0)
-		lockedCoins := sdk.NewCoin(baseDenom, periodLock.GetCoins().AmountOf(baseDenom))
-		valAddr, err := ValidatorAddressFromSyntheticDenom(syntheticLock.SynthDenom)
-
-		// Find how many osmo tokens this delegation is worth at superfluids current risk adjustment
-		// and twap of the denom.
-		equivalentAmount := q.Keeper.GetSuperfluidOSMOTokens(ctx, baseDenom, lockedCoins.Amount)
-		coin := sdk.NewCoin(appparams.BaseCoinUnit, equivalentAmount)
-
-		if err != nil {
-			return nil, err
-		}
-		res.SuperfluidDelegationRecords = append(res.SuperfluidDelegationRecords,
-			types.SuperfluidDelegationRecord{
-				DelegatorAddress:       req.DelegatorAddress,
-				ValidatorAddress:       valAddr,
-				DelegationAmount:       lockedCoins,
-				EquivalentStakedAmount: &coin,
-			},
-		)
-		res.TotalDelegatedCoins = res.TotalDelegatedCoins.Add(lockedCoins)
-		res.TotalEquivalentStakedAmount = res.TotalEquivalentStakedAmount.Add(coin)
+	res := types.QueryTotalDelegationByDelegatorResponse{
+		SuperfluidDelegationRecords: superfluidDelegationResp.SuperfluidDelegationRecords,
+		DelegationResponse:          []stakingtypes.DelegationResponse{},
+		TotalDelegatedCoins:         superfluidDelegationResp.TotalDelegatedCoins,
+		TotalEquivalentStakedAmount: superfluidDelegationResp.TotalEquivalentStakedAmount,
 	}
 
 	//this is for getting normal staking


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

We had literally copies of another query in the superfluid `TotalDelegationByDelegator`, so we simplify this. 
cc @nghuyenthevinh2000, its preferable for maintainance & code complexity to re-use existing queries / logic if possible! (https://github.com/osmosis-labs/osmosis/pull/1539)

## Brief Changelog

- remove some duplicate code

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable