### PR TITLE
x/mint(docs): ADR for handling truncations

### DIFF
--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -1,4 +1,4 @@
-# ADR 001: Mint Truncation Refactor
+# ADR 001: Mint Truncations Handling Refactor
 
 ## Changelog
 

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -13,10 +13,10 @@ Draft: https://github.com/osmosis-labs/osmosis/pull/2342
 This ADR focuses on refactoring `x/mint` module to mitigate the discrepancies between the actual and 
 the projected inflation amounts.
 
-Currently, we under mint due to truncation. In the first year of operations, this happens to be approximately 2600 OSMO. As a result, we cannot reach the projected supply one to one.
+Currently, we under-mint due to truncations. In the first year of operations, this happens to be approximately 2600 OSMO. As a result, we cannot reach the projected OSMO supply one-to-one.
 
-Additionally, some of the constraints have made it difficult to refactor the module. Specifically, the developer vesting provisions 
-follow a distinct distribution logic from the rest of the provisions. While that is the case, these providiond are tightly coupled together, causing to utilize unsafe workarounds such as over-minting and later burning developer vesting provisions. This ADR addresses these issues by decoupling the two kinds of provisions and letting them use separate distribution logic.
+Additionally, some of the constraints have made it difficult to refactor the `x/mint` module. Specifically, the developer vesting provisions 
+follow a distinct distribution logic from the rest of the provisions. While that is the case, these provisions are tightly coupled together, causing the utilization of unsafe workarounds such as over-minting and later burning developer vesting provisions. This ADR addresses these issues by decoupling the two kinds of provisions and letting them use separate distribution logic.
 
 ## Context
 
@@ -24,7 +24,7 @@ follow a distinct distribution logic from the rest of the provisions. While that
 
 Ref: https://github.com/osmosis-labs/osmosis/issues/1917
 
-Ultimately, the major sources of the truncation issues are some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256).  These interfaces operate on `sdk.Coin` that use `sdk.Int` for amounts. To use these interfaces, we always round down to the nearest integer by [truncating decimal provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we operate on amounts with precision of 6 decimals by using exponents where we assumme that 1 `sdk.Int` is equal to `1 / 10^6` OSMO, this still does not allow us to observe enough accuracy. As a result, it is possible to undermint. `sdk.Dec` has a precision of `18` decimals. By using it in conjunction with the above  `1 / 10^6` downscaling allows us to achieve a precision of `6 + 18 = 24` decimals. According to tests, this precision is sufficient to accurately represent the projected amounts and achieve the expected supply after [30 years of operations](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/hooks_test.go#L453).
+Ultimately, the major sources of the truncation issues are some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256).  These interfaces operate on `sdk.Coin` that uses `sdk.Int` for amounts. To use these interfaces, we always round down to the nearest integer by [truncating decimal provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we operate on amounts with the precision of 6 decimals by using exponentiation and assuming that 1 `sdk.Int` is equal to `1 / 10^6` OSMO, this still does not allow us to observe enough accuracy. As a result, it is possible to under-mint. `sdk.Dec` has a precision of `18` decimals. By using it in conjunction with the above  `1 / 10^6` downscaling allows us to achieve a precision of `6 + 18 = 24` decimals. According to tests, this precision is sufficient to accurately represent the projected amounts and achieve the expected supply after [30 years of operations](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/hooks_test.go#L453).
 
 The expected amounts have been estimated in Python by using the following formulas:
 
@@ -34,7 +34,7 @@ $$P(n) = EpochsPerPeriod * InitialRewardsPerEpoch * ( (1 - ReductionFactor^{n+1}
 - Total expected supply `S`
 $$S = InitialSupply + EpochsPerPeriod * ( InitialRewardsPerEpoch / (1 - ReductionFactor) )$$
 
-Moreover, developer reward receivers suffer the most because the large source of truncations is identified to occur in [the calculation of the proportions for each developer account](https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265):
+Lastly, developer reward receivers suffer the most because the large source of truncations is identified to occur in [the calculation of the proportions for each developer account](https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265):
 https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/hooks_test.go#L601-L602
 
 ### Additional Limitations
@@ -47,15 +47,15 @@ Ref: https://github.com/osmosis-labs/osmosis/issues/2025
 
 Our developer vesting provisions have been coupled together with the rest of the provisions (futher referred to as "inflation provisions") despite having a distinct distribution logic. The divergence is summarized next:
 
-1. Developer vesting provisions are [pre-minted](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/genesis.go#L30) at genesis to the developer vesting module account
+1. Developer vesting provisions are [pre-minted](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/genesis.go#L30) at genesis to the developer vesting module account.
 2. Since they are pre-minted, we do not need to be minting them every epoch contrary to the inflation provisions.
-   - This has caused a number of issues such as having to [over-mint](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55) by the developer vesting rewards and then [burn them later](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230)
-3. The developer vesting provisions are [distributed from the developer vesting module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) while other rewards are [distributed from the mint module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L194)
+   - This has caused several issues such as having to [over-mint](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55) by the developer vesting rewards and then [burn them later](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230).
+3. The developer vesting provisions are [distributed from the developer vesting module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) while other rewards are [distributed from the mint module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L194).
 4. We use supply offsets to [offset the unvested developer provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L275-L277) since we have pre-minted the full amount at genesis. The offsets
 are unrelated to the inflation provisions.
 
-The above differences portray the distinct handling of the developer rewards provisions. However, the developer vesting provisions handling
-is highly coupled to the regular provisions. leading to increased complexity.
+The above differences portray the distinct handling of the developer vesting provisions. Still, their handling
+is highly coupled to the regular provisions, leading to increased complexity.
 
 #### Complicated `AfterEpochEnd` Hook
 
@@ -78,7 +78,7 @@ also helps to achieve an increased separation of concerns.
 
 #### Summary
 
-We will **minimize truncations and use decimals for estimating distributions**. Specifically, the [`getProportions`](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L477) function will take decimal value and return decimal result so that we can use the (non-truncated) value with increased precision for futher calculating each developer's reward and inflation provisions. Additionally, functions that handle distributions logic such as (`distributeDeveloperVestingProvisions`)[https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L286] will now take
+We will **minimize truncations and use decimals for estimating distributions**. Specifically, the [`getProportions`](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L477) function will take a decimal value and return decimal result so that we can use the (non-truncated) value with increased precision for further calculating each developer's reward and inflation provisions. Additionally, functions that handle distributions logic such as (`distributeDeveloperVestingProvisions`)[https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L286] will now take
 `sdk.DecCoin` as opposed to `sdk.Coin` for the same reason of having to operate on decimals with increased precision.
 
 #### Conseqeunces
@@ -86,7 +86,7 @@ We will **minimize truncations and use decimals for estimating distributions**. 
 ##### Positive
 
 The truncations due to integer interfaces within the `x/mint` module are eliminated completely. All remaining truncations are due
-to dependencies on the `x/bank` and `x/distribution` module.
+to dependencies on the `x/bank` and `x/distribution` modules.
 
 ##### Negative
 
@@ -108,7 +108,7 @@ https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c471734
 
 This is helpful for accounting for truncations and distributing them eventually, not necessarily in the same epoch.
 
-For example, assume that for some number of epochs our expected provisions are 100.6 and the actual amount distributed is 100 every epoch due to truncations. Then, at epoch 1, we have a delta of 0.6. 0.6 cannot be distributed because it is not an integer. So we persist it until the next epoch. Then, at at epoch 2, we get a delta of 1.2 (0.6 from epoch 1 and 0.6 from epoch 2).
+For example, assume that for some number of epochs our expected provisions are 100.6 and the actual amount distributed is 100 every epoch due to truncations. Then, at epoch 1, we have a delta of 0.6. 0.6 cannot be distributed because it is not an integer. So we persist it until the next epoch. Then, at epoch 2, we get a delta of 1.2 (0.6 from epoch 1 and 0.6 from epoch 2).
 Now, 1 can be distributed and 0.2 gets persisted until the next epoch.
 
 ##### Negative
@@ -131,13 +131,13 @@ The [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342
 
 ##### Positive
 
-The above decoupling makes the abstractions clearer, reduces complexity and fixes [#2025](https://github.com/osmosis-labs/osmosis/issues/2025)
+The above decoupling makes the abstractions clearer, reduces complexity, and fixes [#2025](https://github.com/osmosis-labs/osmosis/issues/2025)
 This change also makes it more intuitive to apply the [Decision 2](#decision_2) above since the 2 truncation store indexes are split into 2
-to separate the distribution from separate module account.
+to separate the distribution from separate module accounts.
 
 ##### Negative
 
-This is a large change to the core logic of the `x/mint` module, requiring more thoroigh testing and quality assurance.
+This is a large change to the core logic of the `x/mint` module, requiring more thorough testing and quality assurance.
 
 ### Decision 4
 
@@ -155,21 +155,20 @@ It handles distributing both [inflation provisions](https://github.com/osmosis-l
 
 This change allows for better encapsulation of all distribution logic and for the ability to more thoroughly unit test it.
 
-The enhanced encapulation in turn leads to a more modular mint keeper where each method strives to focus on a single concern. 
+The enhanced encapsulation in turn leads to a more modular mint keeper where each method strives to focus on a single concern. 
 
 ## Backwards Compatibility
 
-This change is not backwards compatibly with any of the previous Osmosis versions and requires a major upgrade to be deployed.
+This change is not backward compatible with any of the previous Osmosis versions and requires a major upgrade to be deployed.
 
 ## Further Discussions
 
 ### Distributing Truncation Delta
 
-The truncation deltas from all epochs from before the proposed implementation is live, will have to be manually estimated
-and minter or burned in the upgrade handler.
+For any truncation deltas occurring at epochs before the proposed implementation is live, it will have to be manually estimated
+and minter/burned in the upgrade handler.
 
-This proposed change is independent from distributing old truncation delta. It only ensures that there are no more discrepancies after
-the proposed implementation is deployed.
+The implementation proposed in this ADR is independent of distributing the old truncation deltas. It only ensures that there are no more discrepancies after the proposed proof-of-concept is deployed.
 
 The work for estimating and isolating the old truncation deltas has been performed in:
 - https://github.com/osmosis-labs/osmosis/pull/1874

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -85,7 +85,7 @@ since we have pre-minted the full amount at genesis. The offsets are unrelated
 to the inflation provisions.
 
 The above differences portray the distinct handling of the developer vesting
-provisions. Still, their handling is highly coupled to the regular provisions,
+provisions. Still, they are highly coupled to the regular provisions,
 leading to increased complexity.
 
 #### Complicated `AfterEpochEnd` Hook
@@ -158,11 +158,11 @@ This is helpful for accounting for truncations and distributing them eventually,
 not necessarily in the same epoch.
 
 For example, assume that for some number of epochs our expected provisions are
-100.6 and the actual amount distributed is 100 every epoch due to truncations.
-Then, at epoch 1, we have a delta of 0.6. 0.6 cannot be distributed because it
-is not an integer. So we persist it until the next epoch. Then, at epoch 2, we
-get a delta of 1.2 (0.6 from epoch 1 and 0.6 from epoch 2). Now, 1 can be
-distributed and 0.2 gets persisted until the next epoch.
+`100.6` and the actual amount distributed is `100` every epoch due to truncations.
+Then, at epoch `1`, we have a delta of `0.6`. `0.6` cannot be distributed because it
+is not an integer. So we persist it until the next epoch. Then, at epoch `2`, we
+get a delta of `1.2` (`0.6` from `epoch 1` and `0.6` from `epoch 2`). Now, `1` can be
+distributed and `0.2` persisted until the next epoch.
 
 ##### Negative
 

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -192,8 +192,8 @@ provisions and the inflation provisions clearer by:
 
 The above decoupling makes the abstractions clearer, reduces complexity, and
 fixes [#2025][14]. This change also makes it more intuitive to apply
-the [Decision 2](#decision-2) above since the 2 truncation store
-indexes are split into two to separate the distribution from separate module accounts.
+the [Decision 2](#decision-2) above by separating distribution logic to account
+for the 2 distinct indexes.
 
 ##### Negative
 
@@ -254,14 +254,14 @@ and applied in the upgrade handler.
 
 ## References
 
-  * Draft POC: <https://github.com/osmosis-labs/osmosis/pull/2342>
-  * Projected Inflation: <https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db>
-  * Isolating sources of the truncations:
-    * Logically: <https://github.com/osmosis-labs/osmosis/pull/1874>
-    * By module account: <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
-  * Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
-  * Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
-  * Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>
+* Draft POC: <https://github.com/osmosis-labs/osmosis/pull/2342>
+* Projected Inflation: <https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db>
+* Isolating sources of the truncations:
+  * Logically: <https://github.com/osmosis-labs/osmosis/pull/1874>
+  * By module account: <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
+* Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
+* Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
+* Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>
 
 [1]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267
 [2]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -56,13 +56,14 @@ Ref: https://github.com/osmosis-labs/osmosis/issues/1919
 
 Currently, `x/mint` `AfterEpochEnd` hook is focused on several goals such as:
 - Determining when to start or update the provisions.
-- Determining the if the current epoch is the reduction epoch.
-- Handling the reductions
-- Minting and distribution provisions.
+- Determining if the current epoch is the reduction epoch.
+- Handling the reductions.
+- Minting and distributing provisions.
 
-As a result, it is difficult to reason about it, assert correctness and make changes.
+As a result, it is difficult to reason about it, assert its correctness and make new changes.
 
-All minting and distribution logic can be encapsulated into a separate function for better testability and readability.
+All minting and distribution logic can be encapsulated into a separate function for better testability and readability. This encapsulation
+also helps to achieve an increased separation of concerns.
 
 ## Decisions
 
@@ -70,7 +71,8 @@ All minting and distribution logic can be encapsulated into a separate function 
 
 #### Summary
 
-We will **minimize truncations and use decimals for estimating distributions**. For that, the `getProportion` can now return decimals so that we can use the actual (non-truncated) value for calculating each developer's reward.
+We will **minimize truncations and use decimals for estimating distributions**. Specifically, the [`getProportions`](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L477) function will take decimal value and return decimal result so that we can use the (non-truncated) value with increased precision for futher calculating each developer's reward and inflation provisions. Additionally, functions that handle distributions logic such as (`distributeDeveloperVestingProvisions`)[https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L286] will now take
+`sdk.DecCoin` as opposed to `sdk.Coin` for the same reason of having to operate on decimals with increased precision.
 
 #### Conseqeunces
 

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -10,13 +10,20 @@ Draft: <https://github.com/osmosis-labs/osmosis/pull/2342>
 
 ## Abstract
 
-This ADR focuses on refactoring `x/mint` module to mitigate the discrepancies between the actual and 
-the projected inflation amounts.
+This ADR focuses on refactoring `x/mint` module to mitigate the discrepancies
+between the actual and the projected inflation amounts.
 
-Currently, we under-mint due to truncations. In the first year of operations, this happens to be approximately 2600 OSMO. As a result, we cannot reach the projected OSMO supply one-to-one.
+Currently, we under-mint due to truncations. In the first year of operations,
+this happens to be approximately 2600 OSMO. As a result, we cannot reach the
+projected OSMO supply one-to-one.
 
-Additionally, some of the constraints have made it difficult to refactor the `x/mint` module. Specifically, the developer vesting provisions 
-follow a distinct distribution logic from the rest of the provisions. While that is the case, these provisions are tightly coupled together, causing the utilization of unsafe workarounds such as over-minting and later burning developer vesting provisions. This ADR addresses these issues by decoupling the two kinds of provisions and letting them use separate distribution logic.
+Additionally, some of the constraints have made it difficult to refactor the
+`x/mint` module. Specifically, the developer vesting provisions follow a
+distinct distribution logic from the rest of the provisions. While that is
+the case, these provisions are tightly coupled together, causing the
+utilization of unsafe workarounds such as over-minting and later burning
+developer vesting provisions. This ADR addresses these issues by decoupling
+the two kinds of provisions and letting them use separate distribution logic.
 
 ## Context
 
@@ -24,53 +31,83 @@ follow a distinct distribution logic from the rest of the provisions. While that
 
 Ref: <https://github.com/osmosis-labs/osmosis/issues/1917>
 
-Ultimately, the major sources of the truncation issues are some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256).  These interfaces operate on `sdk.Coin` that uses `sdk.Int` for amounts. To use these interfaces, we always round down to the nearest integer by [truncating decimal provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we operate on amounts with the precision of 6 decimals by using exponentiation and assuming that 1 `sdk.Int` is equal to `1 / 10^6` OSMO, this still does not allow us to observe enough accuracy. As a result, it is possible to under-mint. `sdk.Dec` has a precision of `18` decimals. By using it in conjunction with the above  `1 / 10^6` downscaling allows us to achieve a precision of `6 + 18 = 24` decimals. According to tests, this precision is sufficient to accurately represent the projected amounts and achieve the expected supply after [30 years of operations](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/hooks_test.go#L453).
+Ultimately, the major sources of the truncation issues are some SDK interfaces
+such as in [`x/bank`][1] and [`x/distribution`][2].
+These interfaces operate on `sdk.Coin` that uses `sdk.Int` for amounts. To use
+these interfaces, we always round down to the nearest integer by
+[truncating decimal provisions][3].
+While we operate on amounts with the precision of 6 decimals by using
+exponentiation and assuming that 1 `sdk.Int` is equal to `1 / 10^6` OSMO, this
+still does not allow us to observe enough accuracy. As a result, it is possible
+to under-mint. `sdk.Dec` has a precision of `18` decimals. By using it in
+conjunction with the above `1 / 10^6` downscaling allows us to achieve a
+precision of `6 + 18 = 24` decimals. According to tests, this precision is
+sufficient to accurately represent the projected amounts and achieve the
+expected supply after [30 years of operations][4].
 
-The expected amounts have been estimated in Python by using the following formulas:
+The expected amounts have been estimated in Python by using the
+following formulas:
 
 * Total Provisions `P(n)` at yeat `n`
-$$P(n) = EpochsPerPeriod * InitialRewardsPerEpoch * ( (1 - ReductionFactor^{n+1}) /  (1 - ReductionFactor) )$$
+$$P(n)=EpochsPerPeriod*InitialRewardsPerEpoch*((1-ReductionFactor^{n+1})/(1-ReductionFactor))$$
 
 * Total expected supply `S`
-$$S = InitialSupply + EpochsPerPeriod * ( InitialRewardsPerEpoch / (1 - ReductionFactor) )$$
+$$S=InitialSupply+EpochsPerPeriod*(InitialRewardsPerEpoch/(1-ReductionFactor))$$
 
-Lastly, developer reward receivers suffer the most because the large source of truncations is identified to occur in [the calculation of the proportions for each developer account](https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265):
+Lastly, developer reward receivers suffer the most because the large source of
+truncations is identified to occur in [the calculation of the proportions for
+each developer account][5]:
 <https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/hooks_test.go#L601-L602>
 
 ### Additional Limitations
 
-Next, we present the limitations that need to be eliminated to mitigate the above truncation issues.
+Next, we present the limitations that need to be eliminated to mitigate the
+above truncation issues.
 
 #### Coupled Epoch Provisions of Different Kind
 
 Ref: <https://github.com/osmosis-labs/osmosis/issues/2025>
 
-Our developer vesting provisions have been coupled together with the rest of the provisions (futher referred to as "inflation provisions") despite having a distinct distribution logic. The divergence is summarized next:
+Our developer vesting provisions have been coupled together with the rest of
+the provisions (futher referred to as "inflation provisions") despite having
+a distinct distribution logic. The divergence is summarized next:
 
-1. Developer vesting provisions are [pre-minted](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/genesis.go#L30) at genesis to the developer vesting module account.
-2. Since they are pre-minted, we do not need to be minting them every epoch contrary to the inflation provisions.
-   * This has caused several issues such as having to [over-mint](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55) by the developer vesting rewards and then [burn them later](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230).
-3. The developer vesting provisions are [distributed from the developer vesting module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) while other rewards are [distributed from the mint module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L194).
-4. We use supply offsets to [offset the unvested developer provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L275-L277) since we have pre-minted the full amount at genesis. The offsets
-are unrelated to the inflation provisions.
+1. Developer vesting provisions are [pre-minted][6] at genesis to the developer
+vesting module account.
+2. Since they are pre-minted, we do not need to be minting them every epoch
+contrary to the inflation provisions.
+   * This has caused several issues such as having to [over-mint][7]
+   by the developer vesting rewards and then [burn them later][8].
+3. The developer vesting provisions are [distributed from the developer vesting
+module account][9] while other rewards are [distributed from the mint module account][10].
+4. We use supply offsets to [offset the unvested developer provisions][11]
+since we have pre-minted the full amount at genesis. The offsets are unrelated
+to the inflation provisions.
 
-The above differences portray the distinct handling of the developer vesting provisions. Still, their handling
-is highly coupled to the regular provisions, leading to increased complexity.
+The above differences portray the distinct handling of the developer vesting
+provisions. Still, their handling is highly coupled to the regular provisions,
+leading to increased complexity.
 
 #### Complicated `AfterEpochEnd` Hook
 
 Ref: <https://github.com/osmosis-labs/osmosis/issues/1919>
 
 Currently, `x/mint` `AfterEpochEnd` hook is focused on several goals such as:
+
 * Determining when to start or update the provisions.
+
 * Determining if the current epoch is the reduction epoch.
+
 * Handling the reductions.
+
 * Minting and distributing provisions.
 
-As a result, it is difficult to reason about it, assert its correctness and make new changes.
+As a result, it is difficult to reason about it, assert its correctness and
+make new changes.
 
-All minting and distribution logic can be encapsulated into a separate function for better testability and readability. This encapsulation
-also helps to achieve an increased separation of concerns.
+All minting and distribution logic can be encapsulated into a separate function
+for better testability and readability. This encapsulation also helps to
+achieve an increased separation of concerns.
 
 ## Decisions
 
@@ -78,42 +115,59 @@ also helps to achieve an increased separation of concerns.
 
 #### Summary
 
-We will **minimize truncations and use decimals for estimating distributions**. Specifically, the [`getProportions`](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L477) function will take a decimal value and return decimal result so that we can use the (non-truncated) value with increased precision for further calculating each developer's reward and inflation provisions. Additionally, functions that handle distributions logic such as (`distributeDeveloperVestingProvisions`)[https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L286] will now take
-`sdk.DecCoin` as opposed to `sdk.Coin` for the same reason of having to operate on decimals with increased precision.
+We will **minimize truncations and use decimals for estimating distributions**.
+Specifically, the [`getProportions`][12] function will take a decimal value and
+return decimal result so that we can use the (non-truncated) value with
+increased precision for further calculating each developer's reward and
+inflation provisions. Additionally, functions that handle distributions logic
+such as [`distributeDeveloperVestingProvisions`][13] will now take
+`sdk.DecCoin` as opposed to `sdk.Coin` for the same reason of having to operate
+on decimals with increased precision.
 
 #### Conseqeunces
 
 ##### Positive
 
-The truncations due to integer interfaces within the `x/mint` module are eliminated completely. All remaining truncations are due
-to dependencies on the `x/bank` and `x/distribution` modules.
+The truncations due to integer interfaces within the `x/mint` module are
+eliminated completely. All remaining truncations are due to dependencies on the
+`x/bank` and `x/distribution` modules.
 
 ##### Negative
 
-Divergence from the original implementation of the `x/mint` module as well as larger diff, making the review more difficult.
+Divergence from the original implementation of the `x/mint` module as well as
+larger diff, making the review more difficult.
 
 ### Decision 2
 
 #### Summary
 
 We will **add 2  decimal store indexes**:
+
 * for persisting truncation delta resulting from the mint module account across epochs
 <https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L12-L21>
-* for persisting truncation delta resulting from the developer rewards module account across epochs
-<https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L23-L31> 
+
+* for persisting truncation delta resulting from the developer rewards module
+  account across epochs
+<https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L23-L31>
 
 #### Consequences
 
 ##### Positive
 
-This is helpful for accounting for truncations and distributing them eventually, not necessarily in the same epoch.
+This is helpful for accounting for truncations and distributing them eventually,
+not necessarily in the same epoch.
 
-For example, assume that for some number of epochs our expected provisions are 100.6 and the actual amount distributed is 100 every epoch due to truncations. Then, at epoch 1, we have a delta of 0.6. 0.6 cannot be distributed because it is not an integer. So we persist it until the next epoch. Then, at epoch 2, we get a delta of 1.2 (0.6 from epoch 1 and 0.6 from epoch 2).
-Now, 1 can be distributed and 0.2 gets persisted until the next epoch.
+For example, assume that for some number of epochs our expected provisions are
+100.6 and the actual amount distributed is 100 every epoch due to truncations.
+Then, at epoch 1, we have a delta of 0.6. 0.6 cannot be distributed because it
+is not an integer. So we persist it until the next epoch. Then, at epoch 2, we
+get a delta of 1.2 (0.6 from epoch 1 and 0.6 from epoch 2). Now, 1 can be
+distributed and 0.2 gets persisted until the next epoch.
 
 ##### Negative
 
-Added complexity from handing 2 additional store indexes. It is mitigated by better abstractions and extensive documentation though still present.
+Added complexity from handing 2 additional store indexes. It is mitigated by
+better abstractions and extensive documentation though still present.
 
 ### Decision 3
 
@@ -121,61 +175,83 @@ Added complexity from handing 2 additional store indexes. It is mitigated by bet
 
 We will **decouple the developer vesting provisions from the inflation provisions**.
 
-The [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342) makes the distinction between the developer provisions and the inflation provisions clearer by:
+The [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342)
+makes the distinction between the developer provisions and the inflation provisions
+clearer by:
+
 * [Distinctly splitting the two provisions in minter](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/minter.go#L54-L63)
+
 * Decoupling and distinctly handling each provision type separately:
+
    * [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
+
    * [dev reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
 
 #### Consequences
 
 ##### Positive
 
-The above decoupling makes the abstractions clearer, reduces complexity, and fixes [#2025](https://github.com/osmosis-labs/osmosis/issues/2025)
-This change also makes it more intuitive to apply the [Decision 2](#decision_2) above since the 2 truncation store indexes are split into 2
-to separate the distribution from separate module accounts.
+The above decoupling makes the abstractions clearer, reduces complexity, and
+fixes [#2025][14]. This change also makes it more intuitive to apply
+the [Decision 2](#decision_2) above since the 2 truncation store indexes are
+split into 2 to separate the distribution from separate module accounts.
 
 ##### Negative
 
-This is a large change to the core logic of the `x/mint` module, requiring more thorough testing and quality assurance.
+This is a large change to the core logic of the `x/mint` module, requiring more
+thorough testing and quality assurance.
 
 ### Decision 4
 
 #### Summary
 
-We will **encapsulate the minting and distribution logic from `AfterEpochEnd` hook into a separate function**.
+We will **encapsulate the minting and distribution logic from `AfterEpochEnd` hook**
+into a separate function.
 
-In the [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342), the logic for distributing all epoch provisions in the `AfterEpochEnd` hook has been moved to the [distributeEpochProvisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/hooks.go#L49) function.
+In the [**Draft Implementation**][15], the logic for distributing all epoch
+provisions in the `AfterEpochEnd` hook has been moved to the
+[distributeEpochProvisions][16] function.
 
-It handles distributing both [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L147) and [developer vesting provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L153).
+It handles distributing both [inflation provisions][17]
+and [developer vesting provisions][18].
 
 #### Consequences
 
 ##### Positive
 
-This change allows for better encapsulation of all distribution logic and for the ability to more thoroughly unit test it.
+This change allows for better encapsulation of all distribution logic and for
+the ability to more thoroughly unit test it.
 
-The enhanced encapsulation in turn leads to a more modular mint keeper where each method strives to focus on a single concern. 
+The enhanced encapsulation in turn leads to a more modular mint keeper where
+each method strives to focus on a single concern. 
 
 ## Backwards Compatibility
 
-This change is not backward compatible with any of the previous Osmosis versions and requires a major upgrade to be deployed.
+This change is not backward compatible with any of the previous Osmosis
+versions and requires a major upgrade to be deployed.
 
 ## Further Discussions
 
 ### Distributing Truncation Delta
 
-For any truncation deltas occurring at epochs before the proposed implementation is live, it will have to be manually estimated
-and minter/burned in the upgrade handler.
+For any truncation deltas occurring at epochs before the proposed
+implementation is live, it will have to be manually estimated and minted/burned
+in the upgrade handler.
 
-The implementation proposed in this ADR is independent of distributing the old truncation deltas. It only ensures that there are no more discrepancies after the proposed proof-of-concept is deployed.
+The implementation proposed in this ADR is independent of distributing the old
+truncation deltas. It only ensures that there are no more discrepancies after
+the proposed proof-of-concept is deployed.
 
-The work for estimating and isolating the old truncation deltas has been performed in:
+The work for estimating and isolating the old truncation deltas has been
+performed in:
+
 * <https://github.com/osmosis-labs/osmosis/pull/1874>
+
 * <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
 
-As a result, as long as the next upgrade height and epoch are known, the old truncation deltas up until the last epoch before the
-upgrade can be estimated and applied in the upgrade handler.
+As a result, as long as the next upgrade height and epoch are known, the old
+truncation deltas up until the last epoch before the upgrade can be estimated
+and applied in the upgrade handler.
 
 ## References
 
@@ -187,3 +263,22 @@ upgrade can be estimated and applied in the upgrade handler.
 * Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
 * Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
 * Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>
+
+[1]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267
+[2]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256
+[3]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290
+[4]:https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/hooks_test.go#L453
+[5]:https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265
+[6]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/genesis.go#L30
+[7]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55
+[8]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230
+[9]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267
+[10]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L194
+[11]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L275-L277
+[12]:https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L477
+[13]:https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/keeper.go#L286
+[14]:https://github.com/osmosis-labs/osmosis/issues/2025
+[15]:https://github.com/osmosis-labs/osmosis/pull/2342
+[16]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/hooks.go#L49
+[17]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L147
+[18]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L153

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -182,9 +182,9 @@ provisions and the inflation provisions clearer by:
 
 * Decoupling and handling each provision type separately:
 
-   * [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
+  * [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
 
-   * [developer reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
+  * [developer reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
 
 #### Consequences
 
@@ -257,8 +257,8 @@ and applied in the upgrade handler.
 * Draft POC: <https://github.com/osmosis-labs/osmosis/pull/2342>
 * Projected Inflation: <https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db>
 * Isolating sources of the truncations:
-   * Logically: <https://github.com/osmosis-labs/osmosis/pull/1874>
-   * By module account: <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
+    * Logically: <https://github.com/osmosis-labs/osmosis/pull/1874>
+    * By module account: <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
 * Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
 * Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
 * Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -159,14 +159,14 @@ not necessarily in the same epoch.
 
 For example, assume that for some number of epochs our expected provisions are
 `100.6` and the actual amount distributed is `100` every epoch due to truncations.
-Then, at epoch `1`, we have a delta of `0.6`. `0.6` cannot be distributed because it
-is not an integer. So we persist it until the next epoch. Then, at epoch `2`, we
-get a delta of `1.2` (`0.6` from `epoch 1` and `0.6` from `epoch 2`). Now, `1` can be
-distributed and `0.2` persisted until the next epoch.
+Then, at epoch `1`, we have a delta of `0.6`. `0.6` cannot be distributed because
+it is not an integer. So we persist it until the next epoch. Then, at
+epoch `2`, we get a delta of `1.2` (`0.6` from epoch `1` and `0.6` from
+epoch `2`). Now, `1` can be distributed and `0.2` persisted until the next epoch.
 
 ##### Negative
 
-Added complexity from handing 2 additional store indexes. It is mitigated by
+Added complexity from handing two additional store indexes. It is mitigated by
 better abstractions and extensive documentation though still present.
 
 ### Decision 3
@@ -175,17 +175,16 @@ better abstractions and extensive documentation though still present.
 
 We will **decouple the developer vesting provisions from the inflation provisions**.
 
-The [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342)
-makes the distinction between the developer provisions and the inflation provisions
-clearer by:
+The [draft implementation][15] makes the distinction between the developer
+provisions and the inflation provisions clearer by:
 
-* [Distinctly splitting the two provisions in minter](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/minter.go#L54-L63)
+* Distinctly [splitting the two provisions][19] in minter
 
-* Decoupling and distinctly handling each provision type separately:
+* Decoupling and handling each provision type separately:
 
    * [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
 
-   * [dev reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
+   * [developer reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
 
 #### Consequences
 
@@ -193,8 +192,8 @@ clearer by:
 
 The above decoupling makes the abstractions clearer, reduces complexity, and
 fixes [#2025][14]. This change also makes it more intuitive to apply
-the [Decision 2](#decision_2) above since the 2 truncation store indexes are
-split into 2 to separate the distribution from separate module accounts.
+the [Decision 2][#user-content-decision-2] above since the 2 truncation store
+indexes are split into 2 to separate the distribution from separate module accounts.
 
 ##### Negative
 
@@ -208,7 +207,7 @@ thorough testing and quality assurance.
 We will **encapsulate the minting and distribution logic from `AfterEpochEnd` hook**
 into a separate function.
 
-In the [**Draft Implementation**][15], the logic for distributing all epoch
+In the [draft Implementation][15], the logic for distributing all epoch
 provisions in the `AfterEpochEnd` hook has been moved to the
 [distributeEpochProvisions][16] function.
 
@@ -282,3 +281,4 @@ and applied in the upgrade handler.
 [16]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/hooks.go#L49
 [17]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L147
 [18]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L153
+[19]:https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/minter.go#L54-L63

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -229,8 +229,7 @@ each method strives to focus on a single concern.
 
 ### Decision 5
 
-Although the exact distribution proportions are configured via parameters,
-we will still **distribute any truncation delta to the community pool**.
+We will **distribute any truncation delta to the community pool**.
 
 #### Consequences
 

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -167,7 +167,7 @@ epoch `2`). Now, `1` can be distributed and `0.2` persisted until the next epoch
 ##### Negative
 
 Added complexity from handing two additional store indexes. It is mitigated by
-better abstractions and extensive documentation though still present.
+improving abstractions and documentation, though still present.
 
 ### Decision 3
 
@@ -192,8 +192,8 @@ provisions and the inflation provisions clearer by:
 
 The above decoupling makes the abstractions clearer, reduces complexity, and
 fixes [#2025][14]. This change also makes it more intuitive to apply
-the [Decision 2][#user-content-decision-2] above since the 2 truncation store
-indexes are split into 2 to separate the distribution from separate module accounts.
+the [Decision 2](#decision-2) above since the 2 truncation store
+indexes are split into two to separate the distribution from separate module accounts.
 
 ##### Negative
 
@@ -237,9 +237,9 @@ For any truncation deltas occurring at epochs before the proposed
 implementation is live, it will have to be manually estimated and minted/burned
 in the upgrade handler.
 
-The implementation proposed in this ADR is independent of distributing the old
-truncation deltas. It only ensures that there are no more discrepancies after
-the proposed proof-of-concept is deployed.
+The implementation proposed in this ADR is independent of the need for
+distributing the old truncation deltas. It only ensures that there are
+no more discrepancies after the proposed proof-of-concept is deployed.
 
 The work for estimating and isolating the old truncation deltas has been
 performed in:

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-Draft: https://github.com/osmosis-labs/osmosis/pull/2342
+Draft: <https://github.com/osmosis-labs/osmosis/pull/2342>
 
 ## Abstract
 
@@ -22,20 +22,20 @@ follow a distinct distribution logic from the rest of the provisions. While that
 
 ### Truncations
 
-Ref: https://github.com/osmosis-labs/osmosis/issues/1917
+Ref: <https://github.com/osmosis-labs/osmosis/issues/1917>
 
 Ultimately, the major sources of the truncation issues are some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256).  These interfaces operate on `sdk.Coin` that uses `sdk.Int` for amounts. To use these interfaces, we always round down to the nearest integer by [truncating decimal provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we operate on amounts with the precision of 6 decimals by using exponentiation and assuming that 1 `sdk.Int` is equal to `1 / 10^6` OSMO, this still does not allow us to observe enough accuracy. As a result, it is possible to under-mint. `sdk.Dec` has a precision of `18` decimals. By using it in conjunction with the above  `1 / 10^6` downscaling allows us to achieve a precision of `6 + 18 = 24` decimals. According to tests, this precision is sufficient to accurately represent the projected amounts and achieve the expected supply after [30 years of operations](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/hooks_test.go#L453).
 
 The expected amounts have been estimated in Python by using the following formulas:
 
-- Total Provisions `P(n)` at yeat `n`
+* Total Provisions `P(n)` at yeat `n`
 $$P(n) = EpochsPerPeriod * InitialRewardsPerEpoch * ( (1 - ReductionFactor^{n+1}) /  (1 - ReductionFactor) )$$
 
-- Total expected supply `S`
+* Total expected supply `S`
 $$S = InitialSupply + EpochsPerPeriod * ( InitialRewardsPerEpoch / (1 - ReductionFactor) )$$
 
 Lastly, developer reward receivers suffer the most because the large source of truncations is identified to occur in [the calculation of the proportions for each developer account](https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265):
-https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/hooks_test.go#L601-L602
+<https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/hooks_test.go#L601-L602>
 
 ### Additional Limitations
 
@@ -43,13 +43,13 @@ Next, we present the limitations that need to be eliminated to mitigate the abov
 
 #### Coupled Epoch Provisions of Different Kind
 
-Ref: https://github.com/osmosis-labs/osmosis/issues/2025
+Ref: <https://github.com/osmosis-labs/osmosis/issues/2025>
 
 Our developer vesting provisions have been coupled together with the rest of the provisions (futher referred to as "inflation provisions") despite having a distinct distribution logic. The divergence is summarized next:
 
 1. Developer vesting provisions are [pre-minted](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/genesis.go#L30) at genesis to the developer vesting module account.
 2. Since they are pre-minted, we do not need to be minting them every epoch contrary to the inflation provisions.
-   - This has caused several issues such as having to [over-mint](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55) by the developer vesting rewards and then [burn them later](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230).
+   * This has caused several issues such as having to [over-mint](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55) by the developer vesting rewards and then [burn them later](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230).
 3. The developer vesting provisions are [distributed from the developer vesting module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) while other rewards are [distributed from the mint module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L194).
 4. We use supply offsets to [offset the unvested developer provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L275-L277) since we have pre-minted the full amount at genesis. The offsets
 are unrelated to the inflation provisions.
@@ -59,13 +59,13 @@ is highly coupled to the regular provisions, leading to increased complexity.
 
 #### Complicated `AfterEpochEnd` Hook
 
-Ref: https://github.com/osmosis-labs/osmosis/issues/1919
+Ref: <https://github.com/osmosis-labs/osmosis/issues/1919>
 
 Currently, `x/mint` `AfterEpochEnd` hook is focused on several goals such as:
-- Determining when to start or update the provisions.
-- Determining if the current epoch is the reduction epoch.
-- Handling the reductions.
-- Minting and distributing provisions.
+* Determining when to start or update the provisions.
+* Determining if the current epoch is the reduction epoch.
+* Handling the reductions.
+* Minting and distributing provisions.
 
 As a result, it is difficult to reason about it, assert its correctness and make new changes.
 
@@ -97,10 +97,10 @@ Divergence from the original implementation of the `x/mint` module as well as la
 #### Summary
 
 We will **add 2  decimal store indexes**:
-- for persisting truncation delta resulting from the mint module account across epochs
-https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L12-L21
-- for persisting truncation delta resulting from the developer rewards module account across epochs
-https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L23-L31 
+* for persisting truncation delta resulting from the mint module account across epochs
+<https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L12-L21>
+* for persisting truncation delta resulting from the developer rewards module account across epochs
+<https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L23-L31> 
 
 #### Consequences
 
@@ -122,10 +122,10 @@ Added complexity from handing 2 additional store indexes. It is mitigated by bet
 We will **decouple the developer vesting provisions from the inflation provisions**.
 
 The [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342) makes the distinction between the developer provisions and the inflation provisions clearer by:
-- [Distinctly splitting the two provisions in minter](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/minter.go#L54-L63)
-- Decoupling and distinctly handling each provision type separately:
-   - [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
-   - [dev reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
+* [Distinctly splitting the two provisions in minter](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/minter.go#L54-L63)
+* Decoupling and distinctly handling each provision type separately:
+   * [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
+   * [dev reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
 
 #### Consequences
 
@@ -145,7 +145,7 @@ This is a large change to the core logic of the `x/mint` module, requiring more 
 
 We will **encapsulate the minting and distribution logic from `AfterEpochEnd` hook into a separate function**.
 
-In the [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342), the logic for distributing all epoch provisions in the `AfterEpochEnd` hook has been moved to the [`distributeEpochProvisions` ](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/hooks.go#L49) function.
+In the [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342), the logic for distributing all epoch provisions in the `AfterEpochEnd` hook has been moved to the [distributeEpochProvisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/hooks.go#L49) function.
 
 It handles distributing both [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L147) and [developer vesting provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L153).
 
@@ -171,20 +171,19 @@ and minter/burned in the upgrade handler.
 The implementation proposed in this ADR is independent of distributing the old truncation deltas. It only ensures that there are no more discrepancies after the proposed proof-of-concept is deployed.
 
 The work for estimating and isolating the old truncation deltas has been performed in:
-- https://github.com/osmosis-labs/osmosis/pull/1874
-- https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation
+* <https://github.com/osmosis-labs/osmosis/pull/1874>
+* <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
 
 As a result, as long as the next upgrade height and epoch are known, the old truncation deltas up until the last epoch before the
 upgrade can be estimated and applied in the upgrade handler.
 
-
 ## References
 
-* Draft POC: https://github.com/osmosis-labs/osmosis/pull/2342
-* Projected Inflation: https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db
+* Draft POC: <https://github.com/osmosis-labs/osmosis/pull/2342>
+* Projected Inflation: <https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db>
 * Isolating sources of the truncations:
-   - Logically: https://github.com/osmosis-labs/osmosis/pull/1874
-   - By module account: https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation
-* Truncatins Issue: https://github.com/osmosis-labs/osmosis/issues/1919
-* Coupling Developer Vesting with Inflation Provisions: https://github.com/osmosis-labs/osmosis/issues/2025
-* Refactoring `x/mint` `AfterEpochEnd` Hook: https://github.com/osmosis-labs/osmosis/issues/1919
+   * Logically: <https://github.com/osmosis-labs/osmosis/pull/1874>
+   * By module account: <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
+* Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
+* Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
+* Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -14,8 +14,8 @@ This ADR focuses on refactoring `x/mint` module to mitigate the discrepancies
 between the actual and the projected inflation amounts.
 
 Currently, we under-mint due to truncations. In the first year of operations,
-this happens to be approximately 2600 OSMO. As a result, we cannot reach the
-projected OSMO supply one-to-one.
+this happens to be approximately 2600 uosmo. As a result, we cannot reach the
+projected uosmo supply one-to-one.
 
 Additionally, some of the constraints have made it difficult to refactor the
 `x/mint` module. Specifically, the developer vesting provisions follow a

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -24,7 +24,15 @@ follow a distinct distribution logic from the rest of the provisions. While that
 
 Ref: https://github.com/osmosis-labs/osmosis/issues/1917
 
-Ultimately, the major sources of the truncation issues are some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256).  These interfaces operate on `sdk.Coin` that use `sdk.Int` for amounts. To use these interfaces, we always round down to the nearest integer by [truncating decimal provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we operate on amounts with precision of 6 decimals by using exponents where we assumme that 1 `sdk.Int` is equal to $$1 / 10^6$$ OSMO, this still does not allow us to observe enough accuracy. As a result, it is possible to undermint. `sdk.Dec` has a precision of 18 decimals. By using it in conjunction with the above  $$1 / 10^6$$ downscaling allows us to achieve a precision of 24 decimals. According to tests, this precision is sufficient to accurately represent the projected amounts.
+Ultimately, the major sources of the truncation issues are some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256).  These interfaces operate on `sdk.Coin` that use `sdk.Int` for amounts. To use these interfaces, we always round down to the nearest integer by [truncating decimal provisions](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we operate on amounts with precision of 6 decimals by using exponents where we assumme that 1 `sdk.Int` is equal to `1 / 10^6` OSMO, this still does not allow us to observe enough accuracy. As a result, it is possible to undermint. `sdk.Dec` has a precision of `18` decimals. By using it in conjunction with the above  `1 / 10^6` downscaling allows us to achieve a precision of `6 + 18 = 24` decimals. According to tests, this precision is sufficient to accurately represent the projected amounts and achieve the expected supply after [30 years of operations](https://github.com/osmosis-labs/osmosis/blob/724d2cacb38596919c29dd3f9173c1ce0c58804d/x/mint/keeper/hooks_test.go#L453).
+
+The projected amounts have been estimated in Python by using the following formulas:
+
+- Total Provisions `P(n)` at yeat `n`
+$$P(n) = EpochsPerPeriod * InitialRewardsPerEpoch * { (1 - ReductionFactor^{n+1}) /  (1 - ReductionFactor) }$$
+
+- Total supply
+$$S(n) = 
 
 Moreover, developer reward receivers suffer the most because the large source of truncations is identified to occur in [the calculation of the proportions for each developer account](https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265):
 https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/hooks_test.go#L601-L602

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -254,14 +254,14 @@ and applied in the upgrade handler.
 
 ## References
 
-* Draft POC: <https://github.com/osmosis-labs/osmosis/pull/2342>
-* Projected Inflation: <https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db>
-* Isolating sources of the truncations:
+  * Draft POC: <https://github.com/osmosis-labs/osmosis/pull/2342>
+  * Projected Inflation: <https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db>
+  * Isolating sources of the truncations:
     * Logically: <https://github.com/osmosis-labs/osmosis/pull/1874>
     * By module account: <https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation>
-* Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
-* Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
-* Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>
+  * Truncatins Issue: <https://github.com/osmosis-labs/osmosis/issues/1919>
+  * Coupling Developer Vesting with Inflation Provisions: <https://github.com/osmosis-labs/osmosis/issues/2025>
+  * Refactoring `x/mint` `AfterEpochEnd` Hook: <https://github.com/osmosis-labs/osmosis/issues/1919>
 
 [1]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267
 [2]:https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256

--- a/docs/architecture/adr-001-mint-truncation-refactor.md
+++ b/docs/architecture/adr-001-mint-truncation-refactor.md
@@ -1,0 +1,181 @@
+# ADR 001: Mint Truncation Refactor
+
+## Changelog
+
+* 22-08-2022: Initial Draft
+
+## Status
+
+Draft: https://github.com/osmosis-labs/osmosis/pull/2342
+
+## Abstract
+
+This ADR focuses on refactoring `x/mint` module to mitigate the discrepancies between the actual and 
+the projected inflation numbers. These discrepancies are stemming from truncations.
+
+Currently, we under mint due to truncation. In the first year this happened to be approximately 2600 OSMO. As a result, we cannot reach the projected supply one to one.
+
+Additionally, some of the constraints have made it difficult to refactor the module. Specifically, the developer vesting provisions 
+follow a different distribution logic from the rest of the provisions. However, they are tightly coupled together causing to utilize
+unsafe workaround such as over-minting and later burning some coins. This ADR addresses these issues by decoupling the two kinds of
+provisions and letting them use separate distribution logic.
+
+## Context
+
+### Truncations
+
+Ref: https://github.com/osmosis-labs/osmosis/issues/1917
+
+Ultimately, these truncation issues are stemming from the limitations of some SDK interfaces such as in [`x/bank`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) and [`x/distribution`](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L255-L256)  that operate on integers. To use these interfaces, we always round down to the nearest integer by [truncating decimals](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L290). While we increase the precision by assumming that 1 `sdk.Int` is actually 1 / 10^6 OSMO, this still does not let us to be precise enough. As a result, it is possible to undermint.
+
+Moreover, developer reward receivers suffer the most because the large source of truncation happens [when we calculate the proportions for each developer account](https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/keeper.go#L265):
+https://github.com/osmosis-labs/osmosis/blob/4176b287d48338870bfda3029bfa20a6e45ac126/x/mint/keeper/hooks_test.go#L601-L602
+
+### Additional Limitations
+
+Next, we present the limitations that have had to be mitigated to resolve the truncations issues.
+
+#### Coupling of Developer Vesting Provisions with Other (Inflation) Provisions
+
+Ref: https://github.com/osmosis-labs/osmosis/issues/2025
+
+Our developer vesting provisions have been coupled together with the rest of the provisions (referred to as "inflation provisions") despite having a distinct handling logic. The distinction is summarized by the following points
+
+a) Developer vesting rewards are [pre-minted](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/genesis.go#L30) at genesis to the developer vesting module account
+b) Since they are pre-minted, we do not need to be minting them every epoch contrary to the inflation provisions.
+   - This has caused a number of issues such as having to [over-mint](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/hooks.go#L54-L55) by the developer vesting rewards and then [burn them later](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L230)
+c) The developer vesting rewards are [distributed from the developer vesting module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L266-L267) while other rewards are [distributed from the mint module account](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L194)
+d) We use supply offsets to [offset the rewards that are yet unvested](https://github.com/osmosis-labs/osmosis/blob/86bdbebd3cffc16586d0d0c25f751321436d7a44/x/mint/keeper/keeper.go#L275-L277) since we have pre-minted the full amount at genesis. The offsets
+are unrelated to the inflation provisions.
+
+The above 4 differences show the distinct handling of the developer rewards provisions. However, the developer vesting provisions handling
+is highly coupled to the regular provisions. As a result, adding a lot of complexity.
+
+#### Complicated `AfterEpochEnd` Hook
+
+Ref: https://github.com/osmosis-labs/osmosis/issues/1919
+
+Currently, `x/mint` `AfterEpochEnd` hook is focused on several goals such as:
+- Determining when to start or update the provisions.
+- Determining the if the current epoch is the reduction epoch.
+- Handling the reductions
+- Minting and distribution provisions.
+
+As a result, it is difficult to reason about it, assert correctness and make changes.
+
+All minting and distribution logic can be encapsulated into a separate function for better testability and readability.
+
+## Decisions
+
+### Decision 1
+
+#### Summary
+
+We will **minimize truncations and use decimals for estimating distributions**. For that, the `getProportion` can now return decimals so that we can use the actual (non-truncated) value for calculating each developer's reward.
+
+#### Conseqeunces
+
+##### Positive
+
+The truncations due to integer interfaces within the `x/mint` module are eliminated completely. All remaining truncations are due
+to dependencies on the `x/bank` and `x/distribution` module.
+
+##### Negative
+
+Divergence from the original implementation of the `x/mint` module as well as larger diff, making the review more difficult.
+
+### Decision 2
+
+#### Summary
+
+We will **add 2  decimal store indexes**:
+- for persisting truncation delta resulting from the mint module account across epochs
+https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L12-L21
+- for persisting truncation delta resulting from the developer rewards module account across epochs
+https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/keys.go#L23-L31 
+
+#### Consequences
+
+##### Positive
+
+This is helpful for accounting for truncations and distributing them eventually, not necessarily in the same epoch.
+
+For example, assume that for some number of epochs our expected provisions are 100.6 and the actual amount distributed is 100 every epoch due to truncations. Then, at epoch 1, we have a delta of 0.6. 0.6 cannot be distributed because it is not an integer. So we persist it until the next epoch. Then, at at epoch 2, we get a delta of 1.2 (0.6 from epoch 1 and 0.6 from epoch 2).
+Now, 1 can be distributed and 0.2 gets persisted until the next epoch.
+
+##### Negative
+
+Added complexity from handing 2 additional store indexes. It is mitigated by better abstractions and extensive documentation though still present.
+
+### Decision 3
+
+#### Summary
+
+We will **decouple the developer vesting provisions from the inflation provisions**.
+
+The [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342) makes the distinction between the developer provisions and the inflation provisions clearer by:
+- [Distinctly splitting the two provisions in minter](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/types/minter.go#L54-L63)
+- Decoupling and distinctly handling each provision type separately:
+   - [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L167)
+   - [dev reward provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L283)
+
+#### Consequences
+
+##### Positive
+
+The above decoupling makes the abstractions clearer, reduces complexity and fixes [#2025](https://github.com/osmosis-labs/osmosis/issues/2025)
+This change also makes it more intuitive to apply the [Decision 2](#decision_2) above since the 2 truncation store indexes are split into 2
+to separate the distribution from separate module account.
+
+##### Negative
+
+This is a large change to the core logic of the `x/mint` module, requiring more thoroigh testing and quality assurance.
+
+### Decision 4
+
+#### Summary
+
+We will **encapsulate the minting and distribution logic from `AfterEpochEnd` hook into a separate function**.
+
+In the [**Draft Implementation**](https://github.com/osmosis-labs/osmosis/pull/2342), the logic for distributing all epoch provisions in the `AfterEpochEnd` hook has been moved to the [`distributeEpochProvisions` ](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/hooks.go#L49) function.
+
+It handles distributing both [inflation provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L147) and [developer vesting provisions](https://github.com/osmosis-labs/osmosis/blob/0b843fcae194eb9439c3dc5fe879c47173406047/x/mint/keeper/keeper.go#L153).
+
+#### Consequences
+
+##### Positive
+
+This change allows for better encapsulation of all distribution logic and for the ability to more thoroughly unit test it.
+
+## Backwards Compatibility
+
+This change is not backwards compatibly with any of the previous Osmosis versions and requires a major upgrade to be deployed.
+
+## Further Discussions
+
+### Distributing Truncation Delta
+
+The truncation deltas from all epochs from before the proposed implementation is live, will have to be manually estimated
+and minter or burned in the upgrade handler.
+
+This proposed change is independent from distributing old truncation delta. It only ensures that there are no more discrepancies after
+the proposed implementation is deployed.
+
+The work for estimating and isolating the old truncation deltas has been performed in:
+- https://github.com/osmosis-labs/osmosis/pull/1874
+- https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation
+
+As a result, as long as the next upgrade height and epoch are known, the old truncation deltas up until the last epoch before the
+upgrade can be estimated and applied in the upgrade handler.
+
+
+## References
+
+* Draft POC: https://github.com/osmosis-labs/osmosis/pull/2342
+* Projected Inflation: https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db
+* Isolating sources of the truncations:
+   - Logically: https://github.com/osmosis-labs/osmosis/pull/1874
+   - By module account: https://github.com/osmosis-labs/osmosis/tree/roman/mint-rounding-year2-isolation
+* Truncatins Issue: https://github.com/osmosis-labs/osmosis/issues/1919
+* Coupling Developer Vesting with Inflation Provisions: https://github.com/osmosis-labs/osmosis/issues/2025
+* Refactoring `x/mint` `AfterEpochEnd` Hook: https://github.com/osmosis-labs/osmosis/issues/1919


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is an ADR to propose changes for mitigating `x/mint` truncation issues ref #1917. 
The proof of concept implementation is ready in: https://github.com/osmosis-labs/osmosis/pull/2342

The goal of this ADR is to document the large changes in `x/mint` so that anyone can onboard on
the motivations behind this refactor quickly.

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 