### PR TITLE
Deprecate osmobuilder and remove contrib folder [1/2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,11 @@ $(BUILDDIR)/:
 
 build-reproducible: build-reproducible-amd64 build-reproducible-arm64
 
-build-reproducible-amd64: go.sum
+build-reproducible-amd64: go.sum $(BUILDDIR)/
 	$(DOCKER) buildx create --name osmobuilder || true
 	$(DOCKER) buildx use osmobuilder
 	$(DOCKER) buildx build \
-		--build-arg GO_VERSION=$(shell go list -f {{.GoVersion}} -m) \
+		--build-arg GO_VERSION=$(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2) \
 		--platform linux/arm64 \
 		-t osmosis-amd64 \
 		--load \
@@ -112,11 +112,11 @@ build-reproducible-amd64: go.sum
 	$(DOCKER) cp osmobinary:/bin/osmosisd $(BUILDDIR)/osmosisd-linux-amd64
 	$(DOCKER) rm -f osmobinary
 
-build-reproducible-arm64: go.sum
+build-reproducible-arm64: go.sum $(BUILDDIR)/
 	$(DOCKER) buildx create --name osmobuilder || true
 	$(DOCKER) buildx use osmobuilder
 	$(DOCKER) buildx build \
-		--build-arg GO_VERSION=$(shell go list -f {{.GoVersion}} -m) \
+		--build-arg GO_VERSION=$(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2) \
 		--platform linux/arm64 \
 		-t osmosis-arm64 \
 		--load \


### PR DESCRIPTION
Related issue: [#2482](https://github.com/osmosis-labs/osmosis/issues/2482)
Addresses first task

## What is the purpose of the change

This PR makes small changes to the `make build-reproducible` command to adapt it to the new release process.
The new release process doesn't use `osmobuilder` anymore, so we can finally deprecate it.

The new release process is complete and can be seen [here](https://github.com/osmosis-labs/osmosis-ci/blob/main/.github/workflows/create-release.yaml).

## Brief Changelog

- Small changes to `Makefile` 

## Testing and Verifying

Changes are trivial.
I have tested the workflow by creating a fake release. 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 