### PR TITLE
Fix: Add proto reset to Stargate Querier

### DIFF
--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -174,26 +174,6 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 // ConvertProtoToJsonMarshal  unmarshals the given bytes into a proto message and then marshals it to json.
 // This is done so that clients calling stargate queries do not need to define their own proto unmarshalers,
 // being able to use response directly by json marshalling, which is supported in cosmwasm.
-// func ConvertProtoToJSONMarshal(protoResponse interface{}, bz []byte, cdc codec.Codec) ([]byte, error) {
-// 	// all values are proto message
-// 	message, ok := protoResponse.(proto.Message)
-// 	if !ok {
-// 		return nil, wasmvmtypes.Unknown{}
-// 	}
-
-// 	// unmarshal binary into stargate response data structure
-// 	err := proto.Unmarshal(bz, message)
-// 	if err != nil {
-// 		return nil, wasmvmtypes.Unknown{}
-// 	}
-
-// 	bz, err = codec.MarshalJSON(message)
-// 	if err != nil {
-// 		return nil, wasmvmtypes.Unknown{}
-// 	}
-
-// 	return bz, nil
-// }
 func ConvertProtoToJSONMarshal(protoResponse interface{}, bz []byte, cdc codec.Codec) ([]byte, error) {
 	// all values are proto message
 	message, ok := protoResponse.(codec.ProtoMarshaler)
@@ -211,6 +191,8 @@ func ConvertProtoToJSONMarshal(protoResponse interface{}, bz []byte, cdc codec.C
 	if err != nil {
 		return nil, wasmvmtypes.Unknown{}
 	}
+
+	message.Reset()
 
 	return bz, nil
 }

--- a/wasmbinding/query_plugin_test.go
+++ b/wasmbinding/query_plugin_test.go
@@ -226,6 +226,50 @@ func (suite *StargateTestSuite) TestDeterministicJsonMarshal() {
 		responseProtoStruct interface{}
 		expectedProto       func() proto.Message
 	}{
+
+		/**
+		   * Origin Response
+		   * balances:<denom:"bar" amount:"30" > pagination:<next_key:"foo" >
+		   * "0a090a036261721202333012050a03666f6f"
+		   *
+		   * New Version Response
+		   * The binary built from the proto response with additional field address
+		   * balances:<denom:"bar" amount:"30" > pagination:<next_key:"foo" > address:"cosmos1j6j5tsquq2jlw2af7l3xekyaq7zg4l8jsufu78"
+		   * "0a090a036261721202333012050a03666f6f1a2d636f736d6f73316a366a357473717571326a6c77326166376c3378656b796171377a67346c386a737566753738"
+		   // Origin proto
+		   message QueryAllBalancesResponse {
+		  	// balances is the balances of all the coins.
+		  	repeated cosmos.base.v1beta1.Coin balances = 1
+		  	[(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+		  	// pagination defines the pagination in the response.
+		  	cosmos.base.query.v1beta1.PageResponse pagination = 2;
+		  }
+		  // Updated proto
+		  message QueryAllBalancesResponse {
+		  	// balances is the balances of all the coins.
+		  	repeated cosmos.base.v1beta1.Coin balances = 1
+		  	[(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+		  	// pagination defines the pagination in the response.
+		  	cosmos.base.query.v1beta1.PageResponse pagination = 2;
+		  	// address is the address to query all balances for.
+		  	string address = 3;
+		  }
+		*/
+		{
+			"Query All Balances",
+			"0a090a036261721202333012050a03666f6f",
+			"0a090a036261721202333012050a03666f6f1a2d636f736d6f73316a366a357473717571326a6c77326166376c3378656b796171377a67346c386a737566753738",
+			"/cosmos.bank.v1beta1.Query/AllBalances",
+			&banktypes.QueryAllBalancesResponse{},
+			func() proto.Message {
+				return &banktypes.QueryAllBalancesResponse{
+					Balances: sdk.NewCoins(sdk.NewCoin("bar", sdk.NewInt(30))),
+					Pagination: &query.PageResponse{
+						NextKey: []byte("foo"),
+					},
+				}
+			},
+		},
 		/**
 		   *
 		   * Origin Response

--- a/wasmbinding/query_plugin_test.go
+++ b/wasmbinding/query_plugin_test.go
@@ -220,6 +220,7 @@ func (suite *StargateTestSuite) TestConvertProtoToJsonMarshal() {
 func (suite *StargateTestSuite) TestDeterministicJsonMarshal() {
 	testCases := []struct {
 		name                string
+		testSetup           func()
 		originalResponse    string
 		updatedResponse     string
 		queryPath           string
@@ -257,6 +258,9 @@ func (suite *StargateTestSuite) TestDeterministicJsonMarshal() {
 		*/
 		{
 			"Query All Balances",
+			func() {
+				wasmbinding.StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/AllBalances", &banktypes.QueryAllBalancesResponse{})
+			},
 			"0a090a036261721202333012050a03666f6f",
 			"0a090a036261721202333012050a03666f6f1a2d636f736d6f73316a366a357473717571326a6c77326166376c3378656b796171377a67346c386a737566753738",
 			"/cosmos.bank.v1beta1.Query/AllBalances",
@@ -292,6 +296,7 @@ func (suite *StargateTestSuite) TestDeterministicJsonMarshal() {
 		*/
 		{
 			"Query Account",
+			nil,
 			"0a530a202f636f736d6f732e617574682e763162657461312e426173654163636f756e74122f0a2d636f736d6f733166387578756c746e3873717a687a6e72737a3371373778776171756867727367366a79766679",
 			"0a530a202f636f736d6f732e617574682e763162657461312e426173654163636f756e74122f0a2d636f736d6f733166387578756c746e3873717a687a6e72737a3371373778776171756867727367366a79766679122d636f736d6f733166387578756c746e3873717a687a6e72737a3371373778776171756867727367366a79766679",
 			"/cosmos.auth.v1beta1.Query/Account",
@@ -312,6 +317,10 @@ func (suite *StargateTestSuite) TestDeterministicJsonMarshal() {
 	for _, tc := range testCases {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest()
+
+			if tc.testSetup != nil {
+				tc.testSetup()
+			}
 
 			binding, ok := wasmbinding.StargateWhitelist.Load(tc.queryPath)
 			suite.Require().True(ok)

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -36,7 +36,6 @@ func init() {
 
 	// bank
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/Balance", &banktypes.QueryBalanceResponse{})
-	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/AllBalances", &banktypes.QueryAllBalancesResponse{})
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/DenomMetadata", &banktypes.QueryDenomsMetadataResponse{})
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/Params", &banktypes.QueryParamsResponse{})
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/SupplyOf", &banktypes.QuerySupplyOfResponse{})

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -36,6 +36,7 @@ func init() {
 
 	// bank
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/Balance", &banktypes.QueryBalanceResponse{})
+	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/AllBalances", &banktypes.QueryAllBalancesResponse{})
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/DenomMetadata", &banktypes.QueryDenomsMetadataResponse{})
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/Params", &banktypes.QueryParamsResponse{})
 	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/SupplyOf", &banktypes.QuerySupplyOfResponse{})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Current Stargate querier implementation would not proto unmarshal & json marshall as expected, if the query includes a repeated field, the query simply appending on top of the existing struct. This way each time we parse the protobuf data we are simply appending to the existing array, thus having to need to zero it out every time we load. 

This PR solves the existing problem by resetting the message every time we call a query request. 


## Brief Changelog

- Reset proto message every time query is called


## Testing and Verifying

Adds a test case that includes query with iteration

Special thanks to @ethanfrey for helping with the insights here!