### PR TITLE
simulator: return accs with SpendableCoins

### DIFF
--- a/simulation/simtypes/account.go
+++ b/simulation/simtypes/account.go
@@ -42,14 +42,7 @@ func (sim *SimCtx) RandomSimAccountWithConstraint(f SimAccountConstraint) (simul
 func (sim *SimCtx) RandomSimAccountWithMinCoins(ctx sdk.Context, coins sdk.Coins) (simulation.Account, error) {
 	accHasMinCoins := func(acc simulation.Account) bool {
 		spendableCoins := sim.BankKeeper().SpendableCoins(ctx, acc.Address)
-		for _, minCoin := range coins {
-			for _, spendableCoin := range spendableCoins {
-				if minCoin.Denom == spendableCoin.Denom {
-					return spendableCoin.IsGTE(sdk.NewCoin(minCoin.Denom, minCoin.Amount))
-				}
-			}
-		}
-		return false
+		return spendableCoins.IsAllGTE(coins) && coins.DenomsSubsetOf(spendableCoins)
 	}
 	acc, found := sim.RandomSimAccountWithConstraint(accHasMinCoins)
 	if !found {

--- a/x/gamm/simulation/sim_msgs.go
+++ b/x/gamm/simulation/sim_msgs.go
@@ -34,7 +34,7 @@ func RandomJoinPoolMsg(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (
 	if !senderExists {
 		return &types.MsgJoinPool{}, fmt.Errorf("no sender with denoms %s exists", poolDenoms)
 	}
-	// cap joining pool to double the pool liquidity
+	// cap joining pool to the pool liquidity
 	tokenIn = osmoutils.MinCoins(tokenIn, pool.GetTotalPoolLiquidity(ctx))
 
 	// TODO: Fix API so this is a one liner, pool.CalcJoinPoolNoSwapShares()

--- a/x/tokenfactory/module.go
+++ b/x/tokenfactory/module.go
@@ -189,7 +189,7 @@ func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Valid
 // GenerateGenesisState creates a randomized GenState of the tokenfactory module.
 func (am AppModule) SimulatorGenesisState(simState *module.SimulationState, s *simtypes.SimCtx) {
 	tfDefaultGen := types.DefaultGenesis()
-	tfDefaultGen.Params.DenomCreationFee = sdk.NewCoins(sdk.NewInt64Coin("stake", 10_000_000))
+	tfDefaultGen.Params.DenomCreationFee = simulation.TokenFactoryCreationFee
 	tfDefaultGenJson := simState.Cdc.MustMarshalJSON(tfDefaultGen)
 	simState.GenState[types.ModuleName] = tfDefaultGenJson
 }

--- a/x/tokenfactory/simulation/sim_msgs.go
+++ b/x/tokenfactory/simulation/sim_msgs.go
@@ -15,7 +15,8 @@ import (
 
 // RandomMsgCreateDenom creates a random tokenfactory denom that is no greater than 44 alphanumeric characters
 func RandomMsgCreateDenom(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (*types.MsgCreateDenom, error) {
-	acc, err := sim.RandomSimAccountWithMinCoins(ctx, "stake", 10_000_000)
+	minCoins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(10_000_000)))
+	acc, err := sim.RandomSimAccountWithMinCoins(ctx, minCoins)
 	if err != nil {
 		return nil, err
 	}

--- a/x/tokenfactory/simulation/sim_msgs.go
+++ b/x/tokenfactory/simulation/sim_msgs.go
@@ -13,9 +13,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+var (
+	TokenFactoryCreationFee = sdk.NewCoins(sdk.NewInt64Coin("stake", 10_000_000))
+)
+
 // RandomMsgCreateDenom creates a random tokenfactory denom that is no greater than 44 alphanumeric characters
 func RandomMsgCreateDenom(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (*types.MsgCreateDenom, error) {
-	minCoins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(10_000_000)))
+	minCoins := TokenFactoryCreationFee
 	acc, err := sim.RandomSimAccountWithMinCoins(ctx, minCoins)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

There are two purposes of this PR:

1. Change RandomSimAccountWithMinCoins to accept sdk.Coins type as requested [here](https://github.com/osmosis-labs/osmosis/pull/2172#discussion_r926255240) 
2. Have SelAddrWithDenoms, RandomSimAccountWithMinCoins, and RandCoinSubset all return SpendableCoins rather than Coins (this was leading to various issues in the simulator).

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable