### PR TITLE
refactor: make ReverseSlice mutative

### DIFF
--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -24,7 +24,7 @@ func Filter[T interface{}](filter func(T) bool, s []T) []T {
 	return filteredSlice
 }
 
-// Reverse slice reverses the input slice in place.
+// ReverseSlice reverses the input slice in place.
 // Does mutate argument.
 func ReverseSlice[T any](s []T) []T {
 	maxIndex := len(s)

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -24,13 +24,24 @@ func Filter[T interface{}](filter func(T) bool, s []T) []T {
 	return filteredSlice
 }
 
-// ReverseSlice returns a reversed copy of the input slice.
-// Does not mutate argument.
-func ReverseSlice[T any](s []T) []T {
-	newSlice := make([]T, len(s))
-	maxIndex := len(s) - 1
-	for i := 0; i < len(s); i++ {
-		newSlice[maxIndex-i] = s[i]
+// Reverse slice reverses the input slice in place.
+// Does mutate argument.
+func ReverseSlice[T any](s []T) {
+	maxIndex := len(s)
+	for i := 0; i < maxIndex/2; i++ {
+		temp := s[i]
+		s[i] = s[maxIndex-i-1]
+		s[maxIndex-1-i] = temp
 	}
-	return newSlice
 }
+
+// // ReverseSlice returns a reversed copy of the input slice.
+// // Does not mutate argument.
+// func ReverseSlice[T any](s []T) []T {
+// 	newSlice := make([]T, len(s))
+// 	maxIndex := len(s) - 1
+// 	for i := 0; i < len(s); i++ {
+// 		newSlice[maxIndex-i] = s[i]
+// 	}
+// 	return newSlice
+// }

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -26,22 +26,12 @@ func Filter[T interface{}](filter func(T) bool, s []T) []T {
 
 // Reverse slice reverses the input slice in place.
 // Does mutate argument.
-func ReverseSlice[T any](s []T) {
+func ReverseSlice[T any](s []T) []T {
 	maxIndex := len(s)
 	for i := 0; i < maxIndex/2; i++ {
 		temp := s[i]
 		s[i] = s[maxIndex-i-1]
 		s[maxIndex-1-i] = temp
 	}
+	return s
 }
-
-// // ReverseSlice returns a reversed copy of the input slice.
-// // Does not mutate argument.
-// func ReverseSlice[T any](s []T) []T {
-// 	newSlice := make([]T, len(s))
-// 	maxIndex := len(s) - 1
-// 	for i := 0; i < len(s); i++ {
-// 		newSlice[maxIndex-i] = s[i]
-// 	}
-// 	return newSlice
-// }

--- a/osmoutils/slice_helper_test.go
+++ b/osmoutils/slice_helper_test.go
@@ -1,0 +1,28 @@
+package osmoutils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReverseSlice(t *testing.T) {
+	tests := map[string]struct {
+		s []string
+
+		expectedSolvedInput []string
+	}{
+		"Even length array":       {[]string{"a", "b", "c", "d"}, []string{"d", "c", "b", "a"}},
+		"Empty array":             {[]string{}, []string{}},
+		"Odd length array":        {[]string{"a", "b", "c"}, []string{"c", "b", "a"}},
+		"Single element array":    {[]string{"a"}, []string{"a"}},
+		"Array with empty string": {[]string{"a", "b", "c", "", "d"}, []string{"d", "", "c", "b", "a"}},
+		"Array with numbers":      {[]string{"a", "b", "c", "1", "2", "3"}, []string{"3", "2", "1", "c", "b", "a"}},
+	}
+
+	for _, tc := range tests {
+		actualSolvedInput := ReverseSlice(tc.s)
+		require.True(t, reflect.DeepEqual(actualSolvedInput, tc.expectedSolvedInput))
+	}
+}

--- a/osmoutils/slice_helper_test.go
+++ b/osmoutils/slice_helper_test.go
@@ -1,9 +1,11 @@
-package osmoutils
+package osmoutils_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v10/osmoutils"
 )
 
 func TestReverseSlice(t *testing.T) {
@@ -21,7 +23,7 @@ func TestReverseSlice(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			actualSolvedInput := ReverseSlice(tc.s)
+			actualSolvedInput := osmoutils.ReverseSlice(tc.s)
 			require.Equal(t, tc.expectedSolvedInput, actualSolvedInput)
 		})
 	}

--- a/osmoutils/slice_helper_test.go
+++ b/osmoutils/slice_helper_test.go
@@ -1,7 +1,6 @@
 package osmoutils
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,16 +12,17 @@ func TestReverseSlice(t *testing.T) {
 
 		expectedSolvedInput []string
 	}{
-		"Even length array":       {[]string{"a", "b", "c", "d"}, []string{"d", "c", "b", "a"}},
-		"Empty array":             {[]string{}, []string{}},
-		"Odd length array":        {[]string{"a", "b", "c"}, []string{"c", "b", "a"}},
-		"Single element array":    {[]string{"a"}, []string{"a"}},
-		"Array with empty string": {[]string{"a", "b", "c", "", "d"}, []string{"d", "", "c", "b", "a"}},
-		"Array with numbers":      {[]string{"a", "b", "c", "1", "2", "3"}, []string{"3", "2", "1", "c", "b", "a"}},
+		"Even length array":       {s: []string{"a", "b", "c", "d"}, expectedSolvedInput: []string{"d", "c", "b", "a"}},
+		"Empty array":             {s: []string{}, expectedSolvedInput: []string{}},
+		"Odd length array":        {s: []string{"a", "b", "c"}, expectedSolvedInput: []string{"c", "b", "a"}},
+		"Single element array":    {s: []string{"a"}, expectedSolvedInput: []string{"a"}},
+		"Array with empty string": {s: []string{"a", "b", "c", "", "d"}, expectedSolvedInput: []string{"d", "", "c", "b", "a"}},
+		"Array with numbers":      {s: []string{"a", "b", "c", "1", "2", "3"}, expectedSolvedInput: []string{"3", "2", "1", "c", "b", "a"}},
 	}
-
-	for _, tc := range tests {
-		actualSolvedInput := ReverseSlice(tc.s)
-		require.True(t, reflect.DeepEqual(actualSolvedInput, tc.expectedSolvedInput))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualSolvedInput := ReverseSlice(tc.s)
+			require.Equal(t, tc.expectedSolvedInput, actualSolvedInput)
+		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2181 

## What is the purpose of the change

Refactor `ReverseSlice` utility function to be mutative and reverse in place.

## Brief Changelog

* refactor existing `ReverseSlice` function
* add tests in new test file specifically for this function

## Testing and Verifying

This change added tests and can be verified as follows:
* `TestReverseSlice` in `slice_helper_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)