### PR TITLE
Benchmark apptesting setup time

### DIFF
--- a/app/apptesting/bench_test.go
+++ b/app/apptesting/bench_test.go
@@ -1,0 +1,10 @@
+package apptesting
+
+import "testing"
+
+func BenchmarkSetup(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := new(KeeperTestHelper)
+		s.Setup()
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Adds a benchmark for app keeper setup. It currently takes too long, with lots of GC induced. Going to write this in an issue, we should as a backburner task figure out why it creates so much heap and fix it.

## Brief Changelog

- Add benchmark

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
