### PR TITLE
Commit timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+* [#2057](https://github.com/osmosis-labs/osmosis/pull/2057) Reduce block times to about three seconds
 * [#1312] Stableswap: Createpool logic 
 * [#1230] Stableswap CFMM equations
 * [#1429] solver for multi-asset CFMM

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -98,6 +98,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.P2P.Seeds = strings.Join(seeds, ",")
 			config.P2P.MaxNumInboundPeers = 320
 			config.P2P.MaxNumOutboundPeers = 40
+			config.Consensus.TimeoutCommit = 2 * time.Second
 			config.Mempool.Size = 10000
 			config.StateSync.TrustPeriod = 112 * time.Hour
 			config.FastSync.Version = "v0"

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -74,7 +75,11 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 				return err
 			}
+
 			customAppTemplate, customAppConfig := initAppConfig()
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			serverCtx.Config.Consensus.TimeoutCommit = time.Second
+
 			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig)
 		},
 		SilenceUsage: true,

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -78,7 +78,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 
 			customAppTemplate, customAppConfig := initAppConfig()
 			serverCtx := server.GetServerContextFromCmd(cmd)
-			serverCtx.Config.Consensus.TimeoutCommit = time.Second
+			serverCtx.Config.Consensus.TimeoutCommit = 2 * time.Second
 
 			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig)
 		},


### PR DESCRIPTION
## What is the purpose of the change

Reduce osmosis block times to about three seconds. 

* #2009 compliments this and has been used by notional and others since evmos upgraded.  Those using it and not are pretty strikingly visible here:

https://ping.pub/evmos/uptime

The trouble with the tm db branch is it is enormous and it is now very different from the mainline. I don't know if it will ever become the mainline. Here is the branch:

https://github.com/tendermint/tm-db/pull/237

This is still very much draft work, and doesn't help with wall clock time at all yet. 


## Brief Changelog

* make init.go set the commit timeout to two seconds
* fix the commit timeout in root.go to two seconds

Please note that these are the only changes that have been made. I am treating additional changes that may be needed because of shorter block times is out of scope for this PR.  I also think that it's possible that there are not additional changes needed.


## Testing and Verifying

The best test of this code will be to run it on the osmosis test net.  It has not yet been tested like that.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable   