### PR TITLE
fix(e2e): upgrade proposals

### DIFF
--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (n *NodeConfig) CreatePool(poolFile, from string) {
-	n.t.Logf("creating pool for chain-id: %s", n.chainId)
+	n.t.Logf("creating pool from file %s from container %s", poolFile, n.Name)
 	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
@@ -18,7 +18,7 @@ func (n *NodeConfig) CreatePool(poolFile, from string) {
 }
 
 func (n *NodeConfig) SubmitUpgradeProposal(upgradeVersion string, upgradeHeight int64) {
-	n.t.Logf("submitting upgrade proposal on container: %s", n.Name)
+	n.t.Logf("submitting upgrade proposal %s for height %d, from container: %s", upgradeVersion, upgradeHeight, n.Name)
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%d", upgradeHeight), "--upgrade-info=\"\"", "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
@@ -30,43 +30,43 @@ func (n *NodeConfig) SubmitSuperfluidProposal(asset string) {
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), fmt.Sprintf("--title=\"%s superfluid asset\"", asset), fmt.Sprintf("--description=\"%s superfluid asset\"", asset), "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Log("successfully submitted superfluid proposal")
+	n.t.Logf("successfully submitted superfluid proposal for asset %s on container: %s", asset, n.Name)
 }
 
 func (n *NodeConfig) SubmitTextProposal(text string) {
-	n.t.Logf("submitting text proposal on container: %s", n.Name)
+	n.t.Logf("submitting text proposal from container: %s", n.Name)
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "--type=text", fmt.Sprintf("--title=\"%s\"", text), "--description=\"test text proposal\"", "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Log("successfully submitted text proposal")
+	n.t.Logf("successfully submitted from container: %s", n.Name)
 }
 
 func (n *NodeConfig) DepositProposal(proposalNumber int) {
-	n.t.Logf("depositing to proposal from container: %s", n.Name)
+	n.t.Logf("depositing to proposal from container %s, on proposal: %d", n.Name, proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "deposit", fmt.Sprintf("%d", proposalNumber), "500000000uosmo", "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Log("successfully deposited to proposal")
+	n.t.Logf("successfully deposited from container %s, on proposal: %d", n.Name, proposalNumber)
 }
 
 func (n *NodeConfig) VoteYesProposal(from string, proposalNumber int) {
-	n.t.Logf("voting yes on proposal for chain-id: %s", n.chainId)
+	n.t.Logf("voting yes on proposal from node container: %s, on proposal: %d", n.Name, proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "vote", fmt.Sprintf("%d", proposalNumber), "yes", fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully voted yes on proposal from container: %s", n.Name)
+	n.t.Logf("successfully voted yes from node container: %s, on proposal: %d", n.Name, proposalNumber)
 }
 
 func (n *NodeConfig) VoteNoProposal(from string, proposalNumber int) {
-	n.t.Logf("voting no on proposal for chain-id: %s", n.chainId)
+	n.t.Logf("voting no on proposal from node container: %s, on proposal: %d", n.Name, proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "vote", fmt.Sprintf("%d", proposalNumber), "no", fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully voted no for proposal from container: %s", n.Name)
+	n.t.Logf("successfully voted no from node container: %s, on proposal: %d", n.Name, proposalNumber)
 }
 
 func (n *NodeConfig) LockTokens(tokens string, duration string, from string) {
-	n.t.Logf("locking %s for %s on chain-id: %s", tokens, duration, n.chainId)
+	n.t.Logf("locking %s for %s on from container %s", tokens, duration, n.Name)
 	cmd := []string{"osmosisd", "tx", "lockup", "lock-tokens", tokens, fmt.Sprintf("--duration=%s", duration), fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
@@ -75,27 +75,29 @@ func (n *NodeConfig) LockTokens(tokens string, duration string, from string) {
 
 func (n *NodeConfig) SuperfluidDelegate(lockNumber int, valAddress string, from string) {
 	lockStr := strconv.Itoa(lockNumber)
-	n.t.Logf("superfluid delegating lock %s to %s on chain-id: %s", lockStr, valAddress, n.chainId)
+	n.t.Logf("superfluid delegating lock %s to %s from container %s", lockStr, valAddress, n.Name)
 	cmd := []string{"osmosisd", "tx", "superfluid", "delegate", lockStr, valAddress, fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully superfluid delegated from container: %s", n.Name)
+	n.t.Logf("successfully superfluid delegated lock %s to %s from container: %s", lockStr, valAddress, n.Name)
 }
 
 func (n *NodeConfig) BankSend(amount string, sendAddress string, receiveAddress string) {
-	n.t.Logf("bank sending %s from %s to %s on chain-id: %s", amount, sendAddress, receiveAddress, n.chainId)
+	n.t.Logf("bank sending %s from address %s to %s, from container %s", amount, sendAddress, receiveAddress, n.Name)
 	cmd := []string{"osmosisd", "tx", "bank", "send", sendAddress, receiveAddress, amount, "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully sent tx from container: %s", n.Name)
+	n.t.Logf("successfully sent bank sent %s from address %s to %s, from container %s", amount, sendAddress, receiveAddress, n.Name)
 }
 
 func (n *NodeConfig) CreateWallet(walletName string) string {
+	n.t.Logf("creating wallet %s, from container %s", walletName, n.Name)
 	cmd := []string{"osmosisd", "keys", "add", walletName, "--keyring-backend=test"}
 	outBuf, _, err := n.containerManager.ExecCmd(n.t, n.Name, cmd, "")
 	require.NoError(n.t, err)
 	re := regexp.MustCompile("osmo1(.{38})")
 	walletAddr := fmt.Sprintf("%s\n", re.FindString(outBuf.String()))
 	walletAddr = strings.TrimSuffix(walletAddr, "\n")
+	n.t.Logf("created wallet %s, waller address - %s from container %s", walletName, walletAddr, n.Name)
 	return walletAddr
 }

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -143,21 +143,19 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 	// submit, deposit, and vote for upgrade proposal
 	// prop height = current height + voting period + time it takes to submit proposal + small buffer
 	for _, chainConfig := range uc.chainConfigs {
-		node, err := chainConfig.GetDefaultNode()
-		if err != nil {
-			return err
+		for validatorIdx, node := range chainConfig.NodeConfigs {
+			if validatorIdx == 0 {
+				currentHeight, err := node.QueryCurrentHeight()
+				if err != nil {
+					return err
+				}
+				chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
+				node.SubmitUpgradeProposal(uc.upgradeVersion, chainConfig.UpgradePropHeight)
+				chainConfig.LatestProposalNumber += 1
+				node.DepositProposal(chainConfig.LatestProposalNumber)
+			}
+			node.VoteYesProposal(initialization.ValidatorWalletName, chainConfig.LatestProposalNumber)
 		}
-		currentHeight, err := node.QueryCurrentHeight()
-		if err != nil {
-			return err
-		}
-
-		chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
-		node.SubmitUpgradeProposal(uc.upgradeVersion, chainConfig.UpgradePropHeight)
-		chainConfig.LatestProposalNumber += 1
-
-		node.DepositProposal(chainConfig.LatestProposalNumber)
-		node.VoteYesProposal(initialization.ValidatorWalletName, chainConfig.LatestProposalNumber)
 	}
 
 	// wait till all chains halt at upgrade height


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related to: https://github.com/osmosis-labs/osmosis/issues/2039

## What is the purpose of the change


Discovered that upgrade proposals were broken after trying to upgrade our SDK.

I think the reason the CI was passing before is that despite switching v10 to v11 containers during the upgrade, the state machine was compatible so it was able to continue.

However, upon upgrading SDK, that wasn't the case anymore so the CI started failing.

The problem was that each node on a chain was submitting and voting on its own proposal. As a result, none of them would eventually be accepted.

This change makes only one node to submit a proposal and all other nodes vote on the unified proposal.

The tests passed with this change + SDK upgraded. The actual upgrade is coming in a separate PR.
## Passthrough Change

- Formatted command logs consistently to improve the UX

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable