### PR TITLE
error returning epoch hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improvements
 * [#2214](https://github.com/osmosis-labs/osmosis/pull/2214) Speedup epoch distribution, superfluid component
 * [#2515](https://github.com/osmosis-labs/osmosis/pull/2515) Emit events from functions implementing epoch hooks' `panicCatchingEpochHook` cacheCtx
+* [#2526](https://github.com/osmosis-labs/osmosis/pull/2526) EpochHooks interface methods (and hence modules implementing the hooks) return error instead of panic
 
 ### SDK Upgrades
 * [#2245](https://github.com/osmosis-labs/osmosis/pull/2244) Upgrade SDK with the following major changes:

--- a/x/epochs/keeper/abci.go
+++ b/x/epochs/keeper/abci.go
@@ -43,7 +43,8 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 					sdk.NewAttribute(types.AttributeEpochNumber, fmt.Sprintf("%d", epochInfo.CurrentEpoch)),
 				),
 			)
-			k.AfterEpochEnd(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
+			// Error is not handled as AfterEpochEnd Hooks use osmoutils.ApplyFuncIfNoError()
+			_ = k.AfterEpochEnd(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
 			epochInfo.CurrentEpoch += 1
 			epochInfo.CurrentEpochStartTime = epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration)
 			logger.Info(fmt.Sprintf("Starting epoch with identifier %s epoch number %d", epochInfo.Identifier, epochInfo.CurrentEpoch))
@@ -58,7 +59,8 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 			),
 		)
 		k.setEpochInfo(ctx, epochInfo)
-		k.BeforeEpochStart(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
+		// Error is not handled as BeforeEpochStart Hooks use osmoutils.ApplyFuncIfNoError()
+		_ = k.BeforeEpochStart(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
 
 		return false
 	})

--- a/x/epochs/keeper/abci.go
+++ b/x/epochs/keeper/abci.go
@@ -43,8 +43,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 					sdk.NewAttribute(types.AttributeEpochNumber, fmt.Sprintf("%d", epochInfo.CurrentEpoch)),
 				),
 			)
-			// Error is not handled as AfterEpochEnd Hooks use osmoutils.ApplyFuncIfNoError()
-			_ = k.AfterEpochEnd(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
+			k.AfterEpochEnd(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
 			epochInfo.CurrentEpoch += 1
 			epochInfo.CurrentEpochStartTime = epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration)
 			logger.Info(fmt.Sprintf("Starting epoch with identifier %s epoch number %d", epochInfo.Identifier, epochInfo.CurrentEpoch))
@@ -59,8 +58,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 			),
 		)
 		k.setEpochInfo(ctx, epochInfo)
-		// Error is not handled as BeforeEpochStart Hooks use osmoutils.ApplyFuncIfNoError()
-		_ = k.BeforeEpochStart(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
+		k.BeforeEpochStart(ctx, epochInfo.Identifier, epochInfo.CurrentEpoch)
 
 		return false
 	})

--- a/x/epochs/keeper/hooks.go
+++ b/x/epochs/keeper/hooks.go
@@ -5,11 +5,11 @@ import (
 )
 
 // AfterEpochEnd gets called at the end of the epoch, end of epoch is the timestamp of first block produced after epoch duration.
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, identifier string, epochNumber int64) {
-	k.hooks.AfterEpochEnd(ctx, identifier, epochNumber)
+func (k Keeper) AfterEpochEnd(ctx sdk.Context, identifier string, epochNumber int64) error {
+	return k.hooks.AfterEpochEnd(ctx, identifier, epochNumber)
 }
 
 // BeforeEpochStart new epoch is next block of epoch end block
-func (k Keeper) BeforeEpochStart(ctx sdk.Context, identifier string, epochNumber int64) {
-	k.hooks.BeforeEpochStart(ctx, identifier, epochNumber)
+func (k Keeper) BeforeEpochStart(ctx sdk.Context, identifier string, epochNumber int64) error {
+	return k.hooks.BeforeEpochStart(ctx, identifier, epochNumber)
 }

--- a/x/epochs/keeper/hooks.go
+++ b/x/epochs/keeper/hooks.go
@@ -5,11 +5,13 @@ import (
 )
 
 // AfterEpochEnd gets called at the end of the epoch, end of epoch is the timestamp of first block produced after epoch duration.
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, identifier string, epochNumber int64) error {
-	return k.hooks.AfterEpochEnd(ctx, identifier, epochNumber)
+func (k Keeper) AfterEpochEnd(ctx sdk.Context, identifier string, epochNumber int64) {
+	// Error is not handled as AfterEpochEnd Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.AfterEpochEnd(ctx, identifier, epochNumber)
 }
 
 // BeforeEpochStart new epoch is next block of epoch end block
-func (k Keeper) BeforeEpochStart(ctx sdk.Context, identifier string, epochNumber int64) error {
-	return k.hooks.BeforeEpochStart(ctx, identifier, epochNumber)
+func (k Keeper) BeforeEpochStart(ctx sdk.Context, identifier string, epochNumber int64) {
+	// Error is not handled as BeforeEpochStart Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.BeforeEpochStart(ctx, identifier, epochNumber)
 }

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"github.com/cosmos/cosmos-sdk/types/errors"
 	"strconv"
 	"testing"
 
@@ -43,49 +44,65 @@ func dummyBeforeEpochStartEvent(epochIdentifier string, epochNumber int64) sdk.E
 	)
 }
 
+var dummyErr = errors.New("9", 9, "dummyError")
+
 // dummyEpochHook is a struct satisfying the epoch hook interface,
 // that maintains a counter for how many times its been succesfully called,
 // and a boolean for whether it should panic during its execution.
 type dummyEpochHook struct {
 	successCounter int
 	shouldPanic    bool
+	shouldError    bool
 }
 
-func (hook *dummyEpochHook) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (hook *dummyEpochHook) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	if hook.shouldPanic {
 		panic("dummyEpochHook is panicking")
+	}
+	if hook.shouldError {
+		return dummyErr
 	}
 	hook.successCounter += 1
 	ctx.EventManager().EmitEvent(dummyAfterEpochEndEvent(epochIdentifier, epochNumber))
+	return nil
 }
 
-func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	if hook.shouldPanic {
 		panic("dummyEpochHook is panicking")
 	}
+	if hook.shouldError {
+		return dummyErr
+	}
 	hook.successCounter += 1
 	ctx.EventManager().EmitEvent(dummyBeforeEpochStartEvent(epochIdentifier, epochNumber))
+	return nil
 
 }
 
 func (hook *dummyEpochHook) Clone() *dummyEpochHook {
-	newHook := dummyEpochHook{shouldPanic: hook.shouldPanic, successCounter: hook.successCounter}
+	newHook := dummyEpochHook{shouldPanic: hook.shouldPanic, successCounter: hook.successCounter, shouldError: hook.shouldError}
 	return &newHook
 }
 
 var _ types.EpochHooks = &dummyEpochHook{}
 
-func (suite *KeeperTestSuite) TestHooksPanicRecoveryAndEvents() {
+func (suite *KeeperTestSuite) TestHooksPanicRecovery() {
 	panicHook := dummyEpochHook{shouldPanic: true}
 	noPanicHook := dummyEpochHook{shouldPanic: false}
-	simpleHooks := []dummyEpochHook{panicHook, noPanicHook}
+	errorHook := dummyEpochHook{shouldError: true}
+	noErrorHook := dummyEpochHook{shouldError: false} //same as nopanic
+	simpleHooks := []dummyEpochHook{panicHook, noPanicHook, errorHook, noErrorHook}
 
 	tests := []struct {
 		hooks                 []dummyEpochHook
 		expectedCounterValues []int
+		lenEvents             int
 	}{
-		{[]dummyEpochHook{noPanicHook}, []int{1}},
-		{simpleHooks, []int{0, 1}},
+		{[]dummyEpochHook{noPanicHook}, []int{1}, 1},
+		{[]dummyEpochHook{panicHook}, []int{0}, 0},
+		{[]dummyEpochHook{errorHook}, []int{0}, 0},
+		{simpleHooks, []int{0, 1, 0, 1}, 2},
 	}
 
 	for tcIndex, tc := range tests {
@@ -98,16 +115,24 @@ func (suite *KeeperTestSuite) TestHooksPanicRecoveryAndEvents() {
 			}
 
 			hooks := types.NewMultiEpochHooks(hookRefs...)
+
+			events := func(epochID string, epochNumber int64, dummyEvent func(id string, number int64) sdk.Event) sdk.Events {
+				evts := make(sdk.Events, tc.lenEvents)
+				for i := 0; i < tc.lenEvents; i++ {
+					evts[i] = dummyEvent(epochID, epochNumber)
+				}
+				return evts
+			}
+
 			suite.NotPanics(func() {
 				if epochActionSelector == 0 {
 					hooks.BeforeEpochStart(suite.Ctx, "id", 0)
-					suite.Require().Equal(suite.Ctx.EventManager().Events(), sdk.Events{dummyBeforeEpochStartEvent("id", 0)},
+					suite.Require().Equal(events("id", 0, dummyBeforeEpochStartEvent), suite.Ctx.EventManager().Events(),
 						"test case index %d, before epoch event check", tcIndex)
 				} else if epochActionSelector == 1 {
 					hooks.AfterEpochEnd(suite.Ctx, "id", 0)
-					suite.Require().Equal(suite.Ctx.EventManager().Events(), sdk.Events{dummyAfterEpochEndEvent("id", 0)},
+					suite.Require().Equal(events("id", 0, dummyAfterEpochEndEvent), suite.Ctx.EventManager().Events(),
 						"test case index %d, after epoch event check", tcIndex)
-
 				}
 			})
 

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -1,11 +1,11 @@
 package types_test
 
 import (
-	"github.com/cosmos/cosmos-sdk/types/errors"
 	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/osmosis-labs/osmosis/v11/app/apptesting"

--- a/x/incentives/keeper/hooks.go
+++ b/x/incentives/keeper/hooks.go
@@ -9,11 +9,12 @@ import (
 )
 
 // BeforeEpochStart is the epoch start hook.
-func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return nil
 }
 
 // AfterEpochEnd is the epoch end hook.
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	params := k.GetParams(ctx)
 	if epochIdentifier == params.DistrEpochIdentifier {
 		// begin distribution if it's start time
@@ -21,7 +22,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		for _, gauge := range gauges {
 			if !ctx.BlockTime().Before(gauge.StartTime) {
 				if err := k.moveUpcomingGaugeToActiveGauge(ctx, gauge); err != nil {
-					panic(err)
+					return err
 				}
 			}
 		}
@@ -41,9 +42,10 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		}
 		_, err := k.Distribute(ctx, distrGauges)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
+	return nil
 }
 
 // ___________________________________________________________________________________________________
@@ -61,11 +63,11 @@ func (k Keeper) Hooks() Hooks {
 }
 
 // BeforeEpochStart is the epoch start hook.
-func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
-	h.k.BeforeEpochStart(ctx, epochIdentifier, epochNumber)
+func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.BeforeEpochStart(ctx, epochIdentifier, epochNumber)
 }
 
 // AfterEpochEnd is the epoch end hook.
-func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
-	h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
+func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
 }

--- a/x/mint/keeper/hooks.go
+++ b/x/mint/keeper/hooks.go
@@ -11,8 +11,9 @@ import (
 )
 
 // BeforeEpochStart is a hook which is executed before the start of an epoch. It is a no-op for mint module.
-func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	// no-op
+	return nil
 }
 
 // AfterEpochEnd is a hook which is executed after the end of an epoch.
@@ -22,13 +23,13 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochN
 // For an attempt to mint to occur:
 // - given epochIdentifier must be equal to the mint epoch identifier set via parameters.
 // - given epochNumber must be greater than or equal to the mint start epoch set via parameters.
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	params := k.GetParams(ctx)
 
 	if epochIdentifier == params.EpochIdentifier {
 		// not distribute rewards if it's not time yet for rewards distribution
 		if epochNumber < params.MintingRewardsDistributionStartEpoch {
-			return
+			return nil
 		} else if epochNumber == params.MintingRewardsDistributionStartEpoch {
 			k.setLastReductionEpochNum(ctx, epochNumber)
 		}
@@ -54,13 +55,13 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		// We over-allocate by the developer vesting portion, and burn this later
 		err := k.mintCoins(ctx, mintedCoins)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		// send the minted coins to the fee collector account
 		err = k.DistributeMintedCoin(ctx, mintedCoin)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		if mintedCoin.Amount.IsInt64() {
@@ -76,6 +77,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			),
 		)
 	}
+	return nil
 }
 
 // ___________________________________________________________________________________________________
@@ -93,10 +95,10 @@ func (k Keeper) Hooks() Hooks {
 }
 
 // epochs hooks.
-func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
-	h.k.BeforeEpochStart(ctx, epochIdentifier, epochNumber)
+func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.BeforeEpochStart(ctx, epochIdentifier, epochNumber)
 }
 
-func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
-	h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
+func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
 }

--- a/x/mint/keeper/hooks_test.go
+++ b/x/mint/keeper/hooks_test.go
@@ -395,7 +395,10 @@ func (suite *KeeperTestSuite) TestAfterEpochEnd() {
 
 			osmoassert.ConditionalPanic(suite.T(), tc.expectedPanic, func() {
 				// System under test.
-				mintKeeper.AfterEpochEnd(ctx, defaultEpochIdentifier, tc.hookArgEpochNum)
+				err := mintKeeper.AfterEpochEnd(ctx, defaultEpochIdentifier, tc.hookArgEpochNum)
+				if err != nil {
+					panic(err)
+				}
 			})
 
 			// If panics, the behavior is undefined.

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -14,7 +14,8 @@ import (
 	"github.com/osmosis-labs/osmosis/v11/x/superfluid/types"
 )
 
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64) {
+func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64) error {
+	return nil
 }
 
 func (k Keeper) AfterEpochStartBeginBlock(ctx sdk.Context) {

--- a/x/superfluid/keeper/hooks.go
+++ b/x/superfluid/keeper/hooks.go
@@ -24,11 +24,12 @@ func (k Keeper) Hooks() Hooks {
 
 // epochs hooks
 // Don't do anything pre epoch start.
-func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return nil
 }
 
-func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
-	h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
+func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
 }
 
 // lockup hooks

--- a/x/twap/listeners.go
+++ b/x/twap/listeners.go
@@ -18,15 +18,18 @@ func (k Keeper) EpochHooks() epochtypes.EpochHooks {
 	return &epochhook{k}
 }
 
-func (hook *epochhook) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (hook *epochhook) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	if epochIdentifier == hook.k.PruneEpochIdentifier(ctx) {
 		if err := hook.k.pruneRecords(ctx); err != nil {
 			ctx.Logger().Error("Error pruning old twaps at the epoch end", err)
 		}
 	}
+	return nil
 }
 
-func (hook *epochhook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {}
+func (hook *epochhook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return nil
+}
 
 type gammhook struct {
 	k Keeper

--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -8,10 +8,12 @@ import (
 	txfeestypes "github.com/osmosis-labs/osmosis/v11/x/txfees/types"
 )
 
-func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {}
+func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return nil
+}
 
 // at the end of each epoch, swap all non-OSMO fees into OSMO and transfer to fee module account
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
+func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	nonNativeFeeAddr := k.accountKeeper.GetModuleAddress(txfeestypes.NonNativeFeeCollectorName)
 	baseDenom, _ := k.GetBaseDenom(ctx)
 	feeTokens := k.GetFeeTokens(ctx)
@@ -44,6 +46,8 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		err := k.bankKeeper.SendCoinsFromModuleToModule(ctx, txfeestypes.NonNativeFeeCollectorName, txfeestypes.FeeCollectorName, baseDenomCoins)
 		return err
 	})
+
+	return nil
 }
 
 // Hooks wrapper struct for incentives keeper
@@ -58,8 +62,10 @@ func (k Keeper) Hooks() Hooks {
 	return Hooks{k}
 }
 
-func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {}
+func (h Hooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.BeforeEpochStart(ctx, epochIdentifier, epochNumber)
+}
 
-func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
-	h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
+func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX
A part of #2520 only implemented for epochs module. 
If it looks good, can go ahead and implement for other modules as well. 
would wait for #2519 to be merged before. (rebase, etc. then open up)

## What is the purpose of the change

- Hooks errors can now be handled with [`ApplyFuncIfNoError`](https://github.com/osmosis-labs/osmosis/blob/main/osmoutils/cache_ctx.go#L16) 
- This implementation allows `hooks interface` functions to return an error.
- If functions return an error any state changes will not be written to the state.
- Currently it is only done for [`EpochHooks interface`](https://github.com/osmosis-labs/osmosis/blob/main/x/epochs/types/hooks.go#L9)


## Brief Changelog

- Epoch Hooks now allow returning of error.
- All modules implementing EpochHooks also return error in place of panic.


## Testing and Verifying
- Updated and fixed test cases :::NOTE: unable to verify errorMessage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? - no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) yes
  - How is the feature or change documented? - not applicable