### PR TITLE
chore(upgrade): move v11 upgrade handler to v12, no-op for v11

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -86,3 +86,11 @@ pull_request_rules:
       backport:
         branches:
           - v10.x
+  - name: backport patches to v11.x branch
+    conditions:
+      - base=main
+      - label=A:backport/v11.x
+    actions:
+      backport:
+        branches:
+          - v11.x

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ test-sim:
 	@VERSION=$(VERSION) go test -mod=readonly $(PACKAGES_SIM)
 
 test-e2e:
-	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v11" go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 test-e2e-skip-upgrade:
 	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)

--- a/app/app.go
+++ b/app/app.go
@@ -44,6 +44,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
 	v10 "github.com/osmosis-labs/osmosis/v10/app/upgrades/v10"
 	v11 "github.com/osmosis-labs/osmosis/v10/app/upgrades/v11"
+	v12 "github.com/osmosis-labs/osmosis/v10/app/upgrades/v12"
 	v3 "github.com/osmosis-labs/osmosis/v10/app/upgrades/v3"
 	v4 "github.com/osmosis-labs/osmosis/v10/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/v10/app/upgrades/v5"
@@ -89,7 +90,7 @@ var (
 
 	// _ sdksimapp.App = (*OsmosisApp)(nil)
 
-	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade}
+	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade}
 	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork, v10.Fork}
 )
 

--- a/app/upgrades/v11/constants.go
+++ b/app/upgrades/v11/constants.go
@@ -2,19 +2,12 @@ package v11
 
 import (
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
-	twaptypes "github.com/osmosis-labs/osmosis/v10/x/gamm/twap/types"
-
-	store "github.com/cosmos/cosmos-sdk/store/types"
 )
 
-// UpgradeName defines the on-chain upgrade name for the Osmosis v9 upgrade.
+// UpgradeName defines the on-chain upgrade name for the Osmosis v11 upgrade.
 const UpgradeName = "v11"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
-	StoreUpgrades: store.StoreUpgrades{
-		Added:   []string{twaptypes.StoreKey},
-		Deleted: []string{}, // double check bech32ibc
-	},
 }

--- a/app/upgrades/v11/constants.go
+++ b/app/upgrades/v11/constants.go
@@ -1,6 +1,8 @@
 package v11
 
 import (
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
 )
 
@@ -10,4 +12,5 @@ const UpgradeName = "v11"
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -9,10 +9,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
 )
 
-// We set the app version to pre-upgrade because it will be incremented by one
-// after the upgrade is applied by the handler.
-const preUpgradeAppVersion = 10
-
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
@@ -20,25 +16,6 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Although the app version was already set during the v9 upgrade, our v10 was a fork.
-		// As a result, the upgrade handler was not executed to increment the app version.
-		// This change helps to correctly set the app version for v11.
-		if err := keepers.UpgradeKeeper.SetAppVersion(ctx, preUpgradeAppVersion); err != nil {
-			return nil, err
-		}
-
-		// Set the max_age_num_blocks in the evidence params to reflect the 14 day
-		// unbonding period.
-		//
-		// Ref: https://github.com/osmosis-labs/osmosis/issues/1160
-		cp := bpm.GetConsensusParams(ctx)
-		if cp != nil && cp.Evidence != nil {
-			evParams := cp.Evidence
-			evParams.MaxAgeNumBlocks = 186_092
-
-			bpm.StoreConsensusParams(ctx, cp)
-		}
-
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -16,6 +16,6 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		return vm, nil
+		return mm.RunMigrations(ctx, configurator, vm)
 	}
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -15,7 +15,7 @@ func CreateUpgradeHandler(
 	bpm upgrades.BaseAppParamManager,
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
-	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return mm.RunMigrations(ctx, configurator, fromVM)
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return vm, nil
 	}
 }

--- a/app/upgrades/v12/constants.go
+++ b/app/upgrades/v12/constants.go
@@ -1,0 +1,20 @@
+package v12
+
+import (
+	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
+	twaptypes "github.com/osmosis-labs/osmosis/v10/x/gamm/twap/types"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v12 upgrade.
+const UpgradeName = "v12"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{twaptypes.StoreKey},
+		Deleted: []string{}, // double check bech32ibc
+	},
+}

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -21,7 +21,7 @@ func CreateUpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		// Although the app version was already set during the v9 upgrade, our v10 was a fork and
-		// v11 was decided to be limiteg to the "gauge creation minimum fee" change only:
+		// v11 was decided to be limited to the "gauge creation minimum fee" change only:
 		// https://github.com/osmosis-labs/osmosis/pull/2202
 		//
 		// As a result, the upgrade handler was not executed to increment the app version.

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -1,0 +1,47 @@
+package v12
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v10/app/keepers"
+	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
+)
+
+// We set the app version to pre-upgrade because it will be incremented by one
+// after the upgrade is applied by the handler.
+const preUpgradeAppVersion = 11
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bpm upgrades.BaseAppParamManager,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Although the app version was already set during the v9 upgrade, our v10 was a fork and
+		// v11 was decided to be limiteg to the "gauge creation minimum fee" change only:
+		// https://github.com/osmosis-labs/osmosis/pull/2202
+		//
+		// As a result, the upgrade handler was not executed to increment the app version.
+		// This change helps to correctly set the app version for v12.
+		if err := keepers.UpgradeKeeper.SetAppVersion(ctx, preUpgradeAppVersion); err != nil {
+			return nil, err
+		}
+
+		// Set the max_age_num_blocks in the evidence params to reflect the 14 day
+		// unbonding period.
+		//
+		// Ref: https://github.com/osmosis-labs/osmosis/issues/1160
+		cp := bpm.GetConsensusParams(ctx)
+		if cp != nil && cp.Evidence != nil {
+			evParams := cp.Evidence
+			evParams.MaxAgeNumBlocks = 186_092
+
+			bpm.StoreConsensusParams(ctx, cp)
+		}
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Moves v11 upgrade handler to v12, making v11 upgrade a no-op. This is done so that v11 upgrade is limited to the following change only:
https://github.com/osmosis-labs/osmosis/pull/2202

The limitation is done because v11 upgrade is expedited to mitigate the impact of gauge creation spam.

This also updated the mergify configuration to enable backports to the v11.x branch.

## Testing and Verifying

This change is covered by e2e upgrade tests here: #2217

The e2e upgrade test is failing in this PR because our `main` uses an updated sdk fork. Since we are now moving the upgrade handler logic to v12, to properly test v11 upgrade it needs to use SDK fork from `v10.x`

##217 PR is made to ensure that the upgrade logic for v11 is sound. E2E CI on main should be fixed separately by reconfiguring e2e to now upgrade to v12 instead

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable