### PR TITLE
minor: fix comments about pool state update in `CalcJoinPoolShares`

### DIFF
--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -726,6 +726,7 @@ func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee s
 
 	// 4) Still more coins to join, so we update our pool tracker map here to account for
 	// join that just happened. Importantly, this step does not actually change the pool state.
+	// Instead, it mutates the pool assets argument to be further used by the caller.
 	// * We add the joined coins to our "current pool liquidity" object (poolAssetsByDenom)
 	// * We increment a variable for our "newTotalShares" to add in the shares that've been added.
 	tokensJoined = tokensIn.Sub(remainingTokensIn)

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -724,8 +724,8 @@ func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee s
 		return numShares, tokensJoined, nil
 	}
 
-	// 4) Still more coins to join, so we update the effective pool state here to account for
-	// join that just happened.
+	// 4) Still more coins to join, so we update our pool tracker map here to account for
+	// join that just happened. Importantly, this step does not actually change the pool state.
 	// * We add the joined coins to our "current pool liquidity" object (poolAssetsByDenom)
 	// * We increment a variable for our "newTotalShares" to add in the shares that've been added.
 	tokensJoined = tokensIn.Sub(remainingTokensIn)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

`CalcJoinPoolShares` has a misleading/incorrect comment that claims that `updateIntermediaryPoolAssetsLiquidity` updates "effective pool state". 

This might lead someone to believe that `CalcJoinPoolShares` mutates pool state, which is not true and can lead to a lot of confusion on how our balancer pool joins work. This isn't immediately apparent from the code unless you're already familiar with other parts of the gamm module, so I figured it would be worth correcting in a small PR.

## Brief Changelog

- Minor comment change

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)