### PR TITLE
feat(osmoutils/mint): mint truncations pt1 - store helpers

### DIFF
--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -2,6 +2,7 @@ package osmoutils
 
 import (
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	db "github.com/tendermint/tm-db"
@@ -102,4 +103,30 @@ func gatherValuesFromIteratorWithStop[T any](iterator db.Iterator, parseValue fu
 
 func noStopFn([]byte) bool {
 	return false
+}
+
+// MustGet gets key from store by mutating result
+// Panics on any error.
+func MustGet(store store.KVStore, key []byte, result proto.Message) {
+	b := store.Get(key)
+	if b == nil {
+		panic(fmt.Errorf("getting at key (%v) should not have been nil", key))
+	}
+	if err := proto.Unmarshal(b, result); err != nil {
+		panic(err)
+	}
+}
+
+// MustSetDec sets dec value to store at key. Panics on any error.
+func MustSetDec(store store.KVStore, key []byte, value sdk.Dec) {
+	MustSet(store, key, &sdk.DecProto{
+		Dec: value,
+	})
+}
+
+// MustGetDec gets dec value from store at key. Panics on any error.
+func MustGetDec(store store.KVStore, key []byte) sdk.Dec {
+	result := &sdk.DecProto{}
+	MustGet(store, key, result)
+	return result.Dec
 }

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -274,7 +274,7 @@ func (s *TestSuite) TestMustGet() {
 // and panics if an error is encountered.
 func (s *TestSuite) TestMustSet() {
 	tests := map[string]struct {
-		// keyys and values to preset
+		// keys and values to preset
 		setKey   string
 		setValue proto.Message
 

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -363,7 +363,8 @@ func (s *TestSuite) TestMustGetDec() {
 			},
 
 			expectedGetKeyValues: map[string]sdk.Dec{
-				keyB: sdk.OneDec().Add(sdk.OneDec()),
+				keyA: sdk.OneDec(),
+				keyB: sdk.Dec{}, // this one panics
 			},
 
 			expectPanic: true,

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -394,6 +394,11 @@ func (s *TestSuite) TestMustGetDec() {
 
 // TestMustSetDec tests that MustSetDec updates the store correctly
 // with the right decimal value.
+// N.B.: It is non-trivial to cause a panic
+// by calling `MustSetDec` because it provides
+// a valid proto argument to `MustSet` which will
+// only panic if the proto argument is invalid.
+// Therefore, we only test a success case here.
 func (s *TestSuite) TestMustSetDec() {
 	// Setup.
 	s.SetupStoreWithBasePrefix()

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -339,7 +339,7 @@ func (s *TestSuite) TestMustGetDec() {
 		preSetKeyValues map[string]sdk.Dec
 
 		// keys and values to attempt to get and validate
-		getKeyValues map[string]sdk.Dec
+		expectedGetKeyValues map[string]sdk.Dec
 
 		expectPanic bool
 	}{
@@ -350,7 +350,7 @@ func (s *TestSuite) TestMustGetDec() {
 				keyC: sdk.OneDec().Add(sdk.OneDec()).Add(sdk.OneDec()),
 			},
 
-			getKeyValues: map[string]sdk.Dec{
+			expectedGetKeyValues: map[string]sdk.Dec{
 				keyA: sdk.OneDec(),
 				keyB: sdk.OneDec().Add(sdk.OneDec()),
 				keyC: sdk.OneDec().Add(sdk.OneDec()).Add(sdk.OneDec()),
@@ -362,7 +362,7 @@ func (s *TestSuite) TestMustGetDec() {
 				keyC: sdk.OneDec().Add(sdk.OneDec()).Add(sdk.OneDec()),
 			},
 
-			getKeyValues: map[string]sdk.Dec{
+			expectedGetKeyValues: map[string]sdk.Dec{
 				keyB: sdk.OneDec().Add(sdk.OneDec()),
 			},
 
@@ -380,7 +380,7 @@ func (s *TestSuite) TestMustGetDec() {
 			}
 
 			osmoassert.ConditionalPanic(s.T(), tc.expectPanic, func() {
-				for key, expectedValue := range tc.getKeyValues {
+				for key, expectedValue := range tc.expectedGetKeyValues {
 					// System under test.
 					actualDec := osmoutils.MustGetDec(s.store, []byte(key))
 					// Assertions.

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -199,7 +199,7 @@ func (s *TestSuite) TestMustGet() {
 		preSetKeyValues map[string]proto.Message
 
 		// keys and values to attempt to get and validate
-		getKeyValues map[string]proto.Message
+		expectedGetKeyValues map[string]proto.Message
 
 		actualResultProto proto.Message
 
@@ -212,7 +212,7 @@ func (s *TestSuite) TestMustGet() {
 				keyC: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
 			},
 
-			getKeyValues: map[string]proto.Message{
+			expectedGetKeyValues: map[string]proto.Message{
 				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
 				keyB: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
 				keyC: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
@@ -226,7 +226,7 @@ func (s *TestSuite) TestMustGet() {
 				keyC: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
 			},
 
-			getKeyValues: map[string]proto.Message{
+			expectedGetKeyValues: map[string]proto.Message{
 				keyB: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
 			},
 
@@ -239,7 +239,7 @@ func (s *TestSuite) TestMustGet() {
 				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
 			},
 
-			getKeyValues: map[string]proto.Message{
+			expectedGetKeyValues: map[string]proto.Message{
 				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
 			},
 
@@ -259,7 +259,7 @@ func (s *TestSuite) TestMustGet() {
 			}
 
 			osmoassert.ConditionalPanic(s.T(), tc.expectPanic, func() {
-				for key, expectedValue := range tc.getKeyValues {
+				for key, expectedValue := range tc.expectedGetKeyValues {
 					// System under test.
 					osmoutils.MustGet(s.store, []byte(key), tc.actualResultProto)
 					// Assertions.

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -335,7 +335,7 @@ func (s *TestSuite) TestMustSet() {
 func (s *TestSuite) TestMustGetDec() {
 
 	tests := map[string]struct {
-		// keyys and values to preset
+		// keys and values to preset
 		preSetKeyValues map[string]sdk.Dec
 
 		// keys and values to attempt to get and validate

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -195,7 +195,7 @@ func (s *TestSuite) TestNoStopFn_AlwaysFalse() {
 func (s *TestSuite) TestMustGet() {
 
 	tests := map[string]struct {
-		// keyys and values to preset
+		// keys and values to preset
 		preSetKeyValues map[string]proto.Message
 
 		// keys and values to attempt to get and validate


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is the first PR for merging the mint truncations solution.

ADR is available in: https://github.com/osmosis-labs/osmosis/pull/2486
This change is extracted from: https://github.com/osmosis-labs/osmosis/pull/2342

This change only includes store helpers used from the original mint truncations solution as well as their tests.

In addition, it covers an already existing function `MustSet` with tests.

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable