### PR TITLE
Add type safety to query whitelist

### DIFF
--- a/wasmbinding/export_test.go
+++ b/wasmbinding/export_test.go
@@ -1,0 +1,7 @@
+package wasmbinding
+
+import "github.com/cosmos/cosmos-sdk/codec"
+
+func SetWhitelistedQuery(queryPath string, protoType codec.ProtoMarshaler) {
+	setWhitelistedQuery(queryPath, protoType)
+}

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -174,25 +174,19 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 // ConvertProtoToJsonMarshal  unmarshals the given bytes into a proto message and then marshals it to json.
 // This is done so that clients calling stargate queries do not need to define their own proto unmarshalers,
 // being able to use response directly by json marshalling, which is supported in cosmwasm.
-func ConvertProtoToJSONMarshal(protoResponse codec.ProtoMarshaler, bz []byte, cdc codec.Codec) ([]byte, error) {
-	// all values are proto message
-	message, ok := protoResponse.(codec.ProtoMarshaler)
-	if !ok {
-		return nil, wasmvmtypes.Unknown{}
-	}
-
+func ConvertProtoToJSONMarshal(protoResponseType codec.ProtoMarshaler, bz []byte, cdc codec.Codec) ([]byte, error) {
 	// unmarshal binary into stargate response data structure
-	err := cdc.Unmarshal(bz, message)
+	err := cdc.Unmarshal(bz, protoResponseType)
 	if err != nil {
 		return nil, wasmvmtypes.Unknown{}
 	}
 
-	bz, err = cdc.MarshalJSON(message)
+	bz, err = cdc.MarshalJSON(protoResponseType)
 	if err != nil {
 		return nil, wasmvmtypes.Unknown{}
 	}
 
-	message.Reset()
+	protoResponseType.Reset()
 
 	return bz, nil
 }

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -15,11 +15,11 @@ import (
 )
 
 // StargateQuerier dispatches whitelisted stargate queries
-func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, codec codec.Codec) func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
+func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
 	return func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
-		protoResponse, whitelisted := StargateWhitelist.Load(request.Path)
-		if !whitelisted {
-			return nil, wasmvmtypes.UnsupportedRequest{Kind: fmt.Sprintf("'%s' path is not allowed from the contract", request.Path)}
+		protoResponseType, err := GetWhitelistedQuery(request.Path)
+		if err != nil {
+			return nil, err
 		}
 
 		route := queryRouter.Route(request.Path)
@@ -35,7 +35,7 @@ func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, codec codec.Codec) fun
 			return nil, err
 		}
 
-		bz, err := ConvertProtoToJSONMarshal(protoResponse, res.Value, codec)
+		bz, err := ConvertProtoToJSONMarshal(protoResponseType, res.Value, cdc)
 		if err != nil {
 			return nil, err
 		}
@@ -174,7 +174,7 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 // ConvertProtoToJsonMarshal  unmarshals the given bytes into a proto message and then marshals it to json.
 // This is done so that clients calling stargate queries do not need to define their own proto unmarshalers,
 // being able to use response directly by json marshalling, which is supported in cosmwasm.
-func ConvertProtoToJSONMarshal(protoResponse interface{}, bz []byte, cdc codec.Codec) ([]byte, error) {
+func ConvertProtoToJSONMarshal(protoResponse codec.ProtoMarshaler, bz []byte, cdc codec.Codec) ([]byte, error) {
 	// all values are proto message
 	message, ok := protoResponse.(codec.ProtoMarshaler)
 	if !ok {

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -109,6 +109,8 @@ func init() {
 	setWhitelistedQuery("/osmosis.txfees.v1beta1.Query/BaseDenom", &txfeestypes.QueryBaseDenomResponse{})
 }
 
+// GetWhitelistedQuery returns the whitelisted query at the provided path.
+// If the query does not exist, or it was setup wrong by the chain, this returns an error.
 func GetWhitelistedQuery(queryPath string) (codec.ProtoMarshaler, error) {
 	protoResponseAny, isWhitelisted := stargateWhitelist.Load(queryPath)
 	if !isWhitelisted {

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -1,8 +1,11 @@
 package wasmbinding
 
 import (
+	"fmt"
 	"sync"
 
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -20,88 +23,104 @@ import (
 	txfeestypes "github.com/osmosis-labs/osmosis/v12/x/txfees/types"
 )
 
-// StargateWhitelist keeps whitelist and its deterministic
+// stargateWhitelist keeps whitelist and its deterministic
 // response binding for stargate queries.
 //
 // The query can be multi-thread, so we have to use
 // thread safe sync.Map.
-var StargateWhitelist sync.Map
+var stargateWhitelist sync.Map
 
 func init() {
 	// cosmos-sdk queries
 
 	// auth
-	StargateWhitelist.Store("/cosmos.auth.v1beta1.Query/Account", &authtypes.QueryAccountResponse{})
-	StargateWhitelist.Store("/cosmos.auth.v1beta1.Query/Params", &authtypes.QueryParamsResponse{})
+	setWhitelistedQuery("/cosmos.auth.v1beta1.Query/Account", &authtypes.QueryAccountResponse{})
+	setWhitelistedQuery("/cosmos.auth.v1beta1.Query/Params", &authtypes.QueryParamsResponse{})
 
 	// bank
-	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/Balance", &banktypes.QueryBalanceResponse{})
-	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/DenomMetadata", &banktypes.QueryDenomsMetadataResponse{})
-	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/Params", &banktypes.QueryParamsResponse{})
-	StargateWhitelist.Store("/cosmos.bank.v1beta1.Query/SupplyOf", &banktypes.QuerySupplyOfResponse{})
+	setWhitelistedQuery("/cosmos.bank.v1beta1.Query/Balance", &banktypes.QueryBalanceResponse{})
+	setWhitelistedQuery("/cosmos.bank.v1beta1.Query/DenomMetadata", &banktypes.QueryDenomsMetadataResponse{})
+	setWhitelistedQuery("/cosmos.bank.v1beta1.Query/Params", &banktypes.QueryParamsResponse{})
+	setWhitelistedQuery("/cosmos.bank.v1beta1.Query/SupplyOf", &banktypes.QuerySupplyOfResponse{})
 
 	// distribution
-	StargateWhitelist.Store("/cosmos.distribution.v1beta1.Query/Params", &distributiontypes.QueryParamsResponse{})
-	StargateWhitelist.Store("/cosmos.distribution.v1beta1.Query/DelegatorWithdrawAddress", &distributiontypes.QueryDelegatorWithdrawAddressResponse{})
-	StargateWhitelist.Store("/cosmos.distribution.v1beta1.Query/ValidatorCommission", &distributiontypes.QueryValidatorCommissionResponse{})
+	setWhitelistedQuery("/cosmos.distribution.v1beta1.Query/Params", &distributiontypes.QueryParamsResponse{})
+	setWhitelistedQuery("/cosmos.distribution.v1beta1.Query/DelegatorWithdrawAddress", &distributiontypes.QueryDelegatorWithdrawAddressResponse{})
+	setWhitelistedQuery("/cosmos.distribution.v1beta1.Query/ValidatorCommission", &distributiontypes.QueryValidatorCommissionResponse{})
 
 	// gov
-	StargateWhitelist.Store("/cosmos.gov.v1beta1.Query/Deposit", &govtypes.QueryDepositResponse{})
-	StargateWhitelist.Store("/cosmos.gov.v1beta1.Query/Params", &govtypes.QueryParamsResponse{})
-	StargateWhitelist.Store("/cosmos.gov.v1beta1.Query/Vote", &govtypes.QueryVoteResponse{})
+	setWhitelistedQuery("/cosmos.gov.v1beta1.Query/Deposit", &govtypes.QueryDepositResponse{})
+	setWhitelistedQuery("/cosmos.gov.v1beta1.Query/Params", &govtypes.QueryParamsResponse{})
+	setWhitelistedQuery("/cosmos.gov.v1beta1.Query/Vote", &govtypes.QueryVoteResponse{})
 
 	// slashing
-	StargateWhitelist.Store("/cosmos.slashing.v1beta1.Query/Params", &slashingtypes.QueryParamsResponse{})
-	StargateWhitelist.Store("/cosmos.slashing.v1beta1.Query/SigningInfo", &slashingtypes.QuerySigningInfoResponse{})
+	setWhitelistedQuery("/cosmos.slashing.v1beta1.Query/Params", &slashingtypes.QueryParamsResponse{})
+	setWhitelistedQuery("/cosmos.slashing.v1beta1.Query/SigningInfo", &slashingtypes.QuerySigningInfoResponse{})
 
 	// staking
-	StargateWhitelist.Store("/cosmos.staking.v1beta1.Query/Delegation", &stakingtypes.QueryDelegationResponse{})
-	StargateWhitelist.Store("/cosmos.staking.v1beta1.Query/Params", &stakingtypes.QueryParamsResponse{})
-	StargateWhitelist.Store("/cosmos.staking.v1beta1.Query/Validator", &stakingtypes.QueryValidatorResponse{})
+	setWhitelistedQuery("/cosmos.staking.v1beta1.Query/Delegation", &stakingtypes.QueryDelegationResponse{})
+	setWhitelistedQuery("/cosmos.staking.v1beta1.Query/Params", &stakingtypes.QueryParamsResponse{})
+	setWhitelistedQuery("/cosmos.staking.v1beta1.Query/Validator", &stakingtypes.QueryValidatorResponse{})
 
 	// osmosis queries
 
 	//epochs
-	StargateWhitelist.Store("/osmosis.epochs.v1beta1.Query/EpochInfos", &epochtypes.QueryEpochsInfoResponse{})
-	StargateWhitelist.Store("/osmosis.epochs.v1beta1.Query/CurrentEpoch", &epochtypes.QueryCurrentEpochResponse{})
+	setWhitelistedQuery("/osmosis.epochs.v1beta1.Query/EpochInfos", &epochtypes.QueryEpochsInfoResponse{})
+	setWhitelistedQuery("/osmosis.epochs.v1beta1.Query/CurrentEpoch", &epochtypes.QueryCurrentEpochResponse{})
 
 	// gamm
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/NumPools", &gammtypes.QueryNumPoolsResponse{})
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/TotalLiquidity", &gammtypes.QueryTotalLiquidityResponse{})
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/Pool", &gammtypes.QueryPoolResponse{})
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/PoolParams", &gammtypes.QueryPoolParamsResponse{})
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/TotalPoolLiquidity", &gammtypes.QueryTotalPoolLiquidityResponse{})
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/TotalShares", &gammtypes.QueryTotalSharesResponse{})
-	StargateWhitelist.Store("/osmosis.gamm.v1beta1.Query/SpotPrice", &gammtypes.QuerySpotPriceResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/NumPools", &gammtypes.QueryNumPoolsResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/TotalLiquidity", &gammtypes.QueryTotalLiquidityResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/Pool", &gammtypes.QueryPoolResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/PoolParams", &gammtypes.QueryPoolParamsResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/TotalPoolLiquidity", &gammtypes.QueryTotalPoolLiquidityResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/TotalShares", &gammtypes.QueryTotalSharesResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/SpotPrice", &gammtypes.QuerySpotPriceResponse{})
 
 	// incentives
-	StargateWhitelist.Store("/osmosis.incentives.Query/ModuleToDistributeCoins", &incentivestypes.ModuleToDistributeCoinsResponse{})
-	StargateWhitelist.Store("/osmosis.incentives.Query/ModuleDistributedCoins", &incentivestypes.ModuleDistributedCoinsResponse{})
-	StargateWhitelist.Store("/osmosis.incentives.Query/LockableDurations", &incentivestypes.QueryLockableDurationsResponse{})
+	setWhitelistedQuery("/osmosis.incentives.Query/ModuleToDistributeCoins", &incentivestypes.ModuleToDistributeCoinsResponse{})
+	setWhitelistedQuery("/osmosis.incentives.Query/ModuleDistributedCoins", &incentivestypes.ModuleDistributedCoinsResponse{})
+	setWhitelistedQuery("/osmosis.incentives.Query/LockableDurations", &incentivestypes.QueryLockableDurationsResponse{})
 
 	// lockup
-	StargateWhitelist.Store("/osmosis.lockup.Query/ModuleBalance", &lockuptypes.ModuleBalanceResponse{})
-	StargateWhitelist.Store("/osmosis.lockup.Query/ModuleLockedAmount", &lockuptypes.ModuleLockedAmountResponse{})
-	StargateWhitelist.Store("/osmosis.lockup.Query/AccountUnlockableCoins", &lockuptypes.AccountUnlockableCoinsResponse{})
-	StargateWhitelist.Store("/osmosis.lockup.Query/AccountUnlockingCoins", &lockuptypes.AccountUnlockingCoinsResponse{})
-	StargateWhitelist.Store("/osmosis.lockup.Query/LockedDenom", &lockuptypes.LockedDenomResponse{})
+	setWhitelistedQuery("/osmosis.lockup.Query/ModuleBalance", &lockuptypes.ModuleBalanceResponse{})
+	setWhitelistedQuery("/osmosis.lockup.Query/ModuleLockedAmount", &lockuptypes.ModuleLockedAmountResponse{})
+	setWhitelistedQuery("/osmosis.lockup.Query/AccountUnlockableCoins", &lockuptypes.AccountUnlockableCoinsResponse{})
+	setWhitelistedQuery("/osmosis.lockup.Query/AccountUnlockingCoins", &lockuptypes.AccountUnlockingCoinsResponse{})
+	setWhitelistedQuery("/osmosis.lockup.Query/LockedDenom", &lockuptypes.LockedDenomResponse{})
 
 	// mint
-	StargateWhitelist.Store("/osmosis.mint.v1beta1.Query/EpochProvisions", &minttypes.QueryEpochProvisionsResponse{})
-	StargateWhitelist.Store("/osmosis.mint.v1beta1.Query/Params", &minttypes.QueryParamsResponse{})
+	setWhitelistedQuery("/osmosis.mint.v1beta1.Query/EpochProvisions", &minttypes.QueryEpochProvisionsResponse{})
+	setWhitelistedQuery("/osmosis.mint.v1beta1.Query/Params", &minttypes.QueryParamsResponse{})
 
 	// pool-incentives
-	StargateWhitelist.Store("/osmosis.poolincentives.v1beta1.Query/GaugeIds", &poolincentivestypes.QueryGaugeIdsResponse{})
+	setWhitelistedQuery("/osmosis.poolincentives.v1beta1.Query/GaugeIds", &poolincentivestypes.QueryGaugeIdsResponse{})
 
 	// superfluid
-	StargateWhitelist.Store("/osmosis.superfluid.Query/Params", &superfluidtypes.QueryParamsResponse{})
-	StargateWhitelist.Store("/osmosis.superfluid.Query/AssetType", &superfluidtypes.AssetTypeResponse{})
-	StargateWhitelist.Store("/osmosis.superfluid.Query/AllAssets", &superfluidtypes.AllAssetsResponse{})
-	StargateWhitelist.Store("/osmosis.superfluid.Query/AssetMultiplier", &superfluidtypes.AssetMultiplierResponse{})
+	setWhitelistedQuery("/osmosis.superfluid.Query/Params", &superfluidtypes.QueryParamsResponse{})
+	setWhitelistedQuery("/osmosis.superfluid.Query/AssetType", &superfluidtypes.AssetTypeResponse{})
+	setWhitelistedQuery("/osmosis.superfluid.Query/AllAssets", &superfluidtypes.AllAssetsResponse{})
+	setWhitelistedQuery("/osmosis.superfluid.Query/AssetMultiplier", &superfluidtypes.AssetMultiplierResponse{})
 
 	// txfees
-	StargateWhitelist.Store("/osmosis.txfees.v1beta1.Query/FeeTokens", &txfeestypes.QueryFeeTokensResponse{})
-	StargateWhitelist.Store("/osmosis.txfees.v1beta1.Query/DenomSpotPrice", &txfeestypes.QueryDenomSpotPriceResponse{})
-	StargateWhitelist.Store("/osmosis.txfees.v1beta1.Query/DenomPoolId", &txfeestypes.QueryDenomPoolIdResponse{})
-	StargateWhitelist.Store("/osmosis.txfees.v1beta1.Query/BaseDenom", &txfeestypes.QueryBaseDenomResponse{})
+	setWhitelistedQuery("/osmosis.txfees.v1beta1.Query/FeeTokens", &txfeestypes.QueryFeeTokensResponse{})
+	setWhitelistedQuery("/osmosis.txfees.v1beta1.Query/DenomSpotPrice", &txfeestypes.QueryDenomSpotPriceResponse{})
+	setWhitelistedQuery("/osmosis.txfees.v1beta1.Query/DenomPoolId", &txfeestypes.QueryDenomPoolIdResponse{})
+	setWhitelistedQuery("/osmosis.txfees.v1beta1.Query/BaseDenom", &txfeestypes.QueryBaseDenomResponse{})
+}
+
+func GetWhitelistedQuery(queryPath string) (codec.ProtoMarshaler, error) {
+	protoResponseAny, isWhitelisted := stargateWhitelist.Load(queryPath)
+	if !isWhitelisted {
+		return nil, wasmvmtypes.UnsupportedRequest{Kind: fmt.Sprintf("'%s' path is not allowed from the contract", queryPath)}
+	}
+	protoResponseType, ok := protoResponseAny.(codec.ProtoMarshaler)
+	if !ok {
+		return nil, wasmvmtypes.Unknown{}
+	}
+	return protoResponseType, nil
+}
+
+func setWhitelistedQuery(queryPath string, protoType codec.ProtoMarshaler) {
+	stargateWhitelist.Store(queryPath, protoType)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Make type safety guaranteed for Stargate query whitelist, and make it impossible to set things on it from other packages.
