### PR TITLE
Fix: epoch module imports mint rest

### DIFF
--- a/x/epochs/module.go
+++ b/x/epochs/module.go
@@ -31,7 +31,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v11/x/epochs/client/cli"
 	"github.com/osmosis-labs/osmosis/v11/x/epochs/keeper"
 	"github.com/osmosis-labs/osmosis/v11/x/epochs/types"
-	"github.com/osmosis-labs/osmosis/v11/x/mint/client/rest"
 )
 
 var (
@@ -77,9 +76,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 }
 
 // RegisterRESTRoutes registers the capability module's REST service handlers.
-func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Router) {
-	rest.RegisterRoutes(clientCtx, rtr)
-}
+func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Router) {}
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
- Epoch module imports mint/cli/rest and Registers it to it's routes.

## Brief Changelog
- fixes typo causing epoch module to register mint rest routes.
- `RegisterRESTRoutes` does nothing now as epochs doesn't have legacy rest implemented.

## Testing and Verifying
- cannot test as ["mint paraters - legacy querier not supported for the x/mint module "](https://lcd.osmosis.zone/minting/parameters)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no) no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) no 
  - How is the feature or change documented? not applicable 