### PR TITLE
Puneet/epochevents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 * [#2214](https://github.com/osmosis-labs/osmosis/pull/2214) Speedup epoch distribution, superfluid component
+* [#2515](https://github.com/osmosis-labs/osmosis/pull/2515) Emit events from functions implementing epoch hooks' `panicCatchingEpochHook` cacheCtx
 
 ### SDK Upgrades
 * [#2245](https://github.com/osmosis-labs/osmosis/pull/2244) Upgrade SDK with the following major changes:

--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -50,4 +50,5 @@ func panicCatchingEpochHook(
 	cacheCtx, write := ctx.CacheContext()
 	hookFn(cacheCtx, epochIdentifier, epochNumber)
 	write()
+	ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 }

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -26,6 +27,22 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
 }
 
+func dummyAfterEpochEndEvent(epochIdentifier string, epochNumber int64) sdk.Event {
+	return sdk.NewEvent(
+		"afterEpochEnd",
+		sdk.NewAttribute("epochIdentifier", epochIdentifier),
+		sdk.NewAttribute("epochNumber", strconv.FormatInt(epochNumber, 10)),
+	)
+}
+
+func dummyBeforeEpochStartEvent(epochIdentifier string, epochNumber int64) sdk.Event {
+	return sdk.NewEvent(
+		"beforeEpochStart",
+		sdk.NewAttribute("epochIdentifier", epochIdentifier),
+		sdk.NewAttribute("epochNumber", strconv.FormatInt(epochNumber, 10)),
+	)
+}
+
 // dummyEpochHook is a struct satisfying the epoch hook interface,
 // that maintains a counter for how many times its been succesfully called,
 // and a boolean for whether it should panic during its execution.
@@ -39,6 +56,7 @@ func (hook *dummyEpochHook) AfterEpochEnd(ctx sdk.Context, epochIdentifier strin
 		panic("dummyEpochHook is panicking")
 	}
 	hook.successCounter += 1
+	ctx.EventManager().EmitEvent(dummyAfterEpochEndEvent(epochIdentifier, epochNumber))
 }
 
 func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
@@ -46,6 +64,8 @@ func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier st
 		panic("dummyEpochHook is panicking")
 	}
 	hook.successCounter += 1
+	ctx.EventManager().EmitEvent(dummyBeforeEpochStartEvent(epochIdentifier, epochNumber))
+
 }
 
 func (hook *dummyEpochHook) Clone() *dummyEpochHook {
@@ -55,7 +75,7 @@ func (hook *dummyEpochHook) Clone() *dummyEpochHook {
 
 var _ types.EpochHooks = &dummyEpochHook{}
 
-func (suite *KeeperTestSuite) TestHooksPanicRecovery() {
+func (suite *KeeperTestSuite) TestHooksPanicRecoveryAndEvents() {
 	panicHook := dummyEpochHook{shouldPanic: true}
 	noPanicHook := dummyEpochHook{shouldPanic: false}
 	simpleHooks := []dummyEpochHook{panicHook, noPanicHook}
@@ -81,8 +101,13 @@ func (suite *KeeperTestSuite) TestHooksPanicRecovery() {
 			suite.NotPanics(func() {
 				if epochActionSelector == 0 {
 					hooks.BeforeEpochStart(suite.Ctx, "id", 0)
+					suite.Require().Equal(suite.Ctx.EventManager().Events(), sdk.Events{dummyBeforeEpochStartEvent("id", 0)},
+						"test case index %d, before epoch event check", tcIndex)
 				} else if epochActionSelector == 1 {
 					hooks.AfterEpochEnd(suite.Ctx, "id", 0)
+					suite.Require().Equal(suite.Ctx.EventManager().Events(), sdk.Events{dummyAfterEpochEndEvent("id", 0)},
+						"test case index %d, after epoch event check", tcIndex)
+
 				}
 			})
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
<!-- -->
<!-- > Add a description of the overall background and high level changes that this PR introduces -->
- the new error handling mechanism for hooks `panicCatchingEpochHook` does not append events happening in modules implementing the hooks
- cacheCtx has events that are not emitted as the cacheCtx is dumped after write() happens. 
- adds `ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())`



## Brief Changelog

<--! *(for example:)* -->
 - `func panicCatchingEpochHook` now emits the events that are part of `cacheCtx`

## Testing and Verifying
- added the tests to check for events after epochs are called as part of d49cb6af031b310400c6e739aa24518a265194ba

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no) ~ users no, clients parsing events - yes.
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) - yes
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented) - not documented