### PR TITLE
x/twap: replace panics in `ParseTimeFromHistoricalTimeIndexKe` with error returns

### DIFF
--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -60,17 +60,17 @@ func FormatHistoricalPoolIndexTimePrefix(poolId uint64, accumulatorWriteTime tim
 	return []byte(fmt.Sprintf("%s%d%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, timeS, KeySeparator))
 }
 
-func ParseTimeFromHistoricalTimeIndexKey(key []byte) time.Time {
+func ParseTimeFromHistoricalTimeIndexKey(key []byte) (time.Time, error) {
 	keyS := string(key)
 	s := strings.Split(keyS, KeySeparator)
 	if len(s) != 5 || s[0] != historicalTWAPTimeIndexNoSeparator {
-		panic("Called ParseTimeFromHistoricalTimeIndexKey on incorrectly formatted key")
+		return time.Time{}, fmt.Errorf("Called ParseTimeFromHistoricalPoolIndexKey on incorrectly formatted key: %v", s)
 	}
 	t, err := osmoutils.ParseTimeString(s[1])
 	if err != nil {
-		panic("incorrectly formatted time string in key")
+		return time.Time{}, fmt.Errorf("incorrectly formatted time string in key %s : %v", keyS, err)
 	}
-	return t
+	return t, nil
 }
 
 func ParseTimeFromHistoricalPoolIndexKey(key []byte) (time.Time, error) {

--- a/x/twap/types/keys_test.go
+++ b/x/twap/types/keys_test.go
@@ -50,9 +50,10 @@ func TestFormatHistoricalTwapKeys(t *testing.T) {
 			require.Equal(t, tt.wantTimeIndex, string(gotTimeKey))
 			require.Equal(t, tt.wantPoolIndex, string(gotPoolKey))
 
-			parsedTime := ParseTimeFromHistoricalTimeIndexKey(gotTimeKey)
+			parsedTime, err := ParseTimeFromHistoricalTimeIndexKey(gotTimeKey)
+			require.NoError(t, err)
 			require.Equal(t, tt.time, parsedTime)
-			parsedTime, err := ParseTimeFromHistoricalPoolIndexKey(gotPoolKey)
+			parsedTime, err = ParseTimeFromHistoricalPoolIndexKey(gotPoolKey)
 			require.Equal(t, tt.time, parsedTime)
 			require.NoError(t, err)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2594 

## What is the purpose of the change

Our parser for time-indexed TWAP keys panics if invalid keys are passed in. Since core TWAP logic runs in endblock, any issues relating to this function could cause the chain to halt if it is ever used in TWAP logic. This PR replaces the function's panics with error returns as is done in its pool-indexed counterpart.


## Brief Changelog

- Replace panics with error returns and fix related wiring
- Update tests


## Testing and Verifying

This change is already covered by existing tests, such as `TestFormatHistoricalTwapKeys` in `keys_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)