### PR TITLE
refactor(x/superfluid): improve lock validation errors

### DIFF
--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -154,7 +154,7 @@ func (k Keeper) validateLockForSFDelegate(ctx sdk.Context, lock *lockuptypes.Per
 	// ensure that lock duration >= staking.UnbondingTime
 	unbondingTime := k.sk.GetParams(ctx).UnbondingTime
 	if lock.Duration < unbondingTime {
-		return sdkerrors.Wrapf(types.ErrNotEnoughLockupDuration, "lock duration (%d) must be less than unbonding time (%d)", lock.Duration, unbondingTime)
+		return sdkerrors.Wrapf(types.ErrNotEnoughLockupDuration, "lock duration (%d) must be greater than unbonding time (%d)", lock.Duration, unbondingTime)
 	}
 
 	// Thus when we stake now, this will be the only superfluid position for this lockID.

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -148,7 +148,7 @@ func (k Keeper) validateLockForSFDelegate(ctx sdk.Context, lock *lockuptypes.Per
 
 	// prevent unbonding lockups to be not able to be used for superfluid staking
 	if lock.IsUnlocking() {
-		return sdkerrors.Wrapf(types.ErrUnbondingLockupNotSupported, "lock id : %s", lock.ID)
+		return sdkerrors.Wrapf(types.ErrUnbondingLockupNotSupported, "lock id : %d", lock.ID)
 	}
 
 	// ensure that lock duration >= staking.UnbondingTime
@@ -159,7 +159,7 @@ func (k Keeper) validateLockForSFDelegate(ctx sdk.Context, lock *lockuptypes.Per
 
 	// Thus when we stake now, this will be the only superfluid position for this lockID.
 	if k.alreadySuperfluidStaking(ctx, lock.ID) {
-		return sdkerrors.Wrapf(types.ErrAlreadyUsedSuperfluidLockup, "lock id : %s", lock.ID)
+		return sdkerrors.Wrapf(types.ErrAlreadyUsedSuperfluidLockup, "lock id : %d", lock.ID)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Started getting some errors without a descriptive message in e2e:
https://github.com/osmosis-labs/osmosis/runs/7886227803?check_suite_focus=true

This PR improves the error messages to help with debugging.


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable