### PR TITLE
e2e: enable state-sync tests (final MVP)

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -161,6 +161,8 @@ tests require IBC logic.
 
 - `OSMOSIS_E2E_SKIP_IBC` - when true, skips the IBC tests tests.
 
+- `OSMOSIS_E2E_SKIP_STATE_SYNC` - when true, skips the state sync tests.
+
 - `OSMOSIS_E2E_SKIP_CLEANUP` - when true, avoids cleaning up the e2e Docker
 containers.
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -191,6 +191,7 @@ This debug configuration helps to run e2e tests locally and skip the desired tes
         "OSMOSIS_E2E_SKIP_IBC": "true",
         "OSMOSIS_E2E_SKIP_UPGRADE": "true",
         "OSMOSIS_E2E_SKIP_CLEANUP": "true",
+        "OSMOSIS_E2E_SKIP_STATE_SYNC": "true",
         "OSMOSIS_E2E_UPGRADE_VERSION": "v10",
         "OSMOSIS_E2E_FORK_HEIGHT": "4713065" # this is v10 fork height.
     }

--- a/tests/e2e/configurer/base.go
+++ b/tests/e2e/configurer/base.go
@@ -178,8 +178,8 @@ func (bc *baseConfigurer) initializeChainConfigFromInitChain(initializedChain *i
 	chainConfig.ChainMeta = initializedChain.ChainMeta
 	chainConfig.NodeConfigs = make([]*chain.NodeConfig, 0, len(initializedChain.Nodes))
 	setupTime := time.Now()
-	for _, validator := range initializedChain.Nodes {
-		conf := chain.NewNodeConfig(bc.t, validator, chainConfig.Id, bc.containerManager).WithSetupTime(setupTime)
+	for i, validator := range initializedChain.Nodes {
+		conf := chain.NewNodeConfig(bc.t, validator, chainConfig.ValidatorInitConfigs[i], chainConfig.Id, bc.containerManager).WithSetupTime(setupTime)
 		chainConfig.NodeConfigs = append(chainConfig.NodeConfigs, conf)
 	}
 }

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -67,8 +67,7 @@ func (c *Config) RemoveNode(nodeName string) error {
 	for i, node := range c.NodeConfigs {
 		if node.Name == nodeName {
 			c.NodeConfigs = append(c.NodeConfigs[:i], c.NodeConfigs[i+1:]...)
-			node.Stop()
-			return nil
+			return node.Stop()
 		}
 	}
 	return fmt.Errorf("node %s not found", nodeName)

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -50,6 +50,18 @@ func New(t *testing.T, containerManager *containers.Manager, id string, initVali
 	}
 }
 
+// CreateNodeConfig returns new initialized NodeConfig.
+func (c *Config) CreateNodeConfig(initNode *initialization.Node) *NodeConfig {
+	nodeConfig := &NodeConfig{
+		Node:             *initNode,
+		chainId:          c.Id,
+		containerManager: c.containerManager,
+		t:                c.t,
+	}
+	c.NodeConfigs = append(c.NodeConfigs, nodeConfig)
+	return nodeConfig
+}
+
 // WaitUntilHeight waits for all validators to reach the specified height at the minimum.
 // returns error, if any.
 func (c *Config) WaitUntilHeight(height int64) error {

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -62,7 +62,7 @@ func (c *Config) CreateNode(initNode *initialization.Node) *NodeConfig {
 	return nodeConfig
 }
 
-// RemoveNode removes the node from chain and stops it from running.
+// RemoveNode removes node and stops it from running.
 func (c *Config) RemoveNode(nodeName string) error {
 	for i, node := range c.NodeConfigs {
 		if node.Name == nodeName {

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -50,8 +50,8 @@ func New(t *testing.T, containerManager *containers.Manager, id string, initVali
 	}
 }
 
-// CreateNodeConfig returns new initialized NodeConfig.
-func (c *Config) CreateNodeConfig(initNode *initialization.Node) *NodeConfig {
+// CreateNode returns new initialized NodeConfig.
+func (c *Config) CreateNode(initNode *initialization.Node) *NodeConfig {
 	nodeConfig := &NodeConfig{
 		Node:             *initNode,
 		chainId:          c.Id,
@@ -60,6 +60,18 @@ func (c *Config) CreateNodeConfig(initNode *initialization.Node) *NodeConfig {
 	}
 	c.NodeConfigs = append(c.NodeConfigs, nodeConfig)
 	return nodeConfig
+}
+
+// RemoveNode removes the node from chain and stops it from running.
+func (c *Config) RemoveNode(nodeName string) error {
+	for i, node := range c.NodeConfigs {
+		if node.Name == nodeName {
+			c.NodeConfigs = append(c.NodeConfigs[:i], c.NodeConfigs[i+1:]...)
+			node.Stop()
+			return nil
+		}
+	}
+	return fmt.Errorf("node %s not found", nodeName)
 }
 
 // WaitUntilHeight waits for all validators to reach the specified height at the minimum.

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -130,6 +130,16 @@ func (c *Config) GetDefaultNode() (*NodeConfig, error) {
 	return c.getNodeAtIndex(defaultNodeIndex)
 }
 
+// GetPersistentPeers returns persistent peers from every node
+// associated with a chain.
+func (c *Config) GetPersistentPeers() []string {
+	peers := make([]string, len(c.NodeConfigs))
+	for i, node := range c.NodeConfigs {
+		peers[i] = node.PeerId
+	}
+	return peers
+}
+
 func (c *Config) getNodeAtIndex(nodeIndex int) (*NodeConfig, error) {
 	if nodeIndex > len(c.NodeConfigs) {
 		return nil, fmt.Errorf("node index (%d) is greter than the number of nodes available (%d)", nodeIndex, len(c.NodeConfigs))

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -44,7 +44,7 @@ func NewNodeConfig(t *testing.T, initNode *initialization.Node, chainId string, 
 // The node configuration must be already added to the chain config prior to calling this
 // method.
 func (n *NodeConfig) Run() error {
-	n.t.Logf("starting %s validator container: %s", n.chainId, n.Name)
+	n.t.Logf("starting node container: %s", n.Name)
 	resource, err := n.containerManager.RunNodeResource(n.chainId, n.Name, n.ConfigDir)
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ func (n *NodeConfig) Run() error {
 				return false
 			}
 
-			n.t.Logf("started %s node container: %s", resource.Container.Name[1:], resource.Container.ID)
+			n.t.Logf("started node container: %s", n.Name)
 			return true
 		},
 		5*time.Minute,
@@ -77,6 +77,16 @@ func (n *NodeConfig) Run() error {
 		return err
 	}
 
+	return nil
+}
+
+// Stop stops the node from running and removes its container.
+func (n *NodeConfig) Stop() error {
+	n.t.Logf("stopping node container: %s", n.Name)
+	if err := n.containerManager.RemoveNodeResource(n.Name); err != nil {
+		return err
+	}
+	n.t.Logf("stopped node container: %s", n.Name)
 	return nil
 }
 

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -20,6 +20,7 @@ type NodeConfig struct {
 	initialization.Node
 
 	OperatorAddress  string
+	SnapshotInterval uint64
 	chainId          string
 	rpcClient        *rpchttp.HTTP
 	t                *testing.T
@@ -30,9 +31,10 @@ type NodeConfig struct {
 }
 
 // NewNodeConfig returens new initialized NodeConfig.
-func NewNodeConfig(t *testing.T, initNode *initialization.Node, chainId string, containerManager *containers.Manager) *NodeConfig {
+func NewNodeConfig(t *testing.T, initNode *initialization.Node, initConfig *initialization.NodeConfig, chainId string, containerManager *containers.Manager) *NodeConfig {
 	return &NodeConfig{
 		Node:             *initNode,
+		SnapshotInterval: initConfig.SnapshotInterval,
 		chainId:          chainId,
 		containerManager: containerManager,
 		t:                t,

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -118,6 +118,10 @@ func (n *NodeConfig) extractOperatorAddressIfValidator() error {
 	return nil
 }
 
+func (n *NodeConfig) GetHostPort(portId string) (string, error) {
+	return n.containerManager.GetHostPort(n.Name, portId)
+}
+
 func (n *NodeConfig) WithSetupTime(t time.Time) *NodeConfig {
 	n.setupTime = t
 	return n

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
+	tmabcitypes "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/osmosis-labs/osmosis/v10/tests/e2e/util"
 	superfluidtypes "github.com/osmosis-labs/osmosis/v10/x/superfluid/types"
@@ -111,4 +113,19 @@ func (n *NodeConfig) QueryCurrentHeight() (int64, error) {
 		return 0, err
 	}
 	return status.SyncInfo.LatestBlockHeight, nil
+}
+
+// QueryListSnapshots gets all snapshots currently created for a node.
+func (n *NodeConfig) QueryListSnapshots() ([]*tmabcitypes.Snapshot, error) {
+	abciResponse, err := n.rpcClient.ABCIQuery(context.Background(), "/app/snapshots", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var listSnapshots tmabcitypes.ResponseListSnapshots
+	if err := json.Unmarshal(abciResponse.Response.Value, &listSnapshots); err != nil {
+		return nil, err
+	}
+
+	return listSnapshots.Snapshots, nil
 }

--- a/tests/e2e/configurer/factory.go
+++ b/tests/e2e/configurer/factory.go
@@ -28,12 +28,14 @@ var (
 	// the configurations below.
 	validatorConfigsChainA = []*initialization.NodeConfig{
 		{
-			Name:               "prune-default-snapshot",
+			// this is a node that is used to state-sync from so its snapshot-interval
+			// is frequent.
+			Name:               "prune-default-snapshot-state-sync-from",
 			Pruning:            "default",
 			PruningKeepRecent:  "0",
 			PruningInterval:    "0",
-			SnapshotInterval:   1500,
-			SnapshotKeepRecent: 2,
+			SnapshotInterval:   25,
+			SnapshotKeepRecent: 10,
 			IsValidator:        true,
 		},
 		{

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -27,7 +27,7 @@ const (
 	previousVersionOsmoTag        = "v10.0.0-debug"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "v10.0.0-e2e-v2"
+	previousVersionInitTag        = "v10.0.0-e2e-v4"
 	// Hermes repo/version for relayer
 	relayerRepository = "osmolabs/hermes"
 	relayerTag        = "0.13.0"

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -16,6 +16,8 @@ const (
 	skipUpgradeEnv = "OSMOSIS_E2E_SKIP_UPGRADE"
 	// Environment variable name to skip the IBC tests
 	skipIBCEnv = "OSMOSIS_E2E_SKIP_IBC"
+	// Environment variable name to skip state sync testing
+	skipStateSyncEnv = "OSMOSIS_E2E_SKIP_STATE_SYNC"
 	// Environment variable name to determine if this upgrade is a fork
 	forkHeightEnv = "OSMOSIS_E2E_FORK_HEIGHT"
 	// Environment variable name to skip cleaning up Docker resources in teardown
@@ -27,10 +29,11 @@ const (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	configurer  configurer.Configurer
-	skipUpgrade bool
-	skipIBC     bool
-	forkHeight  int
+	configurer    configurer.Configurer
+	skipUpgrade   bool
+	skipIBC       bool
+	skipStateSync bool
+	forkHeight    int
 }
 
 func TestIntegrationTestSuite(t *testing.T) {
@@ -70,6 +73,12 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		s.skipIBC, err = strconv.ParseBool(str)
 		s.Require().NoError(err)
 		s.T().Log(fmt.Sprintf("%s was true, skipping IBC tests", skipIBCEnv))
+	}
+
+	if str := os.Getenv("OSMOSIS_E2E_SKIP_STATE_SYNC"); len(str) > 0 {
+		s.skipStateSync, err = strconv.ParseBool(str)
+		s.Require().NoError(err)
+		s.T().Log("skipping state sync testing")
 	}
 
 	if str := os.Getenv(upgradeVersionEnv); len(str) > 0 {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -204,7 +204,7 @@ func (s *IntegrationTestSuite) TestStateSync() {
 		500*time.Millisecond,
 	)
 
-	// stop the state synchin node.
+	// stop the state synching node.
 	err = chain.RemoveNode(stateSynchingNode.Name)
 	s.NoError(err)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -175,16 +175,14 @@ func (s *IntegrationTestSuite) TestStateSync() {
 		snapshots, err := runningNode.QueryListSnapshots()
 		s.Require().NoError(err)
 
-		foundAvailableSnapshot := false
 		for _, snapshot := range snapshots {
 			if snapshot.Height > uint64(trustHeight) {
-				foundAvailableSnapshot = true
 				s.T().Log("found state sync snapshot after trust height")
 				return true
 			}
 		}
 		s.T().Log("state sync snashot after trust height is not found")
-		return foundAvailableSnapshot
+		return false
 	}
 	runningNode.WaitUntil(hasSnapshotsAvailable)
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -144,9 +145,12 @@ func (s *IntegrationTestSuite) TestStateSync() {
 		SnapshotKeepRecent: 2,
 	}
 
+	tempDir, err := os.MkdirTemp("", "osmosis-e2e-statesync-")
+	s.Require().NoError(err)
+
 	nodeInit, err := initialization.InitSingleNode(
 		chain.Id,
-		chain.DataDir,
+		tempDir,
 		filepath.Join(runningNode.ConfigDir, "config", "genesis.json"),
 		stateSynchingNodeConfig,
 		time.Duration(chain.VotingPeriod),
@@ -157,7 +161,7 @@ func (s *IntegrationTestSuite) TestStateSync() {
 	)
 	s.Require().NoError(err)
 
-	stateSynchingNode := chain.CreateNodeConfig(nodeInit)
+	stateSynchingNode := chain.CreateNode(nodeInit)
 
 	hasSnapshotsAvailable := func(syncInfo coretypes.SyncInfo) bool {
 		const snapshotHeight = 25
@@ -200,4 +204,7 @@ func (s *IntegrationTestSuite) TestStateSync() {
 		3*time.Minute,
 		2*time.Second,
 	)
+
+	err = chain.RemoveNode(stateSynchingNode.Name)
+	s.NoError(err)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -166,8 +166,8 @@ func (s *IntegrationTestSuite) TestStateSync() {
 
 	// ensure that the running node has snapshots at a height > trustHeight.
 	hasSnapshotsAvailable := func(syncInfo coretypes.SyncInfo) bool {
-		const snapshotHeight = 25
-		if syncInfo.LatestBlockHeight < snapshotHeight {
+		snapshotHeight := runningNode.SnapshotInterval
+		if uint64(syncInfo.LatestBlockHeight) < snapshotHeight {
 			s.T().Logf("snapshot height is not reached yet, current (%d), need (%d)", syncInfo.LatestBlockHeight, snapshotHeight)
 			return false
 		}

--- a/tests/e2e/initialization/init.go
+++ b/tests/e2e/initialization/init.go
@@ -36,7 +36,7 @@ func InitChain(id, dataDir string, nodeConfigs []*NodeConfig, votingPeriod time.
 
 	for _, node := range chain.nodes {
 		if node.isValidator {
-			if err := node.initValidatorConfigs(chain, peers); err != nil {
+			if err := node.initNodeConfigs(peers); err != nil {
 				return nil, err
 			}
 		}
@@ -44,7 +44,7 @@ func InitChain(id, dataDir string, nodeConfigs []*NodeConfig, votingPeriod time.
 	return chain.export(), nil
 }
 
-func InitSingleNode(chainId, dataDir string, existingGenesisDir string, nodeConfig *NodeConfig, votingPeriod time.Duration, trustHeight int64, trustHash string, stateSyncRPCServers []string) (*Node, error) {
+func InitSingleNode(chainId, dataDir string, existingGenesisDir string, nodeConfig *NodeConfig, votingPeriod time.Duration, trustHeight int64, trustHash string, stateSyncRPCServers []string, persistentPeers []string) (*Node, error) {
 	if nodeConfig.IsValidator {
 		return nil, errors.New("creating individual validator nodes after starting up chain is not currently supported")
 	}
@@ -64,6 +64,10 @@ func InitSingleNode(chainId, dataDir string, existingGenesisDir string, nodeConf
 		filepath.Join(newNode.configDir(), "config", "genesis.json"),
 	)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := newNode.initNodeConfigs(persistentPeers); err != nil {
 		return nil, err
 	}
 

--- a/tests/e2e/initialization/init_test.go
+++ b/tests/e2e/initialization/init_test.go
@@ -109,7 +109,7 @@ func TestSingleNodeInit(t *testing.T) {
 	existingChain, err := initialization.InitChain(id, dataDir, existingChainNodeConfigs, time.Second*3, forkHeight)
 	require.NoError(t, err)
 
-	actualNode, err := initialization.InitSingleNode(existingChain.ChainMeta.Id, dataDir, filepath.Join(existingChain.Nodes[0].ConfigDir, "config", "genesis.json"), expectedConfig, time.Second*3, 3, "testHash", []string{"some server"})
+	actualNode, err := initialization.InitSingleNode(existingChain.ChainMeta.Id, dataDir, filepath.Join(existingChain.Nodes[0].ConfigDir, "config", "genesis.json"), expectedConfig, time.Second*3, 3, "testHash", []string{"some server"}, []string{"some server"})
 	require.NoError(t, err)
 
 	validateNode(t, id, dataDir, expectedConfig, actualNode)

--- a/tests/e2e/initialization/node.go
+++ b/tests/e2e/initialization/node.go
@@ -101,7 +101,7 @@ func (n *internalNode) buildCreateValidatorMsg(amount sdk.Coin) (sdk.Msg, error)
 
 func (n *internalNode) createConfig() error {
 	p := path.Join(n.configDir(), "config")
-	return os.MkdirAll(p, 0o777)
+	return os.MkdirAll(p, 0o755)
 }
 
 func (n *internalNode) createAppConfig(nodeConfig *NodeConfig) {

--- a/tests/e2e/initialization/node.go
+++ b/tests/e2e/initialization/node.go
@@ -310,7 +310,6 @@ func (n *internalNode) initNodeConfigs(persistentPeers []string) error {
 	valConfig.StateSync.Enable = false
 	valConfig.LogLevel = "info"
 	valConfig.P2P.PersistentPeers = strings.Join(persistentPeers, ",")
-	valConfig.Consensus = tmconfig.TestConsensusConfig()
 
 	tmconfig.WriteConfigFile(tmCfgPath, valConfig)
 	return nil

--- a/tests/e2e/initialization/node.go
+++ b/tests/e2e/initialization/node.go
@@ -289,7 +289,7 @@ func (n *internalNode) createMnemonic() (string, error) {
 	return mnemonic, nil
 }
 
-func (n *internalNode) initValidatorConfigs(c *internalChain, persistentPeers []string) error {
+func (n *internalNode) initNodeConfigs(persistentPeers []string) error {
 	tmCfgPath := filepath.Join(n.configDir(), "config", "config.toml")
 
 	vpr := viper.New()

--- a/tests/e2e/initialization/node.go
+++ b/tests/e2e/initialization/node.go
@@ -101,7 +101,7 @@ func (n *internalNode) buildCreateValidatorMsg(amount sdk.Coin) (sdk.Msg, error)
 
 func (n *internalNode) createConfig() error {
 	p := path.Join(n.configDir(), "config")
-	return os.MkdirAll(p, 0o755)
+	return os.MkdirAll(p, 0o777)
 }
 
 func (n *internalNode) createAppConfig(nodeConfig *NodeConfig) {

--- a/tests/e2e/initialization/node/main.go
+++ b/tests/e2e/initialization/node/main.go
@@ -24,6 +24,8 @@ func main() {
 
 		stateSyncRPCServersStr string
 
+		persistentPeersStr string
+
 		trustHeight int64
 
 		trustHash string
@@ -35,6 +37,7 @@ func main() {
 	flag.StringVar(&nodeConfigStr, "node-config", "", "serialized node config")
 	flag.DurationVar(&votingPeriod, "voting-period", 30000000000, "voting period")
 	flag.StringVar(&stateSyncRPCServersStr, "rpc-servers", "", "state sync RPC servers")
+	flag.StringVar(&persistentPeersStr, "peers", "", "state sync RPC servers")
 	flag.Int64Var(&trustHeight, "trust-height", 0, "trust Height")
 	flag.StringVar(&trustHash, "trust-hash", "", "trust hash")
 
@@ -55,11 +58,16 @@ func main() {
 		panic("rpc-servers is required, separated by commas")
 	}
 
+	persistenrPeers := strings.Split(persistentPeersStr, ",")
+	if len(persistenrPeers) == 0 {
+		panic("persistent peers are required, separated by commas")
+	}
+
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		panic(err)
 	}
 
-	_, err = initialization.InitSingleNode(chainId, dataDir, existingGenesisDir, &nodeConfig, votingPeriod, trustHeight, trustHash, stateSyncRPCServers)
+	_, err = initialization.InitSingleNode(chainId, dataDir, existingGenesisDir, &nodeConfig, votingPeriod, trustHeight, trustHash, stateSyncRPCServers, persistenrPeers)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1879

## What is the purpose of the change

This is a final state sync e2e test MVP. It adds a `TestStateSync` that works independently from any other test.

`TestStateSync` works in the following way:

1.  Initializes configs for a new state-synching node. 
2. It queries trust height and trust hash from a running node.
3. It waits for the running node to produce snapshots at a height greater than trust height.
4. It starts the state-synching node and waits for it to catch up to the running node.
5. Finally, the state synching node is stopped and removed.

Verified that state-sync indeed works by exploring the logs:
```
9:21PM INF Discovered new snapshot format=1 hash="\\W�簮�~P��zm�02z���y[�]\x12�4\x0fM��n" height=25 module=statesync
9:21PM INF VerifyHeader hash=EE38ADA1C660EE1E06E5A7804D782E8C11CD42DCB3AB091CF22C8ED36BABB41C height=126 module=light
9:21PM INF VerifyHeader hash=0040847FD66AA6E8929793626B25CDA90B48BECAC0DE640453986A87CAB924F0 height=127 module=light
9:21PM INF Offering snapshot to ABCI app format=2 hash="\x14� \x05O����~\x05�\x00փM�\x05\x02�i�3����\\��u�" height=125 module=statesync
9:21PM INF Snapshot accepted, restoring format=2 hash="\x14� \x05O����~\x05�\x00փM�\x05\x02�i�3����\\��u�" height=125 module=statesync
9:21PM INF Fetching snapshot chunk chunk=0 format=2 height=125 module=statesync total=1
9:21PM INF VerifyHeader hash=7917722B8F4A448DE73BEEED98048E3BFFF8CEA8E6E67D14CB84C680A2A8567D height=125 module=light
9:21PM INF Header has already been verified hash=EE38ADA1C660EE1E06E5A7804D782E8C11CD42DCB3AB091CF22C8ED36BABB41C height=126 module=light
9:21PM INF Header has already been verified hash=0040847FD66AA6E8929793626B25CDA90B48BECAC0DE640453986A87CAB924F0 height=127 module=light
9:21PM INF Header has already been verified hash=EE38ADA1C660EE1E06E5A7804D782E8C11CD42DCB3AB091CF22C8ED36BABB41C height=126 module=light
9:21PM INF Header has already been verified hash=7917722B8F4A448DE73BEEED98048E3BFFF8CEA8E6E67D14CB84C680A2A8567D height=125 module=light
9:21PM INF Applied snapshot chunk to ABCI app chunk=0 format=2 height=125 module=statesync total=1
9:21PM INF Verified ABCI app appHash="jn!�|�\x16*�zr>\x1eNv�\x03�BK%�>)oq@�Z\x11Ֆ" height=125 module=statesync
9:21PM INF Snapshot restored format=2 hash="\x14� \x05O����~\x05�\x00փM�\x05\x02�i�3����\\��u�" height=125 module=statesync
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable