### PR TITLE
Create equivalent make commands for markdown linting

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,14 +1,16 @@
 # Default state for all rules
 default: true
-MD003: 
+MD003:
   # Heading style
-  style: "atx"
+  style: 'atx'
+MD004: false
 # Can't disable MD007 :/
 MD007: false
 MD009: false
 MD010:
   code_blocks: false
-MD013:
-  code_blocks: false
+MD013: false
 MD024: false
+MD029: false
+MD033: false
 MD037: false # breaks on latex

--- a/Makefile
+++ b/Makefile
@@ -338,13 +338,13 @@ lint:
 format:
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./... --fix
 	@go run mvdan.cc/gofumpt -l -w x/ app/ ante/ tests/
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
 
 mdlint:
 	@echo "--> Running markdown linter"
 	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033
 
 markdown:
-	@echo "--> Running markdown linter"
 	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
 	
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -334,19 +334,19 @@ e2e-remove-resources:
 lint:
 	@echo "--> Running linter"
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout=10m
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md"
 
 format:
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./... --fix
 	@go run mvdan.cc/gofumpt -l -w x/ app/ ante/ tests/
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --fix
 
 mdlint:
 	@echo "--> Running markdown linter"
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md"
 
 markdown:
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --fix
 	
 ###############################################################################
 ###                                Localnet                                 ###

--- a/Makefile
+++ b/Makefile
@@ -334,18 +334,19 @@ e2e-remove-resources:
 lint:
 	@echo "--> Running linter"
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout=10m
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033
 
 format:
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./... --fix
 	@go run mvdan.cc/gofumpt -l -w x/ app/ ante/ tests/
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
 
 mdlint:
 	@echo "--> Running markdown linter"
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033
 
 markdown:
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
 	
 ###############################################################################
 ###                                Localnet                                 ###

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,14 @@ format:
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./... --fix
 	@go run mvdan.cc/gofumpt -l -w x/ app/ ante/ tests/
 
+mdlint:
+	@echo "--> Running markdown linter"
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033
+
+markdown:
+	@echo "--> Running markdown linter"
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --disable MD013 MD029 MD004 MD033 --fix
+	
 ###############################################################################
 ###                                Localnet                                 ###
 ###############################################################################


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2528 

## What is the purpose of the change

Adds two makefile commands, `make mdlint` and `make markdown` that allow our markdown linter to be run locally in a way that is aligned with our CI markdown linter.

Running `make markdown` on our full codebase currently yields this: #2631 

## Brief Changelog

- Add `make mdlint`, which runs our markdown linter without making any changes
- Add `make markdown`, which fixes as many markdown issues as it can and then displays the remaining ones

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)