### PR TITLE
E2E: speedup execution time, add basic time tracking

### DIFF
--- a/tests/e2e/configurer/base.go
+++ b/tests/e2e/configurer/base.go
@@ -177,7 +177,9 @@ func (bc *baseConfigurer) connectIBCChains(chainA *chain.Config, chainB *chain.C
 func (bc *baseConfigurer) initializeChainConfigFromInitChain(initializedChain *initialization.Chain, chainConfig *chain.Config) {
 	chainConfig.ChainMeta = initializedChain.ChainMeta
 	chainConfig.NodeConfigs = make([]*chain.NodeConfig, 0, len(initializedChain.Nodes))
+	setupTime := time.Now()
 	for _, validator := range initializedChain.Nodes {
-		chainConfig.NodeConfigs = append(chainConfig.NodeConfigs, chain.NewNodeConfig(bc.t, validator, chainConfig.Id, bc.containerManager))
+		conf := chain.NewNodeConfig(bc.t, validator, chainConfig.Id, bc.containerManager).WithSetupTime(setupTime)
+		chainConfig.NodeConfigs = append(chainConfig.NodeConfigs, conf)
 	}
 }

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -10,94 +10,94 @@ import (
 )
 
 func (n *NodeConfig) CreatePool(poolFile, from string) {
-	n.t.Logf("creating pool from file %s from container %s", poolFile, n.Name)
+	n.LogActionF("creating pool from file %s", poolFile)
 	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully created pool from container: %s", n.Name)
+	n.LogActionF("successfully created pool")
 }
 
 func (n *NodeConfig) SubmitUpgradeProposal(upgradeVersion string, upgradeHeight int64) {
-	n.t.Logf("submitting upgrade proposal %s for height %d, from container: %s", upgradeVersion, upgradeHeight, n.Name)
+	n.LogActionF("submitting upgrade proposal %s for height %d", upgradeVersion, upgradeHeight)
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%d", upgradeHeight), "--upgrade-info=\"\"", "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Log("successfully submitted upgrade proposal")
+	n.LogActionF("successfully submitted upgrade proposal")
 }
 
 func (n *NodeConfig) SubmitSuperfluidProposal(asset string) {
-	n.t.Logf("submitting superfluid proposal for asset %s on container: %s", asset, n.Name)
+	n.LogActionF("submitting superfluid proposal for asset %s", asset)
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), fmt.Sprintf("--title=\"%s superfluid asset\"", asset), fmt.Sprintf("--description=\"%s superfluid asset\"", asset), "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully submitted superfluid proposal for asset %s on container: %s", asset, n.Name)
+	n.LogActionF("successfully submitted superfluid proposal for asset %s", asset)
 }
 
 func (n *NodeConfig) SubmitTextProposal(text string) {
-	n.t.Logf("submitting text proposal from container: %s", n.Name)
+	n.LogActionF("submitting text gov proposal")
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "--type=text", fmt.Sprintf("--title=\"%s\"", text), "--description=\"test text proposal\"", "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully submitted from container: %s", n.Name)
+	n.LogActionF("successfully submitted text gov proposal")
 }
 
 func (n *NodeConfig) DepositProposal(proposalNumber int) {
-	n.t.Logf("depositing to proposal from container %s, on proposal: %d", n.Name, proposalNumber)
+	n.LogActionF("depositing on proposal: %d", proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "deposit", fmt.Sprintf("%d", proposalNumber), "500000000uosmo", "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully deposited from container %s, on proposal: %d", n.Name, proposalNumber)
+	n.LogActionF("successfully deposited on proposal %d", proposalNumber)
 }
 
 func (n *NodeConfig) VoteYesProposal(from string, proposalNumber int) {
-	n.t.Logf("voting yes on proposal from node container: %s, on proposal: %d", n.Name, proposalNumber)
+	n.LogActionF("voting yes on proposal: %d", proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "vote", fmt.Sprintf("%d", proposalNumber), "yes", fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully voted yes from node container: %s, on proposal: %d", n.Name, proposalNumber)
+	n.LogActionF("successfully voted yes on proposal %d", proposalNumber)
 }
 
 func (n *NodeConfig) VoteNoProposal(from string, proposalNumber int) {
-	n.t.Logf("voting no on proposal from node container: %s, on proposal: %d", n.Name, proposalNumber)
+	n.LogActionF("voting no on proposal: %d", proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "vote", fmt.Sprintf("%d", proposalNumber), "no", fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully voted no from node container: %s, on proposal: %d", n.Name, proposalNumber)
+	n.LogActionF("successfully voted no on proposal: %d", proposalNumber)
 }
 
 func (n *NodeConfig) LockTokens(tokens string, duration string, from string) {
-	n.t.Logf("locking %s for %s on from container %s", tokens, duration, n.Name)
+	n.LogActionF("locking %s for %s", tokens, duration)
 	cmd := []string{"osmosisd", "tx", "lockup", "lock-tokens", tokens, fmt.Sprintf("--duration=%s", duration), fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully created lock from container: %s", n.Name)
+	n.LogActionF("successfully created lock")
 }
 
 func (n *NodeConfig) SuperfluidDelegate(lockNumber int, valAddress string, from string) {
 	lockStr := strconv.Itoa(lockNumber)
-	n.t.Logf("superfluid delegating lock %s to %s from container %s", lockStr, valAddress, n.Name)
+	n.LogActionF("superfluid delegating lock %s to %s", lockStr, valAddress)
 	cmd := []string{"osmosisd", "tx", "superfluid", "delegate", lockStr, valAddress, fmt.Sprintf("--from=%s", from)}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully superfluid delegated lock %s to %s from container: %s", lockStr, valAddress, n.Name)
+	n.LogActionF("successfully superfluid delegated lock %s to %s", lockStr, valAddress)
 }
 
 func (n *NodeConfig) BankSend(amount string, sendAddress string, receiveAddress string) {
-	n.t.Logf("bank sending %s from address %s to %s, from container %s", amount, sendAddress, receiveAddress, n.Name)
+	n.LogActionF("bank sending %s from address %s to %s", amount, sendAddress, receiveAddress)
 	cmd := []string{"osmosisd", "tx", "bank", "send", sendAddress, receiveAddress, amount, "--from=val"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.t.Logf("successfully sent bank sent %s from address %s to %s, from container %s", amount, sendAddress, receiveAddress, n.Name)
+	n.LogActionF("successfully sent bank sent %s from address %s to %s", amount, sendAddress, receiveAddress)
 }
 
 func (n *NodeConfig) CreateWallet(walletName string) string {
-	n.t.Logf("creating wallet %s, from container %s", walletName, n.Name)
+	n.LogActionF("creating wallet %s", walletName)
 	cmd := []string{"osmosisd", "keys", "add", walletName, "--keyring-backend=test"}
 	outBuf, _, err := n.containerManager.ExecCmd(n.t, n.Name, cmd, "")
 	require.NoError(n.t, err)
 	re := regexp.MustCompile("osmo1(.{38})")
 	walletAddr := fmt.Sprintf("%s\n", re.FindString(outBuf.String()))
 	walletAddr = strings.TrimSuffix(walletAddr, "\n")
-	n.t.Logf("created wallet %s, waller address - %s from container %s", walletName, walletAddr, n.Name)
+	n.LogActionF("created wallet %s, waller address - %s", walletName, walletAddr)
 	return walletAddr
 }

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -124,7 +124,7 @@ func (n *NodeConfig) WithSetupTime(t time.Time) *NodeConfig {
 }
 
 func (n *NodeConfig) LogActionF(msg string, args ...interface{}) {
-	timeSinceStart := time.Since(n.setupTime)
+	timeSinceStart := time.Since(n.setupTime).Round(time.Millisecond)
 	s := fmt.Sprintf(msg, args...)
 	n.t.Logf("[%s] %s. From container %s", timeSinceStart, s, n.Name)
 }

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -24,6 +24,9 @@ type NodeConfig struct {
 	rpcClient        *rpchttp.HTTP
 	t                *testing.T
 	containerManager *containers.Manager
+
+	// Add this to help with logging / tracking time since start.
+	setupTime time.Time
 }
 
 // NewNodeConfig returens new initialized NodeConfig.
@@ -33,6 +36,7 @@ func NewNodeConfig(t *testing.T, initNode *initialization.Node, chainId string, 
 		chainId:          chainId,
 		containerManager: containerManager,
 		t:                t,
+		setupTime:        time.Now(),
 	}
 }
 
@@ -112,4 +116,10 @@ func (n *NodeConfig) extractOperatorAddressIfValidator() error {
 	operAddr := fmt.Sprintf("%s\n", re.FindString(errBuf.String()))
 	n.OperatorAddress = strings.TrimSuffix(operAddr, "\n")
 	return nil
+}
+
+func (n *NodeConfig) LogActionF(msg string, args ...interface{}) {
+	timeSinceStart := time.Now().Sub(n.setupTime)
+	s := fmt.Sprintf(msg, args...)
+	n.t.Logf("[%s] %s. From container %s", timeSinceStart, s, n.Name)
 }

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -118,8 +118,13 @@ func (n *NodeConfig) extractOperatorAddressIfValidator() error {
 	return nil
 }
 
+func (n *NodeConfig) WithSetupTime(t time.Time) *NodeConfig {
+	n.setupTime = t
+	return n
+}
+
 func (n *NodeConfig) LogActionF(msg string, args ...interface{}) {
-	timeSinceStart := time.Now().Sub(n.setupTime)
+	timeSinceStart := time.Since(n.setupTime)
 	s := fmt.Sprintf(msg, args...)
 	n.t.Logf("[%s] %s. From container %s", timeSinceStart, s, n.Name)
 }

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -34,7 +34,7 @@ func (n *NodeConfig) QueryGRPCGateway(path string) ([]byte, error) {
 		}
 
 		return resp.StatusCode != http.StatusServiceUnavailable
-	}, time.Minute, time.Second*10, "failed to execute HTTP request")
+	}, time.Minute, time.Millisecond*10, "failed to execute HTTP request")
 
 	defer resp.Body.Close()
 

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -125,7 +125,7 @@ func (m *Manager) ExecCmd(t *testing.T, containerName string, command []string, 
 			return true
 		},
 		time.Minute,
-		time.Second,
+		50*time.Millisecond,
 		"tx returned a non-zero code",
 	)
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -85,7 +85,7 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 			return true
 		},
 		1*time.Minute,
-		time.Second,
+		10*time.Millisecond,
 		"Osmosis node failed to retrieve prop tally",
 	)
 	noTotal, _, _, _, _ := node.QueryPropTally(chain.LatestProposalNumber)
@@ -106,7 +106,7 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 			return true
 		},
 		1*time.Minute,
-		time.Second,
+		10*time.Millisecond,
 		"superfluid delegation vote overwrite not working as expected",
 	)
 }

--- a/tests/e2e/initialization/node.go
+++ b/tests/e2e/initialization/node.go
@@ -310,6 +310,7 @@ func (n *internalNode) initValidatorConfigs(c *internalChain, persistentPeers []
 	valConfig.StateSync.Enable = false
 	valConfig.LogLevel = "info"
 	valConfig.P2P.PersistentPeers = strings.Join(persistentPeers, ",")
+	valConfig.Consensus = tmconfig.TestConsensusConfig()
 
 	tmconfig.WriteConfigFile(tmCfgPath, valConfig)
 	return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1624 , progress on #2100

## What is the purpose of the change

To help with finding out why e2e execution is so slow. This PR achieves the following:
- add some basic time tracking to logs.
- Makes a unified method, and abstracts the log formatting for the container. This PR does it for txs, its up to a future PR to apply it everywhere else
- Switch the consensus config to be TM's test config (lower wait times intended for CI)
- Lower polling intervals. (This is also shows that we need more unification, theres so many different requires in this code. Really there should only be 2, One for CLI submission, one for query submission)

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)