### PR TITLE
chore: Have our own proto build env image

### DIFF
--- a/.github/workflows/proto-env.yml
+++ b/.github/workflows/proto-env.yml
@@ -1,0 +1,80 @@
+name: ghcr.io/osmosis-labs/proto-builder
+# Build & Push rebuilds the cosmos sdk development environment image every time the master branch is updated,
+# and pushes the image to https://ghcr.io/cosmos/cosmos-sdk
+# Other images in the cosmos-sdk consume ghcr.io/cosmos/cosmos-sdk
+
+on:
+  pull_request:
+  schedule:
+    # Run hourly, to speed downstream builds
+    - cron:  '0 * * * *'
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]?-rc*" # Push events to matching v*, i.e. v1.0, v20.15.10 or Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=ghcr.io/osmosis-labs/proto-builder
+          VERSION=noop
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=latest
+            fi
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      -
+        name: Build
+        uses: docker/build-push-action@v2
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          file: contrib/proto-docker/Dockerfile
+          context: contrib/proto-docker
+          platforms: linux/amd64,linux/arm64
+          push: false
+          
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
+
+        with:
+          file: contrib/proto-docker/Dockerfile
+          context: contrib/proto-docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/contrib/proto-docker/Dockerfile
+++ b/contrib/proto-docker/Dockerfile
@@ -1,0 +1,39 @@
+## To test locally:
+# docker build --pull --rm -f "contrib/devtools/Dockerfile" -t cosmossdk-proto:latest "contrib/devtools"
+# docker run --rm -v $(pwd):/workspace --workdir /workspace cosmossdk-proto sh ./scripts/protocgen.sh
+
+FROM bufbuild/buf:1.1.0 as BUILDER
+
+FROM golang:1.19-alpine
+
+RUN apk add --no-cache \
+  nodejs \
+  npm \
+  git \
+  make
+
+ENV GOLANG_PROTOBUF_VERSION=1.28.0 \
+  GOGO_PROTOBUF_VERSION=1.3.2 \
+  GRPC_GATEWAY_VERSION=1.16.0
+
+
+RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
+RUN go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION}
+
+# install all gogo protobuf binaries
+RUN git clone https://github.com/regen-network/protobuf.git; \
+    cd protobuf; \
+    go mod download; \
+    make install
+
+# we need to use git clone because we use 'replace' directive in go.mod
+# protoc-gen-gocosmos was moved to to in cosmos/gogoproto but pending a migration there.
+RUN git clone https://github.com/regen-network/cosmos-proto.git; \
+    cd cosmos-proto/protoc-gen-gocosmos; \
+    go install .
+
+RUN npm install -g swagger-combine
+
+COPY --from=BUILDER /usr/local/bin /usr/local/bin


### PR DESCRIPTION
This will allow us to have a proto build env image of our own, automatically built when it needs to be. 



## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)