### PR TITLE
refactor(x/mint): unexport keeper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1857](https://github.com/osmosis-labs/osmosis/pull/1857) x/mint rename GetLastHalvenEpochNum to GetLastReductionEpochNum
 * [#2394](https://github.com/osmosis-labs/osmosis/pull/2394) Remove unused interface methods from expected keepers of each module
 * [#2390](https://github.com/osmosis-labs/osmosis/pull/2390) x/mint remove unused mintCoins parameter from AfterDistributeMintedCoin
+* [#2417](https://github.com/osmosis-labs/osmosis/pull/2417) x/mint unexport keeper `SetLastReductionEpochNum`, `getLastReductionEpochNum`, `CreateDeveloperVestingModuleAccount`, and `MintCoins`
 
 ### Features
 

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -34,6 +34,7 @@ import (
 	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	lockupkeeper "github.com/osmosis-labs/osmosis/v11/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/v11/x/lockup/types"
+	minttypes "github.com/osmosis-labs/osmosis/v11/x/mint/types"
 )
 
 type KeeperTestHelper struct {
@@ -92,6 +93,11 @@ func (s *KeeperTestHelper) Commit() {
 // FundAcc funds target address with specified amount.
 func (s *KeeperTestHelper) FundAcc(acc sdk.AccAddress, amounts sdk.Coins) {
 	err := simapp.FundAccount(s.App.BankKeeper, s.Ctx, acc, amounts)
+	s.Require().NoError(err)
+}
+
+func (s *KeeperTestHelper) MintCoins(coins sdk.Coins) {
+	err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, coins)
 	s.Require().NoError(err)
 }
 

--- a/x/mint/keeper/export_test.go
+++ b/x/mint/keeper/export_test.go
@@ -20,12 +20,28 @@ var (
 	GetProportions = getProportions
 )
 
+func (k Keeper) CreateDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.Coin) error {
+	return k.createDeveloperVestingModuleAccount(ctx, amount)
+}
+
 func (k Keeper) DistributeToModule(ctx sdk.Context, recipientModule string, mintedCoin sdk.Coin, proportion sdk.Dec) (sdk.Int, error) {
 	return k.distributeToModule(ctx, recipientModule, mintedCoin, proportion)
 }
 
 func (k Keeper) DistributeDeveloperRewards(ctx sdk.Context, totalMintedCoin sdk.Coin, developerRewardsProportion sdk.Dec, developerRewardsReceivers []types.WeightedAddress) (sdk.Int, error) {
 	return k.distributeDeveloperRewards(ctx, totalMintedCoin, developerRewardsProportion, developerRewardsReceivers)
+}
+
+func (k Keeper) GetLastReductionEpochNum(ctx sdk.Context) int64 {
+	return k.getLastReductionEpochNum(ctx)
+}
+
+func (k Keeper) SetLastReductionEpochNum(ctx sdk.Context, epochNum int64) {
+	k.setLastReductionEpochNum(ctx, epochNum)
+}
+
+func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
+	return k.mintCoins(ctx, newCoins)
 }
 
 // Set the mint hooks. This is used for testing purposes only.

--- a/x/mint/keeper/genesis.go
+++ b/x/mint/keeper/genesis.go
@@ -27,14 +27,14 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data *types.GenesisState) {
 	if !k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
 		totalDeveloperVestingCoins := sdk.NewCoin(data.Params.MintDenom, sdk.NewInt(developerVestingAmount))
 
-		if err := k.CreateDeveloperVestingModuleAccount(ctx, totalDeveloperVestingCoins); err != nil {
+		if err := k.createDeveloperVestingModuleAccount(ctx, totalDeveloperVestingCoins); err != nil {
 			panic(err)
 		}
 
 		k.bankKeeper.AddSupplyOffset(ctx, data.Params.MintDenom, sdk.NewInt(developerVestingAmount).Neg())
 	}
 
-	k.SetLastReductionEpochNum(ctx, data.ReductionStartedEpoch)
+	k.setLastReductionEpochNum(ctx, data.ReductionStartedEpoch)
 }
 
 // ExportGenesis returns a GenesisState for a given context and keeper.
@@ -46,6 +46,6 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		params.WeightedDeveloperRewardsReceivers = make([]types.WeightedAddress, 0)
 	}
 
-	lastHalvenEpoch := k.GetLastReductionEpochNum(ctx)
+	lastHalvenEpoch := k.getLastReductionEpochNum(ctx)
 	return types.NewGenesisState(minter, params, lastHalvenEpoch)
 }

--- a/x/mint/keeper/hooks.go
+++ b/x/mint/keeper/hooks.go
@@ -30,7 +30,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		if epochNumber < params.MintingRewardsDistributionStartEpoch {
 			return
 		} else if epochNumber == params.MintingRewardsDistributionStartEpoch {
-			k.SetLastReductionEpochNum(ctx, epochNumber)
+			k.setLastReductionEpochNum(ctx, epochNumber)
 		}
 		// fetch stored minter & params
 		minter := k.GetMinter(ctx)
@@ -40,11 +40,11 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		// This avoids issues with measuring in block numbers, as epochs have fixed intervals, with very
 		// low variance at the relevant sizes. As a result, it is safe to store the epoch number
 		// of the last reduction to be later retrieved for comparison.
-		if epochNumber >= params.ReductionPeriodInEpochs+k.GetLastReductionEpochNum(ctx) {
+		if epochNumber >= params.ReductionPeriodInEpochs+k.getLastReductionEpochNum(ctx) {
 			// Reduce the reward per reduction period
 			minter.EpochProvisions = minter.NextEpochProvisions(params)
 			k.SetMinter(ctx, minter)
-			k.SetLastReductionEpochNum(ctx, epochNumber)
+			k.setLastReductionEpochNum(ctx, epochNumber)
 		}
 
 		// mint coins, update supply
@@ -52,7 +52,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		mintedCoins := sdk.NewCoins(mintedCoin)
 
 		// We over-allocate by the developer vesting portion, and burn this later
-		err := k.MintCoins(ctx, mintedCoins)
+		err := k.mintCoins(ctx, mintedCoins)
 		if err != nil {
 			panic(err)
 		}

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -108,7 +108,7 @@ func (k *Keeper) SetHooks(h types.MintHooks) *Keeper {
 	return k
 }
 
-// GetMinter get the minter.
+// GetMinter gets the minter.
 func (k Keeper) GetMinter(ctx sdk.Context) (minter types.Minter) {
 	store := ctx.KVStore(k.storeKey)
 	b := store.Get(types.MinterKey)

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -92,34 +92,6 @@ func (k Keeper) SetInitialSupplyOffsetDuringMigration(ctx sdk.Context) error {
 	return nil
 }
 
-// CreateDeveloperVestingModuleAccount creates the developer vesting module account
-// and mints amount of tokens to it.
-// Should only be called during the initial genesis creation, never again. Returns nil on success.
-// Returns error in the following cases:
-// - amount is nil or zero.
-// - if ctx has block height greater than 0.
-// - developer vesting module account is already created prior to calling this method.
-func (k Keeper) CreateDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.Coin) error {
-	if amount.IsNil() || amount.Amount.IsZero() {
-		return sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero")
-	}
-	if k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
-		return sdkerrors.Wrapf(types.ErrModuleAccountAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName)
-	}
-
-	moduleAcc := authtypes.NewEmptyModuleAccount(
-		types.DeveloperVestingModuleAcctName, authtypes.Minter)
-	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
-
-	err := k.bankKeeper.MintCoins(ctx, types.DeveloperVestingModuleAcctName, sdk.NewCoins(amount))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// _____________________________________________________________________
-
 // Logger returns a module-specific logger.
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", "x/"+types.ModuleName)
@@ -136,24 +108,7 @@ func (k *Keeper) SetHooks(h types.MintHooks) *Keeper {
 	return k
 }
 
-// GetLastReductionEpochNum returns last reduction epoch number.
-func (k Keeper) GetLastReductionEpochNum(ctx sdk.Context) int64 {
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(types.LastReductionEpochKey)
-	if b == nil {
-		return 0
-	}
-
-	return int64(sdk.BigEndianToUint64(b))
-}
-
-// SetLastReductionEpochNum set last reduction epoch number.
-func (k Keeper) SetLastReductionEpochNum(ctx sdk.Context, epochNum int64) {
-	store := ctx.KVStore(k.storeKey)
-	store.Set(types.LastReductionEpochKey, sdk.Uint64ToBigEndian(uint64(epochNum)))
-}
-
-// get the minter.
+// GetMinter get the minter.
 func (k Keeper) GetMinter(ctx sdk.Context) (minter types.Minter) {
 	store := ctx.KVStore(k.storeKey)
 	b := store.Get(types.MinterKey)
@@ -165,14 +120,12 @@ func (k Keeper) GetMinter(ctx sdk.Context) (minter types.Minter) {
 	return
 }
 
-// set the minter.
+// SetMinter set the minter.
 func (k Keeper) SetMinter(ctx sdk.Context, minter types.Minter) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshal(&minter)
 	store.Set(types.MinterKey, b)
 }
-
-// _____________________________________________________________________
 
 // GetParams returns the total set of minting parameters.
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
@@ -183,19 +136,6 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 // SetParams sets the total set of minting parameters.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
-}
-
-// _____________________________________________________________________
-
-// MintCoins implements an alias call to the underlying supply keeper's
-// MintCoins to be used in BeginBlocker.
-func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
-	if newCoins.Empty() {
-		// skip as no coins need to be minted
-		return nil
-	}
-
-	return k.bankKeeper.MintCoins(ctx, types.ModuleName, newCoins)
 }
 
 // DistributeMintedCoins implements distribution of minted coins from mint to external modules.
@@ -232,6 +172,34 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 	k.hooks.AfterDistributeMintedCoin(ctx)
 
 	return err
+}
+
+// getLastReductionEpochNum returns last reduction epoch number.
+func (k Keeper) getLastReductionEpochNum(ctx sdk.Context) int64 {
+	store := ctx.KVStore(k.storeKey)
+	b := store.Get(types.LastReductionEpochKey)
+	if b == nil {
+		return 0
+	}
+
+	return int64(sdk.BigEndianToUint64(b))
+}
+
+// setLastReductionEpochNum set last reduction epoch number.
+func (k Keeper) setLastReductionEpochNum(ctx sdk.Context, epochNum int64) {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.LastReductionEpochKey, sdk.Uint64ToBigEndian(uint64(epochNum)))
+}
+
+// mintCoins implements an alias call to the underlying bank keeper's
+// MintCoins to be used in BeginBlocker.
+func (k Keeper) mintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
+	if newCoins.Empty() {
+		// skip as no coins need to be minted
+		return nil
+	}
+
+	return k.bankKeeper.MintCoins(ctx, types.ModuleName, newCoins)
 }
 
 // distributeToModule distributes mintedCoin multiplied by proportion to the recepientModule account.
@@ -337,4 +305,30 @@ func getProportions(mintedCoin sdk.Coin, ratio sdk.Dec) (sdk.Coin, error) {
 		return sdk.Coin{}, invalidRatioError{ratio}
 	}
 	return sdk.NewCoin(mintedCoin.Denom, mintedCoin.Amount.ToDec().Mul(ratio).TruncateInt()), nil
+}
+
+// CreateDeveloperVestingModuleAccount creates the developer vesting module account
+// and mints amount of tokens to it.
+// Should only be called during the initial genesis creation, never again. Returns nil on success.
+// Returns error in the following cases:
+// - amount is nil or zero.
+// - if ctx has block height greater than 0.
+// - developer vesting module account is already created prior to calling this method.
+func (k Keeper) createDeveloperVestingModuleAccount(ctx sdk.Context, amount sdk.Coin) error {
+	if amount.IsNil() || amount.Amount.IsZero() {
+		return sdkerrors.Wrap(types.ErrAmountNilOrZero, "amount cannot be nil or zero")
+	}
+	if k.accountKeeper.HasAccount(ctx, k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)) {
+		return sdkerrors.Wrapf(types.ErrModuleAccountAlreadyExist, "%s vesting module account already exist", types.DeveloperVestingModuleAcctName)
+	}
+
+	moduleAcc := authtypes.NewEmptyModuleAccount(
+		types.DeveloperVestingModuleAcctName, authtypes.Minter)
+	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
+
+	err := k.bankKeeper.MintCoins(ctx, types.DeveloperVestingModuleAcctName, sdk.NewCoins(amount))
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -120,7 +120,7 @@ func (k Keeper) GetMinter(ctx sdk.Context) (minter types.Minter) {
 	return
 }
 
-// SetMinter set the minter.
+// SetMinter sets the minter.
 func (k Keeper) SetMinter(ctx sdk.Context, minter types.Minter) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshal(&minter)

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -138,7 +138,7 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
 }
 
-// DistributeMintedCoins implements distribution of minted coins from mint to external modules.
+// DistributeMintedCoin implements distribution of a minted coin from mint to external modules.
 func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error {
 	params := k.GetParams(ctx)
 	proportions := params.DistributionProportions

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -307,7 +307,7 @@ func getProportions(mintedCoin sdk.Coin, ratio sdk.Dec) (sdk.Coin, error) {
 	return sdk.NewCoin(mintedCoin.Denom, mintedCoin.Amount.ToDec().Mul(ratio).TruncateInt()), nil
 }
 
-// CreateDeveloperVestingModuleAccount creates the developer vesting module account
+// createDeveloperVestingModuleAccount creates the developer vesting module account
 // and mints amount of tokens to it.
 // Should only be called during the initial genesis creation, never again. Returns nil on success.
 // Returns error in the following cases:

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -230,11 +230,10 @@ func (suite *KeeperTestSuite) TestDistributeMintedCoin() {
 			}
 
 			// mints coins so supply exists on chain
-			err := mintKeeper.MintCoins(ctx, sdk.NewCoins(tc.mintCoin))
-			suite.Require().NoError(err)
+			suite.MintCoins(sdk.NewCoins(tc.mintCoin))
 
 			// System under test.
-			err = mintKeeper.DistributeMintedCoin(ctx, tc.mintCoin)
+			err := mintKeeper.DistributeMintedCoin(ctx, tc.mintCoin)
 			suite.Require().NoError(err)
 
 			// validate that AfterDistributeMintedCoin hook was called once.
@@ -339,7 +338,7 @@ func (suite *KeeperTestSuite) TestSetInitialSupplyOffsetDuringMigration() {
 			// in order to ensure the offset is correctly calculated, we need to mint the supply + 1
 			// this is because a negative supply offset will always return zero
 			// by setting this to the supply + 1, we ensure we are correctly calculating the offset by keeping it delta positive
-			mintKeeper.MintCoins(ctx, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(keeper.DeveloperVestingAmount+1))))
+			suite.MintCoins(sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(keeper.DeveloperVestingAmount+1))))
 
 			supplyWithOffsetBefore := bankKeeper.GetSupplyWithOffset(ctx, sdk.DefaultBondDenom)
 			supplyOffsetBefore := bankKeeper.GetSupplyOffset(ctx, sdk.DefaultBondDenom)
@@ -441,7 +440,7 @@ func (suite *KeeperTestSuite) TestDistributeToModule() {
 				ctx := suite.Ctx
 
 				// Setup.
-				suite.Require().NoError(mintKeeper.MintCoins(ctx, sdk.NewCoins(tc.preMintCoin)))
+				suite.MintCoins(sdk.NewCoins(tc.preMintCoin))
 
 				// TODO: Should not be truncated. Remove truncation after rounding errors are addressed and resolved.
 				// Ref: https://github.com/osmosis-labs/osmosis/issues/1917

--- a/x/pool-incentives/keeper/distr_test.go
+++ b/x/pool-incentives/keeper/distr_test.go
@@ -26,10 +26,9 @@ func (suite *KeeperTestSuite) TestAllocateAssetToCommunityPoolWhenNoDistrRecords
 	// At this time, there is no distr record, so the asset should be allocated to the community pool.
 	mintCoin := sdk.NewCoin("stake", sdk.NewInt(100000))
 	mintCoins := sdk.Coins{mintCoin}
-	err := mintKeeper.MintCoins(suite.Ctx, mintCoins)
-	suite.NoError(err)
+	suite.MintCoins(mintCoins)
 
-	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
+	err := mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
 	distribution.BeginBlocker(suite.Ctx, abci.RequestBeginBlock{}, *suite.App.DistrKeeper)
@@ -42,8 +41,7 @@ func (suite *KeeperTestSuite) TestAllocateAssetToCommunityPoolWhenNoDistrRecords
 	// Community pool should be increased
 	mintCoin = sdk.NewCoin("stake", sdk.NewInt(100000))
 	mintCoins = sdk.Coins{mintCoin}
-	err = mintKeeper.MintCoins(suite.Ctx, mintCoins)
-	suite.NoError(err)
+	suite.MintCoins(mintCoins)
 	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
 
@@ -102,8 +100,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	// In this time, there are 3 records, so the assets to be allocated to the gauges proportionally.
 	mintCoin := sdk.NewCoin("stake", sdk.NewInt(100000))
 	mintCoins := sdk.Coins{mintCoin}
-	err = mintKeeper.MintCoins(suite.Ctx, mintCoins)
-	suite.NoError(err)
+	suite.MintCoins(mintCoins)
 
 	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
@@ -127,7 +124,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	// Allocate more.
 	mintCoin = sdk.NewCoin("stake", sdk.NewInt(50000))
 	mintCoins = sdk.Coins{mintCoin}
-	err = mintKeeper.MintCoins(suite.Ctx, mintCoins)
+	suite.MintCoins(mintCoins)
 	suite.NoError(err)
 	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
@@ -171,7 +168,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	// In this time, there are 3 records, so the assets to be allocated to the gauges proportionally.
 	mintCoin = sdk.NewCoin("stake", sdk.NewInt(100000))
 	mintCoins = sdk.Coins{mintCoin}
-	err = mintKeeper.MintCoins(suite.Ctx, mintCoins)
+	suite.MintCoins(mintCoins)
 	suite.NoError(err)
 	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)
@@ -194,7 +191,7 @@ func (suite *KeeperTestSuite) TestAllocateAsset() {
 	// In this time, all should be allocated to community pool
 	mintCoin = sdk.NewCoin("stake", sdk.NewInt(100000))
 	mintCoins = sdk.Coins{mintCoin}
-	err = mintKeeper.MintCoins(suite.Ctx, mintCoins)
+	suite.MintCoins(mintCoins)
 	suite.NoError(err)
 	err = mintKeeper.DistributeMintedCoin(suite.Ctx, mintCoin) // this calls AllocateAsset via hook
 	suite.NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently, a lot of the keeper methods are exported when they are only used inside the keeper package or in tests.

For the purposes of information hiding, we should unexport as many methods as possible to avoid misuse from incorrect locations.

There are no changes other than unexporting some methods and none of the methods were removed.

## Brief Changelog

- unexport `setLastReductionEpochNum`
- unexport `getLastReductionEpochNum`
- unexport `createDeveloperVestingModuleAccount`
- unexport `mintCoins`
- create a helper in `apptesting` for minting tokens in tests
- reshuffle order in mint `keeper.go` so that exported methods go first, then unexported

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable