### PR TITLE
fix: e2e flakiness

### DIFF
--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -58,10 +58,12 @@ func (n *NodeConfig) Run() error {
 		return err
 	}
 
+	n.rpcClient = rpcClient
+
 	require.Eventually(
 		n.t,
 		func() bool {
-			if _, err := rpcClient.Health(context.Background()); err != nil {
+			if _, err := n.QueryCurrentHeight(); err != nil {
 				return false
 			}
 
@@ -72,8 +74,6 @@ func (n *NodeConfig) Run() error {
 		time.Second,
 		"Osmosis node failed to produce blocks",
 	)
-
-	n.rpcClient = rpcClient
 
 	if err := n.extractOperatorAddressIfValidator(); err != nil {
 		return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

It seems we have zero issue running e2e tests locally, however have intermittent issues running through CI. By looking through previous failed runs and where they fail, they seem to fail specifically when starting the new containers after upgrade. While I don't have evidence since this is hard to debug when its only happening in CI, I have a feeling this has to do with weird docker networking problems rather than the upgrade itself failing. Because of this, I wanted to see if changing from the rpcClient health call to instead a height call would make a difference. 


## Brief Changelog

- changes the run command to check the height rather than health

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable