### PR TITLE
[CI] Improve state-compatibility check

### DIFF
--- a/.github/workflows/state-compatibility-check.yml
+++ b/.github/workflows/state-compatibility-check.yml
@@ -77,16 +77,16 @@ jobs:
         name: 🧪 Initialize Osmosis Node
         run:  |
           rm -rf $HOME/.osmosisd/ || true
-          osmosisd init osmo-runner -o
+          osmosisd init runner -o
 
           # Download genesis file if not present
-          mkdir -p $HOME/genesis/osmosis-1/
-          if [ ! -f "$HOME/genesis/osmosis-1/genesis.json" ]; then
-            wget -O $HOME/genesis/osmosis-1/genesis.json ${{ env.GENESIS_URL }}
+          mkdir -p /mnt/data/genesis/osmosis-1/
+          if [ ! -f "/mnt/data/genesis/osmosis-1/genesis.json" ]; then
+            wget -O /mnt/data/genesis/osmosis-1/genesis.json ${{ env.GENESIS_URL }}
           fi
 
           # Copy genesis to config folder
-          cp $HOME/genesis/osmosis-1/genesis.json $HOME/.osmosisd/config/genesis.json
+          cp /mnt/data/genesis/osmosis-1/genesis.json $HOME/.osmosisd/config/genesis.json
       -
         name: ⏬ Download last pre-epoch snapshot
         run:  |
@@ -110,15 +110,15 @@ jobs:
           SNAPSHOT_ID=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).filename' | cut -f 1 -d '.')
 
           # Download snapshot if not already present
-          mkdir -p $HOME/snapshots/$REPO_MAJOR_VERSION/
-          if [ ! -d "$HOME/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID" ]; then
-              rm -rf $HOME/snapshots/$REPO_MAJOR_VERSION/*
-              mkdir $HOME/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID
-              wget -q -O - $SNAPSHOT_URL | lz4 -d | tar -C $HOME/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID -xvf -
+          mkdir -p /mnt/data/snapshots/$REPO_MAJOR_VERSION/
+          if [ ! -d "/mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID" ]; then
+              rm -rf /mnt/data/snapshots/$REPO_MAJOR_VERSION/*
+              mkdir /mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID
+              wget -q -O - $SNAPSHOT_URL | lz4 -d | tar -C /mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID -xvf -
           fi
 
           # Copy snapshot in Data folder
-          cp -R $HOME/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID/data $HOME/.osmosisd/
+          cp -R /mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID/* $HOME/.osmosisd/
       -
         name: 🧪 Configure Osmosis Node
         run:  |
@@ -135,11 +135,17 @@ jobs:
             # I'm in the latest major, fetch the epoch info from the lcd endpoint
             LAST_EPOCH_BLOCK_HEIGHT=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 ${{ env.LCD_ENDPOINT }}/osmosis/epochs/v1beta1/epochs | dasel --plain -r json 'epochs.(identifier=day).current_epoch_start_height')
           else
-            # Get hardcoded epoch height for previous versions
+            # Hardcoded epoch for v10 (waiting for snapshot service to catch up)
             if [ $REPO_MAJOR_VERSION == "10" ]; then
               LAST_EPOCH_BLOCK_HEIGHT=5418098
             else
-              echo "Unrecognized version: $REPO_MAJOR_VERSION"
+              # I'm in a previous major, fetch the epoch info from the snapshot
+              SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/$REPO_MAJOR_VERSION/osmosis.json
+              SNAPSHOT_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" $SNAPSHOT_INFO_URL)
+
+              # Snapshot is taken 100 blocks before epoch
+              SNAPSHOT_HEIGHT=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).height')
+              LAST_EPOCH_BLOCK_HEIGHT=$(($SNAPSHOT_HEIGHT + 100 ))
             fi
           fi
 
@@ -161,7 +167,8 @@ jobs:
         run: osmosisd start
       -
         name: 🧹 Clean up Osmosis Home
-        run:  rm -rf $HOME/.osmosisd/
+        if: always()
+        run: rm -rf $HOME/.osmosisd/ || true
       -
         name: Send alert via Slack message
         if: failure()


### PR DESCRIPTION
Continues: [2299](https://github.com/osmosis-labs/osmosis/pull/2299)

## What is the purpose of the change

This PR improves the state-compatibility checks by:

- Improving the self-hosted setup by using an external volume to cache latest snapshots
- Fixing halting height computation of previous versions

The state-compatibility  check works now on `v10.x` and `v11.x`. 
For the previous versions we have to backport the `osmo-builder` (I will open a new PR about it).

## Brief Changelog

- Update state check CI

## Testing and Verifying

Check running on `osmosis-ci` repo:

- [v10](https://github.com/osmosis-labs/osmosis-ci/runs/7788544173?check_suite_focus=true)
- [v11](https://github.com/osmosis-labs/osmosis-ci/runs/7790521793?check_suite_focus=true)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 