### PR TITLE
x/gamm: Delete the height < v10forkheight { use broken code } check

### DIFF
--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -724,9 +724,6 @@ func (p *Pool) calcJoinPoolSharesBroken(ctx sdk.Context, tokensIn sdk.Coins, swa
 // It returns the number of shares created, the amount of coins actually joined into the pool
 // (in case of not being able to fully join), or an error.
 func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, tokensJoined sdk.Coins, err error) {
-	if ctx.BlockHeight() < v10Fork {
-		return p.calcJoinPoolSharesBroken(ctx, tokensIn, swapFee)
-	}
 	// 1) Get pool current liquidity + and token weights
 	// 2) If single token provided, do single asset join and exit.
 	// 3) If multi-asset join, first do as much of a join as we can with no swaps.

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -661,61 +661,6 @@ func (p *Pool) JoinPool(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (n
 	return numShares, nil
 }
 
-func (p *Pool) calcJoinPoolSharesBroken(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
-	poolAssets := p.GetAllPoolAssets()
-	poolAssetsByDenom := make(map[string]PoolAsset)
-	for _, poolAsset := range poolAssets {
-		poolAssetsByDenom[poolAsset.Token.Denom] = poolAsset
-	}
-
-	totalShares := p.GetTotalShares()
-
-	if tokensIn.Len() == 1 {
-		numShares, err = p.calcSingleAssetJoin(tokensIn[0], swapFee, poolAssetsByDenom[tokensIn[0].Denom], totalShares)
-		if err != nil {
-			return sdk.ZeroInt(), sdk.NewCoins(), err
-		}
-
-		newLiquidity = tokensIn
-
-		return numShares, newLiquidity, nil
-	} else if tokensIn.Len() != p.NumAssets() {
-		return sdk.ZeroInt(), sdk.NewCoins(), errors.New("balancer pool only supports LP'ing with one asset or all assets in pool")
-	}
-
-	// Add all exact coins we can (no swap). ctx arg doesn't matter for Balancer.
-	numShares, remCoins, err := cfmm_common.MaximalExactRatioJoinBroken(p, sdk.Context{}, tokensIn)
-	if err != nil {
-		return sdk.ZeroInt(), sdk.NewCoins(), err
-	}
-
-	// update liquidity for accurate calcSingleAssetJoin calculation
-	newLiquidity = tokensIn.Sub(remCoins)
-	for _, coin := range newLiquidity {
-		poolAsset := poolAssetsByDenom[coin.Denom]
-		poolAsset.Token.Amount = poolAssetsByDenom[coin.Denom].Token.Amount.Add(coin.Amount)
-		poolAssetsByDenom[coin.Denom] = poolAsset
-	}
-
-	totalShares = totalShares.Add(numShares)
-
-	// If there are coins that couldn't be perfectly joined, do single asset joins
-	// for each of them.
-	if !remCoins.Empty() {
-		for _, coin := range remCoins {
-			newShares, err := p.calcSingleAssetJoin(coin, swapFee, poolAssetsByDenom[coin.Denom], totalShares)
-			if err != nil {
-				return sdk.ZeroInt(), sdk.NewCoins(), err
-			}
-
-			newLiquidity = newLiquidity.Add(coin)
-			numShares = numShares.Add(newShares)
-		}
-	}
-
-	return numShares, newLiquidity, nil
-}
-
 // CalcJoinPoolShares calculates the number of shares created to join pool with the provided amount of `tokenIn`.
 // The input tokens must either be:
 // - a single token


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1935 

## What is the purpose of the change

Removes v10 height gating from `CalcJoinPoolShares` since it is no longer necessary now that we are on v10.

## Brief Changelog

- Remove block height check from `CalcJoinPoolShares`
- Remove related broken functions

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)