### PR TITLE
x/superfluid: no delegation distribution info

### DIFF
--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -5,6 +5,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
 	"github.com/osmosis-labs/osmosis/v7/osmoutils"
 	gammtypes "github.com/osmosis-labs/osmosis/v7/x/gamm/types"
 	incentivestypes "github.com/osmosis-labs/osmosis/v7/x/incentives/types"
@@ -61,6 +63,10 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context) {
 		// we use cacheCtx and apply the changes later
 		_ = osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
 			_, err := k.dk.WithdrawDelegationRewards(cacheCtx, addr, valAddr)
+			if err == distributiontypes.ErrEmptyDelegationDistInfo {
+				ctx.Logger().Debug("no swaps occurred in this pool between last epoch and this epoch")
+				return nil
+			}
 			return err
 		})
 

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -63,7 +63,7 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context) {
 		// we use cacheCtx and apply the changes later
 		_ = osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
 			_, err := k.dk.WithdrawDelegationRewards(cacheCtx, addr, valAddr)
-			if err == distributiontypes.ErrEmptyDelegationDistInfo {
+			if errors.Is(err, distributiontypes.ErrEmptyDelegationDistInfo) {
 				ctx.Logger().Debug("no swaps occurred in this pool between last epoch and this epoch")
 				return nil
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1797 

## What is the purpose of the change

Whenever a pool does not have swaps occur between last epoch and the current epoch, an error message is displayed during epoch. Since we have many pools that this is the case for, there are many error logs which does not help the end user. 

More specifically, we call WithdrawDelegationRewards here

https://github.com/osmosis-labs/osmosis/blob/079bdd496aefea6ad386263b349f2b60f0358738/x/superfluid/keeper/epoch.go#L60-L65

When we make this call to the sdk, we return an ErrEmptyDelegationDistInfo

https://github.com/osmosis-labs/cosmos-sdk/blob/d49b3e7549293d3bdf70c898c7afa58728438338/x/distribution/keeper/keeper.go#L84-L94



## Brief Changelog

This change simply handles the ErrEmptyDelegationDistInfo with a debug log stating that "no swaps occurred in this pool between last epoch and this epoch" instead of spamming the daemon with error logs every epoch.


## Testing and Verifying

I tested this by running a local state exported testnet and setting the epoch time to every 60 seconds.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable