### PR TITLE
Refactor EstimateSwap (https://github.com/osmosis-labs/osmosis/pull/2378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1857](https://github.com/osmosis-labs/osmosis/pull/1857) x/mint rename GetLastHalvenEpochNum to GetLastReductionEpochNum
 * [#2394](https://github.com/osmosis-labs/osmosis/pull/2394) Remove unused interface methods from expected keepers of each module
 * [#2390](https://github.com/osmosis-labs/osmosis/pull/2390) x/mint remove unused mintCoins parameter from AfterDistributeMintedCoin
+* [#2501](https://github.com/osmosis-labs/osmosis/pull/2501) Change `EstimateSwap` query to not require assets from sender
 
 ### Features
 

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -214,115 +214,24 @@ func (m *CustomMessenger) swapTokens(ctx sdk.Context, contractAddr sdk.AccAddres
 
 // PerformSwap can be used both for the real swap, and the EstimateSwap query
 func PerformSwap(keeper *gammkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, swap *bindings.SwapMsg) (*bindings.SwapAmount, error) {
-	if swap == nil {
-		return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap null swap"}
-	}
 	if swap.Amount.ExactIn != nil {
-		routes := []gammtypes.SwapAmountInRoute{{
-			PoolId:        swap.First.PoolId,
-			TokenOutDenom: swap.First.DenomOut,
-		}}
-		for _, step := range swap.Route {
-			routes = append(routes, gammtypes.SwapAmountInRoute{
-				PoolId:        step.PoolId,
-				TokenOutDenom: step.DenomOut,
-			})
+		routes, tokenIn, tokenOutMinAmount, err := getSwapExactAmountInParams(swap)
+		if err != nil {
+			return nil, err
 		}
-		if swap.Amount.ExactIn.Input.IsNegative() {
-			return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap negative amount in"}
-		}
-		tokenIn := sdk.Coin{
-			Denom:  swap.First.DenomIn,
-			Amount: swap.Amount.ExactIn.Input,
-		}
-		tokenOutMinAmount := swap.Amount.ExactIn.MinOutput
+
 		tokenOutAmount, err := keeper.MultihopSwapExactAmountIn(ctx, contractAddr, routes, tokenIn, tokenOutMinAmount)
 		if err != nil {
 			return nil, sdkerrors.Wrap(err, "gamm perform swap exact amount in")
 		}
 		return &bindings.SwapAmount{Out: &tokenOutAmount}, nil
 	} else if swap.Amount.ExactOut != nil {
-		routes := []gammtypes.SwapAmountOutRoute{{
-			PoolId:       swap.First.PoolId,
-			TokenInDenom: swap.First.DenomIn,
-		}}
-		output := swap.First.DenomOut
-		for _, step := range swap.Route {
-			routes = append(routes, gammtypes.SwapAmountOutRoute{
-				PoolId:       step.PoolId,
-				TokenInDenom: output,
-			})
-			output = step.DenomOut
-		}
-		tokenInMaxAmount := swap.Amount.ExactOut.MaxInput
-		if swap.Amount.ExactOut.Output.IsNegative() {
-			return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap negative amount out"}
-		}
-		tokenOut := sdk.Coin{
-			Denom:  output,
-			Amount: swap.Amount.ExactOut.Output,
-		}
-		tokenInAmount, err := keeper.MultihopSwapExactAmountOut(ctx, contractAddr, routes, tokenInMaxAmount, tokenOut)
+		routes, tokenOut, tokenInMaxAmount, err := getSwapAmountOutParams(swap)
 		if err != nil {
-			return nil, sdkerrors.Wrap(err, "gamm perform swap exact amount out")
+			return nil, err
 		}
-		return &bindings.SwapAmount{In: &tokenInAmount}, nil
-	} else {
-		return nil, wasmvmtypes.UnsupportedRequest{Kind: "must support either Swap.ExactIn or Swap.ExactOut"}
-	}
-}
 
-// EstimatePerformSwap can be used to query
-func EstimatePerformSwap(keeper *gammkeeper.Keeper, ctx sdk.Context, swap *bindings.SwapMsg) (*bindings.SwapAmount, error) {
-	if swap == nil {
-		return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap null swap"}
-	}
-	if swap.Amount.ExactIn != nil {
-		routes := []gammtypes.SwapAmountInRoute{{
-			PoolId:        swap.First.PoolId,
-			TokenOutDenom: swap.First.DenomOut,
-		}}
-		for _, step := range swap.Route {
-			routes = append(routes, gammtypes.SwapAmountInRoute{
-				PoolId:        step.PoolId,
-				TokenOutDenom: step.DenomOut,
-			})
-		}
-		if swap.Amount.ExactIn.Input.IsNegative() {
-			return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap negative amount in"}
-		}
-		tokenIn := sdk.Coin{
-			Denom:  swap.First.DenomIn,
-			Amount: swap.Amount.ExactIn.Input,
-		}
-		tokenOutMinAmount := swap.Amount.ExactIn.MinOutput
-		tokenOutAmount, err := keeper.EstimateMultihopSwapExactAmountIn(ctx, routes, tokenIn, tokenOutMinAmount)
-		if err != nil {
-			return nil, sdkerrors.Wrap(err, "gamm perform swap exact amount in")
-		}
-		return &bindings.SwapAmount{Out: &tokenOutAmount}, nil
-	} else if swap.Amount.ExactOut != nil {
-		routes := []gammtypes.SwapAmountOutRoute{{
-			PoolId:       swap.First.PoolId,
-			TokenInDenom: swap.First.DenomIn,
-		}}
-		output := swap.First.DenomOut
-		for _, step := range swap.Route {
-			routes = append(routes, gammtypes.SwapAmountOutRoute{
-				PoolId:       step.PoolId,
-				TokenInDenom: output,
-			})
-			output = step.DenomOut
-		}
-		tokenInMaxAmount := swap.Amount.ExactOut.MaxInput
-		if swap.Amount.ExactOut.Output.IsNegative() {
-			return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap negative amount out"}
-		}
-		tokenOut := sdk.Coin{
-			Denom:  output,
-			Amount: swap.Amount.ExactOut.Output,
-		}
-		tokenInAmount, err := keeper.EstimateMultihopSwapExactAmountOut(ctx, routes, tokenInMaxAmount, tokenOut)
+		tokenInAmount, err := keeper.MultihopSwapExactAmountOut(ctx, contractAddr, routes, tokenInMaxAmount, tokenOut)
 		if err != nil {
 			return nil, sdkerrors.Wrap(err, "gamm perform swap exact amount out")
 		}
@@ -357,4 +266,50 @@ func parseAddress(addr string) (sdk.AccAddress, error) {
 		return nil, sdkerrors.Wrap(err, "verify address format")
 	}
 	return parsed, nil
+}
+
+func getSwapExactAmountInParams(swap *bindings.SwapMsg) (routes []gammtypes.SwapAmountInRoute, tokenIn sdk.Coin, tokenOutMinAmount sdk.Int, err error) {
+	routes = []gammtypes.SwapAmountInRoute{{
+		PoolId:        swap.First.PoolId,
+		TokenOutDenom: swap.First.DenomOut,
+	}}
+	for _, step := range swap.Route {
+		routes = append(routes, gammtypes.SwapAmountInRoute{
+			PoolId:        step.PoolId,
+			TokenOutDenom: step.DenomOut,
+		})
+	}
+	if swap.Amount.ExactIn.Input.IsNegative() {
+		return nil, sdk.Coin{}, sdk.Int{}, wasmvmtypes.InvalidRequest{Err: "gamm perform swap negative amount in"}
+	}
+	tokenIn = sdk.Coin{
+		Denom:  swap.First.DenomIn,
+		Amount: swap.Amount.ExactIn.Input,
+	}
+	tokenOutMinAmount = swap.Amount.ExactIn.MinOutput
+	return routes, tokenIn, tokenOutMinAmount, nil
+}
+
+func getSwapAmountOutParams(swap *bindings.SwapMsg) (routes []gammtypes.SwapAmountOutRoute, tokenOut sdk.Coin, tokenInMaxAmount sdk.Int, err error) {
+	routes = []gammtypes.SwapAmountOutRoute{{
+		PoolId:       swap.First.PoolId,
+		TokenInDenom: swap.First.DenomIn,
+	}}
+	output := swap.First.DenomOut
+	for _, step := range swap.Route {
+		routes = append(routes, gammtypes.SwapAmountOutRoute{
+			PoolId:       step.PoolId,
+			TokenInDenom: output,
+		})
+		output = step.DenomOut
+	}
+	tokenInMaxAmount = swap.Amount.ExactOut.MaxInput
+	if swap.Amount.ExactOut.Output.IsNegative() {
+		return nil, sdk.Coin{}, sdk.Int{}, wasmvmtypes.InvalidRequest{Err: "gamm perform swap negative amount out"}
+	}
+	tokenOut = sdk.Coin{
+		Denom:  output,
+		Amount: swap.Amount.ExactOut.Output,
+	}
+	return routes, tokenOut, tokenInMaxAmount, nil
 }

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -214,6 +214,9 @@ func (m *CustomMessenger) swapTokens(ctx sdk.Context, contractAddr sdk.AccAddres
 
 // PerformSwap can be used both for the real swap, and the EstimateSwap query
 func PerformSwap(keeper *gammkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, swap *bindings.SwapMsg) (*bindings.SwapAmount, error) {
+	if swap == nil {
+		return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap null swap"}
+	}
 	if swap.Amount.ExactIn != nil {
 		routes, tokenIn, tokenOutMinAmount, err := getSwapExactAmountInParams(swap)
 		if err != nil {

--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -105,6 +105,38 @@ func (qp QueryPlugin) EstimateSwap(ctx sdk.Context, estimateSwap *bindings.Estim
 	return estimate, err
 }
 
+// EstimatePerformSwap can be used to query
+func EstimatePerformSwap(keeper *gammkeeper.Keeper, ctx sdk.Context, swap *bindings.SwapMsg) (*bindings.SwapAmount, error) {
+	if swap == nil {
+		return nil, wasmvmtypes.InvalidRequest{Err: "gamm perform swap null swap"}
+	}
+	if swap.Amount.ExactIn != nil {
+		routes, tokenIn, tokenOutMinAmount, err := getSwapExactAmountInParams(swap)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenOutAmount, err := keeper.EstimateMultihopSwapExactAmountIn(ctx, routes, tokenIn, tokenOutMinAmount)
+		if err != nil {
+			return nil, sdkerrors.Wrap(err, "gamm perform swap exact amount in")
+		}
+		return &bindings.SwapAmount{Out: &tokenOutAmount}, nil
+	} else if swap.Amount.ExactOut != nil {
+		routes, tokenOut, tokenInMaxAmount, err := getSwapAmountOutParams(swap)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenInAmount, err := keeper.EstimateMultihopSwapExactAmountOut(ctx, routes, tokenInMaxAmount, tokenOut)
+		if err != nil {
+			return nil, sdkerrors.Wrap(err, "gamm perform swap exact amount out")
+		}
+		return &bindings.SwapAmount{In: &tokenInAmount}, nil
+	} else {
+		return nil, wasmvmtypes.UnsupportedRequest{Kind: "must support either Swap.ExactIn or Swap.ExactOut"}
+	}
+}
+
 func (qp QueryPlugin) ArithmeticTwap(ctx sdk.Context, arithmeticTwap *bindings.ArithmeticTwap) (*sdk.Dec, error) {
 	if arithmeticTwap == nil {
 		return nil, wasmvmtypes.InvalidRequest{Err: "gamm arithmetic twap null"}

--- a/wasmbinding/test/messages_test.go
+++ b/wasmbinding/test/messages_test.go
@@ -636,6 +636,8 @@ func TestSwap(t *testing.T) {
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			// when
+			fmt.Println("=====swap message")
+			fmt.Println(spec.swap)
 			gotAmount, gotErr := wasmbinding.PerformSwap(osmosis.GAMMKeeper, ctx, actor, spec.swap)
 			// then
 			if spec.expErr {

--- a/wasmbinding/test/messages_test.go
+++ b/wasmbinding/test/messages_test.go
@@ -636,8 +636,6 @@ func TestSwap(t *testing.T) {
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			// when
-			fmt.Println("=====swap message")
-			fmt.Println(spec.swap)
 			gotAmount, gotErr := wasmbinding.PerformSwap(osmosis.GAMMKeeper, ctx, actor, spec.swap)
 			// then
 			if spec.expErr {

--- a/x/gamm/keeper/estimate_swap.go
+++ b/x/gamm/keeper/estimate_swap.go
@@ -181,23 +181,3 @@ func (k Keeper) estimateSwapExactAmountOut(
 
 	return pool, tokenIn, nil
 }
-
-func (k Keeper) EstimateUpdatePoolForSwap(
-	ctx sdk.Context,
-	pool types.PoolI,
-	tokenIn sdk.Coin,
-	tokenOut sdk.Coin,
-) error {
-	tokensIn := sdk.Coins{tokenIn}
-	tokensOut := sdk.Coins{tokenOut}
-
-	err := k.setPool(ctx, pool)
-	if err != nil {
-		return err
-	}
-
-	k.RecordTotalLiquidityIncrease(ctx, tokensIn)
-	k.RecordTotalLiquidityDecrease(ctx, tokensOut)
-
-	return err
-}

--- a/x/gamm/keeper/estimate_swap.go
+++ b/x/gamm/keeper/estimate_swap.go
@@ -95,6 +95,11 @@ func (k Keeper) EstimateSwapExactAmountIn(
 
 	swapFee := pool.GetSwapFee(ctx)
 	_, tokenOut, err := k.estimateSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
+	if err != nil {
+		return tokenOut.Amount, err
+	}
+
+	err = k.EstimateUpdatePoolForSwap(ctx, pool, tokenIn, tokenOut)
 	return tokenOut.Amount, err
 }
 

--- a/x/gamm/keeper/estimate_swap.go
+++ b/x/gamm/keeper/estimate_swap.go
@@ -92,7 +92,6 @@ func (k Keeper) EstimateSwapExactAmountIn(
 	if err != nil {
 		return sdk.Int{}, err
 	}
-
 	swapFee := pool.GetSwapFee(ctx)
 	_, tokenOut, err := k.estimateSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
 	if err != nil {
@@ -133,12 +132,6 @@ func (k Keeper) estimateSwapExactAmountIn(
 		return pool, sdk.Coin{}, sdkerrors.Wrapf(types.ErrLimitMinAmount, "%s token is lesser than min amount", tokenOutDenom)
 	}
 
-	// Settles balances between the tx sender and the pool to match the swap that was executed earlier.
-	// Also emits swap event and updates related liquidity metrics
-	if err := k.EstimateUpdatePoolForSwap(ctx, pool, tokenIn, tokenOutCoin); err != nil {
-		return pool, sdk.Coin{}, err
-	}
-
 	return pool, tokenOutCoin, nil
 }
 
@@ -153,6 +146,7 @@ func (k Keeper) EstimateSwapExactAmountOut(
 	if err != nil {
 		return sdk.Int{}, err
 	}
+
 	swapFee := pool.GetSwapFee(ctx)
 	_, tokenIn, err := k.estimateSwapExactAmountOut(ctx, pool, tokenInDenom, tokenInMaxAmount, tokenOut, swapFee)
 	if err != nil {
@@ -193,11 +187,6 @@ func (k Keeper) estimateSwapExactAmountOut(
 
 	if tokenInAmount.GT(tokenInMaxAmount) {
 		return pool, sdk.Coin{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, "Swap requires %s, which is greater than the amount %s", tokenIn, tokenInMaxAmount)
-	}
-
-	err = k.EstimateUpdatePoolForSwap(ctx, pool, tokenIn, tokenOut)
-	if err != nil {
-		return pool, sdk.Coin{}, err
 	}
 
 	return pool, tokenIn, nil

--- a/x/gamm/keeper/estimate_swap.go
+++ b/x/gamm/keeper/estimate_swap.go
@@ -150,6 +150,11 @@ func (k Keeper) EstimateSwapExactAmountOut(
 	}
 	swapFee := pool.GetSwapFee(ctx)
 	_, tokenIn, err := k.estimateSwapExactAmountOut(ctx, pool, tokenInDenom, tokenInMaxAmount, tokenOut, swapFee)
+	if err != nil {
+		return tokenIn.Amount, err
+	}
+
+	err = k.EstimateUpdatePoolForSwap(ctx, pool, tokenIn, tokenOut)
 	return tokenIn.Amount, err
 }
 

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -332,7 +332,6 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountIn() {
 
 	for _, tc := range testCases {
 		tc := tc
-
 		suite.Run(tc.name, func() {
 			result, err := queryClient.EstimateSwapExactAmountIn(gocontext.Background(), tc.req)
 			if tc.expectErr {
@@ -359,11 +358,11 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountOut() {
 			name: "multi route",
 			req: &types.QuerySwapExactAmountOutRequest{
 				PoolId:   poolID,
-				TokenOut: "100000baz",
+				TokenOut: "100000foo",
 				Routes: types.SwapAmountOutRoutes{
 					types.SwapAmountOutRoute{
 						PoolId:       poolID,
-						TokenInDenom: "foo",
+						TokenInDenom: "baz",
 					},
 					types.SwapAmountOutRoute{
 						PoolId:       poolID,
@@ -372,22 +371,22 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountOut() {
 				},
 			},
 			expectErr: false,
-			result:    sdk.NewInt(322486),
+			result:    sdk.NewInt(34131),
 		},
 		{
 			name: "one route",
 			req: &types.QuerySwapExactAmountOutRequest{
 				PoolId:   poolID,
-				TokenOut: "100000baz",
+				TokenOut: "100000foo",
 				Routes: types.SwapAmountOutRoutes{
 					types.SwapAmountOutRoute{
 						PoolId:       poolID,
-						TokenInDenom: "foo",
+						TokenInDenom: "baz",
 					},
 				},
 			},
 			expectErr: false,
-			result:    sdk.NewInt(322486),
+			result:    sdk.NewInt(33785),
 		},
 	}
 

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -372,7 +372,7 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountOut() {
 				},
 			},
 			expectErr: false,
-			result:    sdk.NewInt(312413),
+			result:    sdk.NewInt(322486),
 		},
 		{
 			name: "one route",
@@ -387,7 +387,7 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountOut() {
 				},
 			},
 			expectErr: false,
-			result:    sdk.NewInt(312413),
+			result:    sdk.NewInt(322486),
 		},
 	}
 

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -298,7 +298,7 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountIn() {
 			name: "multi route",
 			req: &types.QuerySwapExactAmountInRequest{
 				PoolId:  poolID,
-				TokenIn: "32895foo",
+				TokenIn: "100000foo",
 				Routes: types.SwapAmountInRoutes{
 					types.SwapAmountInRoute{
 						PoolId:        poolID,
@@ -311,13 +311,13 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountIn() {
 				},
 			},
 			expectErr: false,
-			result:    sdk.NewInt(33),
+			result:    sdk.NewInt(32895),
 		},
 		{
 			name: "one route",
 			req: &types.QuerySwapExactAmountInRequest{
 				PoolId:  poolID,
-				TokenIn: "32895foo",
+				TokenIn: "100000foo",
 				Routes: types.SwapAmountInRoutes{
 					types.SwapAmountInRoute{
 						PoolId:        poolID,
@@ -326,7 +326,7 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountIn() {
 				},
 			},
 			expectErr: false,
-			result:    sdk.NewInt(33),
+			result:    sdk.NewInt(32895),
 		},
 	}
 
@@ -340,6 +340,67 @@ func (suite *KeeperTestSuite) TestEstimateSwapExactAmountIn() {
 			} else {
 				suite.Require().NoError(err, "unexpected error")
 				suite.Require().Equal(tc.result, result.TokenOutAmount)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestEstimateSwapExactAmountOut() {
+	queryClient := suite.queryClient
+	poolID := suite.PrepareBalancerPool()
+
+	testCases := []struct {
+		name      string
+		req       *types.QuerySwapExactAmountOutRequest
+		expectErr bool
+		result    sdk.Int
+	}{
+		{
+			name: "multi route",
+			req: &types.QuerySwapExactAmountOutRequest{
+				PoolId:   poolID,
+				TokenOut: "100000baz",
+				Routes: types.SwapAmountOutRoutes{
+					types.SwapAmountOutRoute{
+						PoolId:       poolID,
+						TokenInDenom: "foo",
+					},
+					types.SwapAmountOutRoute{
+						PoolId:       poolID,
+						TokenInDenom: "bar",
+					},
+				},
+			},
+			expectErr: false,
+			result:    sdk.NewInt(312413),
+		},
+		{
+			name: "one route",
+			req: &types.QuerySwapExactAmountOutRequest{
+				PoolId:   poolID,
+				TokenOut: "100000baz",
+				Routes: types.SwapAmountOutRoutes{
+					types.SwapAmountOutRoute{
+						PoolId:       poolID,
+						TokenInDenom: "foo",
+					},
+				},
+			},
+			expectErr: false,
+			result:    sdk.NewInt(312413),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		suite.Run(tc.name, func() {
+			result, err := queryClient.EstimateSwapExactAmountOut(gocontext.Background(), tc.req)
+			if tc.expectErr {
+				suite.Require().Error(err, "expected error")
+			} else {
+				suite.Require().NoError(err, "unexpected error")
+				suite.Require().Equal(tc.result, result.TokenInAmount)
 			}
 		})
 	}

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -1,10 +1,7 @@
 package keeper
 
 import (
-	"errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/keeper/internal/events"
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/types"
@@ -45,31 +42,14 @@ func (k Keeper) swapExactAmountIn(
 	tokenOutMinAmount sdk.Int,
 	swapFee sdk.Dec,
 ) (tokenOutAmount sdk.Int, err error) {
-	if tokenIn.Denom == tokenOutDenom {
-		return sdk.Int{}, errors.New("cannot trade same denomination in and out")
-	}
-	tokensIn := sdk.Coins{tokenIn}
-
-	// Executes the swap in the pool and stores the output. Updates pool assets but
-	// does not actually transfer any tokens to or from the pool.
-	tokenOutCoin, err := pool.SwapOutAmtGivenIn(ctx, tokensIn, tokenOutDenom, swapFee)
+	pool, tokenOut, err := k.estimateSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
 	if err != nil {
 		return sdk.Int{}, err
 	}
 
-	tokenOutAmount = tokenOutCoin.Amount
-
-	if !tokenOutAmount.IsPositive() {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrInvalidMathApprox, "token amount must be positive")
-	}
-
-	if tokenOutAmount.LT(tokenOutMinAmount) {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMinAmount, "%s token is lesser than min amount", tokenOutDenom)
-	}
-
 	// Settles balances between the tx sender and the pool to match the swap that was executed earlier.
 	// Also emits swap event and updates related liquidity metrics
-	if err := k.updatePoolForSwap(ctx, pool, sender, tokenIn, tokenOutCoin); err != nil {
+	if err := k.updatePoolForSwap(ctx, pool, sender, tokenIn, tokenOut); err != nil {
 		return sdk.Int{}, err
 	}
 
@@ -105,34 +85,16 @@ func (k Keeper) swapExactAmountOut(
 	tokenOut sdk.Coin,
 	swapFee sdk.Dec,
 ) (tokenInAmount sdk.Int, err error) {
-	if tokenInDenom == tokenOut.Denom {
-		return sdk.Int{}, errors.New("cannot trade same denomination in and out")
-	}
-
-	poolOutBal := pool.GetTotalPoolLiquidity(ctx).AmountOf(tokenOut.Denom)
-	if tokenOut.Amount.GTE(poolOutBal) {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrTooManyTokensOut,
-			"can't get more tokens out than there are tokens in the pool")
-	}
-
-	tokenIn, err := pool.SwapInAmtGivenOut(ctx, sdk.Coins{tokenOut}, tokenInDenom, swapFee)
+	pool, tokenIn, err := k.estimateSwapExactAmountOut(ctx, pool, tokenInDenom, tokenInMaxAmount, tokenOut, swapFee)
 	if err != nil {
 		return sdk.Int{}, err
-	}
-	tokenInAmount = tokenIn.Amount
-
-	if tokenInAmount.LTE(sdk.ZeroInt()) {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrInvalidMathApprox, "token amount is zero or negative")
-	}
-
-	if tokenInAmount.GT(tokenInMaxAmount) {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, "Swap requires %s, which is greater than the amount %s", tokenIn, tokenInMaxAmount)
 	}
 
 	err = k.updatePoolForSwap(ctx, pool, sender, tokenIn, tokenOut)
 	if err != nil {
 		return sdk.Int{}, err
 	}
+
 	return tokenInAmount, nil
 }
 

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -53,7 +53,7 @@ func (k Keeper) swapExactAmountIn(
 		return sdk.Int{}, err
 	}
 
-	return tokenOutAmount, nil
+	return tokenOut.Amount, nil
 }
 
 func (k Keeper) SwapExactAmountOut(
@@ -95,7 +95,7 @@ func (k Keeper) swapExactAmountOut(
 		return sdk.Int{}, err
 	}
 
-	return tokenInAmount, nil
+	return tokenIn.Amount, nil
 }
 
 // updatePoolForSwap takes a pool, sender, and tokenIn, tokenOut amounts


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Sub component of  https://github.com/osmosis-labs/osmosis/pull/2378

## What is the purpose of the change

https://github.com/osmosis-labs/osmosis/pull/2378 has some parts in code where code de-duplication can take place. This PR includes minor refactoring to for code cleanup and code de-duplication.


## Brief Changelog
- Remove code duplication for Estimate methods

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)