### PR TITLE
x/gamm: refactor balancer pool_test.go tests to be properly table-driven

### DIFF
--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -42,11 +42,11 @@ func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
 		weight = 100
 	)
 	testCases := []struct {
-		name               string
-		newLiquidity       sdk.Coins
-		originalPoolAssets map[string]balancer.PoolAsset
-		expectPass         bool
-		err                error
+		name         string
+		newLiquidity sdk.Coins
+		poolAssets   map[string]balancer.PoolAsset
+		expectPass   bool
+		err          error
 	}{
 		{
 			name: "regular case with multiple pool assets and a subset of newLiquidity to update",
@@ -54,7 +54,7 @@ func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
 				sdk.NewInt64Coin("uosmo", 1_000),
 				sdk.NewInt64Coin("atom", 2_000),
 				sdk.NewInt64Coin("ion", 3_000)),
-			originalPoolAssets: map[string]balancer.PoolAsset{
+			poolAssets: map[string]balancer.PoolAsset{
 				"uosmo": {
 					Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
 					Weight: sdk.NewInt(weight),
@@ -73,7 +73,7 @@ func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
 		{
 			name:         "new liquidity has no coins",
 			newLiquidity: sdk.NewCoins(),
-			originalPoolAssets: map[string]balancer.PoolAsset{
+			poolAssets: map[string]balancer.PoolAsset{
 				"uosmo": {
 					Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
 					Weight: sdk.NewInt(weight),
@@ -93,7 +93,7 @@ func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
 			name: "newLiquidity has a coin that poolAssets don't",
 			newLiquidity: sdk.NewCoins(
 				sdk.NewInt64Coin("juno", 1_000)),
-			originalPoolAssets: map[string]balancer.PoolAsset{
+			poolAssets: map[string]balancer.PoolAsset{
 				"uosmo": {
 					Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
 					Weight: sdk.NewInt(weight),
@@ -107,22 +107,22 @@ func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			expectedPoolAssetsByDenom := map[string]balancer.PoolAsset{}
-			for denom, asset := range tc.originalPoolAssets {
+			for denom, asset := range tc.poolAssets {
 				expectedValue := asset
 				expectedValue.Token.Amount = expectedValue.Token.Amount.Add(tc.newLiquidity.AmountOf(denom))
 				expectedPoolAssetsByDenom[denom] = expectedValue
 			}
 
-			err := balancer.UpdateIntermediaryPoolAssetsLiquidity(tc.newLiquidity, tc.originalPoolAssets)
+			err := balancer.UpdateIntermediaryPoolAssetsLiquidity(tc.newLiquidity, tc.poolAssets)
 
 			if tc.expectPass {
 				require.NoError(t, tc.err, "test: %v", tc.name)
-				// make sure actual pool assets aren't changed
-				require.Equal(t, expectedPoolAssetsByDenom, tc.originalPoolAssets)
+				// make sure actual pool assets are properly updated
+				require.Equal(t, expectedPoolAssetsByDenom, tc.poolAssets)
 			} else {
 				require.Error(t, tc.err, "test: %v", tc.name)
 				require.Equal(t, tc.err, err)
-				require.Equal(t, expectedPoolAssetsByDenom, tc.originalPoolAssets)
+				require.Equal(t, expectedPoolAssetsByDenom, tc.poolAssets)
 			}
 			return
 		})

--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -122,6 +122,7 @@ func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
 			} else {
 				require.Error(t, tc.err, "test: %v", tc.name)
 				require.Equal(t, tc.err, err)
+				require.Equal(t, expectedPoolAssetsByDenom, tc.originalPoolAssets)
 			}
 			return
 		})

--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -33,131 +33,97 @@ var (
 // TestUpdateIntermediaryPoolAssetsLiquidity tests if `updateIntermediaryPoolAssetsLiquidity` returns poolAssetsByDenom map
 // with the updated liquidity given by the parameter
 func TestUpdateIntermediaryPoolAssetsLiquidity(t *testing.T) {
+	const (
+		uosmoValueOriginal = 1_000_000_000_000
+		atomValueOriginal  = 123
+		ionValueOriginal   = 657
+
+		// Weight does not affect calculations so it is shared
+		weight = 100
+	)
 	testCases := []struct {
-		name string
-
-		// returns newLiquidity, originalPoolAssetsByDenom, expectedPoolAssetsByDenom
-		setup func() (sdk.Coins, map[string]balancer.PoolAsset, map[string]balancer.PoolAsset)
-
-		err error
+		name               string
+		newLiquidity       sdk.Coins
+		originalPoolAssets map[string]balancer.PoolAsset
+		expectPass         bool
+		err                error
 	}{
 		{
 			name: "regular case with multiple pool assets and a subset of newLiquidity to update",
-
-			setup: func() (sdk.Coins, map[string]balancer.PoolAsset, map[string]balancer.PoolAsset) {
-				const (
-					uosmoValueOriginal = 1_000_000_000_000
-					atomValueOriginal  = 123
-					ionValueOriginal   = 657
-
-					// Weight does not affect calculations so it is shared
-					weight = 100
-				)
-
-				newLiquidity := sdk.NewCoins(
-					sdk.NewInt64Coin("uosmo", 1_000),
-					sdk.NewInt64Coin("atom", 2_000),
-					sdk.NewInt64Coin("ion", 3_000))
-
-				originalPoolAssetsByDenom := map[string]balancer.PoolAsset{
-					"uosmo": {
-						Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-					"atom": {
-						Token:  sdk.NewInt64Coin("atom", atomValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-					"ion": {
-						Token:  sdk.NewInt64Coin("ion", ionValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-				}
-
-				expectedPoolAssetsByDenom := map[string]balancer.PoolAsset{}
-				for k, v := range originalPoolAssetsByDenom {
-					expectedValue := balancer.PoolAsset{Token: v.Token, Weight: v.Weight}
-					expectedValue.Token.Amount = expectedValue.Token.Amount.Add(newLiquidity.AmountOf(k))
-					expectedPoolAssetsByDenom[k] = expectedValue
-				}
-
-				return newLiquidity, originalPoolAssetsByDenom, expectedPoolAssetsByDenom
+			newLiquidity: sdk.NewCoins(
+				sdk.NewInt64Coin("uosmo", 1_000),
+				sdk.NewInt64Coin("atom", 2_000),
+				sdk.NewInt64Coin("ion", 3_000)),
+			originalPoolAssets: map[string]balancer.PoolAsset{
+				"uosmo": {
+					Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
+				"atom": {
+					Token:  sdk.NewInt64Coin("atom", atomValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
+				"ion": {
+					Token:  sdk.NewInt64Coin("ion", ionValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
 			},
+			expectPass: true,
 		},
 		{
-			name: "new liquidity has no coins",
-
-			setup: func() (sdk.Coins, map[string]balancer.PoolAsset, map[string]balancer.PoolAsset) {
-				const (
-					uosmoValueOriginal = 1_000_000_000_000
-					atomValueOriginal  = 123
-					ionValueOriginal   = 657
-
-					// Weight does not affect calculations so it is shared
-					weight = 100
-				)
-
-				newLiquidity := sdk.NewCoins()
-
-				originalPoolAssetsByDenom := map[string]balancer.PoolAsset{
-					"uosmo": {
-						Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-					"atom": {
-						Token:  sdk.NewInt64Coin("atom", atomValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-					"ion": {
-						Token:  sdk.NewInt64Coin("ion", ionValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-				}
-
-				return newLiquidity, originalPoolAssetsByDenom, originalPoolAssetsByDenom
+			name:         "new liquidity has no coins",
+			newLiquidity: sdk.NewCoins(),
+			originalPoolAssets: map[string]balancer.PoolAsset{
+				"uosmo": {
+					Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
+				"atom": {
+					Token:  sdk.NewInt64Coin("atom", atomValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
+				"ion": {
+					Token:  sdk.NewInt64Coin("ion", ionValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
 			},
+			expectPass: true,
 		},
 		{
 			name: "newLiquidity has a coin that poolAssets don't",
-
-			setup: func() (sdk.Coins, map[string]balancer.PoolAsset, map[string]balancer.PoolAsset) {
-				const (
-					uosmoValueOriginal = 1_000_000_000_000
-
-					// Weight does not affect calculations so it is shared
-					weight = 100
-				)
-
-				newLiquidity := sdk.NewCoins(
-					sdk.NewInt64Coin("juno", 1_000))
-
-				originalPoolAssetsByDenom := map[string]balancer.PoolAsset{
-					"uosmo": {
-						Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
-						Weight: sdk.NewInt(weight),
-					},
-				}
-
-				return newLiquidity, originalPoolAssetsByDenom, originalPoolAssetsByDenom
+			newLiquidity: sdk.NewCoins(
+				sdk.NewInt64Coin("juno", 1_000)),
+			originalPoolAssets: map[string]balancer.PoolAsset{
+				"uosmo": {
+					Token:  sdk.NewInt64Coin("uosmo", uosmoValueOriginal),
+					Weight: sdk.NewInt(weight),
+				},
 			},
-
-			err: fmt.Errorf(balancer.ErrMsgFormatFailedInterimLiquidityUpdate, "juno"),
+			expectPass: false,
+			err:        fmt.Errorf(balancer.ErrMsgFormatFailedInterimLiquidityUpdate, "juno"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			newLiquidity, originalPoolAssetsByDenom, expectedPoolAssetsByDenom := tc.setup()
-
-			err := balancer.UpdateIntermediaryPoolAssetsLiquidity(newLiquidity, originalPoolAssetsByDenom)
-
-			require.Equal(t, tc.err, err)
-
-			if tc.err != nil {
-				return
+			expectedPoolAssetsByDenom := map[string]balancer.PoolAsset{}
+			for i, asset := range tc.originalPoolAssets {
+				expectedValue := balancer.PoolAsset{Token: asset.Token, Weight: asset.Weight}
+				expectedValue.Token.Amount = expectedValue.Token.Amount.Add(tc.newLiquidity.AmountOf(i))
+				expectedPoolAssetsByDenom[i] = expectedValue
 			}
 
-			require.Equal(t, expectedPoolAssetsByDenom, originalPoolAssetsByDenom)
+			err := balancer.UpdateIntermediaryPoolAssetsLiquidity(tc.newLiquidity, tc.originalPoolAssets)
+
+			if tc.expectPass {
+				require.NoError(t, tc.err, "test: %v", tc.name)
+				// make sure actual pool assets aren't changed
+				require.Equal(t, expectedPoolAssetsByDenom, tc.originalPoolAssets)
+			} else {
+				require.Error(t, tc.err, "test: %v", tc.name)
+				require.Equal(t, tc.err, err)
+			}
+			return
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1944 

## What is the purpose of the change

Several tests in our balancer `pool_test.go` had setup functions as fields in test cases. These functions repeated code and overall were functionally not really "table-driven". This PR factors out the logic in these setup functions and replaces the function itself with relevant fields.

## Brief Changelog

- Remove setup function field from `TestUpdateIntermediaryPoolAssetsLiquidity` and replace it with `newLiquidity`,
`originalPoolAssets`, and `expectPass` fields
- Move logic for finding expected assets to test-wide for loop
- Clean up error checks using `expectPass`

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)