### PR TITLE
chore(app/upgrades): set app version correctly for v11

### DIFF
--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -9,6 +9,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v7/app/upgrades"
 )
 
+// We set the app version to pre-upgrade because it will be incremented by one
+// after the upgrade is applied by the handler.
+const preUpgradeAppVersion = 10
+
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
@@ -16,6 +20,14 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+
+		// Although the app version was already set during the v9 upgrade, our v10 was a fork.
+		// As a result, the upgrade handler was not executed to increment the app version.
+		// This change helps to correctly set the app version for v11.
+		if err := keepers.UpgradeKeeper.SetAppVersion(ctx, preUpgradeAppVersion); err != nil {
+			return nil, err
+		}
+
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -20,7 +20,6 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-
 		// Although the app version was already set during the v9 upgrade, our v10 was a fork.
 		// As a result, the upgrade handler was not executed to increment the app version.
 		// This change helps to correctly set the app version for v11.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related to: https://github.com/osmosis-labs/osmosis/issues/1805

## What is the purpose of the change

Although the app version was already set during the v9 upgrade, our v10 was a fork.
As a result, the upgrade handler was not executed to increment the app version.
This change helps to correctly set the app version for v11.


## Testing and Verifying

This change can be verified by e2e upgrade tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable