### PR TITLE
DO NOT MERGE: e2e upgrade test for v11

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -86,3 +86,11 @@ pull_request_rules:
       backport:
         branches:
           - v10.x
+  - name: backport patches to v11.x branch
+    conditions:
+      - base=main
+      - label=A:backport/v11.x
+    actions:
+      backport:
+        branches:
+          - v11.x

--- a/app/upgrades/v11/constants.go
+++ b/app/upgrades/v11/constants.go
@@ -2,19 +2,12 @@ package v11
 
 import (
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
-	twaptypes "github.com/osmosis-labs/osmosis/v10/x/gamm/twap/types"
-
-	store "github.com/cosmos/cosmos-sdk/store/types"
 )
 
-// UpgradeName defines the on-chain upgrade name for the Osmosis v9 upgrade.
+// UpgradeName defines the on-chain upgrade name for the Osmosis v11 upgrade.
 const UpgradeName = "v11"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
-	StoreUpgrades: store.StoreUpgrades{
-		Added:   []string{twaptypes.StoreKey},
-		Deleted: []string{}, // double check bech32ibc
-	},
 }

--- a/app/upgrades/v11/constants.go
+++ b/app/upgrades/v11/constants.go
@@ -1,6 +1,8 @@
 package v11
 
 import (
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
 )
 
@@ -10,4 +12,5 @@ const UpgradeName = "v11"
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -9,10 +9,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
 )
 
-// We set the app version to pre-upgrade because it will be incremented by one
-// after the upgrade is applied by the handler.
-const preUpgradeAppVersion = 10
-
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
@@ -20,25 +16,6 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Although the app version was already set during the v9 upgrade, our v10 was a fork.
-		// As a result, the upgrade handler was not executed to increment the app version.
-		// This change helps to correctly set the app version for v11.
-		if err := keepers.UpgradeKeeper.SetAppVersion(ctx, preUpgradeAppVersion); err != nil {
-			return nil, err
-		}
-
-		// Set the max_age_num_blocks in the evidence params to reflect the 14 day
-		// unbonding period.
-		//
-		// Ref: https://github.com/osmosis-labs/osmosis/issues/1160
-		cp := bpm.GetConsensusParams(ctx)
-		if cp != nil && cp.Evidence != nil {
-			evParams := cp.Evidence
-			evParams.MaxAgeNumBlocks = 186_092
-
-			bpm.StoreConsensusParams(ctx, cp)
-		}
-
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -15,7 +15,7 @@ func CreateUpgradeHandler(
 	bpm upgrades.BaseAppParamManager,
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
-	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return mm.RunMigrations(ctx, configurator, fromVM)
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return vm, nil
 	}
 }

--- a/app/upgrades/v12/constants.go
+++ b/app/upgrades/v12/constants.go
@@ -1,0 +1,20 @@
+package v12
+
+import (
+	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
+	twaptypes "github.com/osmosis-labs/osmosis/v10/x/gamm/twap/types"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v12 upgrade.
+const UpgradeName = "v12"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{twaptypes.StoreKey},
+		Deleted: []string{}, // double check bech32ibc
+	},
+}

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -1,0 +1,47 @@
+package v12
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v10/app/keepers"
+	"github.com/osmosis-labs/osmosis/v10/app/upgrades"
+)
+
+// We set the app version to pre-upgrade because it will be incremented by one
+// after the upgrade is applied by the handler.
+const preUpgradeAppVersion = 11
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bpm upgrades.BaseAppParamManager,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Although the app version was already set during the v9 upgrade, our v10 was a fork and
+		// v11 was decided to be limiteg to the "gauge creation minimum fee" change only:
+		// https://github.com/osmosis-labs/osmosis/pull/2202
+		//
+		// As a result, the upgrade handler was not executed to increment the app version.
+		// This change helps to correctly set the app version for v12.
+		if err := keepers.UpgradeKeeper.SetAppVersion(ctx, preUpgradeAppVersion); err != nil {
+			return nil, err
+		}
+
+		// Set the max_age_num_blocks in the evidence params to reflect the 14 day
+		// unbonding period.
+		//
+		// Ref: https://github.com/osmosis-labs/osmosis/issues/1160
+		cp := bpm.GetConsensusParams(ctx)
+		if cp != nil && cp.Evidence != nil {
+			evParams := cp.Evidence
+			evParams.MaxAgeNumBlocks = 186_092
+
+			bpm.StoreConsensusParams(ctx, cp)
+		}
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ replace (
 	// branch: v0.27.0.rc3-osmo, current tag: v0.27.0.rc3-osmo
 	github.com/CosmWasm/wasmd => github.com/osmosis-labs/wasmd v0.27.0-rc2.0.20220517191021-59051aa18d58
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current tag: v0.45.0x-osmo-v11-alpha.2, current branch: osmosis-main
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220721082708-0aca1df58871
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220709005907-f37e34d99505
 	// Use Osmosis fast iavl
 	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v7
 	// use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -1042,8 +1042,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.9.1 h1:v4dkG+dlu76goxMiTT2j8zV7s4oPPEppKT8K8p2f1kY=
 github.com/ory/dockertest/v3 v3.9.1/go.mod h1:42Ir9hmvaAPm0Mgibk6mBPi7SFvTXxEcnztDYOJ//uM=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220721082708-0aca1df58871 h1:VkQCYrUg8xpUOoDRP7pBcQi8ceqvxC75SBkDAKFFh3g=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220721082708-0aca1df58871/go.mod h1:uUkGXyCWol+CHoaMxZA0nKglvlN5uHBCMbMSsZoGSAs=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220709005907-f37e34d99505 h1:vrTGp5Yty0U3X4718KaZLhdznEeAs6010LEFpJH+z1k=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220709005907-f37e34d99505/go.mod h1:pMiEr6WR7drhXAXK1FOdAKPazWCi7b+WOyWOF4O0OXY=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7 h1:6KcADC/WhL7yDmNQxUIJt2XmzNt4FfRmq9gRke45w74=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7/go.mod h1:lJEOIlsd3sVO0JDyXWIXa9/Ur5FBscP26zJx0KxHjto=
 github.com/osmosis-labs/wasmd v0.27.0-rc2.0.20220517191021-59051aa18d58 h1:15l3Iss2oCGCeJRi2g3CuCnqmEjpAr3Le7cDnoN/LS0=

--- a/wasmbinding/test/custom_query_test.go
+++ b/wasmbinding/test/custom_query_test.go
@@ -308,7 +308,7 @@ func storeReflectCode(t *testing.T, ctx sdk.Context, osmosis *app.OsmosisApp, ad
 	})
 
 	// when stored
-	storedProposal, err := govKeeper.SubmitProposal(ctx, src, false)
+	storedProposal, err := govKeeper.SubmitProposal(ctx, src)
 	require.NoError(t, err)
 
 	// and proposal execute

--- a/wasmbinding/test/store_run_test.go
+++ b/wasmbinding/test/store_run_test.go
@@ -44,7 +44,7 @@ func storeCodeViaProposal(t *testing.T, ctx sdk.Context, osmosis *app.OsmosisApp
 	})
 
 	// when stored
-	storedProposal, err := govKeeper.SubmitProposal(ctx, src, false)
+	storedProposal, err := govKeeper.SubmitProposal(ctx, src)
 	require.NoError(t, err)
 
 	// and proposal execute


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

e2e test in the original upgrade handler change https://github.com/osmosis-labs/osmosis/pull/2216 is failing.

This is because our main uses updated sdk fork. Since we are now moving the upgrade handler logic to v12, to properly test v11 upgrade it needs to use SDK fork from `v10.x`

This PR is made to test that. E2E CI on main should be fixed separately by reconfiguring e2e to now upgrade to v12 instead

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)