### PR TITLE
Small simulator backend cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tendermint/tendermint v0.34.21
 	github.com/tendermint/tm-db v0.6.8-0.20220506192307-f628bb5dc95b
+	go.uber.org/multierr v1.8.0
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b
 	google.golang.org/grpc v1.48.0
@@ -44,7 +45,6 @@ require (
 	github.com/timonwong/logrlint v0.1.0 // indirect
 	github.com/zimmski/go-mutesting v0.0.0-20210610104036-6d9217011a00 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 )
 

--- a/simulation/executor/mock_tendermint.go
+++ b/simulation/executor/mock_tendermint.go
@@ -164,7 +164,7 @@ func RandomRequestBeginBlock(r *rand.Rand, params Params,
 		}
 	}
 
-	voteInfos := randomVoteInfos(r, params, validators, event)
+	voteInfos := randomVoteInfos(r, params, validators)
 	evidence := randomDoubleSignEvidence(r, params, validators, pastTimes, pastVoteInfos, event, header, voteInfos)
 
 	return abci.RequestBeginBlock{
@@ -176,7 +176,7 @@ func RandomRequestBeginBlock(r *rand.Rand, params Params,
 	}
 }
 
-func randomVoteInfos(r *rand.Rand, simParams Params, validators mockValidators, event func(route, op, evResult string),
+func randomVoteInfos(r *rand.Rand, simParams Params, validators mockValidators,
 ) []abci.VoteInfo {
 	voteInfos := make([]abci.VoteInfo, len(validators))
 
@@ -195,11 +195,7 @@ func randomVoteInfos(r *rand.Rand, simParams Params, validators mockValidators, 
 			signed = false
 		}
 
-		if signed {
-			event("begin_block", "signing", "signed")
-		} else {
-			event("begin_block", "signing", "missed")
-		}
+		// TODO: Do we want to log any data to statsdb here?
 
 		pubkey, err := cryptoenc.PubKeyFromProto(mVal.val.PubKey)
 		if err != nil {

--- a/simulation/executor/mock_tendermint.go
+++ b/simulation/executor/mock_tendermint.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"testing"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/types/simulation"
@@ -84,21 +83,20 @@ func (mv mockValidators) randomProposer(r *rand.Rand) crypto.PubKey {
 
 // updateValidators mimics Tendermint's update logic.
 func updateValidators(
-	tb testing.TB,
 	r *rand.Rand,
 	params simulation.Params,
 	current map[string]mockValidator,
 	updates []abci.ValidatorUpdate,
 	// logWriter LogWriter,
 	event func(route, op, evResult string),
-) map[string]mockValidator {
+) (map[string]mockValidator, error) {
 	nextSet := mockValidators(current).Clone()
 	for _, update := range updates {
 		str := fmt.Sprintf("%X", update.PubKey.GetEd25519())
 
 		if update.Power == 0 {
 			if _, ok := nextSet[str]; !ok {
-				tb.Fatalf("tried to delete a nonexistent validator: %s", str)
+				return nil, fmt.Errorf("tried to delete a nonexistent validator: %s", str)
 			}
 
 			// logWriter.AddEntry(NewOperationEntry())("kicked", str)
@@ -118,7 +116,7 @@ func updateValidators(
 		}
 	}
 
-	return nextSet
+	return nextSet, nil
 }
 
 // RandomRequestBeginBlock generates a list of signing validators according to

--- a/simulation/executor/schema.sql
+++ b/simulation/executor/schema.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS blocks;
--- comment
+-- TODO: Restructure into multiple tables, to have better encapsulation of block, action log, begin/end block, etc.
 CREATE TABLE blocks (
     id INTEGER PRIMARY KEY,
     height INT,

--- a/simulation/executor/schema.sql
+++ b/simulation/executor/schema.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS blocks;
+;; TODO: 
+CREATE TABLE blocks (
+    id INTEGER PRIMARY KEY,
+    height INT,
+    module TEXT, 
+    name TEXT, 
+    comment TEXT, 
+    passed BOOL, 
+    gasWanted INT, 
+    gasUsed INT, 
+    msg STRING, 
+    resData STRING, 
+    appHash STRING);

--- a/simulation/executor/schema.sql
+++ b/simulation/executor/schema.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS blocks;
-;; TODO: 
+-- comment
 CREATE TABLE blocks (
     id INTEGER PRIMARY KEY,
     height INT,

--- a/simulation/executor/simulate.go
+++ b/simulation/executor/simulate.go
@@ -287,7 +287,6 @@ Comment: %s`,
 	return nil
 }
 
-// nolint: errcheck
 func (simState *simState) runQueuedOperations(simCtx *simtypes.SimCtx, ctx sdk.Context) (numOpsRan int, err error) {
 	height := int(simState.header.Height)
 	queuedOp, ok := simState.operationQueue[height]

--- a/simulation/executor/stats_db.go
+++ b/simulation/executor/stats_db.go
@@ -10,6 +10,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
+// TODO: Setup an sql schema file instead of doing it in-line here
 type statsDb struct {
 	enabled bool
 	db      *sql.DB

--- a/simulation/executor/stats_db.go
+++ b/simulation/executor/stats_db.go
@@ -1,0 +1,53 @@
+package simulation
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/cosmos/cosmos-sdk/types/simulation"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+type statsDb struct {
+	enabled bool
+	db      *sql.DB
+}
+
+func setupStatsDb(config ExportConfig) (statsDb, error) {
+	if !config.WriteStatsToDB {
+		return statsDb{enabled: false}, nil
+	}
+	db, err := sql.Open("sqlite3", "./blocks.db")
+	if err != nil {
+		return statsDb{}, err
+	}
+
+	sts := `
+	DROP TABLE IF EXISTS blocks;
+	CREATE TABLE blocks (id INTEGER PRIMARY KEY, height INT,module TEXT, name TEXT, comment TEXT, passed BOOL, gasWanted INT, gasUsed INT, msg STRING, resData STRING, appHash STRING);
+	`
+	_, err = db.Exec(sts)
+
+	if err != nil {
+		db.Close()
+		return statsDb{}, err
+	}
+	return statsDb{enabled: true, db: db}, nil
+}
+
+func (stats statsDb) cleanup() {
+	stats.db.Close()
+}
+
+func (stats statsDb) logActionResult(header tmproto.Header, opMsg simulation.OperationMsg, resultData []byte) error {
+	if !stats.enabled {
+		return nil
+	}
+	appHash := fmt.Sprintf("%X", header.AppHash)
+	resData := fmt.Sprintf("%X", resultData)
+	sts := "INSERT INTO blocks(height,module,name,comment,passed, gasWanted, gasUsed, msg, resData, appHash) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10);"
+	_, err := stats.db.Exec(sts, header.Height, opMsg.Route, opMsg.Name, opMsg.Comment, opMsg.OK, opMsg.GasWanted, opMsg.GasUsed, opMsg.Msg, resData, appHash)
+	return err
+}

--- a/simulation/executor/stats_db.go
+++ b/simulation/executor/stats_db.go
@@ -27,7 +27,7 @@ func setupStatsDb(config ExportConfig) (statsDb, error) {
 
 	setupSqlCmd, err := embedFs.ReadFile("schema.sql")
 	if err != nil {
-		return statsDb{}, fmt.Errorf("error in schema.sql init: %w", err)
+		return statsDb{}, fmt.Errorf("error in reading schema.sql: %w", err)
 	}
 
 	db, err := sql.Open("sqlite3", "./blocks.db")
@@ -37,7 +37,7 @@ func setupStatsDb(config ExportConfig) (statsDb, error) {
 
 	if _, err := db.Exec(string(setupSqlCmd)); err != nil {
 		db.Close()
-		return statsDb{}, err
+		return statsDb{}, fmt.Errorf("error in init from schema.sql init: %w", err)
 	}
 
 	return statsDb{enabled: true, db: db}, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This is some small simulator backend cleanup. Was doing this as driveby's with property check integration, decided to split this out into its own PR.

- We move validator type juggling to mock_tendermint
- Abstract db work into its own file + a schema file

To get further significant improvements in code readability & debugging, I think we need to:
* Be able to create the traces produced by logWriter, off of the statsDb, then we can start deleting  the logWriter and move `runBlockSimulator` to be based off the simpler simstate struct
* Ditto for event logging / tally fn
* Finally open up & tackle genesis handling
* Start improving queued operation (e.g. queued action)

Going to move some of these further works into new issues

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? N/A