### PR TITLE
Add error handling for incentive hooks interface

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -74,6 +74,7 @@ func (k Keeper) moveActiveGaugeToFinishedGauge(ctx sdk.Context, gauge types.Gaug
 	if err := k.deleteGaugeIDForDenom(ctx, gauge.Id, gauge.DistributeTo.Denom); err != nil {
 		return err
 	}
+	
 	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
 	_ = k.hooks.AfterFinishDistribution(ctx, gauge.Id)
 	return nil

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -74,7 +74,8 @@ func (k Keeper) moveActiveGaugeToFinishedGauge(ctx sdk.Context, gauge types.Gaug
 	if err := k.deleteGaugeIDForDenom(ctx, gauge.Id, gauge.DistributeTo.Denom); err != nil {
 		return err
 	}
-	k.hooks.AfterFinishDistribution(ctx, gauge.Id)
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.AfterFinishDistribution(ctx, gauge.Id)
 	return nil
 }
 
@@ -364,7 +365,9 @@ func (k Keeper) Distribute(ctx sdk.Context, gauges []types.Gauge) (sdk.Coins, er
 	if err != nil {
 		return nil, err
 	}
-	k.hooks.AfterEpochDistribution(ctx)
+
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.AfterEpochDistribution(ctx)
 
 	k.checkFinishDistribution(ctx, gauges)
 	return totalDistributedCoins, nil

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -74,7 +74,7 @@ func (k Keeper) moveActiveGaugeToFinishedGauge(ctx sdk.Context, gauge types.Gaug
 	if err := k.deleteGaugeIDForDenom(ctx, gauge.Id, gauge.DistributeTo.Denom); err != nil {
 		return err
 	}
-	
+
 	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
 	_ = k.hooks.AfterFinishDistribution(ctx, gauge.Id)
 	return nil

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -138,7 +138,9 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 	if err != nil {
 		return 0, err
 	}
-	k.hooks.AfterCreateGauge(ctx, gauge.Id)
+
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.AfterCreateGauge(ctx, gauge.Id)
 	return gauge.Id, nil
 }
 
@@ -157,7 +159,9 @@ func (k Keeper) AddToGaugeRewards(ctx sdk.Context, owner sdk.AccAddress, coins s
 	if err != nil {
 		return err
 	}
-	k.hooks.AfterAddToGauge(ctx, gauge.Id)
+
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.AfterAddToGauge(ctx, gauge.Id)
 	return nil
 }
 

--- a/x/incentives/types/hooks.go
+++ b/x/incentives/types/hooks.go
@@ -56,10 +56,7 @@ func (h MultiIncentiveHooks) AfterFinishDistribution(ctx sdk.Context, gaugeId ui
 
 func (h MultiIncentiveHooks) AfterEpochDistribution(ctx sdk.Context) error {
 	for i := range h {
-		err := osmoutils.ApplyFuncIfNoError(ctx, h[i].AfterEpochDistribution)
-		if err != nil {
-			ctx.Logger().Error(fmt.Sprintf("error in incentive hook %v", err))
-		}
+		handleHooksError(ctx, osmoutils.ApplyFuncIfNoError(ctx, h[i].AfterEpochDistribution))
 	}
 	return nil
 }
@@ -73,7 +70,10 @@ func errorCatchingIncentiveHook(
 		return hookFn(ctx, gaugeId)
 	}
 
-	err := osmoutils.ApplyFuncIfNoError(ctx, wrappedHookFn)
+	handleHooksError(ctx, osmoutils.ApplyFuncIfNoError(ctx, wrappedHookFn))
+}
+
+func handleHooksError(ctx sdk.Context, err error) {
 	if err != nil {
 		ctx.Logger().Error(fmt.Sprintf("error in incentive hook %v", err))
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: #2520 
Not sure if this PR is needed, as there are no implementation for the hooks.

## What is the purpose of the change
* Avoid using panics on hook functions, and instead add ability to return errors
* Hooks errors can now be handled with [ApplyFuncIfNoError](https://github.com/osmosis-labs/osmosis/blob/main/osmoutils/cache_ctx.go#L16)
* This implementation allows hooks interface functions to return an error.
* If functions return an error any state changes will not be written to the state.

## Brief Changelog
* Update the interface for IncentiveHooks hooks, to add return type error
**Note: There are no current implementations for the hook functions**

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)