### PR TITLE
lint: enable stylecheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,7 @@ linters:
     # - sqlclosecheck <- needs go 1.18 support
 #    - staticcheck <- later
 #    - structcheck <- later
-#    - stylecheck <- enable later, atriggers on underscores in variable names and on poolId
+    - stylecheck # replacement of golint, subset of staticcheck binary.
     #    - tagliatelle <- disabled for defying cosmos idiom
     - tenv
     - testpackage
@@ -102,5 +102,8 @@ issues:
         # across its files, once stableswap is fully complete.
         - unused
         - deadcode
+    - linters:
+      - stylecheck
+      text: "ST1003:" # requires identifiers with "id" to be "ID".
   max-issues-per-linter: 10000
   max-same-issues: 10000

--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -15,8 +15,8 @@ var DefaultAcctFunds sdk.Coins = sdk.NewCoins(
 )
 
 // Returns a Univ2 pool with the initial liquidity being the provided balances
-func (suite *KeeperTestHelper) PrepareUni2PoolWithAssets(asset1, asset2 sdk.Coin) uint64 {
-	return suite.PrepareBalancerPoolWithPoolAsset(
+func (s *KeeperTestHelper) PrepareUni2PoolWithAssets(asset1, asset2 sdk.Coin) uint64 {
+	return s.PrepareBalancerPoolWithPoolAsset(
 		[]balancer.PoolAsset{
 			{
 				Weight: sdk.NewInt(1),
@@ -30,30 +30,30 @@ func (suite *KeeperTestHelper) PrepareUni2PoolWithAssets(asset1, asset2 sdk.Coin
 	)
 }
 
-func (suite *KeeperTestHelper) PrepareBalancerPool() uint64 {
-	poolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+func (s *KeeperTestHelper) PrepareBalancerPool() uint64 {
+	poolId := s.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
 		SwapFee: sdk.NewDec(0),
 		ExitFee: sdk.NewDec(0),
 	})
 
-	spotPrice, err := suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "foo", "bar")
-	suite.NoError(err)
-	suite.Equal(sdk.NewDec(2).String(), spotPrice.String())
-	spotPrice, err = suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "bar", "baz")
-	suite.NoError(err)
-	suite.Equal(sdk.NewDecWithPrec(15, 1).String(), spotPrice.String())
-	spotPrice, err = suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, poolId, "baz", "foo")
-	suite.NoError(err)
-	s := sdk.NewDec(1).Quo(sdk.NewDec(3))
-	sp := s.MulInt(gammtypes.SigFigs).RoundInt().ToDec().QuoInt(gammtypes.SigFigs)
-	suite.Equal(sp.String(), spotPrice.String())
+	spotPrice, err := s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, "foo", "bar")
+	s.NoError(err)
+	s.Equal(sdk.NewDec(2).String(), spotPrice.String())
+	spotPrice, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, "bar", "baz")
+	s.NoError(err)
+	s.Equal(sdk.NewDecWithPrec(15, 1).String(), spotPrice.String())
+	spotPrice, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, "baz", "foo")
+	s.NoError(err)
+	oneThird := sdk.NewDec(1).Quo(sdk.NewDec(3))
+	sp := oneThird.MulInt(gammtypes.SigFigs).RoundInt().ToDec().QuoInt(gammtypes.SigFigs)
+	s.Equal(sp.String(), spotPrice.String())
 
 	return poolId
 }
 
-func (suite *KeeperTestHelper) PrepareBalancerPoolWithPoolParams(poolParams balancer.PoolParams) uint64 {
+func (s *KeeperTestHelper) PrepareBalancerPoolWithPoolParams(poolParams balancer.PoolParams) uint64 {
 	// Mint some assets to the account.
-	suite.FundAcc(suite.TestAccs[0], DefaultAcctFunds)
+	s.FundAcc(s.TestAccs[0], DefaultAcctFunds)
 
 	poolAssets := []balancer.PoolAsset{
 		{
@@ -69,27 +69,27 @@ func (suite *KeeperTestHelper) PrepareBalancerPoolWithPoolParams(poolParams bala
 			Token:  sdk.NewCoin("baz", sdk.NewInt(5000000)),
 		},
 	}
-	msg := balancer.NewMsgCreateBalancerPool(suite.TestAccs[0], poolParams, poolAssets, "")
-	poolId, err := suite.App.GAMMKeeper.CreatePool(suite.Ctx, msg)
-	suite.NoError(err)
+	msg := balancer.NewMsgCreateBalancerPool(s.TestAccs[0], poolParams, poolAssets, "")
+	poolId, err := s.App.GAMMKeeper.CreatePool(s.Ctx, msg)
+	s.NoError(err)
 	return poolId
 }
 
-func (suite *KeeperTestHelper) PrepareBalancerPoolWithPoolAsset(assets []balancer.PoolAsset) uint64 {
-	suite.Require().Len(assets, 2)
+func (s *KeeperTestHelper) PrepareBalancerPoolWithPoolAsset(assets []balancer.PoolAsset) uint64 {
+	s.Require().Len(assets, 2)
 
 	// Add coins for pool creation fee + coins needed to mint balances
 	fundCoins := sdk.Coins{sdk.NewCoin("uosmo", sdk.NewInt(10000000000))}
 	for _, a := range assets {
 		fundCoins = fundCoins.Add(a.Token)
 	}
-	suite.FundAcc(suite.TestAccs[0], fundCoins)
+	s.FundAcc(s.TestAccs[0], fundCoins)
 
-	msg := balancer.NewMsgCreateBalancerPool(suite.TestAccs[0], balancer.PoolParams{
+	msg := balancer.NewMsgCreateBalancerPool(s.TestAccs[0], balancer.PoolParams{
 		SwapFee: sdk.ZeroDec(),
 		ExitFee: sdk.ZeroDec(),
 	}, assets, "")
-	poolId, err := suite.App.GAMMKeeper.CreatePool(suite.Ctx, msg)
-	suite.NoError(err)
+	poolId, err := s.App.GAMMKeeper.CreatePool(s.Ctx, msg)
+	s.NoError(err)
 	return poolId
 }

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -20,7 +20,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/libs/log"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
@@ -42,7 +41,7 @@ type KeeperTestHelper struct {
 
 func (s *KeeperTestHelper) Setup() {
 	s.App = app.Setup(false)
-	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,
@@ -138,7 +137,7 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(executeNextEpoch bool, prop
 		newBlockTime = endEpochTime.Add(time.Second)
 	}
 
-	header := tmproto.Header{Height: s.Ctx.BlockHeight() + 1, Time: newBlockTime}
+	header := tmtypes.Header{Height: s.Ctx.BlockHeight() + 1, Time: newBlockTime}
 	newCtx := s.Ctx.WithBlockTime(newBlockTime).WithBlockHeight(s.Ctx.BlockHeight() + 1)
 	s.Ctx = newCtx
 	lastCommitInfo := abci.LastCommitInfo{
@@ -200,16 +199,16 @@ func (s *KeeperTestHelper) SetupGammPoolsWithBondDenomMultiplier(multipliers []s
 			defaultFutureGovernor = ""
 
 			// pool assets
-			defaultFooAsset balancer.PoolAsset = balancer.PoolAsset{
+			defaultFooAsset = balancer.PoolAsset{
 				Weight: sdk.NewInt(100),
 				Token:  sdk.NewCoin(bondDenom, uosmoAmount),
 			}
-			defaultBarAsset balancer.PoolAsset = balancer.PoolAsset{
+			defaultBarAsset = balancer.PoolAsset{
 				Weight: sdk.NewInt(100),
 				Token:  sdk.NewCoin(token, sdk.NewInt(10000)),
 			}
 
-			poolAssets []balancer.PoolAsset = []balancer.PoolAsset{defaultFooAsset, defaultBarAsset}
+			poolAssets = []balancer.PoolAsset{defaultFooAsset, defaultBarAsset}
 		)
 
 		poolParams := balancer.PoolParams{

--- a/store/node.go
+++ b/store/node.go
@@ -238,8 +238,8 @@ func (node *Node) setAcc(idx int, acc sdk.Int) *Node {
 	return node
 }
 
-func (cs *Node) insert(idx int, c *Child) *Node {
-	arr := append(cs.Children[:idx], append([]*Child{c}, cs.Children[idx:]...)...)
+func (node *Node) insert(idx int, c *Child) *Node {
+	arr := append(node.Children[:idx], append([]*Child{c}, node.Children[idx:]...)...)
 	return NewNode(arr...)
 }
 

--- a/x/gamm/pool-models/balancer/marshal.go
+++ b/x/gamm/pool-models/balancer/marshal.go
@@ -16,8 +16,8 @@ type balancerPoolPretty struct {
 	PoolAssets         []PoolAsset    `json:"pool_assets" yaml:"pool_assets"`
 }
 
-func (pa Pool) String() string {
-	out, err := pa.MarshalJSON()
+func (p Pool) String() string {
+	out, err := p.MarshalJSON()
 	if err != nil {
 		panic(err)
 	}
@@ -25,39 +25,39 @@ func (pa Pool) String() string {
 }
 
 // MarshalJSON returns the JSON representation of a Pool.
-func (pa Pool) MarshalJSON() ([]byte, error) {
-	accAddr, err := sdk.AccAddressFromBech32(pa.Address)
+func (p Pool) MarshalJSON() ([]byte, error) {
+	accAddr, err := sdk.AccAddressFromBech32(p.Address)
 	if err != nil {
 		return nil, err
 	}
 
-	decTotalWeight := sdk.NewDecFromInt(pa.TotalWeight)
+	decTotalWeight := sdk.NewDecFromInt(p.TotalWeight)
 
 	return json.Marshal(balancerPoolPretty{
 		Address:            accAddr,
-		Id:                 pa.Id,
-		PoolParams:         pa.PoolParams,
-		FuturePoolGovernor: pa.FuturePoolGovernor,
+		Id:                 p.Id,
+		PoolParams:         p.PoolParams,
+		FuturePoolGovernor: p.FuturePoolGovernor,
 		TotalWeight:        decTotalWeight,
-		TotalShares:        pa.TotalShares,
-		PoolAssets:         pa.PoolAssets,
+		TotalShares:        p.TotalShares,
+		PoolAssets:         p.PoolAssets,
 	})
 }
 
 // UnmarshalJSON unmarshals raw JSON bytes into a Pool.
-func (pa *Pool) UnmarshalJSON(bz []byte) error {
+func (p *Pool) UnmarshalJSON(bz []byte) error {
 	var alias balancerPoolPretty
 	if err := json.Unmarshal(bz, &alias); err != nil {
 		return err
 	}
 
-	pa.Address = alias.Address.String()
-	pa.Id = alias.Id
-	pa.PoolParams = alias.PoolParams
-	pa.FuturePoolGovernor = alias.FuturePoolGovernor
-	pa.TotalWeight = alias.TotalWeight.RoundInt()
-	pa.TotalShares = alias.TotalShares
-	pa.PoolAssets = alias.PoolAssets
+	p.Address = alias.Address.String()
+	p.Id = alias.Id
+	p.PoolParams = alias.PoolParams
+	p.FuturePoolGovernor = alias.FuturePoolGovernor
+	p.TotalWeight = alias.TotalWeight.RoundInt()
+	p.TotalShares = alias.TotalShares
+	p.PoolAssets = alias.PoolAssets
 
 	return nil
 }

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -91,7 +91,7 @@ func (p Pool) GetSwapFee(_ sdk.Context) sdk.Dec {
 }
 
 func (p Pool) GetTotalPoolLiquidity(_ sdk.Context) sdk.Coins {
-	return poolAssetsCoins(pa.PoolAssets)
+	return poolAssetsCoins(p.PoolAssets)
 }
 
 func (p Pool) GetExitFee(_ sdk.Context) sdk.Dec {

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -73,48 +73,48 @@ func NewBalancerPool(poolId uint64, balancerPoolParams PoolParams, assets []Pool
 
 // GetAddress returns the address of a pool.
 // If the pool address is not bech32 valid, it returns an empty address.
-func (pa Pool) GetAddress() sdk.AccAddress {
-	addr, err := sdk.AccAddressFromBech32(pa.Address)
+func (p Pool) GetAddress() sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(p.Address)
 	if err != nil {
-		panic(fmt.Sprintf("could not bech32 decode address of pool with id: %d", pa.GetId()))
+		panic(fmt.Sprintf("could not bech32 decode address of pool with id: %d", p.GetId()))
 	}
 	return addr
 }
 
-func (pa Pool) GetId() uint64 {
-	return pa.Id
+func (p Pool) GetId() uint64 {
+	return p.Id
 }
 
-func (pa Pool) GetSwapFee(_ sdk.Context) sdk.Dec {
-	return pa.PoolParams.SwapFee
+func (p Pool) GetSwapFee(_ sdk.Context) sdk.Dec {
+	return p.PoolParams.SwapFee
 }
 
-func (pa Pool) GetTotalPoolLiquidity(_ sdk.Context) sdk.Coins {
-	return PoolAssetsCoins(pa.PoolAssets)
+func (p Pool) GetTotalPoolLiquidity(_ sdk.Context) sdk.Coins {
+	return PoolAssetsCoins(p.PoolAssets)
 }
 
-func (pa Pool) GetExitFee(_ sdk.Context) sdk.Dec {
-	return pa.PoolParams.ExitFee
+func (p Pool) GetExitFee(_ sdk.Context) sdk.Dec {
+	return p.PoolParams.ExitFee
 }
 
-func (pa Pool) GetPoolParams() PoolParams {
-	return pa.PoolParams
+func (p Pool) GetPoolParams() PoolParams {
+	return p.PoolParams
 }
 
-func (pa Pool) GetTotalWeight() sdk.Int {
-	return pa.TotalWeight
+func (p Pool) GetTotalWeight() sdk.Int {
+	return p.TotalWeight
 }
 
-func (pa Pool) GetTotalShares() sdk.Int {
-	return pa.TotalShares.Amount
+func (p Pool) GetTotalShares() sdk.Int {
+	return p.TotalShares.Amount
 }
 
-func (pa *Pool) AddTotalShares(amt sdk.Int) {
-	pa.TotalShares.Amount = pa.TotalShares.Amount.Add(amt)
+func (p *Pool) AddTotalShares(amt sdk.Int) {
+	p.TotalShares.Amount = p.TotalShares.Amount.Add(amt)
 }
 
-func (pa *Pool) SubTotalShares(amt sdk.Int) {
-	pa.TotalShares.Amount = pa.TotalShares.Amount.Sub(amt)
+func (p *Pool) SubTotalShares(amt sdk.Int) {
+	p.TotalShares.Amount = p.TotalShares.Amount.Sub(amt)
 }
 
 // SetInitialPoolAssets sets the PoolAssets in the pool. It is only designed to
@@ -125,13 +125,13 @@ func (pa *Pool) SubTotalShares(amt sdk.Int) {
 // for a PoolAsset by denomination.
 // TODO: Unify story for validation of []PoolAsset, some is here, some is in
 // CreatePool.ValidateBasic()
-func (pa *Pool) SetInitialPoolAssets(PoolAssets []PoolAsset) error {
+func (p *Pool) SetInitialPoolAssets(PoolAssets []PoolAsset) error {
 	exists := make(map[string]bool)
-	for _, asset := range pa.PoolAssets {
+	for _, asset := range p.PoolAssets {
 		exists[asset.Token.Denom] = true
 	}
 
-	newTotalWeight := pa.TotalWeight
+	newTotalWeight := p.TotalWeight
 	scaledPoolAssets := make([]PoolAsset, 0, len(PoolAssets))
 
 	// TODO: Refactor this into PoolAsset.validate()
@@ -159,17 +159,17 @@ func (pa *Pool) SetInitialPoolAssets(PoolAssets []PoolAsset) error {
 	// TODO: Change this to a more efficient sorted insert algorithm.
 	// Furthermore, consider changing the underlying data type to allow in-place modification if the
 	// number of PoolAssets is expected to be large.
-	pa.PoolAssets = append(pa.PoolAssets, scaledPoolAssets...)
-	SortPoolAssetsByDenom(pa.PoolAssets)
+	p.PoolAssets = append(p.PoolAssets, scaledPoolAssets...)
+	SortPoolAssetsByDenom(p.PoolAssets)
 
-	pa.TotalWeight = newTotalWeight
+	p.TotalWeight = newTotalWeight
 
 	return nil
 }
 
 // setInitialPoolParams
-func (pa *Pool) setInitialPoolParams(params PoolParams, sortedAssets []PoolAsset, curBlockTime time.Time) error {
-	pa.PoolParams = params
+func (p *Pool) setInitialPoolParams(params PoolParams, sortedAssets []PoolAsset, curBlockTime time.Time) error {
+	p.PoolParams = params
 	if params.SmoothWeightChangeParams != nil {
 		// set initial assets
 		initialWeights := make([]PoolAsset, len(sortedAssets))
@@ -191,7 +191,7 @@ func (pa *Pool) setInitialPoolParams(params PoolParams, sortedAssets []PoolAsset
 			if err != nil {
 				return err
 			}
-			pa.PoolParams.SmoothWeightChangeParams.TargetPoolWeights[i] = PoolAsset{
+			p.PoolParams.SmoothWeightChangeParams.TargetPoolWeights[i] = PoolAsset{
 				Weight: v.Weight.MulRaw(GuaranteedWeightPrecision),
 				Token:  v.Token,
 			}
@@ -210,37 +210,37 @@ func (pa *Pool) setInitialPoolParams(params PoolParams, sortedAssets []PoolAsset
 // GetPoolAssets returns the denom's PoolAsset, If the PoolAsset doesn't exist, will return error.
 // As above, it will search the denom's PoolAsset by using binary search.
 // So, it is important to make sure that the PoolAssets are sorted.
-func (pa Pool) GetPoolAsset(denom string) (PoolAsset, error) {
-	_, asset, err := pa.getPoolAssetAndIndex(denom)
+func (p Pool) GetPoolAsset(denom string) (PoolAsset, error) {
+	_, asset, err := p.getPoolAssetAndIndex(denom)
 	return asset, err
 }
 
 // Returns a pool asset, and its index. If err != nil, then the index will be valid.
-func (pa Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
+func (p Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	if denom == "" {
 		return -1, PoolAsset{}, fmt.Errorf("you tried to find the PoolAsset with empty denom")
 	}
 
-	if len(pa.PoolAssets) == 0 {
+	if len(p.PoolAssets) == 0 {
 		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
 	}
 
-	i := sort.Search(len(pa.PoolAssets), func(i int) bool {
-		PoolAssetA := pa.PoolAssets[i]
+	i := sort.Search(len(p.PoolAssets), func(i int) bool {
+		PoolAssetA := p.PoolAssets[i]
 
 		compare := strings.Compare(PoolAssetA.Token.Denom, denom)
 		return compare >= 0
 	})
 
-	if i < 0 || i >= len(pa.PoolAssets) {
+	if i < 0 || i >= len(p.PoolAssets) {
 		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
 	}
 
-	if pa.PoolAssets[i].Token.Denom != denom {
+	if p.PoolAssets[i].Token.Denom != denom {
 		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
 	}
 
-	return i, pa.PoolAssets[i], nil
+	return i, p.PoolAssets[i], nil
 }
 
 func (p Pool) parsePoolAssetsByDenoms(tokenADenom, tokenBDenom string) (
@@ -282,9 +282,9 @@ func (p *Pool) IncreaseLiquidity(sharesOut sdk.Int, coinsIn sdk.Coins) {
 	p.AddTotalShares(sharesOut)
 }
 
-func (pa *Pool) UpdatePoolAssetBalance(coin sdk.Coin) error {
+func (p *Pool) UpdatePoolAssetBalance(coin sdk.Coin) error {
 	// Check that PoolAsset exists.
-	assetIndex, existingAsset, err := pa.getPoolAssetAndIndex(coin.Denom)
+	assetIndex, existingAsset, err := p.getPoolAssetAndIndex(coin.Denom)
 	if err != nil {
 		return err
 	}
@@ -295,11 +295,11 @@ func (pa *Pool) UpdatePoolAssetBalance(coin sdk.Coin) error {
 
 	// Update the supply of the asset
 	existingAsset.Token = coin
-	pa.PoolAssets[assetIndex] = existingAsset
+	p.PoolAssets[assetIndex] = existingAsset
 	return nil
 }
 
-func (pa *Pool) UpdatePoolAssetBalances(coins sdk.Coins) error {
+func (p *Pool) UpdatePoolAssetBalances(coins sdk.Coins) error {
 	// Ensures that there are no duplicate denoms, all denom's are valid,
 	// and amount is > 0
 	err := coins.Validate()
@@ -311,7 +311,7 @@ func (pa *Pool) UpdatePoolAssetBalances(coins sdk.Coins) error {
 		// TODO: We may be able to make this log(|coins|) faster in how it
 		// looks up denom -> Coin by doing a multi-search,
 		// but as we don't anticipate |coins| to be large, we omit this.
-		err = pa.UpdatePoolAssetBalance(coin)
+		err = p.UpdatePoolAssetBalance(coin)
 		if err != nil {
 			return err
 		}
@@ -320,23 +320,23 @@ func (pa *Pool) UpdatePoolAssetBalances(coins sdk.Coins) error {
 	return nil
 }
 
-func (pa *Pool) addToPoolAssetBalances(coins sdk.Coins) error {
+func (p *Pool) addToPoolAssetBalances(coins sdk.Coins) error {
 	for _, coin := range coins {
-		i, poolAsset, err := pa.getPoolAssetAndIndex(coin.Denom)
+		i, poolAsset, err := p.getPoolAssetAndIndex(coin.Denom)
 		if err != nil {
 			return err
 		}
 		poolAsset.Token.Amount = poolAsset.Token.Amount.Add(coin.Amount)
-		pa.PoolAssets[i] = poolAsset
+		p.PoolAssets[i] = poolAsset
 	}
 	return nil
 }
 
-func (pa Pool) GetPoolAssets(denoms ...string) ([]PoolAsset, error) {
+func (p Pool) GetPoolAssets(denoms ...string) ([]PoolAsset, error) {
 	result := make([]PoolAsset, 0, len(denoms))
 
 	for _, denom := range denoms {
-		PoolAsset, err := pa.GetPoolAsset(denom)
+		PoolAsset, err := p.GetPoolAsset(denom)
 		if err != nil {
 			return nil, err
 		}
@@ -347,9 +347,9 @@ func (pa Pool) GetPoolAssets(denoms ...string) ([]PoolAsset, error) {
 	return result, nil
 }
 
-func (pa Pool) GetAllPoolAssets() []PoolAsset {
-	copyslice := make([]PoolAsset, len(pa.PoolAssets))
-	copy(copyslice, pa.PoolAssets)
+func (p Pool) GetAllPoolAssets() []PoolAsset {
+	copyslice := make([]PoolAsset, len(p.PoolAssets))
+	copy(copyslice, p.PoolAssets)
 	return copyslice
 }
 
@@ -364,12 +364,12 @@ func (pa Pool) GetAllPoolAssets() []PoolAsset {
 // TODO: (post-launch) If newWeights excludes an existing denomination,
 // remove the weight from the pool, and figure out something to do
 // with any remaining coin.
-func (pa *Pool) updateAllWeights(newWeights []PoolAsset) {
-	if len(pa.PoolAssets) != len(newWeights) {
+func (p *Pool) updateAllWeights(newWeights []PoolAsset) {
+	if len(p.PoolAssets) != len(newWeights) {
 		panic("updateAllWeights called with invalid input, len(newWeights) != len(existingWeights)")
 	}
 	totalWeight := sdk.ZeroInt()
-	for i, asset := range pa.PoolAssets {
+	for i, asset := range p.PoolAssets {
 		if asset.Token.Denom != newWeights[i].Token.Denom {
 			panic(fmt.Sprintf("updateAllWeights called with invalid input, "+
 				"expected new weights' %vth asset to be %v, got %v",
@@ -379,22 +379,22 @@ func (pa *Pool) updateAllWeights(newWeights []PoolAsset) {
 		if err != nil {
 			panic("updateAllWeights: Tried to set an invalid weight")
 		}
-		pa.PoolAssets[i].Weight = newWeights[i].Weight
-		totalWeight = totalWeight.Add(pa.PoolAssets[i].Weight)
+		p.PoolAssets[i].Weight = newWeights[i].Weight
+		totalWeight = totalWeight.Add(p.PoolAssets[i].Weight)
 	}
-	pa.TotalWeight = totalWeight
+	p.TotalWeight = totalWeight
 }
 
 // PokePool checks to see if the pool's token weights need to be updated, and
 // if so, does so. Currently doesn't do anything outside out LBPs.
-func (pa *Pool) PokePool(blockTime time.Time) {
+func (p *Pool) PokePool(blockTime time.Time) {
 	// check if pool weights didn't change
-	poolWeightsChanging := pa.PoolParams.SmoothWeightChangeParams != nil
+	poolWeightsChanging := p.PoolParams.SmoothWeightChangeParams != nil
 	if !poolWeightsChanging {
 		return
 	}
 
-	params := *pa.PoolParams.SmoothWeightChangeParams
+	params := *p.PoolParams.SmoothWeightChangeParams
 
 	// The weights w(t) for the pool at time `t` is defined in one of three
 	// possible ways:
@@ -418,10 +418,10 @@ func (pa *Pool) PokePool(blockTime time.Time) {
 		//
 		// TODO: When we add support for adding new assets via this method, ensure
 		// the new asset has some token sent with it.
-		pa.updateAllWeights(params.TargetPoolWeights)
+		p.updateAllWeights(params.TargetPoolWeights)
 
 		// we've finished updating the weights, so reset the following fields
-		pa.PoolParams.SmoothWeightChangeParams = nil
+		p.PoolParams.SmoothWeightChangeParams = nil
 		return
 
 	default:
@@ -433,7 +433,7 @@ func (pa *Pool) PokePool(blockTime time.Time) {
 		// If the duration elapsed is equal to the total time, or a rounding error
 		// makes it seem like it is, just set to target weight.
 		if percentDurationElapsed.GTE(sdk.OneDec()) {
-			pa.updateAllWeights(params.TargetPoolWeights)
+			p.updateAllWeights(params.TargetPoolWeights)
 			return
 		}
 
@@ -442,12 +442,12 @@ func (pa *Pool) PokePool(blockTime time.Time) {
 		scaledDiff := poolAssetsMulDec(totalWeightsDiff, percentDurationElapsed)
 		updatedWeights := addPoolAssetWeights(params.InitialPoolWeights, scaledDiff)
 
-		pa.updateAllWeights(updatedWeights)
+		p.updateAllWeights(updatedWeights)
 	}
 }
 
-func (pa Pool) GetTokenWeight(denom string) (sdk.Int, error) {
-	PoolAsset, err := pa.GetPoolAsset(denom)
+func (p Pool) GetTokenWeight(denom string) (sdk.Int, error) {
+	PoolAsset, err := p.GetPoolAsset(denom)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -455,8 +455,8 @@ func (pa Pool) GetTokenWeight(denom string) (sdk.Int, error) {
 	return PoolAsset.Weight, nil
 }
 
-func (pa Pool) GetTokenBalance(denom string) (sdk.Int, error) {
-	PoolAsset, err := pa.GetPoolAsset(denom)
+func (p Pool) GetTokenBalance(denom string) (sdk.Int, error) {
+	PoolAsset, err := p.GetPoolAsset(denom)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -464,11 +464,11 @@ func (pa Pool) GetTokenBalance(denom string) (sdk.Int, error) {
 	return PoolAsset.Token.Amount, nil
 }
 
-func (pa Pool) NumAssets() int {
-	return len(pa.PoolAssets)
+func (p Pool) NumAssets() int {
+	return len(p.PoolAssets)
 }
 
-func (pa Pool) IsActive(ctx sdk.Context) bool {
+func (p Pool) IsActive(ctx sdk.Context) bool {
 	return true
 }
 
@@ -732,7 +732,7 @@ func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee s
 	tokensJoined = tokensJoined.Add(newLiquidityFromRemaining...)
 
 	if tokensJoined.IsAnyGT(tokensIn) {
-		return sdk.ZeroInt(), sdk.NewCoins(), errors.New("An error has occurred, more coins joined than token In")
+		return sdk.ZeroInt(), sdk.NewCoins(), errors.New("an error has occurred, more coins joined than token In")
 	}
 
 	return numShares, tokensJoined, nil

--- a/x/gamm/pool-models/balancer/pool_asset.go
+++ b/x/gamm/pool-models/balancer/pool_asset.go
@@ -18,8 +18,8 @@ type poolAssetPretty struct {
 }
 
 // validates a pool asset, to check if it has a valid weight.
-func (asset PoolAsset) validateWeight() error {
-	if asset.Weight.LTE(sdk.ZeroInt()) {
+func (pa PoolAsset) validateWeight() error {
+	if pa.Weight.LTE(sdk.ZeroInt()) {
 		return fmt.Errorf("a token's weight in the pool must be greater than 0")
 	}
 

--- a/x/gamm/pool-models/balancer/pool_asset.go
+++ b/x/gamm/pool-models/balancer/pool_asset.go
@@ -13,8 +13,8 @@ import (
 )
 
 // Validates a pool asset, to check if it has a valid weight.
-func (asset PoolAsset) ValidateWeight() error {
-	if asset.Weight.LTE(sdk.ZeroInt()) {
+func (pa PoolAsset) ValidateWeight() error {
+	if pa.Weight.LTE(sdk.ZeroInt()) {
 		return fmt.Errorf("a token's weight in the pool must be greater than 0")
 	}
 
@@ -31,10 +31,10 @@ type poolAssetPretty struct {
 	Weight sdk.Dec  `json:"weight" yaml:"weight"`
 }
 
-func (asset PoolAsset) prettify() poolAssetPretty {
+func (pa PoolAsset) prettify() poolAssetPretty {
 	return poolAssetPretty{
-		Weight: sdk.NewDecFromInt(asset.Weight).QuoInt64(GuaranteedWeightPrecision),
-		Token:  asset.Token,
+		Weight: sdk.NewDecFromInt(pa.Weight).QuoInt64(GuaranteedWeightPrecision),
+		Token:  pa.Token,
 	}
 }
 

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -336,21 +336,21 @@ func spotPrice(baseReserve, quoteReserve sdk.Dec) sdk.Dec {
 }
 
 // returns outAmt as a decimal
-func (pa *Pool) calcOutAmtGivenIn(tokenIn sdk.Coin, tokenOutDenom string, swapFee sdk.Dec) (sdk.Dec, error) {
-	reserves, err := pa.getScaledPoolAmts(tokenIn.Denom, tokenOutDenom)
+func (p *Pool) calcOutAmtGivenIn(tokenIn sdk.Coin, tokenOutDenom string, swapFee sdk.Dec) (sdk.Dec, error) {
+	reserves, err := p.getScaledPoolAmts(tokenIn.Denom, tokenOutDenom)
 	if err != nil {
 		return sdk.Dec{}, err
 	}
 	tokenInSupply, tokenOutSupply := reserves[0], reserves[1]
 	// We are solving for the amount of token out, hence x = tokenOutSupply, y = tokenInSupply
 	cfmmOut := solveCfmm(tokenOutSupply, tokenInSupply, tokenIn.Amount.ToDec())
-	outAmt := pa.getDescaledPoolAmt(tokenOutDenom, cfmmOut)
+	outAmt := p.getDescaledPoolAmt(tokenOutDenom, cfmmOut)
 	return outAmt, nil
 }
 
 // returns inAmt as a decimal
-func (pa *Pool) calcInAmtGivenOut(tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec) (sdk.Dec, error) {
-	reserves, err := pa.getScaledPoolAmts(tokenInDenom, tokenOut.Denom)
+func (p *Pool) calcInAmtGivenOut(tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec) (sdk.Dec, error) {
+	reserves, err := p.getScaledPoolAmts(tokenInDenom, tokenOut.Denom)
 	if err != nil {
 		return sdk.Dec{}, err
 	}
@@ -358,46 +358,46 @@ func (pa *Pool) calcInAmtGivenOut(tokenOut sdk.Coin, tokenInDenom string, swapFe
 	// We are solving for the amount of token in, cfmm(x,y) = cfmm(x + x_in, y - y_out)
 	// x = tokenInSupply, y = tokenOutSupply, yIn = -tokenOutAmount
 	cfmmIn := solveCfmm(tokenInSupply, tokenOutSupply, tokenOut.Amount.ToDec().Neg())
-	inAmt := pa.getDescaledPoolAmt(tokenInDenom, cfmmIn.NegMut())
+	inAmt := p.getDescaledPoolAmt(tokenInDenom, cfmmIn.NegMut())
 	return inAmt, nil
 }
 
-func (pa *Pool) calcSingleAssetJoinShares(tokenIn sdk.Coin, swapFee sdk.Dec) (sdk.Int, error) {
+func (p *Pool) calcSingleAssetJoinShares(tokenIn sdk.Coin, swapFee sdk.Dec) (sdk.Int, error) {
 	poolWithAddedLiquidityAndShares := func(newLiquidity sdk.Coin, newShares sdk.Int) types.PoolI {
-		paCopy := pa.Copy()
+		paCopy := p.Copy()
 		paCopy.updatePoolForJoin(sdk.NewCoins(tokenIn), newShares)
 		return &paCopy
 	}
 	// TODO: Correctly handle swap fee
-	return cfmm_common.BinarySearchSingleAssetJoin(pa, tokenIn, poolWithAddedLiquidityAndShares)
+	return cfmm_common.BinarySearchSingleAssetJoin(p, tokenIn, poolWithAddedLiquidityAndShares)
 }
 
 // We can mutate pa here
 // TODO: some day switch this to a COW wrapped pa, for better perf
-func (pa *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
+func (p *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
 	if len(tokensIn) == 1 {
-		numShares, err = pa.calcSingleAssetJoinShares(tokensIn[0], swapFee)
+		numShares, err = p.calcSingleAssetJoinShares(tokensIn[0], swapFee)
 		newLiquidity = tokensIn
 		return numShares, newLiquidity, err
-	} else if len(tokensIn) != pa.NumAssets() {
+	} else if len(tokensIn) != p.NumAssets() {
 		return sdk.ZeroInt(), sdk.NewCoins(), errors.New(
 			"stableswap pool only supports LP'ing with one asset, or all assets in pool")
 	}
 
 	// Add all exact coins we can (no swap). ctx arg doesn't matter for Stableswap
-	numShares, remCoins, err := cfmm_common.MaximalExactRatioJoin(pa, sdk.Context{}, tokensIn)
+	numShares, remCoins, err := cfmm_common.MaximalExactRatioJoin(p, sdk.Context{}, tokensIn)
 	if err != nil {
 		return sdk.ZeroInt(), sdk.NewCoins(), err
 	}
-	pa.updatePoolForJoin(tokensIn.Sub(remCoins), numShares)
+	p.updatePoolForJoin(tokensIn.Sub(remCoins), numShares)
 
 	for _, coin := range remCoins {
 		// TODO: Perhaps add a method to skip if this is too small.
-		newShare, err := pa.calcSingleAssetJoinShares(coin, swapFee)
+		newShare, err := p.calcSingleAssetJoinShares(coin, swapFee)
 		if err != nil {
 			return sdk.ZeroInt(), sdk.NewCoins(), err
 		}
-		pa.updatePoolForJoin(sdk.NewCoins(coin), newShare)
+		p.updatePoolForJoin(sdk.NewCoins(coin), newShare)
 		numShares = numShares.Add(newShare)
 	}
 

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -15,64 +15,64 @@ import (
 
 var _ types.PoolI = &Pool{}
 
-func (pa Pool) GetAddress() sdk.AccAddress {
-	addr, err := sdk.AccAddressFromBech32(pa.Address)
+func (p Pool) GetAddress() sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(p.Address)
 	if err != nil {
-		panic(fmt.Sprintf("could not bech32 decode address of pool with id: %d", pa.GetId()))
+		panic(fmt.Sprintf("could not bech32 decode address of pool with id: %d", p.GetId()))
 	}
 	return addr
 }
 
-func (pa Pool) String() string {
-	out, err := json.Marshal(pa)
+func (p Pool) String() string {
+	out, err := json.Marshal(p)
 	if err != nil {
 		panic(err)
 	}
 	return string(out)
 }
 
-func (pa Pool) GetId() uint64 {
-	return pa.Id
+func (p Pool) GetId() uint64 {
+	return p.Id
 }
 
-func (pa Pool) GetSwapFee(ctx sdk.Context) sdk.Dec {
-	return pa.PoolParams.SwapFee
+func (p Pool) GetSwapFee(ctx sdk.Context) sdk.Dec {
+	return p.PoolParams.SwapFee
 }
 
-func (pa Pool) GetExitFee(ctx sdk.Context) sdk.Dec {
-	return pa.PoolParams.ExitFee
+func (p Pool) GetExitFee(ctx sdk.Context) sdk.Dec {
+	return p.PoolParams.ExitFee
 }
 
-func (pa Pool) IsActive(ctx sdk.Context) bool {
+func (p Pool) IsActive(ctx sdk.Context) bool {
 	return true
 }
 
 // Returns the coins in the pool owned by all LP shareholders
-func (pa Pool) GetTotalPoolLiquidity(ctx sdk.Context) sdk.Coins {
-	return pa.PoolLiquidity
+func (p Pool) GetTotalPoolLiquidity(ctx sdk.Context) sdk.Coins {
+	return p.PoolLiquidity
 }
 
-func (pa Pool) GetTotalShares() sdk.Int {
-	return pa.TotalShares.Amount
+func (p Pool) GetTotalShares() sdk.Int {
+	return p.TotalShares.Amount
 }
 
-func (pa Pool) GetScalingFactors() []uint64 {
-	return pa.ScalingFactor
+func (p Pool) GetScalingFactors() []uint64 {
+	return p.ScalingFactor
 }
 
 // CONTRACT: scaling factors follow the same index with pool liquidity denoms
-func (pa Pool) GetScalingFactorByLiquidityIndex(liquidityIndex int) uint64 {
-	return pa.ScalingFactor[liquidityIndex]
+func (p Pool) GetScalingFactorByLiquidityIndex(liquidityIndex int) uint64 {
+	return p.ScalingFactor[liquidityIndex]
 }
 
-func (pa Pool) NumAssets() int {
-	return len(pa.PoolLiquidity)
+func (p Pool) NumAssets() int {
+	return len(p.PoolLiquidity)
 }
 
 // returns pool liquidity of the provided denoms, in the same order the denoms were provided in
-func (pa Pool) getPoolAmts(denoms ...string) ([]sdk.Int, error) {
+func (p Pool) getPoolAmts(denoms ...string) ([]sdk.Int, error) {
 	result := make([]sdk.Int, len(denoms))
-	poolLiquidity := pa.PoolLiquidity
+	poolLiquidity := p.PoolLiquidity
 	for i, d := range denoms {
 		amt := poolLiquidity.AmountOf(d)
 		if amt.IsZero() {
@@ -84,10 +84,10 @@ func (pa Pool) getPoolAmts(denoms ...string) ([]sdk.Int, error) {
 }
 
 // getScaledPoolAmts returns scaled amount of pool liquidity based on each asset's precisions
-func (pa Pool) getScaledPoolAmts(denoms ...string) ([]sdk.Dec, error) {
+func (p Pool) getScaledPoolAmts(denoms ...string) ([]sdk.Dec, error) {
 	result := make([]sdk.Dec, len(denoms))
-	poolLiquidity := pa.PoolLiquidity
-	liquidityIndexes := pa.getLiquidityIndexMap()
+	poolLiquidity := p.PoolLiquidity
+	liquidityIndexes := p.getLiquidityIndexMap()
 
 	for i, denom := range denoms {
 		liquidityIndex := liquidityIndexes[denom]
@@ -96,24 +96,24 @@ func (pa Pool) getScaledPoolAmts(denoms ...string) ([]sdk.Dec, error) {
 		if amt.IsZero() {
 			return []sdk.Dec{}, fmt.Errorf("denom %s does not exist in pool", denom)
 		}
-		scalingFactor := pa.GetScalingFactorByLiquidityIndex(liquidityIndex)
+		scalingFactor := p.GetScalingFactorByLiquidityIndex(liquidityIndex)
 		result[i] = amt.ToDec().QuoInt64Mut(int64(scalingFactor))
 	}
 	return result, nil
 }
 
 // getDescaledPoolAmts gets descaled amount of given denom and amount
-func (pa Pool) getDescaledPoolAmt(denom string, amount sdk.Dec) sdk.Dec {
-	liquidityIndexes := pa.getLiquidityIndexMap()
+func (p Pool) getDescaledPoolAmt(denom string, amount sdk.Dec) sdk.Dec {
+	liquidityIndexes := p.getLiquidityIndexMap()
 	liquidityIndex := liquidityIndexes[denom]
 
-	scalingFactor := pa.GetScalingFactorByLiquidityIndex(liquidityIndex)
+	scalingFactor := p.GetScalingFactorByLiquidityIndex(liquidityIndex)
 	return amount.MulInt64(int64(scalingFactor))
 }
 
 // getLiquidityIndexMap creates a map of denoms to its index in pool liquidity
-func (pa Pool) getLiquidityIndexMap() map[string]int {
-	poolLiquidity := pa.PoolLiquidity
+func (p Pool) getLiquidityIndexMap() map[string]int {
+	poolLiquidity := p.PoolLiquidity
 	liquidityIndexMap := make(map[string]int, poolLiquidity.Len())
 	for i, coin := range poolLiquidity {
 		liquidityIndexMap[coin.Denom] = i
@@ -148,11 +148,11 @@ func (p *Pool) updatePoolForJoin(tokensIn sdk.Coins, newShares sdk.Int) {
 }
 
 // TODO: These should all get moved to amm.go
-func (pa Pool) CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error) {
+func (p Pool) CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error) {
 	if tokenIn.Len() != 1 {
 		return sdk.Coin{}, errors.New("stableswap CalcOutAmtGivenIn: tokenIn is of wrong length")
 	}
-	outAmtDec, err := pa.calcOutAmtGivenIn(tokenIn[0], tokenOutDenom, swapFee)
+	outAmtDec, err := p.calcOutAmtGivenIn(tokenIn[0], tokenOutDenom, swapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -165,23 +165,23 @@ func (pa Pool) CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDen
 	return sdk.NewCoin(tokenOutDenom, tokenOutAmt), nil
 }
 
-func (pa *Pool) SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error) {
-	tokenOut, err = pa.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee)
+func (p *Pool) SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error) {
+	tokenOut, err = p.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
 
-	pa.updatePoolLiquidityForSwap(tokenIn, sdk.NewCoins(tokenOut))
+	p.updatePoolLiquidityForSwap(tokenIn, sdk.NewCoins(tokenOut))
 
 	return tokenOut, nil
 }
 
-func (pa Pool) CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error) {
+func (p Pool) CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error) {
 	if tokenOut.Len() != 1 {
 		return sdk.Coin{}, errors.New("stableswap CalcInAmtGivenOut: tokenOut is of wrong length")
 	}
 	// TODO: Refactor this later to handle scaling factors
-	amt, err := pa.calcInAmtGivenOut(tokenOut[0], tokenInDenom, swapFee)
+	amt, err := p.calcInAmtGivenOut(tokenOut[0], tokenInDenom, swapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -196,59 +196,59 @@ func (pa Pool) CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDen
 	return sdk.NewCoin(tokenInDenom, tokenInAmt), nil
 }
 
-func (pa *Pool) SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error) {
-	tokenIn, err = pa.CalcInAmtGivenOut(ctx, tokenOut, tokenInDenom, swapFee)
+func (p *Pool) SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error) {
+	tokenIn, err = p.CalcInAmtGivenOut(ctx, tokenOut, tokenInDenom, swapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
 
-	pa.updatePoolLiquidityForSwap(sdk.NewCoins(tokenIn), tokenOut)
+	p.updatePoolLiquidityForSwap(sdk.NewCoins(tokenIn), tokenOut)
 
 	return tokenIn, nil
 }
 
-func (pa Pool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (sdk.Dec, error) {
-	reserves, err := pa.getScaledPoolAmts(baseAssetDenom, quoteAssetDenom)
+func (p Pool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (sdk.Dec, error) {
+	reserves, err := p.getScaledPoolAmts(baseAssetDenom, quoteAssetDenom)
 	if err != nil {
 		return sdk.Dec{}, err
 	}
 	scaledSpotPrice := spotPrice(reserves[0], reserves[1])
-	spotPrice := pa.getDescaledPoolAmt(baseAssetDenom, scaledSpotPrice)
+	spotPrice := p.getDescaledPoolAmt(baseAssetDenom, scaledSpotPrice)
 
 	return spotPrice, nil
 }
 
-func (pa Pool) Copy() Pool {
-	pa2 := pa
-	pa2.PoolLiquidity = sdk.NewCoins(pa.PoolLiquidity...)
-	return pa2
+func (p Pool) Copy() Pool {
+	p2 := p
+	p2.PoolLiquidity = sdk.NewCoins(p.PoolLiquidity...)
+	return p2
 }
 
-func (pa *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
-	paCopy := pa.Copy()
-	return paCopy.joinPoolSharesInternal(ctx, tokensIn, swapFee)
+func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
+	pCopy := p.Copy()
+	return pCopy.joinPoolSharesInternal(ctx, tokensIn, swapFee)
 }
 
-func (pa *Pool) JoinPool(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, err error) {
-	numShares, _, err = pa.joinPoolSharesInternal(ctx, tokensIn, swapFee)
+func (p *Pool) JoinPool(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, err error) {
+	numShares, _, err = p.joinPoolSharesInternal(ctx, tokensIn, swapFee)
 	return numShares, err
 }
 
-func (pa *Pool) ExitPool(ctx sdk.Context, exitingShares sdk.Int, exitFee sdk.Dec) (exitingCoins sdk.Coins, err error) {
-	exitingCoins, err = pa.CalcExitPoolShares(ctx, exitingShares, exitFee)
+func (p *Pool) ExitPool(ctx sdk.Context, exitingShares sdk.Int, exitFee sdk.Dec) (exitingCoins sdk.Coins, err error) {
+	exitingCoins, err = p.CalcExitPoolShares(ctx, exitingShares, exitFee)
 	if err != nil {
 		return sdk.Coins{}, err
 	}
 
-	pa.TotalShares.Amount = pa.TotalShares.Amount.Sub(exitingShares)
-	pa.updatePoolLiquidityForExit(exitingCoins)
+	p.TotalShares.Amount = p.TotalShares.Amount.Sub(exitingShares)
+	p.updatePoolLiquidityForExit(exitingCoins)
 
 	return exitingCoins, nil
 }
 
-func (pa Pool) CalcExitPoolShares(ctx sdk.Context, exitingShares sdk.Int, exitFee sdk.Dec) (exitingCoins sdk.Coins, err error) {
-	return cfmm_common.CalcExitPool(ctx, &pa, exitingShares, exitFee)
+func (p Pool) CalcExitPoolShares(ctx sdk.Context, exitingShares sdk.Int, exitFee sdk.Dec) (exitingCoins sdk.Coins, err error) {
+	return cfmm_common.CalcExitPool(ctx, &p, exitingShares, exitFee)
 }
 
 // no-op for stableswap
-func (pa *Pool) PokePool(blockTime time.Time) {}
+func (p *Pool) PokePool(blockTime time.Time) {}

--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/osmosis-labs/osmosis/v7/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
-	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -66,7 +67,7 @@ func NewCreateGaugeCmd() *cobra.Command {
 			} else if timeRFC, err := time.Parse(time.RFC3339, timeStr); err == nil { // RFC time
 				startTime = timeRFC
 			} else { // invalid input
-				return errors.New("Invalid start time format")
+				return errors.New("invalid start time format")
 			}
 
 			epochs, err := cmd.Flags().GetUint64(FlagEpochs)

--- a/x/pool-incentives/types/expected_keepers.go
+++ b/x/pool-incentives/types/expected_keepers.go
@@ -9,7 +9,6 @@ import (
 
 	gammtypes "github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 	incentivestypes "github.com/osmosis-labs/osmosis/v7/x/incentives/types"
-	types "github.com/osmosis-labs/osmosis/v7/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
 )
 
@@ -33,7 +32,7 @@ type GAMMKeeper interface {
 type IncentivesKeeper interface {
 	CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddress, coins sdk.Coins, distrTo lockuptypes.QueryCondition, startTime time.Time, numEpochsPaidOver uint64) (uint64, error)
 	GetGaugeByID(ctx sdk.Context, gaugeID uint64) (*incentivestypes.Gauge, error)
-	GetGauges(ctx sdk.Context) []types.Gauge
+	GetGauges(ctx sdk.Context) []incentivestypes.Gauge
 
 	AddToGaugeRewards(ctx sdk.Context, owner sdk.AccAddress, coins sdk.Coins, gaugeID uint64) error
 }

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -13,8 +13,8 @@ import (
 func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string) (newTokenDenom string, err error) {
 	// Temporary check until IBC bug is sorted out
 	if k.bankKeeper.HasSupply(ctx, subdenom) {
-		return "", fmt.Errorf("Temporary error until IBC bug is sorted out, " +
-			"can't create subdenoms that are the same as a native denom.")
+		return "", fmt.Errorf("temporary error until IBC bug is sorted out, " +
+			"can't create subdenoms that are the same as a native denom")
 	}
 
 	// Send creation fee to community pool

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -155,7 +155,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 
 	// checks to make sure the module account has been set to collect fees in base token
 	if addr := dfd.ak.GetModuleAddress(types.FeeCollectorName); addr == nil {
-		return ctx, fmt.Errorf("Fee collector module account (%s) has not been set", types.FeeCollectorName)
+		return ctx, fmt.Errorf("fee collector module account (%s) has not been set", types.FeeCollectorName)
 	}
 
 	// checks to make sure a separate module account has been set to collect fees not in base token

--- a/x/txfees/types/options.go
+++ b/x/txfees/types/options.go
@@ -12,7 +12,8 @@ import (
 // If Options are not set in a config somewhere,
 // use defaults to preserve functionality with old node software
 
-// TODO: Bump after next minor version. (in 6.2+).
+// DefaultMinGasPriceForArbitrageTx represents minimum gas price
+// for arbitrage transactions.
 var DefaultMinGasPriceForArbitrageTx = sdk.ZeroDec()
 
 var (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Follow-up to: https://github.com/osmosis-labs/osmosis/issues/1897

Linter that enforces style rules. A subset of rules from the staticcheck binary.

## Brief Changelog

- disable annoying check requiring "Id" to be "ID"
- ensure that receivers are named consistently
- remove duplicate imports that had different identifiers
- remove redundant types in var declarations
- errors messages are not capitalized
- godoc starts with var name

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable