### PR TITLE
feat: speedup epoch distribution, superfluid component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v10.1.1
+#### Improvements
+* [#2213](https://github.com/osmosis-labs/osmosis/pull/2213) Speedup epoch distribution, superfluid component
+
 ## v10.1.0
 
 #### Bug Fixes

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -227,20 +227,38 @@ func (k Keeper) doDistributionSends(ctx sdk.Context, distrs *distributionInfo) e
 func (k Keeper) distributeSyntheticInternal(
 	ctx sdk.Context, gauge types.Gauge, locks []lockuptypes.PeriodLock, distrInfo *distributionInfo,
 ) (sdk.Coins, error) {
-	denom := gauge.DistributeTo.Denom
+	qualifiedLocks := k.lk.GetLocksLongerThanDurationDenom(ctx, gauge.DistributeTo.Denom, gauge.DistributeTo.Duration)
 
-	qualifiedLocks := make([]lockuptypes.PeriodLock, 0, len(locks))
+	// map from lockID to present index in resultant list
+	// to be state compatible with what we had before, we iterate over locks, to get qualified locks
+	// to be in the same order as what is present in locks.
+	// in a future release, we can just use qualified locks directly.
+	type lockIndexPair struct {
+		lock  lockuptypes.PeriodLock
+		index int
+	}
+	qualifiedLocksMap := make(map[uint64]lockIndexPair, len(qualifiedLocks))
+	for _, lock := range qualifiedLocks {
+		qualifiedLocksMap[lock.ID] = lockIndexPair{lock, -1}
+	}
+	curIndex := 0
 	for _, lock := range locks {
-		// See if this lock has a synthetic lockup. If so, err == nil, and we add to qualifiedLocks
-		// otherwise it does not, and we continue.
-		_, err := k.lk.GetSyntheticLockup(ctx, lock.ID, denom)
-		if err != nil {
-			continue
+		if v, ok := qualifiedLocksMap[lock.ID]; ok {
+			qualifiedLocksMap[lock.ID] = lockIndexPair{v.lock, curIndex}
+			curIndex += 1
 		}
-		qualifiedLocks = append(qualifiedLocks, lock)
 	}
 
-	return k.distributeInternal(ctx, gauge, qualifiedLocks, distrInfo)
+	sortedAndTrimmedQualifiedLocks := make([]lockuptypes.PeriodLock, curIndex, curIndex)
+	for _, v := range qualifiedLocksMap {
+		if v.index < 0 {
+			continue
+		}
+		sortedAndTrimmedQualifiedLocks[v.index] = v.lock
+	}
+
+	return k.distributeInternal(ctx, gauge, sortedAndTrimmedQualifiedLocks, distrInfo)
+
 }
 
 // distributeInternal runs the distribution logic for a gauge, and adds the sends to

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -258,7 +258,6 @@ func (k Keeper) distributeSyntheticInternal(
 	}
 
 	return k.distributeInternal(ctx, gauge, sortedAndTrimmedQualifiedLocks, distrInfo)
-
 }
 
 // distributeInternal runs the distribution logic for a gauge, and adds the sends to


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This change is Devs work. He was able to speedup epoch in a state compatible manner. We decided to include this fix and tag it as v10.1.1.


## Brief Changelog

- Utilize GetLocksLongerThanDurationDenom to get qualified lock list. Resulting list is less to iterate over.

## Testing and Verifying

This test ran through our new v10 state compatibility epoch check and passed.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)