### PR TITLE
Remove ibc rate limiting tests from gh workflow

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -2,13 +2,12 @@ name: Cosmwasm Contracts
 on:
   pull_request:
     branches:
-      - "**"
+      - '**'
   push:
     branches:
-      - "main"
-      - "v[0-9]**"
+      - 'main'
+      - 'v[0-9]**'
   workflow_dispatch:
-
 
 jobs:
   test:
@@ -16,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        contract: [{workdir: ./x/ibc-rate-limit/, output: testdata/rate_limiter.wasm, build: artifacts/rate_limiter-x86_64.wasm, name: rate_limiter}]
+        contract: []
 
     steps:
       - name: Checkout sources
@@ -38,7 +37,6 @@ jobs:
         working-directory: ${{ matrix.contract.workdir }}
         run: >
           rustup target add wasm32-unknown-unknown;
-
 
       - name: Build
         working-directory: ${{ matrix.contract.workdir }}
@@ -82,12 +80,11 @@ jobs:
           path: ${{ matrix.contract.workdir }}${{ matrix.contract.build }}
           retention-days: 1
 
-#      - name: Check Test Data
-#        working-directory: ${{ matrix.contract.workdir }}
-#        if: ${{ matrix.contract.output != null }}
-#        run: >
-#          diff ${{ matrix.contract.output }} ${{ matrix.contract.build }}
-  
+  #      - name: Check Test Data
+  #        working-directory: ${{ matrix.contract.workdir }}
+  #        if: ${{ matrix.contract.output != null }}
+  #        run: >
+  #          diff ${{ matrix.contract.output }} ${{ matrix.contract.build }}
 
   lints:
     name: Cosmwasm Lints
@@ -120,4 +117,3 @@ jobs:
         working-directory: ${{ matrix.workdir }}
         run: >
           cargo clippy -- -D warnings
-


### PR DESCRIPTION
## What is the purpose of the change

This PR removes IBC rate-limiting tests from our github workflow as IBC rate-limiting code was removed from the v12 branch so these tests are causing backports to fail

## Brief Changelog

- Remove ibc rate-limiting tests from workflow

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)