### PR TITLE
x/gamm: Reduce swap fee for Osmo-routed trades (#2406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#2418](https://github.com/osmosis-labs/osmosis/pull/2418) x/mint remove SetInitialSupplyOffsetDuringMigration from keeper
 * [#2417](https://github.com/osmosis-labs/osmosis/pull/2417) x/mint unexport keeper `SetLastReductionEpochNum`, `getLastReductionEpochNum`, `CreateDeveloperVestingModuleAccount`, and `MintCoins`
 * [#2587](https://github.com/osmosis-labs/osmosis/pull/2587) remove encoding config argument from NewOsmosisApp
+* [#2454](https://github.com/osmosis-labs/osmosis/pull/2454) x/gamm Change `SwapExactAmountIn` and `SwapExactAmountOut` to take fee multiplier as addition input param.
 
 ### Features
 

--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -80,6 +80,10 @@ func (s *KeeperTestHelper) PrepareBalancerPoolWithPoolParams(poolParams balancer
 			Weight: sdk.NewInt(300),
 			Token:  sdk.NewCoin("baz", sdk.NewInt(5000000)),
 		},
+		{
+			Weight: sdk.NewInt(400),
+			Token:  sdk.NewCoin("uosmo", sdk.NewInt(5000000)),
+		},
 	}
 	msg := balancer.NewMsgCreateBalancerPool(s.TestAccs[0], poolParams, poolAssets, "")
 	poolId, err := s.App.GAMMKeeper.CreatePool(s.Ctx, msg)

--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -86,6 +86,11 @@ All tokens are swapped using a multi-hop mechanism. That is, all swaps
 are routed via the most cost-efficient way, swapping in and out from
 multiple pools in the process.
 
+When a trade consists of just two OSMO-included routes during a single transaction,
+the swap fees on each hop would be automatically halved. 
+Example: for converting `ATOM -> OSMO -> LUNA` using two pools with swap fees `0.3% + 0.2%`,
+instead `0.15% + 0.1%` fees will be aplied. 
+
 [Multi-Hop](https://github.com/osmosis-labs/osmosis/blob/main/x/gamm/keeper/multihop.go)
 
 ## Weights

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -114,7 +114,7 @@ func (suite *KeeperTestSuite) TestQueryTotalPoolLiquidity() {
 
 	res, err := queryClient.TotalPoolLiquidity(gocontext.Background(), &types.QueryTotalPoolLiquidityRequest{PoolId: poolId})
 	suite.Require().NoError(err)
-	expectedCoins := sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(5000000)), sdk.NewCoin("bar", sdk.NewInt(5000000)), sdk.NewCoin("baz", sdk.NewInt(5000000)))
+	expectedCoins := sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(5000000)), sdk.NewCoin("bar", sdk.NewInt(5000000)), sdk.NewCoin("baz", sdk.NewInt(5000000)), sdk.NewCoin("uosmo", sdk.NewInt(5000000)))
 	suite.Require().Equal(res.Liquidity, expectedCoins)
 }
 
@@ -158,7 +158,7 @@ func (suite *KeeperTestSuite) TestQueryBalancerPoolTotalLiquidity() {
 	// create pool
 	res, err = queryClient.TotalLiquidity(gocontext.Background(), &types.QueryTotalLiquidityRequest{})
 	suite.Require().NoError(err)
-	suite.Require().Equal("5000000bar,5000000baz,5000000foo", sdk.Coins(res.Liquidity).String())
+	suite.Require().Equal("5000000bar,5000000baz,5000000foo,5000000uosmo", sdk.Coins(res.Liquidity).String())
 }
 
 // TODO: Come fix

--- a/x/gamm/keeper/msg_server_test.go
+++ b/x/gamm/keeper/msg_server_test.go
@@ -241,6 +241,7 @@ func (suite *KeeperTestSuite) TestJoinPool_Events() {
 				sdk.NewCoin("foo", sdk.NewInt(tokenInMaxAmount)),
 				sdk.NewCoin("bar", sdk.NewInt(tokenInMaxAmount)),
 				sdk.NewCoin("baz", sdk.NewInt(tokenInMaxAmount)),
+				sdk.NewCoin("uosmo", sdk.NewInt(tokenInMaxAmount)),
 			),
 			expectedAddLiquidityEvents: 1,
 			expectedMessageEvents:      3, // 1 gamm + 2 events emitted by other keeper methods.
@@ -334,6 +335,7 @@ func (suite *KeeperTestSuite) TestExitPool_Events() {
 					sdk.NewCoin("foo", sdk.NewInt(int64Max)),
 					sdk.NewCoin("bar", sdk.NewInt(int64Max)),
 					sdk.NewCoin("baz", sdk.NewInt(int64Max)),
+					sdk.NewCoin("uosmo", sdk.NewInt(int64Max)),
 				),
 			})
 			suite.Require().NoError(err)

--- a/x/gamm/keeper/multihop.go
+++ b/x/gamm/keeper/multihop.go
@@ -17,6 +17,11 @@ func (k Keeper) MultihopSwapExactAmountIn(
 	tokenOutMinAmount sdk.Int,
 ) (tokenOutAmount sdk.Int, err error) {
 	for i, route := range routes {
+		swapFeeMultiplier := sdk.OneDec()
+		if types.SwapAmountInRoutes(routes).IsOsmoRoutedMultihop() {
+			swapFeeMultiplier = sdk.NewDecWithPrec(5, 1)
+		}
+
 		// To prevent the multihop swap from being interrupted prematurely, we keep
 		// the minimum expected output at a very low number until the last pool
 		_outMinAmount := sdk.NewInt(1)
@@ -25,7 +30,13 @@ func (k Keeper) MultihopSwapExactAmountIn(
 		}
 
 		// Execute the expected swap on the current routed pool
-		tokenOutAmount, err = k.SwapExactAmountIn(ctx, sender, route.PoolId, tokenIn, route.TokenOutDenom, _outMinAmount)
+		pool, poolErr := k.getPoolForSwap(ctx, route.PoolId)
+		if poolErr != nil {
+			return sdk.Int{}, poolErr
+		}
+
+		swapFee := pool.GetSwapFee(ctx).Mul(swapFeeMultiplier)
+		tokenOutAmount, err = k.swapExactAmountIn(ctx, sender, pool, tokenIn, route.TokenOutDenom, _outMinAmount, swapFee)
 		if err != nil {
 			return sdk.Int{}, err
 		}
@@ -33,7 +44,7 @@ func (k Keeper) MultihopSwapExactAmountIn(
 		// Chain output of current pool as the input for the next routed pool
 		tokenIn = sdk.NewCoin(route.TokenOutDenom, tokenOutAmount)
 	}
-	return
+	return tokenOutAmount, err
 }
 
 // MultihopSwapExactAmountOut defines the output denom and output amount for the last pool.
@@ -47,8 +58,14 @@ func (k Keeper) MultihopSwapExactAmountOut(
 	tokenInMaxAmount sdk.Int,
 	tokenOut sdk.Coin,
 ) (tokenInAmount sdk.Int, err error) {
+	swapFeeMultiplier := sdk.OneDec()
+
+	if types.SwapAmountOutRoutes(routes).IsOsmoRoutedMultihop() {
+		swapFeeMultiplier = sdk.NewDecWithPrec(5, 1)
+	}
+
 	// Determine what the estimated input would be for each pool along the multihop route
-	insExpected, err := k.createMultihopExpectedSwapOuts(ctx, routes, tokenOut)
+	insExpected, err := k.createMultihopExpectedSwapOuts(ctx, routes, tokenOut, swapFeeMultiplier)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -71,9 +88,14 @@ func (k Keeper) MultihopSwapExactAmountOut(
 		}
 
 		// Execute the expected swap on the current routed pool
-		_tokenInAmount, err := k.SwapExactAmountOut(ctx, sender, route.PoolId, route.TokenInDenom, insExpected[i], _tokenOut)
-		if err != nil {
-			return sdk.Int{}, err
+		pool, poolErr := k.getPoolForSwap(ctx, route.PoolId)
+		if poolErr != nil {
+			return sdk.Int{}, poolErr
+		}
+		swapFee := pool.GetSwapFee(ctx).Mul(swapFeeMultiplier)
+		_tokenInAmount, swapErr := k.swapExactAmountOut(ctx, sender, pool, route.TokenInDenom, insExpected[i], _tokenOut, swapFee)
+		if swapErr != nil {
+			return sdk.Int{}, swapErr
 		}
 
 		// Sets the final amount of tokens that need to be input into the first pool. Even though this is the final return value for the
@@ -92,7 +114,11 @@ func (k Keeper) MultihopSwapExactAmountOut(
 // amount for this last pool and then chains that input as the output of the previous pool in the route, repeating
 // until the first pool is reached. It returns an array of inputs, each of which correspond to a pool ID in the
 // route of pools for the original multihop transaction.
-func (k Keeper) createMultihopExpectedSwapOuts(ctx sdk.Context, routes []types.SwapAmountOutRoute, tokenOut sdk.Coin) ([]sdk.Int, error) {
+func (k Keeper) createMultihopExpectedSwapOuts(
+	ctx sdk.Context,
+	routes []types.SwapAmountOutRoute,
+	tokenOut sdk.Coin, swapFeeMultiplier sdk.Dec,
+) ([]sdk.Int, error) {
 	insExpected := make([]sdk.Int, len(routes))
 	for i := len(routes) - 1; i >= 0; i-- {
 		route := routes[i]
@@ -102,7 +128,7 @@ func (k Keeper) createMultihopExpectedSwapOuts(ctx sdk.Context, routes []types.S
 			return nil, err
 		}
 
-		tokenIn, err := pool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), route.TokenInDenom, pool.GetSwapFee(ctx))
+		tokenIn, err := pool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), route.TokenInDenom, pool.GetSwapFee(ctx).Mul(swapFeeMultiplier))
 		if err != nil {
 			return nil, err
 		}

--- a/x/gamm/keeper/multihop.go
+++ b/x/gamm/keeper/multihop.go
@@ -19,7 +19,7 @@ func (k Keeper) MultihopSwapExactAmountIn(
 	for i, route := range routes {
 		swapFeeMultiplier := sdk.OneDec()
 		if types.SwapAmountInRoutes(routes).IsOsmoRoutedMultihop() {
-			swapFeeMultiplier = sdk.NewDecWithPrec(5, 1)
+			swapFeeMultiplier = types.MultihopSwapFeeMultiplierForOsmoPools.Clone()
 		}
 
 		// To prevent the multihop swap from being interrupted prematurely, we keep
@@ -61,7 +61,7 @@ func (k Keeper) MultihopSwapExactAmountOut(
 	swapFeeMultiplier := sdk.OneDec()
 
 	if types.SwapAmountOutRoutes(routes).IsOsmoRoutedMultihop() {
-		swapFeeMultiplier = sdk.NewDecWithPrec(5, 1)
+		swapFeeMultiplier = types.MultihopSwapFeeMultiplierForOsmoPools.Clone()
 	}
 
 	// Determine what the estimated input would be for each pool along the multihop route

--- a/x/gamm/keeper/multihop_test.go
+++ b/x/gamm/keeper/multihop_test.go
@@ -149,7 +149,6 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountIn() 
 				} else {
 					suite.Require().True(multihopTokenOutAmount.Equal(tokenOutCalculatedAsSeparateSwaps.Amount))
 				}
-
 			} else {
 				_, err := keeper.MultihopSwapExactAmountIn(suite.Ctx, suite.TestAccs[0], test.param.routes, test.param.tokenIn, test.param.tokenOutMinAmount)
 				suite.Error(err, "test: %v", test.name)

--- a/x/gamm/keeper/multihop_test.go
+++ b/x/gamm/keeper/multihop_test.go
@@ -102,7 +102,7 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountIn() 
 
 				if adjustedPoolSwapFee != poolDefaultSwapFee {
 					for _, hop := range test.param.routes {
-						err := suite.UpdatePoolSwapFee(cacheCtx, hop.PoolId, adjustedPoolSwapFee)
+						err := suite.updatePoolSwapFee(cacheCtx, hop.PoolId, adjustedPoolSwapFee)
 						suite.NoError(err, "test: %v", test.name)
 					}
 				}
@@ -253,7 +253,7 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 
 				if adjustedPoolSwapFee != poolDefaultSwapFee {
 					for _, hop := range test.param.routes {
-						err := suite.UpdatePoolSwapFee(cacheCtx, hop.PoolId, adjustedPoolSwapFee)
+						err := suite.updatePoolSwapFee(cacheCtx, hop.PoolId, adjustedPoolSwapFee)
 						suite.NoError(err, "test: %v", test.name)
 					}
 				}
@@ -308,7 +308,7 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 	}
 }
 
-func (s *KeeperTestSuite) UpdatePoolSwapFee(ctx sdk.Context, poolId uint64, adjustedPoolSwapFee sdk.Dec) error {
+func (s *KeeperTestSuite) updatePoolSwapFee(ctx sdk.Context, poolId uint64, adjustedPoolSwapFee sdk.Dec) error {
 	pool, err := s.App.GAMMKeeper.GetPoolAndPoke(ctx, poolId)
 	if err != nil {
 		return err

--- a/x/gamm/keeper/multihop_test.go
+++ b/x/gamm/keeper/multihop_test.go
@@ -1,7 +1,7 @@
 package keeper_test
 
 import (
-	"fmt"
+	"github.com/osmosis-labs/osmosis/v11/x/gamm/pool-models/balancer"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -16,9 +16,10 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountIn() 
 	}
 
 	tests := []struct {
-		name       string
-		param      param
-		expectPass bool
+		name              string
+		param             param
+		expectPass        bool
+		reducedFeeApplied bool
 	}{
 		{
 			name: "Proper swap - foo -> bar(pool 1) - bar(pool 2) -> baz",
@@ -38,6 +39,25 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountIn() 
 			},
 			expectPass: true,
 		},
+		{
+			name: "Swap - foo -> uosmo(pool 1) - uosmo(pool 2) -> baz with a half fee applied",
+			param: param{
+				routes: []types.SwapAmountInRoute{
+					{
+						PoolId:        1,
+						TokenOutDenom: "uosmo",
+					},
+					{
+						PoolId:        2,
+						TokenOutDenom: "baz",
+					},
+				},
+				tokenIn:           sdk.NewCoin("foo", sdk.NewInt(100000)),
+				tokenOutMinAmount: sdk.NewInt(1),
+			},
+			reducedFeeApplied: true,
+			expectPass:        true,
+		},
 	}
 
 	for _, test := range tests {
@@ -45,15 +65,29 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountIn() 
 		suite.SetupTest()
 
 		suite.Run(test.name, func() {
-			// Prepare 2 pools
-			suite.PrepareBalancerPool()
-			suite.PrepareBalancerPool()
+			// Prepare 2 pools pairs
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDecWithPrec(1, 2), // 1%
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDecWithPrec(1, 2),
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDec(0),
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDec(0),
+				ExitFee: sdk.NewDec(0),
+			})
 
 			keeper := suite.App.GAMMKeeper
 
 			if test.expectPass {
 				// Calculate the chained spot price.
-				spotPriceBefore := func() sdk.Dec {
+				calcSpotPrice := func() sdk.Dec {
 					dec := sdk.NewDec(1)
 					tokenInDenom := test.param.tokenIn.Denom
 					for i, route := range test.param.routes {
@@ -68,33 +102,48 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountIn() 
 						dec = dec.Mul(sp)
 					}
 					return dec
-				}()
+				}
+
+				// we create exact the same except swap fee 2 pool pairs
+				// use +2 to calc using second pair (w/o swap fee)
+				calcOutAmountAsSeparateSwaps := func(poolIdShift uint64) sdk.Coin {
+					cacheCtx, _ := suite.Ctx.CacheContext()
+					nextTokenIn := test.param.tokenIn
+					for _, hop := range test.param.routes {
+
+						tokenOut, err := keeper.SwapExactAmountIn(cacheCtx, suite.TestAccs[0], hop.PoolId+poolIdShift, nextTokenIn, hop.TokenOutDenom, sdk.OneInt())
+						suite.Require().NoError(err)
+						nextTokenIn = sdk.NewCoin(hop.TokenOutDenom, tokenOut)
+					}
+					return nextTokenIn
+				}
+
+				tokenOutCalculatedAsSeparateSwaps := calcOutAmountAsSeparateSwaps(0)
+				tokenOutCalculatedAsSeparateSwapsWithoutFee := calcOutAmountAsSeparateSwaps(2)
+
+				spotPriceBefore := calcSpotPrice()
 
 				tokenOutAmount, err := keeper.MultihopSwapExactAmountIn(suite.Ctx, suite.TestAccs[0], test.param.routes, test.param.tokenIn, test.param.tokenOutMinAmount)
 				suite.NoError(err, "test: %v", test.name)
 
-				// Calculate the chained spot price.
-				spotPriceAfter := func() sdk.Dec {
-					dec := sdk.NewDec(1)
-					tokenInDenom := test.param.tokenIn.Denom
-					for i, route := range test.param.routes {
-						if i != 0 {
-							tokenInDenom = test.param.routes[i-1].TokenOutDenom
-						}
-
-						pool, err := keeper.GetPoolAndPoke(suite.Ctx, route.PoolId)
-						suite.NoError(err, "test: %v", test.name)
-
-						sp, err := pool.SpotPrice(suite.Ctx, tokenInDenom, route.TokenOutDenom)
-						suite.NoError(err, "test: %v", test.name)
-						dec = dec.Mul(sp)
-					}
-					return dec
-				}()
+				spotPriceAfter := calcSpotPrice()
 
 				// Ratio of the token out should be between the before spot price and after spot price.
 				sp := test.param.tokenIn.Amount.ToDec().Quo(tokenOutAmount.ToDec())
 				suite.True(sp.GT(spotPriceBefore) && sp.LT(spotPriceAfter), "test: %v", test.name)
+
+				if test.reducedFeeApplied {
+					// here we do not have exact 50% reduce due to amm math rounding and other staff
+					// playing with input values for this test can result in different discount %
+					// so lets check, that we have around 50% +-1% reduction
+					diffA := tokenOutCalculatedAsSeparateSwapsWithoutFee.Amount.Sub(tokenOutAmount)
+					diffB := tokenOutAmount.Sub(tokenOutCalculatedAsSeparateSwaps.Amount)
+					diffDistinctionPercent := diffA.Sub(diffB).Abs().ToDec().Quo(diffA.Add(diffB).ToDec())
+					suite.Require().True(diffDistinctionPercent.LT(sdk.MustNewDecFromStr("0.01")))
+				} else {
+					suite.Require().True(tokenOutAmount.Equal(tokenOutCalculatedAsSeparateSwaps.Amount))
+				}
+
 			} else {
 				_, err := keeper.MultihopSwapExactAmountIn(suite.Ctx, suite.TestAccs[0], test.param.routes, test.param.tokenIn, test.param.tokenOutMinAmount)
 				suite.Error(err, "test: %v", test.name)
@@ -111,9 +160,10 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 	}
 
 	tests := []struct {
-		name       string
-		param      param
-		expectPass bool
+		name              string
+		param             param
+		expectPass        bool
+		reducedFeeApplied bool
 	}{
 		{
 			name: "Proper swap: foo -> bar (pool 1), bar -> baz (pool 2)",
@@ -133,6 +183,25 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 			},
 			expectPass: true,
 		},
+		{
+			name: "Swap - foo -> uosmo(pool 1) - uosmo(pool 2) -> baz with a half fee applied",
+			param: param{
+				routes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       1,
+						TokenInDenom: "foo",
+					},
+					{
+						PoolId:       2,
+						TokenInDenom: "uosmo",
+					},
+				},
+				tokenInMaxAmount: sdk.NewInt(90000000),
+				tokenOut:         sdk.NewCoin("baz", sdk.NewInt(100000)),
+			},
+			expectPass:        true,
+			reducedFeeApplied: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -140,15 +209,29 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 		suite.SetupTest()
 
 		suite.Run(test.name, func() {
-			// Prepare 2 pools
-			suite.PrepareBalancerPool()
-			suite.PrepareBalancerPool()
+			// Prepare 2 pools pairs
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDecWithPrec(1, 3), // 1%
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDecWithPrec(1, 3),
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDec(0),
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: sdk.NewDec(0),
+				ExitFee: sdk.NewDec(0),
+			})
 
 			keeper := suite.App.GAMMKeeper
 
 			if test.expectPass {
 				// Calculate the chained spot price.
-				spotPriceBefore := func() sdk.Dec {
+				calcSpotPrice := func() sdk.Dec {
 					dec := sdk.NewDec(1)
 					for i, route := range test.param.routes {
 						tokenOutDenom := test.param.tokenOut.Denom
@@ -164,35 +247,46 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 						dec = dec.Mul(sp)
 					}
 					return dec
-				}()
+				}
 
+				// we create exact the same except swap fee 2 pool pairs
+				// use +2 to calc using second pair (w/o swap fee)
+				calcInAmountAsSeparateSwaps := func(poolIdShift uint64) sdk.Coin {
+					cacheCtx, _ := suite.Ctx.CacheContext()
+					nextTokenOut := test.param.tokenOut
+					for i := len(test.param.routes) - 1; i >= 0; i-- {
+						hop := test.param.routes[i]
+						tokenOut, err := keeper.SwapExactAmountOut(cacheCtx, suite.TestAccs[0], hop.PoolId+poolIdShift, hop.TokenInDenom, sdk.NewInt(100000000), nextTokenOut)
+						suite.Require().NoError(err)
+						nextTokenOut = sdk.NewCoin(hop.TokenInDenom, tokenOut)
+					}
+					return nextTokenOut
+				}
+
+				tokenInCalculatedAsSeparateSwaps := calcInAmountAsSeparateSwaps(0)
+				tokenInCalculatedAsSeparateSwapsWithoutFee := calcInAmountAsSeparateSwaps(2)
+
+				spotPriceBefore := calcSpotPrice()
 				tokenInAmount, err := keeper.MultihopSwapExactAmountOut(suite.Ctx, suite.TestAccs[0], test.param.routes, test.param.tokenInMaxAmount, test.param.tokenOut)
 				suite.Require().NoError(err, "test: %v", test.name)
 
-				// Calculate the chained spot price.
-				spotPriceAfter := func() sdk.Dec {
-					dec := sdk.NewDec(1)
-					for i, route := range test.param.routes {
-						tokenOutDenom := test.param.tokenOut.Denom
-						if i != len(test.param.routes)-1 {
-							tokenOutDenom = test.param.routes[i+1].TokenInDenom
-						}
-
-						pool, err := keeper.GetPoolAndPoke(suite.Ctx, route.PoolId)
-						suite.NoError(err, "test: %v", test.name)
-
-						sp, err := pool.SpotPrice(suite.Ctx, route.TokenInDenom, tokenOutDenom)
-						suite.NoError(err, "test: %v", test.name)
-						dec = dec.Mul(sp)
-					}
-					return dec
-				}()
-
+				spotPriceAfter := calcSpotPrice()
 				// Ratio of the token out should be between the before spot price and after spot price.
 				// This is because the swap increases the spot price
 				sp := tokenInAmount.ToDec().Quo(test.param.tokenOut.Amount.ToDec())
-				fmt.Printf("spBefore %s, spAfter %s, sp actual %s\n", spotPriceBefore, spotPriceAfter, sp)
 				suite.True(sp.GT(spotPriceBefore) && sp.LT(spotPriceAfter), "multi-hop spot price wrong, test: %v", test.name)
+
+				if test.reducedFeeApplied {
+					// here we do not have exact 50% reduce due to amm math rounding and other staff
+					// playing with input values for this test can result in different discount %
+					// so lets check, that we have around 50% +-1% reduction
+					diffA := tokenInCalculatedAsSeparateSwaps.Amount.Sub(tokenInAmount)
+					diffB := tokenInAmount.Sub(tokenInCalculatedAsSeparateSwapsWithoutFee.Amount)
+					diffDistinctionPercent := diffA.Sub(diffB).Abs().ToDec().Quo(diffA.Add(diffB).ToDec())
+					suite.Require().True(diffDistinctionPercent.LT(sdk.MustNewDecFromStr("0.01")))
+				} else {
+					suite.Require().True(tokenInAmount.Equal(tokenInCalculatedAsSeparateSwaps.Amount))
+				}
 			} else {
 				_, err := keeper.MultihopSwapExactAmountOut(suite.Ctx, suite.TestAccs[0], test.param.routes, test.param.tokenInMaxAmount, test.param.tokenOut)
 				suite.Error(err, "test: %v", test.name)

--- a/x/gamm/keeper/multihop_test.go
+++ b/x/gamm/keeper/multihop_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/osmosis-labs/osmosis/v11/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/balancer"
 
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -14,7 +14,7 @@ import (
 // denominated via tokenOutDenom through a pool denoted by poolId specifying that
 // tokenOutMinAmount must be returned in the resulting asset returning an error
 // upon failure. Upon success, the resulting tokens swapped for are returned. A
-// swap fee is applied determined by the pool's parameters.
+// swap fee is applied determined by the pool's parameters and given multiplier.
 func (k Keeper) SwapExactAmountIn(
 	ctx sdk.Context,
 	sender sdk.AccAddress,

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -14,7 +14,7 @@ import (
 // denominated via tokenOutDenom through a pool denoted by poolId specifying that
 // tokenOutMinAmount must be returned in the resulting asset returning an error
 // upon failure. Upon success, the resulting tokens swapped for are returned. A
-// swap fee is applied determined by the pool's parameters and given multiplier.
+// swap fee is applied determined by the pool's parameters.
 func (k Keeper) SwapExactAmountIn(
 	ctx sdk.Context,
 	sender sdk.AccAddress,

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -26,4 +26,7 @@ var (
 	SpotPriceSigFigs = sdk.NewDec(10).Power(SigFigsExponent).TruncateInt()
 	// MaxSpotPrice is the maximum supported spot price. Anything greater than this will error.
 	MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
+
+	// MultihopSwapFeeMultiplierForOsmoPools if a swap fees multiplier for trades consists of just two OSMO pools during a single transaction.
+	MultihopSwapFeeMultiplierForOsmoPools = sdk.NewDecWithPrec(5, 1) // 0.5
 )

--- a/x/gamm/types/route.go
+++ b/x/gamm/types/route.go
@@ -1,8 +1,15 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	appparams "github.com/osmosis-labs/osmosis/v11/app/params"
+)
 
 type SwapAmountInRoutes []SwapAmountInRoute
+
+func (routes SwapAmountInRoutes) IsOsmoRoutedMultihop() bool {
+	return len(routes) == 2 && (routes[0].TokenOutDenom == appparams.BaseCoinUnit)
+}
 
 func (routes SwapAmountInRoutes) Validate() error {
 	if len(routes) == 0 {
@@ -20,6 +27,10 @@ func (routes SwapAmountInRoutes) Validate() error {
 }
 
 type SwapAmountOutRoutes []SwapAmountOutRoute
+
+func (routes SwapAmountOutRoutes) IsOsmoRoutedMultihop() bool {
+	return len(routes) == 2 && (routes[1].TokenInDenom == appparams.BaseCoinUnit)
+}
 
 func (routes SwapAmountOutRoutes) Validate() error {
 	if len(routes) == 0 {

--- a/x/gamm/types/route.go
+++ b/x/gamm/types/route.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	appparams "github.com/osmosis-labs/osmosis/v11/app/params"
+	appparams "github.com/osmosis-labs/osmosis/v12/app/params"
 )
 
 type SwapAmountInRoutes []SwapAmountInRoute


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2406

## What is the purpose of the change

This pull request reduce swap fee for a half during calculation for each pool for routes with length of 2 and osmo intermediate, ex `ATOM -> OSMO -> USDC`. 

In general it is re-implementation of https://github.com/osmosis-labs/osmosis/pull/1069 with addition tests added.


## Brief Changelog

  - x/gamm Change `SwapExactAmountIn` and `SwapExactAmountOut`to take fee multiplier as addition input param.
  - Update multihop swaps test, to insure that half fee applies only for osmo routed multihop swaps.


## Testing and Verifying

This change added tests and can be verified as follows:

  - *Added cases for existing multihop unit tests.*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes 
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?  yes
  - How is the feature or change documented? specification (`x/<module>/spec/`) 