### PR TITLE
Try to speedup dockerfile build time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests & Code Coverage
 
 on:
   pull_request:
@@ -59,9 +59,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
-          key: ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
       -
         name: Run all tests
         run: make test-unit
@@ -100,11 +100,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
-            /tmp/.buildx-cache
-            /var/lib/docker/buildkit
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-docker-
+            ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,9 +103,10 @@ jobs:
             ~\AppData\Local\go-build
             /tmp/.buildx-cache
             /var/lib/docker/buildkit
-          key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-docker-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
+            ${{ runner.os }}-docker-${{ hashFiles('**/go.sum') }}
+            ${{ runner.os }}-docker-
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,6 @@ jobs:
           build-args: |
             BASE_IMG_TAG=debug
       -
-        name: Test e2e and Upgrade
-        run: make test-e2e
-      -
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
@@ -133,3 +130,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      -
+        name: Test e2e and Upgrade
+        run: make test-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,20 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - 
+        name: Enable buildkit cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildkit-cache/buildkit-state.tar
+          key: ${{ runner.os }}-buildkit-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-
+      - name: Load buildkit state from cache
+        uses: dashevo/gh-action-cache-buildkit-state@v1
+        with:
+          builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
+          cache-path: /tmp/buildkit-cache
+          cache-max-size: 2g
       -
         name: Build e2e image
         uses: docker/build-push-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,20 @@ jobs:
           load: true
           context: .
           tags: osmosis:debug
+          # Use experimental Cache backend API: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,src=/tmp/.buildx-cache,mode=max
+          cache-to: type=local,src=/tmp/.buildx-cache-new,mode=max
           build-args: |
             BASE_IMG_TAG=debug
       -
         name: Test e2e and Upgrade
         run: make test-e2e
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
             /tmp/.buildx-cache
+            /var/lib/docker/buildkit
           key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
@@ -113,20 +114,6 @@ jobs:
         with:
           install: true
           driver-opts: image=moby/buildkit:buildx-stable-1
-      - 
-        name: Enable buildkit cache
-        uses: actions/cache@v2
-        with:
-          path: /tmp/buildkit-cache/buildkit-state.tar
-          key: ${{ runner.os }}-buildkit-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildkit-
-      - name: Load buildkit state from cache
-        uses: dashevo/gh-action-cache-buildkit-state@v1
-        with:
-          builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
-          cache-path: /tmp/buildkit-cache
-          cache-max-size: 2g
       -
         name: Build e2e image
         uses: docker/build-push-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          driver-opts: image=moby/buildkit:buildx-stable-1
       - 
         name: Enable buildkit cache
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests & Code Coverage
+name: Tests
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ jobs:
         name: Skipping test
         run: echo Should I skip tests? ${{ steps.skip_check.outputs.should_skip }}
 
-  go_test:
+  go:
     needs: should_run_go_test
     if: ${{ needs.should_run_test.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
@@ -66,7 +66,7 @@ jobs:
         name: Run all tests
         run: make test-unit
   
-  e2e_test:
+  e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
+            /tmp/.buildx-cache
           key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
@@ -116,9 +117,8 @@ jobs:
           load: true
           context: .
           tags: osmosis:debug
-          # Use experimental Cache backend API: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,src=/tmp/.buildx-cache,mode=max
           build-args: |
             BASE_IMG_TAG=debug
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,10 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}-
+            ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+            ${{ runner.os }}-
       -
         name: Run all tests
         run: make test-unit
@@ -119,8 +120,8 @@ jobs:
           context: .
           tags: osmosis:debug
           # Use experimental Cache backend API: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests & Code Coverage
+name: Tests
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-
       -
         name: Run all tests
@@ -105,7 +104,6 @@ jobs:
             /var/lib/docker/buildkit
           key: ${{ runner.os }}-docker-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-docker-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-docker-
       -
         name: Set up QEMU
@@ -125,14 +123,6 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       -
         name: Test e2e and Upgrade
         run: make test-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,13 +119,12 @@ jobs:
           tags: osmosis:debug
           # Use experimental Cache backend API: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,src=/tmp/.buildx-cache-new,mode=max
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           build-args: |
             BASE_IMG_TAG=debug
       -
         name: Test e2e and Upgrade
         run: make test-e2e
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       -
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,9 +111,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          install: true
-          driver-opts: image=moby/buildkit:buildx-stable-1
       -
         name: Build e2e image
         uses: docker/build-push-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,12 @@ RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd
 # Copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
+# Get go dependencies first
+COPY go.mod go.lock /osmosis/
 WORKDIR /osmosis
-
 RUN go mod download
-# TODO: Document what this is for
+
+# Copy all files into our docker repo
 COPY . /osmosis
 
 # build
@@ -39,7 +41,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG}
 
-COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
+COPY --from=build /osmosis-copy/build/osmosisd /bin/osmosisd
 
 ENV HOME /osmosis
 WORKDIR $HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 # Get go dependencies first
-COPY go.mod go.lock /osmosis/
+COPY go.mod go.sum /osmosis/
 WORKDIR /osmosis
 RUN go mod download
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ COPY . /osmosis
 # build
 # FROM golang
 
-RUN --mount=type=cache,target=~/.cache/go-build \
-  --mount=type=cache,target=~/go/pkg/mod \
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/root/go/pkg/mod \
   BUILD_TAGS=muslc LINK_STATICALLY=true make build
 
 # --------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,26 @@ ARG BASE_IMG_TAG=nonroot
 
 FROM golang:1.18.2-alpine3.15 as build
 
-RUN set -eux; apk add --no-cache ca-certificates build-base;
-RUN apk add git
-# Needed by github.com/zondax/hid
-RUN apk add linux-headers
+# linux-headers needed by github.com/zondax/hid
+RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-headers
 
 # CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
+# 1) Add the releases into /lib/
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a \ 
+  https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a \ 
+  /lib/
+# 2) Verify their hashes
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc; \
+  sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
 # Copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 # Get go dependencies first
 COPY go.mod go.sum /osmosis/
 WORKDIR /osmosis
-RUN go mod download
+RUN --mount=type=cache,target=/root/.cache/go-build \
+ --mount=type=cache,target=/root/go/pkg/mod \
+ go mod download
 
 # Copy all files into our docker repo
 COPY . /osmosis

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG}
 
-COPY --from=build /osmosis-copy/build/osmosisd /bin/osmosisd
+COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
 
 ENV HOME /osmosis
 WORKDIR $HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 # build
 FROM golang
+
 RUN --mount=type=cache,target=/root/.cache/go-build \
   BUILD_TAGS=muslc LINK_STATICALLY=true make build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 # build
-FROM golang
+# FROM golang
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
   BUILD_TAGS=muslc LINK_STATICALLY=true make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,16 @@ RUN apk add git
 # Needed by github.com/zondax/hid
 RUN apk add linux-headers
 
-WORKDIR /osmosis
-COPY . /osmosis
-
 # CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
 ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
 RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
 RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
-
-# CosmWasm: copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
+# Copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
+
+WORKDIR /osmosis
+COPY . /osmosis
 
 # build
 # FROM golang

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd
 # CosmWasm: copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
-RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build
+# build
+FROM golang
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  BUILD_TAGS=muslc LINK_STATICALLY=true make build
 
 # --------------------------------------------------------
 # Runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY . /osmosis
 # build
 # FROM golang
 
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=~/.cache/go-build \
+  --mount=type=cache,target=~/go/pkg/mod \
   BUILD_TAGS=muslc LINK_STATICALLY=true make build
 
 # --------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,12 @@ RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 WORKDIR /osmosis
+
+RUN go mod download
+# TODO: Document what this is for
 COPY . /osmosis
 
 # build
-# FROM golang
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/root/go/pkg/mod \

--- a/Makefile
+++ b/Makefile
@@ -248,13 +248,13 @@ build-e2e-script:
 	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
 docker-build-debug:
-	@docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f Dockerfile .
 
 docker-build-e2e-init-chain:
-	@docker build -t osmosis-e2e-init-chain:debug --build-arg E2E_SCRIPT_NAME=chain -f tests/e2e/initialization/init.Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-chain:debug --build-arg E2E_SCRIPT_NAME=chain -f tests/e2e/initialization/init.Dockerfile .
 
 docker-build-e2e-init-node:
-	@docker build -t osmosis-e2e-init-node:debug --build-arg E2E_SCRIPT_NAME=node -f tests/e2e/initialization/init.Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-node:debug --build-arg E2E_SCRIPT_NAME=node -f tests/e2e/initialization/init.Dockerfile .
 
 .PHONY: test-mutation
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ BUILD_TARGETS := build install
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
 $(BUILD_TARGETS): go.sum $(BUILDDIR)/
-	go $@ -v -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
+	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 
 $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ benchmark:
 
 build-e2e-script:
 	mkdir -p $(BUILDDIR)
-	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
+	go build -v -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
 docker-build-debug:
 	@docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ BUILD_TARGETS := build install
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
 $(BUILD_TARGETS): go.sum $(BUILDDIR)/
-	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
+	go $@ -v -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 
 $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/
@@ -245,7 +245,7 @@ benchmark:
 
 build-e2e-script:
 	mkdir -p $(BUILDDIR)
-	go build -v -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
+	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
 docker-build-debug:
 	@docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f Dockerfile .

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ Conceptually, we can split the e2e setup into 2 parts:
 
 1. Chain Initialization
 
-    The chain can either be initailized off of the current branch, or off the prior mainnet release and then upgraded to the current branch.
+    The chain can either be initialized off of the current branch, or off the prior mainnet release and then upgraded to the current branch.
 
     If current, we run chain initialization off of the current Git branch
     by calling `chain.Init(...)` method in the `configurer/current.go`.

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -68,7 +68,7 @@ func (n *NodeConfig) Run() error {
 			n.t.Logf("started node container: %s", n.Name)
 			return true
 		},
-		5*time.Minute,
+		2*time.Minute,
 		time.Second,
 		"Osmosis node failed to produce blocks",
 	)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

* Reorder cosmwasm steps to come earlier in dockerfile
* Run go mod download to cache the go dependency downloads. (Shaves ~30 seconds as far as I can tell)
* Use RUN --mount=type=cache to speedup repeat docker builds locally. (See below for why this doesn't work in CI, I tried a few times, at some point github cache stopped working, so I quit trying)
* Rename github action steps to be more concise
* Combine a few of the prior layers

## Brief Changelog

Add go cache to dockerfile

## Testing and Verifying

This change is already covered by E2E tests