### PR TITLE
feat: mutation test script improvements

### DIFF
--- a/.github/workflows/mutest-issue-generate.yml
+++ b/.github/workflows/mutest-issue-generate.yml
@@ -1,4 +1,4 @@
-name: Generate Mutation Test Errors 
+name: Generate Mutation Test Errors
 
 on:
   schedule:
@@ -14,14 +14,14 @@ jobs:
       -
         name: Run mutation test
         continue-on-error: true
-        run: make test-mutation
+        run: make test-mutation MODULES=tokenfactory
       -
         name: Execute mutation test format script
         id: mutest-formatted
         run: |
           cat mutation_test_result.txt | grep -Ev "PASS" | grep -Ev "SKIP" | tee mutation_test_result.txt
       -
-        name: Generate code blocks 
+        name: Generate code blocks
         id: gen-code-blocks
         run: |
           cat mutation_test_result.txt  | sed "s# @@# @@\n\`\`\`go\n#g " | sed "s#FAIL#\`\`\`\nFAIL\n\n\n#g " > mutation_test_result.txt 
@@ -29,8 +29,8 @@ jobs:
         name: Get today's date
         id: date
         run: |
-          echo "::set-output name=today::$(date "+%Y/%m/%d")" 
-      - 
+          echo "::set-output name=today::$(date "+%Y/%m/%d")"
+      -
         name: Read mutation_test_result file
         id: result
         uses: juliangruber/read-file-action@v1

--- a/.github/workflows/mutest-issue-generate.yml
+++ b/.github/workflows/mutest-issue-generate.yml
@@ -14,7 +14,9 @@ jobs:
       -
         name: Run mutation test
         continue-on-error: true
-        run: make test-mutation MODULES=tokenfactory
+        run: make test-mutation
+        env:
+          MODULES: tokenfactory
       -
         name: Execute mutation test format script
         id: mutest-formatted

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ test-e2e-skip-upgrade:
 	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 test-mutation:
-	@bash scripts/mutation-test.sh
+	@bash scripts/mutation-test.sh $(MODULES)
 
 benchmark:
 	@go test -mod=readonly -bench=. $(PACKAGES_UNIT)

--- a/scripts/mutation-test.sh
+++ b/scripts/mutation-test.sh
@@ -15,12 +15,12 @@ arg_len=$#
 
 for i in "$@"; do
   if [ $arg_len -gt 1 ]; then
-  MODULE_FORMAT+="./x/$i\|"
-  MODULE_NAMES+="${i} "
-  let "arg_len--"
+    MODULE_FORMAT+="./x/$i\|"
+    MODULE_NAMES+="${i} "
+    let "arg_len--"
   else
-  MODULE_FORMAT+="./x/$i"
-  MODULE_NAMES+="${i}"
+    MODULE_FORMAT+="./x/$i"
+    MODULE_NAMES+="${i}"
   fi
 done
 

--- a/scripts/mutation-test.sh
+++ b/scripts/mutation-test.sh
@@ -1,22 +1,35 @@
 #!/usr/bin/env bash
 
 set -eo pipefail
+oIFS="$IFS"; IFS=, ; set -- $1 ; IFS="$oIFS"
 
 DISABLED_MUTATORS='branch/*'
 
 # Only consider the following:
-# * go files in types or keeper packages
+# * go files in types, keeper, or module root directories
 # * ignore test and Protobuf files
-MUTATION_SOURCES=$(find ./x -type f \( -path '*/keeper/*' -or -path '*/types/*' \) \( -name '*.go' -and -not -name '*_test.go' -and -not -name '*pb*' \))
+MUTATION_SOURCES=$(find ./x -type f \( -path '*/keeper/*' -or -path '*/types/*' -or -path '*' \) \( -name '*.go' -and -not -name '*_test.go' -and -not -name '*pb*' \))
 
-# XXX: Filter on a module-by-module basis and expand when we think other modules
-# are ready. Once all modules are considered stable enough to be tested, remove
-# this filter entirely.
-MUTATION_SOURCES=$(echo "$MUTATION_SOURCES" | grep './x/tokenfactory')
+# Filter on a module-by-module basis as provided by input
+arg_len=$#
+
+for i in "$@"; do
+  if [ $arg_len -gt 1 ]; then
+  MODULE_FORMAT+="./x/$i\|"
+  MODULE_NAMES+="${i} "
+  let "arg_len--"
+  else
+  MODULE_FORMAT+="./x/$i"
+  MODULE_NAMES+="${i}"
+  fi
+done
+
+MUTATION_SOURCES=$(echo "$MUTATION_SOURCES" | grep "$MODULE_FORMAT")
 
 # Collect multiple lines into a single line to be fed into go-mutesting
 MUTATION_SOURCES=$(echo $MUTATION_SOURCES | tr '\n' ' ')
 
+echo "running mutation tests for the following module(s): $MODULE_NAMES"
 OUTPUT=$(go run github.com/osmosis-labs/go-mutesting/cmd/go-mutesting --disable=$DISABLED_MUTATORS $MUTATION_SOURCES)
 
 # Fetch the final result output and the overall mutation testing score
@@ -26,6 +39,7 @@ SCORE=$(echo "$RESULT" | grep -Eo '[[:digit:]]\.[[:digit:]]+')
 echo "writing mutation test result to mutation_test_result.txt"
 echo "$OUTPUT" > mutation_test_result.txt
 
+# Print the mutation score breakdown
 echo $RESULT
 
 # Return a non-zero exit code if the score is below 75%

--- a/scripts/mutation-test.sh
+++ b/scripts/mutation-test.sh
@@ -29,23 +29,22 @@ MUTATION_SOURCES=$(echo "$MUTATION_SOURCES" | grep "$MODULE_FORMAT")
 
 # Collect multiple lines into a single line to be fed into go-mutesting
 MUTATION_SOURCES=$(echo $MUTATION_SOURCES | tr '\n' ' ')
-echo $MUTATION_SOURCES
 
-# echo "running mutation tests for the following module(s): $MODULE_NAMES"
-# OUTPUT=$(go run github.com/osmosis-labs/go-mutesting/cmd/go-mutesting --disable=$DISABLED_MUTATORS $MUTATION_SOURCES)
+echo "running mutation tests for the following module(s): $MODULE_NAMES"
+OUTPUT=$(go run github.com/osmosis-labs/go-mutesting/cmd/go-mutesting --disable=$DISABLED_MUTATORS $MUTATION_SOURCES)
 
-# # Fetch the final result output and the overall mutation testing score
-# RESULT=$(echo "$OUTPUT" | grep 'The mutation score')
-# SCORE=$(echo "$RESULT" | grep -Eo '[[:digit:]]\.[[:digit:]]+')
+# Fetch the final result output and the overall mutation testing score
+RESULT=$(echo "$OUTPUT" | grep 'The mutation score')
+SCORE=$(echo "$RESULT" | grep -Eo '[[:digit:]]\.[[:digit:]]+')
 
-# echo "writing mutation test result to mutation_test_result.txt"
-# echo "$OUTPUT" > mutation_test_result.txt
+echo "writing mutation test result to mutation_test_result.txt"
+echo "$OUTPUT" > mutation_test_result.txt
 
-# # Print the mutation score breakdown
-# echo $RESULT
+# Print the mutation score breakdown
+echo $RESULT
 
-# # Return a non-zero exit code if the score is below 75%
-# if (( $(echo "$SCORE < 0.75" |bc -l) )); then
-#   echo "Mutation testing score below desired level ($SCORE < 0.75)"
-#   exit 1
-# fi
+# Return a non-zero exit code if the score is below 75%
+if (( $(echo "$SCORE < 0.75" |bc -l) )); then
+  echo "Mutation testing score below desired level ($SCORE < 0.75)"
+  exit 1
+fi

--- a/scripts/mutation-test.sh
+++ b/scripts/mutation-test.sh
@@ -8,7 +8,8 @@ DISABLED_MUTATORS='branch/*'
 # Only consider the following:
 # * go files in types, keeper, or module root directories
 # * ignore test and Protobuf files
-MUTATION_SOURCES=$(find ./x -type f \( -path '*/keeper/*' -or -path '*/types/*' -or -path '*' \) \( -name '*.go' -and -not -name '*_test.go' -and -not -name '*pb*' \))
+MUTATION_SOURCES=$(find ./x -type f \( -path '*/keeper/*' -or -path '*/types/*' \) \( -name '*.go' -and -not -name '*_test.go' -and -not -name '*pb*' \))
+MUTATION_SOURCES+=$(find ./x -maxdepth 2 -type f \( -name '*.go' -and -not -name '*_test.go' -and -not -name '*pb*' \))
 
 # Filter on a module-by-module basis as provided by input
 arg_len=$#
@@ -28,22 +29,23 @@ MUTATION_SOURCES=$(echo "$MUTATION_SOURCES" | grep "$MODULE_FORMAT")
 
 # Collect multiple lines into a single line to be fed into go-mutesting
 MUTATION_SOURCES=$(echo $MUTATION_SOURCES | tr '\n' ' ')
+echo $MUTATION_SOURCES
 
-echo "running mutation tests for the following module(s): $MODULE_NAMES"
-OUTPUT=$(go run github.com/osmosis-labs/go-mutesting/cmd/go-mutesting --disable=$DISABLED_MUTATORS $MUTATION_SOURCES)
+# echo "running mutation tests for the following module(s): $MODULE_NAMES"
+# OUTPUT=$(go run github.com/osmosis-labs/go-mutesting/cmd/go-mutesting --disable=$DISABLED_MUTATORS $MUTATION_SOURCES)
 
-# Fetch the final result output and the overall mutation testing score
-RESULT=$(echo "$OUTPUT" | grep 'The mutation score')
-SCORE=$(echo "$RESULT" | grep -Eo '[[:digit:]]\.[[:digit:]]+')
+# # Fetch the final result output and the overall mutation testing score
+# RESULT=$(echo "$OUTPUT" | grep 'The mutation score')
+# SCORE=$(echo "$RESULT" | grep -Eo '[[:digit:]]\.[[:digit:]]+')
 
-echo "writing mutation test result to mutation_test_result.txt"
-echo "$OUTPUT" > mutation_test_result.txt
+# echo "writing mutation test result to mutation_test_result.txt"
+# echo "$OUTPUT" > mutation_test_result.txt
 
-# Print the mutation score breakdown
-echo $RESULT
+# # Print the mutation score breakdown
+# echo $RESULT
 
-# Return a non-zero exit code if the score is below 75%
-if (( $(echo "$SCORE < 0.75" |bc -l) )); then
-  echo "Mutation testing score below desired level ($SCORE < 0.75)"
-  exit 1
-fi
+# # Return a non-zero exit code if the score is below 75%
+# if (( $(echo "$SCORE < 0.75" |bc -l) )); then
+#   echo "Mutation testing score below desired level ($SCORE < 0.75)"
+#   exit 1
+# fi


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related To: https://github.com/osmosis-labs/osmosis/issues/2426

## What is the purpose of the change

We were previously hardcoding which module to run mutation tests on. This PR now allows for a comma separated `MODULES` argument to be given to the mutation test script and allows it to run all desired modules.

Example: 
`make test-mutation MODULES=twap`
OR
`make test-mutation MODULES=twap,superfluid`

Leaving `MODULES` blank assumes all modules are desired.

## Brief Changelog

- Adds comma separated module arguments to be passed into script
- Runs mutation tests on root directory of module (twap especially needs this)
- Sets current weekly CI to only run for tokenfactory


## Testing and Verifying

This change is already covered by existing tests


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable