### PR TITLE
Add error handling for mint hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#2214](https://github.com/osmosis-labs/osmosis/pull/2214) Speedup epoch distribution, superfluid component
 * [#2515](https://github.com/osmosis-labs/osmosis/pull/2515) Emit events from functions implementing epoch hooks' `panicCatchingEpochHook` cacheCtx
 * [#2526](https://github.com/osmosis-labs/osmosis/pull/2526) EpochHooks interface methods (and hence modules implementing the hooks) return error instead of panic
+* [#2565](https://github.com/osmosis-labs/osmosis/pull/2565) MintHooks interface methods (and hence modules implementing the hooks) return error instead of panic
 
 ### SDK Upgrades
 * [#2245](https://github.com/osmosis-labs/osmosis/pull/2244) Upgrade SDK with the following major changes:

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -152,7 +152,7 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 	}
 
 	// call an hook after the minting and distribution of new coins
-	k.hooks.AfterDistributeMintedCoin(ctx)
+	_ = k.hooks.AfterDistributeMintedCoin(ctx)
 
 	return err
 }

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -152,9 +152,7 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 	}
 
 	// call an hook after the minting and distribution of new coins
-	_ = k.hooks.AfterDistributeMintedCoin(ctx)
-
-	return err
+	return k.hooks.AfterDistributeMintedCoin(ctx)
 }
 
 // getLastReductionEpochNum returns last reduction epoch number.

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -29,8 +29,9 @@ type mintHooksMock struct {
 	hookCallCount int
 }
 
-func (hm *mintHooksMock) AfterDistributeMintedCoin(ctx sdk.Context) {
+func (hm *mintHooksMock) AfterDistributeMintedCoin(ctx sdk.Context) error {
 	hm.hookCallCount++
+	return nil
 }
 
 var _ types.MintHooks = (*mintHooksMock)(nil)

--- a/x/mint/types/hooks.go
+++ b/x/mint/types/hooks.go
@@ -1,12 +1,16 @@
 package types
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v11/osmoutils"
 )
 
 // MintHooks defines an interface for mint module's hooks.
 type MintHooks interface {
-	AfterDistributeMintedCoin(ctx sdk.Context)
+	AfterDistributeMintedCoin(ctx sdk.Context) error
 }
 
 var _ MintHooks = MultiMintHooks{}
@@ -22,8 +26,19 @@ func NewMultiMintHooks(hooks ...MintHooks) MultiMintHooks {
 
 // AfterDistributeMintedCoin is a hook that runs after minter mints and distributes coins
 // at the beginning of each epoch.
-func (h MultiMintHooks) AfterDistributeMintedCoin(ctx sdk.Context) {
+func (h MultiMintHooks) AfterDistributeMintedCoin(ctx sdk.Context) error {
 	for i := range h {
-		h[i].AfterDistributeMintedCoin(ctx)
+		wrappedHookFn := func(ctx sdk.Context) error {
+			return h[i].AfterDistributeMintedCoin(ctx)
+		}
+		handleHooksError(ctx, osmoutils.ApplyFuncIfNoError(ctx, wrappedHookFn))
+	}
+	return nil
+}
+
+// handleHooksError logs the error using the ctx logger
+func handleHooksError(ctx sdk.Context, err error) {
+	if err != nil {
+		ctx.Logger().Error(fmt.Sprintf("error in mint hook %v", err))
 	}
 }

--- a/x/pool-incentives/keeper/hooks.go
+++ b/x/pool-incentives/keeper/hooks.go
@@ -40,7 +40,7 @@ func (h Hooks) AfterSwap(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, 
 }
 
 // Distribute coins after minter module allocate assets to pool-incentives module.
-func (h Hooks) AfterDistributeMintedCoin(ctx sdk.Context) {
+func (h Hooks) AfterDistributeMintedCoin(ctx sdk.Context) error {
 	// @Sunny, @Tony, @Dev, what comments should we keep after modifying own BeginBlocker to hooks?
 
 	// WARNING: The order of how modules interact with the default distribution module matters if the distribution module is used in a similar way to:
@@ -55,8 +55,5 @@ func (h Hooks) AfterDistributeMintedCoin(ctx sdk.Context) {
 	// Calculate the AllocatableAsset using the AllocationRatio and the MintedDenom,
 	// then allocate the tokens to the registered pools’ gauges.
 	// If there is no record, inflation is not drained and the all amounts are used by the distribution module’s next BeginBlock.
-	err := h.k.AllocateAsset(ctx)
-	if err != nil {
-		panic(err)
-	}
+	return h.k.AllocateAsset(ctx)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: #2520 (Final PR for closing #2520)

## What is the purpose of the change

* Avoid using panics on hook functions, and instead add ability to return errors
* Hooks errors can now be handled with [ApplyFuncIfNoError](https://github.com/osmosis-labs/osmosis/blob/main/osmoutils/cache_ctx.go#L16)
* This implementation allows hooks interface functions to return an error.
* If functions return an error any state changes will not be written to the state.

## Brief Changelog

* Update the interface for MintHooks hooks, to add return type error
* Update method for superfluid hook to return error

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable