### PR TITLE
refactor(osmoassert): format additional parameters in DecApproxEq

### DIFF
--- a/app/apptesting/osmoassert/assertions.go
+++ b/app/apptesting/osmoassert/assertions.go
@@ -40,7 +40,11 @@ func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
 		return fmt.Sprintf("%+v", msg)
 	}
 	if len(msgAndArgs) > 1 {
-		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+		msgFormat, ok := msgAndArgs[0].(string)
+		if !ok {
+			return "error formatting additional arguments for DecApproxEq, please disregard."
+		}
+		return fmt.Sprintf(msgFormat, msgAndArgs[1:]...)
 	}
 	return ""
 }

--- a/app/apptesting/osmoassert/assertions.go
+++ b/app/apptesting/osmoassert/assertions.go
@@ -1,6 +1,7 @@
 package osmoassert
 
 import (
+	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,7 +22,25 @@ func ConditionalPanic(t *testing.T, expectPanic bool, sut func()) {
 // DecApproxEq is a helper function to compare two decimals.
 // It validates the two decimal are within a certain tolerance.
 // If not, it fails with a message.
-func DecApproxEq(t *testing.T, d1 sdk.Dec, d2 sdk.Dec, tol sdk.Dec) {
+func DecApproxEq(t *testing.T, d1 sdk.Dec, d2 sdk.Dec, tol sdk.Dec, msgAndArgs ...interface{}) {
 	diff := d1.Sub(d2).Abs()
-	require.True(t, diff.LTE(tol), "expected |d1 - d2| <:\t%s\ngot |d1 - d2| = \t\t%s\nd1: %s, d2: %s", tol, diff, d1, d2)
+	msg := messageFromMsgAndArgs(msgAndArgs...)
+	require.True(t, diff.LTE(tol), "expected |d1 - d2| <:\t%s\ngot |d1 - d2| = \t\t%s\nd1: %s, d2: %s\n%s", tol, diff, d1, d2, msg)
+}
+
+func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+	if len(msgAndArgs) == 0 || msgAndArgs == nil {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		msg := msgAndArgs[0]
+		if msgAsStr, ok := msg.(string); ok {
+			return msgAsStr
+		}
+		return fmt.Sprintf("%+v", msg)
+	}
+	if len(msgAndArgs) > 1 {
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+	return ""
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently, there is no way to format additional messages in `DecApproxEq`. These messages could be helpful with debugging.


For example, we currently have:
```
           Messages:   	expected |d1 - d2| <:	2.000000000000000000
            	           got |d1 - d2| = 		325000000000290.000000000000000000
            	           d1: 50000000000000.000000000000000000, d2: 375000000000290.000000000000000000
```

With this change, we could format additional messages like:
```
         Messages:   	expected |d1 - d2| <:	2.000000000000000000
            	         got |d1 - d2| = 		325000000000290.000000000000000000
            	         d1: 50000000000000.000000000000000000, d2: 375000000000290.000000000000000000
            	         i:365
```
- note `i:365`

The implementation is taken from:
https://github.com/stretchr/testify/blob/181cea6eab8b2de7071383eca4be32a424db38dd/assert/assertions.go#L181

## Testing and Verifying

- Manually tested with and without additional formatting

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable