### PR TITLE
feat: Removed authz and added unbound to ics host params

### DIFF
--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -57,6 +57,8 @@ func CreateUpgradeHandler(
 			sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
 			sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
 			sdk.MsgTypeURL(&stakingtypes.MsgEditValidator{}),
+			// Change: Added MsgUndelegate
+			sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
 			sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
 			sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
 			sdk.MsgTypeURL(&distrtypes.MsgWithdrawValidatorCommission{}),

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -8,6 +8,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
 	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	superfluidtypes "github.com/osmosis-labs/osmosis/v11/x/superfluid/types"
 
@@ -48,35 +49,36 @@ func CreateUpgradeHandler(
 			bpm.StoreConsensusParams(ctx, cp)
 		}
 
-		// Update ICA allowedMessages param
-		params := keepers.ICAHostKeeper.GetParams(ctx)
 		// Specifying the whole list instead of adding and removing. Less fragile.
-		params.AllowMessages = []string{
-			sdk.MsgTypeURL(&banktypes.MsgSend{}),
-			sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
-			sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
-			sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
-			sdk.MsgTypeURL(&stakingtypes.MsgEditValidator{}),
-			// Change: Added MsgUndelegate
-			sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
-			sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
-			sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
-			sdk.MsgTypeURL(&distrtypes.MsgWithdrawValidatorCommission{}),
-			sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
-			sdk.MsgTypeURL(&govtypes.MsgVote{}),
-			// Change: Removed authz messages
-			sdk.MsgTypeURL(&gammtypes.MsgJoinPool{}),
-			sdk.MsgTypeURL(&gammtypes.MsgExitPool{}),
-			sdk.MsgTypeURL(&gammtypes.MsgSwapExactAmountIn{}),
-			sdk.MsgTypeURL(&gammtypes.MsgSwapExactAmountOut{}),
-			sdk.MsgTypeURL(&gammtypes.MsgJoinSwapExternAmountIn{}),
-			sdk.MsgTypeURL(&gammtypes.MsgJoinSwapShareAmountOut{}),
-			sdk.MsgTypeURL(&gammtypes.MsgExitSwapExternAmountOut{}),
-			sdk.MsgTypeURL(&gammtypes.MsgExitSwapShareAmountIn{}),
-			// Change: Added superfluid unbound
-			sdk.MsgTypeURL(&superfluidtypes.MsgSuperfluidUnbondLock{}),
+		hostParams := icahosttypes.Params{
+			HostEnabled: true,
+			AllowMessages: []string{
+				sdk.MsgTypeURL(&banktypes.MsgSend{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgEditValidator{}),
+				// Change: Added MsgUndelegate
+				sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
+				sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
+				sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
+				sdk.MsgTypeURL(&distrtypes.MsgWithdrawValidatorCommission{}),
+				sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
+				sdk.MsgTypeURL(&govtypes.MsgVote{}),
+				// Change: Removed authz messages
+				sdk.MsgTypeURL(&gammtypes.MsgJoinPool{}),
+				sdk.MsgTypeURL(&gammtypes.MsgExitPool{}),
+				sdk.MsgTypeURL(&gammtypes.MsgSwapExactAmountIn{}),
+				sdk.MsgTypeURL(&gammtypes.MsgSwapExactAmountOut{}),
+				sdk.MsgTypeURL(&gammtypes.MsgJoinSwapExternAmountIn{}),
+				sdk.MsgTypeURL(&gammtypes.MsgJoinSwapShareAmountOut{}),
+				sdk.MsgTypeURL(&gammtypes.MsgExitSwapExternAmountOut{}),
+				sdk.MsgTypeURL(&gammtypes.MsgExitSwapShareAmountIn{}),
+				// Change: Added superfluid unbound
+				sdk.MsgTypeURL(&superfluidtypes.MsgSuperfluidUnbondLock{}),
+			},
 		}
-		keepers.ICAHostKeeper.SetParams(ctx, params)
+		keepers.ICAHostKeeper.SetParams(ctx, hostParams)
 
 		// Initialize TWAP state
 		// TODO: Get allPoolIds from gamm keeper, and write test for migration.

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -3,7 +3,13 @@ package v12
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
+	superfluidtypes "github.com/osmosis-labs/osmosis/v11/x/superfluid/types"
 
 	"github.com/osmosis-labs/osmosis/v11/app/keepers"
 	"github.com/osmosis-labs/osmosis/v11/app/upgrades"
@@ -41,6 +47,34 @@ func CreateUpgradeHandler(
 
 			bpm.StoreConsensusParams(ctx, cp)
 		}
+
+		// Update ICA allowedMessages param
+		params := keepers.ICAHostKeeper.GetParams(ctx)
+		// Specifying the whole list instead of adding and removing. Less fragile.
+		params.AllowMessages = []string{
+			sdk.MsgTypeURL(&banktypes.MsgSend{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgEditValidator{}),
+			sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
+			sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
+			sdk.MsgTypeURL(&distrtypes.MsgWithdrawValidatorCommission{}),
+			sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
+			sdk.MsgTypeURL(&govtypes.MsgVote{}),
+			// Change: Removed authz messages
+			sdk.MsgTypeURL(&gammtypes.MsgJoinPool{}),
+			sdk.MsgTypeURL(&gammtypes.MsgExitPool{}),
+			sdk.MsgTypeURL(&gammtypes.MsgSwapExactAmountIn{}),
+			sdk.MsgTypeURL(&gammtypes.MsgSwapExactAmountOut{}),
+			sdk.MsgTypeURL(&gammtypes.MsgJoinSwapExternAmountIn{}),
+			sdk.MsgTypeURL(&gammtypes.MsgJoinSwapShareAmountOut{}),
+			sdk.MsgTypeURL(&gammtypes.MsgExitSwapExternAmountOut{}),
+			sdk.MsgTypeURL(&gammtypes.MsgExitSwapShareAmountIn{}),
+			// Change: Added superfluid unbound
+			sdk.MsgTypeURL(&superfluidtypes.MsgSuperfluidUnbondLock{}),
+		}
+		keepers.ICAHostKeeper.SetParams(ctx, params)
 
 		// Initialize TWAP state
 		// TODO: Get allPoolIds from gamm keeper, and write test for migration.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2432

## What is the purpose of the change

Removes authz messages from ICA and adds superfluid unbound


## Brief Changelog

 - Authz messages can no longer be executed via ICA on v12
 - Superfluid unbound messages can now be executed via ICA on v12


## Testing and Verifying

TBD. Not sure how to test upgrades

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes )
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)