### PR TITLE
TWAP notes/fixes from code review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v12.0.0
+
+This release includes several cosmwasm-developer and appchain-ecosystem affecting upgrades:
+
+* TWAP - Time weighted average prices for all AMM pools
+* Cosmwasm contract developers
+  * Enabling select queries for cosmwasm contracts
+  * 
+* Enabling Interchain accounts (for real this time)
+* Upgrading IBC to v3.2.0
+* Fixing State Sync
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ This release includes several cosmwasm-developer and appchain-ecosystem affectin
 * TWAP - Time weighted average prices for all AMM pools
 * Cosmwasm contract developers
   * Enabling select queries for cosmwasm contracts
-  * 
 * Enabling Interchain accounts (for real this time)
 * Upgrading IBC to v3.2.0
 * Fixing State Sync

--- a/x/twap/README.md
+++ b/x/twap/README.md
@@ -28,7 +28,6 @@ Using the latest spot price in each record, we create the accumulator value for 
 `a_10 = a_9 + a_9_latest_spot_price * (10s - 9s)`, and `a_15 = a_13 + a_13_latest_spot_price * (15s - 13s)`. 
 Given these interpolated accumulation values, we can compute the TWAP as before.
 
-
 ## Module API
 
 The primary intended API is `GetArithmeticTwap`, which is documented below, and has a similar cosmwasm binding.
@@ -71,9 +70,9 @@ For users who need TWAPs outside the 48 hours stored in the state machine, you c
 
 - client/* - Implementation of GRPC and CLI queries
 - types/* - Implement TwapRecord, GenesisState. Define AMM interface, and methods to format keys.
-- module/module.go - SDK AppModule interface implementation.
+- twapmodule/module.go - SDK AppModule interface implementation.
 - api.go - Public API, that other users / modules can/should depend on
-- hook_listener.go - Defines hooks & calls to logic.go, for triggering actions on 
+- listeners.go - Defines hooks & calls to logic.go, for triggering actions on 
 - keeper.go - generic SDK boilerplate (defining a wrapper for store keys + params)
 - logic.go - Implements all TWAP module 'logic'. (Arithmetic, defining what to get/set where, etc.)
 - store.go - Managing logic for getting and setting things to underlying stores

--- a/x/twap/client/query_proto_wrap.go
+++ b/x/twap/client/query_proto_wrap.go
@@ -19,7 +19,7 @@ func (q Querier) GetArithmeticTwap(ctx sdk.Context,
 	req queryproto.GetArithmeticTwapRequest,
 ) (*queryproto.GetArithmeticTwapResponse, error) {
 	if (req.EndTime == nil || *req.EndTime == time.Time{}) {
-		*req.EndTime = time.Now()
+		*req.EndTime = ctx.BlockTime()
 	}
 
 	twap, err := q.K.GetArithmeticTwap(ctx, req.PoolId, req.BaseAsset, req.QuoteAsset, req.StartTime, *req.EndTime)

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -96,12 +96,15 @@ func (k Keeper) EndBlock(ctx sdk.Context) {
 	}
 }
 
+// TODO: Consider rename to "save new record"
 func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 	// Will only err if pool doesn't have most recent entry set
 	records, err := k.getAllMostRecentRecordsForPool(ctx, poolId)
 	if err != nil {
 		return err
 	}
+	// TODO: Add a safety assert, that # of records is as we expect, given # of denoms in the pool
+	// namely, that for `k` denoms in pool, there should be k * (k - 1) / 2 records
 
 	for _, record := range records {
 		newRecord := k.updateRecord(ctx, record)
@@ -155,11 +158,11 @@ func recordWithUpdatedAccumulators(record types.TwapRecord, newTime time.Time) t
 	// record.LastSpotPrice is the last spot price from the block the record was created in,
 	// thus it is treated as the effective spot price until the new time.
 	// (As there was no change until at or after this time)
-	p0Accum := types.SpotPriceMulDuration(record.P0LastSpotPrice, timeDelta)
-	newRecord.P0ArithmeticTwapAccumulator = newRecord.P0ArithmeticTwapAccumulator.Add(p0Accum)
+	p0NewAccum := types.SpotPriceMulDuration(record.P0LastSpotPrice, timeDelta)
+	newRecord.P0ArithmeticTwapAccumulator = newRecord.P0ArithmeticTwapAccumulator.Add(p0NewAccum)
 
-	p1Accum := types.SpotPriceMulDuration(record.P1LastSpotPrice, timeDelta)
-	newRecord.P1ArithmeticTwapAccumulator = newRecord.P1ArithmeticTwapAccumulator.Add(p1Accum)
+	p1NewAccum := types.SpotPriceMulDuration(record.P1LastSpotPrice, timeDelta)
+	newRecord.P1ArithmeticTwapAccumulator = newRecord.P1ArithmeticTwapAccumulator.Add(p1NewAccum)
 
 	return newRecord
 }

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -96,7 +96,6 @@ func (k Keeper) EndBlock(ctx sdk.Context) {
 	}
 }
 
-// TODO: Consider rename to "save new record"
 func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 	// Will only err if pool doesn't have most recent entry set
 	records, err := k.getAllMostRecentRecordsForPool(ctx, poolId)

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -186,7 +186,8 @@ func (k Keeper) getRecordAtOrBeforeTime(ctx sdk.Context, poolId uint64, t time.T
 	// Note that we cannot get any time entries from t + 1ns, as the key would be `prefix|t+1ns`
 	// and the end for a reverse iterator is exclusive. Thus the largest key that can be returned
 	// begins with a prefix of `prefix|t`
-	// TODO: Consider seperator tricks, to not have the + 1 ns.
+	// TODO: Consider separator tricks, to not have the + 1 ns
+	// TODO: Change key prefix indexing, to include assets, and not re-order assets at end.
 	startKey := types.FormatHistoricalPoolIndexTimePrefix(poolId, time.Unix(0, 0))
 	endKey := types.FormatHistoricalPoolIndexTimePrefix(poolId, t.Add(time.Nanosecond))
 	lastParsedTime := time.Time{}

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -82,7 +82,6 @@ func (k Keeper) storeHistoricalTWAP(ctx sdk.Context, twap types.TwapRecord) {
 // So, in order to have correct behavior for the desired guarantee,
 // we keep the newest record that is older than the pruning time.
 // This is why we would keep the -50 hour and -1hour twaps despite a 48hr pruning period
-// TODO: RENAME THIS FUNCTION TO BE MORE ACCURATE
 func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime time.Time) error {
 	store := ctx.KVStore(k.storeKey)
 

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -30,11 +30,11 @@ var (
 	historicalTWAPPoolIndexNoSeparator = "historical_pool_index"
 	expectedKeySeparatedParts          = 5
 
-	mostRecentTWAPsPrefix = mostRecentTWAPsNoSeparator + KeySeparator
-	// keySeparatorPlusOne is used for creating prefixes for the key end in iterators
-	// when we want to get all of the keys in a prefix. Since it is one byte larger
-	// than the original key separator and the end prefix is exclusive, it is valid
-	// for getting all values under the original key separator.
+	// We do key management to let us easily meet the goals of (AKA minimal iteration):
+	// Get most recent twap for a (pool id, asset 1, asset 2) with no iteration
+	// Get all records for all pools, within a given time range
+	// Get all records for a pool, within a given time range
+	mostRecentTWAPsPrefix         = mostRecentTWAPsNoSeparator + KeySeparator
 	HistoricalTWAPTimeIndexPrefix = historicalTWAPTimeIndexNoSeparator + KeySeparator
 	HistoricalTWAPPoolIndexPrefix = historicalTWAPPoolIndexNoSeparator + KeySeparator
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Notes / fixes from the live TWAP code review

Two important bugs found during code review! 

* Time.Now() bug in query that was getting vendored (fixed in this PR)
  * Thankfully wouldn't have caused mainnet issue, since exec time always greater than block time, and we've well defined returning an error in this case
* Bug in pruning logic (not yet fixed)

## Testing and Verifying

Mostly comment + TODO adds

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)