### PR TITLE
Remove ibc rate limiting tests from github workflow

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -2,21 +2,17 @@ name: Cosmwasm Contracts
 on:
   pull_request:
     branches:
-      - "**"
+      - '**'
   push:
     branches:
-      - "main"
-      - "v[0-9]**"
+      - 'main'
+      - 'v[0-9]**'
   workflow_dispatch:
-
 
 jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        contract: [{workdir: ./x/ibc-rate-limit/, output: testdata/rate_limiter.wasm, build: artifacts/rate_limiter-x86_64.wasm, name: rate_limiter}]
 
     steps:
       - name: Checkout sources
@@ -38,7 +34,6 @@ jobs:
         working-directory: ${{ matrix.contract.workdir }}
         run: >
           rustup target add wasm32-unknown-unknown;
-
 
       - name: Build
         working-directory: ${{ matrix.contract.workdir }}
@@ -82,12 +77,11 @@ jobs:
           path: ${{ matrix.contract.workdir }}${{ matrix.contract.build }}
           retention-days: 1
 
-#      - name: Check Test Data
-#        working-directory: ${{ matrix.contract.workdir }}
-#        if: ${{ matrix.contract.output != null }}
-#        run: >
-#          diff ${{ matrix.contract.output }} ${{ matrix.contract.build }}
-  
+  #      - name: Check Test Data
+  #        working-directory: ${{ matrix.contract.workdir }}
+  #        if: ${{ matrix.contract.output != null }}
+  #        run: >
+  #          diff ${{ matrix.contract.output }} ${{ matrix.contract.build }}
 
   lints:
     name: Cosmwasm Lints
@@ -120,4 +114,3 @@ jobs:
         working-directory: ${{ matrix.workdir }}
         run: >
           cargo clippy -- -D warnings
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1667](https://github.com/osmosis-labs/osmosis/pull/1673) Move wasm-bindings code out of app package into its own root level package.
 * [#2013](https://github.com/osmosis-labs/osmosis/pull/2013) Make `SetParams`, `SetPool`, `SetTotalLiquidity`, and `SetDenomLiquidity` GAMM APIs private
 * [#1857](https://github.com/osmosis-labs/osmosis/pull/1857) x/mint rename GetLastHalvenEpochNum to GetLastReductionEpochNum
+* [#2133](https://github.com/osmosis-labs/osmosis/pull/2133) Add `JoinPoolNoSwap` and `CalcJoinPoolNoSwapShares` to GAMM pool interface and route `JoinPoolNoSwap` in pool_service.go to new method in pool interface
 * [#2353](https://github.com/osmosis-labs/osmosis/pull/2353) Re-enable stargate query via whitelsit
 * [#2394](https://github.com/osmosis-labs/osmosis/pull/2394) Remove unused interface methods from expected keepers of each module
 * [#2390](https://github.com/osmosis-labs/osmosis/pull/2390) x/mint remove unused mintCoins parameter from AfterDistributeMintedCoin

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -36,6 +36,19 @@ func (n *NodeConfig) CreatePool(poolFile, from string) uint64 {
 	return poolID
 }
 
+// SwapExactAmountIn swaps tokenInCoin to get at least tokenOutMinAmountInt of the other token's pool out.
+// swapRoutePoolIds is the comma separated list of pool ids to swap through.
+// swapRouteDenoms is the comma separated list of denoms to swap through.
+// To reproduce locally:
+// docker container exec <container id> osmosisd tx gamm swap-exact-amount-in <tokeinInCoin> <tokenOutMinAmountInt> --swap-route-pool-ids <swapRoutePoolIds> --swap-route-denoms <swapRouteDenoms> --chain-id=<id>--from=<address> --keyring-backend=test -b=block --yes --log_format=json
+func (n *NodeConfig) SwapExactAmountIn(tokenInCoin, tokenOutMinAmountInt string, swapRoutePoolIds string, swapRouteDenoms string, from string) {
+	n.LogActionF("swapping %s to get a minimum of %s with pool id routes (%s) and denom routes (%s)", tokenInCoin, tokenOutMinAmountInt, swapRoutePoolIds, swapRouteDenoms)
+	cmd := []string{"osmosisd", "tx", "gamm", "swap-exact-amount-in", tokenInCoin, tokenOutMinAmountInt, fmt.Sprintf("--swap-route-pool-ids=%s", swapRoutePoolIds), fmt.Sprintf("--swap-route-denoms=%s", swapRouteDenoms), fmt.Sprintf("--from=%s", from)}
+	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
+	require.NoError(n.t, err)
+	n.LogActionF("successfully swapped")
+}
+
 func (n *NodeConfig) SubmitUpgradeProposal(upgradeVersion string, upgradeHeight int64, initialDeposit sdk.Coin) {
 	n.LogActionF("submitting upgrade proposal %s for height %d", upgradeVersion, upgradeHeight)
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "software-upgrade", upgradeVersion, fmt.Sprintf("--title=\"%s upgrade\"", upgradeVersion), "--description=\"upgrade proposal submission\"", fmt.Sprintf("--upgrade-height=%d", upgradeHeight), "--upgrade-info=\"\"", "--from=val", fmt.Sprintf("--deposit=%s", initialDeposit)}

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -63,10 +63,8 @@ func (n *NodeConfig) Run() error {
 	require.Eventually(
 		n.t,
 		func() bool {
-			if _, err := n.QueryCurrentHeight(); err != nil {
-				return false
-			}
-
+			// This fails if unsuccessful.
+			n.QueryCurrentHeight()
 			n.t.Logf("started node container: %s", n.Name)
 			return true
 		},

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -159,10 +159,7 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 	for _, chainConfig := range uc.chainConfigs {
 		for validatorIdx, node := range chainConfig.NodeConfigs {
 			if validatorIdx == 0 {
-				currentHeight, err := node.QueryCurrentHeight()
-				if err != nil {
-					return err
-				}
+				currentHeight := node.QueryCurrentHeight()
 				chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
 				node.SubmitUpgradeProposal(uc.upgradeVersion, chainConfig.UpgradePropHeight, sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(config.InitialMinDeposit)))
 				chainConfig.LatestProposalNumber += 1

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -18,10 +18,9 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/tests/e2e/initialization"
 )
 
-// Test01IBCTokenTransfer tests that IBC token transfers work as expected.
-// This test must precede Test02CreatePoolPostUpgrade. That's why it is prefixed with "01"
-// to ensure correct ordering. See Test02CreatePoolPostUpgrade for more details.
-func (s *IntegrationTestSuite) Test01IBCTokenTransfer() {
+// TestIBCTokenTransfer tests that IBC token transfers work as expected.
+// Additionally, it attempst to create a pool with IBC denoms.
+func (s *IntegrationTestSuite) TestIBCTokenTransferAndCreatePool() {
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -31,29 +30,13 @@ func (s *IntegrationTestSuite) Test01IBCTokenTransfer() {
 	chainB.SendIBC(chainA, chainA.NodeConfigs[0].PublicAddress, initialization.OsmoToken)
 	chainA.SendIBC(chainB, chainB.NodeConfigs[0].PublicAddress, initialization.StakeToken)
 	chainB.SendIBC(chainA, chainA.NodeConfigs[0].PublicAddress, initialization.StakeToken)
-}
 
-// Test02CreatePoolPostUpgrade tests that a pool can be created.
-// It attempts to create a pool with both native and IBC denoms.
-// As a result, it must run after Test01IBCTokenTransfer.
-// This is the reason for prefixing the name with 02 to ensure
-// correct order.
-func (s *IntegrationTestSuite) Test02CreatePool() {
-	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
-
-	chainANode.CreatePool("nativeDenomPool.json", initialization.ValidatorWalletName)
-
-	if s.skipIBC {
-		s.T().Log("skipping creating pool with IBC denoms because IBC tests are disabled")
-		return
-	}
-
 	chainANode.CreatePool("ibcDenomPool.json", initialization.ValidatorWalletName)
 }
 
-// Test03SuperfluidVoting tests that superfluid voting is functioning as expected.
+// TestSuperfluidVoting tests that superfluid voting is functioning as expected.
 // It does so by doing the following:
 //- creating a pool
 // - attempting to submit a proposal to enable superfluid voting in that pool
@@ -71,7 +54,7 @@ func (s *IntegrationTestSuite) TestSuperfluidVoting() {
 	chainA.EnableSuperfluidAsset(fmt.Sprintf("gamm/pool/%d", poolId))
 
 	// setup wallets and send gamm tokens to these wallets (both chains)
-	superfluildVotingWallet := chainANode.CreateWallet("Test03SuperfluidVoting")
+	superfluildVotingWallet := chainANode.CreateWallet("TestSuperfluidVoting")
 	chainANode.BankSend(fmt.Sprintf("10000000000000000000gamm/pool/%d", poolId), chainA.NodeConfigs[0].PublicAddress, superfluildVotingWallet)
 	chainANode.LockTokens(fmt.Sprintf("%v%s", sdk.NewInt(1000000000000000000), fmt.Sprintf("gamm/pool/%d", poolId)), "240s", superfluildVotingWallet)
 	chainA.LatestLockNumber += 1
@@ -160,6 +143,67 @@ func (s *IntegrationTestSuite) TestAddToExistingLock() {
 	chainA.LockAndAddToExistingLock(sdk.NewInt(1000000000000000000), fmt.Sprintf("gamm/pool/%d", poolId), lockupWalletAddr, lockupWalletSuperfluidAddr)
 }
 
+// TestTWAP tests TWAP by creating a pool, performing a swap.
+// These two operations should create TWAP records.
+// Then, we wait until the epoch for the records to be pruned.
+// The records are guranteed to be pruned at the next epoch
+// because twap keep time = epoch time / 4 and we use a timer
+// to wait for at least the twap keep time.
+// TODO: implement querying for TWAP, once such queries are exposed:
+// https://github.com/osmosis-labs/osmosis/issues/2602
+func (s *IntegrationTestSuite) TestTWAP() {
+	const (
+		poolFile   = "nativeDenomPool.json"
+		walletName = "swap-exact-amount-in-wallet"
+
+		coinIn       = "101stake"
+		minAmountOut = "99"
+		denomOut     = "uosmo"
+
+		epochIdentifier = "day"
+	)
+
+	chainA := s.configurer.GetChainConfig(0)
+	chainANode, err := chainA.GetDefaultNode()
+	s.NoError(err)
+
+	// Triggers the creation of TWAP records.
+	poolId := chainANode.CreatePool(poolFile, initialization.ValidatorWalletName)
+	swapWalletAddr := chainANode.CreateWallet(walletName)
+
+	chainANode.BankSend(coinIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
+	heightBeforeSwap := chainANode.QueryCurrentHeight()
+
+	// Triggers the creation of TWAP records.
+	chainANode.SwapExactAmountIn(coinIn, minAmountOut, fmt.Sprintf("%d", poolId), denomOut, swapWalletAddr)
+
+	keepPeriodCountDown := time.NewTimer(initialization.TWAPPruningKeepPeriod)
+
+	// Make sure still producing blocks.
+	chainA.WaitUntilHeight(heightBeforeSwap + 3)
+
+	if !s.skipUpgrade {
+		// TODO: we should reduce the pruning time in the v11
+		// genesis to make this test run faster
+		// Currenty, we are testing the upgrade from v11 to v12,
+		// the pruning time is set to whatever is in the upgrade
+		// handler (two days). Therefore, we cannot reasonably
+		// test twap pruning post-upgrade.
+		s.T().Skip("skipping TWAP Pruning test. This can be re-enabled post v12")
+	}
+
+	// Make sure that the pruning keep period has passed.
+	s.T().Logf("waiting for pruning keep period of (%.f) seconds to pass", initialization.TWAPPruningKeepPeriod.Seconds())
+	<-keepPeriodCountDown.C
+	oldEpochNumber := chainANode.QueryCurrentEpoch(epochIdentifier)
+	// The pruning should happen at the next epoch.
+	chainANode.WaitUntil(func(_ coretypes.SyncInfo) bool {
+		newEpochNumber := chainANode.QueryCurrentEpoch(epochIdentifier)
+		s.T().Logf("Current epoch number is (%d), waiting to reach (%d)", newEpochNumber, oldEpochNumber+1)
+		return newEpochNumber > oldEpochNumber
+	})
+}
+
 func (s *IntegrationTestSuite) TestStateSync() {
 	if s.skipStateSync {
 		s.T().Skip()
@@ -175,8 +219,7 @@ func (s *IntegrationTestSuite) TestStateSync() {
 	stateSyncRPCServers := []string{stateSyncHostPort, stateSyncHostPort}
 
 	// get trust height and trust hash.
-	trustHeight, err := runningNode.QueryCurrentHeight()
-	s.Require().NoError(err)
+	trustHeight := runningNode.QueryCurrentHeight()
 
 	trustHash, err := runningNode.QueryHashFromBlock(trustHeight)
 	s.Require().NoError(err)
@@ -238,12 +281,8 @@ func (s *IntegrationTestSuite) TestStateSync() {
 
 	// ensure that the state synching node cathes up to the running node.
 	s.Require().Eventually(func() bool {
-		stateSyncNodeHeight, err := stateSynchingNode.QueryCurrentHeight()
-		s.NoError(err)
-
-		runningNodeHeight, err := runningNode.QueryCurrentHeight()
-		s.NoError(err)
-
+		stateSyncNodeHeight := stateSynchingNode.QueryCurrentHeight()
+		runningNodeHeight := runningNode.QueryCurrentHeight()
 		return stateSyncNodeHeight == runningNodeHeight
 	},
 		3*time.Minute,

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -23,6 +23,7 @@ import (
 	incentivestypes "github.com/osmosis-labs/osmosis/v12/x/incentives/types"
 	minttypes "github.com/osmosis-labs/osmosis/v12/x/mint/types"
 	poolitypes "github.com/osmosis-labs/osmosis/v12/x/pool-incentives/types"
+	twaptypes "github.com/osmosis-labs/osmosis/v12/x/twap/types"
 	txfeestypes "github.com/osmosis-labs/osmosis/v12/x/txfees/types"
 
 	"github.com/osmosis-labs/osmosis/v12/tests/e2e/util"
@@ -61,6 +62,9 @@ const (
 	OsmoBalanceB  = 500000000000
 	StakeBalanceB = 440000000000
 	StakeAmountB  = 400000000000
+
+	EpochDuration         = time.Second * 60
+	TWAPPruningKeepPeriod = EpochDuration / 4
 )
 
 var (
@@ -245,6 +249,11 @@ func initGenesis(chain *internalChain, votingPeriod, expeditedVotingPeriod time.
 		return err
 	}
 
+	err = updateModuleGenesis(appGenState, twaptypes.ModuleName, &twaptypes.GenesisState{}, updateTWAPGenesis)
+	if err != nil {
+		return err
+	}
+
 	err = updateModuleGenesis(appGenState, crisistypes.ModuleName, &crisistypes.GenesisState{}, updateCrisisGenesis)
 	if err != nil {
 		return err
@@ -353,6 +362,11 @@ func updateEpochGenesis(epochGenState *epochtypes.GenesisState) {
 		// override day epochs which are in default integrations, to be 1min
 		epochtypes.NewGenesisEpochInfo("day", time.Second*60),
 	}
+}
+
+func updateTWAPGenesis(twapGenState *twaptypes.GenesisState) {
+	// Lower keep period from defaults to allos us to test pruning.
+	twapGenState.Params.RecordHistoryKeepPeriod = time.Second * 15
 }
 
 func updateCrisisGenesis(crisisGenState *crisistypes.GenesisState) {

--- a/tests/mocks/mock_pool.go
+++ b/tests/mocks/mock_pool.go
@@ -65,6 +65,22 @@ func (mr *MockPoolIMockRecorder) CalcInAmtGivenOut(ctx, tokenOut, tokenInDenom, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcInAmtGivenOut", reflect.TypeOf((*MockPoolI)(nil).CalcInAmtGivenOut), ctx, tokenOut, tokenInDenom, swapFee)
 }
 
+// CalcJoinPoolNoSwapShares mocks base method.
+func (m *MockPoolI) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, swapFee types.Dec) (types.Int, types.Coins, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, swapFee)
+	ret0, _ := ret[0].(types.Int)
+	ret1, _ := ret[1].(types.Coins)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CalcJoinPoolNoSwapShares indicates an expected call of CalcJoinPoolNoSwapShares.
+func (mr *MockPoolIMockRecorder) CalcJoinPoolNoSwapShares(ctx, tokensIn, swapFee interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcJoinPoolNoSwapShares", reflect.TypeOf((*MockPoolI)(nil).CalcJoinPoolNoSwapShares), ctx, tokensIn, swapFee)
+}
+
 // CalcJoinPoolShares mocks base method.
 func (m *MockPoolI) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, swapFee types.Dec) (types.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
@@ -224,6 +240,21 @@ func (mr *MockPoolIMockRecorder) JoinPool(ctx, tokensIn, swapFee interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinPool", reflect.TypeOf((*MockPoolI)(nil).JoinPool), ctx, tokensIn, swapFee)
 }
 
+// JoinPoolNoSwap mocks base method.
+func (m *MockPoolI) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, swapFee types.Dec) (types.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, swapFee)
+	ret0, _ := ret[0].(types.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// JoinPoolNoSwap indicates an expected call of JoinPoolNoSwap.
+func (mr *MockPoolIMockRecorder) JoinPoolNoSwap(ctx, tokensIn, swapFee interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinPoolNoSwap", reflect.TypeOf((*MockPoolI)(nil).JoinPoolNoSwap), ctx, tokensIn, swapFee)
+}
+
 // PokePool mocks base method.
 func (m *MockPoolI) PokePool(blockTime time.Time) {
 	m.ctrl.T.Helper()
@@ -370,6 +401,22 @@ func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenO
 func (mr *MockPoolAmountOutExtensionMockRecorder) CalcInAmtGivenOut(ctx, tokenOut, tokenInDenom, swapFee interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcInAmtGivenOut", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).CalcInAmtGivenOut), ctx, tokenOut, tokenInDenom, swapFee)
+}
+
+// CalcJoinPoolNoSwapShares mocks base method.
+func (m *MockPoolAmountOutExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, swapFee types.Dec) (types.Int, types.Coins, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, swapFee)
+	ret0, _ := ret[0].(types.Int)
+	ret1, _ := ret[1].(types.Coins)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CalcJoinPoolNoSwapShares indicates an expected call of CalcJoinPoolNoSwapShares.
+func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolNoSwapShares(ctx, tokensIn, swapFee interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcJoinPoolNoSwapShares", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).CalcJoinPoolNoSwapShares), ctx, tokensIn, swapFee)
 }
 
 // CalcJoinPoolShares mocks base method.
@@ -571,6 +618,21 @@ func (m *MockPoolAmountOutExtension) JoinPool(ctx types.Context, tokensIn types.
 func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPool(ctx, tokensIn, swapFee interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinPool", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).JoinPool), ctx, tokensIn, swapFee)
+}
+
+// JoinPoolNoSwap mocks base method.
+func (m *MockPoolAmountOutExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, swapFee types.Dec) (types.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, swapFee)
+	ret0, _ := ret[0].(types.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// JoinPoolNoSwap indicates an expected call of JoinPoolNoSwap.
+func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPoolNoSwap(ctx, tokensIn, swapFee interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinPoolNoSwap", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).JoinPoolNoSwap), ctx, tokensIn, swapFee)
 }
 
 // JoinPoolTokenInMaxShareAmountOut mocks base method.

--- a/x/epochs/keeper/grpc_query.go
+++ b/x/epochs/keeper/grpc_query.go
@@ -38,6 +38,9 @@ func (q Querier) CurrentEpoch(c context.Context, req *types.QueryCurrentEpochReq
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
+	if req.Identifier == "" {
+		return nil, status.Error(codes.InvalidArgument, "identifier is empty")
+	}
 
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -572,7 +572,7 @@ func NewBuildSwapExactAmountInMsg(clientCtx client.Context, tokenInStr, tokenOut
 
 	tokenOutMinAmt, ok := sdk.NewIntFromString(tokenOutMinAmtStr)
 	if !ok {
-		return txf, nil, errors.New("invalid token out min amount")
+		return txf, nil, fmt.Errorf("invalid token out min amount, %s", tokenOutMinAmtStr)
 	}
 	msg := &types.MsgSwapExactAmountIn{
 		Sender:            clientCtx.GetFromAddress().String(),

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -236,7 +236,7 @@ func (k Keeper) JoinPoolNoSwap(
 		}
 	}
 
-	sharesOut, err = pool.JoinPool(ctx, neededLpLiquidity, pool.GetSwapFee(ctx))
+	sharesOut, err = pool.JoinPoolNoSwap(ctx, neededLpLiquidity, pool.GetSwapFee(ctx))
 	if err != nil {
 		return nil, sdk.ZeroInt(), err
 	}

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -228,3 +228,15 @@ func calcPoolSharesInGivenSingleAssetOut(
 	sharesInFeeIncluded := sharesIn.Quo(sdk.OneDec().Sub(exitFee))
 	return sharesInFeeIncluded
 }
+
+// ensureDenomInPool check to make sure the input denoms exist in the provided pool asset map
+func ensureDenomInPool(poolAssetsByDenom map[string]PoolAsset, tokensIn sdk.Coins) error {
+	for _, coin := range tokensIn {
+		_, ok := poolAssetsByDenom[coin.Denom]
+		if !ok {
+			return sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, invalidInputDenomsErrFormat, coin.Denom)
+		}
+	}
+
+	return nil
+}

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/internal/test_helpers"
+  "github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )
 
 type BalancerTestSuite struct {
@@ -53,5 +54,50 @@ func TestBalancerPoolParams(t *testing.T) {
 		} else {
 			require.NoError(t, err, "unexpected error, tc %v", i)
 		}
+	}
+}
+
+func (suite *KeeperTestSuite) TestEnsureDenomInPool() {
+	tests := map[string]struct {
+		poolAssets  []balancer.PoolAsset
+		tokensIn    sdk.Coins
+		expectPass  bool
+		expectedErr error
+	}{
+		"all of tokensIn is in pool asset map": {
+			poolAssets:  []balancer.PoolAsset{defaultOsmoPoolAsset, defaultAtomPoolAsset},
+			tokensIn:    sdk.NewCoins(sdk.NewCoin("uatom", sdk.OneInt())),
+			expectPass:  true,
+			expectedErr: nil,
+		},
+		"one of tokensIn is in pool asset map": {
+			poolAssets:  []balancer.PoolAsset{defaultOsmoPoolAsset, defaultAtomPoolAsset},
+			tokensIn:    sdk.NewCoins(sdk.NewCoin("uatom", sdk.OneInt()), sdk.NewCoin("foo", sdk.OneInt())),
+			expectPass:  false,
+			expectedErr: types.ErrDenomNotFoundInPool,
+		},
+		"none of tokensIn is in pool asset map": {
+			poolAssets:  []balancer.PoolAsset{defaultOsmoPoolAsset, defaultAtomPoolAsset},
+			tokensIn:    sdk.NewCoins(sdk.NewCoin("foo", sdk.OneInt())),
+			expectPass:  false,
+			expectedErr: types.ErrDenomNotFoundInPool,
+		},
+	}
+
+	for name, tc := range tests {
+		suite.Run(name, func() {
+			suite.SetupTest()
+
+			poolAssetsByDenom, err := balancer.GetPoolAssetsByDenom(tc.poolAssets)
+			suite.Require().NoError(err, "test: %s", name)
+
+			err = balancer.EnsureDenomInPool(poolAssetsByDenom, tc.tokensIn)
+
+			if tc.expectPass {
+				suite.Require().NoError(err, "test: %s", name)
+			} else {
+				suite.Require().ErrorIs(err, tc.expectedErr, "test: %s", name)
+			}
+		})
 	}
 }

--- a/x/gamm/pool-models/balancer/export_test.go
+++ b/x/gamm/pool-models/balancer/export_test.go
@@ -15,6 +15,7 @@ var (
 	UpdateIntermediaryPoolAssetsLiquidity = updateIntermediaryPoolAssetsLiquidity
 
 	GetPoolAssetsByDenom = getPoolAssetsByDenom
+	EnsureDenomInPool    = ensureDenomInPool
 )
 
 func (p *Pool) CalcSingleAssetJoin(tokenIn sdk.Coin, swapFee sdk.Dec, tokenInPoolAsset PoolAsset, totalShares sdk.Int) (numShares sdk.Int, err error) {

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -790,6 +790,28 @@ func (suite *KeeperTestSuite) TestCalcJoinPoolShares() {
 			),
 			expectShares: sdk.NewInt(100_000_000),
 		},
+		{
+			// Input assets do not exist in pool
+			// P_issued = 1e20 * 1e-12 = 1e8
+			name:    "attempt join with denoms not in pool",
+			swapFee: sdk.MustNewDecFromStr("0"),
+			poolAssets: []balancer.PoolAsset{
+				{
+					Token:  sdk.NewInt64Coin("uosmo", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+				{
+					Token:  sdk.NewInt64Coin("uatom", 1_000_000_000_000),
+					Weight: sdk.NewInt(100),
+				},
+			},
+			tokensIn: sdk.NewCoins(
+				sdk.NewInt64Coin("foo", 1),
+				sdk.NewInt64Coin("baz", 1),
+			),
+			expectShares: sdk.NewInt(0),
+			expErr:       types.ErrDenomNotFoundInPool,
+		},
 	}
 	testCases = append(testCases, calcSingleAssetJoinTestCases...)
 

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -258,9 +258,19 @@ func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee s
 	return pCopy.joinPoolSharesInternal(ctx, tokensIn, swapFee)
 }
 
+// TODO: implement this
+func (p *Pool) CalcJoinPoolNoSwapShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error) {
+	return sdk.ZeroInt(), nil, err
+}
+
 func (p *Pool) JoinPool(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, err error) {
 	numShares, _, err = p.joinPoolSharesInternal(ctx, tokensIn, swapFee)
 	return numShares, err
+}
+
+// TODO: implement this
+func (p *Pool) JoinPoolNoSwap(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, err error) {
+	return sdk.ZeroInt(), err
 }
 
 func (p *Pool) ExitPool(ctx sdk.Context, exitingShares sdk.Int, exitFee sdk.Dec) (exitingCoins sdk.Coins, err error) {

--- a/x/gamm/types/pool.go
+++ b/x/gamm/types/pool.go
@@ -59,9 +59,18 @@ type PoolI interface {
 	// Pools are expected to guarantee LP'ing at the exact ratio, and single sided LP'ing.
 	JoinPool(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, err error)
 
+	// JoinPoolNoSwap joins the pool with an all-asset join using the maximum amount possible given the tokensIn provided.
+	// This function is mutative and updates the pool's internal state if there is no error.
+	// Pools are expected to guarantee LP'ing at the exact ratio.
+	JoinPoolNoSwap(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, err error)
+
 	// CalcJoinPoolShares returns how many LP shares JoinPool would return on these arguments.
 	// This does not mutate the pool, or state.
 	CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error)
+
+	// CalcJoinPoolNoSwapShares returns how many LP shares JoinPoolNoSwap would return on these arguments.
+	// This does not mutate the pool, or state.
+	CalcJoinPoolNoSwapShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error)
 
 	// ExitPool exits #numShares LP shares from the pool, decreases its internal liquidity & LP share totals,
 	// and returns the number of coins that are being returned.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR removes IBC rate-limiting tests from our github workflow as IBC rate-limiting code was removed from the v12 branch so these tests are causing backports to fail

## Brief Changelog

- Remove ibc rate-limiting tests from workflow

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)