### PR TITLE
fix: remove suite receiver from IsActive test

### DIFF
--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -1196,7 +1196,7 @@ func TestBalancerPoolPokeTokenWeights(t *testing.T) {
 // This test (currently trivially) checks to make sure that `IsActive` returns true for balancer pools.
 // This is mainly to make sure that if IsActive is ever used as an emergency switch, it is not accidentally left off for any (or all) pools.
 // TODO: create a test with mocks to make sure IsActive works as intended when flipped for specific pools/all pools
-func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
+func TestIsActive(t *testing.T) {
 	tests := map[string]struct {
 		expectedIsActive bool
 	}{
@@ -1207,7 +1207,7 @@ func (suite *BalancerTestSuite) TestIsActive(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := suite.CreateTestContext()
+			ctx := sdk.Context{}
 
 			// Initialize a pool
 			pool, err := balancer.NewBalancerPool(defaultPoolId, defaultBalancerPoolParams, dummyPoolAssets, defaultFutureGovernor, defaultCurBlockTime)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR fixes an issue with the test for `IsActive` in balancer that prevented it from ever actually running.

## Brief Changelog

- Remove use of test suite from `IsActive` test in balancer

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)