### PR TITLE
ci: improve import path action

### DIFF
--- a/.github/workflows/import_paths.yml
+++ b/.github/workflows/import_paths.yml
@@ -57,21 +57,17 @@ jobs:
       -
         name: Run find & replace script
         run: ./scripts/replace_import_paths.sh ${{ inputs.version }}
-      - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_message: "auto: update Go import paths to v${{ inputs.version }}"
-          target_branch: update-paths
-      - name: Open PR
-        uses: devops-infra/action-pull-request@v0.5.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          title: ${{ github.event.commits[0].message }}
-          source_branch: ${{ inputs.source-branch }}
-          target_branch: ${{ inputs.target-branch }}
-          assignee: ${{ github.actor }}
-          draft: true
-          label: T:auto,T:code-hygiene
+          token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          title: "auto: update Go import paths to v${{ inputs.version }}"
+          commit-message: "auto: update Go import paths to v${{ inputs.version }}"
           body: "**Automated pull request**\n\nUpdating Go import paths to v${{ inputs.version }}"
-          get_diff: true
+          base: ${{ inputs.target-branch }}
+          branch-suffix: random
+          branch: ${{ inputs.source-branch }}
+          delete-branch: true
+          assignees: ${{ github.actor }}
+          draft: true
+          labels: T:auto,T:code-hygiene


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related to: https://github.com/osmosis-labs/osmosis/issues/1709

## What is the purpose of the change

After testing #2094 more, I realized that there are 3 issues:
1. A pull request opened from the manual action does not trigger CI
    * There was a security limitation related to a supported token
    * To work around this, I changed the GitHub action to [this](https://github.com/peter-evans/create-pull-request). It supports using `PAT` token that mitigates the security limitation
    * Pull requests now trigger CI correctly
2. Proto files and proto scripts were not updates
   * To fix this, added logic to the shell script, finding and replacing import paths in the proto files and scripts, running `make proto-gen` at the end
3. Did not have support of updating multiple branches at once because the same branch was always used as base of the pull request
   * Now, the branch name has a randomized suffix, allowing to update both `main` and, for example, `v10` concurrently

## Testing and Verifying

Ran this change several times on the fork and it worked as expected:
- https://github.com/p0mvn/osmosis/pull/24
- https://github.com/p0mvn/osmosis/pull/25

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable