### PR TITLE
Unify cache_ctx wraps

### DIFF
--- a/osmoutils/cache_ctx.go
+++ b/osmoutils/cache_ctx.go
@@ -29,6 +29,8 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	} else {
 		// no error, write the output of f
 		write()
+		// Temporary, should be removed once: https://github.com/cosmos/cosmos-sdk/issues/12912
+		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	}
 	return err
 }

--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	fmt "fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v11/osmoutils"
@@ -49,6 +51,6 @@ func panicCatchingEpochHook(
 	// TODO: Thread info for which hook this is, may be dependent on larger hook system refactoring
 	err := osmoutils.ApplyFuncIfNoError(ctx, wrappedHookFn)
 	if err != nil {
-		ctx.Logger().Info("an epoch hook errored")
+		ctx.Logger().Error(fmt.Sprintf("error in epoch hook %v", err))
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

In #2515 @puneet2019 fixed that epochs isn't returning events, due to https://github.com/cosmos/cosmos-sdk/issues/12912 .

This also showed that were actually duplicating panic wrapping logic. This PR adds that fix to the general osmosis helper, and makes epochs use the general osmosis helper

## Brief Changelog

- Apply events bug fix from #2515 to the general panic wrapper
- Make epochs use the general panic wrapper

## Testing and Verifying

This change is already covered by existing tests, that @puneet2019 added in #2515

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? N/A