### PR TITLE
refactor(x/mint): simplify TestDistributeMintedCoin

### DIFF
--- a/x/mint/keeper/export_test.go
+++ b/x/mint/keeper/export_test.go
@@ -27,3 +27,14 @@ func (k Keeper) DistributeToModule(ctx sdk.Context, recipientModule string, mint
 func (k Keeper) DistributeDeveloperRewards(ctx sdk.Context, totalMintedCoin sdk.Coin, developerRewardsProportion sdk.Dec, developerRewardsReceivers []types.WeightedAddress) (sdk.Int, error) {
 	return k.distributeDeveloperRewards(ctx, totalMintedCoin, developerRewardsProportion, developerRewardsReceivers)
 }
+
+// Set the mint hooks. This is used for testing purposes only.
+func (k *Keeper) SetMintHooksUnsafe(h types.MintHooks) *Keeper {
+	k.hooks = h
+	return k
+}
+
+// Get the mint hooks. This is used for testing purposes only.
+func (k *Keeper) GetMintHooksUnsafe() types.MintHooks {
+	return k.hooks
+}

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -25,15 +25,15 @@ type KeeperTestSuite struct {
 	queryClient types.QueryClient
 }
 
-type hooksMock struct {
+type mintHooksMock struct {
 	hookCallCount int
 }
 
-func (hm *hooksMock) AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) {
+func (hm *mintHooksMock) AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) {
 	hm.hookCallCount++
 }
 
-var _ types.MintHooks = (*hooksMock)(nil)
+var _ types.MintHooks = (*mintHooksMock)(nil)
 
 var (
 	testAddressOne   = sdk.AccAddress([]byte("addr1---------------"))
@@ -211,7 +211,7 @@ func (suite *KeeperTestSuite) TestDistributeMintedCoin() {
 			// about the results of the call to DistributeMintedCoin.
 			// The goal is to assert that AfterDistributeMintedCoin
 			// is called once.
-			mintKeeper.SetMintHooksUnsafe(&hooksMock{})
+			mintKeeper.SetMintHooksUnsafe(&mintHooksMock{})
 
 			mintAmount := tc.mintCoin.Amount.ToDec()
 
@@ -233,7 +233,7 @@ func (suite *KeeperTestSuite) TestDistributeMintedCoin() {
 			suite.Require().NoError(err)
 
 			// validate that AfterDistributeMintedCoin hook was called once.
-			suite.Require().Equal(1, mintKeeper.GetMintHooksUnsafe().(*hooksMock).hookCallCount)
+			suite.Require().Equal(1, mintKeeper.GetMintHooksUnsafe().(*mintHooksMock).hookCallCount)
 
 			// validate distributions to fee collector.
 			feeCollectorBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(authtypes.FeeCollectorName), sdk.DefaultBondDenom).Amount.ToDec()

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -3,22 +3,18 @@ package keeper_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/cosmos/btcutil/bech32"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/distribution"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/suite"
-	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/osmosis-labs/osmosis/v10/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v10/osmoutils"
-	lockuptypes "github.com/osmosis-labs/osmosis/v10/x/lockup/types"
 	"github.com/osmosis-labs/osmosis/v10/x/mint/keeper"
 	"github.com/osmosis-labs/osmosis/v10/x/mint/types"
 	poolincentivestypes "github.com/osmosis-labs/osmosis/v10/x/pool-incentives/types"
@@ -28,6 +24,16 @@ type KeeperTestSuite struct {
 	apptesting.KeeperTestHelper
 	queryClient types.QueryClient
 }
+
+type hooksMock struct {
+	hookCallCount int
+}
+
+func (hm *hooksMock) AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) {
+	hm.hookCallCount++
+}
+
+var _ types.MintHooks = (*hooksMock)(nil)
 
 var (
 	testAddressOne   = sdk.AccAddress([]byte("addr1---------------"))
@@ -147,17 +153,13 @@ func (suite *KeeperTestSuite) TestGetProportions() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestDistributeMintedCoin_ToDeveloperRewardsAddr() {
+func (suite *KeeperTestSuite) TestDistributeMintedCoin() {
+	const (
+		mintAmount = 10000
+	)
+
 	var (
-		distrTo = lockuptypes.QueryCondition{
-			LockQueryType: lockuptypes.ByDuration,
-			Denom:         "lptoken",
-			Duration:      time.Second,
-		}
-		params       = suite.App.MintKeeper.GetParams(suite.Ctx)
-		gaugeCoins   = sdk.Coins{sdk.NewInt64Coin("stake", 10000)}
-		gaugeCreator = testAddressTwo
-		mintLPtokens = sdk.Coins{sdk.NewInt64Coin(distrTo.Denom, 200)}
+		params = types.DefaultParams()
 	)
 
 	tests := []struct {
@@ -173,7 +175,7 @@ func (suite *KeeperTestSuite) TestDistributeMintedCoin_ToDeveloperRewardsAddr() 
 					Weight:  sdk.NewDec(1),
 				},
 			},
-			mintCoin: sdk.NewCoin("stake", sdk.NewInt(10000)),
+			mintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(mintAmount)),
 		},
 		{
 			name: "multiple dev reward addresses",
@@ -187,121 +189,81 @@ func (suite *KeeperTestSuite) TestDistributeMintedCoin_ToDeveloperRewardsAddr() 
 					Weight:  sdk.NewDecWithPrec(4, 1),
 				},
 			},
-			mintCoin: sdk.NewCoin("stake", sdk.NewInt(100000)),
+			mintCoin: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(mintAmount)),
 		},
 		{
-			name:              "nil dev reward address",
+			name:              "nil dev reward address - dev rewards go to community pool",
 			weightedAddresses: nil,
-			mintCoin:          sdk.NewCoin("stake", sdk.NewInt(100000)),
+			mintCoin:          sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(mintAmount)),
 		},
 	}
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
 			suite.Setup()
 
-			mintKeeper := suite.App.MintKeeper
+			ctx := suite.Ctx
+
 			bankKeeper := suite.App.BankKeeper
-			intencentivesKeeper := suite.App.IncentivesKeeper
-			poolincentivesKeeper := suite.App.PoolIncentivesKeeper
-			distrKeeper := suite.App.DistrKeeper
 			accountKeeper := suite.App.AccountKeeper
+
+			mintKeeper := suite.App.MintKeeper
+			// We reset the hooks with a mock to simplify the assertions
+			// about the results of the call to DistributeMintedCoin.
+			// The goal is to assert that AfterDistributeMintedCoin
+			// is called once.
+			mintKeeper.SetMintHooksUnsafe(&hooksMock{})
+
+			mintAmount := tc.mintCoin.Amount.ToDec()
 
 			// set WeightedDeveloperRewardsReceivers
 			params.WeightedDeveloperRewardsReceivers = tc.weightedAddresses
-			mintKeeper.SetParams(suite.Ctx, params)
+			mintKeeper.SetParams(ctx, params)
+
+			expectedCommunityPoolAmount := mintAmount.Mul((params.DistributionProportions.CommunityPool))
+			expectedDevRewardsAmount := mintAmount.Mul(params.DistributionProportions.DeveloperRewards)
+			expectedPoolIncentivesAmount := mintAmount.Mul(params.DistributionProportions.PoolIncentives)
+			expectedStakingAmount := tc.mintCoin.Amount.ToDec().Mul(params.DistributionProportions.Staking)
 
 			// mints coins so supply exists on chain
-			suite.FundAcc(gaugeCreator, gaugeCoins)
-			suite.FundAcc(gaugeCreator, mintLPtokens)
-
-			gaugeId, err := intencentivesKeeper.CreateGauge(suite.Ctx, true, gaugeCreator, gaugeCoins, distrTo, time.Now(), 1)
-			suite.Require().NoError(err)
-			err = poolincentivesKeeper.UpdateDistrRecords(suite.Ctx, poolincentivestypes.DistrRecord{
-				GaugeId: gaugeId,
-				Weight:  sdk.NewInt(100),
-			})
+			err := mintKeeper.MintCoins(ctx, sdk.NewCoins(tc.mintCoin))
 			suite.Require().NoError(err)
 
-			err = mintKeeper.MintCoins(suite.Ctx, sdk.NewCoins(tc.mintCoin))
+			// System under test.
+			err = mintKeeper.DistributeMintedCoin(ctx, tc.mintCoin)
 			suite.Require().NoError(err)
 
-			err = mintKeeper.DistributeMintedCoin(suite.Ctx, tc.mintCoin)
-			suite.Require().NoError(err)
+			// validate that AfterDistributeMintedCoin hook was called once.
+			suite.Require().Equal(1, mintKeeper.GetMintHooksUnsafe().(*hooksMock).hookCallCount)
 
-			// check feePool
-			feePool := distrKeeper.GetFeePool(suite.Ctx)
-			feeCollector := accountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+			// validate distributions to fee collector.
+			feeCollectorBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(authtypes.FeeCollectorName), sdk.DefaultBondDenom).Amount.ToDec()
 			suite.Require().Equal(
-				tc.mintCoin.Amount.ToDec().Mul(params.DistributionProportions.Staking).TruncateInt(),
-				bankKeeper.GetAllBalances(suite.Ctx, feeCollector).AmountOf("stake"))
+				expectedStakingAmount,
+				feeCollectorBalanceAmount)
 
-			if tc.weightedAddresses != nil {
-				suite.Require().Equal(
-					tc.mintCoin.Amount.ToDec().Mul(params.DistributionProportions.CommunityPool),
-					feePool.CommunityPool.AmountOf("stake"))
-			} else {
-				suite.Require().Equal(
-					// distribution go to community pool because nil dev reward addresses.
-					tc.mintCoin.Amount.ToDec().Mul((params.DistributionProportions.DeveloperRewards).Add(params.DistributionProportions.CommunityPool)),
-					feePool.CommunityPool.AmountOf("stake"))
+			// validate distributions to community pool.
+			actualCommunityPoolBalanceAmount := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(distributiontypes.ModuleName), sdk.DefaultBondDenom).Amount.ToDec()
+
+			// distributions go to community pool because nil dev reward addresses.
+			if tc.weightedAddresses == nil {
+				expectedCommunityPoolAmount = expectedCommunityPoolAmount.Add(expectedDevRewardsAmount)
 			}
 
-			// check devAddress balances
+			// If gauges are not created, all pool incentive rewards go to community pool.
+			actualPoolIncentivesBalance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(poolincentivestypes.ModuleName), sdk.DefaultBondDenom).Amount.ToDec()
+			suite.Require().Equal(expectedPoolIncentivesAmount, actualPoolIncentivesBalance)
+
+			suite.Require().Equal(expectedCommunityPoolAmount, actualCommunityPoolBalanceAmount)
+
+			// validate distributions to developer addresses.
 			for i, weightedAddress := range tc.weightedAddresses {
 				devRewardsReceiver, _ := sdk.AccAddressFromBech32(weightedAddress.GetAddress())
 				suite.Require().Equal(
 					tc.mintCoin.Amount.ToDec().Mul(params.DistributionProportions.DeveloperRewards).Mul(params.WeightedDeveloperRewardsReceivers[i].Weight).TruncateInt(),
-					bankKeeper.GetBalance(suite.Ctx, devRewardsReceiver, "stake").Amount)
+					bankKeeper.GetBalance(ctx, devRewardsReceiver, sdk.DefaultBondDenom).Amount)
 			}
 		})
 	}
-}
-
-func (suite *KeeperTestSuite) TestDistrAssetToCommunityPoolWhenNoDeveloperRewardsAddr() {
-	mintKeeper := suite.App.MintKeeper
-	bankKeeper := suite.App.BankKeeper
-	distrKeeper := suite.App.DistrKeeper
-	accountKeeper := suite.App.AccountKeeper
-
-	params := suite.App.MintKeeper.GetParams(suite.Ctx)
-	// At this time, there is no distr record, so the asset should be allocated to the community pool.
-	mintCoin := sdk.NewCoin("stake", sdk.NewInt(100000))
-	mintCoins := sdk.Coins{mintCoin}
-	err := mintKeeper.MintCoins(suite.Ctx, mintCoins)
-	suite.Require().NoError(err)
-	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin)
-	suite.Require().NoError(err)
-
-	distribution.BeginBlocker(suite.Ctx, abci.RequestBeginBlock{}, *distrKeeper)
-
-	feePool := distrKeeper.GetFeePool(suite.Ctx)
-	feeCollector := accountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
-	// PoolIncentives + DeveloperRewards + CommunityPool => CommunityPool
-	proportionToCommunity := params.DistributionProportions.PoolIncentives.
-		Add(params.DistributionProportions.DeveloperRewards).
-		Add(params.DistributionProportions.CommunityPool)
-	suite.Require().Equal(
-		mintCoins[0].Amount.ToDec().Mul(params.DistributionProportions.Staking).TruncateInt(),
-		bankKeeper.GetBalance(suite.Ctx, feeCollector, "stake").Amount)
-	suite.Require().Equal(
-		mintCoins[0].Amount.ToDec().Mul(proportionToCommunity),
-		feePool.CommunityPool.AmountOf("stake"))
-
-	// Mint more and community pool should be increased
-	err = mintKeeper.MintCoins(suite.Ctx, mintCoins)
-	suite.Require().NoError(err)
-	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin)
-	suite.Require().NoError(err)
-
-	distribution.BeginBlocker(suite.Ctx, abci.RequestBeginBlock{}, *distrKeeper)
-
-	feePool = distrKeeper.GetFeePool(suite.Ctx)
-	suite.Require().Equal(
-		mintCoins[0].Amount.ToDec().Mul(params.DistributionProportions.Staking).TruncateInt().Mul(sdk.NewInt(2)),
-		bankKeeper.GetBalance(suite.Ctx, feeCollector, "stake").Amount)
-	suite.Require().Equal(
-		mintCoins[0].Amount.ToDec().Mul(proportionToCommunity).Mul(sdk.NewDec(2)),
-		feePool.CommunityPool.AmountOf("stake"))
 }
 
 func (suite *KeeperTestSuite) TestCreateDeveloperVestingModuleAccount() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This change simplifies `DistributeMintedCoin` by doing the following:
-  removing `TestDistributeMintedCoin_ToDeveloperRewardsAddr`. Instead, making this a table-driven test case in `TestDistributeMintedCoin`
- Removing all gauge logic from `TestDistributeMintedCoin`. 
   * By having gauge logic in that test, as it was previously,  we were overcomplicating that test and making it a functional test as opposed to a unit test. 
   * What we want to assert in the table-driven unit test at this level of abstraction is simply the fact that the `AfterDistributeMintedCoin` hook is called. It should be irrelevant what the `AfterDistributeMintedCoin` hook does. Instead, this should be verified by the tests for the  `AfterDistributeMintedCoin` or functional / integration tests.
   * The fact that the hook is called can be verified with the newly added mock.

## Testing and Verifying

This change is already covered by existing tests, such as:
- `TestDistributeMintedCoin`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable