### PR TITLE
Multi-hop swaps emit events for every intermediate swap amount

### DIFF
--- a/x/gamm/keeper/internal/events/emit.go
+++ b/x/gamm/keeper/internal/events/emit.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v11/x/gamm/utils"
 )
 
 func EmitSwapEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, input sdk.Coins, output sdk.Coins) {
@@ -66,5 +67,41 @@ func newRemoveLiquidityEvent(sender sdk.AccAddress, poolId uint64, liquidity sdk
 		sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
 		sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
 		sdk.NewAttribute(types.AttributeKeyTokensOut, liquidity.String()),
+	)
+}
+
+func EmitMultiHopAmountInEvent(ctx sdk.Context, poolId uint64, tokenOutAmount sdk.Int) {
+	if ctx.EventManager() == nil {
+		return
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		newMultiHopAmountInEvent(poolId, tokenOutAmount),
+	})
+}
+
+func newMultiHopAmountInEvent(poolId uint64, tokenOutAmount sdk.Int) sdk.Event {
+	return sdk.NewEvent(
+		types.TypeEvtMultiHopAmtIn,
+		sdk.NewAttribute(types.AttributeKeyPoolId, utils.Uint64ToString(poolId)),
+		sdk.NewAttribute(types.AttributeKeyTokensIn, tokenOutAmount.String()),
+	)
+}
+
+func EmitMultiHopAmountOutEvent(ctx sdk.Context, poolId uint64, tokenInAmount sdk.Int) {
+	if ctx.EventManager() == nil {
+		return
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		newMultiHopAmountOutEvent(poolId, tokenInAmount),
+	})
+}
+
+func newMultiHopAmountOutEvent(poolId uint64, tokenInAmount sdk.Int) sdk.Event {
+	return sdk.NewEvent(
+		types.TypeEvtMultiHopAmtOut,
+		sdk.NewAttribute(types.AttributeKeyPoolId, utils.Uint64ToString(poolId)),
+		sdk.NewAttribute(types.AttributeKeyTokensOut, tokenInAmount.String()),
 	)
 }

--- a/x/gamm/keeper/multihop.go
+++ b/x/gamm/keeper/multihop.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
+	"github.com/osmosis-labs/osmosis/v11/x/gamm/keeper/internal/events"
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 )
 
@@ -32,6 +32,8 @@ func (k Keeper) MultihopSwapExactAmountIn(
 
 		// Chain output of current pool as the input for the next routed pool
 		tokenIn = sdk.NewCoin(route.TokenOutDenom, tokenOutAmount)
+
+		events.EmitMultiHopAmountInEvent(ctx, route.PoolId, tokenOutAmount)
 	}
 	return
 }
@@ -82,6 +84,8 @@ func (k Keeper) MultihopSwapExactAmountOut(
 		if i == 0 {
 			tokenInAmount = _tokenInAmount
 		}
+
+		events.EmitMultiHopAmountOutEvent(ctx, route.PoolId, tokenInAmount)
 	}
 
 	return tokenInAmount, nil

--- a/x/gamm/keeper/multihop_test.go
+++ b/x/gamm/keeper/multihop_test.go
@@ -1,8 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v11/x/gamm/types"
@@ -191,7 +189,7 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleMultihopSwapExactAmountOut()
 				// Ratio of the token out should be between the before spot price and after spot price.
 				// This is because the swap increases the spot price
 				sp := tokenInAmount.ToDec().Quo(test.param.tokenOut.Amount.ToDec())
-				fmt.Printf("spBefore %s, spAfter %s, sp actual %s\n", spotPriceBefore, spotPriceAfter, sp)
+
 				suite.True(sp.GT(spotPriceBefore) && sp.LT(spotPriceAfter), "multi-hop spot price wrong, test: %v", test.name)
 			} else {
 				_, err := keeper.MultihopSwapExactAmountOut(suite.Ctx, suite.TestAccs[0], test.param.routes, test.param.tokenInMaxAmount, test.param.tokenOut)

--- a/x/gamm/types/events.go
+++ b/x/gamm/types/events.go
@@ -1,10 +1,12 @@
 package types
 
 const (
-	TypeEvtPoolJoined   = "pool_joined"
-	TypeEvtPoolExited   = "pool_exited"
-	TypeEvtPoolCreated  = "pool_created"
-	TypeEvtTokenSwapped = "token_swapped"
+	TypeEvtPoolJoined     = "pool_joined"
+	TypeEvtPoolExited     = "pool_exited"
+	TypeEvtPoolCreated    = "pool_created"
+	TypeEvtTokenSwapped   = "token_swapped"
+	TypeEvtMultiHopAmtIn  = "multihop_tokenin"
+	TypeEvtMultiHopAmtOut = "multihop_tokenout"
 
 	AttributeValueCategory = ModuleName
 	AttributeKeyPoolId     = "pool_id"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2524

## What is the purpose of the change
Make multi-hop swaps emit events for the amount out for every constituent trade within a successful multi-hop.


## Brief Changelog
n/a

## Testing and Verifying
Tested events emit functions  

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)