### PR TITLE
simulator: add makefile cmds and fix determinism test

### DIFF
--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -16,9 +16,9 @@ jobs:
           go-version: 1.18
       - name: Display go version
         run: go version
-      - name: Run simulation
+      - name: Run full application simulation
         run: |
           make test-sim-app
-      - name: Run simulation determinism
+      - name: Run simulation determinism check
         run: |
           make test-sim-determinism

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -18,4 +18,7 @@ jobs:
         run: go version
       - name: Run simulation
         run: |
-          make test-sim
+          make test-sim-app
+      - name: Run simulation determinism
+        run: |
+          make test-sim-determinism

--- a/Makefile
+++ b/Makefile
@@ -228,14 +228,23 @@ test-race:
 test-cover:
 	@VERSION=$(VERSION) go test -mod=readonly -timeout 30m -coverprofile=coverage.txt -tags='norace' -covermode=atomic $(PACKAGES_UNIT)
 
-test-sim:
+test-sim-suite:
 	@VERSION=$(VERSION) go test -mod=readonly $(PACKAGES_SIM)
+
+test-sim-app:
+	@VERSION=$(VERSION) go test -mod=readonly -run ^TestFullAppSimulation -v $(PACKAGES_SIM)
+
+test-sim-determinism:
+	@VERSION=$(VERSION) go test -mod=readonly -run ^TestAppStateDeterminism -v $(PACKAGES_SIM)
+
+test-sim-benchmark:
+	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation $(PACKAGES_SIM)
 
 test-e2e:
 	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 test-e2e-skip-upgrade:
-	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -mod=readonly -timeout=25m -v -cpuprofile cpu.out $(PACKAGES_E2E)
 
 test-mutation:
 	@bash scripts/mutation-test.sh

--- a/Makefile
+++ b/Makefile
@@ -238,13 +238,13 @@ test-sim-determinism:
 	@VERSION=$(VERSION) go test -mod=readonly -run ^TestAppStateDeterminism -v $(PACKAGES_SIM)
 
 test-sim-benchmark:
-	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation $(PACKAGES_SIM)
+	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation -cpuprofile cpu.out $(PACKAGES_SIM)
 
 test-e2e:
 	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 test-e2e-skip-upgrade:
-	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -mod=readonly -timeout=25m -v -cpuprofile cpu.out $(PACKAGES_E2E)
+	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 test-mutation:
 	@bash scripts/mutation-test.sh

--- a/tests/simulator/sim_test.go
+++ b/tests/simulator/sim_test.go
@@ -135,6 +135,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	config.OnOperation = false
 	config.AllInvariants = false
 	config.ChainID = helpers.SimAppChainID
+	config.Commit = true
 
 	// This file is needed to provide the correct path
 	// to reflect.wasm test file needed for wasmd simulation testing.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

As part of the simulator epic, we wanted to create various makefile cmds that isolate specific portions of the simulator as a whole.

## Brief Changelog

- Fixes bug where app state determinism check wouldn't commit when run by itself
- Adds separate makefile cmds for 
  - Running the entire simulation package
  - Running just the simulator application check
  - Running just the simulator determinism check
  - Running just the benchmark that outputs to a file


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable