### PR TITLE
Fix reproducible linux builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,61 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMG_TAG=nonroot
+ARG GO_VERSION="1.18"
+ARG RUNNER_IMAGE="gcr.io/distroless/static:nonroot"
 
 # --------------------------------------------------------
-# Build 
+# Builder
 # --------------------------------------------------------
 
-FROM golang:1.18.2-alpine3.15 as build
+FROM golang:${GO_VERSION}-alpine as builder
 
-# linux-headers needed by github.com/zondax/hid
 RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-headers
 
-# CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
-# 1) Add the releases into /lib/
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a \ 
-  https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a \ 
-  /lib/
-# 2) Verify their hashes
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc; \
-  sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
-# Copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
-RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
-
-# Get go dependencies first
-COPY go.mod go.sum /osmosis/
+# Download go dependencies
 WORKDIR /osmosis
+COPY go.mod go.mod
+COPY go.sum go.sum
 RUN --mount=type=cache,target=/root/.cache/go-build \
- --mount=type=cache,target=/root/go/pkg/mod \
- go mod download
+    --mount=type=cache,target=/root/go/pkg/mod \
+    go mod download
 
-# Copy all files into our docker repo
-COPY . /osmosis
+# Cosmwasm - download correct libwasmvm version
+RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
+      -O /lib/libwasmvm_muslc.a
 
-# build
+# Cosmwasm - verify checksum
+RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/checksums.txt -O /tmp/checksums.txt && \
+    sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep $(uname -m) | cut -d ' ' -f 1)
 
+# Copy the remaining files
+COPY . .
+
+# Build osmosisd binary
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/root/go/pkg/mod \
-  BUILD_TAGS=muslc LINK_STATICALLY=true make build
+    --mount=type=cache,target=/root/go/pkg/mod \
+    VERSION=$(echo $(git describe --tags) | sed 's/^v//') && \
+    COMMIT=$(git log -1 --format='%H') && \
+    go build \
+      -mod=readonly \
+      -tags "netgo,ledger,muslc" \
+      -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name="osmosis" \
+              -X github.com/cosmos/cosmos-sdk/version.AppName="osmosisd" \
+              -X github.com/cosmos/cosmos-sdk/version.Version=$VERSION \
+              -X github.com/cosmos/cosmos-sdk/version.Commit=$COMMIT \
+              -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,ledger,muslc' \
+              -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
+      -trimpath \
+      -o /osmosis/build/ \
+      ./...
 
 # --------------------------------------------------------
 # Runner
 # --------------------------------------------------------
 
-FROM gcr.io/distroless/base-debian11:${BASE_IMG_TAG}
+FROM ${RUNNER_IMAGE}
 
-COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
+COPY --from=builder /osmosis/build/osmosisd /bin/osmosisd
 
 ENV HOME /osmosis
 WORKDIR $HOME
@@ -54,4 +65,3 @@ EXPOSE 26657
 EXPOSE 1317
 
 ENTRYPOINT ["osmosisd"]
-CMD [ "start" ]

--- a/contrib/images/osmobuilder/Makefile
+++ b/contrib/images/osmobuilder/Makefile
@@ -13,7 +13,7 @@
 
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
-COSMWASM_VERSION := "v1.0.0"
+COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2)
 BUILD_TAGS := "netgo ledger muslc"
 
 IMAGE:=osmobuilder:$(VERSION)

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -208,6 +208,7 @@ func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir st
 		Tag:        m.OsmosisTag,
 		NetworkID:  m.network.Network.ID,
 		User:       "root:root",
+		Cmd:        []string{"start"},
 		Mounts: []string{
 			fmt.Sprintf("%s/:/osmosis/.osmosisd", valCondifDir),
 			fmt.Sprintf("%s/scripts:/osmosis", pwd),


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis/issues/2362

## What is the purpose of the change

This PR:

- Improves the main Dockerfile 
- Fixes reproducible builds in the Makefile

**🐳 General Dockerfile improvements:**

- Move up the layer to download `go` dependencies
- Automatically detect CosmWasm version and architecture to download the correct `libwasm`
- Explicitly use the `go build...` command
- Generalize runner images

**🛠 Reproducible build** idea:

- Compile the binary (statically linked with CosmWasm) while building the container image
- `cp` the binary out of the container and place it in the build folder

These simple changes drastically simplify the build process, and they allow very nice improvements:

1. `osmobuilder` is now deprecated as the functionality is now integrated in the main `Dockerfile`

> Removing `osmobuilder` would requires:
> - [ ] Changing the state-compatibility-check to build the binary using `make build-reproducible-amd64`
> - [ ] Update release docs

2. Deprecating `osmobuilder` allows to deprecated the whole `contrib/` folder, that can now be removed. 

> We would need to move the `scripts` 

4. We can now backport this build process to all `vX` branches to have consistent way to build the `osmosisd` binary across all versions (only difference would be the CosmWasm line)

5. The generalization of the runner image allows to create different flavour of the images starting from the same Dockerfile. This can be used to:
- Create different flavours of the `osmosis` Docker image (`distroless`, `nonroot`, `alpine`)
- Reduce the number of Dockerfile used internally (ref: https://github.com/osmosis-labs/osmosis/issues/1679)

I will create issues for every point.

## Brief Changelog

- Improve `Dockerfile`
- Fix commands in `Makefile` to create reproducible builds for linux

## Testing and Verifying

You can build the binaries with:

```
make build-reproducible
# Inspected build folder 
ls build
# osmosisd-linux-amd64 osmosisd-linux-arm64
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable