### PR TITLE
simulator: prevent locking zero tokens

### DIFF
--- a/simulation/simtypes/account.go
+++ b/simulation/simtypes/account.go
@@ -39,6 +39,17 @@ func (sim *SimCtx) RandomSimAccountWithConstraint(f SimAccountConstraint) (simul
 	return sim.randomSimAccount(filteredAddrs), true
 }
 
+func (sim *SimCtx) RandomSimAccountWithMinCoins(ctx sdk.Context, denom string, amount int64) (simulation.Account, error) {
+	accHasMinCoins := func(acc simulation.Account) bool {
+		return sim.BankKeeper().GetBalance(ctx, acc.Address, denom).IsGTE(sdk.NewCoin(denom, sdk.NewInt(amount)))
+	}
+	acc, found := sim.RandomSimAccountWithConstraint(accHasMinCoins)
+	if !found {
+		return simulation.Account{}, errors.New("no address with min balance found.")
+	}
+	return acc, nil
+}
+
 func (sim *SimCtx) RandomExistingAddress() sdk.AccAddress {
 	acc := sim.RandomSimAccount()
 	return acc.Address

--- a/simulation/simtypes/action.go
+++ b/simulation/simtypes/action.go
@@ -102,7 +102,7 @@ func (m msgBasedAction) Execute(sim *SimCtx, ctx sdk.Context) (
 	}
 	err = msg.ValidateBasic()
 	if err != nil {
-		return simulation.NoOpMsg(m.name, m.name, fmt.Sprintf("msg did not pass validation: %v", err)), nil, nil
+		return simulation.NoOpMsg(m.name, m.name, fmt.Sprintf("msg did not pass ValidateBasic: %v", err)), nil, nil
 	}
 	tx, err := sim.txbuilder(ctx, msg, m.name)
 	if err != nil {

--- a/simulation/simtypes/action.go
+++ b/simulation/simtypes/action.go
@@ -100,6 +100,10 @@ func (m msgBasedAction) Execute(sim *SimCtx, ctx sdk.Context) (
 	if err != nil {
 		return simulation.NoOpMsg(m.name, m.name, fmt.Sprintf("unable to build msg due to: %v", err)), nil, nil
 	}
+	err = msg.ValidateBasic()
+	if err != nil {
+		return simulation.NoOpMsg(m.name, m.name, fmt.Sprintf("msg did not pass validation: %v", err)), nil, nil
+	}
 	tx, err := sim.txbuilder(ctx, msg, m.name)
 	if err != nil {
 		return simulation.NoOpMsg(m.name, m.name, fmt.Sprintf("unable to build tx due to: %v", err)), nil, err

--- a/x/lockup/simulation/operations.go
+++ b/x/lockup/simulation/operations.go
@@ -2,6 +2,7 @@ package simulation
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	legacysimulationtype "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -20,6 +21,9 @@ func RandomMsgLockTokens(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context)
 		return nil, err
 	}
 	lockCoin := sim.RandExponentialCoin(ctx, sender.Address)
+	if lockCoin.Amount.LTE(sdk.ZeroInt()) {
+		return &types.MsgLockTokens{}, fmt.Errorf("cannot lock coin that is zero or negative")
+	}
 	duration := simtypes.RandSelect(sim, time.Minute, time.Hour, time.Hour*24)
 	return &types.MsgLockTokens{
 		Owner:    sender.Address.String(),

--- a/x/lockup/simulation/operations.go
+++ b/x/lockup/simulation/operations.go
@@ -2,7 +2,6 @@ package simulation
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	legacysimulationtype "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -21,9 +20,6 @@ func RandomMsgLockTokens(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context)
 		return nil, err
 	}
 	lockCoin := sim.RandExponentialCoin(ctx, sender.Address)
-	if lockCoin.Amount.LTE(sdk.ZeroInt()) {
-		return &types.MsgLockTokens{}, fmt.Errorf("cannot lock coin that is zero or negative")
-	}
 	duration := simtypes.RandSelect(sim, time.Minute, time.Hour, time.Hour*24)
 	return &types.MsgLockTokens{
 		Owner:    sender.Address.String(),

--- a/x/tokenfactory/simulation/sim_msgs.go
+++ b/x/tokenfactory/simulation/sim_msgs.go
@@ -19,7 +19,6 @@ func RandomMsgCreateDenom(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context
 	if !senderExists {
 		return nil, errors.New("no addr has enough to pay for tokenfactory creation fee")
 	}
-	ctx.Logger().Error("acc" + sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").String())
 	return &types.MsgCreateDenom{
 		Sender:   acc.Address.String(),
 		Subdenom: sim.RandStringOfLength(types.MaxSubdenomLength),

--- a/x/tokenfactory/simulation/sim_msgs.go
+++ b/x/tokenfactory/simulation/sim_msgs.go
@@ -15,9 +15,9 @@ import (
 
 // RandomMsgCreateDenom creates a random tokenfactory denom that is no greater than 44 alphanumeric characters
 func RandomMsgCreateDenom(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (*types.MsgCreateDenom, error) {
-	acc, senderExists := sim.RandomSimAccountWithConstraint(accountCanPayTokenCreationFee(k, sim, ctx))
-	if !senderExists {
-		return nil, errors.New("no addr has enough to pay for tokenfactory creation fee")
+	acc, err := sim.RandomSimAccountWithMinCoins(ctx, "stake", 10_000_000)
+	if err != nil {
+		return nil, err
 	}
 	return &types.MsgCreateDenom{
 		Sender:   acc.Address.String(),
@@ -51,12 +51,5 @@ func accountCreatedTokenFactoryDenom(k keeper.Keeper, ctx sdk.Context) simtypes.
 		iterator := store.Iterator(nil, nil)
 		defer iterator.Close()
 		return iterator.Valid()
-	}
-}
-
-func accountCanPayTokenCreationFee(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) simtypes.SimAccountConstraint {
-	return func(acc legacysimulationtype.Account) bool {
-		ctx.Logger().Error("TEST" + sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").String())
-		return sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").IsGTE(sdk.NewCoin("stake", sdk.NewInt(10_000_000)))
 	}
 }

--- a/x/tokenfactory/simulation/sim_msgs.go
+++ b/x/tokenfactory/simulation/sim_msgs.go
@@ -54,8 +54,6 @@ func accountCreatedTokenFactoryDenom(k keeper.Keeper, ctx sdk.Context) simtypes.
 	}
 }
 
-// TODO: We are going to need to index the owner of an account as well, rather than creator
-// to simulate admin changes
 func accountCanPayTokenCreationFee(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) simtypes.SimAccountConstraint {
 	return func(acc legacysimulationtype.Account) bool {
 		ctx.Logger().Error("TEST" + sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").String())

--- a/x/tokenfactory/simulation/sim_msgs.go
+++ b/x/tokenfactory/simulation/sim_msgs.go
@@ -15,8 +15,13 @@ import (
 
 // RandomMsgCreateDenom creates a random tokenfactory denom that is no greater than 44 alphanumeric characters
 func RandomMsgCreateDenom(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (*types.MsgCreateDenom, error) {
+	acc, senderExists := sim.RandomSimAccountWithConstraint(accountCanPayTokenCreationFee(k, sim, ctx))
+	if !senderExists {
+		return nil, errors.New("no addr has enough to pay for tokenfactory creation fee")
+	}
+	ctx.Logger().Error("acc" + sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").String())
 	return &types.MsgCreateDenom{
-		Sender:   sim.RandomSimAccount().Address.String(),
+		Sender:   acc.Address.String(),
 		Subdenom: sim.RandStringOfLength(types.MaxSubdenomLength),
 	}, nil
 }
@@ -47,5 +52,14 @@ func accountCreatedTokenFactoryDenom(k keeper.Keeper, ctx sdk.Context) simtypes.
 		iterator := store.Iterator(nil, nil)
 		defer iterator.Close()
 		return iterator.Valid()
+	}
+}
+
+// TODO: We are going to need to index the owner of an account as well, rather than creator
+// to simulate admin changes
+func accountCanPayTokenCreationFee(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) simtypes.SimAccountConstraint {
+	return func(acc legacysimulationtype.Account) bool {
+		ctx.Logger().Error("TEST" + sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").String())
+		return sim.BankKeeper().GetBalance(ctx, acc.Address, "stake").IsGTE(sdk.NewCoin("stake", sdk.NewInt(10_000_000)))
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Small patch that prevents the simulator from panicking when trying to lock a zero amount token. Also made this prevent negative numbers while I was at it.


## Brief Changelog

- Adds check to RandomMsgLockTokens to prevent locking <= 0 coin amount

## Testing and Verifying

This change is already covered by existing tests


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable