### PR TITLE
[Test] Create suite.SetupGenesisTest() that takes care of module account removal

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v11/app"
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/pool-models/balancer"
-	"github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	lockupkeeper "github.com/osmosis-labs/osmosis/v11/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/v11/x/lockup/types"
@@ -63,15 +62,17 @@ func (s *KeeperTestHelper) Setup() {
 
 	s.SetEpochStartTime()
 	s.TestAccs = CreateRandomAccounts(3)
-	s.SetupGenesisTest()
 }
 
-func (s *KeeperTestHelper) SetupGenesisTest() {
-	accountKeeper := s.App.AccountKeeper
+func (s *KeeperTestHelper) SetupTestForInitGenesis() {
+	s.App = app.Setup(true)
+	s.Ctx = s.App.BaseApp.NewContext(true, tmtypes.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	// remove module account to ensure initGenesis initializes it on its own
+	// accountKeeper := s.App.AccountKeeper
 
-	moduleAddress := accountKeeper.GetModuleAddress(types.ModuleName)
-	tokenFactoryModuleAccount := accountKeeper.GetAccount(s.Ctx, moduleAddress)
-	accountKeeper.RemoveAccount(s.Ctx, tokenFactoryModuleAccount)
+	// moduleAddress := accountKeeper.GetModuleAddress(types.ModuleName)
+	// tokenFactoryModuleAccount := accountKeeper.GetAccount(s.Ctx, moduleAddress)
+	// accountKeeper.RemoveAccount(s.Ctx, tokenFactoryModuleAccount)
 }
 
 func (s *KeeperTestHelper) SetEpochStartTime() {

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -66,13 +66,6 @@ func (s *KeeperTestHelper) Setup() {
 
 func (s *KeeperTestHelper) SetupTestForInitGenesis() {
 	s.App = app.Setup(true)
-	s.Ctx = s.App.BaseApp.NewContext(true, tmtypes.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
-	// remove module account to ensure initGenesis initializes it on its own
-	// accountKeeper := s.App.AccountKeeper
-
-	// moduleAddress := accountKeeper.GetModuleAddress(types.ModuleName)
-	// tokenFactoryModuleAccount := accountKeeper.GetAccount(s.Ctx, moduleAddress)
-	// accountKeeper.RemoveAccount(s.Ctx, tokenFactoryModuleAccount)
 }
 
 func (s *KeeperTestHelper) SetEpochStartTime() {

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v11/app"
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	lockupkeeper "github.com/osmosis-labs/osmosis/v11/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/v11/x/lockup/types"
@@ -62,6 +63,15 @@ func (s *KeeperTestHelper) Setup() {
 
 	s.SetEpochStartTime()
 	s.TestAccs = CreateRandomAccounts(3)
+	s.SetupGenesisTest()
+}
+
+func (s *KeeperTestHelper) SetupGenesisTest() {
+	accountKeeper := s.App.AccountKeeper
+
+	moduleAddress := accountKeeper.GetModuleAddress(types.ModuleName)
+	tokenFactoryModuleAccount := accountKeeper.GetAccount(s.Ctx, moduleAddress)
+	accountKeeper.RemoveAccount(s.Ctx, tokenFactoryModuleAccount)
 }
 
 func (s *KeeperTestHelper) SetEpochStartTime() {

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -35,6 +35,7 @@ import (
 	lockupkeeper "github.com/osmosis-labs/osmosis/v11/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/v11/x/lockup/types"
 	minttypes "github.com/osmosis-labs/osmosis/v11/x/mint/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 type KeeperTestHelper struct {
@@ -65,7 +66,9 @@ func (s *KeeperTestHelper) Setup() {
 }
 
 func (s *KeeperTestHelper) SetupTestForInitGenesis() {
+	// Setting to True, leads to init genesis not running
 	s.App = app.Setup(true)
+	s.Ctx = s.App.BaseApp.NewContext(true, tmproto.Header{})
 }
 
 func (s *KeeperTestHelper) SetEpochStartTime() {

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -35,7 +35,6 @@ import (
 	lockupkeeper "github.com/osmosis-labs/osmosis/v11/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/v11/x/lockup/types"
 	minttypes "github.com/osmosis-labs/osmosis/v11/x/mint/types"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 type KeeperTestHelper struct {
@@ -68,7 +67,7 @@ func (s *KeeperTestHelper) Setup() {
 func (s *KeeperTestHelper) SetupTestForInitGenesis() {
 	// Setting to True, leads to init genesis not running
 	s.App = app.Setup(true)
-	s.Ctx = s.App.BaseApp.NewContext(true, tmproto.Header{})
+	s.Ctx = s.App.BaseApp.NewContext(true, tmtypes.Header{})
 }
 
 func (s *KeeperTestHelper) SetEpochStartTime() {

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -32,8 +32,6 @@ func (suite *KeeperTestSuite) TestGenesis() {
 		},
 	}
 
-	suite.SetupGenesisTest()
-
 	app := suite.App
 	suite.Ctx = app.BaseApp.NewContext(false, tmproto.Header{})
 	// Test both with bank denom metadata set, and not set.

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -1,35 +1,14 @@
 package keeper_test
 
 import (
-	"testing"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	"github.com/osmosis-labs/osmosis/v11/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v11/x/tokenfactory/types"
 )
 
-type GenesisTestSuite struct {
-	apptesting.KeeperTestHelper
-}
-
-func (suite *GenesisTestSuite) SetupTest() {
-	suite.Setup()
-
-	// remove module account to ensure initGenesis initializes it on its own
-	moduleAddress := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
-	tokenfactoryModuleAccount := suite.App.AccountKeeper.GetAccount(suite.Ctx, moduleAddress)
-	suite.App.AccountKeeper.RemoveAccount(suite.Ctx, tokenfactoryModuleAccount)
-}
-
-func TestGenesisTestSuite(t *testing.T) {
-	suite.Run(t, new(GenesisTestSuite))
-}
-
-func (suite *GenesisTestSuite) TestGenesis() {
+func (suite *KeeperTestSuite) TestGenesis() {
 	genesisState := types.GenesisState{
 		FactoryDenoms: []types.GenesisDenom{
 			{
@@ -52,6 +31,8 @@ func (suite *GenesisTestSuite) TestGenesis() {
 			},
 		},
 	}
+
+	suite.SetupGenesisTest()
 
 	app := suite.App
 	suite.Ctx = app.BaseApp.NewContext(false, tmproto.Header{})

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -33,7 +33,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 	}
 
 	app := suite.App
-	suite.Ctx = app.BaseApp.NewContext(false, tmproto.Header{})
+	suite.Ctx = app.BaseApp.NewContext(true, tmproto.Header{})
 
 	// Test both with bank denom metadata set, and not set.
 	for i, denom := range genesisState.FactoryDenoms {

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -34,6 +34,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 
 	app := suite.App
 	suite.Ctx = app.BaseApp.NewContext(false, tmproto.Header{})
+
 	// Test both with bank denom metadata set, and not set.
 	for i, denom := range genesisState.FactoryDenoms {
 		// hacky, sets bank metadata to exist if i != 0, to cover both cases.
@@ -41,6 +42,9 @@ func (suite *KeeperTestSuite) TestGenesis() {
 			app.BankKeeper.SetDenomMetaData(suite.Ctx, banktypes.Metadata{Base: denom.GetDenom()})
 		}
 	}
+
+	suite.SetupTestForInitGenesis()
+
 	// check before initGenesis that the module account is nil
 	tokenfactoryModuleAccount := app.AccountKeeper.GetAccount(suite.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
 	suite.Require().Nil(tokenfactoryModuleAccount)

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/osmosis-labs/osmosis/v11/x/tokenfactory/types"
 )
@@ -32,8 +31,8 @@ func (suite *KeeperTestSuite) TestGenesis() {
 		},
 	}
 
+	suite.SetupTestForInitGenesis()
 	app := suite.App
-	suite.Ctx = app.BaseApp.NewContext(true, tmproto.Header{})
 
 	// Test both with bank denom metadata set, and not set.
 	for i, denom := range genesisState.FactoryDenoms {
@@ -42,8 +41,6 @@ func (suite *KeeperTestSuite) TestGenesis() {
 			app.BankKeeper.SetDenomMetaData(suite.Ctx, banktypes.Metadata{Base: denom.GetDenom()})
 		}
 	}
-
-	suite.SetupTestForInitGenesis()
 
 	// check before initGenesis that the module account is nil
 	tokenfactoryModuleAccount := app.AccountKeeper.GetAccount(suite.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -25,15 +25,6 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
-func (suite *KeeperTestSuite) SetupGenesisTest() {
-	suite.Setup()
-
-	// remove module account to ensure initGenesis initializes it on its own
-	moduleAddress := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
-	tokenfactoryModuleAccount := suite.App.AccountKeeper.GetAccount(suite.Ctx, moduleAddress)
-	suite.App.AccountKeeper.RemoveAccount(suite.Ctx, tokenfactoryModuleAccount)
-}
-
 func (suite *KeeperTestSuite) SetupTest() {
 	suite.Setup()
 	// Fund every TestAcc with two denoms, one of which is the denom creation fee

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -25,6 +25,15 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
+func (suite *KeeperTestSuite) SetupGenesisTest() {
+	suite.Setup()
+
+	// remove module account to ensure initGenesis initializes it on its own
+	moduleAddress := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
+	tokenfactoryModuleAccount := suite.App.AccountKeeper.GetAccount(suite.Ctx, moduleAddress)
+	suite.App.AccountKeeper.RemoveAccount(suite.Ctx, tokenfactoryModuleAccount)
+}
+
 func (suite *KeeperTestSuite) SetupTest() {
 	suite.Setup()
 	// Fund every TestAcc with two denoms, one of which is the denom creation fee

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/osmosis-labs/osmosis/v11/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v11/x/tokenfactory/keeper"
@@ -40,24 +39,4 @@ func (suite *KeeperTestSuite) SetupTest() {
 func (suite *KeeperTestSuite) CreateDefaultDenom() {
 	res, _ := suite.msgServer.CreateDenom(sdk.WrapSDKContext(suite.Ctx), types.NewMsgCreateDenom(suite.TestAccs[0].String(), "bitcoin"))
 	suite.defaultDenom = res.GetNewTokenDenom()
-}
-
-func (suite *KeeperTestSuite) TestCreateModuleAccount() {
-	app := suite.App
-
-	// remove module account
-	tokenfactoryModuleAccount := app.AccountKeeper.GetAccount(suite.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
-	app.AccountKeeper.RemoveAccount(suite.Ctx, tokenfactoryModuleAccount)
-
-	// ensure module account was removed
-	suite.Ctx = app.BaseApp.NewContext(false, tmproto.Header{})
-	tokenfactoryModuleAccount = app.AccountKeeper.GetAccount(suite.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
-	suite.Require().Nil(tokenfactoryModuleAccount)
-
-	// create module account
-	app.TokenFactoryKeeper.CreateModuleAccount(suite.Ctx)
-
-	// check that the module account is now initialized
-	tokenfactoryModuleAccount = app.AccountKeeper.GetAccount(suite.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
-	suite.Require().NotNil(tokenfactoryModuleAccount)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2502 

## What is the purpose of the change

In the keeper tests, in order to test that we are properly generating the module account, we need to first remove it. However, 
Dev suggested the following: Make a new suite.SetupGenesisTest() constructor that takes care of this so we don't need to worry about this with future tests.


## Brief Changelog
n/a

## Testing and Verifying
Create new suite `TestGenesisTestSuite` for genesis_test

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)