### PR TITLE
fix unclosed iterators

### DIFF
--- a/store/node.go
+++ b/store/node.go
@@ -54,7 +54,9 @@ func (ptr *ptr) delete() {
 }
 
 func (ptr *ptr) leftSibling() *ptr {
-	return ptr.tree.ptrReverseIterator(ptr.level, nil, ptr.key).ptr()
+	iter := ptr.tree.ptrReverseIterator(ptr.level, nil, ptr.key)
+	defer iter.Close()
+	return iter.ptr()
 }
 
 func (ptr *ptr) rightSibling() *ptr {
@@ -72,7 +74,9 @@ func (ptr *ptr) rightSibling() *ptr {
 
 func (ptr *ptr) child(n uint16) *ptr {
 	// TODO: set end to prefix iterator end
-	return ptr.tree.ptrIterator(ptr.level-1, ptr.node().Children[n].Index, nil).ptr()
+	iter := ptr.tree.ptrIterator(ptr.level-1, ptr.node().Children[n].Index, nil)
+	defer iter.Close()
+	return iter.ptr()
 }
 
 // parent returns the parent of the provided pointer.

--- a/x/superfluid/keeper/intermediary_account.go
+++ b/x/superfluid/keeper/intermediary_account.go
@@ -132,6 +132,7 @@ func (k Keeper) GetAllLockIdIntermediaryAccountConnections(ctx sdk.Context) []ty
 	prefixStore := prefix.NewStore(store, types.KeyPrefixLockIntermediaryAccAddr)
 
 	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
 
 	connections := []types.LockIdIntermediaryAccountConnection{}
 	for ; iterator.Valid(); iterator.Next() {


### PR DESCRIPTION
Relates to https://github.com/osmosis-labs/osmosis/issues/2414

## What is the purpose of the change

Fix unclosed iterators

## Testing and Verifying

  - Use custom tool to find unclosed iterators: https://github.com/baabeetaa/osmosis/issues/1
  - Tested manually with osmosis v11.0.0 on mainnet for ~20mins and found no unclosed iterators.

## Note
Sometime i see an err in log, im not sure its is a new bug with pebbledb only (i havent tested with goleveldb) or maybe it does not relate to this PR.

```
11:41AM ERR recovered (default) panic. Could not capture logs in ctx, see stdout
Recovering from panic  {WritePerByte}
goroutine 664 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
        /usr/lib/go/src/runtime/debug/stack.go:16 +0x19
github.com/osmosis-labs/osmosis/v10/osmoutils.PrintPanicRecoveryError({{0x277bd18, 0xc10a913f50}, {0x278e6a0, 0xc0fad67e80}, {{0xb, 0xa}, {0xc12843a020, 0x9}, 0x561b58, {0x1138bf87, ...}, ...}, ...}, ...)
        /root/osmosis/osmoutils/cache_ctx.go:50 +0x3f4
github.com/osmosis-labs/osmosis/v10/osmoutils.ApplyFuncIfNoError.func1()
        /root/osmosis/osmoutils/cache_ctx.go:20 +0x78
panic({0x1ebc8c0, 0xc14a713680})
        /usr/lib/go/src/runtime/panic.go:884 +0x212
github.com/cosmos/cosmos-sdk/store/types.(*basicGasMeter).ConsumeGas(0x15?, 0x2b?, {0x211d04b?, 0x30?})
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/store/types/gas.go:99 +0x75
github.com/cosmos/cosmos-sdk/store/gaskv.(*Store).Set(0xc01f6cff20, {0xc05d766f00, 0x2b, 0x30}, {0xc05d766e70, 0x28, 0x28})
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/store/gaskv/store.go:54 +0xa3
github.com/cosmos/cosmos-sdk/x/distribution/keeper.Keeper.SetDelegatorStartingInfo({{0x2763be8, 0xc001358050}, {0x278c060, 0xc0010e69d0}, {{0x278c060, 0xc0010e69d0}, 0xc0016042c0, {0x2763be8, 0xc001358080}, {0x2763c38, ...}, ...}, ...}, ...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/x/distribution/keeper/store.go:97 +0x1bc
github.com/cosmos/cosmos-sdk/x/distribution/keeper.Keeper.initializeDelegation({{0x2763be8, 0xc001358050}, {0x278c060, 0xc0010e69d0}, {{0x278c060, 0xc0010e69d0}, 0xc0016042c0, {0x2763be8, 0xc001358080}, {0x2763c38, ...}, ...}, ...}, ...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/x/distribution/keeper/delegation.go:27 +0x2bc
github.com/cosmos/cosmos-sdk/x/distribution/keeper.Hooks.AfterDelegationModified(...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/x/distribution/keeper/hooks.go:96
github.com/cosmos/cosmos-sdk/x/staking/types.MultiStakingHooks.AfterDelegationModified(...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/x/staking/types/hooks.go:56
github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.AfterDelegationModified(...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/x/staking/keeper/hooks.go:70
github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.Delegate({{0x2763be8, 0xc001358030}, {0x278c060, 0xc0010e69d0}, {0x277e540, 0xc000e1fa70}, {0x2789060, 0xc000f41760}, {0x278ca70, 0xc000013590}, ...}, ...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/x/staking/keeper/delegation.go:624 +0x1019
github.com/osmosis-labs/osmosis/v10/x/superfluid/keeper.Keeper.mintOsmoTokensAndDelegate.func1({{0x277bd18, 0xc10a913f50}, {0x278e6a0, 0xc06994ed00}, {{0xb, 0xa}, {0xc12843a020, 0x9}, 0x561b58, {0x1138bf87, ...}, ...}, ...})
        /root/osmosis/x/superfluid/keeper/stake.go:296 +0x438
github.com/osmosis-labs/osmosis/v10/osmoutils.ApplyFuncIfNoError({{0x277bd18, 0xc10a913f50}, {0x278e6a0, 0xc0fad67e80}, {{0xb, 0xa}, {0xc12843a020, 0x9}, 0x561b58, {0x1138bf87, ...}, ...}, ...}, ...)
        /root/osmosis/osmoutils/cache_ctx.go:26 +0x182
github.com/osmosis-labs/osmosis/v10/x/superfluid/keeper.Keeper.mintOsmoTokensAndDelegate({{0x2791e38, 0xc0010e69d0}, {0x2763be8, 0xc001358170}, {{0x278c060, 0xc0010e69d0}, 0xc0016042c0, {0x2763be8, 0xc001358080}, {0x2763c38, ...}, ...}, ...}, ...)
        /root/osmosis/x/superfluid/keeper/stake.go:280 +0x285
github.com/osmosis-labs/osmosis/v10/x/superfluid/keeper.Keeper.SuperfluidDelegate({{0x2791e38, 0xc0010e69d0}, {0x2763be8, 0xc001358170}, {{0x278c060, 0xc0010e69d0}, 0xc0016042c0, {0x2763be8, 0xc001358080}, {0x2763c38, ...}, ...}, ...}, ...)
        /root/osmosis/x/superfluid/keeper/stake.go:199 +0x425
github.com/osmosis-labs/osmosis/v10/x/superfluid/keeper.msgServer.SuperfluidDelegate({0x277bd18?}, {0x277bd18?, 0xc10bc6bcb0?}, 0xc013c94ea8)
        /root/osmosis/x/superfluid/keeper/msg_server.go:35 +0x1a5
github.com/osmosis-labs/osmosis/v10/x/superfluid/keeper.msgServer.LockAndSuperfluidDelegate({0x419105?}, {0x277bd18, 0xc10bc6bcb0}, 0xc1045ad680)
        /root/osmosis/x/superfluid/keeper/msg_server.go:101 +0x39e
github.com/osmosis-labs/osmosis/v10/x/superfluid/types._Msg_LockAndSuperfluidDelegate_Handler.func1({0x277bd18, 0xc10bc6bcb0}, {0x20a6020?, 0xc1045ad680})
        /root/osmosis/x/superfluid/types/tx.pb.go:756 +0x78
github.com/cosmos/cosmos-sdk/baseapp.(*MsgServiceRouter).RegisterService.func2.1({0x277bd18, 0xc10bc6bc80}, {0x4c9ae6?, 0x418b4b?}, 0x20fc600?, 0xc02407f608)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/baseapp/msg_service_router.go:113 +0xd2
github.com/osmosis-labs/osmosis/v10/x/superfluid/types._Msg_LockAndSuperfluidDelegate_Handler({0x1f34860?, 0xc001604738}, {0x277bd18, 0xc10bc6bc80}, 0x24d1190, 0xc0d08d6440)
        /root/osmosis/x/superfluid/types/tx.pb.go:758 +0x138
github.com/cosmos/cosmos-sdk/baseapp.(*MsgServiceRouter).RegisterService.func2({{0x277bd18, 0xc10a913f50}, {0x278e6a0, 0xc0fad67e80}, {{0xb, 0xa}, {0xc12843a020, 0x9}, 0x561b58, {0x1138bf87, ...}, ...}, ...}, ...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/baseapp/msg_service_router.go:117 +0x2f3
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runMsgs(_, {{0x277bd18, 0xc10a913f50}, {0x278e6a0, 0xc0fad67e80}, {{0xb, 0xa}, {0xc12843a020, 0x9}, 0x561b58, ...}, ...}, ...)
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/baseapp/baseapp.go:740 +0x5a5
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0xc000490780, 0x3, {0xc0905c8300, 0x171, 0x171})
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/baseapp/baseapp.go:697 +0xbc5
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).DeliverTx(0xc000490780, {{0xc0905c8300?, 0x20?, 0xc13a0b04e0?}})
        /root/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.45.1-0.20220728141005-f09814c9e23f/baseapp/abci.go:289 +0x193
github.com/tendermint/tendermint/abci/client.(*localClient).DeliverTxAsync(0xc0067764e0, {{0xc0905c8300?, 0xe8b584?, 0xc0067764e0?}})
        /root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/abci/client/local_client.go:93 +0x105
github.com/tendermint/tendermint/proxy.(*appConnConsensus).DeliverTxAsync(0xc18a5132e0?, {{0xc0905c8300?, 0x20?, 0xb?}})
        /root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/proxy/app_conn.go:85 +0x26
github.com/tendermint/tendermint/state.execBlockOnProxyApp({0x277d090?, 0xc006c54a80}, {0x27851e0, 0xc006d0a220}, 0xc13b627860, {0x278cbc0, 0xc0095ec110}, 0x561b57?)
        /root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/state/execution.go:320 +0x847
github.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0xa}, {0xc003407180, 0x7}}, {0xc003407187, 0x9}, 0x1, 0x561b57, {{0xc01e0534a0, ...}, ...}, ...}, ...)
        /root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/state/execution.go:140 +0x171
github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).poolRoutine(0xc00105a8c0, 0x0)
        /root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/blockchain/v0/reactor.go:398 +0xb5a
created by github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).OnStart
        /root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/blockchain/v0/reactor.go:110 +0x7a
```
