### PR TITLE
x/gamm: Catch overflow panics on `CalculateSpotPrice`

### DIFF
--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -622,7 +622,7 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (spotPric
 		// defer function to escape the panic when spot price overflows
 		if r := recover(); r != nil {
 			spotPrice = sdk.Dec{}
-			err = types.ErrSpotPriceOverflow
+			err = errors.New("spot price overflow")
 		}
 	}()
 
@@ -633,6 +633,10 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (spotPric
 	fullRatio := supplyRatio.Mul(invWeightRatio)
 	// we want to round this to `SigFigs` of precision
 	spotPrice = osmomath.SigFigRound(fullRatio, types.SigFigs)
+	if spotPrice.GT(sdk.NewDec(2).Power(160)) {
+		spotPrice = sdk.Dec{}
+		err = errors.New("spot price overflow")
+	}
 
 	return spotPrice, err
 }

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -622,7 +622,7 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (spotPric
 		// defer function to escape the panic when spot price overflows
 		if r := recover(); r != nil {
 			spotPrice = sdk.Dec{}
-			err = errors.New("spot price overflow")
+			err = types.ErrSpotPriceInternal
 		}
 	}()
 
@@ -635,7 +635,7 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (spotPric
 	spotPrice = osmomath.SigFigRound(fullRatio, types.SigFigs)
 	if spotPrice.GT(sdk.NewDec(2).Power(160)) {
 		spotPrice = sdk.Dec{}
-		err = errors.New("spot price overflow")
+		err = types.ErrSpotPriceOverflow
 	}
 
 	return spotPrice, err

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -531,6 +531,102 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 	}
 }
 
+// This test sets up 2 asset pools, and then checks the spot price on them.
+// It uses the pools spot price method, rather than the Gamm keepers spot price method.
+func (suite *KeeperTestSuite) TestBalancerSpotPriceBounds() {
+	baseDenom := "uosmo"
+	quoteDenom := "uion"
+	defaultFutureGovernor = ""
+
+	tests := []struct {
+		name                string
+		baseDenomPoolInput  sdk.Coin
+		baseDenomWeight     sdk.Int
+		quoteDenomPoolInput sdk.Coin
+		quoteDenomWeight    sdk.Int
+		expectError         bool
+		expectedOutput      sdk.Dec
+	}{
+		{
+			name: "spot price check at max bitlen supply",
+			// 2^196, as >= 2^197 trips max bitlen of 256
+			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt()),
+			baseDenomWeight:     sdk.NewInt(100),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206337").TruncateInt()),
+			quoteDenomWeight:    sdk.NewInt(100),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("1.000000000000000000"),
+		},
+		{
+			name:                "spot price check at min supply",
+			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.OneInt()),
+			baseDenomWeight:     sdk.NewInt(100),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.OneInt()),
+			quoteDenomWeight:    sdk.NewInt(100),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("1.000000000000000000"),
+		},
+		{
+			name: "max spot price with equal weights",
+			// 2^196, as >= 2^197 trips max bitlen of 256
+			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt()),
+			baseDenomWeight:     sdk.NewInt(100),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.OneInt()),
+			quoteDenomWeight:    sdk.NewInt(100),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336"),
+		},
+		{
+			// test overflows
+			name: "max spot price with extreme weights",
+			// 2^196, as >= 2^197 trips max bitlen of 256
+			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt()),
+			baseDenomWeight:     sdk.OneInt(),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.OneInt()),
+			quoteDenomWeight:    sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt(),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("1.000000000000000000"),
+		},
+	}
+
+	for _, tc := range tests {
+		suite.SetupTest()
+		suite.Run(tc.name, func() {
+			// pool assets
+			defaultBaseAsset := balancer.PoolAsset{
+				Weight: tc.baseDenomWeight,
+				Token:  tc.baseDenomPoolInput,
+			}
+			defaultQuoteAsset := balancer.PoolAsset{
+				Weight: tc.quoteDenomWeight,
+				Token:  tc.quoteDenomPoolInput,
+			}
+
+			poolAssets := []balancer.PoolAsset{defaultBaseAsset, defaultQuoteAsset}
+
+			pool, err := balancer.NewBalancerPool(defaultPoolId, defaultBalancerPoolParams, poolAssets, defaultFutureGovernor, defaultCurBlockTime)
+			suite.Require().NoError(err, "test: %s", tc.name)
+
+			sut := func() {
+				spotPrice, err := pool.SpotPrice(
+					suite.Ctx,
+					tc.baseDenomPoolInput.Denom,
+					tc.quoteDenomPoolInput.Denom)
+				fmt.Println("SPOT PRICE: ", spotPrice)
+				if tc.expectError {
+					suite.Require().Error(err, "test: %s", tc.name)
+				} else {
+					suite.Require().NoError(err, "test: %s", tc.name)
+					suite.Require().True(spotPrice.Equal(tc.expectedOutput),
+						"test: %s\nSpot price wrong, got %s, expected %s\n", tc.name,
+						spotPrice, tc.expectedOutput)
+				}
+			}
+			assertPoolStateNotModified(suite.T(), &pool, sut)
+		})
+	}
+}
+
 func (suite *KeeperTestSuite) TestCalcJoinPoolShares() {
 	// We append shared calcSingleAssetJoinTestCases with multi-asset and edge
 	// test cases.

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -578,6 +578,18 @@ func (suite *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 		},
 		{
 			// test int overflows
+			name: "max spot price with unequal weights",
+			// 2^196, as >= 2^197 trips max bitlen of 256
+			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt()),
+			baseDenomWeight:     sdk.NewInt(10),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.OneInt()),
+			quoteDenomWeight:    sdk.NewInt(90),
+			expectError:         false,
+			// doesn't work bc exceeds max bitlen
+			expectedOutput:      sdk.MustNewDecFromStr("903902649895682029992353676941903963918739184002820969857024.000000000000000000"),
+		},
+		{
+			// test int overflows
 			name: "max spot price with extreme weights",
 			// 2^196, as >= 2^197 trips max bitlen of 256
 			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt()),

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -577,7 +577,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 			expectedOutput:      sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336"),
 		},
 		{
-			// test overflows
+			// test int overflows
 			name: "max spot price with extreme weights",
 			// 2^196, as >= 2^197 trips max bitlen of 256
 			baseDenomPoolInput:  sdk.NewCoin(baseDenom, sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt()),
@@ -585,7 +585,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.OneInt()),
 			quoteDenomWeight:    sdk.MustNewDecFromStr("100433627766186892221372630771322662657637687111424552206336").TruncateInt(),
 			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("1.000000000000000000"),
+			expectedOutput:      sdk.MustNewDecFromStr("1.000000000000000000"), // temp, should fail
 		},
 	}
 

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -28,6 +28,8 @@ var (
 	ErrNotPositiveCriteria      = sdkerrors.Register(ModuleName, 29, "min out amount or max in amount should be positive")
 	ErrNotPositiveRequireAmount = sdkerrors.Register(ModuleName, 30, "required amount should be positive")
 	ErrTooManyTokensOut         = sdkerrors.Register(ModuleName, 31, "tx is trying to get more tokens out of the pool than exist")
+	ErrSpotPriceOverflow        = sdkerrors.Register(ModuleName, 32, "invalid spot price (overflowed)")
+	ErrSpotPriceInternal        = sdkerrors.Register(ModuleName, 33, "internal spot price error")
 
 	ErrPoolParamsInvalidDenom     = sdkerrors.Register(ModuleName, 50, "pool params' LBP params has an invalid denomination")
 	ErrPoolParamsInvalidNumDenoms = sdkerrors.Register(ModuleName, 51, "pool params' LBP doesn't have same number of params as underlying pool")

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -28,7 +28,6 @@ var (
 	ErrNotPositiveCriteria      = sdkerrors.Register(ModuleName, 29, "min out amount or max in amount should be positive")
 	ErrNotPositiveRequireAmount = sdkerrors.Register(ModuleName, 30, "required amount should be positive")
 	ErrTooManyTokensOut         = sdkerrors.Register(ModuleName, 31, "tx is trying to get more tokens out of the pool than exist")
-	ErrSpotPriceOverflow        = sdkerrors.Register(ModuleName, 32, "invalid spot price (overflowed)")
 
 	ErrPoolParamsInvalidDenom     = sdkerrors.Register(ModuleName, 50, "pool params' LBP params has an invalid denomination")
 	ErrPoolParamsInvalidNumDenoms = sdkerrors.Register(ModuleName, 51, "pool params' LBP doesn't have same number of params as underlying pool")

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrNotPositiveCriteria      = sdkerrors.Register(ModuleName, 29, "min out amount or max in amount should be positive")
 	ErrNotPositiveRequireAmount = sdkerrors.Register(ModuleName, 30, "required amount should be positive")
 	ErrTooManyTokensOut         = sdkerrors.Register(ModuleName, 31, "tx is trying to get more tokens out of the pool than exist")
+	ErrSpotPriceOverflow        = sdkerrors.Register(ModuleName, 32, "invalid spot price (overflowed)")
 
 	ErrPoolParamsInvalidDenom     = sdkerrors.Register(ModuleName, 50, "pool params' LBP params has an invalid denomination")
 	ErrPoolParamsInvalidNumDenoms = sdkerrors.Register(ModuleName, 51, "pool params' LBP doesn't have same number of params as underlying pool")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2207, #2445

## What is the purpose of the change

This PR prevents `SpotPrice` from panicing and makes it return an error for invalid or overflowing spot prices instead. It also adds tests to ensure spot prices stay within the set bounds.

## Brief Changelog

- `SpotPrice` now recovers panics and returns an error. It also sets a max spot price of 2^160

## Testing and Verifying

- New tests can be found in x/gamm/pool-models/balancer/pool_suite_test.go

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)