### PR TITLE
refactor(e2e): run individual nodes; rely on rpc client in setup

### DIFF
--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -40,9 +40,9 @@ type syncInfo struct {
 
 const (
 	// waitUntilRepeatPauseTime is the time to wait between each check of the node status.
-	waitUntilRepeatPauseTime = 500 * time.Millisecond
+	waitUntilRepeatPauseTime = 2 * time.Second
 	// waitUntilrepeatMax is the maximum number of times to repeat the wait until condition.
-	waitUntilrepeatMax = 20
+	waitUntilrepeatMax = 60
 )
 
 func New(t *testing.T, containerManager *containers.Manager, id string, initValidatorConfigs []*initialization.NodeConfig) *Config {

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -57,7 +57,7 @@ func New(t *testing.T, containerManager *containers.Manager, id string, initVali
 }
 
 // RunNode runs a node container for the given nodeIndex.
-// The node configuration must be already added to chain prior to calling this
+// The node configuration must be already added to the chain config prior to calling this
 // method.
 func (c *Config) RunNode(nodeIndex int) error {
 	c.t.Logf("starting %s validator containers...", c.Id)

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -102,9 +102,7 @@ func (c *Config) RunNode(nodeIndex int) error {
 func (c *Config) WaitUntil(nodeIndex int, doneCondition func(syncInfo coretypes.SyncInfo) bool) error {
 	var latestBlockHeight int64
 	for i := 0; i < waitUntilrepeatMax; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), waitUntilRepeatPauseTime)
-		defer cancel()
-		status, err := c.NodeConfigs[nodeIndex].rpcClient.Status(ctx)
+		status, err := c.NodeConfigs[nodeIndex].rpcClient.Status(context.Background())
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -1,7 +1,14 @@
 package chain
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/containers"
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/initialization"
@@ -17,7 +24,7 @@ type Config struct {
 	PropHeight           int
 	LatestProposalNumber int
 	LatestLockNumber     int
-	NodeConfigs          []*ValidatorConfig
+	NodeConfigs          []*NodeConfig
 
 	t                *testing.T
 	containerManager *containers.Manager
@@ -31,6 +38,13 @@ type syncInfo struct {
 	SyncInfo status `json:"SyncInfo"`
 }
 
+const (
+	// waitUntilRepeatPauseTime is the time to wait between each check of the node status.
+	waitUntilRepeatPauseTime = 5 * time.Second
+	// waitUntilrepeatMax is the maximum number of times to repeat the wait until condition.
+	waitUntilrepeatMax = 20
+)
+
 func New(t *testing.T, containerManager *containers.Manager, id string, initValidatorConfigs []*initialization.NodeConfig) *Config {
 	return &Config{
 		ChainMeta: initialization.ChainMeta{
@@ -40,4 +54,97 @@ func New(t *testing.T, containerManager *containers.Manager, id string, initVali
 		t:                    t,
 		containerManager:     containerManager,
 	}
+}
+
+// RunNode runs a node container for the given nodeIndex.
+// The node configuration must be already added to chain prior to calling this
+// method.
+func (c *Config) RunNode(nodeIndex int) error {
+	c.t.Logf("starting %s validator containers...", c.Id)
+
+	resource, err := c.containerManager.RunValidatorResource(c.Id, c.NodeConfigs[nodeIndex].Name, c.NodeConfigs[nodeIndex].ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	hostPort := resource.GetHostPort("26657/tcp")
+	rpcClient, err := rpchttp.New("tcp://"+hostPort, "/websocket")
+	if err != nil {
+		return err
+	}
+
+	require.Eventually(
+		c.t,
+		func() bool {
+			if _, err := rpcClient.Health(context.Background()); err != nil {
+				return false
+			}
+
+			c.t.Logf("started %s node container: %s", resource.Container.Name[1:], resource.Container.ID)
+			return true
+		},
+		5*time.Minute,
+		time.Second,
+		"Osmosis node failed to produce blocks",
+	)
+
+	c.NodeConfigs[nodeIndex].rpcClient = rpcClient
+
+	if c.NodeConfigs[nodeIndex].IsValidator {
+		return c.ExtractValidatorOperatorAddress(nodeIndex)
+	}
+
+	return nil
+}
+
+// WaitUntil waits until validator with validatorIndex reaches doneCondition. Return nil
+// if reached, error otherwise.
+func (c *Config) WaitUntil(nodeIndex int, doneCondition func(syncInfo coretypes.SyncInfo) bool) error {
+	var latestBlockHeight int64
+	for i := 0; i < waitUntilrepeatMax; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), waitUntilRepeatPauseTime)
+		defer cancel()
+		status, err := c.NodeConfigs[nodeIndex].rpcClient.Status(ctx)
+		if err != nil {
+			return err
+		}
+		latestBlockHeight = status.SyncInfo.LatestBlockHeight
+		// let the node produce a few blocks
+		if !doneCondition(status.SyncInfo) {
+			time.Sleep(waitUntilRepeatPauseTime)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("validator with index %d timed out waiting for condition, latest block height was %d", nodeIndex, latestBlockHeight)
+}
+
+// WaitUntilHeight waits for all validators to reach the specified height at the minimum.
+// returns error, if any.
+func (c *Config) WaitUntilHeight(height int64) error {
+	// Ensure the nodes are making progress.
+	doneCondition := func(syncInfo coretypes.SyncInfo) bool {
+		curHeight := syncInfo.LatestBlockHeight
+
+		if curHeight < height {
+			c.t.Logf("current block height is %d, waiting to reach: %d", curHeight, height)
+			return false
+		}
+
+		return !syncInfo.CatchingUp
+	}
+
+	for nodeIndex := range c.NodeConfigs {
+		nodeResource, exists := c.containerManager.GetValidatorResource(c.Id, nodeIndex)
+		container := nodeResource.Container
+		c.t.Logf("node container: %s, id: %s, waiting to reach height %d", container.Name[1:], container.ID, height)
+		if !exists {
+			return fmt.Errorf("validator on chain %s  with index %d does not exist", c.Id, nodeIndex)
+		}
+		if err := c.WaitUntil(nodeIndex, doneCondition); err != nil {
+			c.t.Errorf("validator with index %d failed to start", nodeIndex)
+			return err
+		}
+	}
+	return nil
 }

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -40,7 +40,7 @@ type syncInfo struct {
 
 const (
 	// waitUntilRepeatPauseTime is the time to wait between each check of the node status.
-	waitUntilRepeatPauseTime = 5 * time.Second
+	waitUntilRepeatPauseTime = 500 * time.Millisecond
 	// waitUntilrepeatMax is the maximum number of times to repeat the wait until condition.
 	waitUntilrepeatMax = 20
 )

--- a/tests/e2e/configurer/chain/validator.go
+++ b/tests/e2e/configurer/chain/validator.go
@@ -1,9 +1,14 @@
 package chain
 
-import "github.com/osmosis-labs/osmosis/v7/tests/e2e/initialization"
+import (
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 
-type ValidatorConfig struct {
+	"github.com/osmosis-labs/osmosis/v7/tests/e2e/initialization"
+)
+
+type NodeConfig struct {
 	initialization.Node
 
 	OperatorAddress string
+	rpcClient       *rpchttp.HTTP
 }

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/configurer/chain"
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/configurer/config"
 	"github.com/osmosis-labs/osmosis/v7/tests/e2e/containers"
@@ -146,35 +144,11 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 
 	// wait till all chains halt at upgrade height
 	for _, chainConfig := range uc.chainConfigs {
-		for validatorIndex := range chainConfig.NodeConfigs {
-			validatorResource, exists := uc.containerManager.GetValidatorResource(chainConfig.Id, validatorIndex)
-			require.True(uc.t, exists, "validator container not found: chain id %s, valIdx %d ", chainConfig.Id, validatorIndex)
-			containerId := validatorResource.Container.ID
-			containerName := validatorResource.Container.Name[1:]
-
-			// use counter to ensure no new blocks are being created
-			counter := 0
-			uc.t.Logf("waiting to reach upgrade height on %s validator container: %s", containerName, containerId)
-			require.Eventually(
-				uc.t,
-				func() bool {
-					currentHeight := chainConfig.QueryCurrentChainHeightFromValidator(validatorIndex)
-					if currentHeight != chainConfig.PropHeight {
-						uc.t.Logf("current block height on %s is %v, waiting for block %v container: %s", containerName, currentHeight, chainConfig.PropHeight, containerId)
-					}
-					if currentHeight > chainConfig.PropHeight {
-						panic("chain did not halt at upgrade height")
-					}
-					if currentHeight == chainConfig.PropHeight {
-						counter++
-					}
-					return counter == 3
-				},
-				5*time.Minute,
-				time.Second,
-			)
-			uc.t.Logf("reached upgrade height on %s container: %s", containerName, containerId)
+		uc.t.Logf("waiting to reach upgrade height on chain %s", chainConfig.Id)
+		if err := chainConfig.WaitUntilHeight(int64(chainConfig.PropHeight)); err != nil {
+			return err
 		}
+		uc.t.Logf("upgrade height reached on chain %s", chainConfig.Id)
 	}
 
 	// remove all containers so we can upgrade them to the new version
@@ -189,71 +163,40 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 
 	// remove all containers so we can upgrade them to the new version
 	for _, chainConfig := range uc.chainConfigs {
-		uc.upgradeContainers(chainConfig, chainConfig.PropHeight)
+		if err := uc.upgradeContainers(chainConfig, chainConfig.PropHeight); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (uc *UpgradeConfigurer) runForkUpgrade() error {
 	for _, chainConfig := range uc.chainConfigs {
-		for i := range chainConfig.NodeConfigs {
-			validatorResource, exists := uc.containerManager.GetValidatorResource(chainConfig.Id, i)
-			if !exists {
-				return fmt.Errorf("validator container not found: chain id %s, valIdx %d ", chainConfig.Id, i)
-			}
-			containerId := validatorResource.Container.ID
-			containerName := validatorResource.Container.Name[1:]
-
-			uc.t.Logf("waiting to reach fork height on %s validator container: %s", containerName, containerId)
-			require.Eventually(
-				uc.t,
-				func() bool {
-					currentHeight := chainConfig.QueryCurrentChainHeightFromValidator(i)
-					if int64(currentHeight) < uc.forkHeight {
-						uc.t.Logf("current block height on %s is %v, waiting for block %v container: %s", containerName, currentHeight, uc.forkHeight, containerId)
-						return false
-					}
-					return true
-				},
-				5*time.Minute,
-				time.Second,
-			)
-			uc.t.Logf("successfully got past fork height on %s container: %s", containerName, containerId)
+		uc.t.Logf("waiting to reach fork height on chain %s", chainConfig.Id)
+		if err := chainConfig.WaitUntilHeight(uc.forkHeight); err != nil {
+			return err
 		}
+		uc.t.Logf("fork height reached on chain %s", chainConfig.Id)
 	}
 	return nil
 }
 
-func (uc *UpgradeConfigurer) upgradeContainers(chainConfig *chain.Config, propHeight int) {
+func (uc *UpgradeConfigurer) upgradeContainers(chainConfig *chain.Config, propHeight int) error {
 	// upgrade containers to the locally compiled daemon
 	uc.t.Logf("starting upgrade for chain-id: %s...", chainConfig.Id)
 	uc.containerManager.OsmosisRepository = containers.CurrentBranchOsmoRepository
 	uc.containerManager.OsmosisTag = containers.CurrentBranchOsmoTag
-	for _, val := range chainConfig.NodeConfigs {
-		validatorResource, err := uc.containerManager.RunValidatorResource(chainConfig.Id, val.Name, val.ConfigDir)
-		require.NoError(uc.t, err)
-		uc.t.Logf("started %s validator container: %s", validatorResource.Container.Name[1:], validatorResource.Container.ID)
+
+	for nodeIndex := range chainConfig.NodeConfigs {
+		if err := chainConfig.RunNode(nodeIndex); err != nil {
+			return err
+		}
 	}
 
-	// check that we are creating blocks again
-	for validatorIndex := range chainConfig.NodeConfigs {
-		validatorResource, exists := uc.containerManager.GetValidatorResource(chainConfig.Id, validatorIndex)
-		require.True(uc.t, exists, "validator container not found: chain id %s, valIdx %d ", chainConfig.Id, validatorIndex)
-		containerId := validatorResource.Container.ID
-		containerName := validatorResource.Container.Name[1:]
-
-		require.Eventually(
-			uc.t,
-			func() bool {
-				currentHeight := chainConfig.QueryCurrentChainHeightFromValidator(validatorIndex)
-				if currentHeight <= propHeight {
-					uc.t.Logf("current block height on %s is %v, waiting to create blocks container: %s", containerName, currentHeight, containerId)
-				}
-				return currentHeight > propHeight
-			},
-			5*time.Minute,
-			time.Second,
-		)
-		uc.t.Logf("upgrade successful on %s validator container: %s", containerName, containerId)
+	uc.t.Logf("waiting to upgrade containers on chain %s", chainConfig.Id)
+	if err := chainConfig.WaitUntilHeight(int64(propHeight)); err != nil {
+		return err
 	}
+	uc.t.Logf("upgrade successful on chain %s", chainConfig.Id)
+	return nil
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -60,7 +60,7 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 	chainA.VoteNoProposal(0, walletName)
 
 	sfProposalNumber := strconv.Itoa(chainA.LatestProposalNumber)
-	s.Require().Eventually(
+	s.Eventually(
 		func() bool {
 			noTotal, yesTotal, noWithVetoTotal, abstainTotal, err := chainA.QueryPropTally(0, sfProposalNumber)
 			if err != nil {
@@ -77,9 +77,9 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 	)
 	noTotal, _, _, _, _ := chainA.QueryPropTally(0, sfProposalNumber)
 	noTotalFinal, err := strconv.Atoi(noTotal.String())
-	s.Require().NoError(err)
+	s.NoError(err)
 
-	s.Require().Eventually(
+	s.Eventually(
 		func() bool {
 			intAccountBalance, err := chainA.QueryIntermediaryAccount(0, "gamm/pool/1", chainA.NodeConfigs[1].OperatorAddress)
 			s.Require().NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Next step in: https://github.com/osmosis-labs/osmosis/issues/1879
Related to: https://github.com/osmosis-labs/osmosis/issues/2039

## What is the purpose of the change

This change includes the following interconnected parts:

1. Ability to run individual nodes by calling `chainConfig.RunNode(...)`
We need the ability to run each node individually for testing state sync. This refactor implements it.

2. Use the Tendermint RPC client in setup
Switch from relying on CLI during setup to using Tendermint RPC client. It should be more reliable and easier to debug than the CLI. This might help to resolve or mitigate issues in #2039 

3. Reduce code duplication
We used to have code duplicated for waiting for a certain height:
- upgrade containers: https://github.com/osmosis-labs/osmosis/blob/5f17b1941d85e1bf906370327a635733bce2a65f/tests/e2e/configurer/upgrade.go#L239-L258
- halt at upgrade height: https://github.com/osmosis-labs/osmosis/blob/5f17b1941d85e1bf906370327a635733bce2a65f/tests/e2e/configurer/upgrade.go#L148-L178
- wait to reach fork height: https://github.com/osmosis-labs/osmosis/blob/5f17b1941d85e1bf906370327a635733bce2a65f/tests/e2e/configurer/upgrade.go#L207-L221

This is now reduced to [`WaitUntilHeight`](https://github.com/osmosis-labs/osmosis/blob/ad093356b21fac3dfbf3135e37efd5f7397b2861/tests/e2e/configurer/chain/chain.go#L124)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable