### PR TITLE
feat/test(osmoutils): prefix iteration for osmoutils gather; begin testing store

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -72,12 +72,18 @@ func (s *KeeperTestHelper) SetEpochStartTime() {
 
 // CreateTestContext creates a test context.
 func (s *KeeperTestHelper) CreateTestContext() sdk.Context {
+	ctx, _ := s.CreateTestContextWithMultiStore()
+	return ctx
+}
+
+// CreateTestContextWithMultiStore creates a test context and returns it together with multi store.
+func (s *KeeperTestHelper) CreateTestContextWithMultiStore() (sdk.Context, sdk.CommitMultiStore) {
 	db := dbm.NewMemDB()
 	logger := log.NewNopLogger()
 
 	ms := rootmulti.NewStore(db, logger)
 
-	return sdk.NewContext(ms, tmtypes.Header{}, false, logger)
+	return sdk.NewContext(ms, tmtypes.Header{}, false, logger), ms
 }
 
 // CreateTestContext creates a test context.

--- a/osmoutils/export_test.go
+++ b/osmoutils/export_test.go
@@ -5,3 +5,7 @@ import db "github.com/tendermint/tm-db"
 func GatherValuesFromIteratorWithStop[T any](iterator db.Iterator, parseValue func([]byte) (T, error), stopFn func([]byte) bool) ([]T, error) {
 	return gatherValuesFromIteratorWithStop(iterator, parseValue, stopFn)
 }
+
+func NoStopFn(key []byte) bool {
+	return noStopFn(key)
+}

--- a/osmoutils/export_test.go
+++ b/osmoutils/export_test.go
@@ -1,0 +1,7 @@
+package osmoutils
+
+import db "github.com/tendermint/tm-db"
+
+func GatherValuesFromIteratorWithStop[T any](iterator db.Iterator, parseValue func([]byte) (T, error), stopFn func([]byte) bool) ([]T, error) {
+	return gatherValuesFromIteratorWithStop(iterator, parseValue, stopFn)
+}

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -24,13 +24,13 @@ func GatherAllKeysFromStore(storeObj store.KVStore) []string {
 func GatherValuesFromStore[T any](storeObj store.KVStore, keyStart []byte, keyEnd []byte, parseValue func([]byte) (T, error)) ([]T, error) {
 	iterator := storeObj.Iterator(keyStart, keyEnd)
 	defer iterator.Close()
-	return gatherValuesFromIteratorWithStop(iterator, parseValue, func(b []byte) bool { return false })
+	return gatherValuesFromIteratorWithStop(iterator, parseValue, noStopFn)
 }
 
 func GatherValuesFromStorePrefix[T any](storeObj store.KVStore, prefix []byte, parseValue func([]byte) (T, error)) ([]T, error) {
 	iterator := sdk.KVStorePrefixIterator(storeObj, prefix)
 	defer iterator.Close()
-	return gatherValuesFromIteratorWithStop(iterator, parseValue, func(b []byte) bool { return false })
+	return gatherValuesFromIteratorWithStop(iterator, parseValue, noStopFn)
 }
 
 func GetValuesUntilDerivedStop[T any](storeObj store.KVStore, keyStart []byte, stopFn func([]byte) bool, parseValue func([]byte) (T, error)) ([]T, error) {
@@ -98,4 +98,8 @@ func gatherValuesFromIteratorWithStop[T any](iterator db.Iterator, parseValue fu
 		values = append(values, val)
 	}
 	return values, nil
+}
+
+func noStopFn([]byte) bool {
+	return false
 }

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -181,3 +181,8 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 		})
 	}
 }
+
+func (s *TestSuite) TestNoStopFn_AlwaysFalse() {
+	s.Require().False(osmoutils.NoStopFn([]byte(keyA)))
+	s.Require().False(osmoutils.NoStopFn([]byte(keyB)))
+}

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -1,0 +1,183 @@
+package osmoutils_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v11/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v11/osmoutils"
+)
+
+type TestSuite struct {
+	apptesting.KeeperTestHelper
+	store sdk.KVStore
+}
+
+const (
+	keyA               = "a"
+	keyB               = "b"
+	keyC               = "c"
+	mockStopValue      = "stop"
+	afterMockStopValue = mockStopValue + keyA
+	basePrefix         = "base"
+	prefixOne          = "one"
+	prefixTwo          = "two"
+)
+
+func TestOsmoUtilsTestSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}
+
+func (s *TestSuite) SetupStoreWithBasePrefix() {
+	_, ms := s.CreateTestContextWithMultiStore()
+	prefix := sdk.NewKVStoreKey(basePrefix)
+	ms.MountStoreWithDB(prefix, sdk.StoreTypeIAVL, nil)
+	err := ms.LoadLatestVersion()
+	s.Require().NoError(err)
+	s.store = ms.GetKVStore(prefix)
+}
+
+func mockParseValue(b []byte) (string, error) {
+	return string(b), nil
+}
+
+func mockParseValueWithError(b []byte) (string, error) {
+	return "", errors.New("mock error")
+}
+
+func mockStop(b []byte) bool {
+	return string(b) == fmt.Sprintf("%s%s", prefixOne, mockStopValue)
+}
+
+func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
+
+	testcases := map[string]struct {
+		// if prefix is set, startValue and endValue are ignored.
+		// we either create an iterator prefix or a range iterator.
+		prefix     string
+		startValue string
+		endValue   string
+		preSetKeys []string
+		isReverse  bool
+
+		expectedValues []string
+		expectedErr    bool
+	}{
+		"prefix iterator, no stop": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+
+			prefix: prefixOne,
+
+			expectedValues: []string{"0", "1", "2"},
+		},
+		"prefix iterator, with stop": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + mockStopValue + keyA},
+			prefix:     prefixOne,
+
+			expectedValues: []string{"0"},
+		},
+		"prefix iterator, with stop, different insertion order": {
+			// keyB is lexicographically before mockStopValue so it is returned, but before c
+			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + keyB, prefixOne + mockStopValue + keyA},
+			prefix:     prefixOne,
+
+			expectedValues: []string{"0", "2"},
+		},
+		"range iterator, no end, no stop": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+
+			startValue: prefixOne + keyB,
+
+			expectedValues: []string{"1", "2"},
+		},
+		"range iterator, no start, no stop": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+
+			endValue: prefixOne + keyB,
+
+			expectedValues: []string{"0"},
+		},
+		"range iterator, no start no end, no stop": {
+			preSetKeys:     []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			expectedValues: []string{"0", "1", "2"},
+		},
+		"range iterator, with stop": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + afterMockStopValue},
+
+			expectedValues: []string{"0"},
+		},
+		"range iterator, reverse": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			isReverse:  true,
+
+			expectedValues: []string{"2", "1", "0"},
+		},
+		"range iterator, other prefix is excluded with end value": {
+			preSetKeys: []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB, prefixOne + keyC, prefixTwo + keyC},
+			startValue: prefixOne + keyB,
+			endValue:   prefixOne + "d",
+			isReverse:  true,
+
+			expectedValues: []string{"4", "2"},
+		},
+		"parse with error": {
+			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+
+			prefix: prefixOne,
+
+			expectedErr: true,
+		},
+	}
+
+	for name, tc := range testcases {
+		s.Run(name, func() {
+			s.SetupStoreWithBasePrefix()
+
+			var iterator sdk.Iterator
+
+			for i, key := range tc.preSetKeys {
+				s.store.Set([]byte(key), []byte(fmt.Sprintf("%v", i)))
+			}
+
+			if tc.prefix != "" {
+				iterator = sdk.KVStorePrefixIterator(s.store, []byte(tc.prefix))
+			} else {
+				var startValue, endValue []byte
+				if tc.startValue != "" {
+					startValue = []byte(tc.startValue)
+				}
+				if tc.endValue != "" {
+					endValue = []byte(tc.endValue)
+				}
+
+				if tc.isReverse {
+					iterator = s.store.ReverseIterator(startValue, endValue)
+				} else {
+					iterator = s.store.Iterator(startValue, endValue)
+				}
+				defer iterator.Close()
+			}
+
+			mockParseValueFn := mockParseValue
+			if tc.expectedErr {
+				mockParseValueFn = mockParseValueWithError
+			}
+
+			actualValues, err := osmoutils.GatherValuesFromIteratorWithStop(iterator, mockParseValueFn, mockStop)
+
+			if tc.expectedErr {
+				s.Require().Error(err)
+				s.Require().Nil(actualValues)
+				return
+			}
+
+			s.Require().NoError(err)
+
+			s.Require().Equal(tc.expectedValues, actualValues)
+		})
+	}
+}

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -93,12 +93,12 @@ func (k Keeper) getAllMostRecentRecordsForPool(ctx sdk.Context, poolId uint64) (
 
 // getAllHistoricalTimeIndexedTWAPs returns all historical TWAPs indexed by time.
 func (k Keeper) getAllHistoricalTimeIndexedTWAPs(ctx sdk.Context) ([]types.TwapRecord, error) {
-	return osmoutils.GatherValuesFromStore(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPTimeIndexPrefix), []byte(types.HistoricalTWAPTimeIndexPrefixEnd), types.ParseTwapFromBz)
+	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPTimeIndexPrefix), types.ParseTwapFromBz)
 }
 
 // getAllHistoricalPoolIndexedTWAPs returns all historical TWAPs indexed by pool id.
 func (k Keeper) getAllHistoricalPoolIndexedTWAPs(ctx sdk.Context) ([]types.TwapRecord, error) {
-	return osmoutils.GatherValuesFromStore(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPPoolIndexPrefix), []byte(types.HistoricalTWAPPoolIndexPrefixEnd), types.ParseTwapFromBz)
+	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPPoolIndexPrefix), types.ParseTwapFromBz)
 }
 
 // storeNewRecord stores a record, in both the most recent record store and historical stores.

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -34,11 +34,8 @@ var (
 	// when we want to get all of the keys in a prefix. Since it is one byte larger
 	// than the original key separator and the end prefix is exclusive, it is valid
 	// for getting all values under the original key separator.
-	keySeparatorPlusOne              = string(KeySeparator[0] + 1)
-	HistoricalTWAPTimeIndexPrefix    = historicalTWAPTimeIndexNoSeparator + KeySeparator
-	HistoricalTWAPTimeIndexPrefixEnd = historicalTWAPTimeIndexNoSeparator + keySeparatorPlusOne
-	HistoricalTWAPPoolIndexPrefix    = historicalTWAPPoolIndexNoSeparator + KeySeparator
-	HistoricalTWAPPoolIndexPrefixEnd = historicalTWAPPoolIndexNoSeparator + keySeparatorPlusOne
+	HistoricalTWAPTimeIndexPrefix = historicalTWAPTimeIndexNoSeparator + KeySeparator
+	HistoricalTWAPPoolIndexPrefix = historicalTWAPPoolIndexNoSeparator + KeySeparator
 )
 
 // TODO: make utility command to automatically interlace separators


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of #2179

## What is the purpose of the change

This change spearheads store testing of `osmoutils`. Additionally, it adds a convinenet way to iterate over prefix.

In future PRs, the rest of the methods will be tested.

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable