### PR TITLE
refactor(x/mint): truncations pt 2 - provisions split in params and minter

### DIFF
--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -52,3 +52,19 @@ func (m Minter) EpochProvision(params Params) sdk.Coin {
 	provisionAmt := m.EpochProvisions
 	return sdk.NewCoin(params.MintDenom, provisionAmt.TruncateInt())
 }
+
+// GetInflationProvisions returns the inflation provisions.
+// These are calculated as the current epoch provisons * (1 - developer rewards proportion)
+// The returned denom is taken from input parameters.
+func (m Minter) GetInflationProvisions(params Params) sdk.DecCoin {
+	provisionAmt := m.EpochProvisions.Mul(params.GetInflationProportion())
+	return sdk.NewDecCoinFromDec(params.MintDenom, provisionAmt)
+}
+
+// GetDeveloperVestingEpochProvisions returns the developer vesting provisions.
+// These are calculated as the current epoch provisons * developer rewards proportion
+// The returned denom is taken from input parameters.
+func (m Minter) GetDeveloperVestingEpochProvisions(params Params) sdk.DecCoin {
+	provisionAmt := m.EpochProvisions.Mul(params.GetDeveloperVestingProportion())
+	return sdk.NewDecCoinFromDec(params.MintDenom, provisionAmt)
+}

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	defaultDeveloperVestingProportion = sdk.NewDecWithPrec(3, 1)
+	defaultProvisionsAmount           = sdk.NewDec(10)
+	defaultParams                     = types.Params{
+		MintDenom: sdk.DefaultBondDenom,
+		DistributionProportions: types.DistributionProportions{
+			DeveloperRewards: defaultDeveloperVestingProportion,
+		},
+	}
+)
+
 // Benchmarking :)
 // previously using sdk.Int operations:
 // BenchmarkEpochProvision-4 5000000 220 ns/op
@@ -80,4 +91,40 @@ func TestMinterValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetInflationProvisions sanity checks that inflation provisons are calculated correctly.
+func TestGetInflationProvisions(t *testing.T) {
+	// Setup
+	var (
+		minter = types.NewMinter(defaultProvisionsAmount)
+
+		expectedDenom           = defaultParams.MintDenom
+		expectedInflationAmount = defaultProvisionsAmount.Mul(sdk.OneDec().Sub(defaultDeveloperVestingProportion))
+	)
+
+	// System under test
+	actualInflationProvisions := minter.GetInflationProvisions(defaultParams)
+
+	// Assertions
+	require.Equal(t, expectedDenom, actualInflationProvisions.Denom)
+	require.Equal(t, expectedInflationAmount, actualInflationProvisions.Amount)
+}
+
+// TestGetDeveloperVestingProvisions sanity checks that developer vesting provisons are calculated correctly.
+func TestGetDeveloperVestingProvisions(t *testing.T) {
+	// Setup
+	var (
+		minter = types.NewMinter(defaultProvisionsAmount)
+
+		expectedDenom           = defaultParams.MintDenom
+		expectedInflationAmount = defaultProvisionsAmount.Mul(defaultDeveloperVestingProportion)
+	)
+
+	// System under test
+	actualInflationProvisions := minter.GetDeveloperVestingEpochProvisions(defaultParams)
+
+	// Assertions
+	require.Equal(t, expectedDenom, actualInflationProvisions.Denom)
+	require.Equal(t, expectedInflationAmount, actualInflationProvisions.Amount)
 }

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -120,6 +120,18 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	}
 }
 
+// GetInflationProportion returns the inflation proportion of epoch
+// provisions.
+func (p Params) GetInflationProportion() sdk.Dec {
+	return sdk.OneDec().Sub(p.DistributionProportions.DeveloperRewards)
+}
+
+// GetDeveloperVestingProportion returns the developer vesting proportion of epoch
+// provisions.
+func (p Params) GetDeveloperVestingProportion() sdk.Dec {
+	return p.DistributionProportions.DeveloperRewards
+}
+
 func validateMintDenom(i interface{}) error {
 	v, ok := i.(string)
 	if !ok {

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -123,7 +123,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 // GetInflationProportion returns the inflation proportion of epoch
 // provisions.
 func (p Params) GetInflationProportion() sdk.Dec {
-	return sdk.OneDec().Sub(p.DistributionProportions.DeveloperRewards)
+	return sdk.OneDec().Sub(p.GetDeveloperVestingProportion())
 }
 
 // GetDeveloperVestingProportion returns the developer vesting proportion of epoch

--- a/x/mint/types/params_test.go
+++ b/x/mint/types/params_test.go
@@ -1,0 +1,42 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v11/x/mint/types"
+)
+
+// TestGetInflationProportion sanity checks that inflation
+// proportion equals to 1 - developer vesting proportion.
+func TestGetInflationProportion(t *testing.T) {
+	developerVestingProportion := sdk.NewDecWithPrec(4, 1)
+	expectedInflationProportion := sdk.OneDec().Sub(developerVestingProportion)
+
+	params := types.Params{
+		DistributionProportions: types.DistributionProportions{
+			DeveloperRewards: developerVestingProportion,
+		},
+	}
+
+	actualInflationProportion := params.GetInflationProportion()
+	require.Equal(t, expectedInflationProportion, actualInflationProportion)
+}
+
+// TestGetDeveloperVestingProportion sanity checks that developer
+// vesting proportion equals to the value set by
+// parameter for dev rewards.
+func TestGetDeveloperVestingProportion(t *testing.T) {
+	expectedDevVestingProportion := sdk.NewDecWithPrec(4, 1)
+
+	params := types.Params{
+		DistributionProportions: types.DistributionProportions{
+			DeveloperRewards: expectedDevVestingProportion,
+		},
+	}
+
+	actualDevVestingProportion := params.GetDeveloperVestingProportion()
+	require.Equal(t, expectedDevVestingProportion, actualDevVestingProportion)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is the second PR for merging the mint truncations solution.

ADR is available in: https://github.com/osmosis-labs/osmosis/pull/2486
This change is extracted from: https://github.com/osmosis-labs/osmosis/pull/2342

This change focuses on splitting the epoch provisions into 2 parts:
- so called "inflation provisions" - these are distributed from the mint module account
- developer vesting provisions - distributed from the developer vesting module account

The added params and minter logic is not used anywhere yet. The new changes will be used in future mint truncations PRs.

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable