### PR TITLE
Add error handling for lockup hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#2214](https://github.com/osmosis-labs/osmosis/pull/2214) Speedup epoch distribution, superfluid component
 * [#2515](https://github.com/osmosis-labs/osmosis/pull/2515) Emit events from functions implementing epoch hooks' `panicCatchingEpochHook` cacheCtx
 * [#2526](https://github.com/osmosis-labs/osmosis/pull/2526) EpochHooks interface methods (and hence modules implementing the hooks) return error instead of panic
+* [#2564](https://github.com/osmosis-labs/osmosis/pull/2564) LockupHooks interface methods (and hence modules implementing the hooks) return error instead of panic
 
 ### SDK Upgrades
 * [#2245](https://github.com/osmosis-labs/osmosis/pull/2244) Upgrade SDK with the following major changes:

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -103,7 +103,8 @@ func (k Keeper) AddTokensToLockByID(ctx sdk.Context, lockID uint64, owner sdk.Ac
 		return lock, nil
 	}
 
-	k.hooks.AfterAddTokensToLock(ctx, lock.OwnerAddress(), lock.GetID(), sdk.NewCoins(tokensToAdd))
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.AfterAddTokensToLock(ctx, lock.OwnerAddress(), lock.GetID(), sdk.NewCoins(tokensToAdd))
 
 	return lock, nil
 }
@@ -155,7 +156,8 @@ func (k Keeper) lock(ctx sdk.Context, lock types.PeriodLock, tokensToLock sdk.Co
 		k.accumulationStore(ctx, coin.Denom).Increase(accumulationKey(lock.Duration), coin.Amount)
 	}
 
-	k.hooks.OnTokenLocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.OnTokenLocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
 	return nil
 }
 
@@ -232,7 +234,8 @@ func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Co
 	}
 
 	if k.hooks != nil {
-		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+		// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+		_ = k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
 	}
 
 	return nil
@@ -281,7 +284,8 @@ func (k Keeper) beginForceUnlockWithEndTime(ctx sdk.Context, lock types.PeriodLo
 	}
 
 	if k.hooks != nil {
-		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+		// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+		_ = k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
 	}
 
 	return nil
@@ -360,7 +364,8 @@ func (k Keeper) unlockMaturedLockInternalLogic(ctx sdk.Context, lock types.Perio
 		k.accumulationStore(ctx, coin.Denom).Decrease(accumulationKey(lock.Duration), coin.Amount)
 	}
 
-	k.hooks.OnTokenUnlocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.OnTokenUnlocked(ctx, owner, lock.ID, lock.Coins, lock.Duration, lock.EndTime)
 	return nil
 }
 
@@ -421,7 +426,8 @@ func (k Keeper) ExtendLockup(ctx sdk.Context, lockID uint64, owner sdk.AccAddres
 		return err
 	}
 
-	k.hooks.OnLockupExtend(ctx,
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.OnLockupExtend(ctx,
 		lock.GetID(),
 		oldDuration,
 		lock.GetDuration(),
@@ -583,7 +589,8 @@ func (k Keeper) SlashTokensFromLockByID(ctx sdk.Context, lockID uint64, coins sd
 		return lock, nil
 	}
 
-	k.hooks.OnTokenSlashed(ctx, lock.ID, coins)
+	// Error is not handled as Hooks use osmoutils.ApplyFuncIfNoError()
+	_ = k.hooks.OnTokenSlashed(ctx, lock.ID, coins)
 	return lock, nil
 }
 

--- a/x/superfluid/keeper/hooks.go
+++ b/x/superfluid/keeper/hooks.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	epochstypes "github.com/osmosis-labs/osmosis/v11/x/epochs/types"
-	"github.com/osmosis-labs/osmosis/v11/x/superfluid/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	epochstypes "github.com/osmosis-labs/osmosis/v11/x/epochs/types"
+	lockuptypes "github.com/osmosis-labs/osmosis/v11/x/lockup/types"
+	"github.com/osmosis-labs/osmosis/v11/x/superfluid/types"
 )
 
 // Hooks wrapper struct for incentives keeper.
@@ -16,6 +17,7 @@ type Hooks struct {
 }
 
 var _ epochstypes.EpochHooks = Hooks{}
+var _ lockuptypes.LockupHooks = Hooks{}
 
 // Return the wrapper struct.
 func (k Keeper) Hooks() Hooks {
@@ -36,13 +38,13 @@ func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumbe
 // if you add tokens to a lock that is superfluid unbonding, nothing happens superfluid side.
 // This lock does as an edge case take on the slashing risk as well for historical slashes.
 // This is deemed as fine, governance can re-pay if it occurs on mainnet.
-func (h Hooks) AfterAddTokensToLock(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins) {
+func (h Hooks) AfterAddTokensToLock(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins) error {
 	intermediaryAccAddr := h.k.GetLockIdIntermediaryAccountConnection(ctx, lockID)
 	if !intermediaryAccAddr.Empty() {
 		// superfluid delegate for additional amount
 		err := h.k.IncreaseSuperfluidDelegation(ctx, lockID, amount)
 		if err != nil {
-			h.k.Logger(ctx).Error(err.Error())
+			return err
 		} else {
 			ctx.EventManager().EmitEvent(sdk.NewEvent(
 				types.TypeEvtSuperfluidIncreaseDelegation,
@@ -51,21 +53,27 @@ func (h Hooks) AfterAddTokensToLock(ctx sdk.Context, address sdk.AccAddress, loc
 			))
 		}
 	}
+	return nil
 }
 
-func (h Hooks) OnTokenLocked(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins, lockDuration time.Duration, unlockTime time.Time) {
+func (h Hooks) OnTokenLocked(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins, lockDuration time.Duration, unlockTime time.Time) error {
+	return nil
 }
 
-func (h Hooks) OnStartUnlock(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins, lockDuration time.Duration, unlockTime time.Time) {
+func (h Hooks) OnStartUnlock(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins, lockDuration time.Duration, unlockTime time.Time) error {
+	return nil
 }
 
-func (h Hooks) OnTokenUnlocked(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins, lockDuration time.Duration, unlockTime time.Time) {
+func (h Hooks) OnTokenUnlocked(ctx sdk.Context, address sdk.AccAddress, lockID uint64, amount sdk.Coins, lockDuration time.Duration, unlockTime time.Time) error {
+	return nil
 }
 
-func (h Hooks) OnTokenSlashed(ctx sdk.Context, lockID uint64, amount sdk.Coins) {
+func (h Hooks) OnTokenSlashed(ctx sdk.Context, lockID uint64, amount sdk.Coins) error {
+	return nil
 }
 
-func (h Hooks) OnLockupExtend(ctx sdk.Context, lockID uint64, oldDuration, newDuration time.Duration) {
+func (h Hooks) OnLockupExtend(ctx sdk.Context, lockID uint64, prevDuration time.Duration, newDuration time.Duration) error {
+	return nil
 }
 
 // staking hooks.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: #2520 

## What is the purpose of the change
* Avoid using panics on hook functions, and instead add ability to return errors
* Hooks errors can now be handled with [ApplyFuncIfNoError](https://github.com/osmosis-labs/osmosis/blob/main/osmoutils/cache_ctx.go#L16)
* This implementation allows hooks interface functions to return an error.
* If functions return an error any state changes will not be written to the state.

## Brief Changelog
* Update the interface for LockupHooks hooks, to add return type error
* Update method for superfluid hook to return error

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable