### PR TITLE
use distributeInternal in distributeSyntheticInternal

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -230,7 +230,7 @@ func (k Keeper) doDistributionSends(ctx sdk.Context, distrs *distributionInfo) e
 func (k Keeper) distributeSyntheticInternal(
 	ctx sdk.Context, gauge types.Gauge, locks []lockuptypes.PeriodLock, distrInfo *distributionInfo,
 ) (sdk.Coins, error) {
-	totalDistrCoins := sdk.NewCoins()
+	// totalDistrCoins := sdk.NewCoins()
 	denom := gauge.DistributeTo.Denom
 
 	qualifiedLocks := make([]lockuptypes.PeriodLock, 0, len(locks))
@@ -244,50 +244,7 @@ func (k Keeper) distributeSyntheticInternal(
 		qualifiedLocks = append(qualifiedLocks, lock)
 	}
 
-	lockSum := lockuptypes.SumLocksByDenom(qualifiedLocks, lockuptypes.NativeDenom(denom))
-
-	if lockSum.IsZero() {
-		return nil, nil
-	}
-
-	remainCoins := gauge.Coins.Sub(gauge.DistributedCoins)
-	remainEpochs := uint64(1)
-	if !gauge.IsPerpetual { // set remain epochs when it's not perpetual gauge
-		remainEpochs = gauge.NumEpochsPaidOver - gauge.FilledEpochs
-	}
-
-	for _, lock := range qualifiedLocks {
-		distrCoins := sdk.Coins{}
-		for _, coin := range remainCoins {
-			lockedCoin, err := lock.SingleCoin()
-			if err != nil {
-				k.Logger(ctx).Error(err.Error())
-				continue
-			}
-			// distribution amount = gauge_size * denom_lock_amount / (total_denom_lock_amount * remain_epochs)
-			// check if the synthlock is qualified for GetLocksToDistribution
-			amt := coin.Amount.Mul(lockedCoin.Amount).Quo(lockSum.Mul(sdk.NewIntFromUint64(remainEpochs)))
-			if amt.IsPositive() {
-				newlyDistributedCoin := sdk.Coin{Denom: coin.Denom, Amount: amt}
-				distrCoins = distrCoins.Add(newlyDistributedCoin)
-			}
-		}
-		distrCoins = distrCoins.Sort()
-		if distrCoins.Empty() {
-			continue
-		}
-		// Update the amount for that address
-		err := distrInfo.addLockRewards(lock.Owner, distrCoins)
-		if err != nil {
-			return nil, err
-		}
-
-		totalDistrCoins = totalDistrCoins.Add(distrCoins...)
-	}
-
-	// increase filled epochs after distribution
-	err := k.updateGaugePostDistribute(ctx, gauge, totalDistrCoins)
-	return totalDistrCoins, err
+	return k.distributeInternal(ctx, gauge, qualifiedLocks, distrInfo)
 }
 
 // distributeInternal runs the distribution logic for a gauge, and adds the sends to
@@ -297,7 +254,7 @@ func (k Keeper) distributeInternal(
 	ctx sdk.Context, gauge types.Gauge, locks []lockuptypes.PeriodLock, distrInfo *distributionInfo,
 ) (sdk.Coins, error) {
 	totalDistrCoins := sdk.NewCoins()
-	denom := gauge.DistributeTo.Denom
+	denom := lockuptypes.NativeDenom(gauge.DistributeTo.Denom)
 	lockSum := lockuptypes.SumLocksByDenom(locks, denom)
 
 	if lockSum.IsZero() {

--- a/x/superfluid/keeper/hooks_test.go
+++ b/x/superfluid/keeper/hooks_test.go
@@ -78,7 +78,7 @@ func (suite *KeeperTestSuite) TestSuperfluidAfterEpochEnd() {
 				suite.Require().Equal(gauge.Id, intermediaryAcc.GaugeId)
 				suite.Require().Equal(gauge.IsPerpetual, true)
 				suite.Require().Equal(gauge.Coins, tc.expRewards[index])
-				suite.Require().Equal(gauge.DistributedCoins, tc.expRewards[index])
+				suite.Require().Equal(gauge.DistributedCoins.String(), tc.expRewards[index].String())
 			}
 
 			// check delegation changes


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2007

## What is the purpose of the change

Is to use reuse `distributeInternal` in `distributeSyntheticInternal`

## Brief Changelog

- Change `distributeInternal` and use  `distributeInternal` in `distributeSyntheticInternal`

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes?  no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?  no
  - How is the feature or change documented?  not documented