### PR TITLE
Update chain registry for Osmosis upgrade

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -2,15 +2,15 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "codebase":{
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v10.0.1",
-    "compatible_versions": ["v10.0.0", "v10.0.1"],
+    "recommended_version": "11.0.0",
+    "compatible_versions": ["11.0.0"],
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-amd64",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.0.0/osmosis-10.0.0-linux-arm64"
-    },
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v11.0.0/osmosisd-11.0.0-linux-amd64?checksum=sha256:d01423cf847b7f95a94ade8811bbf6dd9ec5938d46af0a14bc62caaaa7b7143e",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v11.0.0/osmosisd-11.0.0-linux-arm64?checksum=sha256:375699e90e5b76fd3d7e7a9ab631b40badd97140136f361e6b3f06be3fbd863d"
+  },
     "cosmos_sdk_version": "0.45",
     "tendermint_version": "0.34",
-    "cosmwasm_version": "0.24",
+    "cosmwasm_version": "0.27",
     "cosmwasm_enabled": true
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/osmosis-labs/osmosis/v10
 go 1.18
 
 require (
-	github.com/CosmWasm/wasmd v0.24.0
+	github.com/CosmWasm/wasmd v0.27.0
 	github.com/cosmos/cosmos-proto v1.0.0-alpha7
 	github.com/cosmos/cosmos-sdk v0.46.0
 	github.com/cosmos/go-bip39 v1.0.0


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Updates chain registry, also fixes incorrect cosmwasm version entry in both go.mod and chain registry. (Note that nothing about the cosmwasm version changed, despite the go.mod update, We have a replace directive further below that moves it to v0.27.0 thats been on mainnet since v9)

## Brief Changelog

Update chain registry for upgrade

## Testing and Verifying

End to end should cover go/mod sanity check.