### PR TITLE
Add time range safety check to GetArithmeticTwapToNow

### DIFF
--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -61,6 +61,9 @@ func (k Keeper) GetArithmeticTwapToNow(
 	baseAssetDenom string,
 	quoteAssetDenom string,
 	startTime time.Time) (sdk.Dec, error) {
+	if startTime.After(ctx.BlockTime()) {
+		return sdk.Dec{}, types.StartTimeAfterEndTimeError{StartTime: startTime, EndTime: ctx.BlockTime()}
+	}
 	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom)
 	if err != nil {
 		return sdk.Dec{}, err

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -473,6 +473,12 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 			input:         makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), quoteAssetA),
 			expectedError: twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
+		"start time too new": {
+			recordsToSet:  []types.TwapRecord{baseRecord},
+			ctxTime:       tPlusOne,
+			input:         makeSimpleTwapToNowInput(baseTime.Add(time.Hour), quoteAssetA),
+			expectedError: types.StartTimeAfterEndTimeError{StartTime: baseTime.Add(time.Hour), EndTime: tPlusOne},
+		},
 	}
 	for name, test := range tests {
 		s.Run(name, func() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Add time range safety check to GetArithmeticTwapToNow, to prevent incorrect API usage.


## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable