### PR TITLE
[TWAP]: Add safety check regarding the number of records in updateRecords

### DIFF
--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -108,12 +108,13 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 		return err
 	}
 
-	// check if there is k * (k - 1) / 2 records, k = denoms
+	// given # of denoms in the pool namely, that for `k` denoms in pool,
+	// there should be k * (k - 1) / 2 records
 	denomNum := len(denoms)
 	expectedRecordsLength := denomNum * (denomNum - 1) / 2
 
 	if expectedRecordsLength != len(records) {
-		return fmt.Errorf("The number of records do not match")
+		return fmt.Errorf("The number of records do not match, expected: %d\n got: %d\n", expectedRecordsLength, len(records))
 	}
 
 	for _, record := range records {

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -103,6 +103,19 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 		return err
 	}
 
+	denoms, err := k.ammkeeper.GetPoolDenoms(ctx, poolId)
+	if err != nil {
+		return err
+	}
+
+	// check if there is k * (k - 1) / 2 records, k = denoms
+	denomNum := len(denoms)
+	expectedRecordsLength := denomNum * (denomNum - 1) / 2
+
+	if expectedRecordsLength != len(records) {
+		return fmt.Errorf("The number of records do not match")
+	}
+
 	for _, record := range records {
 		newRecord := k.updateRecord(ctx, record)
 		k.storeNewRecord(ctx, newRecord)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2644

## What is the purpose of the change

## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

n/a

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)