### PR TITLE
Add basic test for IsActive

### DIFF
--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -1225,3 +1225,40 @@ func TestBalancerPoolPokeTokenWeights(t *testing.T) {
 		require.Nil(t, pacc.PoolParams.SmoothWeightChangeParams)
 	}
 }
+
+// TODO: create a test with mocks to make sure IsActive works as intended when flipped for specific pools/all pools
+func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
+	tests := map[string]struct {
+		expectedIsActive bool
+		expectPass       bool
+	}{
+		"IsActive is true": {
+			expectedIsActive: true,
+			expectPass:       true,
+		},
+		"IsActive is false": {
+			expectedIsActive: false,
+			expectPass:       false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := suite.CreateTestContext()
+
+			// Initialize the pool
+			pool, err := balancer.NewBalancerPool(defaultPoolId, defaultBalancerPoolParams, dummyPoolAssets, defaultFutureGovernor, defaultCurBlockTime)
+			require.NoError(t, err, "test %v", name)
+
+			isActive := pool.IsActive(ctx)
+
+			if tc.expectPass {
+				require.Equal(t, tc.expectedIsActive, isActive)
+				require.NoError(t, err, "test %v", name)
+			} else {
+				require.NotEqual(t, tc.expectedIsActive, isActive)
+				require.Error(t, err, "test %v", name)
+			}
+		})
+	}
+}

--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -1232,11 +1232,9 @@ func TestBalancerPoolPokeTokenWeights(t *testing.T) {
 func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
 	tests := map[string]struct {
 		expectedIsActive bool
-		expectPass       bool
 	}{
 		"IsActive is true": {
 			expectedIsActive: true,
-			expectPass:       true,
 		},
 	}
 
@@ -1244,19 +1242,12 @@ func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := suite.CreateTestContext()
 
-			// Initialize the pool
+			// Initialize a pool
 			pool, err := balancer.NewBalancerPool(defaultPoolId, defaultBalancerPoolParams, dummyPoolAssets, defaultFutureGovernor, defaultCurBlockTime)
 			require.NoError(t, err, "test %v", name)
 
 			isActive := pool.IsActive(ctx)
-
-			if tc.expectPass {
-				require.Equal(t, tc.expectedIsActive, isActive)
-				require.NoError(t, err, "test %v", name)
-			} else {
-				require.NotEqual(t, tc.expectedIsActive, isActive)
-				require.Error(t, err, "test %v", name)
-			}
+			require.Equal(t, tc.expectedIsActive, isActive)
 		})
 	}
 }

--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -1226,6 +1226,8 @@ func TestBalancerPoolPokeTokenWeights(t *testing.T) {
 	}
 }
 
+// This test (currently trivially) checks to make sure that `IsActive` returns true for balancer pools.
+// This is mainly to make sure that if IsActive is ever used as an emergency switch, it is not accidentally left off for any (or all) pools.
 // TODO: create a test with mocks to make sure IsActive works as intended when flipped for specific pools/all pools
 func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
 	tests := map[string]struct {
@@ -1235,10 +1237,6 @@ func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
 		"IsActive is true": {
 			expectedIsActive: true,
 			expectPass:       true,
-		},
-		"IsActive is false": {
-			expectedIsActive: false,
-			expectPass:       false,
 		},
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1904 

## What is the purpose of the change

This PR adds a test that (trivially) checks to make sure that `IsActive` returns true for balancer pools. The primary purpose of this change is to make sure that if IsActive is ever used as an emergency switch, it is not accidentally left off for any or all pools.

I realize that my implementation has more structure than might seem necessary for a test this simple, but given how we intend to add more complex mock tests to cover `IsActive` flipping functionality in the future (https://github.com/osmosis-labs/osmosis/issues/1904#issuecomment-1182730437), I figured setting it up properly the first time around might make it easier to implement these other tests later.

## Brief Changelog

- Add a test that makes sure `IsActive` always returns true

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)