### PR TITLE
feat(e2e): container logs printed by default and option to disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-sim-benchmark:
 	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation -cpuprofile cpu.out $(PACKAGES_SIM)
 
 test-e2e:
-	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" OSMOSIS_E2E_DEBUG_LOG=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 test-e2e-skip-upgrade:
 	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -171,6 +171,9 @@ of the height in which the network should fork. This should match the ForkHeight
 
 - `OSMOSIS_E2E_UPGRADE_VERSION` - string of what version will be upgraded to (for example, "v10")
 
+- `OSMOSIS_E2E_DEBUG_LOG` - when true, prints debug logs from executing CLI commands
+via Docker containers. Set to trus in CI by default.
+
 #### VS Code Debug Configuration
 
 This debug configuration helps to run e2e tests locally and skip the desired tests.
@@ -197,6 +200,7 @@ This debug configuration helps to run e2e tests locally and skip the desired tes
         "OSMOSIS_E2E_SKIP_CLEANUP": "true",
         "OSMOSIS_E2E_SKIP_STATE_SYNC": "true",
         "OSMOSIS_E2E_UPGRADE_VERSION": "v10",
+        "OSMOSIS_E2E_DEBUG_LOG": "true",
         "OSMOSIS_E2E_FORK_HEIGHT": "4713065" # this is v10 fork height.
     }
 }

--- a/tests/e2e/configurer/factory.go
+++ b/tests/e2e/configurer/factory.go
@@ -105,8 +105,8 @@ var (
 // at the previous Osmosis version.
 // - If !isIBCEnabled and !isUpgradeEnabled, we only need one chain at the current
 // Git branch version of the Osmosis code.
-func New(t *testing.T, isIBCEnabled bool, upgradeSettings UpgradeSettings) (Configurer, error) {
-	containerManager, err := containers.NewManager(upgradeSettings.IsEnabled, upgradeSettings.ForkHeight > 0)
+func New(t *testing.T, isIBCEnabled, isDebugLogEnabled bool, upgradeSettings UpgradeSettings) (Configurer, error) {
+	containerManager, err := containers.NewManager(upgradeSettings.IsEnabled, upgradeSettings.ForkHeight > 0, isDebugLogEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	hermesContainerName    = "hermes-relayer"
+	hermesContainerName = "hermes-relayer"
+	// The maximum number of times debug logs are printed to console
+	// per CLI command.
 	maxDebugLogsPerCommand = 3
 )
 

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -84,12 +84,19 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		s.T().Log("skipping state sync testing")
 	}
 
+	isDebugLogEnabled := false
+	if str := os.Getenv("OSMOSIS_E2E_DEBUG_LOG"); len(str) > 0 {
+		isDebugLogEnabled, err = strconv.ParseBool(str)
+		s.Require().NoError(err)
+		s.T().Log("debug logging is enabled. container logs from running cli commands will be printed to stdout")
+	}
+
 	if str := os.Getenv(upgradeVersionEnv); len(str) > 0 {
 		upgradeSettings.Version = str
 		s.T().Log(fmt.Sprintf("upgrade version set to %s", upgradeSettings.Version))
 	}
 
-	s.configurer, err = configurer.New(s.T(), !s.skipIBC, upgradeSettings)
+	s.configurer, err = configurer.New(s.T(), !s.skipIBC, isDebugLogEnabled, upgradeSettings)
 	s.Require().NoError(err)
 
 	err = s.configurer.ConfigureChains()

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -61,34 +61,41 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	if str := os.Getenv(skipUpgradeEnv); len(str) > 0 {
 		s.skipUpgrade, err = strconv.ParseBool(str)
 		s.Require().NoError(err)
-		s.T().Log(fmt.Sprintf("%s was true, skipping upgrade tests", skipIBCEnv))
+		if s.skipUpgrade {
+			s.T().Log(fmt.Sprintf("%s was true, skipping upgrade tests", skipIBCEnv))
+		}
 	}
 	upgradeSettings.IsEnabled = !s.skipUpgrade
 
 	if str := os.Getenv(forkHeightEnv); len(str) > 0 {
 		upgradeSettings.ForkHeight, err = strconv.ParseInt(str, 0, 64)
 		s.Require().NoError(err)
-
 		s.T().Log(fmt.Sprintf("fork upgrade is enabled, %s was set to height %d", forkHeightEnv, upgradeSettings.ForkHeight))
 	}
 
 	if str := os.Getenv(skipIBCEnv); len(str) > 0 {
 		s.skipIBC, err = strconv.ParseBool(str)
 		s.Require().NoError(err)
-		s.T().Log(fmt.Sprintf("%s was true, skipping IBC tests", skipIBCEnv))
+		if s.skipIBC {
+			s.T().Log(fmt.Sprintf("%s was true, skipping IBC tests", skipIBCEnv))
+		}
 	}
 
 	if str := os.Getenv("OSMOSIS_E2E_SKIP_STATE_SYNC"); len(str) > 0 {
 		s.skipStateSync, err = strconv.ParseBool(str)
 		s.Require().NoError(err)
-		s.T().Log("skipping state sync testing")
+		if s.skipStateSync {
+			s.T().Log("skipping state sync testing")
+		}
 	}
 
 	isDebugLogEnabled := false
 	if str := os.Getenv("OSMOSIS_E2E_DEBUG_LOG"); len(str) > 0 {
 		isDebugLogEnabled, err = strconv.ParseBool(str)
 		s.Require().NoError(err)
-		s.T().Log("debug logging is enabled. container logs from running cli commands will be printed to stdout")
+		if isDebugLogEnabled {
+			s.T().Log("debug logging is enabled. container logs from running cli commands will be printed to stdout")
+		}
 	}
 
 	if str := os.Getenv(upgradeVersionEnv); len(str) > 0 {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2042

## What is the purpose of the change

Based on my experience with e2e, we should be printing container logs from executing CLI commands by default to assist with debugging.

It does add verbosity. However, I think having more logs is better than having none.

Therefore, this PR adds a change to enable logs by default and adds an option to disable it via an environment variable `OSMOSIS_E2E_DEBUG_LOG`.

The output is printed at most 3 times per CLI command. Multiple prints may happen if the container is unresponsive/slow on startup. However, from my tests locally, it prints once per command most of the time.

## Testing and Verifying

Tested locally.

Example new logs: https://github.com/osmosis-labs/osmosis/runs/7811392841?check_suite_focus=true

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)