### PR TITLE
Finalize CI state compatibility to osmosisd version

### DIFF
--- a/.github/workflows/state-compatibility-check.yml
+++ b/.github/workflows/state-compatibility-check.yml
@@ -32,8 +32,6 @@ on:
   pull_request:
     branches:
       - 'v[0-9]+.x'
-  schedule:
-      - cron: '01 23 * * *' # Runs at 01:23 UTC every day
 
 env:
   GENESIS_URL: https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
@@ -46,21 +44,11 @@ jobs:
 
   check_state_compatibility:
     # DO NOT CHANGE THIS: please read the note above
-    if: ${{ github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == 'osmosis-labs/osmosis' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == 'osmosis-labs/osmosis' }}
     runs-on: osmo-runner 
     steps:
       - 
-        # If workflow was triggered by a schedule, explicitly checkout the latest branch
-        # otherwise checkout the release branch were targetting
-        name: Checkout v11.x branch
-        if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: v11.x
-      - 
         name: Checkout branch
-        if: ${{ github.event_name != 'schedule' }}
         uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/state-compatibility-check.yml
+++ b/.github/workflows/state-compatibility-check.yml
@@ -34,18 +34,19 @@ on:
       - 'v[0-9]+.x'
 
 env:
+  GOLANG_VERSION: 1.18
   GENESIS_URL: https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
   SNAPSHOT_BUCKET: https://osmosis-snapshot.sfo3.cdn.digitaloceanspaces.com
   RPC_ENDPOINT: https://rpc.osmosis.zone
   LCD_ENDPOINT: https://lcd.osmosis.zone
-  DELTA_HALT_HEIGHT: 25
+  DELTA_HALT_HEIGHT: 50
  
 jobs:
 
   check_state_compatibility:
     # DO NOT CHANGE THIS: please read the note above
     if: ${{ github.event.pull_request.head.repo.full_name == 'osmosis-labs/osmosis' }}
-    runs-on: osmo-runner 
+    runs-on: self-hosted
     steps:
       - 
         name: Checkout branch
@@ -53,19 +54,20 @@ jobs:
         with:
           fetch-depth: 0
       -
-        name: 🔨 Build the osmosisd binary with osmobuilder
+        name: 🐿 Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^${{ env.GOLANG_VERSION }}'
+      -
+        name: 🔨 Build the osmosisd binary
         run: |
-          VERSION=$(echo $(git describe --tags) | sed 's/^v//')
-          make -f contrib/images/osmobuilder/Makefile get-binary-amd64
-
-          sudo cp release/osmosisd-$VERSION-linux-amd64 /usr/local/bin/osmosisd
-          sudo chmod +x /usr/local/bin/osmosisd
-          osmosisd version
+          make build
+          build/osmosisd version
       -
         name: 🧪 Initialize Osmosis Node
         run:  |
           rm -rf $HOME/.osmosisd/ || true
-          osmosisd init runner -o
+          build/osmosisd init runner -o
 
           # Download genesis file if not present
           mkdir -p /mnt/data/genesis/osmosis-1/
@@ -123,18 +125,13 @@ jobs:
             # I'm in the latest major, fetch the epoch info from the lcd endpoint
             LAST_EPOCH_BLOCK_HEIGHT=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 ${{ env.LCD_ENDPOINT }}/osmosis/epochs/v1beta1/epochs | dasel --plain -r json 'epochs.(identifier=day).current_epoch_start_height')
           else
-            # Hardcoded epoch for v10 (waiting for snapshot service to catch up)
-            if [ $REPO_MAJOR_VERSION == "10" ]; then
-              LAST_EPOCH_BLOCK_HEIGHT=5418098
-            else
-              # I'm in a previous major, fetch the epoch info from the snapshot
-              SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/$REPO_MAJOR_VERSION/osmosis.json
-              SNAPSHOT_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" $SNAPSHOT_INFO_URL)
+            # I'm in a previous major, calculate the epoch height from the snapshot height
+            # (Snapshot is taken 100 blocks before epoch)
 
-              # Snapshot is taken 100 blocks before epoch
-              SNAPSHOT_HEIGHT=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).height')
-              LAST_EPOCH_BLOCK_HEIGHT=$(($SNAPSHOT_HEIGHT + 100 ))
-            fi
+            SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/v$REPO_MAJOR_VERSION/osmosis.json
+            SNAPSHOT_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" $SNAPSHOT_INFO_URL)
+            SNAPSHOT_BLOCK_HEIGHT=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).height')
+            LAST_EPOCH_BLOCK_HEIGHT=$(($SNAPSHOT_BLOCK_HEIGHT + 100))
           fi
 
           HALT_HEIGHT=$(($LAST_EPOCH_BLOCK_HEIGHT + ${{ env.DELTA_HALT_HEIGHT }}))
@@ -152,37 +149,8 @@ jobs:
           dasel put string -f $CONFIG_FOLDER/app.toml '.state-sync.snapshot-interval' 0
       -
         name: 🧪 Start Osmosis Node
-        run: osmosisd start
+        run: build/osmosisd start
       -
         name: 🧹 Clean up Osmosis Home
         if: always()
         run: rm -rf $HOME/.osmosisd/ || true
-      -
-        name: Send alert via Slack message
-        if: failure()
-        uses: slackapi/slack-github-action@v1.19.0
-        with:
-          payload: |
-            {
-              "text": "State-compatibility check failed!",
-              	"blocks": [
-                  {
-                    "type": "header",
-                    "text": {
-                      "type": "plain_text",
-                      "text": ":warning: State-compatibility check failed!",
-                      "emoji": true
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url }}|View code changes>\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
-                    }
-                  }
-                ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis/issues/2413

## What is the purpose of the change

This PR finalizes the state compatibility check to make it compatible with:

- `v11.x`
- `v10.x`
- `v8.x`
- `v6.x`
- `v3.x` 

Every new PR to these branches would trigger this workflow that:

- Builds the binary
- Downloads (if not already present in the runner) a snapshot that was taken 100 blocks before the last epoch of that version
- Configures the node to halt 50 blocks after the epoch

I also have:

- Removed the alarm step
- Moved the schedule trigger to the `osmosis-ci` repository to avoid confusion

## Brief Changelog

- Modify state compatibility check to work with `v11.x`, `v10.x`, `v8.x`, `v6.x` and `v3.x` 

## Testing and Verifying

This workflow can be triggered manually in the `osmosis-ci` repository:

- [v11.x](https://github.com/osmosis-labs/osmosis-ci/runs/7921829704?check_suite_focus=true) 
- [v10.x](https://github.com/osmosis-labs/osmosis-ci/runs/7922622829?check_suite_focus=true)
- [v8.x](https://github.com/osmosis-labs/osmosis-ci/runs/7923185828?check_suite_focus=true)
- [v6.x](https://github.com/osmosis-labs/osmosis-ci/runs/7923203745?check_suite_focus=true)
- [v3.x](https://github.com/osmosis-labs/osmosis-ci/runs/7923357233?check_suite_focus=true)

At the time of writing, [v6.x](https://github.com/osmosis-labs/osmosis-ci/runs/7923203745?check_suite_focus=true) workflow hasn't been completed yet, even if it has been running for over 1 hour. 
The logic seems fine; not sure what is happening.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 