### PR TITLE
fix(linter): markdown lint in epochs and gamm on v11.x

### DIFF
--- a/x/epochs/spec/README.md
+++ b/x/epochs/spec/README.md
@@ -17,7 +17,6 @@ they can easily be signalled upon such events.
 4. **[Keeper](#keeper)**
 5. **[Hooks](#hooks)**
 6. **[Queries](#queries)**
-7. **[Downtime Recovery](#downtime-recovery)**
 
 ## Concepts
 
@@ -59,7 +58,7 @@ The `epochs` module emits the following events:
 |  ------------| ---------------| -----------------|
 |  epoch\_end  | epoch\_number  | {epoch\_number} |
 
-## Keepers
+## Keeper
 
 ### Keeper functions
 

--- a/x/gamm/spec/README.md
+++ b/x/gamm/spec/README.md
@@ -145,8 +145,6 @@ Pools have the following parameters:
 
 The GAMM module also has a **PoolCreationFee** parameter, which currently is set to `100000000 uosmo` or `100 OSMO`.
 
-[comment]: <> (TODO Add better description of how the weights affect things)
-
 </br>
 </br>
 
@@ -382,9 +380,6 @@ Swap a **maximum** of `.407239 AKT` through `pool 3` into **exactly** `.140530 O
 ```sh
 osmosisd tx gamm swap-exact-amount-out 140530uosmo 407239 --swap-route-pool-ids 3 --swap-route-denoms ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4 --from WALLET_NAME --chain-id osmosis-1
 ```
-
-[comment]: <> (Other resources Creating a liquidity bootstrapping pool and Creating a pool with a pool file)
-:::
 
 ## Queries and Transactions
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The markdown linter on v11.x is failing and breaking all other backport PRs. E.g. #2258

This PR fixes it.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable