### PR TITLE
Add partial ord for begin block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -226,7 +226,7 @@ func NewOsmosisApp(
 	// NOTE: capability module's beginblocker must come before any modules using capabilities (e.g. IBC)
 
 	// Tell the app's module manager how to set the order of BeginBlockers, which are run at the beginning of every block.
-	app.mm.SetOrderBeginBlockers(orderBeginBlockers()...)
+	app.mm.SetOrderBeginBlockers(orderBeginBlockers(app.mm.ModuleNames())...)
 
 	// Tell the app's module manager how to set the order of EndBlockers, which are run at the end of every block.
 	app.mm.SetOrderEndBlockers(OrderEndBlockers(app.mm.ModuleNames())...)

--- a/app/modules.go
+++ b/app/modules.go
@@ -142,58 +142,23 @@ func appModules(
 	}
 }
 
-// orderBeginBlockers Tell the app's module manager how to set the order of
-// BeginBlockers, which are run at the beginning of every block.
+// orderBeginBlockers returns the order of BeginBlockers, by module name.
 func orderBeginBlockers(allModuleNames []string) []string {
-	// ord := partialord.NewPartialOrdering(allModuleNames)
-	// // Upgrades should be run VERY first
-	// // Epochs is set to be next right now, this in principle could change to come later / be at the end.
-	// // requires more thought into if it breaks existing logic.
-	// ord.FirstElements(upgradetypes.ModuleName, epochstypes.ModuleName, capabilitytypes.ModuleName)
+	ord := partialord.NewPartialOrdering(allModuleNames)
+	// Upgrades should be run VERY first
+	// Epochs is set to be next right now, this in principle could change to come later / be at the end.
+	// But would have to be a holistic change with other pipelines taken into account.
+	ord.FirstElements(upgradetypes.ModuleName, epochstypes.ModuleName, capabilitytypes.ModuleName)
 
-	// // IBC ordering constraint
-	// ord.Sequence(ibchost.ModuleName)
-	// // token distribution ordering constraint
-	// // staking, slashing & superfluid should come after distribution
-	// ord.Before(distrtypes.ModuleName, slashingtypes.ModuleName)
-	// ord.Before(distrtypes.ModuleName, stakingtypes.ModuleName)
-	// ord.Before(distrtypes.ModuleName, superfluidtypes.ModuleName)
-	// // evidence should come after slashing
-	// ord.After(evidencetypes.ModuleName, slashingtypes.ModuleName)
-	return []string{
-		// Upgrades should be run VERY first
-		upgradetypes.ModuleName,
-		// Note: epochs' begin should be "real" start of epochs, we keep epochs beginblock at the beginning
-		epochstypes.ModuleName,
-		capabilitytypes.ModuleName,
-		minttypes.ModuleName,           // no begin block logic
-		poolincentivestypes.ModuleName, // no begin block logic
-		distrtypes.ModuleName,
-		slashingtypes.ModuleName,
-		evidencetypes.ModuleName,
-		stakingtypes.ModuleName,
-		ibchost.ModuleName,             // no begin block logic
-		ibctransfertypes.ModuleName,    // no begin block logic
-		icatypes.ModuleName,            // no begin block logic
-		authtypes.ModuleName,           // no begin block logic
-		banktypes.ModuleName,           // no begin block logic
-		govtypes.ModuleName,            // no begin block logic (only end block oddly)
-		crisistypes.ModuleName,         // no begin block logic (only end block)
-		genutiltypes.ModuleName,        // no begin block logic
-		authz.ModuleName,               // no begin block logic
-		paramstypes.ModuleName,         // no begin block logic
-		vestingtypes.ModuleName,        // no begin block logic
-		gammtypes.ModuleName,           // no begin block logic
-		incentivestypes.ModuleName,     // no begin block logic
-		lockuptypes.ModuleName,         // no begin block logic
-		poolincentivestypes.ModuleName, // no begin block logic
-		tokenfactorytypes.ModuleName,   // no begin block logic
-		// superfluid must come after distribution and epochs
-		superfluidtypes.ModuleName,
-		bech32ibctypes.ModuleName, // no begin block logic
-		txfeestypes.ModuleName,    // no begin block logic
-		wasm.ModuleName,           // no begin block logic
-	}
+	// Staking ordering
+	// TODO: Perhaps this can be relaxed, left to future work to analyze.
+	ord.Sequence(distrtypes.ModuleName, slashingtypes.ModuleName, evidencetypes.ModuleName, stakingtypes.ModuleName)
+	// superfluid must come after distribution & epochs.
+	// TODO: we actually set it to come after staking, since thats what happened before, and want to minimize chance of break.
+	ord.After(superfluidtypes.ModuleName, stakingtypes.ModuleName)
+
+	// every remaining module's begin block is a no-op.
+	return ord.TotalOrdering()
 }
 
 func OrderEndBlockers(allModuleNames []string) []string {

--- a/app/modules.go
+++ b/app/modules.go
@@ -145,53 +145,54 @@ func appModules(
 // orderBeginBlockers Tell the app's module manager how to set the order of
 // BeginBlockers, which are run at the beginning of every block.
 func orderBeginBlockers(allModuleNames []string) []string {
-	ord := partialord.NewPartialOrdering(allModuleNames)
-	// Upgrades should be run VERY first
-	// Epochs is set to be next right now, this in principle could change to come later / be at the end.
-	// requires more thought into if it breaks existing logic.
-	ord.FirstElements(upgradetypes.ModuleName, epochstypes.ModuleName, capabilitytypes.ModuleName)
-	// mint must come before pool incentives & distribution
-	ord.Before(minttypes.ModuleName, poolincentivestypes.ModuleName)
-	ord.Before(minttypes.ModuleName, distrtypes.ModuleName)
-	// staking, slashing & superfluid should come after distribution
-	ord.Before(distrtypes.ModuleName, slashingtypes.ModuleName)
-	ord.Before(distrtypes.ModuleName, stakingtypes.ModuleName)
-	ord.Before(distrtypes.ModuleName, superfluidtypes.ModuleName)
-	// evidence should come after slashing
-	ord.Before(slashingtypes.ModuleName, evidencetypes.ModuleName)
+	// ord := partialord.NewPartialOrdering(allModuleNames)
+	// // Upgrades should be run VERY first
+	// // Epochs is set to be next right now, this in principle could change to come later / be at the end.
+	// // requires more thought into if it breaks existing logic.
+	// ord.FirstElements(upgradetypes.ModuleName, epochstypes.ModuleName, capabilitytypes.ModuleName)
+
+	// // IBC ordering constraint
+	// ord.Sequence(ibchost.ModuleName)
+	// // token distribution ordering constraint
+	// // staking, slashing & superfluid should come after distribution
+	// ord.Before(distrtypes.ModuleName, slashingtypes.ModuleName)
+	// ord.Before(distrtypes.ModuleName, stakingtypes.ModuleName)
+	// ord.Before(distrtypes.ModuleName, superfluidtypes.ModuleName)
+	// // evidence should come after slashing
+	// ord.After(evidencetypes.ModuleName, slashingtypes.ModuleName)
 	return []string{
 		// Upgrades should be run VERY first
 		upgradetypes.ModuleName,
 		// Note: epochs' begin should be "real" start of epochs, we keep epochs beginblock at the beginning
 		epochstypes.ModuleName,
 		capabilitytypes.ModuleName,
-		minttypes.ModuleName,
-		poolincentivestypes.ModuleName,
+		minttypes.ModuleName,           // no begin block logic
+		poolincentivestypes.ModuleName, // no begin block logic
 		distrtypes.ModuleName,
 		slashingtypes.ModuleName,
 		evidencetypes.ModuleName,
 		stakingtypes.ModuleName,
-		ibchost.ModuleName,
-		ibctransfertypes.ModuleName,
-		icatypes.ModuleName,
-		authtypes.ModuleName,
-		banktypes.ModuleName,
-		govtypes.ModuleName,
-		crisistypes.ModuleName,
-		genutiltypes.ModuleName,
-		authz.ModuleName,
-		paramstypes.ModuleName,
-		vestingtypes.ModuleName,
-		gammtypes.ModuleName,
-		incentivestypes.ModuleName,
-		lockuptypes.ModuleName,
-		poolincentivestypes.ModuleName,
-		tokenfactorytypes.ModuleName,
+		ibchost.ModuleName,             // no begin block logic
+		ibctransfertypes.ModuleName,    // no begin block logic
+		icatypes.ModuleName,            // no begin block logic
+		authtypes.ModuleName,           // no begin block logic
+		banktypes.ModuleName,           // no begin block logic
+		govtypes.ModuleName,            // no begin block logic (only end block oddly)
+		crisistypes.ModuleName,         // no begin block logic (only end block)
+		genutiltypes.ModuleName,        // no begin block logic
+		authz.ModuleName,               // no begin block logic
+		paramstypes.ModuleName,         // no begin block logic
+		vestingtypes.ModuleName,        // no begin block logic
+		gammtypes.ModuleName,           // no begin block logic
+		incentivestypes.ModuleName,     // no begin block logic
+		lockuptypes.ModuleName,         // no begin block logic
+		poolincentivestypes.ModuleName, // no begin block logic
+		tokenfactorytypes.ModuleName,   // no begin block logic
 		// superfluid must come after distribution and epochs
 		superfluidtypes.ModuleName,
-		bech32ibctypes.ModuleName,
-		txfeestypes.ModuleName,
-		wasm.ModuleName,
+		bech32ibctypes.ModuleName, // no begin block logic
+		txfeestypes.ModuleName,    // no begin block logic
+		wasm.ModuleName,           // no begin block logic
 	}
 }
 

--- a/osmoutils/partialord/partialord.go
+++ b/osmoutils/partialord/partialord.go
@@ -76,6 +76,18 @@ func (ord *PartialOrdering) LastElements(elems ...string) {
 	ord.lastSealed = true
 }
 
+// Sequence sets a sequence of ordering constraints.
+// So if were making an ordering over {A, B, C, D, E}, and elems provided is {D, B, A}
+// then we are guaranteed that the total ordering will have D comes before B comes before A.
+// (They're may be elements interspersed, e.g. {D, C, E, B, A} is a valid ordering)
+func (ord *PartialOrdering) Sequence(seq ...string) {
+	// We make every node in the sequence have a prior node
+	for i := 0; i < (len(seq) - 1); i++ {
+		err := ord.dag.AddEdge(seq[i], seq[i+1])
+		handleDAGErr(err)
+	}
+}
+
 // TotalOrdering returns a deterministically chosen total ordering that satisfies all specified
 // partial ordering constraints.
 //

--- a/osmoutils/partialord/partialord_test.go
+++ b/osmoutils/partialord/partialord_test.go
@@ -55,7 +55,9 @@ func TestNonStandardAPIOrder(t *testing.T) {
 	require.Equal(t, expOrdering, ord.TotalOrdering())
 }
 
-func TestSetSequence(t *testing.T) {
+// This test ad-hocly tests combination of multiple sequences, first elements, and an After
+// invokation.
+func TestSequence(t *testing.T) {
 	// This test uses direct ordering before First, and after Last
 	names := []string{"A", "B", "C", "D", "E", "F", "G"}
 	ord := partialord.NewPartialOrdering(names)

--- a/osmoutils/partialord/partialord_test.go
+++ b/osmoutils/partialord/partialord_test.go
@@ -54,3 +54,20 @@ func TestNonStandardAPIOrder(t *testing.T) {
 	expOrdering = []string{"A", "B", "C", "D", "E", "F", "G"}
 	require.Equal(t, expOrdering, ord.TotalOrdering())
 }
+
+func TestSetSequence(t *testing.T) {
+	// This test uses direct ordering before First, and after Last
+	names := []string{"A", "B", "C", "D", "E", "F", "G"}
+	ord := partialord.NewPartialOrdering(names)
+	// Make B A C a sequence
+	ord.Sequence("B", "A", "C")
+	// Make A G E a sub-sequence
+	ord.Sequence("A", "G", "E")
+	// make first elements D B F
+	ord.FirstElements("D", "B", "F")
+	// make C come after E
+	ord.After("C", "G")
+
+	expOrdering := []string{"D", "B", "F", "A", "G", "C", "E"}
+	require.Equal(t, expOrdering, ord.TotalOrdering())
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Adds a partial ordering for begin block. Right now, this replicates the exact same ordering that was present before,
and just removes no-op begin blockers. Its left to future work to further improve this.

I'd like this to be backported, so we can easily sanity check state compatibility / not have to worry about that come release time. (Our WIP minor release workflow should catch this if problematic =)) )

## Brief Changelog
 
  - Use partial ordering for begin blockers
  - Adds a partial ord.Sequence method, for setting a sequence of modules.

## Testing and Verifying

- Verify the github comment, for every module listed as no-op in fact being a no-op
- Checking that every remaining module is constrained to be in the same order that was present before.
- Existing tests pass
- New test for partialOrd.Sequence

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? In-line comments / reducing surrounding noise.