### PR TITLE
lint: enable unused in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters:
     - typecheck
     - unconvert
 #    - unparam <- looks for unused parameters (enable later)
-#    - unused <- looks for unused variables (enable later)
+    - unused # looks for unused variables, subset of staticcheck binary.
 #    - varcheck <- later
     #    - varnamelen <- disabled because defies idiom
     #    - wastedassign
@@ -95,5 +95,12 @@ issues:
     - path: client/docs
       linters:
         - all
+    - path: x/gamm/pool-models/stableswap
+      linters:
+        # Stableswap is in development.
+        # We should re-enable deadcode and unused linting
+        # across its files, once stableswap is fully complete.
+        - unused
+        - deadcode
   max-issues-per-linter: 10000
   max-same-issues: 10000

--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -11,7 +11,7 @@ import (
 var powPrecision, _ = sdk.NewDecFromStr("0.00000001")
 
 // Singletons.
-//nolint:deadcode
+// nolint: deadcode, unused
 var zero sdk.Dec = sdk.ZeroDec()
 
 var (

--- a/store/node.go
+++ b/store/node.go
@@ -233,11 +233,6 @@ func (node Node) find(key []byte) (idx int, match bool) {
 	return len(node.Children), false
 }
 
-func (node *Node) set(idx int, child *Child) *Node {
-	node.Children[idx] = child
-	return node
-}
-
 func (node *Node) setAcc(idx int, acc sdk.Int) *Node {
 	node.Children[idx] = &Child{node.Children[idx].Index, acc}
 	return node

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -20,11 +20,6 @@ const (
 	// This image should be pre-built with `make docker-build-debug` either in CI or locally.
 	CurrentBranchOsmoRepository = "osmosis"
 	CurrentBranchOsmoTag        = "debug"
-	/// Current Git branch repo/version for osmosis initialization. It is meant to be built locally.
-	// It is used when skipping upgrade by setting OSMOSIS_E2E_SKIP_UPGRADE to true).
-	// This image should be pre-built with `make docker-build-e2e-chain-init` either in CI or locally.
-	currentBranchInitRepository = "osmosis-e2e-chain-init"
-	currentBranchInitTag        = "debug"
 	// Pre-upgrade osmosis repo/tag to pull.
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.

--- a/tests/e2e/initialization/chain.go
+++ b/tests/e2e/initialization/chain.go
@@ -52,33 +52,6 @@ func (c *internalChain) createAndInitValidators(count int) error {
 	return nil
 }
 
-func (c *internalChain) createAndInitValidatorsWithMnemonics(count int, mnemonics []string) error {
-	for i := 0; i < count; i++ {
-		// create node
-		node := c.createValidator(i)
-
-		// generate genesis files
-		if err := node.init(); err != nil {
-			return err
-		}
-
-		c.validators = append(c.validators, node)
-
-		// create keys
-		if err := node.createKeyFromMnemonic("val", mnemonics[i]); err != nil {
-			return err
-		}
-		if err := node.createNodeKey(); err != nil {
-			return err
-		}
-		if err := node.createConsensusKey(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (c *internalChain) createValidator(index int) *internalValidator {
 	return &internalValidator{
 		chain:   c,

--- a/tests/e2e/initialization/validator.go
+++ b/tests/e2e/initialization/validator.go
@@ -31,15 +31,14 @@ import (
 )
 
 type internalValidator struct {
-	chain            *internalChain
-	index            int
-	moniker          string
-	mnemonic         string
-	keyInfo          keyring.Info
-	privateKey       cryptotypes.PrivKey
-	consensusKey     privval.FilePVKey
-	consensusPrivKey cryptotypes.PrivKey
-	nodeKey          p2p.NodeKey
+	chain        *internalChain
+	index        int
+	moniker      string
+	mnemonic     string
+	keyInfo      keyring.Info
+	privateKey   cryptotypes.PrivKey
+	consensusKey privval.FilePVKey
+	nodeKey      p2p.NodeKey
 }
 
 func (v *internalValidator) instanceName() string {
@@ -56,10 +55,6 @@ func (v *internalValidator) getKeyInfo() keyring.Info {
 
 func (v *internalValidator) getMoniker() string {
 	return v.moniker
-}
-
-func (v *internalValidator) getMnemonic() string {
-	return v.mnemonic
 }
 
 func (v *internalValidator) buildCreateValidatorMsg(amount sdk.Coin) (sdk.Msg, error) {

--- a/x/gamm/keeper/keeper.go
+++ b/x/gamm/keeper/keeper.go
@@ -61,6 +61,7 @@ func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey, paramSpace paramtyp
 	}
 }
 
+// nolint: unused
 func (k *Keeper) createSwapEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, input sdk.Coins, output sdk.Coins) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
@@ -74,6 +75,7 @@ func (k *Keeper) createSwapEvent(ctx sdk.Context, sender sdk.AccAddress, poolId 
 	})
 }
 
+// nolint: unused
 func (k *Keeper) createAddLiquidityEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, liquidity sdk.Coins) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
@@ -86,6 +88,7 @@ func (k *Keeper) createAddLiquidityEvent(ctx sdk.Context, sender sdk.AccAddress,
 	})
 }
 
+// nolint: unused
 func (k *Keeper) createRemoveLiquidityEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, liquidity sdk.Coins) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(

--- a/x/gamm/module.go
+++ b/x/gamm/module.go
@@ -15,7 +15,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/client/cli"
 	"github.com/osmosis-labs/osmosis/v7/x/gamm/keeper"
@@ -87,9 +86,6 @@ type AppModule struct {
 	ak     types.AccountKeeper
 	bk     types.BankKeeper
 	keeper keeper.Keeper
-
-	accountKeeper stakingtypes.AccountKeeper
-	bankKeeper    stakingtypes.BankKeeper
 }
 
 func (am AppModule) RegisterServices(cfg module.Configurator) {

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -15,7 +15,6 @@ var (
 )
 
 // solidly CFMM is xy(x^2 + y^2) = k
-// nolint:deadcode
 func cfmmConstant(xReserve, yReserve sdk.Dec) sdk.Dec {
 	xy := xReserve.Mul(yReserve)
 	x2 := xReserve.Mul(xReserve)
@@ -28,7 +27,6 @@ func cfmmConstant(xReserve, yReserve sdk.Dec) sdk.Dec {
 // outside of x and y (e.g. u = wz), and v is the sum
 // of their squares (e.g. v = w^2 + z^2).
 // When u = 1 and v = 0, this is equivalent to solidly's CFMM
-// nolint:deadcode
 func cfmmConstantMulti(xReserve, yReserve, uReserve, vSumSquares sdk.Dec) sdk.Dec {
 	xyu := xReserve.Mul(yReserve.Mul(uReserve))
 	x2 := xReserve.Mul(xReserve)
@@ -161,7 +159,6 @@ func solveCfmm(xReserve, yReserve, yIn sdk.Dec) sdk.Dec {
 // how many units `a` of x do we get out.
 // So we solve the following expression for `a`
 // xyz(x^2 + y^2 + w) = (x - a)(y + b)z((x - a)^2 + (y + b)^2 + w)
-// nolint:deadcode
 func solveCfmmMulti(xReserve, yReserve, wSumSquares, yIn sdk.Dec) sdk.Dec {
 	if !yReserve.Add(yIn).IsPositive() {
 		panic("invalid yReserve, yIn combo")
@@ -274,7 +271,6 @@ var (
 
 // solveCFMMBinarySearch searches the correct dx using binary search over constant K.
 // added for future extension
-// nolint:deadcode
 func solveCFMMBinarySearch(constantFunction func(sdk.Dec, sdk.Dec) sdk.Dec) func(sdk.Dec, sdk.Dec, sdk.Dec) sdk.Dec {
 	return func(xReserve, yReserve, yIn sdk.Dec) sdk.Dec {
 		k := constantFunction(xReserve, yReserve)
@@ -298,7 +294,6 @@ func solveCFMMBinarySearch(constantFunction func(sdk.Dec, sdk.Dec) sdk.Dec) func
 
 // solveCFMMBinarySearch searches the correct dx using binary search over constant K.
 // added for future extension
-// nolint:deadcode
 func solveCFMMBinarySearchMulti(constantFunction func(sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) sdk.Dec) func(sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) sdk.Dec {
 	return func(xReserve, yReserve, uReserve, wSumSquares, yIn sdk.Dec) sdk.Dec {
 		k := constantFunction(xReserve, yReserve, uReserve, wSumSquares)
@@ -320,7 +315,6 @@ func solveCFMMBinarySearchMulti(constantFunction func(sdk.Dec, sdk.Dec, sdk.Dec,
 	}
 }
 
-//nolint:unused
 func spotPrice(baseReserve, quoteReserve sdk.Dec) sdk.Dec {
 	// y = baseAsset, x = quoteAsset
 	// Define f_{y -> x}(a) as the function that outputs the amount of tokens X you'd get by

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -46,10 +46,6 @@ func (k Keeper) getCoinsFromGauges(gauges []types.Gauge) sdk.Coins {
 	return coins
 }
 
-func (k Keeper) getCoinsFromIterator(ctx sdk.Context, iterator db.Iterator) sdk.Coins {
-	return k.getCoinsFromGauges(k.getGaugesFromIterator(ctx, iterator))
-}
-
 // setGauge set the gauge inside store.
 func (k Keeper) setGauge(ctx sdk.Context, gauge *types.Gauge) error {
 	store := ctx.KVStore(k.storeKey)

--- a/x/lockup/keeper/store.go
+++ b/x/lockup/keeper/store.go
@@ -52,6 +52,7 @@ func syntheticLockTimeStoreKey(lockID uint64, synthDenom string, endTime time.Ti
 }
 
 // getLockRefs get lock IDs specified on the prefix and timestamp key.
+// nolint: unused
 func (k Keeper) getLockRefs(ctx sdk.Context, key []byte) []uint64 {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, key)

--- a/x/tokenfactory/keeper/bankactions.go
+++ b/x/tokenfactory/keeper/bankactions.go
@@ -51,6 +51,7 @@ func (k Keeper) burnFrom(ctx sdk.Context, amount sdk.Coin, burnFrom string) erro
 	return k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
 }
 
+// nolint: unused
 func (k Keeper) forceTransfer(ctx sdk.Context, amount sdk.Coin, fromAddr string, toAddr string) error {
 	// verify that denom is an x/tokenfactory denom
 	_, _, err := types.DeconstructDenom(amount.Denom)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Follow-up to: https://github.com/osmosis-labs/osmosis/issues/1897

## What is the purpose of the change

We would like to improve the quality of our codebase by trying out components of the [staticcheck](https://staticcheck.io/) linter.

This change introduced `unused` - 1st of the 4 components

Although, we added `deadcode` linter in https://github.com/osmosis-labs/osmosis/pull/1934, `unused` seems to be detecting more unused logic.

In addition to removing the unused code, the following was done:
- disable `unused` and `deadcode` for `x/gamm/pool-models/stableswap` since it is currently in development

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable