### PR TITLE
refactor(ci): improve update paths job with per-branch names and check out non-main branch

### DIFF
--- a/.github/workflows/import_paths.yml
+++ b/.github/workflows/import_paths.yml
@@ -29,6 +29,8 @@ jobs:
       -
         name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.target-branch }}
       -
         name: Setup Golang
         uses: actions/setup-go@v2.1.4
@@ -61,7 +63,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.COMMIT_TO_BRANCH }}
-          title: "auto: update Go import paths to v${{ inputs.version }}"
+          title: "auto: update Go import paths to v${{ inputs.version }} on branch ${{ inputs.target-branch }}"
           commit-message: "auto: update Go import paths to v${{ inputs.version }}"
           body: "**Automated pull request**\n\nUpdating Go import paths to v${{ inputs.version }}"
           base: ${{ inputs.target-branch }}


### PR DESCRIPTION
…
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently, there are issues with running the job on non-main branches that were discovered after trying to use it more:
- one is PR name clash due to duplicate PR names (assuming we update `main` and old branch at ones) 
- checking out code on main by default prevents from opening the PRs on old branches

This change fixes the above problems

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable