### PR TITLE
Fix Initgenesis bug in tokenfactory, when the denom creation fee para…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,5 @@ $RECYCLE.BIN/
 /x/incentives/keeper/osmosis_testing/
 tools-stamp
 /tests/localosmosis/.osmosisd/*
+*.save
+*.save.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [1759](https://github.com/osmosis-labs/osmosis/pull/1759) Fix pagination filter in incentives query.
 * [1698](https://github.com/osmosis-labs/osmosis/pull/1698) Register wasm snapshotter extension.
 * [1931](https://github.com/osmosis-labs/osmosis/pull/1931) Add explicit check for input denoms to `CalcJoinPoolShares`
+* [2011](https://github.com/osmosis-labs/osmosis/pull/2011) Fix bug in TokenFactory initGenesis, relating to denom creation fee param.
+
 
 ## [v9.0.0 - Nitrogen](https://github.com/osmosis-labs/osmosis/releases/tag/v9.0.0)
 

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -28,7 +28,6 @@ func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string
 // Runs CreateDenom logic after the charge has been handled.
 // Made into a separate method for genesis handling.
 func (k Keeper) createDenomAfterValidation(ctx sdk.Context, creatorAddr string, denom string) (err error) {
-
 	denomMetaData := banktypes.Metadata{
 		DenomUnits: []*banktypes.DenomUnit{{
 			Denom:    denom,

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -25,8 +25,8 @@ func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string
 	return denom, err
 }
 
-// Runs CreateDenom logic after the charge has been handled.
-// Made into a separate method for genesis handling.
+// Runs CreateDenom logic after the charge and all denom validation has been handled.
+// Made into a second function for genesis initialization.
 func (k Keeper) createDenomAfterValidation(ctx sdk.Context, creatorAddr string, denom string) (err error) {
 	denomMetaData := banktypes.Metadata{
 		DenomUnits: []*banktypes.DenomUnit{{

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -16,16 +16,18 @@ func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string
 		return "", err
 	}
 
-	return k.createDenomAfterCharge(ctx, creatorAddr, subdenom)
-}
-
-// Runs CreateDenom logic after the charge has been handled.
-// Made into a separate method for genesis handling.
-func (k Keeper) createDenomAfterCharge(ctx sdk.Context, creatorAddr string, subdenom string) (newTokenDenom string, err error) {
 	denom, err := k.validateCreateDenom(ctx, creatorAddr, subdenom)
 	if err != nil {
 		return "", err
 	}
+
+	err = k.createDenomAfterValidation(ctx, creatorAddr, denom)
+	return denom, err
+}
+
+// Runs CreateDenom logic after the charge has been handled.
+// Made into a separate method for genesis handling.
+func (k Keeper) createDenomAfterValidation(ctx sdk.Context, creatorAddr string, denom string) (err error) {
 
 	denomMetaData := banktypes.Metadata{
 		DenomUnits: []*banktypes.DenomUnit{{
@@ -42,11 +44,11 @@ func (k Keeper) createDenomAfterCharge(ctx sdk.Context, creatorAddr string, subd
 	}
 	err = k.setAuthorityMetadata(ctx, denom, authorityMetadata)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	k.addDenomFromCreator(ctx, creatorAddr, denom)
-	return denom, nil
+	return nil
 }
 
 func (k Keeper) validateCreateDenom(ctx sdk.Context, creatorAddr string, subdenom string) (newTokenDenom string, err error) {

--- a/x/tokenfactory/keeper/createdenom_test.go
+++ b/x/tokenfactory/keeper/createdenom_test.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v7/x/tokenfactory/keeper"
 	"github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types"
 )
 
@@ -90,7 +89,6 @@ func (suite *KeeperTestSuite) TestCreateDenom() {
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
-			suite.msgServer = keeper.NewMsgServerImpl(*suite.App.TokenFactoryKeeper)
 			if tc.setup != nil {
 				tc.setup()
 			}

--- a/x/tokenfactory/keeper/genesis.go
+++ b/x/tokenfactory/keeper/genesis.go
@@ -21,7 +21,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 		if err != nil {
 			panic(err)
 		}
-		_, err = k.CreateDenom(ctx, creator, subdenom)
+		_, err = k.createDenomAfterCharge(ctx, creator, subdenom)
 		if err != nil {
 			panic(err)
 		}

--- a/x/tokenfactory/keeper/genesis.go
+++ b/x/tokenfactory/keeper/genesis.go
@@ -16,13 +16,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	}
 	k.SetParams(ctx, genState.Params)
 
-	seenDenoms := make(map[string]bool, len(genState.FactoryDenoms))
-
 	for _, genDenom := range genState.GetFactoryDenoms() {
-		if _, ok := seenDenoms[genDenom.GetDenom()]; ok {
-			panic("duplicate denoms in factory state")
-		}
-
 		creator, _, err := types.DeconstructDenom(genDenom.GetDenom())
 		if err != nil {
 			panic(err)
@@ -35,7 +29,6 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 		if err != nil {
 			panic(err)
 		}
-		seenDenoms[genDenom.GetDenom()] = true
 	}
 }
 

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
@@ -24,6 +25,12 @@ func TestGenesis(t *testing.T) {
 				},
 			},
 			{
+				Denom: "factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/diff-admin",
+				AuthorityMetadata: types.DenomAuthorityMetadata{
+					Admin: "osmo15czt5nhlnvayqq37xun9s9yus0d6y26dw9xnzn",
+				},
+			},
+			{
 				Denom: "factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/litecoin",
 				AuthorityMetadata: types.DenomAuthorityMetadata{
 					Admin: "osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44",
@@ -34,6 +41,7 @@ func TestGenesis(t *testing.T) {
 	app := simapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
+	app.TokenFactoryKeeper.SetParams(ctx, types.Params{DenomCreationFee: sdk.Coins{sdk.NewInt64Coin("uosmo", 100)}})
 	app.TokenFactoryKeeper.InitGenesis(ctx, genesisState)
 	exportedGenesis := app.TokenFactoryKeeper.ExportGenesis(ctx)
 	require.NotNil(t, exportedGenesis)

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -1,21 +1,14 @@
 package keeper_test
 
 import (
-	"testing"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
-	simapp "github.com/osmosis-labs/osmosis/v7/app"
-	appparams "github.com/osmosis-labs/osmosis/v7/app/params"
 
 	"github.com/osmosis-labs/osmosis/v7/x/tokenfactory/types"
 )
 
-func TestGenesis(t *testing.T) {
-	appparams.SetAddressPrefixes()
-
+func (suite *KeeperTestSuite) TestGenesis() {
 	genesisState := types.GenesisState{
 		FactoryDenoms: []types.GenesisDenom{
 			{
@@ -38,12 +31,19 @@ func TestGenesis(t *testing.T) {
 			},
 		},
 	}
-	app := simapp.Setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	app := suite.App
+	suite.Ctx = app.BaseApp.NewContext(false, tmproto.Header{})
+	// Test both with bank denom metadata set, and not set.
+	for i, denom := range genesisState.FactoryDenoms {
+		// hacky, sets bank metadata to exist if i != 0, to cover both cases.
+		if i != 0 {
+			app.BankKeeper.SetDenomMetaData(suite.Ctx, banktypes.Metadata{Base: denom.GetDenom()})
+		}
+	}
 
-	app.TokenFactoryKeeper.SetParams(ctx, types.Params{DenomCreationFee: sdk.Coins{sdk.NewInt64Coin("uosmo", 100)}})
-	app.TokenFactoryKeeper.InitGenesis(ctx, genesisState)
-	exportedGenesis := app.TokenFactoryKeeper.ExportGenesis(ctx)
-	require.NotNil(t, exportedGenesis)
-	require.Equal(t, genesisState, *exportedGenesis)
+	app.TokenFactoryKeeper.SetParams(suite.Ctx, types.Params{DenomCreationFee: sdk.Coins{sdk.NewInt64Coin("uosmo", 100)}})
+	app.TokenFactoryKeeper.InitGenesis(suite.Ctx, genesisState)
+	exportedGenesis := app.TokenFactoryKeeper.ExportGenesis(suite.Ctx)
+	suite.Require().NotNil(exportedGenesis)
+	suite.Require().Equal(genesisState, *exportedGenesis)
 }

--- a/x/tokenfactory/types/errors.go
+++ b/x/tokenfactory/types/errors.go
@@ -10,7 +10,7 @@ import (
 
 // x/tokenfactory module sentinel errors
 var (
-	ErrDenomExists              = sdkerrors.Register(ModuleName, 2, "denom already exists")
+	ErrDenomExists              = sdkerrors.Register(ModuleName, 2, "attempting to create a denom that already exists (has bank metadata)")
 	ErrUnauthorized             = sdkerrors.Register(ModuleName, 3, "unauthorized account")
 	ErrInvalidDenom             = sdkerrors.Register(ModuleName, 4, "invalid denom")
 	ErrInvalidCreator           = sdkerrors.Register(ModuleName, 5, "invalid creator")


### PR DESCRIPTION
…m is set

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fixes a bug Adam pointed out, in TokenFactory genesis handling. (Which led to panics in his testnet generation)

## Brief Changelog

- Refactor TokenFactory createdenom logic, to make a direct method post-fee-charging that genesis can call
- Switch genesis to no longer charge a fee
- Add test cases to cover this.

## Testing and Verifying

This change added tests and can be verified as follows:

- Added a case for a denom with a different admin (previously untested in InitGenesis)
- Sets the token creation fee

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? N/A