### PR TITLE
refactor(x/mint): remove unused parameter from AfterDistributeMintedCoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1667](https://github.com/osmosis-labs/osmosis/pull/1673) Move wasm-bindings code out of app package into its own root level package.
 * [#2013](https://github.com/osmosis-labs/osmosis/pull/2013) Make `SetParams`, `SetPool`, `SetTotalLiquidity`, and `SetDenomLiquidity` GAMM APIs private
 * [#1857](https://github.com/osmosis-labs/osmosis/pull/1857) x/mint rename GetLastHalvenEpochNum to GetLastReductionEpochNum
+* [#2390](https://github.com/osmosis-labs/osmosis/pull/2390) x/mint remove unused mintCoins parameter from AfterDistributeMintedCoin
 
 ### Features
 

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -229,7 +229,7 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 	}
 
 	// call an hook after the minting and distribution of new coins
-	k.hooks.AfterDistributeMintedCoin(ctx, mintedCoin)
+	k.hooks.AfterDistributeMintedCoin(ctx)
 
 	return err
 }

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -29,7 +29,7 @@ type mintHooksMock struct {
 	hookCallCount int
 }
 
-func (hm *mintHooksMock) AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) {
+func (hm *mintHooksMock) AfterDistributeMintedCoin(ctx sdk.Context) {
 	hm.hookCallCount++
 }
 

--- a/x/mint/types/hooks.go
+++ b/x/mint/types/hooks.go
@@ -6,7 +6,7 @@ import (
 
 // MintHooks defines an interface for mint module's hooks.
 type MintHooks interface {
-	AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin)
+	AfterDistributeMintedCoin(ctx sdk.Context)
 }
 
 var _ MintHooks = MultiMintHooks{}
@@ -22,8 +22,8 @@ func NewMultiMintHooks(hooks ...MintHooks) MultiMintHooks {
 
 // AfterDistributeMintedCoin is a hook that runs after minter mints and distributes coins
 // at the beginning of each epoch.
-func (h MultiMintHooks) AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) {
+func (h MultiMintHooks) AfterDistributeMintedCoin(ctx sdk.Context) {
 	for i := range h {
-		h[i].AfterDistributeMintedCoin(ctx, mintedCoin)
+		h[i].AfterDistributeMintedCoin(ctx)
 	}
 }

--- a/x/pool-incentives/keeper/hooks.go
+++ b/x/pool-incentives/keeper/hooks.go
@@ -40,7 +40,7 @@ func (h Hooks) AfterSwap(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, 
 }
 
 // Distribute coins after minter module allocate assets to pool-incentives module.
-func (h Hooks) AfterDistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) {
+func (h Hooks) AfterDistributeMintedCoin(ctx sdk.Context) {
 	// @Sunny, @Tony, @Dev, what comments should we keep after modifying own BeginBlocker to hooks?
 
 	// WARNING: The order of how modules interact with the default distribution module matters if the distribution module is used in a similar way to:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

`AfterDistributeMintedCoin`'s parameter is unused. Removing it in this PR.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable