### PR TITLE
simulator: transition matrix fix

### DIFF
--- a/simulation/executor/params.go
+++ b/simulation/executor/params.go
@@ -38,8 +38,8 @@ var (
 	// rand in range [0, 2 * provided blocksize], 0
 	defaultBlockSizeTransitionMatrix, _ = markov.CreateTransitionMatrix([][]int{
 		{85, 5, 0},
-		{15, 92, 1},
-		{0, 3, 99},
+		{15, 92, 40},
+		{0, 3, 60},
 	})
 )
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

After incorporating the SQL database, I observed that there were large periods of time in which no txs were happening on large stretches of blocks. After a short discussion with @ValarDragon , he found that the transition matrix that decides block sizes was configured in such a way that keeps the blocksize in the "default" state (which is a blocksize of 0) for a longer than intended time period.


## Brief Changelog

- Small change to matrix values


## Testing and Verifying

As desired, we still have blocks with 0 txs, but they are few and far between. We may want to make the 0 txn blocks occur slightly more often, but that would just be a simple mod of this matrix, and now we know where the issue is coming from!

![Screen Shot 2022-08-26 at 4 44 39 PM](https://user-images.githubusercontent.com/40078083/186994916-795c1aea-5552-471c-83bd-f5661e6e6ccd.png)



## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable