### PR TITLE
update documentation for admin role and burning

### DIFF
--- a/x/tokenfactory/README.md
+++ b/x/tokenfactory/README.md
@@ -44,8 +44,8 @@ message MsgCreateDenom {
 
 ### Mint
 
-Minting of a specific denom is only allowed for the creator of the denom
-registered during `CreateDenom`, or the current admin.
+Minting of a specific denom is only allowed for the current admin.
+Note, the current admin is defaulted to the creator of the denom.
 
 ```go
 message MsgMint {
@@ -66,8 +66,9 @@ message MsgMint {
 
 ### Burn
 
-Burning of a specific denom is only allowed for the creator of the denom
-registered during `CreateDenom`, or the current admin.
+
+Burning of a specific denom is only allowed for the current admin.
+Note, the current admin is defaulted to the creator of the denom.
 
 ```go
 message MsgBurn {
@@ -88,8 +89,7 @@ message MsgBurn {
 
 ### ChangeAdmin
 
-Change the admin is only allowed for the creator of the denom
-registered during `CreateDenom`, or the current admin.
+Change the admin of a denom. Note, this is only allowed to be called by the current admin of the denom.
 
 ```go
 message MsgChangeAdmin {

--- a/x/tokenfactory/README.md
+++ b/x/tokenfactory/README.md
@@ -66,7 +66,6 @@ message MsgMint {
 
 ### Burn
 
-
 Burning of a specific denom is only allowed for the current admin.
 Note, the current admin is defaulted to the creator of the denom.
 

--- a/x/tokenfactory/README.md
+++ b/x/tokenfactory/README.md
@@ -45,7 +45,7 @@ message MsgCreateDenom {
 ### Mint
 
 Minting of a specific denom is only allowed for the creator of the denom
-registered during `CreateDenom`.
+registered during `CreateDenom`, or the current admin.
 
 ```go
 message MsgMint {
@@ -67,7 +67,7 @@ message MsgMint {
 ### Burn
 
 Burning of a specific denom is only allowed for the creator of the denom
-registered during `CreateDenom`.
+registered during `CreateDenom`, or the current admin.
 
 ```go
 message MsgBurn {
@@ -88,8 +88,8 @@ message MsgBurn {
 
 ### ChangeAdmin
 
-Burning of a specific denom is only allowed for the creator of the denom
-registered during `CreateDenom`.
+Change the admin is only allowed for the creator of the denom
+registered during `CreateDenom`, or the current admin.
 
 ```go
 message MsgChangeAdmin {


### PR DESCRIPTION
## What is the purpose of the change

Update documentation on role of admin: Since the admin can change, and therefore is not always the creator of the denom, the Burning, Minting, ChangeAdmin documentation should be updated to account for this possibility. 

Incorrect documentation for Burning: Section specified instructions for Minting, not Burning.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 