### PR TITLE
chore: Rename `ResetAllLocks`

### DIFF
--- a/x/lockup/keeper/bench_test.go
+++ b/x/lockup/keeper/bench_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/osmosis-labs/osmosis/v7/app"
-	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/osmosis-labs/osmosis/v7/app"
+	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -74,7 +75,7 @@ func benchmarkResetLogic(numLockups int, b *testing.B) {
 	b.StartTimer()
 	b.ReportAllocs()
 	// distribute coins from gauges to lockup owners
-	_ = app.LockupKeeper.ResetAllLocks(ctx, locks)
+	_ = app.LockupKeeper.InitializeAllLocks(ctx, locks)
 }
 
 func BenchmarkResetLogicMedium(b *testing.B) {

--- a/x/lockup/keeper/genesis.go
+++ b/x/lockup/keeper/genesis.go
@@ -10,10 +10,10 @@ import (
 // state.
 func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	k.SetLastLockID(ctx, genState.LastLockId)
-	if err := k.ResetAllLocks(ctx, genState.Locks); err != nil {
+	if err := k.InitializeAllLocks(ctx, genState.Locks); err != nil {
 		return
 	}
-	if err := k.ResetAllSyntheticLocks(ctx, genState.SyntheticLocks); err != nil {
+	if err := k.InitializeAllSyntheticLocks(ctx, genState.SyntheticLocks); err != nil {
 		return
 	}
 }

--- a/x/lockup/keeper/genesis_test.go
+++ b/x/lockup/keeper/genesis_test.go
@@ -61,12 +61,14 @@ func TestInitGenesis(t *testing.T) {
 	coins = app.LockupKeeper.GetAccountLockedCoins(ctx, acc2)
 	require.Equal(t, coins.String(), sdk.NewInt64Coin("foo", 5000000).String())
 
-	// TODO: module account balance is kept by bank keeper and no need to check here
-	// coins = app.LockupKeeper.GetModuleBalance(ctx)
-	// require.Equal(t, coins.String(), sdk.NewInt64Coin("foo", 30000000).String())
-
 	lastLockId := app.LockupKeeper.GetLastLockID(ctx)
 	require.Equal(t, lastLockId, uint64(10))
+
+	acc := app.LockupKeeper.GetPeriodLocksAccumulation(ctx, types.QueryCondition{
+		Denom:    "foo",
+		Duration: time.Second,
+	})
+	require.Equal(t, sdk.NewInt(30000000), acc)
 }
 
 func TestExportGenesis(t *testing.T) {

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -434,10 +434,10 @@ func (k Keeper) ExtendLockup(ctx sdk.Context, lockID uint64, owner sdk.AccAddres
 	return nil
 }
 
-// ResetAllLocks takes a set of locks, and initializes state to be storing
+// InitializeAllLocks takes a set of locks, and initializes state to be storing
 // them all correctly. This utilizes batch optimizations to improve efficiency,
 // as this becomes a bottleneck at chain initialization & upgrades.
-func (k Keeper) ResetAllLocks(ctx sdk.Context, locks []types.PeriodLock) error {
+func (k Keeper) InitializeAllLocks(ctx sdk.Context, locks []types.PeriodLock) error {
 	// index by coin.Denom, them duration -> amt
 	// We accumulate the accumulation store entries separately,
 	// to avoid hitting the myriad of slowdowns in the SDK iterator creation process.
@@ -449,7 +449,7 @@ func (k Keeper) ResetAllLocks(ctx sdk.Context, locks []types.PeriodLock) error {
 			msg := fmt.Sprintf("Reset %d lock refs, cur lock ID %d", i, lock.ID)
 			ctx.Logger().Info(msg)
 		}
-		err := k.setLockAndResetLockRefs(ctx, lock)
+		err := k.setLockAndAddLockRefs(ctx, lock)
 		if err != nil {
 			return err
 		}
@@ -497,7 +497,7 @@ func (k Keeper) ResetAllLocks(ctx sdk.Context, locks []types.PeriodLock) error {
 	return nil
 }
 
-func (k Keeper) ResetAllSyntheticLocks(ctx sdk.Context, syntheticLocks []types.SyntheticLock) error {
+func (k Keeper) InitializeAllSyntheticLocks(ctx sdk.Context, syntheticLocks []types.SyntheticLock) error {
 	// index by coin.Denom, them duration -> amt
 	// We accumulate the accumulation store entries separately,
 	// to avoid hitting the myriad of slowdowns in the SDK iterator creation process.
@@ -633,9 +633,9 @@ func (k Keeper) setLock(ctx sdk.Context, lock types.PeriodLock) error {
 	return nil
 }
 
-// setLockAndResetLockRefs sets the lock, and resets all of its lock references
+// setLockAndAddLockRefs sets the lock, and resets all of its lock references
 // This puts the lock into a 'clean' state, aside from the AccumulationStore.
-func (k Keeper) setLockAndResetLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
+func (k Keeper) setLockAndAddLockRefs(ctx sdk.Context, lock types.PeriodLock) error {
 	err := k.setLock(ctx, lock)
 	if err != nil {
 		return err

--- a/x/lockup/keeper/synthetic_lock_test.go
+++ b/x/lockup/keeper/synthetic_lock_test.go
@@ -276,7 +276,7 @@ func (suite *KeeperTestSuite) TestResetAllSyntheticLocks() {
 	suite.Require().Len(locks, 1)
 	suite.Require().Equal(locks[0].Coins, coins)
 
-	suite.App.LockupKeeper.ResetAllSyntheticLocks(suite.Ctx, []types.SyntheticLock{
+	suite.App.LockupKeeper.InitializeAllSyntheticLocks(suite.Ctx, []types.SyntheticLock{
 		{
 			UnderlyingLockId: 1,
 			SynthDenom:       "synthstakestakedtovalidator1",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1275 

Sub-component of #1838 

## What is the purpose of the change

The method `ResetAllLocks` implies _resetting_ a state, which implies we're deleting an **existing** state, and setting a new value for the state. This method name is misleading, as this method is not resetting an existing state, it's simply initializing a state, as `ResetAllLocks` are used in `InitGenesis`. 

This PR includes renaming `ResetAllLocks` to `InitializeAllLocks`.

This PR also includes renaming `setLockAndResetLockRefs ` to `setLockAndAddLockRefs`, as the intention of the method is not to delete and add lock refs, but simply add lock refs.


## Brief Changelog

- Rename `ResetAllLocks` to `InitializeAllLocks`, rename `setLockAndResetLockRefs ` to `setLockAndAddLockRefs`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented?    not documented