### PR TITLE
e2e: move endpoint complexity into config.QueryRPC

### DIFF
--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -27,7 +27,6 @@ func (c *Config) QueryRPC(validatorIdx int, path string) ([]byte, error) {
 	endpoint := fmt.Sprintf("http://%s", hostPort)
 	fullQueryPath := fmt.Sprintf("%s/%s", endpoint, path)
 
-	// TODO: Document why we have this loop
 	var resp *http.Response
 	retriesLeft := 5
 	for {

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -94,8 +94,8 @@ func (c *Config) QueryBalances(validatorIndex int, addr string) (sdk.Coins, erro
 	return balancesResp.GetBalances(), nil
 }
 
-func (c *Config) QueryPropTally(validatorIdx int, addr string) (sdk.Int, sdk.Int, sdk.Int, sdk.Int, error) {
-	path := fmt.Sprintf("cosmos/gov/v1beta1/proposals/%s/tally", addr)
+func (c *Config) QueryPropTally(validatorIdx int, proposalNumber int) (sdk.Int, sdk.Int, sdk.Int, sdk.Int, error) {
+	path := fmt.Sprintf("cosmos/gov/v1beta1/proposals/%d/tally", proposalNumber)
 	bz, err := c.QueryRPC(validatorIdx, path)
 	require.NoError(c.t, err)
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -59,10 +59,9 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 	// set delegator vote to no
 	chainA.VoteNoProposal(0, walletName)
 
-	sfProposalNumber := strconv.Itoa(chainA.LatestProposalNumber)
 	s.Eventually(
 		func() bool {
-			noTotal, yesTotal, noWithVetoTotal, abstainTotal, err := chainA.QueryPropTally(0, sfProposalNumber)
+			noTotal, yesTotal, noWithVetoTotal, abstainTotal, err := chainA.QueryPropTally(0, chainA.LatestProposalNumber)
 			if err != nil {
 				return false
 			}
@@ -75,7 +74,7 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 		time.Second,
 		"Osmosis node failed to retrieve prop tally",
 	)
-	noTotal, _, _, _, _ := chainA.QueryPropTally(0, sfProposalNumber)
+	noTotal, _, _, _, _ := chainA.QueryPropTally(0, chainA.LatestProposalNumber)
 	noTotalFinal, err := strconv.Atoi(noTotal.String())
 	s.NoError(err)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Minor commit, moves more complexity around endpoints into QueryRPC

Driveby fix of changing the addr arg of QueryPropTally to be the correct proposalNumber
