### PR TITLE
Add IBC MsgTransfer for ICA Module

### DIFF
--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -8,9 +8,8 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
-
 	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 
 	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	superfluidtypes "github.com/osmosis-labs/osmosis/v11/x/superfluid/types"

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -8,7 +8,10 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+
 	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
+
 	gammtypes "github.com/osmosis-labs/osmosis/v11/x/gamm/types"
 	superfluidtypes "github.com/osmosis-labs/osmosis/v11/x/superfluid/types"
 
@@ -54,6 +57,9 @@ func CreateUpgradeHandler(
 		hostParams := icahosttypes.Params{
 			HostEnabled: true,
 			AllowMessages: []string{
+				// Change: Added MsgTrasnsfer
+				sdk.MsgTypeURL(&ibctransfertypes.MsgTransfer{}),
+
 				sdk.MsgTypeURL(&banktypes.MsgSend{}),
 				sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
 				sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Adds MsgTransfer from `ibctransfertypes` in the ICA Initialization progress for V12 upgrade handler.

## Brief Changelog
- Add `MsgTransfer` from ibc transfer types to ICA Module allowed message

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes?  
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? already documented