### PR TITLE
Make tests for osmoutils/store_helper

### DIFF
--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -62,7 +62,7 @@ func GetIterValuesWithStop[T any](
 	return gatherValuesFromIteratorWithStop(iter, parseValue, stopFn)
 }
 
-// untested
+// TODO: fix GetFirstValueAfterPrefix to return error even if keyStart is lexicographically before existing keys
 func GetFirstValueAfterPrefix[T any](storeObj store.KVStore, keyStart []byte, parseValue func([]byte) (T, error)) (T, error) {
 	// SDK iterator is broken for nil end time, and non-nil start time
 	// https://github.com/cosmos/cosmos-sdk/issues/12661

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -34,7 +34,6 @@ func GatherValuesFromStorePrefix[T any](storeObj store.KVStore, prefix []byte, p
 	return gatherValuesFromIteratorWithStop(iterator, parseValue, noStopFn)
 }
 
-// untested
 func GetValuesUntilDerivedStop[T any](storeObj store.KVStore, keyStart []byte, stopFn func([]byte) bool, parseValue func([]byte) (T, error)) ([]T, error) {
 	// SDK iterator is broken for nil end time, and non-nil start time
 	// https://github.com/cosmos/cosmos-sdk/issues/12661
@@ -43,7 +42,6 @@ func GetValuesUntilDerivedStop[T any](storeObj store.KVStore, keyStart []byte, s
 	return GetIterValuesWithStop(storeObj, keyStart, keyEnd, false, stopFn, parseValue)
 }
 
-// untested
 func GetIterValuesWithStop[T any](
 	storeObj store.KVStore,
 	keyStart []byte,

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -60,7 +60,6 @@ func GetIterValuesWithStop[T any](
 	return gatherValuesFromIteratorWithStop(iter, parseValue, stopFn)
 }
 
-// TODO: fix GetFirstValueAfterPrefix to return error even if keyStart is lexicographically before existing keys
 func GetFirstValueAfterPrefix[T any](storeObj store.KVStore, keyStart []byte, parseValue func([]byte) (T, error)) (T, error) {
 	// SDK iterator is broken for nil end time, and non-nil start time
 	// https://github.com/cosmos/cosmos-sdk/issues/12661

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -22,14 +22,12 @@ func GatherAllKeysFromStore(storeObj store.KVStore) []string {
 	return keys
 }
 
-// untested
 func GatherValuesFromStore[T any](storeObj store.KVStore, keyStart []byte, keyEnd []byte, parseValue func([]byte) (T, error)) ([]T, error) {
 	iterator := storeObj.Iterator(keyStart, keyEnd)
 	defer iterator.Close()
 	return gatherValuesFromIteratorWithStop(iterator, parseValue, noStopFn)
 }
 
-// untested
 func GatherValuesFromStorePrefix[T any](storeObj store.KVStore, prefix []byte, parseValue func([]byte) (T, error)) ([]T, error) {
 	iterator := sdk.KVStorePrefixIterator(storeObj, prefix)
 	defer iterator.Close()

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -22,18 +22,21 @@ func GatherAllKeysFromStore(storeObj store.KVStore) []string {
 	return keys
 }
 
+// untested
 func GatherValuesFromStore[T any](storeObj store.KVStore, keyStart []byte, keyEnd []byte, parseValue func([]byte) (T, error)) ([]T, error) {
 	iterator := storeObj.Iterator(keyStart, keyEnd)
 	defer iterator.Close()
 	return gatherValuesFromIteratorWithStop(iterator, parseValue, noStopFn)
 }
 
+// untested
 func GatherValuesFromStorePrefix[T any](storeObj store.KVStore, prefix []byte, parseValue func([]byte) (T, error)) ([]T, error) {
 	iterator := sdk.KVStorePrefixIterator(storeObj, prefix)
 	defer iterator.Close()
 	return gatherValuesFromIteratorWithStop(iterator, parseValue, noStopFn)
 }
 
+// untested
 func GetValuesUntilDerivedStop[T any](storeObj store.KVStore, keyStart []byte, stopFn func([]byte) bool, parseValue func([]byte) (T, error)) ([]T, error) {
 	// SDK iterator is broken for nil end time, and non-nil start time
 	// https://github.com/cosmos/cosmos-sdk/issues/12661
@@ -42,6 +45,7 @@ func GetValuesUntilDerivedStop[T any](storeObj store.KVStore, keyStart []byte, s
 	return GetIterValuesWithStop(storeObj, keyStart, keyEnd, false, stopFn, parseValue)
 }
 
+// untested
 func GetIterValuesWithStop[T any](
 	storeObj store.KVStore,
 	keyStart []byte,
@@ -60,6 +64,7 @@ func GetIterValuesWithStop[T any](
 	return gatherValuesFromIteratorWithStop(iter, parseValue, stopFn)
 }
 
+// untested
 func GetFirstValueAfterPrefix[T any](storeObj store.KVStore, keyStart []byte, parseValue func([]byte) (T, error)) (T, error) {
 	// SDK iterator is broken for nil end time, and non-nil start time
 	// https://github.com/cosmos/cosmos-sdk/issues/12661
@@ -73,17 +78,6 @@ func GetFirstValueAfterPrefix[T any](storeObj store.KVStore, keyStart []byte, pa
 	}
 
 	return parseValue(iterator.Value())
-}
-
-// MustSet runs store.Set(key, proto.Marshal(value))
-// but panics on any error.
-func MustSet(storeObj store.KVStore, key []byte, value proto.Message) {
-	bz, err := proto.Marshal(value)
-	if err != nil {
-		panic(err)
-	}
-
-	storeObj.Set(key, bz)
 }
 
 func gatherValuesFromIteratorWithStop[T any](iterator db.Iterator, parseValue func([]byte) (T, error), stopFn func([]byte) bool) ([]T, error) {
@@ -103,6 +97,17 @@ func gatherValuesFromIteratorWithStop[T any](iterator db.Iterator, parseValue fu
 
 func noStopFn([]byte) bool {
 	return false
+}
+
+// MustSet runs store.Set(key, proto.Marshal(value))
+// but panics on any error.
+func MustSet(storeObj store.KVStore, key []byte, value proto.Message) {
+	bz, err := proto.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+
+	storeObj.Set(key, bz)
 }
 
 // MustGet gets key from store by mutating result

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -60,7 +60,7 @@ func GetIterValuesWithStop[T any](
 	return gatherValuesFromIteratorWithStop(iter, parseValue, stopFn)
 }
 
-func GetFirstValueAfterPrefix[T any](storeObj store.KVStore, keyStart []byte, parseValue func([]byte) (T, error)) (T, error) {
+func GetFirstValueAfterPrefixInclusive[T any](storeObj store.KVStore, keyStart []byte, parseValue func([]byte) (T, error)) (T, error) {
 	// SDK iterator is broken for nil end time, and non-nil start time
 	// https://github.com/cosmos/cosmos-sdk/issues/12661
 	// hence we use []byte{0xff}

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -917,7 +917,7 @@ func (s *TestSuite) TestMustGetDec() {
 
 			expectedGetKeyValues: map[string]sdk.Dec{
 				keyA: sdk.OneDec(),
-				keyB: {}, // this one panics
+				keyB: sdk.Dec{}, // this one panics
 			},
 
 			expectPanic: true,

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -31,6 +31,18 @@ const (
 	prefixTwo          = "two"
 )
 
+var (
+	oneA = []string{prefixOne + keyA}
+	oneAB = []string{prefixOne + keyA, prefixOne + keyB}
+	twoAB = []string{prefixTwo + keyA, prefixTwo + keyB}
+	oneABC = []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC}
+	oneBCA = []string{prefixOne + keyB, prefixOne + keyC, prefixOne + keyA}
+	oneABtwoAB = []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB}
+	oneBtwoAoneAtwoB = []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB}
+	oneAtwoAoneBtwoB = []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB}
+	onetwoABCalternating = []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB, prefixOne + keyC, prefixTwo + keyC}
+)
+
 func TestOsmoUtilsTestSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }
@@ -63,13 +75,13 @@ func (s *TestSuite) TestGatherAllKeysFromStore() {
 		expectedValues []string
 	}{
 		"multiple keys in lexicographic order": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
-			expectedValues: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
+			expectedValues: oneABC,
 		},
 		"multiple keys out of lexicographic order": {
-			preSetKeys: []string{prefixOne + keyB, prefixOne + keyC, prefixOne + keyA},
+			preSetKeys: oneBCA,
 			// we expect output to be in ascending lexicographic order
-			expectedValues: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			expectedValues: oneABC,
 		},
 		"no keys": {
 			preSetKeys: []string{},
@@ -104,17 +116,17 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 		expectedValues []string
 	}{
 		"common prefix, exlude end": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneAB,
 
 			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte(prefixOne + keyC),
+			keyEnd:   []byte(prefixOne + keyB),
 			parseFn: mockParseValue,
 
 			expectedErr: false,
-			expectedValues: []string{"0", "1"},
+			expectedValues: []string{"0"},
 		},
 		"common prefix, include end": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB},
+			preSetKeys: oneAB,
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyC),
@@ -124,7 +136,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefix, inserted in lexicographic order": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: oneABtwoAB,
 			
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixTwo + keyA),
@@ -134,18 +146,18 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefix, inserted out of lexicographic order": {
-			preSetKeys: []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB},
+			preSetKeys: oneAtwoAoneBtwoB,
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixTwo + keyA),
 			parseFn: mockParseValue,
 
 			expectedErr: false,
-			// should get all prefixOne keys as keys are stored in ascending lexicographic order
+			// should get all prefixOne values as keys are stored in ascending lexicographic order
 			expectedValues: []string{"0", "2"},
 		},
 		"start key and end key same": {
-			preSetKeys: []string{prefixOne + keyA},
+			preSetKeys: oneA,
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyA),
@@ -155,7 +167,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			expectedValues: []string{},
 		},
 		"start key after end key": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			keyStart: []byte(prefixOne + keyB),
 			keyEnd:   []byte(prefixOne + keyA),
@@ -165,7 +177,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			expectedValues: []string{},
 		},
 		"get all values": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			keyStart: nil,
 			keyEnd:   nil,
@@ -178,7 +190,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			// SDK iterator is broken for nil end time, and non-nil start time
 			// https://github.com/cosmos/cosmos-sdk/issues/12661
 			// so we use []byte{0xff}
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			keyStart: []byte(prefixOne + keyB),
 			keyEnd:   []byte{0xff},
@@ -188,7 +200,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			expectedValues: []string{"1", "2"},
 		},
 		"parse with error": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyC),
@@ -231,7 +243,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 		expectedValues []string
 	}{
 		"common prefix": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			prefix: []byte(prefixOne),
 
 			parseFn: mockParseValue,
@@ -240,7 +252,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			expectedValues: []string{"0", "1", "2"},
 		},
 		"different prefixes in order, prefix one requested": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: oneABtwoAB,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
@@ -248,7 +260,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefixes in order, prefix two requested": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: oneABtwoAB,
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
@@ -256,7 +268,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			expectedValues: []string{"2", "3"},
 		},
 		"different prefixes out of order, prefix one requested": {
-			preSetKeys: []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB},
+			preSetKeys: oneBtwoAoneAtwoB,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
@@ -265,7 +277,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			expectedValues: []string{"2", "0"},
 		},
 		"different prefixes out of order, prefix two requested": {
-			preSetKeys: []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB},
+			preSetKeys: oneBtwoAoneAtwoB,
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
@@ -281,7 +293,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			expectedValues: []string{},
 		},
 		"prefix doesn't exist, only keys with another prefix": {
-			preSetKeys: []string{prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: twoAB,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
@@ -289,7 +301,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			expectedValues: []string{},
 		},
 		"parse with error": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValueWithError,
 
@@ -330,7 +342,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 		expectedValues string
 	}{
 		"common prefix": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			prefix: []byte(prefixOne),
 
 			parseFn: mockParseValue,
@@ -339,7 +351,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "0",
 		},
 		"different prefixes in order, prefix one requested": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: oneABtwoAB,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
@@ -347,7 +359,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "0",
 		},
 		"different prefixes in order, prefix two requested": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: oneABtwoAB,
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
@@ -355,7 +367,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "2",
 		},
 		"different prefixes out of order, prefix one requested": {
-			preSetKeys: []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB},
+			preSetKeys: oneBtwoAoneAtwoB,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
@@ -364,7 +376,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "2",
 		},
 		"different prefixes out of order, prefix two requested": {
-			preSetKeys: []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB},
+			preSetKeys: oneBtwoAoneAtwoB,
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
@@ -372,7 +384,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "1",
 		},
 		"prefix doesn't exist, start key lexicographically before existing keys": {
-			preSetKeys: []string{prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: twoAB,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
@@ -391,7 +403,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "",
 		},
 		"prefix doesn't exist, start key lexicographically after existing keys": {
-			preSetKeys: []string{prefixTwo + keyA, prefixTwo + keyB},
+			preSetKeys: twoAB,
 			prefix: []byte{0xff},
 			parseFn: mockParseValue,
 
@@ -399,7 +411,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedValues: "",
 		},
 		"parse with error": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValueWithError,
 
@@ -445,7 +457,7 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 		expectedErr    bool
 	}{
 		"prefix iterator, no stop": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			prefix: prefixOne,
 
@@ -465,21 +477,21 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 			expectedValues: []string{"0", "2"},
 		},
 		"range iterator, no end, no stop": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			startValue: prefixOne + keyB,
 
 			expectedValues: []string{"1", "2"},
 		},
 		"range iterator, no start, no stop": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			endValue: prefixOne + keyB,
 
 			expectedValues: []string{"0"},
 		},
 		"range iterator, no start no end, no stop": {
-			preSetKeys:     []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys:     oneABC,
 			expectedValues: []string{"0", "1", "2"},
 		},
 		"range iterator, with stop": {
@@ -488,13 +500,13 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 			expectedValues: []string{"0"},
 		},
 		"range iterator, reverse": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			isReverse:  true,
 
 			expectedValues: []string{"2", "1", "0"},
 		},
 		"range iterator, other prefix is excluded with end value": {
-			preSetKeys: []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB, prefixOne + keyC, prefixTwo + keyC},
+			preSetKeys: onetwoABCalternating,
 			startValue: prefixOne + keyB,
 			endValue:   prefixOne + "d",
 			isReverse:  true,
@@ -502,7 +514,7 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 			expectedValues: []string{"4", "2"},
 		},
 		"parse with error": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 
 			prefix: prefixOne,
 
@@ -573,7 +585,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 		expectedErr    bool
 	}{
 		"prefix iterator, no stop but exclusive key end": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyC),
 			parseFn: mockParseValue,
@@ -583,7 +595,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 			expectedValues: []string{"0", "1"},
 		},
 		"prefix iterator, no stop and inclusive key end": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB},
+			preSetKeys: oneAB,
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyC),
 			parseFn: mockParseValue,
@@ -635,7 +647,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 			expectedValues: []string{"3"},
 		},
 		"parse with error": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte{0xff},
 			parseFn: mockParseValueWithError,
@@ -681,7 +693,7 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 		expectedErr    bool
 	}{
 		"prefix iterator, no stop": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			keyStart: []byte(prefixOne + keyA),
 			parseFn: mockParseValue,
 			stopFn: mockStop,
@@ -706,7 +718,7 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 			expectedValues: []string{"0", "2"},
 		},
 		"parse with error": {
-			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC},
+			preSetKeys: oneABC,
 			keyStart: []byte(prefixOne + keyA),
 			parseFn: mockParseValueWithError,
 			stopFn:  mockStop,
@@ -917,7 +929,7 @@ func (s *TestSuite) TestMustGetDec() {
 
 			expectedGetKeyValues: map[string]sdk.Dec{
 				keyA: sdk.OneDec(),
-				keyB: sdk.Dec{}, // this one panics
+				keyB: {}, // this one panics
 			},
 
 			expectPanic: true,

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -371,16 +371,15 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			expectedErr: false,
 			expectedValues: "1",
 		},
-		/* TODO: fix GetFirstValueAfterPrefix to return error even if keyStart is lexicographically before existing keys
 		"prefix doesn't exist, start key lexicographically before existing keys": {
 			preSetKeys: []string{prefixTwo + keyA, prefixTwo + keyB},
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
 			expectedErr: false,
-			expectedValues: "",
+			// we expect the first value after the prefix, which is the value associated with the first valid key
+			expectedValues: "0",
 		},
-		*/
 
 		// error catching
 		"prefix doesn't exist, no keys": {

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -212,8 +212,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			actualValues, err := osmoutils.GatherValuesFromStore(s.store, tc.keyStart, tc.keyEnd, tc.parseFn)
 
 			if tc.expectedErr != nil {
-				s.Require().Error(err)
-				s.Require().Equal(tc.expectedErr, err)
+				s.Require().ErrorContains(err, tc.expectedErr.Error())
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -304,8 +303,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			actualValues, err := osmoutils.GatherValuesFromStorePrefix(s.store, tc.prefix, tc.parseFn)
 
 			if tc.expectedErr != nil {
-				s.Require().Error(err)
-				s.Require().Equal(tc.expectedErr, err)
+				s.Require().ErrorContains(err, tc.expectedErr.Error())
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -410,7 +408,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefixInclusive() {
 			actualValues, err := osmoutils.GetFirstValueAfterPrefixInclusive(s.store, tc.prefix, tc.parseFn)
 
 			if tc.expectedErr != nil {
-				s.Require().Error(err)
+				s.Require().ErrorContains(err, tc.expectedErr.Error())
 				s.Require().Equal(tc.expectedValues, actualValues)
 				return
 			}
@@ -538,8 +536,7 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 			actualValues, err := osmoutils.GatherValuesFromIteratorWithStop(iterator, mockParseValueFn, mockStop)
 
 			if tc.expectedErr != nil {
-				s.Require().Error(err)
-				s.Require().Equal(tc.expectedErr, err)
+				s.Require().ErrorContains(err, tc.expectedErr.Error())
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -649,8 +646,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 			actualValues, err := osmoutils.GetIterValuesWithStop(s.store, tc.keyStart, tc.keyEnd, tc.isReverse, tc.stopFn, tc.parseFn)
 
 			if tc.expectedErr != nil {
-				s.Require().Error(err)
-				s.Require().Equal(tc.expectedErr, err)
+				s.Require().ErrorContains(err, tc.expectedErr.Error())
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -719,8 +715,7 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 			actualValues, err := osmoutils.GetValuesUntilDerivedStop(s.store, tc.keyStart, tc.stopFn, tc.parseFn)
 
 			if tc.expectedErr != nil {
-				s.Require().Error(err)
-				s.Require().Equal(tc.expectedErr, err)
+				s.Require().ErrorContains(err, tc.expectedErr.Error())
 				s.Require().Nil(actualValues)
 				return
 			}

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -112,7 +112,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 		keyEnd     []byte
 		parseFn    func(b []byte) (string, error)
 
-		expectedErr 	   bool
+		expectedErr 	   error
 		expectedValues []string
 	}{
 		"common prefix, exlude end": {
@@ -122,7 +122,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixOne + keyB),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"0"},
 		},
 		"common prefix, include end": {
@@ -132,7 +131,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixOne + keyC),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefix, inserted in lexicographic order": {
@@ -142,7 +140,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixTwo + keyA),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefix, inserted out of lexicographic order": {
@@ -152,7 +149,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixTwo + keyA),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			// should get all prefixOne values as keys are stored in ascending lexicographic order
 			expectedValues: []string{"0", "2"},
 		},
@@ -163,7 +159,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixOne + keyA),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{},
 		},
 		"start key after end key": {
@@ -173,7 +168,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixOne + keyA),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{},
 		},
 		"get all values": {
@@ -183,7 +177,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   nil,
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"0", "1", "2"},
 		},
 		"get all values after start key": {
@@ -196,7 +189,6 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte{0xff},
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"1", "2"},
 		},
 		"parse with error": {
@@ -206,7 +198,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 			keyEnd:   []byte(prefixOne + keyC),
 			parseFn: mockParseValueWithError,
 
-			expectedErr: true,
+			expectedErr: errors.New("mock error"),
 		},
 	}
 
@@ -220,8 +212,9 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			actualValues, err := osmoutils.GatherValuesFromStore(s.store, tc.keyStart, tc.keyEnd, tc.parseFn)
 
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				s.Require().Error(err)
+				s.Require().Equal(tc.expectedErr, err)
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -239,7 +232,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 		preSetKeys []string
 		parseFn    func(b []byte) (string, error)
 
-		expectedErr 	   bool
+		expectedErr 	   error
 		expectedValues []string
 	}{
 		"common prefix": {
@@ -248,7 +241,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"0", "1", "2"},
 		},
 		"different prefixes in order, prefix one requested": {
@@ -256,7 +248,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefixes in order, prefix two requested": {
@@ -264,7 +255,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"2", "3"},
 		},
 		"different prefixes out of order, prefix one requested": {
@@ -272,7 +262,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			// we expect the prefixOne values in ascending lexicographic order
 			expectedValues: []string{"2", "0"},
 		},
@@ -281,7 +270,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{"1", "3"},
 		},
 		"prefix doesn't exist, no keys": {
@@ -289,7 +277,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{},
 		},
 		"prefix doesn't exist, only keys with another prefix": {
@@ -297,7 +284,6 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: []string{},
 		},
 		"parse with error": {
@@ -305,7 +291,7 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValueWithError,
 
-			expectedErr: true,
+			expectedErr: errors.New("mock error"),
 		},
 	}
 
@@ -319,8 +305,9 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 
 			actualValues, err := osmoutils.GatherValuesFromStorePrefix(s.store, tc.prefix, tc.parseFn)
 
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				s.Require().Error(err)
+				s.Require().Equal(tc.expectedErr, err)
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -331,14 +318,14 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 	}
 }
 
-func (s *TestSuite) TestGetFirstValueAfterPrefix() {
+func (s *TestSuite) TestGetFirstValueAfterPrefixInclusive() {
 
 	testcases := map[string]struct {
 		prefix     []byte
 		preSetKeys []string
 		parseFn    func(b []byte) (string, error)
 
-		expectedErr 	   bool
+		expectedErr 	   error
 		expectedValues string
 	}{
 		"common prefix": {
@@ -347,7 +334,6 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: "0",
 		},
 		"different prefixes in order, prefix one requested": {
@@ -355,7 +341,6 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: "0",
 		},
 		"different prefixes in order, prefix two requested": {
@@ -363,7 +348,6 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: "2",
 		},
 		"different prefixes out of order, prefix one requested": {
@@ -371,7 +355,6 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			// we expect the prefixOne values in ascending lexicographic order
 			expectedValues: "2",
 		},
@@ -380,7 +363,6 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixTwo),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			expectedValues: "1",
 		},
 		"prefix doesn't exist, start key lexicographically before existing keys": {
@@ -388,7 +370,6 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: false,
 			// we expect the first value after the prefix, which is the value associated with the first valid key
 			expectedValues: "0",
 		},
@@ -399,7 +380,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValue,
 
-			expectedErr: true,
+			expectedErr: errors.New("No values in iterator"),
 			expectedValues: "",
 		},
 		"prefix doesn't exist, start key lexicographically after existing keys": {
@@ -407,7 +388,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte{0xff},
 			parseFn: mockParseValue,
 
-			expectedErr: true,
+			expectedErr: errors.New("No values in iterator"),
 			expectedValues: "",
 		},
 		"parse with error": {
@@ -415,7 +396,7 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 			prefix: []byte(prefixOne),
 			parseFn: mockParseValueWithError,
 
-			expectedErr: true,
+			expectedErr: errors.New("mock error"),
 			expectedValues: "",
 		},
 	}
@@ -428,9 +409,9 @@ func (s *TestSuite) TestGetFirstValueAfterPrefix() {
 				s.store.Set([]byte(key), []byte(fmt.Sprintf("%v", i)))
 			}
 
-			actualValues, err := osmoutils.GetFirstValueAfterPrefix(s.store, tc.prefix, tc.parseFn)
+			actualValues, err := osmoutils.GetFirstValueAfterPrefixInclusive(s.store, tc.prefix, tc.parseFn)
 
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				s.Require().Error(err)
 				s.Require().Equal(tc.expectedValues, actualValues)
 				return
@@ -454,7 +435,7 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 		isReverse  bool
 
 		expectedValues []string
-		expectedErr    bool
+		expectedErr    error
 	}{
 		"prefix iterator, no stop": {
 			preSetKeys: oneABC,
@@ -518,7 +499,7 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 
 			prefix: prefixOne,
 
-			expectedErr: true,
+			expectedErr: errors.New("mock error"),
 		},
 	}
 
@@ -552,14 +533,15 @@ func (s *TestSuite) TestGatherValuesFromIteratorWithStop() {
 			}
 
 			mockParseValueFn := mockParseValue
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				mockParseValueFn = mockParseValueWithError
 			}
 
 			actualValues, err := osmoutils.GatherValuesFromIteratorWithStop(iterator, mockParseValueFn, mockStop)
 
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				s.Require().Error(err)
+				s.Require().Equal(tc.expectedErr, err)
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -582,7 +564,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 		isReverse  bool
 
 		expectedValues []string
-		expectedErr    bool
+		expectedErr    error
 	}{
 		"prefix iterator, no stop but exclusive key end": {
 			preSetKeys: oneABC,
@@ -654,7 +636,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 			stopFn:  mockStop,
 			isReverse: false,
 
-			expectedErr: true,
+			expectedErr: errors.New("mock error"),
 		},
 	}
 
@@ -668,8 +650,9 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 
 			actualValues, err := osmoutils.GetIterValuesWithStop(s.store, tc.keyStart, tc.keyEnd, tc.isReverse, tc.stopFn, tc.parseFn)
 
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				s.Require().Error(err)
+				s.Require().Equal(tc.expectedErr, err)
 				s.Require().Nil(actualValues)
 				return
 			}
@@ -690,7 +673,7 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 		stopFn     func(b []byte) bool
 
 		expectedValues []string
-		expectedErr    bool
+		expectedErr    error
 	}{
 		"prefix iterator, no stop": {
 			preSetKeys: oneABC,
@@ -723,7 +706,7 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 			parseFn: mockParseValueWithError,
 			stopFn:  mockStop,
 
-			expectedErr: true,
+			expectedErr: errors.New("mock error"),
 		},
 	}
 
@@ -737,8 +720,9 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 
 			actualValues, err := osmoutils.GetValuesUntilDerivedStop(s.store, tc.keyStart, tc.stopFn, tc.parseFn)
 
-			if tc.expectedErr {
+			if tc.expectedErr != nil {
 				s.Require().Error(err)
+				s.Require().Equal(tc.expectedErr, err)
 				s.Require().Nil(actualValues)
 				return
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2179 

## What is the purpose of the change

This PR adds tests for all the untested functions in `osmoutils/store_helper.go`.

## Brief Changelog

- Add tests for the following functions:
`GatherAllKeysFromStore`
`GatherValuesFromStore`
`GatherValuesFromStorePrefix`
`GetFirstValueAfterPrefix`
`GetIterValuesWithStop`
`GetValuesUntilDerivedStop`

## Testing and Verifying

This change added tests (see functions listed above)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? ( no)
  - How is the feature or change documented? (not applicable)