### PR TITLE
feat(twap): pruning keep the newest record under keep threshold

### DIFF
--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -9,22 +9,22 @@ import (
 	"github.com/osmosis-labs/osmosis/v11/x/twap/types"
 )
 
-type endTimeInFutureErr struct {
+type endTimeInFutureError struct {
 	EndTime   time.Time
 	BlockTime time.Time
 }
 
-func (e endTimeInFutureErr) Error() string {
+func (e endTimeInFutureError) Error() string {
 	return fmt.Sprintf("called GetArithmeticTwap with an end time in the future."+
 		" (end time %s, current time %s)", e.EndTime, e.BlockTime)
 }
 
-type startTimeAfterEndTimeErr struct {
+type startTimeAfterEndTimeError struct {
 	StartTime time.Time
 	EndTime   time.Time
 }
 
-func (e startTimeAfterEndTimeErr) Error() string {
+func (e startTimeAfterEndTimeError) Error() string {
 	return fmt.Sprintf("called GetArithmeticTwap with a start time that is after the end time."+
 		" (start time %s, end time %s)", e.StartTime, e.EndTime)
 }
@@ -57,12 +57,12 @@ func (k Keeper) GetArithmeticTwap(
 	startTime time.Time,
 	endTime time.Time) (sdk.Dec, error) {
 	if startTime.After(endTime) {
-		return sdk.Dec{}, startTimeAfterEndTimeErr{startTime, endTime}
+		return sdk.Dec{}, startTimeAfterEndTimeError{startTime, endTime}
 	}
 	if endTime.Equal(ctx.BlockTime()) {
 		return k.GetArithmeticTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime)
 	} else if endTime.After(ctx.BlockTime()) {
-		return sdk.Dec{}, endTimeInFutureErr{endTime, ctx.BlockTime()}
+		return sdk.Dec{}, endTimeInFutureError{endTime, ctx.BlockTime()}
 	}
 	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom)
 	if err != nil {

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -1,33 +1,12 @@
 package twap
 
 import (
-	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v11/x/twap/types"
 )
-
-type endTimeInFutureError struct {
-	EndTime   time.Time
-	BlockTime time.Time
-}
-
-func (e endTimeInFutureError) Error() string {
-	return fmt.Sprintf("called GetArithmeticTwap with an end time in the future."+
-		" (end time %s, current time %s)", e.EndTime, e.BlockTime)
-}
-
-type startTimeAfterEndTimeError struct {
-	StartTime time.Time
-	EndTime   time.Time
-}
-
-func (e startTimeAfterEndTimeError) Error() string {
-	return fmt.Sprintf("called GetArithmeticTwap with a start time that is after the end time."+
-		" (start time %s, end time %s)", e.StartTime, e.EndTime)
-}
 
 // GetArithmeticTwap returns an arithmetic time weighted average price.
 // The returned twap is the time weighted average price (TWAP) of:
@@ -57,12 +36,12 @@ func (k Keeper) GetArithmeticTwap(
 	startTime time.Time,
 	endTime time.Time) (sdk.Dec, error) {
 	if startTime.After(endTime) {
-		return sdk.Dec{}, startTimeAfterEndTimeError{startTime, endTime}
+		return sdk.Dec{}, types.StartTimeAfterEndTimeError{StartTime: startTime, EndTime: endTime}
 	}
 	if endTime.Equal(ctx.BlockTime()) {
 		return k.GetArithmeticTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime)
 	} else if endTime.After(ctx.BlockTime()) {
-		return sdk.Dec{}, endTimeInFutureError{endTime, ctx.BlockTime()}
+		return sdk.Dec{}, types.EndTimeInFutureError{EndTime: endTime, BlockTime: ctx.BlockTime()}
 	}
 	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom)
 	if err != nil {

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -9,6 +9,26 @@ import (
 	"github.com/osmosis-labs/osmosis/v11/x/twap/types"
 )
 
+type endTimeInFutureErr struct {
+	EndTime   time.Time
+	BlockTime time.Time
+}
+
+func (e endTimeInFutureErr) Error() string {
+	return fmt.Sprintf("called GetArithmeticTwap with an end time in the future."+
+		" (end time %s, current time %s)", e.EndTime, e.BlockTime)
+}
+
+type startTimeAfterEndTimeErr struct {
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+func (e startTimeAfterEndTimeErr) Error() string {
+	return fmt.Sprintf("called GetArithmeticTwap with a start time that is after the end time."+
+		" (start time %s, end time %s)", e.StartTime, e.EndTime)
+}
+
 // GetArithmeticTwap returns an arithmetic time weighted average price.
 // The returned twap is the time weighted average price (TWAP) of:
 // * the base asset, in units of the quote asset (1 unit of base = x units of quote)
@@ -37,14 +57,12 @@ func (k Keeper) GetArithmeticTwap(
 	startTime time.Time,
 	endTime time.Time) (sdk.Dec, error) {
 	if startTime.After(endTime) {
-		return sdk.Dec{}, fmt.Errorf("called GetArithmeticTwap with a start time that is after the end time."+
-			" (start time %s, end time %s)", startTime, endTime)
+		return sdk.Dec{}, startTimeAfterEndTimeErr{startTime, endTime}
 	}
 	if endTime.Equal(ctx.BlockTime()) {
 		return k.GetArithmeticTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime)
 	} else if endTime.After(ctx.BlockTime()) {
-		return sdk.Dec{}, fmt.Errorf("called GetArithmeticTwap with an end time in the future."+
-			" (end time %s, current time %s)", endTime, ctx.BlockTime())
+		return sdk.Dec{}, endTimeInFutureErr{endTime, ctx.BlockTime()}
 	}
 	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom)
 	if err != nil {

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -213,25 +213,25 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
 			input:        makeSimpleTwapInput(baseTime, tPlusOne, quoteAssetA),
-			expectError:  twap.EndTimeInFutureErr{BlockTime: baseTime, EndTime: tPlusOne},
+			expectError:  twap.EndTimeInFutureError{BlockTime: baseTime, EndTime: tPlusOne},
 		},
 		"start time after end time": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
 			input:        makeSimpleTwapInput(tPlusOne, baseTime, quoteAssetA),
-			expectError:  twap.StartTimeAfterEndTimeErr{StartTime: tPlusOne, EndTime: baseTime},
+			expectError:  twap.StartTimeAfterEndTimeError{StartTime: tPlusOne, EndTime: baseTime},
 		},
 		"start time too old (end time = now)": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, quoteAssetA),
-			expectError:  twap.TimeTooOldErr{Time: baseTime.Add(-time.Hour)},
+			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
 		"start time too old": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime.Add(time.Second),
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, quoteAssetA),
-			expectError:  twap.TimeTooOldErr{Time: baseTime.Add(-time.Hour)},
+			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
 		// TODO: overflow tests, multi-asset pool handling
 	}
@@ -346,13 +346,13 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod, quoteAssetA),
-			expectError:  twap.TimeTooOldErr{Time: baseTime.Add(-time.Millisecond)},
+			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Millisecond)},
 		},
 		"(1 record at keep threshold); with end time; ctxTime = base keep threshold, start time = base time - 1ms (source of error); end time = base keep threshold - ms; error": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod.Add(-time.Millisecond), quoteAssetA),
-			expectError:  twap.TimeTooOldErr{Time: baseTime.Add(-time.Millisecond)},
+			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Millisecond)},
 		},
 		"(2 records); to now; with one directly at threshold, interpolated": {
 			recordsToSet: []types.TwapRecord{baseRecord, recordBeforeKeepThreshold},
@@ -468,7 +468,7 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 			recordsToSet:  []types.TwapRecord{baseRecord},
 			ctxTime:       tPlusOne,
 			input:         makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), quoteAssetA),
-			expectedError: twap.TimeTooOldErr{Time: baseTime.Add(-time.Hour)},
+			expectedError: twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
 		// TODO: overflow tests
 	}

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -383,7 +383,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			expTwap: sdk.MustNewDecFromStr("10.816326421861260894"),
 		},
 	}
-	// for i := 0; i < 2; i++ {
+
 	for name, test := range tests {
 		s.Run(name, func() {
 			s.SetupTest()
@@ -406,7 +406,6 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			s.Require().Equal(test.expTwap, twap)
 		})
 	}
-	// }
 }
 
 // TestGetArithmeticTwapToNow tests if we get the expected twap value from `GetArithmeticTwapToNow`.

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -260,7 +260,7 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 // It specifically focuses on testing edge cases related to the
 // pruning record keep period when interacting with GetArithmeticTwap.
 // The goal of this test is to make sure that we are able to calculate the twap correctly
-// when there are at or below the (current block time - default record history keep period).
+// when they are at or below the (current block time - default record history keep period).
 // This is conditional on the records being present in the store earlier than startTime.
 // If there is no such record, we expect an error.
 func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -256,7 +256,7 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 	}
 }
 
-// TestGetArithmeticTwap_PruningRecordKeepPeriod is simular to TestGetArithmeticTwap.
+// TestGetArithmeticTwap_PruningRecordKeepPeriod is similar to TestGetArithmeticTwap.
 // It specifically focuses on testing edge cases related to the
 // pruning record keep period when interacting with GetArithmeticTwap.
 // The goal of this test is to make sure that we are able to calculate the twap correctly

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -261,8 +261,10 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 // TestGetArithmeticTwap_PruningRecordKeepPeriod is simular to TestGetArithmeticTwap.
 // It specifically focuses on testing edge cases related to the
 // pruning record keep period when interacting with GetArithmeticTwap.
-// The goal of this test is to make sure that
-
+// The goal of this test is to make sure that we are able to calculate the twap correctly
+// when there are at or below the (current block time - default record history keep period).
+// This is conditional on the records being present in the store earlier than startTime.
+// If there is no such record, we expect an error.
 func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 	const quoteAssetA = true
 
@@ -280,7 +282,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 
 		periodBetweenBaseAndOneHourBeforeThreshold           = (defaultRecordHistoryKeepPeriod.Milliseconds() - time.Hour.Milliseconds())
 		accumBeforeKeepThreshold0, accumBeforeKeepThreshold1 = sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10), sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10)
-		// recordBeforeKeepThreshold is a record with t=baseTime-keepPeriod-1h, sp0=30(sp1=0.3) accumulators set relative to baseRecord
+		// recordBeforeKeepThreshold is a record with t=baseTime+keepPeriod-1h, sp0=30(sp1=0.3) accumulators set relative to baseRecord
 		recordBeforeKeepThreshold types.TwapRecord = newTwapRecordWithDefaults(oneHourBeforeKeepThreshold, sdk.NewDec(30), accumBeforeKeepThreshold0, accumBeforeKeepThreshold1)
 	)
 

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -213,13 +213,13 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
 			input:        makeSimpleTwapInput(baseTime, tPlusOne, quoteAssetA),
-			expectError:  twap.EndTimeInFutureError{BlockTime: baseTime, EndTime: tPlusOne},
+			expectError:  types.EndTimeInFutureError{BlockTime: baseTime, EndTime: tPlusOne},
 		},
 		"start time after end time": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
 			input:        makeSimpleTwapInput(tPlusOne, baseTime, quoteAssetA),
-			expectError:  twap.StartTimeAfterEndTimeError{StartTime: tPlusOne, EndTime: baseTime},
+			expectError:  types.StartTimeAfterEndTimeError{StartTime: tPlusOne, EndTime: baseTime},
 		},
 		"start time too old (end time = now)": {
 			recordsToSet: []types.TwapRecord{baseRecord},

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -284,7 +284,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 	)
 
 	// N.B.: when ctxTime = end time, we trigger the "TWAP to now path".
-	// As a result, we duplicate the test cases by trigerring both "to now" and "with end time" paths
+	// As a result, we duplicate the test cases by triggering both "to now" and "with end time" paths
 	// To trigger "with end time" path, we make end time less than ctxTime.
 	tests := map[string]struct {
 		recordsToSet []types.TwapRecord

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -278,7 +278,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 		// oneHourAfterKeepThreshold = baseKeepThreshold + 1 hour
 		oneHourAfterKeepThreshold = baseTimePlusKeepPeriod.Add(time.Hour)
 
-		periodBetweenBaseAndOneHourBeforeThreshold           = (defaultRecordHistoryKeepPeriod.Nanoseconds() - time.Hour.Nanoseconds())
+		periodBetweenBaseAndOneHourBeforeThreshold           = (defaultRecordHistoryKeepPeriod.Milliseconds() - time.Hour.Milliseconds())
 		accumBeforeKeepThreshold0, accumBeforeKeepThreshold1 = sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10), sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10)
 		// recordBeforeKeepThreshold is a record with t=baseTime-keepPeriod-1h, sp0=30(sp1=0.3) accumulators set relative to baseRecord
 		recordBeforeKeepThreshold types.TwapRecord = newTwapRecordWithDefaults(oneHourBeforeKeepThreshold, sdk.NewDec(30), accumBeforeKeepThreshold0, accumBeforeKeepThreshold1)

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -419,11 +419,11 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 	quoteAssetB := false
 
 	tests := map[string]struct {
-		recordsToSet []types.TwapRecord
-		ctxTime      time.Time
-		input        getTwapInput
-		expTwap      sdk.Dec
-		expErrorStr  string
+		recordsToSet  []types.TwapRecord
+		ctxTime       time.Time
+		input         getTwapInput
+		expTwap       sdk.Dec
+		expectedError error
 	}{
 		"(1 record) start time = record time": {
 			recordsToSet: []types.TwapRecord{baseRecord},
@@ -465,10 +465,10 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 
 		// error catching
 		"start time too old": {
-			recordsToSet: []types.TwapRecord{baseRecord},
-			ctxTime:      tPlusOne,
-			input:        makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), quoteAssetA),
-			expErrorStr:  "too old",
+			recordsToSet:  []types.TwapRecord{baseRecord},
+			ctxTime:       tPlusOne,
+			input:         makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), quoteAssetA),
+			expectedError: twap.TimeTooOldErr{Time: baseTime.Add(-time.Hour)},
 		},
 		// TODO: overflow tests
 	}
@@ -486,9 +486,9 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 				test.input.quoteAssetDenom, test.input.baseAssetDenom,
 				test.input.startTime)
 
-			if test.expErrorStr != "" {
+			if test.expectedError != nil {
 				s.Require().Error(err)
-				s.Require().Contains(err.Error(), test.expErrorStr)
+				s.Require().ErrorIs(err, test.expectedError)
 				return
 			}
 			s.Require().NoError(err)

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -311,7 +311,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			input:        makeSimpleTwapInput(oneHourAfterKeepThreshold, oneHourAfterKeepThreshold, quoteAssetA),
 			expTwap:      sdk.NewDec(10),
 		},
-		"(1 record younger than keep threshold); with end time; ctxTime = start time = end time = after keep threshold - 1ns": {
+		"(1 record younger than keep threshold); with end time; ctxTime = start time = end time = after keep threshold - 1ms": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourAfterKeepThreshold,
 			input:        makeSimpleTwapInput(oneHourAfterKeepThreshold.Add(-time.Millisecond), oneHourAfterKeepThreshold.Add(-time.Millisecond), quoteAssetA),
@@ -323,7 +323,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourBeforeKeepThreshold, quoteAssetA),
 			expTwap:      sdk.NewDec(10),
 		},
-		"(1 record older than keep threshold); with end time; ctxTime = baseTime, start time = end time = before keep threshold - 1ns": {
+		"(1 record older than keep threshold); with end time; ctxTime = baseTime, start time = end time = before keep threshold - 1ms": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourBeforeKeepThreshold,
 			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold.Add(-time.Millisecond), oneHourBeforeKeepThreshold.Add(-time.Millisecond), quoteAssetA),
@@ -341,13 +341,13 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, baseTimePlusKeepPeriod, quoteAssetA),
 			expTwap:      sdk.NewDec(10),
 		},
-		"(1 record at keep threshold); to now; ctxTime = base keep threshold, start time = base time - 1mns (source of error); end time = base keep threshold; error": {
+		"(1 record at keep threshold); to now; ctxTime = base keep threshold, start time = base time - 1ms (source of error); end time = base keep threshold; error": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod, quoteAssetA),
 			expErrorStr:  "looking for a time thats too old, not in the historical index",
 		},
-		"(1 record at keep threshold); with end time; ctxTime = base keep threshold, start time = base time - 1mns (source of error); end time = base keep threshold - 1ns; error": {
+		"(1 record at keep threshold); with end time; ctxTime = base keep threshold, start time = base time - 1ms (source of error); end time = base keep threshold - ms; error": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod.Add(-time.Millisecond), quoteAssetA),

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -240,10 +240,7 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 			s.preSetRecords(test.recordsToSet)
 			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
 
-			var twap sdk.Dec
-			var err error
-
-			twap, err = s.twapkeeper.GetArithmeticTwap(s.Ctx, test.input.poolId,
+			twap, err := s.twapkeeper.GetArithmeticTwap(s.Ctx, test.input.poolId,
 				test.input.quoteAssetDenom, test.input.baseAssetDenom,
 				test.input.startTime, test.input.endTime)
 

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 type (
-	TwapNotFoundErr          = twapNotFoundErr
-	TimeTooOldErr            = timeTooOldErr
-	EndTimeInFutureErr       = endTimeInFutureErr
-	StartTimeAfterEndTimeErr = startTimeAfterEndTimeErr
+	TwapNotFoundError          = twapNotFoundError
+	TimeTooOldError            = timeTooOldError
+	EndTimeInFutureError       = endTimeInFutureError
+	StartTimeAfterEndTimeError = startTimeAfterEndTimeError
 )
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 type (
-	TwapNotFoundErr = twapNotFoundErr
-	TimeTooOldErr   = timeTooOldErr
+	TwapNotFoundErr          = twapNotFoundErr
+	TimeTooOldErr            = timeTooOldErr
+	EndTimeInFutureErr       = endTimeInFutureErr
+	StartTimeAfterEndTimeErr = startTimeAfterEndTimeErr
 )
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -44,8 +44,8 @@ func (k Keeper) UpdateRecord(ctx sdk.Context, record types.TwapRecord) types.Twa
 	return k.updateRecord(ctx, record)
 }
 
-func (k Keeper) PruneRecordsBeforeTime(ctx sdk.Context, lastTime time.Time) error {
-	return k.pruneRecordsBeforeTime(ctx, lastTime)
+func (k Keeper) PruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastTime time.Time) error {
+	return k.pruneRecordsBeforeTimeButNewest(ctx, lastTime)
 }
 
 func (k Keeper) PruneRecords(ctx sdk.Context) error {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -51,8 +51,8 @@ func (k Keeper) UpdateRecord(ctx sdk.Context, record types.TwapRecord) types.Twa
 	return k.updateRecord(ctx, record)
 }
 
-func (k Keeper) PruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastTime time.Time) error {
-	return k.pruneRecordsBeforeTimeButNewest(ctx, lastTime)
+func (k Keeper) PruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime time.Time) error {
+	return k.pruneRecordsBeforeTimeButNewest(ctx, lastKeptTime)
 }
 
 func (k Keeper) PruneRecords(ctx sdk.Context) error {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v11/x/twap/types"
 )
 
+type (
+	TwapNotFoundErr = twapNotFoundErr
+	TimeTooOldErr   = timeTooOldErr
+)
+
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
 	k.storeNewRecord(ctx, record)
 }

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -9,10 +9,8 @@ import (
 )
 
 type (
-	TwapNotFoundError          = twapNotFoundError
-	TimeTooOldError            = timeTooOldError
-	EndTimeInFutureError       = endTimeInFutureError
-	StartTimeAfterEndTimeError = startTimeAfterEndTimeError
+	TwapNotFoundError = twapNotFoundError
+	TimeTooOldError   = timeTooOldError
 )
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -310,10 +310,10 @@ func (s *TestSuite) validateExpectedRecords(expectedRecords []types.TwapRecord) 
 }
 
 // createTestRecordsFromTime creates and returns 4 test records in the following order:
-// - at time t - 2 seconds
-// - at time t - 1 seconds
-// - at time t
-// - at time t + 1 seconds
+// - at time t - 2 seconds, with pool id 0
+// - at time t - 1 seconds, with pool id 1
+// - at time t, with pool id 2
+// - at time t + 1 seconds, with pool id 3
 func (s *TestSuite) createTestRecordsFromTime(t time.Time) (types.TwapRecord, types.TwapRecord, types.TwapRecord, types.TwapRecord) {
 	baseRecord := newEmptyPriceRecord(basePoolId, t, denom0, denom1)
 
@@ -327,6 +327,21 @@ func (s *TestSuite) createTestRecordsFromTime(t time.Time) (types.TwapRecord, ty
 	tPlus1Record := newEmptyPriceRecord(basePoolId+3, tPlus1, denom0, denom1)
 
 	return tMin2Record, tMin1Record, baseRecord, tPlus1Record
+}
+
+// createTestRecordsFromTimeInPool creates and returns 4 test records in the following order:
+// - at time t - 2 seconds
+// - at time t - 1 seconds
+// - at time t
+// - at time t + 1 seconds
+// all returned records belong to the same pool with poolId
+func (s *TestSuite) createTestRecordsFromTimeInPool(t time.Time, poolId uint64) (types.TwapRecord, types.TwapRecord, types.TwapRecord, types.TwapRecord) {
+	min2SecRecord, min1SecRecord, baseRecord, plus1SecRecord := s.createTestRecordsFromTime(t)
+	min2SecRecord.PoolId = poolId
+	min1SecRecord.PoolId = poolId
+	baseRecord.PoolId = poolId
+	plus1SecRecord.PoolId = poolId
+	return min2SecRecord, min1SecRecord, baseRecord, plus1SecRecord
 }
 
 func newTwapRecordWithDefaults(t time.Time, sp0, accum0, accum1 sdk.Dec) types.TwapRecord {

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -218,7 +218,6 @@ func (s *TestSuite) TestAfterEpochEnd() {
 
 	twapsBeforeEpoch, err := s.twapkeeper.GetAllHistoricalTimeIndexedTWAPs(s.Ctx)
 	s.Require().NoError(err)
-
 	s.Require().Equal(2, len(twapsBeforeEpoch))
 
 	pruneEpochIdentifier := s.App.TwapKeeper.PruneEpochIdentifier(s.Ctx)

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -201,17 +201,31 @@ func (s *TestSuite) TestEndBlock() {
 
 // TestAfterEpochEnd tests if records get succesfully deleted via `AfterEpochEnd` hook.
 // We test details of correct implementation of pruning method in store test.
+// Specifically, the newest record that is younger than the (current block time - record keep period)
+// is kept, and the rest are deleted.
 func (s *TestSuite) TestAfterEpochEnd() {
 	s.SetupTest()
 	s.Ctx = s.Ctx.WithBlockTime(baseTime)
-	poolId := s.PrepareBalancerPoolWithCoins(defaultTwoAssetCoins...)
-	twapBeforeEpoch, err := s.twapkeeper.GetRecordAtOrBeforeTime(s.Ctx, poolId, s.Ctx.BlockTime(), denom0, denom1)
+
+	// Create TWAP record from pool creation.
+	_ = s.PrepareBalancerPoolWithCoins(defaultTwoAssetCoins...)
+
+	// Assume some time has passed and new record created.
+	s.Ctx = s.Ctx.WithBlockTime(tPlus10sp5Record.Time)
+	newestRecord := tPlus10sp5Record
+
+	s.twapkeeper.StoreNewRecord(s.Ctx, newestRecord)
+
+	twapsBeforeEpoch, err := s.twapkeeper.GetAllHistoricalTimeIndexedTWAPs(s.Ctx)
 	s.Require().NoError(err)
+
+	s.Require().Equal(2, len(twapsBeforeEpoch))
+
 	pruneEpochIdentifier := s.App.TwapKeeper.PruneEpochIdentifier(s.Ctx)
 	recordHistoryKeepPeriod := s.App.TwapKeeper.RecordHistoryKeepPeriod(s.Ctx)
 
 	// make prune record time pass by, running prune epoch after this should prune old record
-	s.Ctx = s.Ctx.WithBlockTime(baseTime.Add(recordHistoryKeepPeriod).Add(time.Second))
+	s.Ctx = s.Ctx.WithBlockTime(newestRecord.Time.Add(recordHistoryKeepPeriod).Add(time.Second))
 
 	allEpochs := s.App.EpochsKeeper.AllEpochInfos(s.Ctx)
 
@@ -220,18 +234,20 @@ func (s *TestSuite) TestAfterEpochEnd() {
 	for i := len(allEpochs) - 1; i >= 0; i-- {
 		s.App.TwapKeeper.EpochHooks().AfterEpochEnd(s.Ctx, allEpochs[i].Identifier, int64(1))
 
-		recentTwapRecords, err := s.twapkeeper.GetRecordAtOrBeforeTime(s.Ctx, poolId, baseTime.Add(allEpochs[i].Duration), denom0, denom1)
+		recordsAfterEpoch, err := s.twapkeeper.GetAllHistoricalTimeIndexedTWAPs(s.Ctx)
 
 		// old record should have been pruned here
+		// however,.the newest younger thant the prune threshold
+		// is kept.
 		if allEpochs[i].Identifier == pruneEpochIdentifier {
-			s.Require().Error(err)
-			s.Require().NotEqual(twapBeforeEpoch, recentTwapRecords)
+			s.Require().Equal(1, len(recordsAfterEpoch))
+			s.Require().Equal(newestRecord, recordsAfterEpoch[0])
 
 			// quit test once the record has been pruned
 			return
 		} else { // pruning should not be triggered at first, not pruning epoch
 			s.Require().NoError(err)
-			s.Require().Equal(twapBeforeEpoch, recentTwapRecords)
+			s.Require().Equal(twapsBeforeEpoch, recordsAfterEpoch)
 		}
 	}
 }

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -208,7 +208,7 @@ func (s *TestSuite) TestAfterEpochEnd() {
 	s.Ctx = s.Ctx.WithBlockTime(baseTime)
 
 	// Create TWAP record from pool creation.
-	_ = s.PrepareBalancerPoolWithCoins(defaultTwoAssetCoins...)
+	s.PrepareBalancerPoolWithCoins(defaultTwoAssetCoins...)
 
 	// Assume some time has passed and new record created.
 	s.Ctx = s.Ctx.WithBlockTime(tPlus10sp5Record.Time)

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -237,7 +237,7 @@ func (s *TestSuite) TestAfterEpochEnd() {
 		recordsAfterEpoch, err := s.twapkeeper.GetAllHistoricalTimeIndexedTWAPs(s.Ctx)
 
 		// old record should have been pruned here
-		// however,.the newest younger thant the prune threshold
+		// however, the newest younger than the prune threshold
 		// is kept.
 		if allEpochs[i].Identifier == pruneEpochIdentifier {
 			s.Require().Equal(1, len(recordsAfterEpoch))

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -92,6 +92,7 @@ func (k Keeper) updateRecord(ctx sdk.Context, record types.TwapRecord) types.Twa
 
 // pruneRecords prunes twap records that happened earlier than recordHistoryKeepPeriod
 // before current block time while preserving the most recent record before the threshold.
+// Such record is preserved for each pool.
 // See TWAP keeper's `pruneRecordsBeforeTimeButNewest(...)` for more details about the reasons for
 // keeping this record.
 func (k Keeper) pruneRecords(ctx sdk.Context) error {

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -91,12 +91,14 @@ func (k Keeper) updateRecord(ctx sdk.Context, record types.TwapRecord) types.Twa
 }
 
 // pruneRecords prunes twap records that happened earlier than recordHistoryKeepPeriod
-// before current block time.
+// before current block time while preserving the most recent record before the threshold.
+// See TWAP keeper's `pruneRecordsBeforeTimeButNewest(...)` for more details about the reasons for
+// keeping this record.
 func (k Keeper) pruneRecords(ctx sdk.Context) error {
 	recordHistoryKeepPeriod := k.RecordHistoryKeepPeriod(ctx)
 
 	lastKeptTime := ctx.BlockTime().Add(-recordHistoryKeepPeriod)
-	return k.pruneRecordsBeforeTime(ctx, lastKeptTime)
+	return k.pruneRecordsBeforeTimeButNewest(ctx, lastKeptTime)
 }
 
 // recordWithUpdatedAccumulators returns a record, with updated accumulator values and time for provided newTime.

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -212,8 +212,9 @@ func TestComputeArithmeticTwap(t *testing.T) {
 	}
 }
 
-// TestPruneRecords tests that all twap records earlier than
-// current block time - RecordHistoryKeepPeriod are pruned from the store.
+// TestPruneRecords tests that twap records earlier than
+// current block time - RecordHistoryKeepPeriod are pruned from the store
+// while keeping the newet record before the above time threshold.
 func (s *TestSuite) TestPruneRecords() {
 	recordHistoryKeepPeriod := s.twapkeeper.RecordHistoryKeepPeriod(s.Ctx)
 
@@ -222,7 +223,10 @@ func (s *TestSuite) TestPruneRecords() {
 	// non-ascending insertion order.
 	recordsToPreSet := []types.TwapRecord{tPlus1Record, tMin1Record, baseRecord, tMin2Record}
 
-	expectedKeptRecords := []types.TwapRecord{baseRecord, tPlus1Record}
+	// tMin2Record is before the threshold and is pruned away.
+	// tmin1Record is the newest record before current block time - record history keep period.
+	// All other records happen after the threshold and are kept.
+	expectedKeptRecords := []types.TwapRecord{tMin1Record, baseRecord, tPlus1Record}
 	s.SetupTest()
 	s.preSetRecords(recordsToPreSet)
 

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -212,7 +212,7 @@ func TestComputeArithmeticTwap(t *testing.T) {
 
 // TestPruneRecords tests that twap records earlier than
 // current block time - RecordHistoryKeepPeriod are pruned from the store
-// while keeping the newet record before the above time threshold.
+// while keeping the newest record before the above time threshold.
 func (s *TestSuite) TestPruneRecords() {
 	recordHistoryKeepPeriod := s.twapkeeper.RecordHistoryKeepPeriod(s.Ctx)
 

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -213,18 +213,45 @@ func TestComputeArithmeticTwap(t *testing.T) {
 // TestPruneRecords tests that twap records earlier than
 // current block time - RecordHistoryKeepPeriod are pruned from the store
 // while keeping the newest record before the above time threshold.
+// Such record is kept for each pool.
 func (s *TestSuite) TestPruneRecords() {
 	recordHistoryKeepPeriod := s.twapkeeper.RecordHistoryKeepPeriod(s.Ctx)
 
-	tMin2Record, tMin1Record, baseRecord, tPlus1Record := s.createTestRecordsFromTime(baseTime.Add(-recordHistoryKeepPeriod))
+	pool1OlderMin2MsRecord, // deleted
+		pool2OlderMin1MsRecord,  // deleted
+		pool3OlderBaseRecord,    // kept as newest under keep period
+		pool4OlderPlus1Record := // kept as newest under keep period
+		s.createTestRecordsFromTime(baseTime.Add(2 * -recordHistoryKeepPeriod))
+
+	pool1Min2MsRecord, // kept as newest under keep period
+		pool2Min1MsRecord,  // kept as newest under keep period
+		pool3BaseRecord,    // kept as it is at the keep period boundary
+		pool4Plus1Record := // kept as it is above the keep period boundary
+		s.createTestRecordsFromTime(baseTime.Add(-recordHistoryKeepPeriod))
 
 	// non-ascending insertion order.
-	recordsToPreSet := []types.TwapRecord{tPlus1Record, tMin1Record, baseRecord, tMin2Record}
+	recordsToPreSet := []types.TwapRecord{
+		pool2OlderMin1MsRecord,
+		pool4Plus1Record,
+		pool4OlderPlus1Record,
+		pool3OlderBaseRecord,
+		pool2Min1MsRecord,
+		pool3BaseRecord,
+		pool1Min2MsRecord,
+		pool1OlderMin2MsRecord,
+	}
 
 	// tMin2Record is before the threshold and is pruned away.
 	// tmin1Record is the newest record before current block time - record history keep period.
 	// All other records happen after the threshold and are kept.
-	expectedKeptRecords := []types.TwapRecord{tMin1Record, baseRecord, tPlus1Record}
+	expectedKeptRecords := []types.TwapRecord{
+		pool3OlderBaseRecord,
+		pool4OlderPlus1Record,
+		pool1Min2MsRecord,
+		pool2Min1MsRecord,
+		pool3BaseRecord,
+		pool4Plus1Record,
+	}
 	s.SetupTest()
 	s.preSetRecords(recordsToPreSet)
 

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -69,7 +69,7 @@ func (k Keeper) storeHistoricalTWAP(ctx sdk.Context, twap types.TwapRecord) {
 	osmoutils.MustSet(store, key2, &twap)
 }
 
-// pruneRecordsBeforeTimeButNewest prunes all records before the given time but the newest
+// pruneRecordsBeforeTimeButNewest prunes all records for each pool before the given time but the newest
 // record. The reason for preserving at least one record earlier than the keep period is
 // to ensure that we have a record to interpolate from in case there is only one or no records
 // within the keep period.

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -12,21 +12,21 @@ import (
 	"github.com/osmosis-labs/osmosis/v11/x/twap/types"
 )
 
-type timeTooOldErr struct {
+type timeTooOldError struct {
 	Time time.Time
 }
 
-func (e timeTooOldErr) Error() string {
+func (e timeTooOldError) Error() string {
 	return fmt.Sprintf("looking for a time thats too old, not in the historical index. "+
 		" Try storing the accumulator value. (requested time %s)", e.Time)
 }
 
-type twapNotFoundErr struct {
+type twapNotFoundError struct {
 	Asset0Denom string
 	Asset1Denom string
 }
 
-func (e twapNotFoundErr) Error() string {
+func (e twapNotFoundError) Error() string {
 	return fmt.Sprintf("TWAP not found, but there are other twaps available for this time."+
 		" Please make sure tha asset0denom and asset1denom (%s, %s) are correct, and in order (asset0 > asset1)?", e.Asset0Denom, e.Asset1Denom)
 }
@@ -198,7 +198,7 @@ func (k Keeper) getRecordAtOrBeforeTime(ctx sdk.Context, poolId uint64, t time.T
 		return types.TwapRecord{}, err
 	}
 	if len(twaps) == 0 {
-		return types.TwapRecord{}, timeTooOldErr{Time: t}
+		return types.TwapRecord{}, timeTooOldError{Time: t}
 	}
 
 	for _, twap := range twaps {
@@ -206,5 +206,5 @@ func (k Keeper) getRecordAtOrBeforeTime(ctx sdk.Context, poolId uint64, t time.T
 			return twap, nil
 		}
 	}
-	return types.TwapRecord{}, twapNotFoundErr{Asset0Denom: asset0Denom, Asset1Denom: asset1Denom}
+	return types.TwapRecord{}, twapNotFoundError{Asset0Denom: asset0Denom, Asset1Denom: asset1Denom}
 }

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -81,7 +81,8 @@ func (k Keeper) storeHistoricalTWAP(ctx sdk.Context, twap types.TwapRecord) {
 func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime time.Time) error {
 	store := ctx.KVStore(k.storeKey)
 
-	// Reverse iterator guarantees that we get the newest records first.
+	// Reverse iterator guarantees that we iterate through the newest per pool first.
+	// Due to how its indexed, we will only iterate times starting from lastKeptTime
 	iter := store.ReverseIterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastKeptTime, 0, "", ""))
 	defer iter.Close()
 

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -82,7 +82,8 @@ func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime ti
 	store := ctx.KVStore(k.storeKey)
 
 	// Reverse iterator guarantees that we iterate through the newest per pool first.
-	// Due to how its indexed, we will only iterate times starting from lastKeptTime
+	// Due to how it is indexed, we will only iterate times starting from
+	// lastKeptTime exclusively down to the oldest record.
 	iter := store.ReverseIterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastKeptTime, 0, "", ""))
 	defer iter.Close()
 

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -50,10 +50,27 @@ func (k Keeper) storeHistoricalTWAP(ctx sdk.Context, twap types.TwapRecord) {
 	osmoutils.MustSet(store, key2, &twap)
 }
 
-func (k Keeper) pruneRecordsBeforeTime(ctx sdk.Context, lastTime time.Time) error {
+// pruneRecordsBeforeTimeButNewest prunes all records before the given time but the newest
+// record. The reason for preserving at least one record earlier than the keep period is
+// to ensure that we have a record to interpolate from in case there is only one or no records
+// within the keep period.
+// For example:
+// - Suppose pruning param -48 hour
+// - Suppose swaps at -50 hour, -1hour
+// - A prune would leave us with only one record at -1 hour, and we are not able to get twaps from the
+// [-48 hour, -1 hour] time range.
+func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastTime time.Time) error {
 	store := ctx.KVStore(k.storeKey)
-	iter := store.Iterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastTime, 0, "", ""))
+
+	// Reverse iterator guarantees that we get the newest records first.
+	iter := store.ReverseIterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastTime, 0, "", ""))
 	defer iter.Close()
+
+	// Skip newest
+	if iter.Valid() {
+		iter.Next()
+	}
+
 	for ; iter.Valid(); iter.Next() {
 		twapToRemove, err := types.ParseTwapFromBz(iter.Value())
 		if err != nil {

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -78,11 +78,11 @@ func (k Keeper) storeHistoricalTWAP(ctx sdk.Context, twap types.TwapRecord) {
 // - Suppose swaps at -50 hour, -1hour
 // - A prune would leave us with only one record at -1 hour, and we are not able to get twaps from the
 // [-48 hour, -1 hour] time range.
-func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastTime time.Time) error {
+func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime time.Time) error {
 	store := ctx.KVStore(k.storeKey)
 
 	// Reverse iterator guarantees that we get the newest records first.
-	iter := store.ReverseIterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastTime, 0, "", ""))
+	iter := store.ReverseIterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastKeptTime, 0, "", ""))
 	defer iter.Close()
 
 	seenPools := map[uint64]struct{}{}

--- a/x/twap/store_test.go
+++ b/x/twap/store_test.go
@@ -232,8 +232,6 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 		beforeTime time.Time
 
 		expectedKeptRecords []types.TwapRecord
-
-		expErr bool
 	}{
 		"base time; across pool 3; 4 records; 3 before prune time; 2 deleted and newest kept": {
 			recordsToPreSet: []types.TwapRecord{
@@ -392,10 +390,6 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 			twapKeeper := s.twapkeeper
 
 			err := twapKeeper.PruneRecordsBeforeTimeButNewest(ctx, tc.beforeTime)
-			if tc.expErr {
-				s.Require().Error(err)
-				return
-			}
 			s.Require().NoError(err)
 
 			s.validateExpectedRecords(tc.expectedKeptRecords)

--- a/x/twap/store_test.go
+++ b/x/twap/store_test.go
@@ -202,27 +202,27 @@ func (s *TestSuite) TestGetRecordAtOrBeforeTime() {
 
 // TestPruneRecordsBeforeTime tests that all twap records earlier than
 // current block time - given time are pruned from the store while
-// the newest record before the time to keep is preserved.
+// the newest record for each pool before the time to keep is preserved.
 func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 	// These are manually created to be able to refer to them by name
 	// for convenience.
-	pool1BaseRecordMin2S, pool2BaseRecordMin1S, pool3BaseRecordBase, pool4BaseRecordPlus1S := s.createTestRecordsFromTime(baseTime)
-	pool1Min1MsMin2S, pool2Min1MsMin1S, pool3Min1MsBase, pool4Min1MsPlus1S := s.createTestRecordsFromTime(baseTime.Add(-time.Millisecond))
-	pool1Min2MsMin2S, pool2Min2MsMin1S, pool3Min2MsBase, pool4Min2MsPlus1S := s.createTestRecordsFromTime(baseTime.Add(2 * -time.Millisecond))
-	pool1Min3MsMin2S, pool2Min3MsMin1S, pool3Min3MsBase, pool4Min3MsPlus1S := s.createTestRecordsFromTime(baseTime.Add(3 * -time.Millisecond))
+	pool1Min2SBaseMs, pool2Min1SBaseMs, pool3BaseSecBaseMs, pool4Plus1SBaseMs := s.createTestRecordsFromTime(baseTime)
+	pool1Min2SMin1Ms, pool2Min1SMin1Ms, pool3BaseSecMin1Ms, pool4Plus1SMin1Ms := s.createTestRecordsFromTime(baseTime.Add(-time.Millisecond))
+	pool1Min2SMin2Ms, pool2Min1SMin2Ms, pool3BaseSecMin2Ms, pool4Plus1SMin2Ms := s.createTestRecordsFromTime(baseTime.Add(2 * -time.Millisecond))
+	pool1Min2SMin3Ms, pool2Min1SMin3Ms, pool3BaseSecMin3Ms, pool4Plus1SMin3Ms := s.createTestRecordsFromTime(baseTime.Add(3 * -time.Millisecond))
 
 	// Create records that match times 1:1 with other pools but have a different pool ID.
-	pool5BaseRecordMin2S, pool5BaseRecordMin1S, pool5BaseRecordBase, pool5BaseRecordPlus1S := s.createTestRecordsFromTime(baseTime)
-	pool5BaseRecordMin2S.PoolId = 5
-	pool5BaseRecordMin1S.PoolId = 5
-	pool5BaseRecordBase.PoolId = 5
-	pool5BaseRecordPlus1S.PoolId = 5
+	pool5Min2SBaseMs, pool5Min1SBaseMs, pool5BaseSecBaseMs, pool5Plus1SBaseMs := s.createTestRecordsFromTime(baseTime)
+	pool5Min2SBaseMs.PoolId = 5
+	pool5Min1SBaseMs.PoolId = 5
+	pool5BaseSecBaseMs.PoolId = 5
+	pool5Plus1SBaseMs.PoolId = 5
 
-	pool5Min1MsMin2S, pool5Min1MsMin1S, pool5Min1MsBase, pool5Min1MsPlus1S := s.createTestRecordsFromTime(baseTime.Add(-time.Millisecond))
-	pool5Min1MsMin2S.PoolId = 5
-	pool5Min1MsMin1S.PoolId = 5
-	pool5Min1MsBase.PoolId = 5
-	pool5Min1MsPlus1S.PoolId = 5
+	pool5Min2SMin1Ms, pool5Min1SMin1Ms, pool5BaseSecMin1Ms, pool5Plus1SMin1Ms := s.createTestRecordsFromTime(baseTime.Add(-time.Millisecond))
+	pool5Min2SMin1Ms.PoolId = 5
+	pool5Min1SMin1Ms.PoolId = 5
+	pool5BaseSecMin1Ms.PoolId = 5
+	pool5Plus1SMin1Ms.PoolId = 5
 
 	tests := map[string]struct {
 		// order does not follow any specific pattern
@@ -237,142 +237,142 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 	}{
 		"base time; across pool 3; 4 records; 3 before prune time; 2 deleted and newest kept": {
 			recordsToPreSet: []types.TwapRecord{
-				pool3Min1MsBase,     // base time - 1ms; kept since newest
-				pool3BaseRecordBase, // base time; kept since at prune time
-				pool3Min3MsBase,     // base time - 3ms; deleted
-				pool3Min2MsBase,     // base time - 2ms; deleted
+				pool3BaseSecMin1Ms, // base time - 1ms; kept since newest
+				pool3BaseSecBaseMs, // base time; kept since at prune time
+				pool3BaseSecMin3Ms, // base time - 3ms; deleted
+				pool3BaseSecMin2Ms, // base time - 2ms; deleted
 			},
 
 			beforeTime: baseTime,
 
-			expectedKeptRecords: []types.TwapRecord{pool3Min1MsBase, pool3BaseRecordBase},
+			expectedKeptRecords: []types.TwapRecord{pool3BaseSecMin1Ms, pool3BaseSecBaseMs},
 		},
 		"base time - 1s - 2 ms; across pool 2; 4 records; 1 before prune time; none pruned since newest kept": {
 			recordsToPreSet: []types.TwapRecord{
-				pool2Min2MsMin1S,     // base time - 1s - 2ms; kept since at prune time
-				pool2Min1MsMin1S,     // base time - 1s - 1ms; kept since older than at prune time
-				pool2BaseRecordMin1S, // base time - 1s; kept since older than prune time
-				pool2Min3MsMin1S,     // base time - 1s - 3ms; kept since newest
+				pool2Min1SMin2Ms, // base time - 1s - 2ms; kept since at prune time
+				pool2Min1SMin1Ms, // base time - 1s - 1ms; kept since older than at prune time
+				pool2Min1SBaseMs, // base time - 1s; kept since older than prune time
+				pool2Min1SMin3Ms, // base time - 1s - 3ms; kept since newest
 			},
 
 			beforeTime: baseTime.Add(-time.Second).Add(2 * -time.Millisecond),
 
 			expectedKeptRecords: []types.TwapRecord{
-				pool2Min3MsMin1S,
-				pool2Min2MsMin1S,
-				pool2Min1MsMin1S,
-				pool2BaseRecordMin1S,
+				pool2Min1SMin3Ms,
+				pool2Min1SMin2Ms,
+				pool2Min1SMin1Ms,
+				pool2Min1SBaseMs,
 			},
 		},
 		"base time - 2s - 3 ms; across pool 1; 4 records; none before prune time; none pruned": {
 			recordsToPreSet: []types.TwapRecord{
-				pool1Min3MsMin2S,     // base time - 2s - 3ms; kept since older than prune time
-				pool1Min1MsMin2S,     // base time - 2s - 1ms; kept since older than prune time
-				pool1Min2MsMin2S,     // base time - 2s - 2ms; kept since older than prune time
-				pool1BaseRecordMin2S, // base time - 2s; kept since older than prune time
+				pool1Min2SMin3Ms, // base time - 2s - 3ms; kept since older than prune time
+				pool1Min2SMin1Ms, // base time - 2s - 1ms; kept since older than prune time
+				pool1Min2SMin2Ms, // base time - 2s - 2ms; kept since older than prune time
+				pool1Min2SBaseMs, // base time - 2s; kept since older than prune time
 			},
 
 			beforeTime: baseTime.Add(2 * -time.Second).Add(3 * -time.Millisecond),
 
-			expectedKeptRecords: []types.TwapRecord{pool1Min3MsMin2S, pool1Min2MsMin2S, pool1Min1MsMin2S, pool1BaseRecordMin2S},
+			expectedKeptRecords: []types.TwapRecord{pool1Min2SMin3Ms, pool1Min2SMin2Ms, pool1Min2SMin1Ms, pool1Min2SBaseMs},
 		},
 		"base time + 1s + 1ms; across pool 4; 4 records; all before prune time; 3 deleted and newest kept": {
 			recordsToPreSet: []types.TwapRecord{
-				pool4BaseRecordPlus1S, // base time + 1s; kept since newest
-				pool4Min3MsPlus1S,     // base time + 1s - 3ms; deleted
-				pool4Min1MsPlus1S,     // base time + 1s -1ms; deleted
-				pool4Min2MsPlus1S,     // base time + 1s - 2ms; deleted
+				pool4Plus1SBaseMs, // base time + 1s; kept since newest
+				pool4Plus1SMin3Ms, // base time + 1s - 3ms; deleted
+				pool4Plus1SMin1Ms, // base time + 1s -1ms; deleted
+				pool4Plus1SMin2Ms, // base time + 1s - 2ms; deleted
 			},
 
 			beforeTime: baseTime.Add(time.Second).Add(time.Millisecond),
 
-			expectedKeptRecords: []types.TwapRecord{pool4BaseRecordPlus1S},
+			expectedKeptRecords: []types.TwapRecord{pool4Plus1SBaseMs},
 		},
 		"base time; across pool 3 and pool 5; pool 3: 4 total records; 3 before prune time; 2 deleted and newest kept. pool 5: 8 total records; 5 before prune time; 4 deleted and 1 kept": {
 			recordsToPreSet: []types.TwapRecord{
-				pool3Min3MsBase,     // base time - 3ms; deleted
-				pool3Min2MsBase,     // base time - 2ms; deleted
-				pool3Min1MsBase,     // base time - 1ms; kept since newest
-				pool3BaseRecordBase, // base time; kept since at prune time
+				pool3BaseSecMin3Ms, // base time - 3ms; deleted
+				pool3BaseSecMin2Ms, // base time - 2ms; deleted
+				pool3BaseSecMin1Ms, // base time - 1ms; kept since newest
+				pool3BaseSecBaseMs, // base time; kept since at prune time
 
-				pool5BaseRecordMin2S,  // base time - 2s; deleted
-				pool5BaseRecordMin1S,  // base time - 1s; ; deleted
-				pool5BaseRecordBase,   // base time; kept since at prune time
-				pool5BaseRecordPlus1S, // base time + 1s; kept since older than prune time
+				pool5Min2SBaseMs,   // base time - 2s; deleted
+				pool5Min1SBaseMs,   // base time - 1s; ; deleted
+				pool5BaseSecBaseMs, // base time; kept since at prune time
+				pool5Plus1SBaseMs,  // base time + 1s; kept since older than prune time
 
-				pool5Min1MsMin2S,  // base time - 2s - 1ms; deleted
-				pool5Min1MsMin1S,  // base time - 1s - 1ms; deleted
-				pool5Min1MsBase,   // base time - 1ms; kept since newest
-				pool5Min1MsPlus1S, // base time + 1s - 1ms; kept since older than prune time
+				pool5Min2SMin1Ms,   // base time - 2s - 1ms; deleted
+				pool5Min1SMin1Ms,   // base time - 1s - 1ms; deleted
+				pool5BaseSecMin1Ms, // base time - 1ms; kept since newest
+				pool5Plus1SMin1Ms,  // base time + 1s - 1ms; kept since older than prune time
 			},
 
 			beforeTime: baseTime,
 
 			expectedKeptRecords: []types.TwapRecord{
-				pool3Min1MsBase,
-				pool5Min1MsBase,
-				pool3BaseRecordBase,
-				pool5BaseRecordBase,
-				pool5Min1MsPlus1S,
-				pool5BaseRecordPlus1S,
+				pool3BaseSecMin1Ms,
+				pool5BaseSecMin1Ms,
+				pool3BaseSecBaseMs,
+				pool5BaseSecBaseMs,
+				pool5Plus1SMin1Ms,
+				pool5Plus1SBaseMs,
 			},
 		},
 		"base time - 1s - 2 ms; all pools; all test records": {
 			recordsToPreSet: []types.TwapRecord{
-				pool3Min3MsBase,     // base time - 3ms; kept since older
-				pool3Min2MsBase,     // base time - 2ms; kept since older
-				pool3Min1MsBase,     // base time - 1ms; kept since older
-				pool3BaseRecordBase, // base time; kept since older
+				pool3BaseSecMin3Ms, // base time - 3ms; kept since older
+				pool3BaseSecMin2Ms, // base time - 2ms; kept since older
+				pool3BaseSecMin1Ms, // base time - 1ms; kept since older
+				pool3BaseSecBaseMs, // base time; kept since older
 
-				pool2Min3MsMin1S,     // base time - 1s - 3ms; kept since newest
-				pool2Min2MsMin1S,     // base time - 1s - 2ms; kept since at prune time
-				pool2Min1MsMin1S,     // base time - 1s - 1ms; kept since older
-				pool2BaseRecordMin1S, // base time - 1s; kept since older
+				pool2Min1SMin3Ms, // base time - 1s - 3ms; kept since newest
+				pool2Min1SMin2Ms, // base time - 1s - 2ms; kept since at prune time
+				pool2Min1SMin1Ms, // base time - 1s - 1ms; kept since older
+				pool2Min1SBaseMs, // base time - 1s; kept since older
 
-				pool1Min3MsMin2S,     // base time - 2s - 3ms; deleted
-				pool1Min2MsMin2S,     // base time - 2s - 2ms; deleted
-				pool1Min1MsMin2S,     // base time - 2s - 1ms; deleted
-				pool1BaseRecordMin2S, // base time - 2s; kept since newest
+				pool1Min2SMin3Ms, // base time - 2s - 3ms; deleted
+				pool1Min2SMin2Ms, // base time - 2s - 2ms; deleted
+				pool1Min2SMin1Ms, // base time - 2s - 1ms; deleted
+				pool1Min2SBaseMs, // base time - 2s; kept since newest
 
-				pool4Min3MsPlus1S,     // base time + 1s - 3ms; kept since older
-				pool4Min2MsPlus1S,     // base time + 1s - 2ms; kept since older
-				pool4Min1MsPlus1S,     // base time + 1s -1ms; kept since older
-				pool4BaseRecordPlus1S, // base time + 1s; kept since older
+				pool4Plus1SMin3Ms, // base time + 1s - 3ms; kept since older
+				pool4Plus1SMin2Ms, // base time + 1s - 2ms; kept since older
+				pool4Plus1SMin1Ms, // base time + 1s -1ms; kept since older
+				pool4Plus1SBaseMs, // base time + 1s; kept since older
 
-				pool5BaseRecordMin2S,  // base time - 2s; kept since newest
-				pool5BaseRecordMin1S,  // base time - 1s; kept since older
-				pool5BaseRecordBase,   // base time; kept since older
-				pool5BaseRecordPlus1S, // base time + 1s; kept since older
+				pool5Min2SBaseMs,   // base time - 2s; kept since newest
+				pool5Min1SBaseMs,   // base time - 1s; kept since older
+				pool5BaseSecBaseMs, // base time; kept since older
+				pool5Plus1SBaseMs,  // base time + 1s; kept since older
 
-				pool5Min1MsMin2S,  // base time - 2s - 1ms; deleted
-				pool5Min1MsMin1S,  // base time - 1s - 1ms; kept since older
-				pool5Min1MsBase,   // base time - 1ms; kept since older
-				pool5Min1MsPlus1S, // base time + 1s - 1ms; kept since older
+				pool5Min2SMin1Ms,   // base time - 2s - 1ms; deleted
+				pool5Min1SMin1Ms,   // base time - 1s - 1ms; kept since older
+				pool5BaseSecMin1Ms, // base time - 1ms; kept since older
+				pool5Plus1SMin1Ms,  // base time + 1s - 1ms; kept since older
 			},
 
 			beforeTime: baseTime.Add(-time.Second).Add(2 * -time.Millisecond),
 
 			expectedKeptRecords: []types.TwapRecord{
-				pool1BaseRecordMin2S,  // base time - 2s; kept since newest
-				pool5BaseRecordMin2S,  // base time - 2s; kept since newest
-				pool2Min3MsMin1S,      // base time - 1s - 3ms; kept since newest
-				pool2Min2MsMin1S,      // base time - 1s - 2ms; kept since at prune time
-				pool2Min1MsMin1S,      // base time - 1s - 1ms; kept since older
-				pool5Min1MsMin1S,      // base time - 1s - 1ms; kept since older
-				pool2BaseRecordMin1S,  // base time - 1s; kept since older
-				pool5BaseRecordMin1S,  // base time - 1s; kept since older
-				pool3Min3MsBase,       // base time - 3ms; kept since older
-				pool3Min2MsBase,       // base time - 2ms; kept since older
-				pool3Min1MsBase,       // base time - 1ms; kept since older
-				pool5Min1MsBase,       // base time - 1ms; kept since older
-				pool3BaseRecordBase,   // base time; kept since older
-				pool5BaseRecordBase,   // base time; kept since older
-				pool4Min3MsPlus1S,     // base time + 1s - 3ms; kept since older
-				pool4Min2MsPlus1S,     // base time + 1s - 2ms; kept since older
-				pool4Min1MsPlus1S,     // base time + 1s -1ms; kept since older
-				pool5Min1MsPlus1S,     // base time + 1s - 1ms; kept since older
-				pool4BaseRecordPlus1S, // base time + 1s; kept since older
-				pool5BaseRecordPlus1S, // base time + 1s; kept since older
+				pool1Min2SBaseMs,   // base time - 2s; kept since newest
+				pool5Min2SBaseMs,   // base time - 2s; kept since newest
+				pool2Min1SMin3Ms,   // base time - 1s - 3ms; kept since newest
+				pool2Min1SMin2Ms,   // base time - 1s - 2ms; kept since at prune time
+				pool2Min1SMin1Ms,   // base time - 1s - 1ms; kept since older
+				pool5Min1SMin1Ms,   // base time - 1s - 1ms; kept since older
+				pool2Min1SBaseMs,   // base time - 1s; kept since older
+				pool5Min1SBaseMs,   // base time - 1s; kept since older
+				pool3BaseSecMin3Ms, // base time - 3ms; kept since older
+				pool3BaseSecMin2Ms, // base time - 2ms; kept since older
+				pool3BaseSecMin1Ms, // base time - 1ms; kept since older
+				pool5BaseSecMin1Ms, // base time - 1ms; kept since older
+				pool3BaseSecBaseMs, // base time; kept since older
+				pool5BaseSecBaseMs, // base time; kept since older
+				pool4Plus1SMin3Ms,  // base time + 1s - 3ms; kept since older
+				pool4Plus1SMin2Ms,  // base time + 1s - 2ms; kept since older
+				pool4Plus1SMin1Ms,  // base time + 1s -1ms; kept since older
+				pool5Plus1SMin1Ms,  // base time + 1s - 1ms; kept since older
+				pool4Plus1SBaseMs,  // base time + 1s; kept since older
+				pool5Plus1SBaseMs,  // base time + 1s; kept since older
 			},
 		},
 		"no pre-set records - no error": {

--- a/x/twap/store_test.go
+++ b/x/twap/store_test.go
@@ -229,7 +229,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 		// across many test cases on purpose.
 		recordsToPreSet []types.TwapRecord
 
-		beforeTime time.Time
+		lastKeptTime time.Time
 
 		expectedKeptRecords []types.TwapRecord
 	}{
@@ -241,7 +241,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 				pool3BaseSecMin2Ms, // base time - 2ms; deleted
 			},
 
-			beforeTime: baseTime,
+			lastKeptTime: baseTime,
 
 			expectedKeptRecords: []types.TwapRecord{pool3BaseSecMin1Ms, pool3BaseSecBaseMs},
 		},
@@ -253,7 +253,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 				pool2Min1SMin3Ms, // base time - 1s - 3ms; kept since newest
 			},
 
-			beforeTime: baseTime.Add(-time.Second).Add(2 * -time.Millisecond),
+			lastKeptTime: baseTime.Add(-time.Second).Add(2 * -time.Millisecond),
 
 			expectedKeptRecords: []types.TwapRecord{
 				pool2Min1SMin3Ms,
@@ -270,7 +270,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 				pool1Min2SBaseMs, // base time - 2s; kept since older than prune time
 			},
 
-			beforeTime: baseTime.Add(2 * -time.Second).Add(3 * -time.Millisecond),
+			lastKeptTime: baseTime.Add(2 * -time.Second).Add(3 * -time.Millisecond),
 
 			expectedKeptRecords: []types.TwapRecord{pool1Min2SMin3Ms, pool1Min2SMin2Ms, pool1Min2SMin1Ms, pool1Min2SBaseMs},
 		},
@@ -282,7 +282,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 				pool4Plus1SMin2Ms, // base time + 1s - 2ms; deleted
 			},
 
-			beforeTime: baseTime.Add(time.Second).Add(time.Millisecond),
+			lastKeptTime: baseTime.Add(time.Second).Add(time.Millisecond),
 
 			expectedKeptRecords: []types.TwapRecord{pool4Plus1SBaseMs},
 		},
@@ -304,7 +304,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 				pool5Plus1SMin1Ms,  // base time + 1s - 1ms; kept since older than prune time
 			},
 
-			beforeTime: baseTime,
+			lastKeptTime: baseTime,
 
 			expectedKeptRecords: []types.TwapRecord{
 				pool3BaseSecMin1Ms,
@@ -348,7 +348,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 				pool5Plus1SMin1Ms,  // base time + 1s - 1ms; kept since older
 			},
 
-			beforeTime: baseTime.Add(-time.Second).Add(2 * -time.Millisecond),
+			lastKeptTime: baseTime.Add(-time.Second).Add(2 * -time.Millisecond),
 
 			expectedKeptRecords: []types.TwapRecord{
 				pool1Min2SBaseMs,   // base time - 2s; kept since newest
@@ -376,7 +376,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 		"no pre-set records - no error": {
 			recordsToPreSet: []types.TwapRecord{},
 
-			beforeTime: baseTime,
+			lastKeptTime: baseTime,
 
 			expectedKeptRecords: []types.TwapRecord{},
 		},
@@ -389,7 +389,7 @@ func (s *TestSuite) TestPruneRecordsBeforeTimeButNewest() {
 			ctx := s.Ctx
 			twapKeeper := s.twapkeeper
 
-			err := twapKeeper.PruneRecordsBeforeTimeButNewest(ctx, tc.beforeTime)
+			err := twapKeeper.PruneRecordsBeforeTimeButNewest(ctx, tc.lastKeptTime)
 			s.Require().NoError(err)
 
 			s.validateExpectedRecords(tc.expectedKeptRecords)

--- a/x/twap/types/errors.go
+++ b/x/twap/types/errors.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"fmt"
+	time "time"
+)
+
+type EndTimeInFutureError struct {
+	EndTime   time.Time
+	BlockTime time.Time
+}
+
+func (e EndTimeInFutureError) Error() string {
+	return fmt.Sprintf("called GetArithmeticTwap with an end time in the future."+
+		" (end time %s, current time %s)", e.EndTime, e.BlockTime)
+}
+
+type StartTimeAfterEndTimeError struct {
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+func (e StartTimeAfterEndTimeError) Error() string {
+	return fmt.Sprintf("called GetArithmeticTwap with a start time that is after the end time."+
+		" (start time %s, end time %s)", e.StartTime, e.EndTime)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2518

## What is the purpose of the change

Modify TWAP pruning to keep the newest record younger than block time - keep period.

Please see #2518 for details.

Additionally, it switched assertions in `api_test.go` from asserting on error strings to actual errors. This required defining several custom errors.

## Brief Changelog

- Modify pruning logic
- Modify existing table-driven tests to account for the change
- Add more tests for getting TWAP from times earlier than block time - keep period
- Modify hook test


## Testing and Verifying

This change added tests mentioned in changelog

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable