### PR TITLE
ux(e2e): Makefile steps to run e2e test suite locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,8 +258,9 @@ Additionally, there is an ability to disable certain components of the e2e suite
 
 To get started:
 
-- Run `make test-e2e`
-- Inspect the logs of the docker containers and see if something it’s there
+- Run `make test-e2e-debug` for the full e2e test suite.
+- Run `make test-e2e-short` for the short e2e test suite that excludes upgrade, IBC and state-sync tests.
+- Inspect the logs of the docker containers and see if something is there.
 - `docker ps -a #` to list all docker containers
 - Note the container id of the one you want to see the logs
 - And then run `docker logs <CONTAINER_NAME>`  to debug via container logs

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
+E2E_UPGRADE_VERSION := "v12"
 
 export GO111MODULE = on
 
@@ -275,19 +276,19 @@ test-sim-bench:
 # manually.
 # Utilizes Go cache.
 test-e2e: e2e-setup
-	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" OSMOSIS_E2E_DEBUG_LOG=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+	@VERSION=$(VERSION) OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_UPGRADE_VERSION=$(E2E_UPGRADE_VERSION)  go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 # test-e2e-debug runs a full e2e test suite but does
 # not attempt to delete Docker resources at the end.
 test-e2e-debug: e2e-setup
-	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_SKIP_CLEANUP=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1
+	@VERSION=$(VERSION) OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_UPGRADE_VERSION=$(E2E_UPGRADE_VERSION) OSMOSIS_E2E_SKIP_CLEANUP=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1
 
 # test-e2e-short runs the e2e test with only short tests.
 # Does not delete any of the containers after running.
 # Deletes any existing containers before running.
 # Does not use Go cache.
 test-e2e-short: e2e-setup
-	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True OSMOSIS_E2E_SKIP_IBC=True OSMOSIS_E2E_SKIP_STATE_SYNC=True OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_SKIP_CLEANUP=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1
+	@VERSION=$(VERSION) OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_SKIP_UPGRADE=True OSMOSIS_E2E_SKIP_IBC=True OSMOSIS_E2E_SKIP_STATE_SYNC=True OSMOSIS_E2E_SKIP_CLEANUP=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1
 
 test-mutation:
 	@bash scripts/mutation-test.sh $(MODULES)

--- a/Makefile
+++ b/Makefile
@@ -266,11 +266,28 @@ test-sim-determinism:
 test-sim-bench:
 	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation -cpuprofile cpu.out $(PACKAGES_SIM)
 
-test-e2e:
+# test-e2e runs a full e2e test suite
+# deletes any pre-existing Osmosis containers before running.
+#
+# Attempts to delete Docker resources at the end.
+# May fail to do so if stopped mid way.
+# In that case, run `make e2e-remove-resources`
+# manually.
+# Utilizes Go cache.
+test-e2e: e2e-setup
 	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" OSMOSIS_E2E_DEBUG_LOG=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
-test-e2e-short:
-	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True OSMOSIS_E2E_SKIP_IBC=True OSMOSIS_E2E_SKIP_STATE_SYNC=True OSMOSIS_E2E_DEBUG_LOG=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+# test-e2e-debug runs a full e2e test suite but does
+# not attempt to delete Docker resources at the end.
+test-e2e-debug: e2e-setup
+	@VERSION=$(VERSION) OSMOSIS_E2E_UPGRADE_VERSION="v12" OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_SKIP_CLEANUP=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1
+
+# test-e2e-short runs the e2e test with only short tests.
+# Does not delete any of the containers after running.
+# Deletes any existing containers before running.
+# Does not use Go cache.
+test-e2e-short: e2e-setup
+	@VERSION=$(VERSION) OSMOSIS_E2E_SKIP_UPGRADE=True OSMOSIS_E2E_SKIP_IBC=True OSMOSIS_E2E_SKIP_STATE_SYNC=True OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_SKIP_CLEANUP=True go test -tags e2e -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1
 
 test-mutation:
 	@bash scripts/mutation-test.sh $(MODULES)
@@ -283,13 +300,23 @@ build-e2e-script:
 	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
 docker-build-debug:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis:debug --build-arg BASE_IMG_TAG=debug -f Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug -f Dockerfile .
+	@DOCKER_BUILDKIT=1 docker tag osmosis:${COMMIT} osmosis:debug
 
 docker-build-e2e-init-chain:
 	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-chain:debug --build-arg E2E_SCRIPT_NAME=chain -f tests/e2e/initialization/init.Dockerfile .
 
 docker-build-e2e-init-node:
 	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-node:debug --build-arg E2E_SCRIPT_NAME=node -f tests/e2e/initialization/init.Dockerfile .
+
+e2e-setup: e2e-check-image-sha e2e-remove-resources
+	@echo Finished e2e environment setup, ready to start the test
+
+e2e-check-image-sha:
+	tests/e2e/scripts/run/check_image_sha.sh
+
+e2e-remove-resources:
+	tests/e2e/scripts/run/remove_stale_resources.sh
 
 .PHONY: test-mutation
 

--- a/tests/e2e/scripts/run/check_image_sha.sh
+++ b/tests/e2e/scripts/run/check_image_sha.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source $(dirname $0)/common.sh
+
 # check_if_exists returns 1 if an "osmosis" image exists, 0 otherwise.
 check_if_exists() {
     if [[ "$(docker images -q osmosis 2> /dev/null)" != "" ]]; then
@@ -13,16 +15,15 @@ check_if_exists() {
 # It assummes that the "osmosis" image was specifically tagged with Git SHA at build
 # time. Please see "docker-build-debug" Makefile step for details.
 check_if_up_to_date() {
-    # N.B.: We match all tags but "Debug" and semantic version tags such as "V10". These are the only
-    # tags we support. As a result, the only remaining tag is the Git SHA tag.
-    sha_from_image=$(docker images osmosis --format "{{ title .Tag }}" | awk "!/Debug/ && !/V[0-9-]+/")
+    sha_from_image=$LIST_DOCKER_IMAGE_HASHES
     local_git_sha=$(git rev-parse HEAD)
-    echo "Docker Tag Git SHA: $sha_from_image"
     echo "Local Git Commit SHA: $local_git_sha"
-
-    if [[ "$sha_from_image" == "$local_git_sha" ]]; then
-        return 1
-    fi
+    for cur_image_sha in $sha_from_image; do        
+        echo "Found Docker Tag Git SHA  : $cur_image_sha"
+        if [[ "$cur_image_sha" == "$local_git_sha" ]]; then
+            return 1
+        fi
+    done
     return 0
 }
 

--- a/tests/e2e/scripts/run/check_image_sha.sh
+++ b/tests/e2e/scripts/run/check_image_sha.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# check_if_exists returns 1 if an "osmosis" image exists, 0 otherwise.
+check_if_exists() {
+    if [[ "$(docker images -q osmosis 2> /dev/null)" != "" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# check_if_exists returns 1 if an "osmosis" image is built from the same commit SHA
+# as the current commit, 0 otherwise.
+# It assummes that the "osmosis" image was specifically tagged with Git SHA at build
+# time. Please see "docker-build-debug" Makefile step for details.
+check_if_up_to_date() {
+    # N.B.: We match all tags but "Debug" and semantic version tags such as "V10". These are the only
+    # tags we support. As a result, the only remaining tag is the Git SHA tag.
+    sha_from_image=$(docker images osmosis --format "{{ title .Tag }}" | awk "!/Debug/ && !/V[0-9-]+/")
+    local_git_sha=$(git rev-parse HEAD)
+    echo "Docker Tag Git SHA: $sha_from_image"
+    echo "Local Git Commit SHA: $local_git_sha"
+
+    if [[ "$sha_from_image" == "$local_git_sha" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+check_if_exists
+exists=$?
+
+if [[ "$exists" -eq 1 ]]; then 
+    echo "osmosis:debug image found"
+    
+    check_if_up_to_date
+    up_to_date=$?
+
+    if [[ "$up_to_date" -eq 1 ]]; then
+        echo "osmosis:debug image is up to date; nothing is done"
+        exit 0
+    else
+        echo "osmosis:debug image is not up to date; rebuilding"
+    fi
+else
+    echo "osmosis:debug image not found; building"
+fi
+
+# Rebuild the image
+make docker-build-debug
+
+check_if_up_to_date

--- a/tests/e2e/scripts/run/common.sh
+++ b/tests/e2e/scripts/run/common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# N.B.: We match all tags but "Debug" and semantic version tags such as "V10". These are the only
+# tags we support. As a result, the only remaining tag is the Git SHA tag.
+LIST_DOCKER_IMAGE_HASHES=$(docker images osmosis --format "{{ title .Tag }}" | awk '!/Debug/ && !/V[0-9-]+/' | awk '{print tolower($0)}')

--- a/tests/e2e/scripts/run/remove_stale_resources.sh
+++ b/tests/e2e/scripts/run/remove_stale_resources.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source $(dirname $0)/common.sh
+
 # Filtering by containers belonging to the "osmosis-testnet" network
 LIST_CONTAINERS_CMD=$(docker ps -a --filter network=osmosis-testnet --format {{.ID}})
 LIST_NETWORKS_CMD=$(docker network ls --filter name=osmosis-testnet --format {{.ID}})
@@ -17,3 +19,11 @@ if [[ "$LIST_NETWORKS_CMD" != "" ]]; then
 else
     echo "No stale e2e networks found"
 fi
+
+local_git_sha=$(git rev-parse HEAD)
+for cur_image_sha in $LIST_DOCKER_IMAGE_HASHES; do
+    if [[ "$cur_image_sha" != "$local_git_sha" ]]; then
+        echo "Removing stale e2e image with SHA $cur_image_sha"
+        docker rmi -f $(docker images --filter=reference="osmosis:$cur_image_sha" -q)
+    fi
+done

--- a/tests/e2e/scripts/run/remove_stale_resources.sh
+++ b/tests/e2e/scripts/run/remove_stale_resources.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Filtering by containers belonging to the "osmosis-testnet" network
+LIST_CONTAINERS_CMD=$(docker ps -a --filter network=osmosis-testnet --format {{.ID}})
+LIST_NETWORKS_CMD=$(docker network ls --filter name=osmosis-testnet --format {{.ID}})
+
+if [[ "$LIST_CONTAINERS_CMD" != "" ]]; then
+    echo "Removing stale e2e containers"
+    docker container rm -f $LIST_CONTAINERS_CMD
+else
+    echo "No stale e2e containers found"
+fi
+
+if [[ "$LIST_NETWORKS_CMD" != "" ]]; then
+    echo "Removing stale e2e networks"
+    docker network rm $LIST_NETWORKS_CMD
+else
+    echo "No stale e2e networks found"
+fi


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2002, #2315

## What is the purpose of the change

1. Add scripts and makefile steps for rebuilding docker image and clearing resources
- `make e2e-check-image-sha`
    * compares the git sha assigned to the pre-existing tag against a local Git commit sha
    * rebuilds the image if hashes do not match
- `make remove-resources`
    * removes all e2e Docker resources, including containers and network
- `make e2e-setup`
    * combines and runs both of the above steps

Create 3 separate Makefile steps for running e2e:
- `make test-e2e` to run in CI
    * before starting runs `make e2e-setup`
- `make test-e2e-debug` to run full suite locally
    * before starting runs `make e2e-setup`
    * does not clear Docker resources at the end (for debugging)
- `make test-e2e-short` to run short test suite locally
    * before starting runs `make e2e-setup`
    * excludes state-sync, IBC and upgrade tests
    * does not clear Docker resources at the end (for debugging)


## Testing and Verifying

Tested all manually

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable