### PR TITLE
simulator: include gauge fees and cap jailed validators

### DIFF
--- a/simulation/executor/mock_tendermint.go
+++ b/simulation/executor/mock_tendermint.go
@@ -200,12 +200,12 @@ func randomDoubleSignEvidence(r *rand.Rand, params Params,
 	var n float64 = 1
 	// TODO: Change this to be markov based & clean this up
 	// Right now we incrementally lower the evidence fraction to make
-	// it less likely to jail many validators in one run
+	// it less likely to jail many validators in one run.
 	// We should also add some method of including new validators into the set
-	// instead of being stuck with the ones we start with during initialization
+	// instead of being stuck with the ones we start with during initialization.
 	for r.Float64() < (params.EvidenceFraction() / n) {
 		// if only one validator remaining, don't jail any more validators
-		if len(voteInfos)-int(n) == 0 {
+		if len(voteInfos)-int(n) <= 0 {
 			return nil
 		}
 		height := header.Height

--- a/simulation/executor/mock_tendermint.go
+++ b/simulation/executor/mock_tendermint.go
@@ -194,7 +194,7 @@ func randomDoubleSignEvidence(r *rand.Rand, params Params,
 	event func(route, op, evResult string), header tmproto.Header, voteInfos []abci.VoteInfo) []abci.Evidence {
 	evidence := []abci.Evidence{}
 	// return if no past times or if only 10 validators remaining in the active set
-	if len(pastTimes) == 0 || len(voteInfos) <= 10 {
+	if len(pastTimes) == 0 {
 		return evidence
 	}
 	var n float64 = 1
@@ -204,6 +204,10 @@ func randomDoubleSignEvidence(r *rand.Rand, params Params,
 	// We should also add some method of including new validators into the set
 	// instead of being stuck with the ones we start with during initialization
 	for r.Float64() < (params.EvidenceFraction() / n) {
+		// if only one validator remaining, don't jail any more validators
+		if len(voteInfos)-int(n) == 0 {
+			return nil
+		}
 		height := header.Height
 		time := header.Time
 		vals := voteInfos

--- a/x/incentives/simulation/operations.go
+++ b/x/incentives/simulation/operations.go
@@ -63,14 +63,23 @@ func WeightedOperations(
 }
 
 // genRewardCoins generates a random number of coin denoms with a respective random value for each coin.
-func genRewardCoins(r *rand.Rand, coins sdk.Coins) (res sdk.Coins) {
+func genRewardCoins(r *rand.Rand, coins sdk.Coins, fee sdk.Int) (res sdk.Coins) {
 	numCoins := 1 + r.Intn(Min(coins.Len(), 1))
 	denomIndices := r.Perm(numCoins)
 	for i := 0; i < numCoins; i++ {
+		var amt sdk.Int
+		var err error
 		denom := coins[denomIndices[i]].Denom
-		amt, err := simtypes.RandPositiveInt(r, coins[i].Amount)
-		if err != nil {
-			panic(err)
+		if denom == sdk.DefaultBondDenom {
+			amt, err = simtypes.RandPositiveInt(r, coins[i].Amount.Sub(fee))
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			amt, err = simtypes.RandPositiveInt(r, coins[i].Amount)
+			if err != nil {
+				panic(err)
+			}
 		}
 		res = append(res, sdk.Coin{Denom: denom, Amount: amt})
 	}
@@ -122,7 +131,7 @@ func SimulateMsgCreateGauge(ak stakingTypes.AccountKeeper, bk stakingTypes.BankK
 
 		isPerpetual := r.Int()%2 == 0
 		distributeTo := genQueryCondition(r, ctx.BlockTime(), simCoins, types.DefaultGenesis().LockableDurations)
-		rewards := genRewardCoins(r, simCoins)
+		rewards := genRewardCoins(r, simCoins, types.CreateGaugeFee)
 		startTimeSecs := r.Intn(1 * 60 * 60 * 24 * 7) // range of 1 week
 		startTime := ctx.BlockTime().Add(time.Duration(startTimeSecs) * time.Second)
 		durationSecs := r.Intn(1*60*60*24*7) + 1*60*60*24 // range of 1 week, min 1 day
@@ -166,7 +175,7 @@ func SimulateMsgAddToGauge(ak stakingTypes.AccountKeeper, bk stakingTypes.BankKe
 		}
 		gaugeId := RandomGauge(ctx, r, k).Id
 
-		rewards := genRewardCoins(r, simCoins)
+		rewards := genRewardCoins(r, simCoins, types.AddToGaugeFee)
 
 		msg := types.MsgAddToGauge{
 			Owner:   simAccount.Address.String(),

--- a/x/incentives/simulation/operations.go
+++ b/x/incentives/simulation/operations.go
@@ -67,8 +67,10 @@ func genRewardCoins(r *rand.Rand, coins sdk.Coins, fee sdk.Int) (res sdk.Coins) 
 	numCoins := 1 + r.Intn(Min(coins.Len(), 1))
 	denomIndices := r.Perm(numCoins)
 	for i := 0; i < numCoins; i++ {
-		var amt sdk.Int
-		var err error
+		var (
+			amt sdk.Int
+			err error
+		)
 		denom := coins[denomIndices[i]].Denom
 		if denom == sdk.DefaultBondDenom {
 			amt, err = simtypes.RandPositiveInt(r, coins[i].Amount.Sub(fee))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

A couple of issues have been found on long simulator runs. This PR fixes both of the issues I have found so far


## Brief Changelog

- Reduces rate at which validators double sign
  - Caps double signs to allow a minimum of 10 validators at any time
  - (we need to address this further by including some mech to add validators to the sim set)
- Now takes into consideration the respective gauge fees when calculating random Create/Add to gauge messages


## Testing and Verifying

*(Please pick one of the following options)*

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable