### PR TITLE
chore(e2e): use `require.Eventually` in QueryRPC

### DIFF
--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -28,6 +28,10 @@ func (n *NodeConfig) QueryGRPCGateway(path string) ([]byte, error) {
 	var resp *http.Response
 	require.Eventually(n.t, func() bool {
 		resp, err = http.Get(fullQueryPath)
+		if err != nil {
+			n.t.Logf("error while executing HTTP request: %s", err.Error())
+			return false
+		}
 
 		return resp.StatusCode != http.StatusServiceUnavailable
 	}, time.Minute, time.Second*10, "failed to execute HTTP request")

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -28,10 +28,10 @@ func (n *NodeConfig) QueryGRPCGateway(path string) ([]byte, error) {
 	var resp *http.Response
 	require.Eventually(n.t, func() bool {
 		resp, err = http.Get(fullQueryPath)
-		if resp.StatusCode == http.StatusServiceUnavailable {
-			return false
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			return true
 		}
-		return true
+		return false
 	}, time.Minute, time.Second*10, "failed to execute HTTP request: %w")
 
 	defer resp.Body.Close()

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -26,24 +26,13 @@ func (n *NodeConfig) QueryGRPCGateway(path string) ([]byte, error) {
 	fullQueryPath := fmt.Sprintf("%s/%s", endpoint, path)
 
 	var resp *http.Response
-	retriesLeft := 5
-	for {
+	require.Eventually(n.t, func() bool {
 		resp, err = http.Get(fullQueryPath)
-
 		if resp.StatusCode == http.StatusServiceUnavailable {
-			retriesLeft--
-			if retriesLeft == 0 {
-				return nil, err
-			}
-			time.Sleep(10 * time.Second)
-		} else {
-			break
+			return false
 		}
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
-	}
+		return true
+	}, time.Minute, time.Second*10, "failed to execute HTTP request: %w")
 
 	defer resp.Body.Close()
 

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -30,7 +30,7 @@ func (n *NodeConfig) QueryGRPCGateway(path string) ([]byte, error) {
 		resp, err = http.Get(fullQueryPath)
 
 		return resp.StatusCode != http.StatusServiceUnavailable
-	}, time.Minute, time.Second*10, "failed to execute HTTP request: %w")
+	}, time.Minute, time.Second*10, "failed to execute HTTP request")
 
 	defer resp.Body.Close()
 

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -28,10 +28,8 @@ func (n *NodeConfig) QueryGRPCGateway(path string) ([]byte, error) {
 	var resp *http.Response
 	require.Eventually(n.t, func() bool {
 		resp, err = http.Get(fullQueryPath)
-		if resp.StatusCode != http.StatusServiceUnavailable {
-			return true
-		}
-		return false
+
+		return resp.StatusCode != http.StatusServiceUnavailable
 	}, time.Minute, time.Second*10, "failed to execute HTTP request: %w")
 
 	defer resp.Body.Close()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2051 

## What is the purpose of the change

Currently we use custom loops with custom logic to try connecting to the rpc enpoints.
This PR includes replacing that custom loop with `require.Eventually`


## Brief Changelog

- Change custom loop used for qurieying to `require.Eventually`


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)