### PR TITLE
chore: add stalebot to CI

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -22,6 +22,6 @@ jobs:
             activity occurs. Thank you!
           days-before-stale: -1
           days-before-close: -1
-          days-before-pr-stale: 30
+          days-before-pr-stale: 14
           days-before-pr-close: 6
           exempt-pr-labels: "security, proposal, blocked"

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,27 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had any recent activity. It will be closed if no further
+            activity occurs. Thank you!
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 6
+          exempt-pr-labels: "security, proposal, blocked"


### PR DESCRIPTION
Add a Github Actions job that uses the stale workflow to automatically mark PRs as stale and close them w/o any activity. Feel free to comment on tweaking any values.