### PR TITLE
Move random genesis to an extension interface

### DIFF
--- a/simulation/types/manager.go
+++ b/simulation/types/manager.go
@@ -19,13 +19,14 @@ import (
 type AppModuleSimulationV2 interface {
 	module.AppModule
 
-	// randomized genesis states
-	// TODO: Come back and improve SimulationState interface
-	// TODO: Move this to an extension interface
-	// default: simState.GenState[types.ModuleName] = app.DefaultGenesis(simState.Cdc)
-	GenerateGenesisState(*module.SimulationState, *SimCtx)
 	Actions() []Action
 	// PropertyTests()
+}
+
+type AppModuleSimulationV2WithRandGenesis interface {
+	AppModuleSimulationV2
+	// TODO: Come back and improve SimulationState interface
+	RandomGenesisState(*module.SimulationState, *SimCtx)
 }
 
 // SimulationManager defines a simulation manager that provides the high level utility
@@ -137,7 +138,12 @@ func (m Manager) Actions(seed int64, cdc codec.JSONCodec) []Action {
 func (m Manager) GenerateGenesisStates(simState *module.SimulationState, sim *SimCtx) {
 	for _, moduleName := range m.moduleManager.OrderInitGenesis {
 		if simModule, ok := m.Modules[moduleName]; ok {
-			simModule.GenerateGenesisState(simState, sim)
+			// if we define a random genesis function use it, otherwise use default genesis
+			if mod, ok := simModule.(AppModuleSimulationV2WithRandGenesis); ok {
+				mod.RandomGenesisState(simState, sim)
+			} else {
+				simState.GenState[simModule.Name()] = simModule.DefaultGenesis(simState.Cdc)
+			}
 		}
 		if simModule, ok := m.legacyModules[moduleName]; ok {
 			simModule.GenerateGenesisState(simState)

--- a/x/gamm/module.go
+++ b/x/gamm/module.go
@@ -158,9 +158,6 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // **** simulation implementation ****
-func (am AppModule) GenerateGenesisState(m *module.SimulationState, s *simulation.SimCtx) {
-	m.GenState[types.ModuleName] = am.DefaultGenesis(m.Cdc)
-}
 
 func (am AppModule) Actions() []simulation.Action {
 	return []simulation.Action{

--- a/x/lockup/module.go
+++ b/x/lockup/module.go
@@ -185,11 +185,6 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // AppModuleSimulationV2 functions
 
-// GenerateGenesisState creates a randomized GenState of the pool-incentives module.
-func (am AppModule) GenerateGenesisState(simState *module.SimulationState, s *simulation.SimCtx) {
-	simState.GenState[types.ModuleName] = am.DefaultGenesis(simState.Cdc)
-}
-
 // WeightedOperations returns the all the lockup module operations with their respective weights.
 func (am AppModule) Actions() []simulation.Action {
 	return []simulation.Action{


### PR DESCRIPTION
\## What is the purpose of the change

Remove random genesis state from module API, and demo this change for other people doing something on the SDK

## Brief Changelog

- Rename and move GenerateGenesisState to a new extension interface, under better name RandomGenesisState.

(We still need to come back and unscrew up all the genesis handling, but this is a nice step in the direction)

## Testing and Verifying

FullAppSimulation still making lockup module messages succesfully. Checked via local execution.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes?  yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? code comment