### PR TITLE
e2e: Reduce repetitive args for tx creation commands

### DIFF
--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -30,7 +30,7 @@ func (c *Config) SubmitUpgradeProposal(upgradeVersion string) {
 
 	upgradeHeightStr := strconv.Itoa(c.PropHeight)
 	c.t.Logf("submitting upgrade proposal on %s container: %s", validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%s", upgradeHeightStr), "--upgrade-info=\"\"", "--from=val", "--log_format=json"}
+	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%s", upgradeHeightStr), "--upgrade-info=\"\"", "--from=val"}
 	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 	c.t.Log("successfully submitted upgrade proposal")
@@ -42,7 +42,7 @@ func (c *Config) SubmitSuperfluidProposal(asset string) {
 	require.True(c.t, exists)
 
 	c.t.Logf("submitting superfluid proposal for asset %s on %s container: %s", asset, validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), fmt.Sprintf("--title=\"%s superfluid asset\"", asset), fmt.Sprintf("--description=\"%s superfluid asset\"", asset), "--from=val", "--log_format=json"}
+	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), fmt.Sprintf("--title=\"%s superfluid asset\"", asset), fmt.Sprintf("--description=\"%s superfluid asset\"", asset), "--from=val"}
 	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 	c.t.Log("successfully submitted superfluid proposal")
@@ -54,7 +54,7 @@ func (c *Config) SubmitTextProposal(text string) {
 	require.True(c.t, exists)
 
 	c.t.Logf("submitting text proposal on %s container: %s", validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "--type=text", fmt.Sprintf("--title=\"%s\"", text), "--description=\"test text proposal\"", "--from=val", "--log_format=json"}
+	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "--type=text", fmt.Sprintf("--title=\"%s\"", text), "--description=\"test text proposal\"", "--from=val"}
 	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	c.t.Log("successfully submitted text proposal")
 	require.NoError(c.t, err)

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -15,8 +15,8 @@ import (
 
 func (c *Config) CreatePool(poolFile, from string) {
 	c.t.Logf("creating pool for chain-id: %s", c.Id)
-	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), fmt.Sprintf("--chain-id=%s", c.Id), fmt.Sprintf("--from=%s", from), "-b=block", "--yes", "--keyring-backend=test"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, 0, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), fmt.Sprintf("--from=%s", from)}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 
 	validatorResource, exists := c.containerManager.GetValidatorResource(c.Id, 0)
@@ -30,8 +30,8 @@ func (c *Config) SubmitUpgradeProposal(upgradeVersion string) {
 
 	upgradeHeightStr := strconv.Itoa(c.PropHeight)
 	c.t.Logf("submitting upgrade proposal on %s container: %s", validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%s", upgradeHeightStr), "--upgrade-info=\"\"", fmt.Sprintf("--chain-id=%s", c.Id), "--from=val", "-b=block", "--yes", "--keyring-backend=test", "--log_format=json"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, 0, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%s", upgradeHeightStr), "--upgrade-info=\"\"", "--from=val", "--log_format=json"}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 	c.t.Log("successfully submitted upgrade proposal")
 	c.LatestProposalNumber = c.LatestProposalNumber + 1
@@ -42,8 +42,8 @@ func (c *Config) SubmitSuperfluidProposal(asset string) {
 	require.True(c.t, exists)
 
 	c.t.Logf("submitting superfluid proposal for asset %s on %s container: %s", asset, validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), fmt.Sprintf("--title=\"%s superfluid asset\"", asset), fmt.Sprintf("--description=\"%s superfluid asset\"", asset), "--from=val", "-b=block", "--yes", "--keyring-backend=test", "--log_format=json", fmt.Sprintf("--chain-id=%s", c.Id)}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, 0, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), fmt.Sprintf("--title=\"%s superfluid asset\"", asset), fmt.Sprintf("--description=\"%s superfluid asset\"", asset), "--from=val", "--log_format=json"}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 	c.t.Log("successfully submitted superfluid proposal")
 	c.LatestProposalNumber = c.LatestProposalNumber + 1
@@ -54,8 +54,8 @@ func (c *Config) SubmitTextProposal(text string) {
 	require.True(c.t, exists)
 
 	c.t.Logf("submitting text proposal on %s container: %s", validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "--type=text", fmt.Sprintf("--title=\"%s\"", text), "--description=\"test text proposal\"", "--from=val", "-b=block", "--yes", "--keyring-backend=test", "--log_format=json", fmt.Sprintf("--chain-id=%s", c.Id)}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, 0, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "--type=text", fmt.Sprintf("--title=\"%s\"", text), "--description=\"test text proposal\"", "--from=val", "--log_format=json"}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	c.t.Log("successfully submitted text proposal")
 	require.NoError(c.t, err)
 	c.LatestProposalNumber = c.LatestProposalNumber + 1
@@ -67,8 +67,8 @@ func (c *Config) DepositProposal() {
 
 	propStr := strconv.Itoa(c.LatestProposalNumber)
 	c.t.Logf("depositing to proposal from %s container: %s", validatorResource.Container.Name[1:], validatorResource.Container.ID)
-	cmd := []string{"osmosisd", "tx", "gov", "deposit", propStr, "500000000uosmo", "--from=val", fmt.Sprintf("--chain-id=%s", c.Id), "-b=block", "--yes", "--keyring-backend=test"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, 0, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "gov", "deposit", propStr, "500000000uosmo", "--from=val"}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 	c.t.Log("successfully deposited to proposal")
 }
@@ -76,9 +76,9 @@ func (c *Config) DepositProposal() {
 func (c *Config) VoteYesProposal() {
 	propStr := strconv.Itoa(c.LatestProposalNumber)
 	c.t.Logf("voting yes on proposal for chain-id: %s", c.Id)
-	cmd := []string{"osmosisd", "tx", "gov", "vote", propStr, "yes", "--from=val", fmt.Sprintf("--chain-id=%s", c.Id), "-b=block", "--yes", "--keyring-backend=test"}
+	cmd := []string{"osmosisd", "tx", "gov", "vote", propStr, "yes", "--from=val"}
 	for i := range c.NodeConfigs {
-		_, _, err := c.containerManager.ExecCmd(c.t, c.Id, i, cmd, "code: 0")
+		_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, i, cmd)
 		require.NoError(c.t, err)
 
 		validatorResource, exists := c.containerManager.GetValidatorResource(c.Id, i)
@@ -90,8 +90,8 @@ func (c *Config) VoteYesProposal() {
 func (c *Config) VoteNoProposal(validatorIdx int, from string) {
 	propStr := strconv.Itoa(c.LatestProposalNumber)
 	c.t.Logf("voting no on proposal for chain-id: %s", c.Id)
-	cmd := []string{"osmosisd", "tx", "gov", "vote", propStr, "no", fmt.Sprintf("--from=%s", from), fmt.Sprintf("--chain-id=%s", c.Id), "-b=block", "--yes", "--keyring-backend=test"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, validatorIdx, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "gov", "vote", propStr, "no", fmt.Sprintf("--from=%s", from)}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, validatorIdx, cmd)
 	require.NoError(c.t, err)
 
 	validatorResource, exists := c.containerManager.GetValidatorResource(c.Id, validatorIdx)
@@ -101,8 +101,8 @@ func (c *Config) VoteNoProposal(validatorIdx int, from string) {
 
 func (c *Config) LockTokens(validatorIdx int, tokens string, duration string, from string) {
 	c.t.Logf("locking %s for %s on chain-id: %s", tokens, duration, c.Id)
-	cmd := []string{"osmosisd", "tx", "lockup", "lock-tokens", tokens, fmt.Sprintf("--chain-id=%s", c.Id), fmt.Sprintf("--duration=%s", duration), fmt.Sprintf("--from=%s", from), "-b=block", "--yes", "--keyring-backend=test"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, validatorIdx, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "lockup", "lock-tokens", tokens, fmt.Sprintf("--duration=%s", duration), fmt.Sprintf("--from=%s", from)}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, validatorIdx, cmd)
 	require.NoError(c.t, err)
 
 	validatorResource, exists := c.containerManager.GetValidatorResource(c.Id, validatorIdx)
@@ -114,8 +114,8 @@ func (c *Config) LockTokens(validatorIdx int, tokens string, duration string, fr
 func (c *Config) SuperfluidDelegate(valAddress string, from string) {
 	lockStr := strconv.Itoa(c.LatestLockNumber)
 	c.t.Logf("superfluid delegating lock %s to %s on chain-id: %s", lockStr, valAddress, c.Id)
-	cmd := []string{"osmosisd", "tx", "superfluid", "delegate", lockStr, valAddress, fmt.Sprintf("--chain-id=%s", c.Id), fmt.Sprintf("--from=%s", from), "-b=block", "--yes", "--keyring-backend=test"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, 0, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "superfluid", "delegate", lockStr, valAddress, fmt.Sprintf("--from=%s", from)}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, 0, cmd)
 	require.NoError(c.t, err)
 
 	validatorResource, exists := c.containerManager.GetValidatorResource(c.Id, 0)
@@ -125,8 +125,8 @@ func (c *Config) SuperfluidDelegate(valAddress string, from string) {
 
 func (c *Config) BankSend(validatorIndex int, amount string, sendAddress string, receiveAddress string) {
 	c.t.Logf("sending %s from %s to %s on chain-id: %s", amount, sendAddress, receiveAddress, c.Id)
-	cmd := []string{"osmosisd", "tx", "bank", "send", sendAddress, receiveAddress, amount, fmt.Sprintf("--chain-id=%s", c.Id), "--from=val", "-b=block", "--yes", "--keyring-backend=test"}
-	_, _, err := c.containerManager.ExecCmd(c.t, c.Id, validatorIndex, cmd, "code: 0")
+	cmd := []string{"osmosisd", "tx", "bank", "send", sendAddress, receiveAddress, amount, "--from=val"}
+	_, _, err := c.containerManager.ExecTxCmd(c.t, c.Id, validatorIndex, cmd)
 	require.NoError(c.t, err)
 
 	validatorResource, exists := c.containerManager.GetValidatorResource(c.Id, 0)

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -47,9 +47,10 @@ func NewManager(isUpgrade bool, isFork bool) (docker *Manager, err error) {
 }
 
 // ExecTxCmd Runs ExecCmd, with flags for txs added.
-// namely `--chain-id={chain-id} -b=block --yes --keyring-backend=test`, and searching for `code: 0`
+// namely adding flags `--chain-id={chain-id} -b=block --yes --keyring-backend=test "--log_format=json"`,
+// and searching for `code: 0`
 func (m *Manager) ExecTxCmd(t *testing.T, chainId string, validatorIndex int, command []string) (bytes.Buffer, bytes.Buffer, error) {
-	allTxArgs := []string{fmt.Sprintf("--chain-id=%s", chainId), "-b=block", "--yes", "--keyring-backend=test"}
+	allTxArgs := []string{fmt.Sprintf("--chain-id=%s", chainId), "-b=block", "--yes", "--keyring-backend=test", "--log_format=json"}
 	txCommand := append(command, allTxArgs...)
 	successStr := "code: 0"
 	return m.ExecCmd(t, chainId, validatorIndex, txCommand, successStr)

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -46,6 +46,15 @@ func NewManager(isUpgrade bool, isFork bool) (docker *Manager, err error) {
 	return docker, nil
 }
 
+// ExecTxCmd Runs ExecCmd, with flags for txs added.
+// namely `--chain-id={chain-id} -b=block --yes --keyring-backend=test`, and searching for `code: 0`
+func (m *Manager) ExecTxCmd(t *testing.T, chainId string, validatorIndex int, command []string) (bytes.Buffer, bytes.Buffer, error) {
+	allTxArgs := []string{fmt.Sprintf("--chain-id=%s", chainId), "-b=block", "--yes", "--keyring-backend=test"}
+	txCommand := append(command, allTxArgs...)
+	successStr := "code: 0"
+	return m.ExecCmd(t, chainId, validatorIndex, txCommand, successStr)
+}
+
 // ExecCmd executes command on chainId by running it on the validator container (specified by validatorIndex)
 // success is the output of the command that needs to be observed for the command to be deemed successful.
 // It is found by checking if stdout or stderr contains the success string anywhere within it.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1623
## What is the purpose of the change

Quick PR to reduce boilerplate in e2e, stemming from CLI.


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.