### PR TITLE
fix(ci):import paths ci job token

### DIFF
--- a/.github/workflows/import_paths.yml
+++ b/.github/workflows/import_paths.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          token: ${{ secrets.COMMIT_TO_BRANCH }}
           title: "auto: update Go import paths to v${{ inputs.version }}"
           commit-message: "auto: update Go import paths to v${{ inputs.version }}"
           body: "**Automated pull request**\n\nUpdating Go import paths to v${{ inputs.version }}"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Our Go imports path job [is broken](https://github.com/osmosis-labs/osmosis/actions/runs/2785591872) due to changing the token permissions for security reasons.

The updated token with the right permissions should be changed here. Context: https://github.com/osmosis-labs/osmosis/pull/2115#issuecomment-1187956054

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable