### PR TITLE
fix(ci): import paths script to work with query gen

### DIFF
--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -24,9 +24,7 @@ files=$(find ./ -type f -and -not \( -path './vendor*' -or -path './.git*' -or -
 
 echo "Updating all files"
 for file in $files; do
-    if [ -f "${file}" ]; then
-        replace_paths ${file}
-    fi
+    replace_paths ${file}
 done
 
 echo "Updating go.mod and vendoring"
@@ -34,8 +32,9 @@ echo "Updating go.mod and vendoring"
 replace_paths "go.mod"
 go mod vendor >/dev/null
 
-echo "running make proto-gen"
 # ensure that generated files are updated.
 # N.B.: This must be run after go mod vendor.
+echo "running make proto-gen"
 make proto-gen >/dev/null
+echo "running make run-querygen"
 make run-querygen >/dev/null

--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -19,7 +19,7 @@ replace_paths() {
 
 echo "Replacing import paths in all files"
 
-files=$(find ./ -type f -and -not \( -path './vendor*' -or -path './.git*' -or -name '*.md' \))
+files=$(find ./ -type f -and -not \( -path "./vendor*" -or -path "./.git*" -or -name "*.md" \))
 
 echo "Updating all files"
 for file in $files; do

--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -17,23 +17,17 @@ replace_paths() {
     sed -i "s/github.com\/osmosis-labs\/osmosis\/v${version_to_replace}/github.com\/osmosis-labs\/osmosis\/v${NEXT_MAJOR_VERSION}/g" ${file}
 }
 
-echo "Replacing import paths in Go files"
-for mod in $modules;
-do
-    for file in $mod/*; do
-        if [ -f "${file}" ]; then
-            replace_paths $file
-        fi
-    done
-done
+echo "Replacing import paths in all files"
+pwd
 
-echo "Replacing import paths in proto files"
-for file in $(find proto/osmosis -type f -name "*.proto"); do
-    replace_paths $file
-done
+files=$(find ./ -type f -and -not \( -path './vendor*' -or -path './.git*' -or -name '*.md' \))
 
-# protocgen.sh
-replace_paths "scripts/protocgen.sh"
+echo "Updating all files"
+for file in $files; do
+    if [ -f "${file}" ]; then
+        replace_paths ${file}
+    fi
+done
 
 echo "Updating go.mod and vendoring"
 # go.mod
@@ -41,6 +35,7 @@ replace_paths "go.mod"
 go mod vendor >/dev/null
 
 echo "running make proto-gen"
-# ensure protos match generated Go files
+# ensure that generated files are updated.
 # N.B.: This must be run after go mod vendor.
 make proto-gen >/dev/null
+make run-querygen >/dev/null


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The ci script is not working for the new query generation because it selects specific files types to update import paths for. Instead, we should relax the constraint of what files should be updated (all but in `vendor/*`, `git/*` or `*.md` files)


## Testing and Verifying

Tested that script works locally

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable