### PR TITLE
feat: add multiple docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,25 @@
-name: docker
+# This workflow pushes new osmosis docker images on every new tag.
+#
+# On every new `vX.Y.Z` tag the following images are pushed:
+#
+# osmolabs/osmosis:X.Y.Z    # is pushed
+# osmolabs/osmosis:X.Y      # is updated to X.Y.Z
+# osmolabs/osmosis:X        # is updated to X.Y.Z
+# osmolabs/osmosis:latest   # is updated to X.Y.Z
+#
+# The same osmosisd binary is copied in different base runner images:
+#
+# - `osmolabs/osmosis:X.Y.Z`             uses `gcr.io/distroless/static` 
+# - `osmolabs/osmosis:X.Y.Z-distroless`  uses `gcr.io/distroless/static` 
+# - `osmolabs/osmosis:X.Y.Z-nonroot`     uses `gcr.io/distroless/static:nonroot`
+# - `osmolabs/osmosis:X.Y.Z-alpine`      uses `alpine:3.16` 
+#
+# All the images above have support for linux/amd64 and linux/arm64.
+#
+# Due to QEMU virtualization used to build multi-platform docker images
+# this workflow might take a while to complete.
+
+name: Push Docker Images
 
 on:
   push:
@@ -7,6 +28,9 @@ on:
   
 env:
   DOCKER_REPOSITORY: osmolabs/osmosis
+  RUNNER_BASE_IMAGE_DISTROLESS: gcr.io/distroless/static
+  RUNNER_BASE_IMAGE_NONROOT: gcr.io/distroless/static:nonroot
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.16
 
 jobs:
   docker:
@@ -17,19 +41,27 @@ jobs:
         uses: actions/checkout@v2
       - 
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - 
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - 
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Docker meta
-        id: meta
+        name: Find go version
+        id: find_go_version
+        run: |
+          GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+          echo "::set-output name=go_version::$(echo ${GO_VERSION})"
+
+      # Distroless Docker image (default)
+      -
+        name: Docker meta (distroless)
+        id: meta_distroless
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.DOCKER_REPOSITORY }}
@@ -37,16 +69,75 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=semver,pattern={{version}}-distroless
+            type=semver,pattern={{major}}.{{minor}}-distroless
+            type=semver,pattern={{major}}-distroless
       - 
-        name: Build and push
+        name: Build and push (distroless)
+        id: build_push_distroless
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            GO_VERSION=${{ steps.find_go_version.outputs.go_version }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_DISTROLESS }}
+          tags: ${{ steps.meta_distroless.outputs.tags }}
 
+      # Distroless nonroot Docker image
+      -
+        name: Docker meta (nonroot)
+        id: meta_nonroot
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_REPOSITORY }}
+          flavor: |
+            latest=false
+            suffix=-nonroot
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       - 
-        name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        name: Build and push (nonroot)
+        id: build_push_nonroot
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GO_VERSION=${{ steps.find_go_version.outputs.go_version }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_NONROOT }}
+          tags: ${{ steps.meta_nonroot.outputs.tags }}
+      
+      # Alpine Docker image
+      -
+        name: Docker meta (alpine)
+        id: meta_alpine
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_REPOSITORY }}
+          flavor: |
+            latest=false
+            suffix=-alpine
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - 
+        name: Build and push (alpine)
+        id: build_push_alpine
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GO_VERSION=${{ steps.find_go_version.outputs.go_version }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_ALPINE }}
+          tags: ${{ steps.meta_alpine.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION="1.18"
-ARG RUNNER_IMAGE="gcr.io/distroless/static:nonroot"
+ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------
 # Builder
@@ -13,8 +13,7 @@ RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-h
 
 # Download go dependencies
 WORKDIR /osmosis
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY go.* .
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     go mod download


### PR DESCRIPTION
Continues: https://github.com/osmosis-labs/osmosis/pull/2427 

## What is the purpose of the change

This PR adds additional flavors to the osmosis Docker image.
Now you can run the `osmosisd` binary from:

- [distroless container image](https://github.com/GoogleContainerTools/distroless#distroless-container-images)
- distroless non-root container image
- alpine image

All images have `amd64` and `arm64` support.
I have also changed the default docker image from `static:nonroot` to `static`.

### Why all of this

Distroless container images are IMHO the best way to run a golang binary. However, `nonroot` images have created permission problems in the past. To simplify, I'm proposing to use `static` distroless images as our default but still offer the possibility to run a `nonroot` Docker image via the `-nonroot` suffix.

Distroless images contain, by design, only the binary and no shell.
This limitation led to the proliferation of various spurious Docker images created ad-hoc to solve specific problems.
Introducing `alpine` images could help reduce the number of Docker images we have: https://github.com/osmosis-labs/osmosis/issues/1679, and it can be helpful in dev/testing scenarios.

## Brief Changelog

- Change the default runner Docker image to `gcr.io/distroless/static`
- Modify Docker workflow to push multiple `osmosisd` docker images with the same binary.

## Testing and Verifying

I have tested the workflow from my fork:  https://github.com/niccoloraspa/osmosis/actions/runs/2875632534.
Triggered the workflow by creating a fake tag `v12.12.22` that pushed the following images in the `osmolabs/osmosis-test` registry.

```bash
docker run osmolabs/osmosis-test:12.12.22
docker run osmolabs/osmosis-test:12.12.22-alpine
docker run osmolabs/osmosis-test:12.12.22-distroless
docker run osmolabs/osmosis-test:12.12.22-nonroot

# Also osmolabs/osmosis-test:12, osmolabs/osmosis-test:12.12, osmolabs/osmosis-test:latest 
```

## Documentation and Release Note

  - Does this pull request introduces a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable   