### PR TITLE
Fix the multi_asset pool pruning bug

### DIFF
--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -87,7 +87,14 @@ func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime ti
 	iter := store.ReverseIterator([]byte(types.HistoricalTWAPTimeIndexPrefix), types.FormatHistoricalTimeIndexTWAPKey(lastKeptTime, 0, "", ""))
 	defer iter.Close()
 
-	seenPools := map[uint64]struct{}{}
+	// We mark what (pool id, asset 0, asset 1) triplets we've seen.
+	// We prune all records for a triplet that we haven't already seen.
+	type uniqueTriplet struct {
+		poolId uint64
+		asset0 string
+		asset1 string
+	}
+	seenPoolAssetTriplets := map[uniqueTriplet]struct{}{}
 
 	for ; iter.Valid(); iter.Next() {
 		twapToRemove, err := types.ParseTwapFromBz(iter.Value())
@@ -95,9 +102,13 @@ func (k Keeper) pruneRecordsBeforeTimeButNewest(ctx sdk.Context, lastKeptTime ti
 			return err
 		}
 
-		_, hasSeenPoolRecord := seenPools[twapToRemove.PoolId]
+		poolKey := uniqueTriplet{
+			poolId: twapToRemove.PoolId,
+			asset0: twapToRemove.Asset0Denom,
+			asset1: twapToRemove.Asset1Denom}
+		_, hasSeenPoolRecord := seenPoolAssetTriplets[poolKey]
 		if !hasSeenPoolRecord {
-			seenPools[twapToRemove.PoolId] = struct{}{}
+			seenPoolAssetTriplets[poolKey] = struct{}{}
 			continue
 		}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fix a bug in multi-asset pool pruning that was found in code review.

## Brief Changelog

  - Fix bug in multi-asset pool pruning, by making seen index a triplet

## Testing and Verifying

Single test case added

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)