### PR TITLE
set epoch time KeeperTestHelper

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -48,7 +48,19 @@ func (s *KeeperTestHelper) Setup() {
 		Ctx:             s.Ctx,
 	}
 
+	s.SetEpochStartTime()
 	s.TestAccs = CreateRandomAccounts(3)
+}
+
+func (s *KeeperTestHelper) SetEpochStartTime() {
+	epochsKeeper := s.App.EpochsKeeper
+
+	for _, epoch := range epochsKeeper.AllEpochInfos(s.Ctx) {
+		epoch.StartTime = s.Ctx.BlockTime()
+		epochsKeeper.DeleteEpochInfo(s.Ctx, epoch.Identifier)
+		err := epochsKeeper.AddEpochInfo(s.Ctx, epoch)
+		s.Require().NoError(err)
+	}
 }
 
 // CreateTestContext creates a test context.
@@ -150,7 +162,7 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(executeNextEpoch bool, prop
 	epoch := s.App.EpochsKeeper.GetEpochInfo(s.Ctx, epochIdentifier)
 	newBlockTime := s.Ctx.BlockTime().Add(5 * time.Second)
 	if executeNextEpoch {
-		endEpochTime := epoch.CurrentEpochStartTime.Add(epoch.Duration)
+		endEpochTime := epoch.StartTime.Add(epoch.Duration)
 		newBlockTime = endEpochTime.Add(time.Second)
 	}
 

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -162,8 +162,7 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(executeNextEpoch bool, prop
 	epoch := s.App.EpochsKeeper.GetEpochInfo(s.Ctx, epochIdentifier)
 	newBlockTime := s.Ctx.BlockTime().Add(5 * time.Second)
 	if executeNextEpoch {
-		endEpochTime := epoch.StartTime.Add(epoch.Duration)
-		newBlockTime = endEpochTime.Add(time.Second)
+		newBlockTime = s.Ctx.BlockTime().Add(epoch.Duration).Add(time.Second)
 	}
 
 	header := tmtypes.Header{Height: s.Ctx.BlockHeight() + 1, Time: newBlockTime}

--- a/x/epochs/keeper/grpc_query_test.go
+++ b/x/epochs/keeper/grpc_query_test.go
@@ -15,5 +15,10 @@ func (suite *KeeperTestSuite) TestQueryEpochInfos() {
 	suite.Require().NoError(err)
 	suite.Require().Len(epochInfosResponse.Epochs, 3)
 	expectedEpochs := types.DefaultGenesis().Epochs
+	for id := range expectedEpochs {
+		expectedEpochs[id].StartTime = suite.Ctx.BlockTime()
+		expectedEpochs[id].CurrentEpochStartHeight = suite.Ctx.BlockHeight()
+	}
+
 	suite.Require().Equal(expectedEpochs, epochInfosResponse.Epochs)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2241

## What is the purpose of the change

- set epoch time KeeperTestHelper 


## Brief Changelog

- set epoch time in `KeeperTestHelper` to be time.Now()
- fix `BeginNewBlock` issue with executeNextEpoch = true

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes?  no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?  no
  - How is the feature or change documented?   not documented