### PR TITLE
TWAP: Add overflow test

### DIFF
--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -62,7 +62,6 @@ func (s *TestSuite) TestGetBeginBlockAccumulatorRecord() {
 		"diff spot price": {zeroAccumTenPoint1Record,
 			recordWithUpdatedAccum(zeroAccumTenPoint1Record, OneSec.MulInt64(10), OneSec.QuoInt64(10)),
 			tPlusOne, 1, denomA, denomB, nil},
-		// TODO: Overflow
 	}
 	for name, tc := range tests {
 		s.Run(name, func() {
@@ -233,7 +232,6 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, quoteAssetA),
 			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
-		// TODO: overflow tests, multi-asset pool handling
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
@@ -475,7 +473,6 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 			input:         makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), quoteAssetA),
 			expectedError: twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
-		// TODO: overflow tests
 	}
 	for name, test := range tests {
 		s.Run(name, func() {

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -155,9 +155,6 @@ func recordWithUpdatedAccumulators(record types.TwapRecord, newTime time.Time) t
 	// record.LastSpotPrice is the last spot price from the block the record was created in,
 	// thus it is treated as the effective spot price until the new time.
 	// (As there was no change until at or after this time)
-	//
-	// TODO (Alpin): Think about overflow
-	// Ref: https://github.com/osmosis-labs/osmosis/issues/2412
 	p0Accum := types.SpotPriceMulDuration(record.P0LastSpotPrice, timeDelta)
 	newRecord.P0ArithmeticTwapAccumulator = newRecord.P0ArithmeticTwapAccumulator.Add(p0Accum)
 

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -69,7 +69,6 @@ func TestRecordWithUpdatedAccumulators(t *testing.T) {
 			interpolateTime: time.Unix(1, 0),
 			expRecord:       newExpRecord(oneDec, twoDec),
 		},
-		// TODO: Overflow tests
 	}
 
 	for name, test := range tests {
@@ -259,8 +258,6 @@ func TestComputeArithmeticTwap(t *testing.T) {
 			pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 
 		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-
-		// TODO: Overflow, rounding
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2412 

## What is the purpose of the change

This PR adds tests regarding overflow in accumulator within the TWAP module, specifically a test proving that it takes 2 ** 128 nano sec(over 292years) with max spot price for a pool to overflow our current accumulator.

This PR tests with testing field of sdk.Dec instead of time.Duration, because it becomes impossible to test overflowing testing scenarios since time.Duration would always automatically cap to time.Duration.MaxDuration, without erroring or panicing if we're trying to create a duration significantly big enough

## Brief Changelog
- Adds overflow test for TWAP Accumulator

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)