### PR TITLE
Cache genesis setup in App.Setup

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -71,7 +71,9 @@ func (s *KeeperTestHelper) SetEpochStartTime() {
 		epoch.StartTime = s.Ctx.BlockTime()
 		epochsKeeper.DeleteEpochInfo(s.Ctx, epoch.Identifier)
 		err := epochsKeeper.AddEpochInfo(s.Ctx, epoch)
-		s.Require().NoError(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -13,6 +13,7 @@ import (
 )
 
 var defaultGenesisBz []byte
+var defaultEncodingConfig = MakeEncodingConfig()
 
 func getDefaultGenesisStateBytes() []byte {
 	if len(defaultGenesisBz) == 0 {
@@ -29,7 +30,7 @@ func getDefaultGenesisStateBytes() []byte {
 // Setup initializes a new OsmosisApp.
 func Setup(isCheckTx bool) *OsmosisApp {
 	db := dbm.NewMemDB()
-	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, MakeEncodingConfig(), simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
+	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, defaultEncodingConfig, simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
 	if !isCheckTx {
 		stateBytes := getDefaultGenesisStateBytes()
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -12,16 +12,26 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// Setup initializes a new OsmosisApp.
-func Setup(isCheckTx bool) *OsmosisApp {
-	db := dbm.NewMemDB()
-	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, MakeEncodingConfig(), simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
-	if !isCheckTx {
+var defaultGenesisBz []byte
+
+func getDefaultGenesisStateBytes() []byte {
+	if len(defaultGenesisBz) == 0 {
 		genesisState := NewDefaultGenesisState()
 		stateBytes, err := json.MarshalIndent(genesisState, "", " ")
 		if err != nil {
 			panic(err)
 		}
+		defaultGenesisBz = stateBytes
+	}
+	return defaultGenesisBz
+}
+
+// Setup initializes a new OsmosisApp.
+func Setup(isCheckTx bool) *OsmosisApp {
+	db := dbm.NewMemDB()
+	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, MakeEncodingConfig(), simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
+	if !isCheckTx {
+		stateBytes := getDefaultGenesisStateBytes()
 
 		app.InitChain(
 			abci.RequestInitChain{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

cref #2148 , small speedup to app setup time / all tests

```
BEFORE
BenchmarkSetup-16             57          20107194 ns/op         1753442 B/op      22513 allocs/op

AFTER
BenchmarkSetup-16    	      76	  16989387 ns/op	 1087661 B/op	   13536 allocs/op
```

## Brief Changelog

deduplicate genesis creation & encoding config every time its needed

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
