### PR TITLE
simulator: create an ActionWithMetadata struct

### DIFF
--- a/simulation/executor/simulate.go
+++ b/simulation/executor/simulate.go
@@ -58,7 +58,7 @@ func SimulateFromSeed(
 	w io.Writer,
 	app simtypes.App,
 	initFunctions simtypes.InitFunctions,
-	actions []simtypes.Action,
+	actions []simtypes.ActionsWithMetadata,
 	config simulation.Config,
 ) (stopEarly bool, err error) {
 	// in case we have to end early, don't os.Exit so that we can run cleanup code.
@@ -205,7 +205,7 @@ type blockSimFn func(simCtx *simtypes.SimCtx, ctx sdk.Context, header tmproto.He
 
 // Returns a function to simulate blocks. Written like this to avoid constant
 // parameters being passed everytime, to minimize memory overhead.
-func createBlockSimulator(testingMode bool, w io.Writer, params Params, actions []simtypes.Action,
+func createBlockSimulator(testingMode bool, w io.Writer, params Params, actions []simtypes.ActionsWithMetadata,
 	simState *simState, config simulation.Config,
 ) blockSimFn {
 	lastBlockSizeState := 0 // state for [4 * uniform distribution]

--- a/simulation/executor/simulate.go
+++ b/simulation/executor/simulate.go
@@ -233,6 +233,7 @@ func createBlockSimulator(testingMode bool, w io.Writer, params Params, actions 
 			// Select and execute tx
 			action := selectAction(actionSimCtx.GetSeededRand("action select"))
 			opMsg, futureOps, err := action.Execute(actionSimCtx, ctx)
+			opMsg.Route = action.ModuleName
 			cleanup()
 
 			simState.logActionResult(header, i, config, blocksize, opMsg, err)

--- a/simulation/simtypes/action.go
+++ b/simulation/simtypes/action.go
@@ -26,7 +26,7 @@ type Action interface {
 	WithFrequency(w Frequency) Action
 }
 
-type selectActionFn func(r *rand.Rand) Action
+type selectActionFn func(r *rand.Rand) ActionsWithMetadata
 
 type weightedOperationAction struct {
 	moduleName string
@@ -123,7 +123,7 @@ func totalFrequency(actions []ActionsWithMetadata) int {
 func GetSelectActionFn(actions []ActionsWithMetadata) selectActionFn {
 	totalOpFrequency := totalFrequency(actions)
 
-	return func(r *rand.Rand) Action {
+	return func(r *rand.Rand) ActionsWithMetadata {
 		x := r.Intn(totalOpFrequency)
 		// TODO: Change to an accum list approach
 		for i := 0; i < len(actions); i++ {

--- a/simulation/simtypes/action.go
+++ b/simulation/simtypes/action.go
@@ -111,7 +111,7 @@ func (m msgBasedAction) Execute(sim *SimCtx, ctx sdk.Context) (
 	return sim.deliverTx(tx, msg, m.name)
 }
 
-func totalFrequency(actions []Action) int {
+func totalFrequency(actions []ActionsWithMetadata) int {
 	totalFrequency := 0
 	for _, action := range actions {
 		totalFrequency += mapFrequencyFromString(action.Frequency())
@@ -120,7 +120,7 @@ func totalFrequency(actions []Action) int {
 	return totalFrequency
 }
 
-func GetSelectActionFn(actions []Action) selectActionFn {
+func GetSelectActionFn(actions []ActionsWithMetadata) selectActionFn {
 	totalOpFrequency := totalFrequency(actions)
 
 	return func(r *rand.Rand) Action {

--- a/simulation/simtypes/manager.go
+++ b/simulation/simtypes/manager.go
@@ -29,6 +29,15 @@ type AppModuleSimulationGenesis interface {
 	SimulatorGenesisState(*module.SimulationState, *SimCtx)
 }
 
+type SimulatorManagerI interface {
+	Actions() []ActionsWithMetadata
+}
+
+type ActionsWithMetadata struct {
+	Action
+	moduleName string
+}
+
 // SimulationManager defines a simulation manager that provides the high level utility
 // for managing and executing simulation functionalities for a group of modules
 type Manager struct {
@@ -80,11 +89,10 @@ func loadAppParamsForWasm(path string) simulation.AppParams {
 	return appParams
 }
 
-func (m Manager) legacyActions(seed int64, cdc codec.JSONCodec) []Action {
+func (m Manager) legacyActions(seed int64, cdc codec.JSONCodec) []ActionsWithMetadata {
 	// We do not support the legacy simulator config format, and just (unfortunately)
 	// hardcode this one filepath for wasm.
 	// TODO: Clean this up / make a better plan
-
 	simState := module.SimulationState{
 		AppParams:    loadAppParamsForWasm("params.json"),
 		ParamChanges: []simulation.ParamChange{},
@@ -101,23 +109,33 @@ func (m Manager) legacyActions(seed int64, cdc codec.JSONCodec) []Action {
 		}
 	}
 	// second pass generate actions
-	actions := []Action{}
+	actions := []ActionsWithMetadata{}
 	for _, moduleName := range m.moduleManager.OrderInitGenesis {
 		if simModule, ok := m.legacyModules[moduleName]; ok {
 			weightedOps := simModule.WeightedOperations(simState)
-			actions = append(actions, actionsFromWeightedOperations(moduleName, weightedOps)...)
+			for _, action := range actionsFromWeightedOperations(moduleName, weightedOps) {
+				var actionWithMetaData ActionsWithMetadata
+				actionWithMetaData.Action = action
+				actionWithMetaData.moduleName = moduleName
+				actions = append(actions, actionWithMetaData)
+			}
 		}
 	}
 	return actions
 }
 
 // TODO: Can we use sim here instead? Perhaps by passing in the simulation module manager to the simulator.
-func (m Manager) Actions(seed int64, cdc codec.JSONCodec) []Action {
+func (m Manager) Actions(seed int64, cdc codec.JSONCodec) []ActionsWithMetadata {
 	actions := m.legacyActions(seed, cdc)
 	moduleKeys := maps.Keys(m.Modules)
 	osmoutils.SortSlice(moduleKeys)
 	for _, simModuleName := range moduleKeys {
-		actions = append(actions, m.Modules[simModuleName].Actions()...)
+		for _, action := range m.Modules[simModuleName].Actions() {
+			var actionWithMetaData ActionsWithMetadata
+			actionWithMetaData.Action = action
+			actionWithMetaData.moduleName = simModuleName
+			actions = append(actions, actionWithMetaData)
+		}
 	}
 	return actions
 }

--- a/simulation/simtypes/manager.go
+++ b/simulation/simtypes/manager.go
@@ -35,7 +35,7 @@ type SimulatorManagerI interface {
 
 type ActionsWithMetadata struct {
 	Action
-	moduleName string
+	ModuleName string
 }
 
 // SimulationManager defines a simulation manager that provides the high level utility
@@ -116,7 +116,7 @@ func (m Manager) legacyActions(seed int64, cdc codec.JSONCodec) []ActionsWithMet
 			for _, action := range actionsFromWeightedOperations(moduleName, weightedOps) {
 				var actionWithMetaData ActionsWithMetadata
 				actionWithMetaData.Action = action
-				actionWithMetaData.moduleName = moduleName
+				actionWithMetaData.ModuleName = moduleName
 				actions = append(actions, actionWithMetaData)
 			}
 		}
@@ -133,7 +133,7 @@ func (m Manager) Actions(seed int64, cdc codec.JSONCodec) []ActionsWithMetadata 
 		for _, action := range m.Modules[simModuleName].Actions() {
 			var actionWithMetaData ActionsWithMetadata
 			actionWithMetaData.Action = action
-			actionWithMetaData.moduleName = simModuleName
+			actionWithMetaData.ModuleName = simModuleName
 			actions = append(actions, actionWithMetaData)
 		}
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2131

## What is the purpose of the change

Creates a struct that exports the module name of an Action. In the future, we can use this to export other various metadata from each action!


## Brief Changelog

- [x] SimulationManager interface made
- [x] ActionsWithMetadata written
  - [x] Struct exists
  - [x] SimualtionManager adds to struct
- [x] Simulator arguments work
- [x] SimulateFromSeed arguments changed
- [x] Logging updated, to just edit OpMsg.Route as the modulename


## Testing and Verifying

Tested locally, the output of each action now filters itself properly to its respective module!

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable