### PR TITLE
TWAP: Simplify historical pool index

### DIFF
--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -32,14 +32,14 @@ const (
 )
 
 var (
-	oneA = []string{prefixOne + keyA}
-	oneAB = []string{prefixOne + keyA, prefixOne + keyB}
-	twoAB = []string{prefixTwo + keyA, prefixTwo + keyB}
-	oneABC = []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC}
-	oneBCA = []string{prefixOne + keyB, prefixOne + keyC, prefixOne + keyA}
-	oneABtwoAB = []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB}
-	oneBtwoAoneAtwoB = []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB}
-	oneAtwoAoneBtwoB = []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB}
+	oneA                 = []string{prefixOne + keyA}
+	oneAB                = []string{prefixOne + keyA, prefixOne + keyB}
+	twoAB                = []string{prefixTwo + keyA, prefixTwo + keyB}
+	oneABC               = []string{prefixOne + keyA, prefixOne + keyB, prefixOne + keyC}
+	oneBCA               = []string{prefixOne + keyB, prefixOne + keyC, prefixOne + keyA}
+	oneABtwoAB           = []string{prefixOne + keyA, prefixOne + keyB, prefixTwo + keyA, prefixTwo + keyB}
+	oneBtwoAoneAtwoB     = []string{prefixOne + keyB, prefixTwo + keyA, prefixOne + keyA, prefixTwo + keyB}
+	oneAtwoAoneBtwoB     = []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB}
 	onetwoABCalternating = []string{prefixOne + keyA, prefixTwo + keyA, prefixOne + keyB, prefixTwo + keyB, prefixOne + keyC, prefixTwo + keyC}
 )
 
@@ -71,11 +71,11 @@ func mockStop(b []byte) bool {
 func (s *TestSuite) TestGatherAllKeysFromStore() {
 
 	testcases := map[string]struct {
-		preSetKeys []string
+		preSetKeys     []string
 		expectedValues []string
 	}{
 		"multiple keys in lexicographic order": {
-			preSetKeys: oneABC,
+			preSetKeys:     oneABC,
 			expectedValues: oneABC,
 		},
 		"multiple keys out of lexicographic order": {
@@ -84,7 +84,7 @@ func (s *TestSuite) TestGatherAllKeysFromStore() {
 			expectedValues: oneABC,
 		},
 		"no keys": {
-			preSetKeys: []string{},
+			preSetKeys:     []string{},
 			expectedValues: []string{},
 		},
 	}
@@ -111,7 +111,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 		keyEnd     []byte
 		parseFn    func(b []byte) (string, error)
 
-		expectedErr 	   error
+		expectedErr    error
 		expectedValues []string
 	}{
 		"common prefix, exclude end": {
@@ -119,7 +119,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyB),
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{"0"},
 		},
@@ -128,16 +128,16 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyC),
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefix, inserted in lexicographic order": {
 			preSetKeys: oneABtwoAB,
-			
+
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixTwo + keyA),
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{"0", "1"},
 		},
@@ -146,7 +146,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixTwo + keyA),
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			// should get all prefixOne values as keys are stored in ascending lexicographic order
 			expectedValues: []string{"0", "2"},
@@ -156,7 +156,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyA),
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{},
 		},
@@ -165,7 +165,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyB),
 			keyEnd:   []byte(prefixOne + keyA),
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{},
 		},
@@ -174,7 +174,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: nil,
 			keyEnd:   nil,
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{"0", "1", "2"},
 		},
@@ -186,7 +186,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyB),
 			keyEnd:   []byte{0xff},
-			parseFn: mockParseValue,
+			parseFn:  mockParseValue,
 
 			expectedValues: []string{"1", "2"},
 		},
@@ -195,7 +195,7 @@ func (s *TestSuite) TestGatherValuesFromStore() {
 
 			keyStart: []byte(prefixOne + keyA),
 			keyEnd:   []byte(prefixOne + keyC),
-			parseFn: mockParseValueWithError,
+			parseFn:  mockParseValueWithError,
 
 			expectedErr: errors.New("mock error"),
 		},
@@ -229,12 +229,12 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 		preSetKeys []string
 		parseFn    func(b []byte) (string, error)
 
-		expectedErr 	   error
+		expectedErr    error
 		expectedValues []string
 	}{
 		"common prefix": {
 			preSetKeys: oneABC,
-			prefix: []byte(prefixOne),
+			prefix:     []byte(prefixOne),
 
 			parseFn: mockParseValue,
 
@@ -242,51 +242,51 @@ func (s *TestSuite) TestGatherValuesFromStorePrefix() {
 		},
 		"different prefixes in order, prefix one requested": {
 			preSetKeys: oneABtwoAB,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			expectedValues: []string{"0", "1"},
 		},
 		"different prefixes in order, prefix two requested": {
 			preSetKeys: oneABtwoAB,
-			prefix: []byte(prefixTwo),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixTwo),
+			parseFn:    mockParseValue,
 
 			expectedValues: []string{"2", "3"},
 		},
 		"different prefixes out of order, prefix one requested": {
 			preSetKeys: oneBtwoAoneAtwoB,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			// we expect the prefixOne values in ascending lexicographic order
 			expectedValues: []string{"2", "0"},
 		},
 		"different prefixes out of order, prefix two requested": {
 			preSetKeys: oneBtwoAoneAtwoB,
-			prefix: []byte(prefixTwo),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixTwo),
+			parseFn:    mockParseValue,
 
 			expectedValues: []string{"1", "3"},
 		},
 		"prefix doesn't exist, no keys": {
 			preSetKeys: []string{},
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			expectedValues: []string{},
 		},
 		"prefix doesn't exist, only keys with another prefix": {
 			preSetKeys: twoAB,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			expectedValues: []string{},
 		},
 		"parse with error": {
 			preSetKeys: oneABC,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValueWithError,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValueWithError,
 
 			expectedErr: errors.New("mock error"),
 		},
@@ -321,12 +321,12 @@ func (s *TestSuite) TestGetFirstValueAfterPrefixInclusive() {
 		preSetKeys []string
 		parseFn    func(b []byte) (string, error)
 
-		expectedErr 	   error
+		expectedErr    error
 		expectedValues string
 	}{
 		"common prefix": {
 			preSetKeys: oneABC,
-			prefix: []byte(prefixOne),
+			prefix:     []byte(prefixOne),
 
 			parseFn: mockParseValue,
 
@@ -334,37 +334,37 @@ func (s *TestSuite) TestGetFirstValueAfterPrefixInclusive() {
 		},
 		"different prefixes in order, prefix one requested": {
 			preSetKeys: oneABtwoAB,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			expectedValues: "0",
 		},
 		"different prefixes in order, prefix two requested": {
 			preSetKeys: oneABtwoAB,
-			prefix: []byte(prefixTwo),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixTwo),
+			parseFn:    mockParseValue,
 
 			expectedValues: "2",
 		},
 		"different prefixes out of order, prefix one requested": {
 			preSetKeys: oneBtwoAoneAtwoB,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			// we expect the prefixOne values in ascending lexicographic order
 			expectedValues: "2",
 		},
 		"different prefixes out of order, prefix two requested": {
 			preSetKeys: oneBtwoAoneAtwoB,
-			prefix: []byte(prefixTwo),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixTwo),
+			parseFn:    mockParseValue,
 
 			expectedValues: "1",
 		},
 		"prefix doesn't exist, start key lexicographically before existing keys": {
 			preSetKeys: twoAB,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
 			// we expect the first value after the prefix, which is the value associated with the first valid key
 			expectedValues: "0",
@@ -373,26 +373,26 @@ func (s *TestSuite) TestGetFirstValueAfterPrefixInclusive() {
 		// error catching
 		"prefix doesn't exist, no keys": {
 			preSetKeys: []string{},
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValue,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValue,
 
-			expectedErr: errors.New("No values in iterator"),
+			expectedErr:    errors.New("No values in range"),
 			expectedValues: "",
 		},
 		"prefix doesn't exist, start key lexicographically after existing keys": {
 			preSetKeys: twoAB,
-			prefix: []byte{0xff},
-			parseFn: mockParseValue,
+			prefix:     []byte{0xff},
+			parseFn:    mockParseValue,
 
-			expectedErr: errors.New("No values in iterator"),
+			expectedErr:    errors.New("No values in range"),
 			expectedValues: "",
 		},
 		"parse with error": {
 			preSetKeys: oneABC,
-			prefix: []byte(prefixOne),
-			parseFn: mockParseValueWithError,
+			prefix:     []byte(prefixOne),
+			parseFn:    mockParseValueWithError,
 
-			expectedErr: errors.New("mock error"),
+			expectedErr:    errors.New("mock error"),
 			expectedValues: "",
 		},
 	}
@@ -554,7 +554,7 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 		preSetKeys []string
 		keyStart   []byte
 		keyEnd     []byte
-		parseFn    func(b []byte)(string, error)
+		parseFn    func(b []byte) (string, error)
 		stopFn     func(b []byte) bool
 		isReverse  bool
 
@@ -563,73 +563,73 @@ func (s *TestSuite) TestGetIterValuesWithStop() {
 	}{
 		"prefix iterator, no stop but exclusive key end": {
 			preSetKeys: oneABC,
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte(prefixOne + keyC),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
-			isReverse: false,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte(prefixOne + keyC),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
+			isReverse:  false,
 
 			expectedValues: []string{"0", "1"},
 		},
 		"prefix iterator, no stop and inclusive key end": {
 			preSetKeys: oneAB,
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte(prefixOne + keyC),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
-			isReverse: false,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte(prefixOne + keyC),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
+			isReverse:  false,
 
 			expectedValues: []string{"0", "1"},
 		},
 		"prefix iterator, with stop before end key": {
 			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + mockStopValue + keyA},
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte(prefixOne + keyC),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
-			isReverse: false,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte(prefixOne + keyC),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
+			isReverse:  false,
 
 			expectedValues: []string{"0"},
 		},
 		"prefix iterator, with end key before stop": {
 			preSetKeys: []string{prefixOne + keyA, prefixOne + keyB, prefixOne + mockStopValue},
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte(prefixOne + keyB),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
-			isReverse: false,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte(prefixOne + keyB),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
+			isReverse:  false,
 
 			expectedValues: []string{"0"},
 		},
 		"prefix iterator, with stop, different insertion order": {
 			// keyB is lexicographically before mockStopValue so we expect it to be returned before we hit the stopper
 			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + keyB, prefixOne + mockStopValue + keyA},
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte{0xff},
-			parseFn: mockParseValue,
-			stopFn: mockStop,
-			isReverse: false,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte{0xff},
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
+			isReverse:  false,
 
 			expectedValues: []string{"0", "2"},
 		},
 		"prefix iterator with stop, different insertion order, and reversed iterator": {
 			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + keyB, prefixOne + mockStopValue + keyA},
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte{0xff},
-			parseFn: mockParseValue,
-			stopFn: mockStop,
-			isReverse: true,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte{0xff},
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
+			isReverse:  true,
 
 			// only the last value in our preSetKeys should be on the other end of the stopper
 			expectedValues: []string{"3"},
 		},
 		"parse with error": {
 			preSetKeys: oneABC,
-			keyStart: []byte(prefixOne + keyA),
-			keyEnd:   []byte{0xff},
-			parseFn: mockParseValueWithError,
-			stopFn:  mockStop,
-			isReverse: false,
+			keyStart:   []byte(prefixOne + keyA),
+			keyEnd:     []byte{0xff},
+			parseFn:    mockParseValueWithError,
+			stopFn:     mockStop,
+			isReverse:  false,
 
 			expectedErr: errors.New("mock error"),
 		},
@@ -663,7 +663,7 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 	testcases := map[string]struct {
 		preSetKeys []string
 		keyStart   []byte
-		parseFn    func(b []byte)(string, error)
+		parseFn    func(b []byte) (string, error)
 		stopFn     func(b []byte) bool
 
 		expectedValues []string
@@ -671,34 +671,34 @@ func (s *TestSuite) TestGetValuesUntilDerivedStop() {
 	}{
 		"prefix iterator, no stop": {
 			preSetKeys: oneABC,
-			keyStart: []byte(prefixOne + keyA),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
+			keyStart:   []byte(prefixOne + keyA),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
 
 			expectedValues: []string{"0", "1", "2"},
 		},
 		"prefix iterator, with stop": {
 			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + mockStopValue + keyA},
-			keyStart: []byte(prefixOne + keyA),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
+			keyStart:   []byte(prefixOne + keyA),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
 
 			expectedValues: []string{"0"},
 		},
 		"prefix iterator, with stop & different insertion order": {
 			// keyB is lexicographically before mockStopValue so we expect it to be returned before we hit the stopper
 			preSetKeys: []string{prefixOne + keyA, prefixOne + mockStopValue, prefixOne + keyB, prefixOne + mockStopValue + keyA},
-			keyStart: []byte(prefixOne + keyA),
-			parseFn: mockParseValue,
-			stopFn: mockStop,
+			keyStart:   []byte(prefixOne + keyA),
+			parseFn:    mockParseValue,
+			stopFn:     mockStop,
 
 			expectedValues: []string{"0", "2"},
 		},
 		"parse with error": {
 			preSetKeys: oneABC,
-			keyStart: []byte(prefixOne + keyA),
-			parseFn: mockParseValueWithError,
-			stopFn:  mockStop,
+			keyStart:   []byte(prefixOne + keyA),
+			parseFn:    mockParseValueWithError,
+			stopFn:     mockStop,
 
 			expectedErr: errors.New("mock error"),
 		},

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -2,7 +2,6 @@ package twap_test
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -75,9 +74,7 @@ func (s *TestSuite) TestGetBeginBlockAccumulatorRecord() {
 			actualRecord, err := s.twapkeeper.GetBeginBlockAccumulatorRecord(s.Ctx, tc.poolId, tc.baseDenom, tc.quoteDenom)
 
 			if tc.expError != nil {
-				if !strings.Contains(err.Error(), tc.expError.Error()) {
-					s.Require().Equal(tc.expError, err)
-				}
+				s.Require().ErrorContains(err, fmt.Sprintf("%s", tc.expError))
 				return
 			}
 

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -2,6 +2,7 @@ package twap_test
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -74,7 +75,9 @@ func (s *TestSuite) TestGetBeginBlockAccumulatorRecord() {
 			actualRecord, err := s.twapkeeper.GetBeginBlockAccumulatorRecord(s.Ctx, tc.poolId, tc.baseDenom, tc.quoteDenom)
 
 			if tc.expError != nil {
-				s.Require().Equal(tc.expError, err)
+				if !strings.Contains(err.Error(), tc.expError.Error()) {
+					s.Require().Equal(tc.expError, err)
+				}
 				return
 			}
 

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 type (
-	TwapNotFoundError = twapNotFoundError
-	TimeTooOldError   = timeTooOldError
+	TimeTooOldError = timeTooOldError
 )
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -21,16 +21,6 @@ func (e timeTooOldError) Error() string {
 		" Try storing the accumulator value. (requested time %s)", e.Time)
 }
 
-type twapNotFoundError struct {
-	Asset0Denom string
-	Asset1Denom string
-}
-
-func (e twapNotFoundError) Error() string {
-	return fmt.Sprintf("TWAP not found, but there are other twaps available for this time."+
-		" Please make sure tha asset0denom and asset1denom (%s, %s) are correct, and in order (asset0 > asset1)?", e.Asset0Denom, e.Asset1Denom)
-}
-
 // trackChangedPool places an entry into a transient store,
 // to track that this pool changed this block.
 // This tracking is for use in EndBlock, to create new TWAP records.
@@ -64,7 +54,7 @@ func (k Keeper) getChangedPools(ctx sdk.Context) []uint64 {
 func (k Keeper) storeHistoricalTWAP(ctx sdk.Context, twap types.TwapRecord) {
 	store := ctx.KVStore(k.storeKey)
 	key1 := types.FormatHistoricalTimeIndexTWAPKey(twap.Time, twap.PoolId, twap.Asset0Denom, twap.Asset1Denom)
-	key2 := types.FormatHistoricalPoolIndexTWAPKey(twap.PoolId, twap.Time, twap.Asset0Denom, twap.Asset1Denom)
+	key2 := types.FormatHistoricalPoolIndexTWAPKey(twap.PoolId, twap.Asset0Denom, twap.Asset1Denom, twap.Time)
 	osmoutils.MustSet(store, key1, &twap)
 	osmoutils.MustSet(store, key2, &twap)
 }
@@ -109,7 +99,7 @@ func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime ti
 func (k Keeper) deleteHistoricalRecord(ctx sdk.Context, twap types.TwapRecord) {
 	store := ctx.KVStore(k.storeKey)
 	key1 := types.FormatHistoricalTimeIndexTWAPKey(twap.Time, twap.PoolId, twap.Asset0Denom, twap.Asset1Denom)
-	key2 := types.FormatHistoricalPoolIndexTWAPKey(twap.PoolId, twap.Time, twap.Asset0Denom, twap.Asset1Denom)
+	key2 := types.FormatHistoricalPoolIndexTWAPKey(twap.PoolId, twap.Asset0Denom, twap.Asset1Denom, twap.Time)
 	store.Delete(key1)
 	store.Delete(key2)
 }
@@ -127,7 +117,12 @@ func (k Keeper) getMostRecentRecordStoreRepresentation(ctx sdk.Context, poolId u
 	store := ctx.KVStore(k.storeKey)
 	key := types.FormatMostRecentTWAPKey(poolId, asset0Denom, asset1Denom)
 	bz := store.Get(key)
-	return types.ParseTwapFromBz(bz)
+	twap, err := types.ParseTwapFromBz(bz)
+	if err != nil {
+		err = fmt.Errorf("error in get most recent twap, likely that asset 0 or asset 1 were wrong: %s %s."+
+			" Underlying error: %w", asset0Denom, asset1Denom, err)
+	}
+	return twap, err
 }
 
 // getAllMostRecentRecordsForPool returns all most recent twap records
@@ -173,40 +168,26 @@ func (k Keeper) getRecordAtOrBeforeTime(ctx sdk.Context, poolId uint64, t time.T
 		return types.TwapRecord{}, err
 	}
 	store := ctx.KVStore(k.storeKey)
-	// We make an iteration from time=t + 1ns, to time=0 for this pool.
-	// Note that we cannot get any time entries from t + 1ns, as the key would be `prefix|t+1ns`
-	// and the end for a reverse iterator is exclusive. Thus the largest key that can be returned
-	// begins with a prefix of `prefix|t`
-	startKey := types.FormatHistoricalPoolIndexTimePrefix(poolId, time.Unix(0, 0))
-	endKey := types.FormatHistoricalPoolIndexTimePrefix(poolId, t.Add(time.Nanosecond))
-	lastParsedTime := time.Time{}
-	stopFn := func(key []byte) bool {
-		// halt iteration if we can't parse the time, or we've successfully parsed
-		// a time, and have iterated beyond records for that time.
-		parsedTime, err := types.ParseTimeFromHistoricalPoolIndexKey(key)
-		if err != nil {
-			return true
-		}
-		if lastParsedTime.After(parsedTime) {
-			return true
-		}
-		lastParsedTime = parsedTime
-		return false
-	}
-
+	// We make an iteration from time=t, to time=0 for this pool.
+	startKey := types.FormatHistoricalPoolIndexTimePrefix(poolId, asset0Denom, asset1Denom)
+	endKey := types.FormatHistoricalPoolIndexTimeSuffix(poolId, asset0Denom, asset1Denom, t)
 	reverseIterate := true
-	twaps, err := osmoutils.GetIterValuesWithStop(store, startKey, endKey, reverseIterate, stopFn, types.ParseTwapFromBz)
-	if err != nil {
-		return types.TwapRecord{}, err
-	}
-	if len(twaps) == 0 {
-		return types.TwapRecord{}, timeTooOldError{Time: t}
-	}
 
-	for _, twap := range twaps {
-		if twap.Asset0Denom == asset0Denom && twap.Asset1Denom == asset1Denom {
-			return twap, nil
+	twap, err := osmoutils.GetFirstValueInRange(store, startKey, endKey, reverseIterate, types.ParseTwapFromBz)
+	if err != nil {
+		// diagnose why we have no results by seeing what happens for getMostRecentRecord for this pool id
+		_, errDiagnose := k.getMostRecentRecord(ctx, poolId, asset0Denom, asset1Denom)
+		if errDiagnose != nil {
+			return types.TwapRecord{}, fmt.Errorf(
+				"getTwapRecord: querying for assets %s %s that are not in pool id %d",
+				asset0Denom, asset1Denom, poolId)
+		} else {
+			return types.TwapRecord{}, timeTooOldError{Time: t}
 		}
 	}
-	return types.TwapRecord{}, twapNotFoundError{Asset0Denom: asset0Denom, Asset1Denom: asset1Denom}
+	if twap.Asset0Denom != asset0Denom || twap.Asset1Denom != asset1Denom || twap.PoolId != poolId {
+		return types.TwapRecord{}, fmt.Errorf("internal error, got twap but its data is wrong")
+	}
+
+	return twap, nil
 }

--- a/x/twap/store_test.go
+++ b/x/twap/store_test.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/osmosis-labs/osmosis/v12/x/twap"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v12/x/twap"
 
 	gammtypes "github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v12/x/twap/types"
@@ -147,7 +148,9 @@ func (s *TestSuite) TestGetRecordAtOrBeforeTime() {
 		expectedRecord types.TwapRecord
 		expErr         error
 	}{
-		"no entries":            {[]types.TwapRecord{}, defaultInputAt(baseTime), baseRecord, twap.TimeTooOldError{Time: baseTime}},
+		"no entries": {[]types.TwapRecord{}, defaultInputAt(baseTime), baseRecord, fmt.Errorf(
+			"getTwapRecord: querying for assets %s %s that are not in pool id %d",
+			baseRecord.Asset0Denom, baseRecord.Asset1Denom, 1)},
 		"get at latest (exact)": {[]types.TwapRecord{baseRecord}, defaultInputAt(baseTime), baseRecord, nil},
 		"rev at latest (exact)": {[]types.TwapRecord{baseRecord}, defaultRevInputAt(baseTime), baseRecord, nil},
 
@@ -180,7 +183,9 @@ func (s *TestSuite) TestGetRecordAtOrBeforeTime() {
 
 		"non-existent pool ID": {
 			[]types.TwapRecord{tMin1Record, baseRecord, tPlus1Record},
-			wrongPoolIdInputAt(baseTime), baseRecord, twap.TimeTooOldError{Time: baseTime}},
+			wrongPoolIdInputAt(baseTime), baseRecord, fmt.Errorf(
+				"getTwapRecord: querying for assets %s %s that are not in pool id %d",
+				baseRecord.Asset0Denom, baseRecord.Asset1Denom, 2)},
 		"pool2 record get": {
 			recordsToSet:   []types.TwapRecord{newEmptyPriceRecord(2, baseTime, denom0, denom1)},
 			input:          wrongPoolIdInputAt(baseTime),

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -51,14 +51,19 @@ func FormatHistoricalTimeIndexTWAPKey(accumulatorWriteTime time.Time, poolId uin
 	return []byte(fmt.Sprintf("%s%s%s%d%s%s%s%s", HistoricalTWAPTimeIndexPrefix, timeS, KeySeparator, poolId, KeySeparator, denom1, KeySeparator, denom2))
 }
 
-func FormatHistoricalPoolIndexTWAPKey(poolId uint64, accumulatorWriteTime time.Time, denom1, denom2 string) []byte {
+func FormatHistoricalPoolIndexTWAPKey(poolId uint64, denom1, denom2 string, accumulatorWriteTime time.Time) []byte {
 	timeS := osmoutils.FormatTimeString(accumulatorWriteTime)
-	return []byte(fmt.Sprintf("%s%d%s%s%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, timeS, KeySeparator, denom1, KeySeparator, denom2))
+	return []byte(fmt.Sprintf("%s%d%s%s%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2, KeySeparator, timeS))
 }
 
-func FormatHistoricalPoolIndexTimePrefix(poolId uint64, accumulatorWriteTime time.Time) []byte {
+func FormatHistoricalPoolIndexTimePrefix(poolId uint64, denom1, denom2 string) []byte {
+	return []byte(fmt.Sprintf("%s%d%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, denom1, KeySeparator, denom2, KeySeparator))
+}
+
+func FormatHistoricalPoolIndexTimeSuffix(poolId uint64, denom1, denom2 string, accumulatorWriteTime time.Time) []byte {
 	timeS := osmoutils.FormatTimeString(accumulatorWriteTime)
-	return []byte(fmt.Sprintf("%s%d%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, timeS, KeySeparator))
+	// . acts as a suffix for lexicographical orderings
+	return []byte(fmt.Sprintf("%s%d%s%s%s%s%s%s.", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2, KeySeparator, timeS))
 }
 
 func ParseTimeFromHistoricalTimeIndexKey(key []byte) (time.Time, error) {
@@ -71,22 +76,6 @@ func ParseTimeFromHistoricalTimeIndexKey(key []byte) (time.Time, error) {
 		return time.Time{}, UnexpectedSeparatorError{ExpectedSeparator: historicalTWAPPoolIndexNoSeparator, ActualSeparator: s[0]}
 	}
 	t, err := osmoutils.ParseTimeString(s[1])
-	if err != nil {
-		return time.Time{}, TimeStringKeyFormatError{Key: keyS, Err: err}
-	}
-	return t, nil
-}
-
-func ParseTimeFromHistoricalPoolIndexKey(key []byte) (time.Time, error) {
-	keyS := string(key)
-	s := strings.Split(keyS, KeySeparator)
-	if len(s) != expectedKeySeparatedParts {
-		return time.Time{}, KeySeparatorLengthError{ExpectedLength: expectedKeySeparatedParts, ActualLength: len(s)}
-	}
-	if s[0] != historicalTWAPPoolIndexNoSeparator {
-		return time.Time{}, UnexpectedSeparatorError{ExpectedSeparator: historicalTWAPPoolIndexNoSeparator, ActualSeparator: s[0]}
-	}
-	t, err := osmoutils.ParseTimeString(s[2])
 	if err != nil {
 		return time.Time{}, TimeStringKeyFormatError{Key: keyS, Err: err}
 	}

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -27,7 +27,6 @@ var (
 	mostRecentTWAPsNoSeparator         = "recent_twap"
 	historicalTWAPTimeIndexNoSeparator = "historical_time_index"
 	historicalTWAPPoolIndexNoSeparator = "historical_pool_index"
-	expectedKeySeparatedParts          = 5
 
 	// format is just pool id | denom1 | denom2
 	// made for getting most recent key

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -57,7 +57,7 @@ func FormatHistoricalPoolIndexTWAPKey(poolId uint64, denom1, denom2 string, accu
 }
 
 func FormatHistoricalPoolIndexTimePrefix(poolId uint64, denom1, denom2 string) []byte {
-	return []byte(fmt.Sprintf("%s%d%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, denom1, KeySeparator, denom2, KeySeparator))
+	return []byte(fmt.Sprintf("%s%d%s%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2, KeySeparator))
 }
 
 func FormatHistoricalPoolIndexTimeSuffix(poolId uint64, denom1, denom2 string, accumulatorWriteTime time.Time) []byte {

--- a/x/twap/types/keys_test.go
+++ b/x/twap/types/keys_test.go
@@ -50,10 +50,6 @@ func TestFormatHistoricalTwapKeys(t *testing.T) {
 			require.Equal(t, tt.wantTimeIndex, string(gotTimeKey))
 			require.Equal(t, tt.wantPoolIndex, string(gotPoolKey))
 
-			parsedTime, err := ParseTimeFromHistoricalTimeIndexKey(gotTimeKey)
-			require.NoError(t, err)
-			require.Equal(t, tt.time, parsedTime)
-
 			poolIndexPrefix := FormatHistoricalPoolIndexTimePrefix(tt.poolId, tt.denom1, tt.denom2)
 			require.True(t, strings.HasPrefix(string(gotPoolKey), string(poolIndexPrefix)), string(gotPoolKey), string(poolIndexPrefix))
 

--- a/x/twap/types/keys_test.go
+++ b/x/twap/types/keys_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 	time "time"
 
@@ -41,24 +40,22 @@ func TestFormatHistoricalTwapKeys(t *testing.T) {
 		wantPoolIndex string
 		wantTimeIndex string
 	}{
-		"standard": {poolId: 1, time: baseTime, denom1: "B", denom2: "A", wantTimeIndex: "historical_time_index|2009-11-10T23:00:00.000000000|1|B|A", wantPoolIndex: "historical_pool_index|1|2009-11-10T23:00:00.000000000|B|A"},
+		"standard": {poolId: 1, time: baseTime, denom1: "B", denom2: "A", wantTimeIndex: "historical_time_index|2009-11-10T23:00:00.000000000|1|B|A", wantPoolIndex: "historical_pool_index|1|B|A|2009-11-10T23:00:00.000000000"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			gotTimeKey := FormatHistoricalTimeIndexTWAPKey(tt.time, tt.poolId, tt.denom1, tt.denom2)
-			gotPoolKey := FormatHistoricalPoolIndexTWAPKey(tt.poolId, tt.time, tt.denom1, tt.denom2)
+			gotPoolKey := FormatHistoricalPoolIndexTWAPKey(tt.poolId, tt.denom1, tt.denom2, tt.time)
 			require.Equal(t, tt.wantTimeIndex, string(gotTimeKey))
 			require.Equal(t, tt.wantPoolIndex, string(gotPoolKey))
 
 			parsedTime, err := ParseTimeFromHistoricalTimeIndexKey(gotTimeKey)
 			require.NoError(t, err)
 			require.Equal(t, tt.time, parsedTime)
-			parsedTime, err = ParseTimeFromHistoricalPoolIndexKey(gotPoolKey)
-			require.Equal(t, tt.time, parsedTime)
-			require.NoError(t, err)
 
-			poolIndexPrefix := FormatHistoricalPoolIndexTimePrefix(tt.poolId, tt.time)
-			require.True(t, strings.HasPrefix(string(gotPoolKey), string(poolIndexPrefix)))
+			// TODO: adjust
+			// poolIndexPrefix := FormatHistoricalPoolIndexTimePrefix(tt.poolId, tt.time)
+			// require.True(t, strings.HasPrefix(string(gotPoolKey), string(poolIndexPrefix)))
 		})
 	}
 }

--- a/x/twap/types/keys_test.go
+++ b/x/twap/types/keys_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"strings"
 	"testing"
 	time "time"
 
@@ -53,9 +54,11 @@ func TestFormatHistoricalTwapKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.time, parsedTime)
 
-			// TODO: adjust
-			// poolIndexPrefix := FormatHistoricalPoolIndexTimePrefix(tt.poolId, tt.time)
-			// require.True(t, strings.HasPrefix(string(gotPoolKey), string(poolIndexPrefix)))
+			poolIndexPrefix := FormatHistoricalPoolIndexTimePrefix(tt.poolId, tt.denom1, tt.denom2)
+			require.True(t, strings.HasPrefix(string(gotPoolKey), string(poolIndexPrefix)), string(gotPoolKey), string(poolIndexPrefix))
+
+			poolIndexSuffix := FormatHistoricalPoolIndexTimeSuffix(tt.poolId, tt.denom1, tt.denom2, tt.time)
+			require.True(t, strings.HasPrefix(string(poolIndexSuffix), string(gotPoolKey)))
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This is a minor performance improvement, but more importantly a complexity reduction for getting entries from the pool index. Do we want to go with this approach?

It came up on the TWAP review call. I am not sure that it is worth simplifying because:
* No known bug here
* Performance improvement isn't really a big deal (reduces gas usage of TWAPs, but should not be a huge deal)
* Removes +1ns hack (though we could also remove that via other means)

Depending on folks thoughts (cc @p0mvn @czarcas7ic @AlpinYukseloglu ), we should decide whether this is a helpful simplfiication or not.

## Brief Changelog

- Simplify method of getting records in all TWAP queries
- Improve gas efficiency for multi-asset pool TWAP queries (not a usecase we care about optimizing)

## Testing and Verifying

This change is already covered by existing tests (except key suffix), including the osmoutils package change.

I can add tests for that if we agree that this is worth doing at all.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)