### PR TITLE
App testing consistency improvements

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -215,9 +215,10 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(executeNextEpoch bool, prop
 
 	fmt.Println("beginning block ", s.Ctx.BlockHeight())
 	s.App.BeginBlocker(s.Ctx, reqBeginBlock)
+	s.Ctx = s.App.NewContext(false, reqBeginBlock.Header)
 }
 
-// EndBlock ends the block.
+// EndBlock ends the block, and runs commit
 func (s *KeeperTestHelper) EndBlock() {
 	reqEndBlock := abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}
 	s.App.EndBlocker(s.Ctx, reqEndBlock)

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -214,14 +214,14 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(executeNextEpoch bool, prop
 	reqBeginBlock := abci.RequestBeginBlock{Header: header, LastCommitInfo: lastCommitInfo}
 
 	fmt.Println("beginning block ", s.Ctx.BlockHeight())
-	s.App.BeginBlocker(s.Ctx, reqBeginBlock)
+	s.App.BeginBlock(reqBeginBlock)
 	s.Ctx = s.App.NewContext(false, reqBeginBlock.Header)
 }
 
 // EndBlock ends the block, and runs commit
 func (s *KeeperTestHelper) EndBlock() {
 	reqEndBlock := abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}
-	s.App.EndBlocker(s.Ctx, reqEndBlock)
+	s.App.EndBlock(reqEndBlock)
 }
 
 // AllocateRewardsToValidator allocates reward tokens to a distribution module then allocates rewards to the validator address.

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -214,14 +214,14 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(executeNextEpoch bool, prop
 	reqBeginBlock := abci.RequestBeginBlock{Header: header, LastCommitInfo: lastCommitInfo}
 
 	fmt.Println("beginning block ", s.Ctx.BlockHeight())
-	s.App.BeginBlock(reqBeginBlock)
+	s.App.BeginBlocker(s.Ctx, reqBeginBlock)
 	s.Ctx = s.App.NewContext(false, reqBeginBlock.Header)
 }
 
 // EndBlock ends the block, and runs commit
 func (s *KeeperTestHelper) EndBlock() {
 	reqEndBlock := abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}
-	s.App.EndBlock(reqEndBlock)
+	s.App.EndBlocker(s.Ctx, reqEndBlock)
 }
 
 // AllocateRewardsToValidator allocates reward tokens to a distribution module then allocates rewards to the validator address.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The SDK baseapp has a very undocumented / hard to understand dependence on new Ctx generations, that are needed for `App.DeliverTx` to work with the same go ctx we use in test code. This is something we reverse engineered to be correct within the simulator, and just painstakingly did for osmosis-rust.

This applies the fixes to our app testing framework, to mitigate chance of edge case in the future.

## Brief Changelog

{TODO, after confirming incremental updates don't break things}

## Testing and Verifying

This change is already covered by existing tests passing

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)