### PR TITLE
Speedup mint keeper tests (20x locally)

### DIFF
--- a/x/mint/keeper/genesis_test.go
+++ b/x/mint/keeper/genesis_test.go
@@ -1,11 +1,8 @@
 package keeper_test
 
 import (
-	"testing"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/osmosis-labs/osmosis/v10/osmoutils"
 	"github.com/osmosis-labs/osmosis/v10/x/mint/keeper"
@@ -38,10 +35,6 @@ var customGenesis = types.NewGenesisState(
 		},
 		2), // minting reward distribution start epoch
 	3) // halven started epoch
-
-func TestMintGenesisTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
-}
 
 // TestMintInitGenesis tests that genesis is initialized correctly
 // with different parameters and state.

--- a/x/mint/keeper/grpc_query_test.go
+++ b/x/mint/keeper/grpc_query_test.go
@@ -2,16 +2,9 @@ package keeper_test
 
 import (
 	gocontext "context"
-	"testing"
-
-	"github.com/stretchr/testify/suite"
 
 	"github.com/osmosis-labs/osmosis/v10/x/mint/types"
 )
-
-func TestMintGRPCQueryTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
-}
 
 func (suite *KeeperTestSuite) TestGRPCParams() {
 	_, _, queryClient := suite.App, suite.Ctx, suite.queryClient

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -44,6 +44,9 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.Setup()
 
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
+	params := suite.App.MintKeeper.GetParams(suite.Ctx)
+	params.ReductionPeriodInEpochs = 10
+	suite.App.MintKeeper.SetParams(suite.Ctx, params)
 }
 
 // setupDeveloperVestingModuleAccountTest sets up test cases that utilize developer vesting


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The mint keeper tests had become egregiously slow - 2 minutes in CI, 45 seconds locally.

It now takes 2 seconds locally

This PR does some pretty basic speedups for it:
- Remove every test being ran 4 times (4x speedup)
- Make the default setup parameters have the `reduction period` be 10 epochs, rather than the default (365), lowering amount of iteration. (Estimated rest of speedup)
- Delete unneeded LP incentive setup. (This was doing absolutely nothing, I don't know why it was here)

From this, it also strikes out to me that we have a ways to go in improving these tests further. (A lot of these legacy tests are hard to follow / egregiously slow / not using our suite.app tooling)

## Brief Changelog
 
  - 20x speedup mint keeper tests

## Testing and Verifying

This change is already covered by existing tests, such as *(please describe tests)*.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)