### PR TITLE
Fix lexicographic ordering of get all most recent keys for pool

### DIFF
--- a/osmoutils/encoding_helper.go
+++ b/osmoutils/encoding_helper.go
@@ -1,10 +1,15 @@
 package osmoutils
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
+
+func FormatFixedLengthU64(d uint64) string {
+	return fmt.Sprintf("%0.20d", d)
+}
 
 func FormatTimeString(t time.Time) string {
 	return t.UTC().Round(0).Format(sdk.SortableTimeFormat)

--- a/osmoutils/encoding_helper_test.go
+++ b/osmoutils/encoding_helper_test.go
@@ -1,0 +1,29 @@
+package osmoutils
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatFixedLengthU64(t *testing.T) {
+	tests := map[string]struct {
+		d    uint64
+		want string
+	}{
+		"0":       {0, "00000000000000000000"},
+		"1":       {1, "00000000000000000001"},
+		"9":       {9, "00000000000000000009"},
+		"10":      {10, "00000000000000000010"},
+		"123":     {123, "00000000000000000123"},
+		"max u64": {math.MaxUint64, "18446744073709551615"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := FormatFixedLengthU64(tt.d)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, len(got), 20)
+		})
+	}
+}

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -138,6 +138,11 @@ var (
 	)
 )
 
+func withPoolId(twap types.TwapRecord, poolId uint64) types.TwapRecord {
+	twap.PoolId = poolId
+	return twap
+}
+
 func withLastErrTime(twap types.TwapRecord, lastErrorTime time.Time) types.TwapRecord {
 	twap.LastErrorTime = lastErrorTime
 	return twap

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -116,6 +116,10 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 	expectedRecordsLength := denomNum * (denomNum - 1) / 2
 
 	if expectedRecordsLength != len(records) {
+		ctx.Logger().Error("starting error")
+		for i := 0; i < len(records); i++ {
+			ctx.Logger().Error(fmt.Sprintf("record pool id %d, asset0 %s, asset1 %s", records[i].PoolId, records[i].Asset0Denom, records[i].Asset1Denom))
+		}
 		return fmt.Errorf("The number of records do not match, expected: %d\n got: %d\n", expectedRecordsLength, len(records))
 	}
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -116,10 +116,6 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 	expectedRecordsLength := denomNum * (denomNum - 1) / 2
 
 	if expectedRecordsLength != len(records) {
-		ctx.Logger().Error("starting error")
-		for i := 0; i < len(records); i++ {
-			ctx.Logger().Error(fmt.Sprintf("record pool id %d, asset0 %s, asset1 %s", records[i].PoolId, records[i].Asset0Denom, records[i].Asset1Denom))
-		}
 		return fmt.Errorf("The number of records do not match, expected: %d\n got: %d\n", expectedRecordsLength, len(records))
 	}
 

--- a/x/twap/store_test.go
+++ b/x/twap/store_test.go
@@ -86,7 +86,7 @@ func (s *TestSuite) TestGetAllMostRecentRecordsForPool() {
 			poolId:          1,
 			expectedRecords: []types.TwapRecord{baseRecord},
 		},
-		"set three records, similar pool Ids": {
+		"lexicographic fooling pool Ids": {
 			recordsToSet: []types.TwapRecord{
 				withPoolId(baseRecord, 1),
 				withPoolId(baseRecord, 2),
@@ -95,6 +95,16 @@ func (s *TestSuite) TestGetAllMostRecentRecordsForPool() {
 				withPoolId(baseRecord, 20)},
 			poolId:          1,
 			expectedRecords: []types.TwapRecord{baseRecord},
+		},
+		"lexicographic fooling pool Ids, with carry": {
+			recordsToSet: []types.TwapRecord{
+				withPoolId(baseRecord, 9),
+				withPoolId(baseRecord, 10),
+				withPoolId(baseRecord, 11),
+				withPoolId(baseRecord, 19),
+				withPoolId(baseRecord, 90)},
+			poolId:          9,
+			expectedRecords: []types.TwapRecord{withPoolId(baseRecord, 9)},
 		},
 		"set multi-asset pool record": {
 			recordsToSet: []types.TwapRecord{

--- a/x/twap/store_test.go
+++ b/x/twap/store_test.go
@@ -86,6 +86,16 @@ func (s *TestSuite) TestGetAllMostRecentRecordsForPool() {
 			poolId:          1,
 			expectedRecords: []types.TwapRecord{baseRecord},
 		},
+		"set three records, similar pool Ids": {
+			recordsToSet: []types.TwapRecord{
+				withPoolId(baseRecord, 1),
+				withPoolId(baseRecord, 2),
+				withPoolId(baseRecord, 10),
+				withPoolId(baseRecord, 11),
+				withPoolId(baseRecord, 20)},
+			poolId:          1,
+			expectedRecords: []types.TwapRecord{baseRecord},
+		},
 		"set multi-asset pool record": {
 			recordsToSet: []types.TwapRecord{
 				newEmptyPriceRecord(1, baseTime, denom0, denom1),

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -42,7 +42,9 @@ var (
 // TODO: make utility command to automatically interlace separators
 
 func FormatMostRecentTWAPKey(poolId uint64, denom1, denom2 string) []byte {
-	return []byte(fmt.Sprintf("%s%d%s%s%s%s", mostRecentTWAPsPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2))
+	d := fmt.Sprintf("%s%d%s%s%s%s", mostRecentTWAPsPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2)
+	fmt.Println(d)
+	return []byte(d)
 }
 
 // TODO: Replace historical management with ORM, we currently accept 2x write amplification right now.

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -42,9 +42,8 @@ var (
 // TODO: make utility command to automatically interlace separators
 
 func FormatMostRecentTWAPKey(poolId uint64, denom1, denom2 string) []byte {
-	d := fmt.Sprintf("%s%d%s%s%s%s", mostRecentTWAPsPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2)
-	fmt.Println(d)
-	return []byte(d)
+	poolIdS := osmoutils.FormatFixedLengthU64(poolId)
+	return []byte(fmt.Sprintf("%s%s%s%s%s%s", mostRecentTWAPsPrefix, poolIdS, KeySeparator, denom1, KeySeparator, denom2))
 }
 
 // TODO: Replace historical management with ORM, we currently accept 2x write amplification right now.
@@ -99,8 +98,10 @@ func ParseTimeFromHistoricalPoolIndexKey(key []byte) (time.Time, error) {
 // GetAllMostRecentTwapsForPool returns all of the most recent twap records for a pool id.
 // if the pool id doesn't exist, then this returns a blank list.
 func GetAllMostRecentTwapsForPool(store sdk.KVStore, poolId uint64) ([]TwapRecord, error) {
-	startPrefix := fmt.Sprintf("%s%d%s", mostRecentTWAPsPrefix, poolId, KeySeparator)
-	endPrefix := fmt.Sprintf("%s%d%s", mostRecentTWAPsPrefix, poolId+1, KeySeparator)
+	poolIdS := osmoutils.FormatFixedLengthU64(poolId)
+	poolIdPlusOneS := osmoutils.FormatFixedLengthU64(poolId + 1)
+	startPrefix := fmt.Sprintf("%s%s%s", mostRecentTWAPsPrefix, poolIdS, KeySeparator)
+	endPrefix := fmt.Sprintf("%s%s%s", mostRecentTWAPsPrefix, poolIdPlusOneS, KeySeparator)
 	return osmoutils.GatherValuesFromStore(store, []byte(startPrefix), []byte(endPrefix), ParseTwapFromBz)
 }
 

--- a/x/twap/types/keys_test.go
+++ b/x/twap/types/keys_test.go
@@ -17,8 +17,8 @@ func TestFormatMostRecentTWAPKey(t *testing.T) {
 		denom2 string
 		want   string
 	}{
-		"standard":       {poolId: 1, denom1: "B", denom2: "A", want: "recent_twap|1|B|A"},
-		"standard2digit": {poolId: 10, denom1: "B", denom2: "A", want: "recent_twap|10|B|A"},
+		"standard":       {poolId: 1, denom1: "B", denom2: "A", want: "recent_twap|00000000000000000001|B|A"},
+		"standard2digit": {poolId: 10, denom1: "B", denom2: "A", want: "recent_twap|00000000000000000010|B|A"},
 		"maxPoolId":      {poolId: ^uint64(0), denom1: "B", denom2: "A", want: "recent_twap|18446744073709551615|B|A"},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fix lexicographic ordering for iterating over our key space by pool Id.

## Brief Changelog

*(for example:)*
 
  - Adds a helper for fixed length padding
  - Uses it for twap MostRecentKey store

## Testing and Verifying

This change added tests.

We can see that the first commit captures the prior failing behavior, and the second subsequently fixes it.
