### PR TITLE
x/gamm : Fix public/private on GetNextPoolNumber API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Golang API breaks
 
+* [#1987](https://github.com/osmosis-labs/osmosis/pull/1987) Remove `GammKeeper.GetNextPoolNumberAndIncrement` in favor of the non-mutative `GammKeeper.GetNextPoolNumber`.
 * [#1937](https://github.com/osmosis-labs/osmosis/pull/1937) Change `lockupKeeper.ExtendLock` to take in lockID instead of the direct lock struct.
 * [#1893](https://github.com/osmosis-labs/osmosis/pull/1893) Change `EpochsKeeper.SetEpochInfo` to `AddEpochInfo`, which has more safety checks with it. (Makes it suitable to be called within upgrades)
 * [#1671](https://github.com/osmosis-labs/osmosis/pull/1671) Remove methods that constitute AppModuleSimulation APIs for several modules' AppModules, which implemented no-ops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1671](https://github.com/osmosis-labs/osmosis/pull/1671) Add hourly epochs to `x/epochs` DefaultGenesis.
 * [#1665](https://github.com/osmosis-labs/osmosis/pull/1665) Delete app/App interface, instead use simapp.App
 * [#1630](https://github.com/osmosis-labs/osmosis/pull/1630) Delete the v043_temp module, now that we're on an updated SDK version.
-* [#1667](https://github.com/osmosis-labs/osmosis/pull/1673) Move wasm-bindings code out of app .
+* [#1667](https://github.com/osmosis-labs/osmosis/pull/1673) Move wasm-bindings code out of app package into its own root level package.
 
 ### Features
 

--- a/x/gamm/keeper/genesis.go
+++ b/x/gamm/keeper/genesis.go
@@ -11,7 +11,7 @@ import (
 // state, which includes the current live pools, global pool parameters (e.g. pool creation fee), next pool number etc.
 func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState, unpacker codectypes.AnyUnpacker) {
 	k.SetParams(ctx, genState.Params)
-	k.SetNextPoolNumber(ctx, genState.NextPoolNumber)
+	k.setNextPoolNumber(ctx, genState.NextPoolNumber)
 
 	// Sums up the liquidity in all genesis state pools to find the total liquidity across all pools.
 	// Also adds each genesis state pool to the x/gamm module's state
@@ -51,7 +51,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		poolAnys = append(poolAnys, any)
 	}
 	return &types.GenesisState{
-		NextPoolNumber: k.GetNextPoolNumberAndIncrement(ctx),
+		NextPoolNumber: k.GetNextPoolNumber(ctx),
 		Pools:          poolAnys,
 		Params:         k.GetParams(ctx),
 	}

--- a/x/gamm/keeper/grpc_query.go
+++ b/x/gamm/keeper/grpc_query.go
@@ -120,7 +120,7 @@ func (q Querier) NumPools(ctx context.Context, _ *types.QueryNumPoolsRequest) (*
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	return &types.QueryNumPoolsResponse{
-		NumPools: q.Keeper.GetNextPoolNumberAndIncrement(sdkCtx) - 1,
+		NumPools: q.Keeper.GetNextPoolNumber(sdkCtx) - 1,
 	}, nil
 }
 

--- a/x/gamm/keeper/pool.go
+++ b/x/gamm/keeper/pool.go
@@ -196,16 +196,17 @@ func (k Keeper) DeletePool(ctx sdk.Context, poolId uint64) error {
 // 	return nil
 // }
 
-// SetNextPoolNumber sets next pool number.
-func (k Keeper) SetNextPoolNumber(ctx sdk.Context, poolNumber uint64) {
+// setNextPoolNumber sets next pool number.
+func (k Keeper) setNextPoolNumber(ctx sdk.Context, poolNumber uint64) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&gogotypes.UInt64Value{Value: poolNumber})
 	store.Set(types.KeyNextGlobalPoolNumber, bz)
 }
 
-// GetNextPoolNumberAndIncrement returns the next pool number, and increments the corresponding state entry.
-func (k Keeper) GetNextPoolNumberAndIncrement(ctx sdk.Context) uint64 {
-	var poolNumber uint64
+// GetNextPoolNumber returns the next pool number.
+// TODO: Rename NextPoolNumber to NextPoolId
+func (k Keeper) GetNextPoolNumber(ctx sdk.Context) uint64 {
+	var nextPoolId uint64
 	store := ctx.KVStore(k.storeKey)
 
 	bz := store.Get(types.KeyNextGlobalPoolNumber)
@@ -219,11 +220,16 @@ func (k Keeper) GetNextPoolNumberAndIncrement(ctx sdk.Context) uint64 {
 			panic(err)
 		}
 
-		poolNumber = val.GetValue()
+		nextPoolId = val.GetValue()
 	}
+	return nextPoolId
+}
 
-	k.SetNextPoolNumber(ctx, poolNumber+1)
-	return poolNumber
+// getNextPoolNumberAndIncrement returns the next pool number, and increments the corresponding state entry.
+func (k Keeper) getNextPoolNumberAndIncrement(ctx sdk.Context) uint64 {
+	nextPoolId := k.GetNextPoolNumber(ctx)
+	k.setNextPoolNumber(ctx, nextPoolId+1)
+	return nextPoolId
 }
 
 // set ScalingFactors in stable stableswap pools

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -105,7 +105,7 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 		return 0, err
 	}
 
-	poolId := k.GetNextPoolNumberAndIncrement(ctx)
+	poolId := k.getNextPoolNumberAndIncrement(ctx)
 	pool, err := msg.CreatePool(ctx, poolId)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Break off from my simulator work -- Make & Use `GetNexttPoolNumber` API, make the increment and set API's internal. 

This likely will fix some unreported edge cases with queries as well.

## Brief Changelog
 
  - Remove public GetNextPoolNumberAndIncrement method in favor of GetNextPoolNumber

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not documented