### PR TITLE
Switch `expectError` to `expectPass` where applicable to keep tests consistent with each other

### DIFF
--- a/tests/e2e/initialization/init_test.go
+++ b/tests/e2e/initialization/init_test.go
@@ -16,11 +16,9 @@ import (
 
 const forkHeight = 10
 
-var (
-	expectedConfigFiles = []string{
-		"app.toml", "config.toml", "genesis.json", "node_key.json", "priv_validator_key.json",
-	}
-)
+var expectedConfigFiles = []string{
+	"app.toml", "config.toml", "genesis.json", "node_key.json", "priv_validator_key.json",
+}
 
 // TestChainInit tests that chain initialization correctly initializes a full chain
 // and produces the desired output with genesis, chain and validator configs.

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -451,49 +451,49 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 		name                string
 		baseDenomPoolInput  sdk.Coin
 		quoteDenomPoolInput sdk.Coin
-		expectError         bool
+		expectPass          bool
 		expectedOutput      sdk.Dec
 	}{
 		{
 			name:                "equal value",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
-			expectError:         false,
+			expectPass:          true,
 			expectedOutput:      sdk.MustNewDecFromStr("1"),
 		},
 		{
 			name:                "1:2 ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 200),
-			expectError:         false,
+			expectPass:          true,
 			expectedOutput:      sdk.MustNewDecFromStr("0.500000000000000000"),
 		},
 		{
 			name:                "2:1 ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
-			expectError:         false,
+			expectPass:          true,
 			expectedOutput:      sdk.MustNewDecFromStr("2.000000000000000000"),
 		},
 		{
 			name:                "rounding after sigfig ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
-			expectError:         false,
+			expectPass:          true,
 			expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
 		},
 		{
 			name:                "check number of sig figs",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
-			expectError:         false,
+			expectPass:          true,
 			expectedOutput:      sdk.MustNewDecFromStr("0.333333330000000000"),
 		},
 		{
 			name:                "check number of sig figs high sizes",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
 			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
-			expectError:         false,
+			expectPass:          true,
 			expectedOutput:      sdk.MustNewDecFromStr("0.000000000001840877"),
 		},
 	}
@@ -517,7 +517,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 				tc.baseDenomPoolInput.Denom,
 				tc.quoteDenomPoolInput.Denom)
 
-			if tc.expectError {
+			if !tc.expectPass {
 				suite.Require().Error(err, "test: %s", tc.name)
 			} else {
 				suite.Require().NoError(err, "test: %s", tc.name)

--- a/x/gamm/twap/module.go
+++ b/x/gamm/twap/module.go
@@ -54,6 +54,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // Interfaces.
 func (b AppModuleBasic) RegisterRESTRoutes(ctx client.Context, r *mux.Router) {
 }
+
 func (b AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) //nolint:errcheck
 }
@@ -62,6 +63,7 @@ func (b AppModuleBasic) GetTxCmd() *cobra.Command {
 	return nil
 	// return cli.NewTxCmd()
 }
+
 func (b AppModuleBasic) GetQueryCmd() *cobra.Command {
 	return nil
 	// return cli.GetQueryCmd()

--- a/x/gamm/twap/types/keys.go
+++ b/x/gamm/twap/types/keys.go
@@ -10,6 +10,4 @@ const (
 	QuerierRoute = ModuleName
 )
 
-var (
-	AlteredPoolIdsPrefix = []byte{0}
-)
+var AlteredPoolIdsPrefix = []byte{0}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1988 

## What is the purpose of the change

Most of our table driven tests check errors by using `expectPass`, but there are a few tests lingering around that seem to use `expectError`. Since we are starting to introduce testing standards for our codebase, a small but important test cleanup would be to align all of our tests to use the same convention to remove the inconsistency. This PR makes this change where applicable.

## Brief Changelog

- Switch `expectError` to `expectPass` in balancer tests

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)