### PR TITLE
Add TWAP stub package

### DIFF
--- a/x/gamm/twap/README.md
+++ b/x/gamm/twap/README.md
@@ -1,0 +1,9 @@
+# TWAP
+
+We maintain TWAP entries for every gamm pool.
+
+NOTE: Not yet integrated into state machine, this package is a stub.
+
+## Basic architecture notes
+
+We maintain the list of pools altered within in a block

--- a/x/gamm/twap/abci.go
+++ b/x/gamm/twap/abci.go
@@ -5,5 +5,9 @@ import sdk "github.com/cosmos/cosmos-sdk/types"
 func (k twapkeeper) endBlockLogic(ctx sdk.Context) {
 	// TODO: Update TWAP entries
 	// step 1: Get all altered pool ids
+	changedPoolIds := k.getChangedPools(ctx)
+	if len(changedPoolIds) == 0 {
+		return
+	}
 	// 'altered pool ids' should be automatically cleared
 }

--- a/x/gamm/twap/abci.go
+++ b/x/gamm/twap/abci.go
@@ -1,0 +1,9 @@
+package twap
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+func (k twapkeeper) endBlockLogic(ctx sdk.Context) {
+	// TODO: Update TWAP entries
+	// step 1: Get all altered pool ids
+	// 'altered pool ids' should be automatically cleared
+}

--- a/x/gamm/twap/hook_listener.go
+++ b/x/gamm/twap/hook_listener.go
@@ -1,0 +1,31 @@
+package twap
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
+)
+
+var _ types.GammHooks = &gammhook{}
+
+type gammhook struct {
+	k twapkeeper
+}
+
+// AfterPoolCreated is called after CreatePool
+func (hook *gammhook) AfterPoolCreated(ctx sdk.Context, sender sdk.AccAddress, poolId uint64) {
+	// TODO: Log pool creation to begin creating TWAPs for it
+}
+
+func (hook *gammhook) AfterSwap(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, input sdk.Coins, output sdk.Coins) {
+	// Log that this pool had a potential spot price change
+	hook.k.trackChangedPool(ctx, poolId)
+}
+
+func (hook *gammhook) AfterJoinPool(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, enterCoins sdk.Coins, shareOutAmount sdk.Int) {
+	// Log that this pool had a potential spot price change
+	hook.k.trackChangedPool(ctx, poolId)
+}
+
+func (hook *gammhook) AfterExitPool(_ sdk.Context, _ sdk.AccAddress, _ uint64, _ sdk.Int, _ sdk.Coins) {
+}

--- a/x/gamm/twap/keeper.go
+++ b/x/gamm/twap/keeper.go
@@ -3,6 +3,6 @@ package twap
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
 type twapkeeper struct {
-	storeKey     sdk.StoreKey
+	// storeKey     sdk.StoreKey
 	transientKey sdk.TransientStoreKey
 }

--- a/x/gamm/twap/keeper.go
+++ b/x/gamm/twap/keeper.go
@@ -1,0 +1,8 @@
+package twap
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+type twapkeeper struct {
+	storeKey     sdk.StoreKey
+	transientKey sdk.TransientStoreKey
+}

--- a/x/gamm/twap/module.go
+++ b/x/gamm/twap/module.go
@@ -1,0 +1,135 @@
+package twap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/osmosis-labs/osmosis/v7/x/gamm/keeper"
+	twaptypes "github.com/osmosis-labs/osmosis/v7/x/gamm/twap/types"
+	"github.com/osmosis-labs/osmosis/v7/x/gamm/types"
+)
+
+var (
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
+)
+
+type AppModuleBasic struct {
+	cdc codec.Codec
+}
+
+func (AppModuleBasic) Name() string { return twaptypes.ModuleName }
+
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+}
+
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	return json.RawMessage{}
+	// return cdc.MustMarshalJSON(types.DefaultGenesis())
+}
+
+// ValidateGenesis performs genesis state validation for the gamm module.
+func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
+	// var genState types.GenesisState
+	// if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
+	// 	return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
+	// }
+	// return genState.Validate()
+	return nil
+}
+
+//---------------------------------------
+// Interfaces.
+func (b AppModuleBasic) RegisterRESTRoutes(ctx client.Context, r *mux.Router) {
+}
+func (b AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) //nolint:errcheck
+}
+
+func (b AppModuleBasic) GetTxCmd() *cobra.Command {
+	return nil
+	// return cli.NewTxCmd()
+}
+func (b AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return nil
+	// return cli.GetQueryCmd()
+}
+
+// RegisterInterfaces registers interfaces and implementations of the gamm module.
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+}
+
+type AppModule struct {
+	AppModuleBasic
+
+	ak types.AccountKeeper
+	bk types.BankKeeper
+	gk keeper.Keeper
+}
+
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+}
+
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper,
+	accountKeeper types.AccountKeeper, bankKeeper types.BankKeeper,
+) AppModule {
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{cdc: cdc},
+		gk:             keeper,
+		ak:             accountKeeper,
+		bk:             bankKeeper,
+	}
+}
+
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+}
+
+func (am AppModule) Route() sdk.Route {
+	return sdk.Route{}
+}
+
+// QuerierRoute returns the gamm module's querier route name.
+func (AppModule) QuerierRoute() string { return types.RouterKey }
+
+// LegacyQuerierHandler returns the x/gamm module's sdk.Querier.
+func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
+	return func(sdk.Context, []string, abci.RequestQuery) ([]byte, error) {
+		return nil, fmt.Errorf("legacy querier not supported for the x/%s module", types.ModuleName)
+	}
+}
+
+// InitGenesis performs genesis initialization for the gamm module. It returns
+// no validator updates.
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis returns the exported genesis state as raw bytes for the gamm
+// module.
+func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	return json.RawMessage{}
+}
+
+// BeginBlock performs a no-op.
+func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+
+// EndBlock returns the end blocker for the gamm module. It returns no validator
+// updates.
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}
+
+// ConsensusVersion implements AppModule/ConsensusVersion.
+func (AppModule) ConsensusVersion() uint64 { return 1 }

--- a/x/gamm/twap/module.go
+++ b/x/gamm/twap/module.go
@@ -77,6 +77,7 @@ type AppModule struct {
 	ak types.AccountKeeper
 	bk types.BankKeeper
 	gk keeper.Keeper
+	tk twapkeeper
 }
 
 func (am AppModule) RegisterServices(cfg module.Configurator) {
@@ -128,6 +129,7 @@ func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 // EndBlock returns the end blocker for the gamm module. It returns no validator
 // updates.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	am.tk.endBlockLogic(ctx)
 	return []abci.ValidatorUpdate{}
 }
 

--- a/x/gamm/twap/store.go
+++ b/x/gamm/twap/store.go
@@ -1,0 +1,30 @@
+package twap
+
+import (
+	"encoding/binary"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (k twapkeeper) trackChangedPool(ctx sdk.Context, poolId uint64) {
+	store := ctx.TransientStore(&k.transientKey)
+	poolIdBz := make([]byte, 8)
+	binary.LittleEndian.PutUint64(poolIdBz, poolId)
+	// just has to not be empty, for store to work / not register as a delete.
+	sentinelExistsValue := []byte{1}
+	store.Set(poolIdBz, sentinelExistsValue)
+}
+
+func (k twapkeeper) getChangedPools(ctx sdk.Context, poolId uint64) []uint64 {
+	store := ctx.TransientStore(&k.transientKey)
+	iter := store.Iterator(nil, nil)
+	defer iter.Close()
+
+	alteredPoolIds := []uint64{}
+	for ; iter.Key() != nil; iter.Next() {
+		k := iter.Key()
+		poolId := binary.LittleEndian.Uint64(k)
+		alteredPoolIds = append(alteredPoolIds, poolId)
+	}
+	return alteredPoolIds
+}

--- a/x/gamm/twap/store.go
+++ b/x/gamm/twap/store.go
@@ -15,7 +15,7 @@ func (k twapkeeper) trackChangedPool(ctx sdk.Context, poolId uint64) {
 	store.Set(poolIdBz, sentinelExistsValue)
 }
 
-func (k twapkeeper) getChangedPools(ctx sdk.Context, poolId uint64) []uint64 {
+func (k twapkeeper) getChangedPools(ctx sdk.Context) []uint64 {
 	store := ctx.TransientStore(&k.transientKey)
 	iter := store.Iterator(nil, nil)
 	defer iter.Close()

--- a/x/gamm/twap/types/keys.go
+++ b/x/gamm/twap/types/keys.go
@@ -1,0 +1,15 @@
+package types
+
+const (
+	ModuleName = "twap"
+
+	StoreKey          = ModuleName
+	TransientStoreKey = "transient_" + ModuleName // this is silly we have to do this
+	RouterKey         = ModuleName
+
+	QuerierRoute = ModuleName
+)
+
+var (
+	AlteredPoolIdsPrefix = []byte{0}
+)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR adds a stub starting some of the TWAP logic. Has a couple high level notes around where more logic goes.
One of the goals is that it is relatively decoupled from gamm, only having read-only access to a pool, along with getting hooks.

This PR basically includes minimum scaffolding necessary to only have complexity once per pool per block, rather than on every swap.

I'd like to merge this if viewed as acceptable, so we can carry forward with more TWAP experimentation with this boilerplate out of the way in review.

## Brief Changelog

- Add Stub

## Testing and Verifying

No core logic / wiring present to test yet. Just stubs for future work / to make this not need to be reviewed in subsequent work.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? Should be added to README of TWAP and gamm.