### PR TITLE
refactor(x/mint, x/gamm errors): move errors in mint and gamm keeper to errors.go

### DIFF
--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -151,7 +151,7 @@ func getPoolAssetsByDenom(poolAssets []PoolAsset) (map[string]PoolAsset, error) 
 	for _, poolAsset := range poolAssets {
 		_, ok := poolAssetsByDenom[poolAsset.Token.Denom]
 		if ok {
-			return nil, fmt.Errorf(errMsgFormatRepeatingPoolAssetsNotAllowed, poolAsset.Token.Denom)
+			return nil, fmt.Errorf(formatRepeatingPoolAssetsNotAllowedErrFormat, poolAsset.Token.Denom)
 		}
 
 		poolAssetsByDenom[poolAsset.Token.Denom] = poolAsset
@@ -174,7 +174,7 @@ func updateIntermediaryPoolAssetsLiquidity(liquidity sdk.Coins, poolAssetsByDeno
 	for _, coin := range liquidity {
 		poolAsset, ok := poolAssetsByDenom[coin.Denom]
 		if !ok {
-			return fmt.Errorf(errMsgFormatFailedInterimLiquidityUpdate, coin.Denom)
+			return fmt.Errorf(failedInterimLiquidityUpdateErrFormat, coin.Denom)
 		}
 
 		poolAsset.Token.Amount = poolAssetsByDenom[coin.Denom].Token.Amount.Add(coin.Amount)

--- a/x/gamm/pool-models/balancer/export_test.go
+++ b/x/gamm/pool-models/balancer/export_test.go
@@ -3,12 +3,12 @@ package balancer
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
 const (
-	ErrMsgFormatRepeatingPoolAssetsNotAllowed = errMsgFormatRepeatingPoolAssetsNotAllowed
-	ErrMsgFormatNoPoolAssetFound              = errMsgFormatNoPoolAssetFound
+	ErrMsgFormatRepeatingPoolAssetsNotAllowed = formatRepeatingPoolAssetsNotAllowedErrFormat
+	ErrMsgFormatNoPoolAssetFound              = formatNoPoolAssetFoundErrFormat
 )
 
 var (
-	ErrMsgFormatFailedInterimLiquidityUpdate = errMsgFormatFailedInterimLiquidityUpdate
+	ErrMsgFormatFailedInterimLiquidityUpdate = failedInterimLiquidityUpdateErrFormat
 
 	CalcPoolSharesOutGivenSingleAssetIn   = calcPoolSharesOutGivenSingleAssetIn
 	CalcSingleAssetInGivenPoolSharesOut   = calcSingleAssetInGivenPoolSharesOut

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -22,10 +22,9 @@ const (
 	sharesLargerThanMaxErrFormat    = "%d resulted shares is larger than the max amount of %d"
 	invalidInputDenomsErrFormat     = "input denoms must already exist in the pool (%s)"
 
-	// the errors below are being used in export_test
-	errMsgFormatFailedInterimLiquidityUpdate  = "failed to update interim liquidity - pool asset %s does not exist"
-	errMsgFormatRepeatingPoolAssetsNotAllowed = "repeating pool assets not allowed, found %s"
-	errMsgFormatNoPoolAssetFound              = "can't find the PoolAsset (%s)"
+	failedInterimLiquidityUpdateErrFormat        = "failed to update interim liquidity - pool asset %s does not exist"
+	formatRepeatingPoolAssetsNotAllowedErrFormat = "repeating pool assets not allowed, found %s"
+	formatNoPoolAssetFoundErrFormat              = "can't find the PoolAsset (%s)"
 )
 
 var (
@@ -224,7 +223,7 @@ func (p Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	}
 
 	if len(p.PoolAssets) == 0 {
-		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
+		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(formatNoPoolAssetFoundErrFormat, denom))
 	}
 
 	i := sort.Search(len(p.PoolAssets), func(i int) bool {
@@ -235,11 +234,11 @@ func (p Pool) getPoolAssetAndIndex(denom string) (int, PoolAsset, error) {
 	})
 
 	if i < 0 || i >= len(p.PoolAssets) {
-		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
+		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(formatNoPoolAssetFoundErrFormat, denom))
 	}
 
 	if p.PoolAssets[i].Token.Denom != denom {
-		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(errMsgFormatNoPoolAssetFound, denom))
+		return -1, PoolAsset{}, sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, fmt.Sprintf(formatNoPoolAssetFoundErrFormat, denom))
 	}
 
 	return i, p.PoolAssets[i], nil

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrAlreadyInvalidPool  = sdkerrors.Register(ModuleName, 9, "destruction on already invalid pool")
 	ErrInvalidPool         = sdkerrors.Register(ModuleName, 10, "attempting to create an invalid pool")
 	ErrDenomNotFoundInPool = sdkerrors.Register(ModuleName, 11, "denom does not exist in pool")
+	ErrDenomAlreadyInPool  = sdkerrors.Register(ModuleName, 12, "denom already exists in the pool")
 
 	ErrEmptyRoutes              = sdkerrors.Register(ModuleName, 21, "routes not defined")
 	ErrEmptyPoolAssets          = sdkerrors.Register(ModuleName, 22, "PoolAssets not defined")

--- a/x/mint/keeper/export_test.go
+++ b/x/mint/keeper/export_test.go
@@ -15,10 +15,6 @@ const (
 )
 
 var (
-	ErrAmountCannotBeNilOrZero               = errAmountCannotBeNilOrZero
-	ErrDevVestingModuleAccountAlreadyCreated = errDevVestingModuleAccountAlreadyCreated
-	ErrDevVestingModuleAccountNotCreated     = errDevVestingModuleAccountNotCreated
-
 	GetProportions = getProportions
 )
 

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
@@ -76,7 +77,7 @@ func NewKeeper(
 // queries. The method returns an error if current height in ctx is greater than the v7 upgrade height.
 func (k Keeper) SetInitialSupplyOffsetDuringMigration(ctx sdk.Context) error {
 	if !k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return types.ErrDevVestingModuleAccountNotCreated
+		return sdkerrors.Wrap(types.ErrModuleDoesnotExist, "vesting module account doesnot exist")
 	}
 
 	moduleAccBalance := k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), k.GetParams(ctx).MintDenom)
@@ -93,10 +94,10 @@ func (k Keeper) SetInitialSupplyOffsetDuringMigration(ctx sdk.Context) error {
 // - developer vesting module account is already created prior to calling this method.
 func (k Keeper) CreateDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.Coin) error {
 	if amount.IsNil() || amount.Amount.IsZero() {
-		return types.ErrAmountCannotBeNilOrZero
+		return sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero")
 	}
 	if k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return types.ErrDevVestingModuleAccountAlreadyCreated
+		return sdkerrors.Wrap(types.ErrModuleAlreadyExist, "vesting module account already exist")
 	}
 
 	moduleAcc := authtypes.NewEmptyModuleAccount(

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -93,7 +93,7 @@ func (k Keeper) CreateDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.
 		return sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero")
 	}
 	if k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return sdkerrors.Wrapf(types.ErrModuleAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName)
+		return sdkerrors.Wrapf(types.ErrModuleAccountAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName)
 	}
 
 	moduleAcc := authtypes.NewEmptyModuleAccount(

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/osmosis-labs/osmosis/v7/x/mint/types"
@@ -33,12 +35,6 @@ type invalidRatioError struct {
 func (e invalidRatioError) Error() string {
 	return fmt.Sprintf("mint allocation ratio (%s) is greater than 1", e.ActualRatio)
 }
-
-var (
-	errAmountCannotBeNilOrZero               = errors.New("amount cannot be nil or zero")
-	errDevVestingModuleAccountAlreadyCreated = fmt.Errorf("%s module account already exists", types.DeveloperVestingModuleAcctName)
-	errDevVestingModuleAccountNotCreated     = fmt.Errorf("%s module account does not exist", types.DeveloperVestingModuleAcctName)
-)
 
 // NewKeeper creates a new mint Keeper instance.
 func NewKeeper(
@@ -77,7 +73,7 @@ func NewKeeper(
 // queries. The method returns an error if current height in ctx is greater than the v7 upgrade height.
 func (k Keeper) SetInitialSupplyOffsetDuringMigration(ctx sdk.Context) error {
 	if !k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return sdkerrors.Wrap(types.ErrModuleDoesnotExist, "vesting module account doesnot exist")
+		return sdkerrors.Wrapf(types.ErrModuleDoesnotExist, "%s vesting module account doesnot exist", types.DeveloperVestingModuleAcctName)
 	}
 
 	moduleAccBalance := k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), k.GetParams(ctx).MintDenom)
@@ -97,7 +93,7 @@ func (k Keeper) CreateDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.
 		return sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero")
 	}
 	if k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return sdkerrors.Wrap(types.ErrModuleAlreadyExist, "vesting module account already exist")
+		return sdkerrors.Wrapf(types.ErrModuleAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName)
 	}
 
 	moduleAcc := authtypes.NewEmptyModuleAccount(

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -1,9 +1,6 @@
 package keeper
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/osmosis-labs/osmosis/v7/x/mint/types"
@@ -79,7 +76,7 @@ func NewKeeper(
 // queries. The method returns an error if current height in ctx is greater than the v7 upgrade height.
 func (k Keeper) SetInitialSupplyOffsetDuringMigration(ctx sdk.Context) error {
 	if !k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return errDevVestingModuleAccountNotCreated
+		return types.ErrDevVestingModuleAccountNotCreated
 	}
 
 	moduleAccBalance := k.bankKeeper.GetBalance(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName), k.GetParams(ctx).MintDenom)
@@ -96,10 +93,10 @@ func (k Keeper) SetInitialSupplyOffsetDuringMigration(ctx sdk.Context) error {
 // - developer vesting module account is already created prior to calling this method.
 func (k Keeper) CreateDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.Coin) error {
 	if amount.IsNil() || amount.Amount.IsZero() {
-		return errAmountCannotBeNilOrZero
+		return types.ErrAmountCannotBeNilOrZero
 	}
 	if k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return errDevVestingModuleAccountAlreadyCreated
+		return types.ErrDevVestingModuleAccountAlreadyCreated
 	}
 
 	moduleAcc := authtypes.NewEmptyModuleAccount(

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -16,7 +16,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/osmosis-labs/osmosis/v7/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v7/osmoutils"
 	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
@@ -327,7 +326,7 @@ func (suite *KeeperTestSuite) TestCreateDeveloperVestingModuleAccount() {
 			blockHeight:                     0,
 			amount:                          sdk.NewCoin("stake", sdk.NewInt(keeper.DeveloperVestingAmount)),
 			isDeveloperModuleAccountCreated: true,
-			expectedError:                   sdkerrors.Wrap(types.ErrModuleAlreadyExist, "vesting module account already exist"),
+			expectedError:                   sdkerrors.Wrapf(types.ErrModuleAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName),
 		},
 	}
 
@@ -362,7 +361,7 @@ func (suite *KeeperTestSuite) TestSetInitialSupplyOffsetDuringMigration() {
 		},
 		"dev vesting module account does not exist": {
 			blockHeight:   1,
-			expectedError: sdkerrors.Wrap(types.ErrModuleDoesnotExist, "vesting module account doesnot exist"),
+			expectedError: sdkerrors.Wrapf(types.ErrModuleDoesnotExist, "%s vesting module account doesnot exist", types.DeveloperVestingModuleAcctName),
 		},
 	}
 

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -315,18 +315,18 @@ func (suite *KeeperTestSuite) TestCreateDeveloperVestingModuleAccount() {
 		},
 		"nil amount": {
 			blockHeight:   0,
-			expectedError: keeper.ErrAmountCannotBeNilOrZero,
+			expectedError: types.ErrAmountCannotBeNilOrZero,
 		},
 		"zero amount": {
 			blockHeight:   0,
 			amount:        sdk.NewCoin("stake", sdk.NewInt(0)),
-			expectedError: keeper.ErrAmountCannotBeNilOrZero,
+			expectedError: types.ErrAmountCannotBeNilOrZero,
 		},
 		"module account is already created": {
 			blockHeight:                     0,
 			amount:                          sdk.NewCoin("stake", sdk.NewInt(keeper.DeveloperVestingAmount)),
 			isDeveloperModuleAccountCreated: true,
-			expectedError:                   keeper.ErrDevVestingModuleAccountAlreadyCreated,
+			expectedError:                   types.ErrDevVestingModuleAccountAlreadyCreated,
 		},
 	}
 
@@ -361,7 +361,7 @@ func (suite *KeeperTestSuite) TestSetInitialSupplyOffsetDuringMigration() {
 		},
 		"dev vesting module account does not exist": {
 			blockHeight:   1,
-			expectedError: keeper.ErrDevVestingModuleAccountNotCreated,
+			expectedError: types.ErrDevVestingModuleAccountNotCreated,
 		},
 	}
 

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -16,6 +16,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/osmosis-labs/osmosis/v7/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v7/osmoutils"
 	lockuptypes "github.com/osmosis-labs/osmosis/v7/x/lockup/types"
@@ -315,18 +316,18 @@ func (suite *KeeperTestSuite) TestCreateDeveloperVestingModuleAccount() {
 		},
 		"nil amount": {
 			blockHeight:   0,
-			expectedError: types.ErrAmountCannotBeNilOrZero,
+			expectedError: sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero"),
 		},
 		"zero amount": {
 			blockHeight:   0,
 			amount:        sdk.NewCoin("stake", sdk.NewInt(0)),
-			expectedError: types.ErrAmountCannotBeNilOrZero,
+			expectedError: sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero"),
 		},
 		"module account is already created": {
 			blockHeight:                     0,
 			amount:                          sdk.NewCoin("stake", sdk.NewInt(keeper.DeveloperVestingAmount)),
 			isDeveloperModuleAccountCreated: true,
-			expectedError:                   types.ErrDevVestingModuleAccountAlreadyCreated,
+			expectedError:                   sdkerrors.Wrap(types.ErrModuleAlreadyExist, "vesting module account already exist"),
 		},
 	}
 
@@ -340,7 +341,7 @@ func (suite *KeeperTestSuite) TestCreateDeveloperVestingModuleAccount() {
 
 			if tc.expectedError != nil {
 				suite.Error(actualError)
-				suite.Equal(actualError, tc.expectedError)
+				suite.ErrorIs(actualError, tc.expectedError)
 				return
 			}
 			suite.NoError(actualError)
@@ -361,7 +362,7 @@ func (suite *KeeperTestSuite) TestSetInitialSupplyOffsetDuringMigration() {
 		},
 		"dev vesting module account does not exist": {
 			blockHeight:   1,
-			expectedError: types.ErrDevVestingModuleAccountNotCreated,
+			expectedError: sdkerrors.Wrap(types.ErrModuleDoesnotExist, "vesting module account doesnot exist"),
 		},
 	}
 
@@ -380,7 +381,7 @@ func (suite *KeeperTestSuite) TestSetInitialSupplyOffsetDuringMigration() {
 
 			if tc.expectedError != nil {
 				suite.Error(actualError)
-				suite.Equal(actualError, tc.expectedError)
+				suite.ErrorIs(actualError, tc.expectedError)
 
 				suite.Equal(supplyWithOffsetBefore.Amount, bankKeeper.GetSupplyWithOffset(ctx, sdk.DefaultBondDenom).Amount)
 				suite.Equal(supplyOffsetBefore, bankKeeper.GetSupplyOffset(ctx, sdk.DefaultBondDenom))

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -326,7 +326,7 @@ func (suite *KeeperTestSuite) TestCreateDeveloperVestingModuleAccount() {
 			blockHeight:                     0,
 			amount:                          sdk.NewCoin("stake", sdk.NewInt(keeper.DeveloperVestingAmount)),
 			isDeveloperModuleAccountCreated: true,
-			expectedError:                   sdkerrors.Wrapf(types.ErrModuleAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName),
+			expectedError:                   sdkerrors.Wrapf(types.ErrModuleAccountAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName),
 		},
 	}
 

--- a/x/mint/types/errors.go
+++ b/x/mint/types/errors.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+var (
+	ErrAmountCannotBeNilOrZero               = sdkerrors.Register(ModuleName, 1, "amount cannot be nil or zero")
+	ErrDevVestingModuleAccountAlreadyCreated = sdkerrors.Register(ModuleName, 2, "module account already exists")
+	ErrDevVestingModuleAccountNotCreated     = sdkerrors.Register(ModuleName, 3, "module account does not exist")
+)

--- a/x/mint/types/errors.go
+++ b/x/mint/types/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	ErrAmountNilOrZero    = sdkerrors.Register(ModuleName, 2, "amount cannot be nil or zero")
-	ErrModuleAlreadyExist = sdkerrors.Register(ModuleName, 3, "module account already exists")
-	ErrModuleDoesnotExist = sdkerrors.Register(ModuleName, 4, "module account does not exist")
+	ErrAmountNilOrZero           = sdkerrors.Register(ModuleName, 2, "amount cannot be nil or zero")
+	ErrModuleAccountAlreadyExist = sdkerrors.Register(ModuleName, 3, "module account already exists")
+	ErrModuleDoesnotExist        = sdkerrors.Register(ModuleName, 4, "module account does not exist")
 )

--- a/x/mint/types/errors.go
+++ b/x/mint/types/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	ErrAmountCannotBeNilOrZero               = sdkerrors.Register(ModuleName, 1, "amount cannot be nil or zero")
-	ErrDevVestingModuleAccountAlreadyCreated = sdkerrors.Register(ModuleName, 2, "module account already exists")
-	ErrDevVestingModuleAccountNotCreated     = sdkerrors.Register(ModuleName, 3, "module account does not exist")
+	ErrAmountNilOrZero    = sdkerrors.Register(ModuleName, 2, "amount cannot be nil or zero")
+	ErrModuleAlreadyExist = sdkerrors.Register(ModuleName, 3, "module account already exists")
+	ErrModuleDoesnotExist = sdkerrors.Register(ModuleName, 4, "module account does not exist")
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2034 and #2035

## What is the purpose of the change
Move tests to errors.go for consistency 

## Brief Changelog
n/a

## Testing and Verifying
n/a

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)