### PR TITLE
feat(twap/upgrade): register TWAP parameters; update epoch id in upgrade handler

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -438,6 +438,7 @@ func (appKeepers *AppKeepers) initParamsKeeper(appCodec codec.BinaryCodec, legac
 	paramsKeeper.Subspace(gammtypes.ModuleName)
 	paramsKeeper.Subspace(wasm.ModuleName)
 	paramsKeeper.Subspace(tokenfactorytypes.ModuleName)
+	paramsKeeper.Subspace(twaptypes.ModuleName)
 
 	return paramsKeeper
 }

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v11/app/keepers"
 	"github.com/osmosis-labs/osmosis/v11/app/upgrades"
+	twaptypes "github.com/osmosis-labs/osmosis/v11/x/twap/types"
 )
 
 // We set the app version to pre-upgrade because it will be incremented by one
@@ -49,6 +50,9 @@ func CreateUpgradeHandler(
 		if err != nil {
 			return nil, err
 		}
+
+		// Set TWAP parameters to default values.
+		keepers.TwapKeeper.SetParams(ctx, twaptypes.DefaultParams())
 
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -23,6 +23,8 @@ var (
 	KeyPoolAllocationRatio                  = []byte("PoolAllocationRatio")
 	KeyDeveloperRewardsReceiver             = []byte("DeveloperRewardsReceiver")
 	KeyMintingRewardsDistributionStartEpoch = []byte("MintingRewardsDistributionStartEpoch")
+
+	_ paramtypes.ParamSet = &Params{}
 )
 
 // ParamTable for minting module.

--- a/x/twap/keeper.go
+++ b/x/twap/keeper.go
@@ -18,6 +18,11 @@ type Keeper struct {
 }
 
 func NewKeeper(storeKey sdk.StoreKey, transientKey *sdk.TransientStoreKey, paramSpace paramtypes.Subspace, ammKeeper types.AmmInterface) *Keeper {
+	// set KeyTable if it has not already been set
+	if !paramSpace.HasKeyTable() {
+		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
+	}
+
 	return &Keeper{storeKey: storeKey, transientKey: transientKey, paramSpace: paramSpace, ammkeeper: ammKeeper}
 }
 

--- a/x/twap/types/params.go
+++ b/x/twap/types/params.go
@@ -9,6 +9,8 @@ import (
 // Parameter store keys.
 var (
 	KeyPruneEpochIdentifier = []byte("PruneEpochIdentifier")
+
+	_ paramtypes.ParamSet = &Params{}
 )
 
 const defaultPruneEpochIdentifier = "day"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Subcomponent of #2451

## What is the purpose of the change

@stackman27 and @mattverse 's findings about parameters not being registered

This is a simplified version of #2451 to ease the review (w/o the genesis logic)

Our TWAP parameters are not registered. As a result, they are causing problems in tests:
https://github.com/osmosis-labs/osmosis/pull/2443/files#diff-9983ccd8fa700e5e15dd45524983b41aa06eb76f59df65691c5564df04cdd4e4R214

This change registers the parameters and updates to defaults ("day") in v12 upgrade handler.

## Testing and Verifying

- covered by e2e + tested more in #2451

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable