### PR TITLE
chore: remove maxAgeNumBlocks from upgrade

### DIFF
--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -40,18 +40,6 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 
-		// Set the max_age_num_blocks in the evidence params to reflect the 14 day
-		// unbonding period.
-		//
-		// Ref: https://github.com/osmosis-labs/osmosis/issues/1160
-		cp := bpm.GetConsensusParams(ctx)
-		if cp != nil && cp.Evidence != nil {
-			evParams := cp.Evidence
-			evParams.MaxAgeNumBlocks = 186_092
-
-			bpm.StoreConsensusParams(ctx, cp)
-		}
-
 		// Specifying the whole list instead of adding and removing. Less fragile.
 		hostParams := icahosttypes.Params{
 			HostEnabled: true,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

As discussed on chain dev call, we will remove the maxAgeNumBlocks change from the upgrade logic. The benefit to changing this is currently unconvincing and would need more time to further look into this.

## Brief Changelog

- remove reduction of maxAgeNumBlocks from v12 upgrade handler

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable