### PR TITLE
Twap: after exit pool hook

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -112,6 +112,13 @@ func (s *KeeperTestHelper) RunBasicSwap(poolId uint64) {
 	s.Require().NoError(err)
 }
 
+func (s *KeeperTestHelper) RunBasicExit(poolId uint64) {
+	shareInAmount := sdk.NewInt(100)
+	tokenOutMins := sdk.NewCoins()
+	_, err := s.App.GAMMKeeper.ExitPool(s.Ctx, s.TestAccs[0], poolId, shareInAmount, tokenOutMins)
+	s.Require().NoError(err)
+}
+
 func (s *KeeperTestHelper) RunBasicJoin(poolId uint64) {
 	pool, _ := s.App.GAMMKeeper.GetPoolAndPoke(s.Ctx, poolId)
 	denoms, err := s.App.GAMMKeeper.GetPoolDenoms(s.Ctx, poolId)

--- a/x/twap/listeners.go
+++ b/x/twap/listeners.go
@@ -53,5 +53,6 @@ func (hook *gammhook) AfterJoinPool(ctx sdk.Context, sender sdk.AccAddress, pool
 	hook.k.trackChangedPool(ctx, poolId)
 }
 
-func (hook *gammhook) AfterExitPool(_ sdk.Context, _ sdk.AccAddress, _ uint64, _ sdk.Int, _ sdk.Coins) {
+func (hook *gammhook) AfterExitPool(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, shareInAmount sdk.Int, exitCoins sdk.Coins) {
+	hook.k.trackChangedPool(ctx, poolId)
 }

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -294,3 +294,38 @@ func (s *TestSuite) TestAfterSwap_JoinPool() {
 		})
 	}
 }
+
+// TestAfterExitPool tests hooks for `AfterExitPool`.
+// The purpose of this test is to test whether we correctly store the state of the
+// pools that has changed with price impact.
+func (s *TestSuite) TestAfterExitPool() {
+	tests := []struct {
+		name      string
+		poolCoins sdk.Coins
+	}{
+		{
+			"exit pool triggers track changed pools",
+			defaultTwoAssetCoins,
+		},
+		{
+			"three asset pool: exit pool triggers track changed pools",
+			defaultThreeAssetCoins,
+		},
+	}
+
+	for _, tc := range tests {
+		s.SetupTest()
+		s.Run(tc.name, func() {
+			poolId := s.PrepareBalancerPoolWithCoins(tc.poolCoins...)
+
+			s.RunBasicExit(poolId)
+
+			// test exiting a pool
+			// has triggered `trackChangedPool`, and that we have the state of price
+			// impacted pools.
+			changedPools := s.twapkeeper.GetChangedPools(s.Ctx)
+			s.Require().Equal(1, len(changedPools))
+			s.Require().Equal(poolId, changedPools[0])
+		})
+	}
+}


### PR DESCRIPTION

Closes: #2540

## What is the purpose of the change

> Add `trackChangedPool` to `AfterExitPool` listener
> Add tests for `AfterExitPool` hooks