### PR TITLE
ci: manual job to replace import paths

### DIFF
--- a/.github/workflows/import_paths.yml
+++ b/.github/workflows/import_paths.yml
@@ -1,0 +1,77 @@
+# This is a manua workflow that does the following when trigerred:
+# - Runs a script to find and replace Go import path major version with given version.
+# - Commits and pushes changes to the source-branch.
+# - Opens a PR from the source branch to the target-branch.
+
+name: Update Go Import Paths
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Current Version that we want to change'
+        default: '11'
+        required: true
+      target-branch:
+        description: 'Target Branch'
+        default: 'main'
+        required: true
+      source-branch:
+        description: 'Source Branch'
+        default: 'update-paths'
+        required: true
+
+jobs:
+  update-import-paths:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Check out repository code
+        uses: actions/checkout@v2
+      -
+        name: Setup Golang
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.18
+      -
+        name: Display go version
+        run: go version
+      -
+        name: Get data from build cache
+        uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
+      -
+        name: Run find & replace script
+        run: ./scripts/replace_import_paths.sh ${{ inputs.version }}
+      - name: Commit and push changes
+        uses: devops-infra/action-commit-push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_message: "auto: update Go import paths to v${{ inputs.version }}"
+          target_branch: update-paths
+      - name: Open PR
+        uses: devops-infra/action-pull-request@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          title: ${{ github.event.commits[0].message }}
+          source_branch: ${{ inputs.source-branch }}
+          target_branch: ${{ inputs.target-branch }}
+          assignee: ${{ github.actor }}
+          draft: true
+          label: T:auto,T:code-hygiene
+          body: "**Automated pull request**\n\nUpdating Go import paths to v${{ inputs.version }}"
+          get_diff: true

--- a/.github/workflows/import_paths.yml
+++ b/.github/workflows/import_paths.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       version:
         description: 'Current Version that we want to change'
-        default: '11'
+        default: '10'
         required: true
       target-branch:
         description: 'Target Branch'

--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+NEXT_MAJOR_VERSION=$1
+import_path_to_replace=$(go list -m)
+
+version_to_replace=$(echo $import_path_to_replace | sed 's/g.*v//') 
+
+echo Current import paths are $version_to_replace, replacing with $NEXT_MAJOR_VERSION
+
+# list all folders containing Go modules.
+modules=$(go list ./... | sed "s/g.*v${version_to_replace}\///")
+
+replace_paths() {
+    file="${1}"
+    sed -i "s/github.com\/osmosis-labs\/osmosis\/v${version_to_replace}/github.com\/osmosis-labs\/osmosis\/v${NEXT_MAJOR_VERSION}/g" ${file}
+}
+
+# Replace all files within Go packages.
+for mod in $modules;
+do
+    for file in $mod/*; do
+        if [ -f "${file}" ]; then
+            replace_paths $file
+        fi
+    done
+done
+
+replace_paths "go.mod"
+
+go mod vendor >/dev/null


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: #1709

## What is the purpose of the change

This is a manual action to run the script to find and replace the import paths, create a branch and a open a pull request.

The following parameters are configurable:
- version (e.g. `v11`)
- source branch
   * it is set to `update-paths` by default and it is added just in case we want to update 2 branches at once (e.g. `main` and `v11.x`)
- target branch (e.g. main or any other)

## Testing and Verifying

Tested on personal fork:
- auto-created PR: https://github.com/p0mvn/osmosis/pull/20
- CI passed on merge of the replaced paths: https://github.com/p0mvn/osmosis/commits/main

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable