### PR TITLE
[CI] Mutation testing: Automated github action to generate issue

### DIFF
--- a/.github/workflows/mutest-issue-generate.yml
+++ b/.github/workflows/mutest-issue-generate.yml
@@ -1,0 +1,45 @@
+name: Generate Mutation Test Errors 
+
+on:
+  schedule:
+    - cron: '0 13 * * 1' # Every Monday at 1PM UTC (9AM EST)
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: checkout repo
+        uses: actions/checkout@v2
+      -
+        name: Run mutation test
+        continue-on-error: true
+        run: make test-mutation
+      -
+        name: Execute mutation test format script
+        id: mutest-formatted
+        run: |
+          cat mutation_test_result.txt | grep -Ev "PASS" | grep -Ev "SKIP" | tee mutation_test_result.txt
+      -
+        name: Generate code blocks 
+        id: gen-code-blocks
+        run: |
+          cat mutation_test_result.txt  | sed "s# @@# @@\n\`\`\`go\n#g " | sed "s#FAIL#\`\`\`\nFAIL\n\n\n#g " > mutation_test_result.txt 
+      -
+        name: Get today's date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date "+%Y/%m/%d")" 
+      - 
+        name: Read mutation_test_result file
+        id: result
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: mutation_test_result.txt
+      -
+        name: Create an issue
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Mutation test ${{ steps.date.outputs.today }}
+          body: ${{steps.result.outputs.content}}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2114

## What is the purpose of the change

1. Make github action that runs once per week
2. It runs make test-mutation
3. Takes mutation_test_result.txt, and creates a github issue. (with some formatting. Perhaps only parse out failures, and split them up with a number and separate code block)

## Brief Changelog
n/a

## Testing and Verifying
Untested because need `secrets.ADD_TO_PROJECT_PAT` access

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)