### PR TITLE
Remove the EndBlock ordering constraints, that didn't matter before

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -183,13 +183,8 @@ func orderBeginBlockers() []string {
 
 func OrderEndBlockers(allModuleNames []string) []string {
 	ord := partialord.NewPartialOrdering(allModuleNames)
-	// Epochs must run after all other end blocks
-	ord.LastElements(epochstypes.ModuleName)
-	// txfees auto-swap code should occur before any potential gamm end block code.
-	ord.Before(txfeestypes.ModuleName, gammtypes.ModuleName)
-	// only remaining modules that aren;t no-ops are: crisis & govtypes
+	// only Osmosis modules with endblock code are: crisis, govtypes, staking
 	// we don't care about the relative ordering between them.
-
 	return ord.TotalOrdering()
 }
 

--- a/x/superfluid/abci.go
+++ b/x/superfluid/abci.go
@@ -1,8 +1,6 @@
 package superfluid
 
 import (
-	abci "github.com/tendermint/tendermint/abci/types"
-
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/superfluid/types"
 
@@ -18,9 +16,4 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper, ek types.EpochKeeper) {
 	if numBlocksSinceEpochStart == 0 {
 		k.AfterEpochStartBeginBlock(ctx)
 	}
-}
-
-// Called every block to automatically unlock matured locks.
-func EndBlocker(ctx sdk.Context, k keeper.Keeper) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
 }

--- a/x/superfluid/module.go
+++ b/x/superfluid/module.go
@@ -187,7 +187,6 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	EndBlocker(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Epochs, txfees, and gamm have no endblock logic. So the prior constraints had no impact.

## Brief Changelog

- Remove some unnecessary logic. 
- Remove the deadcode, to make it clearer superfluid has no endblock logic.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage. Just check the following lines to convince yourself of no EndBlock logic:

epochs - https://github.com/osmosis-labs/osmosis/blob/main/x/epochs/module.go#L157-L161
gamm - https://github.com/osmosis-labs/osmosis/blob/main/x/gamm/module.go#L149-L153
txfees - https://github.com/osmosis-labs/osmosis/blob/main/x/txfees/module.go#L162-L167

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable