### PR TITLE
refactor(x/mint): introduce distributeDeveloperRewards methods; unit tests (1/2)

### DIFF
--- a/x/mint/keeper/export_test.go
+++ b/x/mint/keeper/export_test.go
@@ -1,8 +1,14 @@
 package keeper
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
-type ErrInvalidRatio = invalidRatioError
+	"github.com/osmosis-labs/osmosis/v7/x/mint/types"
+)
+
+type (
+	ErrInvalidRatio = invalidRatioError
+)
 
 const (
 	DeveloperVestingAmount = developerVestingAmount
@@ -16,6 +22,10 @@ var (
 	GetProportions = getProportions
 )
 
-func (k Keeper) DistributeToModule(ctx sdk.Context, recipientModule string, mintedCoin sdk.Coin, proportion sdk.Dec) (sdk.Coin, error) {
+func (k Keeper) DistributeToModule(ctx sdk.Context, recipientModule string, mintedCoin sdk.Coin, proportion sdk.Dec) (sdk.Int, error) {
 	return k.distributeToModule(ctx, recipientModule, mintedCoin, proportion)
+}
+
+func (k Keeper) DistributeDeveloperRewards(ctx sdk.Context, totalMintedCoin sdk.Coin, developerRewardsProportion sdk.Dec, developerRewardsReceivers []types.WeightedAddress) (sdk.Int, error) {
+	return k.distributeDeveloperRewards(ctx, totalMintedCoin, developerRewardsProportion, developerRewardsReceivers)
 }

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -33,7 +33,7 @@ type invalidRatioError struct {
 }
 
 func (e invalidRatioError) Error() string {
-	return fmt.Sprintf("mint allocation ratio %s is greater than 1", e.ActualRatio)
+	return fmt.Sprintf("mint allocation ratio (%s) is greater than 1", e.ActualRatio)
 }
 
 var (
@@ -198,75 +198,27 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 	params := k.GetParams(ctx)
 	proportions := params.DistributionProportions
 
-	// allocate staking incentives into fee collector account to be moved to on next begin blocker by staking module
-	stakingIncentivesCoin, err := k.distributeToModule(ctx, k.feeCollectorName, mintedCoin, proportions.Staking)
+	// allocate staking incentives into fee collector account to be moved to on next begin blocker by staking module account.
+	stakingIncentivesAmount, err := k.distributeToModule(ctx, k.feeCollectorName, mintedCoin, proportions.Staking)
 	if err != nil {
 		return err
 	}
 
-	// allocate pool allocation ratio to pool-incentives module account account
-	poolIncentivesCoin, err := k.distributeToModule(ctx, poolincentivestypes.ModuleName, mintedCoin, proportions.PoolIncentives)
+	// allocate pool allocation ratio to pool-incentives module account.
+	poolIncentivesAmount, err := k.distributeToModule(ctx, poolincentivestypes.ModuleName, mintedCoin, proportions.PoolIncentives)
 	if err != nil {
 		return err
 	}
 
-	devRewardCoin, err := getProportions(ctx, mintedCoin, proportions.DeveloperRewards)
+	// allocate dev rewards to respective accounts from developer vesting module account.
+	devRewardAmount, err := k.distributeDeveloperRewards(ctx, mintedCoin, proportions.DeveloperRewards, params.WeightedDeveloperRewardsReceivers)
 	if err != nil {
 		return err
 	}
-	devRewardCoins := sdk.NewCoins(devRewardCoin)
-	// This is supposed to come from the developer vesting module address, not the mint module address
-	// we over-allocated to the mint module address earlier though, so we burn it right here.
-	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, devRewardCoins); err != nil {
-		return err
-	}
-
-	// Take the current balance of the developer rewards pool and remove it from the supply offset
-	// We re-introduce the new supply at the end, in order to avoid any rounding discrepancies.
-	developerAccountBalance := k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), mintedCoin.Denom)
-	k.bankKeeper.AddSupplyOffset(ctx, mintedCoin.Denom, developerAccountBalance.Amount)
-
-	if len(params.WeightedDeveloperRewardsReceivers) == 0 {
-		// fund community pool when rewards address is empty
-		if err := k.distrKeeper.FundCommunityPool(ctx, devRewardCoins, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)); err != nil {
-			return err
-		}
-	} else {
-		// allocate developer rewards to addresses by weight
-		for _, w := range params.WeightedDeveloperRewardsReceivers {
-			devPortionCoin, err := getProportions(ctx, devRewardCoin, w.Weight)
-			if err != nil {
-				return err
-			}
-			devRewardPortionCoins := sdk.NewCoins(devPortionCoin)
-			if w.Address == "" {
-				err := k.distrKeeper.FundCommunityPool(ctx, devRewardPortionCoins,
-					k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName))
-				if err != nil {
-					return err
-				}
-			} else {
-				devRewardsAddr, err := sdk.AccAddressFromBech32(w.Address)
-				if err != nil {
-					return err
-				}
-				// If recipient is vesting account, pay to account according to its vesting condition
-				err = k.bankKeeper.SendCoinsFromModuleToAccount(
-					ctx, types.DeveloperVestingModuleAcctName, devRewardsAddr, devRewardPortionCoins)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// Take the new balance of the developer rewards pool and add it back to the supply offset deduction
-	developerAccountBalance = k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), mintedCoin.Denom)
-	k.bankKeeper.AddSupplyOffset(ctx, mintedCoin.Denom, developerAccountBalance.Amount.Neg())
 
 	// subtract from original provision to ensure no coins left over after the allocations
-	communityPoolCoin := mintedCoin.Sub(stakingIncentivesCoin).Sub(poolIncentivesCoin).Sub(devRewardCoin)
-	err = k.distrKeeper.FundCommunityPool(ctx, sdk.NewCoins(communityPoolCoin), k.accountKeeper.GetModuleAddress(types.ModuleName))
+	communityPoolAmount := mintedCoin.Amount.Sub(stakingIncentivesAmount).Sub(poolIncentivesAmount).Sub(devRewardAmount)
+	err = k.distrKeeper.FundCommunityPool(ctx, sdk.NewCoins(sdk.NewCoin(params.MintDenom, communityPoolAmount)), k.accountKeeper.GetModuleAddress(types.ModuleName))
 	if err != nil {
 		return err
 	}
@@ -277,19 +229,95 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 	return err
 }
 
-func (k Keeper) distributeToModule(ctx sdk.Context, recipientModule string, mintedCoin sdk.Coin, proportion sdk.Dec) (sdk.Coin, error) {
+// distributeToModule distributes mintedCoin multiplied by proportion to the recepientModule account.
+func (k Keeper) distributeToModule(ctx sdk.Context, recipientModule string, mintedCoin sdk.Coin, proportion sdk.Dec) (sdk.Int, error) {
 	distributionCoin, err := getProportions(ctx, mintedCoin, proportion)
 	if err != nil {
-		return sdk.Coin{}, err
+		return sdk.Int{}, err
 	}
 	if err := k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, recipientModule, sdk.NewCoins(distributionCoin)); err != nil {
-		return sdk.Coin{}, err
+		return sdk.Int{}, err
 	}
-	return distributionCoin, nil
+	return distributionCoin.Amount, nil
+}
+
+// distributeDeveloperRewards distributes developer rewards from developer vesting module account
+// to the respective account receivers by weight (developerRewardsReceivers).
+// If no developer reward receivers given, funds the community pool instead.
+// Returns the total amount distributed from the developer vesting module account.
+// Updates supply offsets to reflect the amount of coins distributed. This is done so because the developer rewards distributions are
+// allocated from its own module account, not the mint module accont (TODO: next step in https://github.com/osmosis-labs/osmosis/issues/1916).
+// Returns nil on success, error otherwise.
+// With respect to input parameters, errors occur when:
+// - developerRewardsProportion is greater than 1.
+// - invalid address in developer rewards receivers.
+// - the balance of developer module account is less than totalMintedCoin * developerRewardsProportion.
+// - the balance of mint module is less than totalMintedCoin * developerRewardsProportion.
+// CONTRACT:
+// - weights in developerRewardsReceivers add up to 1.
+// - addresses in developerRewardsReceivers are valid.
+func (k Keeper) distributeDeveloperRewards(ctx sdk.Context, totalMintedCoin sdk.Coin, developerRewardsProportion sdk.Dec, developerRewardsReceivers []types.WeightedAddress) (sdk.Int, error) {
+	devRewardCoin, err := getProportions(ctx, totalMintedCoin, developerRewardsProportion)
+	if err != nil {
+		return sdk.Int{}, err
+	}
+	devRewardCoins := sdk.NewCoins(devRewardCoin)
+	// This is supposed to come from the developer vesting module address, not the mint module address
+	// we over-allocated to the mint module address earlier though, so we burn it right here.
+	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, devRewardCoins); err != nil {
+		return sdk.Int{}, err
+	}
+
+	// Take the current balance of the developer rewards pool and remove it from the supply offset
+	// We re-introduce the new supply at the end, in order to avoid any rounding discrepancies.
+	developerAccountBalance := k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), totalMintedCoin.Denom)
+	k.bankKeeper.AddSupplyOffset(ctx, totalMintedCoin.Denom, developerAccountBalance.Amount)
+
+	if len(developerRewardsReceivers) == 0 {
+		// fund community pool when rewards address is empty
+		if err := k.distrKeeper.FundCommunityPool(ctx, devRewardCoins, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)); err != nil {
+			return sdk.Int{}, err
+		}
+	} else {
+		// allocate developer rewards to addresses by weight
+		for _, w := range developerRewardsReceivers {
+			devPortionCoin, err := getProportions(ctx, devRewardCoin, w.Weight)
+			if err != nil {
+				return sdk.Int{}, err
+			}
+			devRewardPortionCoins := sdk.NewCoins(devPortionCoin)
+			if w.Address == "" {
+				err := k.distrKeeper.FundCommunityPool(ctx, devRewardPortionCoins,
+					k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName))
+				if err != nil {
+					return sdk.Int{}, err
+				}
+			} else {
+				devRewardsAddr, err := sdk.AccAddressFromBech32(w.Address)
+				if err != nil {
+					return sdk.Int{}, err
+				}
+				// If recipient is vesting account, pay to account according to its vesting condition
+				err = k.bankKeeper.SendCoinsFromModuleToAccount(
+					ctx, types.DeveloperVestingModuleAcctName, devRewardsAddr, devRewardPortionCoins)
+				if err != nil {
+					return sdk.Int{}, err
+				}
+			}
+		}
+	}
+
+	// Take the new balance of the developer rewards pool and add it back to the supply offset deduction
+	developerAccountBalance = k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), totalMintedCoin.Denom)
+	k.bankKeeper.AddSupplyOffset(ctx, totalMintedCoin.Denom, developerAccountBalance.Amount.Neg())
+
+	return devRewardCoin.Amount, nil
 }
 
 // getProportions gets the balance of the `MintedDenom` from minted coins and returns coins according to the
 // allocation ratio. Returns error if ratio is greater than 1.
+// TODO: this currently rounds down and is the cause of rounding discrepancies.
+// To be fixed in: https://github.com/osmosis-labs/osmosis/issues/1917
 func getProportions(ctx sdk.Context, mintedCoin sdk.Coin, ratio sdk.Dec) (sdk.Coin, error) {
 	if ratio.GT(sdk.OneDec()) {
 		return sdk.Coin{}, invalidRatioError{ratio}

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -1,12 +1,16 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/cosmos/btcutil/bech32"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -24,6 +28,13 @@ type KeeperTestSuite struct {
 	apptesting.KeeperTestHelper
 	queryClient types.QueryClient
 }
+
+var (
+	testAddressOne   = sdk.AccAddress([]byte("addr1---------------"))
+	testAddressTwo   = sdk.AccAddress([]byte("addr2---------------"))
+	testAddressThree = sdk.AccAddress([]byte("addr3---------------"))
+	testAddressFour  = sdk.AccAddress([]byte("addr4---------------"))
+)
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
@@ -133,7 +144,7 @@ func (suite *KeeperTestSuite) TestGetProportions() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestDistrAssetToDeveloperRewardsAddr() {
+func (suite *KeeperTestSuite) TestDistributeMintedCoin_ToDeveloperRewardsAddr() {
 	var (
 		distrTo = lockuptypes.QueryCondition{
 			LockQueryType: lockuptypes.ByDuration,
@@ -142,7 +153,7 @@ func (suite *KeeperTestSuite) TestDistrAssetToDeveloperRewardsAddr() {
 		}
 		params       = suite.App.MintKeeper.GetParams(suite.Ctx)
 		gaugeCoins   = sdk.Coins{sdk.NewInt64Coin("stake", 10000)}
-		gaugeCreator = sdk.AccAddress([]byte("addr2---------------"))
+		gaugeCreator = testAddressTwo
 		mintLPtokens = sdk.Coins{sdk.NewInt64Coin(distrTo.Denom, 200)}
 	)
 
@@ -155,7 +166,7 @@ func (suite *KeeperTestSuite) TestDistrAssetToDeveloperRewardsAddr() {
 			name: "one dev reward address",
 			weightedAddresses: []types.WeightedAddress{
 				{
-					Address: sdk.AccAddress([]byte("addr1---------------")).String(),
+					Address: testAddressOne.String(),
 					Weight:  sdk.NewDec(1),
 				}},
 			mintCoin: sdk.NewCoin("stake", sdk.NewInt(10000)),
@@ -164,11 +175,11 @@ func (suite *KeeperTestSuite) TestDistrAssetToDeveloperRewardsAddr() {
 			name: "multiple dev reward addresses",
 			weightedAddresses: []types.WeightedAddress{
 				{
-					Address: sdk.AccAddress([]byte("addr3---------------")).String(),
+					Address: testAddressThree.String(),
 					Weight:  sdk.NewDecWithPrec(6, 1),
 				},
 				{
-					Address: sdk.AccAddress([]byte("addr4---------------")).String(),
+					Address: testAddressFour.String(),
 					Weight:  sdk.NewDecWithPrec(4, 1),
 				}},
 			mintCoin: sdk.NewCoin("stake", sdk.NewInt(100000)),
@@ -389,7 +400,7 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 	)
 
 	tests := map[string]struct {
-		preMintAmount sdk.Coin
+		preMintCoin sdk.Coin
 
 		recepientModule string
 		mintedCoin      sdk.Coin
@@ -399,21 +410,21 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 		expectPanic   bool
 	}{
 		"pre-mint == distribute - poolincentives module - full amount - success": {
-			preMintAmount: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
+			preMintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
 
 			recepientModule: poolincentivestypes.ModuleName,
 			mintedCoin:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
 			proportion:      sdk.NewDec(1),
 		},
 		"pre-mint > distribute - developer vesting module - two thirds - success": {
-			preMintAmount: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(101)),
+			preMintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(101)),
 
 			recepientModule: poolincentivestypes.ModuleName,
 			mintedCoin:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
 			proportion:      sdk.NewDecWithPrec(2, 1).Quo(sdk.NewDecWithPrec(3, 1)),
 		},
 		"pre-mint < distribute (0) - error": {
-			preMintAmount: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(0)),
+			preMintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(0)),
 
 			recepientModule: poolincentivestypes.ModuleName,
 			mintedCoin:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
@@ -422,7 +433,7 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 			expectedError: true,
 		},
 		"denom does not exist - error": {
-			preMintAmount: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
+			preMintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
 
 			recepientModule: poolincentivestypes.ModuleName,
 			mintedCoin:      sdk.NewCoin(denomDoesNotExist, sdk.NewInt(100)),
@@ -431,7 +442,7 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 			expectedError: true,
 		},
 		"invalid module account -panic": {
-			preMintAmount: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
+			preMintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
 
 			recepientModule: moduleAccountDoesNotExist,
 			mintedCoin:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
@@ -440,7 +451,7 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 			expectPanic: true,
 		},
 		"proportion greater than 1 - error": {
-			preMintAmount: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(300)),
+			preMintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(300)),
 
 			recepientModule: poolincentivestypes.ModuleName,
 			mintedCoin:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)),
@@ -459,37 +470,289 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 				ctx := suite.Ctx
 
 				// Setup.
-				suite.NoError(mintKeeper.MintCoins(ctx, sdk.NewCoins(tc.preMintAmount)))
+				suite.NoError(mintKeeper.MintCoins(ctx, sdk.NewCoins(tc.preMintCoin)))
 
 				// TODO: Should not be truncated. Remove truncation after rounding errors are addressed and resolved.
 				// Ref: https://github.com/osmosis-labs/osmosis/issues/1917
 				expectedDistributed := tc.mintedCoin.Amount.ToDec().Mul(tc.proportion).TruncateInt()
-				oldMintModuleBalance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.ModuleName), tc.mintedCoin.Denom)
-				oldRecepientModuleBalance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(tc.recepientModule), tc.mintedCoin.Denom)
+				oldMintModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.ModuleName), tc.mintedCoin.Denom).Amount
+				oldRecepientModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(tc.recepientModule), tc.mintedCoin.Denom).Amount
 
 				// Test.
 				actualDistributed, err := mintKeeper.DistributeToModule(ctx, tc.recepientModule, tc.mintedCoin, tc.proportion)
 
 				// Assertions.
-				actualMintModuleBalance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.ModuleName), tc.mintedCoin.Denom)
-				actualRecepientModuleBalance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(tc.recepientModule), tc.mintedCoin.Denom)
+				actualMintModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.ModuleName), tc.mintedCoin.Denom).Amount
+				actualRecepientModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(tc.recepientModule), tc.mintedCoin.Denom).Amount
 
 				if tc.expectedError {
 					suite.Error(err)
-					suite.Equal(actualDistributed, sdk.Coin{})
+					suite.Equal(actualDistributed, sdk.Int{})
 					// Old balances should not change.
-					suite.Equal(oldMintModuleBalance.Amount.Int64(), actualMintModuleBalance.Amount.Int64())
-					suite.Equal(oldRecepientModuleBalance.Amount.Int64(), actualRecepientModuleBalance.Amount.Int64())
+					suite.Equal(oldMintModuleBalanceAmount.Int64(), actualMintModuleBalanceAmount.Int64())
+					suite.Equal(oldRecepientModuleBalanceAmount.Int64(), actualRecepientModuleBalanceAmount.Int64())
 					return
 				}
 
 				suite.NoError(err)
-				suite.Equal(tc.mintedCoin.Denom, actualDistributed.Denom)
-				suite.Equal(expectedDistributed, actualDistributed.Amount)
+				suite.Equal(expectedDistributed, actualDistributed)
 
 				// Updated balances.
-				suite.Equal(oldMintModuleBalance.Sub(actualDistributed).Amount.Int64(), actualMintModuleBalance.Amount.Int64())
-				suite.Equal(oldRecepientModuleBalance.Add(actualDistributed).Amount.Int64(), actualRecepientModuleBalance.Amount.Int64())
+				suite.Equal(oldMintModuleBalanceAmount.Sub(actualDistributed).Int64(), actualMintModuleBalanceAmount.Int64())
+				suite.Equal(oldRecepientModuleBalanceAmount.Add(actualDistributed).Int64(), actualRecepientModuleBalanceAmount.Int64())
+			})
+		})
+	}
+}
+
+// TestDistributeDeveloperRewards tests the following:
+// - distribution from developer module account to the given weighted addressed occurs.
+// - developer vesting module account balance is correctly updated.
+// - all developer addressed are updated with correct proportions.
+// - mint module account balance is updated - burn over allocations.
+// - if recepients are empty - community pool us updated.
+func (suite *KeeperTestSuite) TestDistributeDeveloperRewards() {
+	const (
+		invalidAddress = "invalid"
+	)
+
+	var (
+		validLargePreMintAmount  = sdk.NewInt(keeper.DeveloperVestingAmount)
+		validPreMintAmountAddOne = sdk.NewInt(keeper.DeveloperVestingAmount).Add(sdk.OneInt())
+		validPreMintCoin         = sdk.NewCoin(sdk.DefaultBondDenom, validLargePreMintAmount)
+		validPreMintCoinSubOne   = sdk.NewCoin(sdk.DefaultBondDenom, validLargePreMintAmount.Sub(sdk.OneInt()))
+	)
+
+	tests := map[string]struct {
+		preMintCoin sdk.Coin
+
+		mintedCoin         sdk.Coin
+		proportion         sdk.Dec
+		recepientAddresses []types.WeightedAddress
+
+		expectedError error
+		expectPanic   bool
+		// See testcases with this flag set to true for details.
+		allowBalanceChange bool
+		// See testcases with this flag set to true for details.
+		expectSameAddresses bool
+	}{
+		"valid case with 1 weighted address": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: validPreMintCoin,
+			proportion: sdk.NewDecWithPrec(153, 3),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDec(1),
+				},
+			},
+		},
+		"valid case with 3 weighted addresses and custom large mint amount under pre mint": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(939_123_546_789)),
+			proportion: sdk.NewDecWithPrec(31347, 5),
+			recepientAddresses: []types.WeightedAddress{ // .231 + .4 + .369
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDecWithPrec(231, 3),
+				},
+				{
+					Address: testAddressTwo.String(),
+					Weight:  sdk.NewDecWithPrec(4, 1),
+				},
+				{
+					Address: testAddressThree.String(),
+					Weight:  sdk.NewDecWithPrec(369, 3),
+				},
+			},
+		},
+		"valid case with 2 addresses that are the same": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: validPreMintCoin,
+			proportion: sdk.NewDecWithPrec(123, 3),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDecWithPrec(5, 1),
+				},
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDecWithPrec(5, 1),
+				},
+			},
+			// Since we have double the full amount allocated
+			/// to the same address, the balance assertions will
+			// differ by expecting the full minted amount.
+			expectSameAddresses: true,
+		},
+		"valid case with 0 reward receivers - goes to community pool": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: validPreMintCoin,
+			proportion: sdk.NewDecWithPrec(153, 3),
+		},
+		"valid case with 0 amount of total minted coin": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.ZeroInt()),
+			proportion: sdk.NewDecWithPrec(153, 3),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDec(1),
+				},
+			},
+		},
+		"invalid value for developer rewards proportion (> 1) - error": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: validPreMintCoin,
+			proportion: sdk.NewDec(2),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDec(1),
+				},
+			},
+
+			expectedError: keeper.ErrInvalidRatio{ActualRatio: sdk.NewDec(2)},
+		},
+		"invalid address in developer reward receivers - error": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: validPreMintCoin,
+			proportion: sdk.NewDecWithPrec(153, 3),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: invalidAddress,
+					Weight:  sdk.NewDec(1),
+				},
+			},
+
+			expectedError: sdkerrors.Wrap(bech32.ErrInvalidLength(len(invalidAddress)), "decoding bech32 failed"),
+			// This case should not happen in practice due to parameter validation.
+			// The method spec also requires that all recepient addresses are valid by CONTRACT.
+			// Since we still handle error returned by the converion from string to address,
+			// we try to cover it explicitly. However, it changes balance so we don't test it.
+			allowBalanceChange: true,
+		},
+		"pre-mint < distribute * proportion - error": {
+			preMintCoin: validPreMintCoinSubOne,
+
+			mintedCoin: validPreMintCoin,
+			proportion: sdk.OneDec(),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDec(1),
+				},
+			},
+			expectedError: sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, fmt.Sprintf("%s is smaller than %s", validPreMintCoinSubOne, validPreMintCoin)),
+		},
+		"distribute * proportion < pre-mint but distribute * proportion > developer vesting amount - error": {
+			preMintCoin: validPreMintCoin,
+
+			mintedCoin: sdk.NewCoin(sdk.DefaultBondDenom, validPreMintAmountAddOne),
+			proportion: sdk.OneDec(),
+			recepientAddresses: []types.WeightedAddress{
+				{
+					Address: testAddressOne.String(),
+					Weight:  sdk.NewDec(1),
+				},
+			},
+			expectedError: sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, fmt.Sprintf("%s is smaller than %s", validPreMintCoin, sdk.NewCoin(sdk.DefaultBondDenom, validPreMintAmountAddOne))),
+		},
+	}
+	for name, tc := range tests {
+		suite.Run(name, func() {
+			suite.Setup()
+
+			osmoutils.ConditionalPanic(suite.T(), tc.expectPanic, func() {
+				mintKeeper := suite.App.MintKeeper
+				bankKeeper := suite.App.BankKeeper
+				accountKeeper := suite.App.AccountKeeper
+				ctx := suite.Ctx
+
+				// Setup.
+				suite.NoError(mintKeeper.MintCoins(ctx, sdk.NewCoins(tc.preMintCoin)))
+
+				// TODO: Should not be truncated. Remove truncation after rounding errors are addressed and resolved.
+				// Ref: https://github.com/osmosis-labs/osmosis/issues/1917
+				expectedDistributed := tc.mintedCoin.Amount.ToDec().Mul(tc.proportion).TruncateInt()
+
+				oldMintModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.ModuleName), tc.mintedCoin.Denom).Amount
+				oldDeveloperVestingModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), tc.mintedCoin.Denom).Amount
+				oldCommunityPoolBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(distributiontypes.ModuleName), tc.mintedCoin.Denom).Amount
+				oldDeveloperRewardsBalanceAmounts := make([]sdk.Int, len(tc.recepientAddresses))
+				for i, weightedAddress := range tc.recepientAddresses {
+					// No error check to be able to test invalid addresses.
+					address, _ := sdk.AccAddressFromBech32(weightedAddress.Address)
+					oldDeveloperRewardsBalanceAmounts[i] = bankKeeper.GetBalance(ctx, address, tc.mintedCoin.Denom).Amount
+				}
+
+				// Test.
+				actualDistributed, err := mintKeeper.DistributeDeveloperRewards(ctx, tc.mintedCoin, tc.proportion, tc.recepientAddresses)
+
+				// Assertions.
+				actualMintModuleBalance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.ModuleName), tc.mintedCoin.Denom)
+				actualDeveloperVestingModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), tc.mintedCoin.Denom).Amount
+				actualCommunityPoolModuleBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(distributiontypes.ModuleName), tc.mintedCoin.Denom).Amount
+
+				if tc.expectedError != nil {
+					suite.Error(err)
+					suite.Equal(tc.expectedError.Error(), err.Error())
+					suite.Equal(actualDistributed, sdk.Int{})
+
+					// See testcases with this flag set to true for details.
+					if tc.allowBalanceChange {
+						return
+					}
+					// Old balances should not change.
+					suite.Equal(oldMintModuleBalanceAmount.Int64(), actualMintModuleBalance.Amount.Int64())
+					suite.Equal(oldDeveloperVestingModuleBalanceAmount.Int64(), actualDeveloperVestingModuleBalanceAmount.Int64())
+					suite.Equal(oldCommunityPoolBalanceAmount.Int64(), actualCommunityPoolModuleBalanceAmount.Int64())
+					return
+				}
+
+				suite.NoError(err)
+				suite.Equal(expectedDistributed, actualDistributed)
+
+				// Updated balances.
+
+				// Burn from mint module account. We over-allocate.
+				// To be fixed: https://github.com/osmosis-labs/osmosis/issues/2025
+				suite.Equal(oldMintModuleBalanceAmount.Sub(expectedDistributed).Int64(), actualMintModuleBalance.Amount.Int64())
+
+				// Allocate to community pool when no addresses are provided.
+				if len(tc.recepientAddresses) == 0 {
+					suite.Equal(oldDeveloperVestingModuleBalanceAmount.Sub(expectedDistributed).Int64(), actualDeveloperVestingModuleBalanceAmount.Int64())
+					suite.Equal(oldCommunityPoolBalanceAmount.Add(expectedDistributed).Int64(), actualCommunityPoolModuleBalanceAmount.Int64())
+					return
+				}
+
+				// TODO: these should be equal, slightly off due to known rounding issues: https://github.com/osmosis-labs/osmosis/issues/1917
+				// suite.Equal(oldDeveloperVestingModuleBalanceAmount.Sub(expectedDistributed).Int64(), actualDeveloperVestingModuleBalanceAmount.Int64())
+
+				for i, weightedAddress := range tc.recepientAddresses {
+					address, err := sdk.AccAddressFromBech32(weightedAddress.Address)
+					suite.NoError(err)
+
+					// TODO: truncation should not occur: https://github.com/osmosis-labs/osmosis/issues/1917
+					expectedAllocation := expectedDistributed.ToDec().Mul(tc.recepientAddresses[i].Weight).TruncateInt()
+					actualDeveloperRewardsBalanceAmounts := bankKeeper.GetBalance(ctx, address, tc.mintedCoin.Denom).Amount
+
+					// Edge case. See testcases with this flag set to true for details.
+					if tc.expectSameAddresses {
+						suite.Equal(oldDeveloperRewardsBalanceAmounts[i].Add(expectedAllocation.Mul(sdk.NewInt(2))).Int64(), actualDeveloperRewardsBalanceAmounts.Int64())
+						return
+					}
+
+					suite.Equal(oldDeveloperRewardsBalanceAmounts[i].Add(expectedAllocation).Int64(), actualDeveloperRewardsBalanceAmounts.Int64())
+				}
 			})
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: https://github.com/osmosis-labs/osmosis/issues/1916

## What is the purpose of the change

Splitting up https://github.com/osmosis-labs/osmosis/pull/2026  [per suggestion](https://github.com/osmosis-labs/osmosis/pull/2026#issuecomment-1184427409).

The dev rewards distribution logic is 1:1 copied from how it used to be and encapsulated into a function. Additionally, unit tested.

## Testing and Verifying

This change added tests and can be verified as follows:

TestDistributeDeveloperRewards

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable