### PR TITLE
x/twap: three asset pool tests (part 1 of 2)

### DIFF
--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -23,7 +23,7 @@ var (
 	// base record is a record with t=baseTime, sp0=10(sp1=0.1) accumulators set to 0
 	baseRecord types.TwapRecord = newTwoAssetPoolTwapRecordWithDefaults(baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec())
 
-	tapRecordAB, tapRecordAC, tapRecordBC types.TwapRecord = newThreeAssetPoolTwapRecordWithDefaults(
+	threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC types.TwapRecord = newThreeAssetPoolTwapRecordWithDefaults(
 		baseTime,
 		sdk.NewDec(10), // spot price 0
 		sdk.ZeroDec(),  // accum A
@@ -41,7 +41,7 @@ var (
 	tPlus10sp5Record = newTwoAssetPoolTwapRecordWithDefaults(
 		baseTime.Add(10*time.Second), sdk.NewDec(5), accumA, accumB)
 
-	tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
+	tPlus10sp5ThreeAssetRecordAB, tPlus10sp5ThreeAssetRecordAC, tPlus10sp5ThreeAssetRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
 		baseTime.Add(10*time.Second), sdk.NewDec(5), accumA, accumB, accumC)
 
 	// accumulators updated from tPlus10sp5Record with
@@ -53,7 +53,7 @@ var (
 		OneSec.MulInt64(10*10+5*10), // accum A
 		OneSec.MulInt64(3))          // accum B
 
-	tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
+	tPlus20sp2ThreeAssetRecordAB, tPlus20sp2ThreeAssetRecordAC, tPlus20sp2ThreeAssetRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
 		baseTime.Add(20*time.Second),
 		sdk.NewDec(2),                // spot price 0
 		OneSec.MulInt64(10*10+5*10),  // accum A
@@ -131,7 +131,7 @@ func makeSimpleTwapInput(startTime time.Time, endTime time.Time, isQuoteTokenA b
 	return getTwapInput{1, quoteAssetDenom, baseAssetDenom, startTime, endTime}
 }
 
-func makeSimpleTapTwapInput(startTime time.Time, endTime time.Time, baseQuoteAB, baseQuoteCA, baseQuoteBC bool) []getTwapInput {
+func makeSimpleThreeAssetTwapInput(startTime time.Time, endTime time.Time, baseQuoteAB, baseQuoteCA, baseQuoteBC bool) []getTwapInput {
 	var twapInput []getTwapInput
 	formatSimpleTwapInput(twapInput, startTime, endTime, baseQuoteAB, denom0, denom1, 2)
 	formatSimpleTwapInput(twapInput, startTime, endTime, baseQuoteAB, denom2, denom0, 2)
@@ -304,21 +304,21 @@ func (s *TestSuite) TestGetArithmeticTwap_ThreeAsset() {
 		expectError  error
 	}{
 		"(2 pairs of 3 records) start exact, end after second record": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
-				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC},
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
+				tPlus10sp5ThreeAssetRecordAB, tPlus10sp5ThreeAssetRecordAC, tPlus10sp5ThreeAssetRecordBC},
 			ctxTime: tPlusOneMin,
-			input:   makeSimpleTapTwapInput(baseTime, baseTime.Add(20*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapInput(baseTime, baseTime.Add(20*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 10 for 10s, 5 for 10s = 150/20 = 7.5
 			// C 20 for 10s, 10 for 10s = 300/20 = 15
 			// B .1 for 10s, .2 for 10s = 3/20 = 0.15
 			expTwap: []sdk.Dec{sdk.NewDecWithPrec(75, 1), sdk.NewDec(15), sdk.NewDecWithPrec(15, 2)},
 		},
 		"(3 pairs of 3 record) start at second record, end after third record": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
-				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC,
-				tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC},
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
+				tPlus10sp5ThreeAssetRecordAB, tPlus10sp5ThreeAssetRecordAC, tPlus10sp5ThreeAssetRecordBC,
+				tPlus20sp2ThreeAssetRecordAB, tPlus20sp2ThreeAssetRecordAC, tPlus20sp2ThreeAssetRecordBC},
 			ctxTime: tPlusOneMin,
-			input:   makeSimpleTapTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 5 for 10s, 2 for 10s = 70/20 = 3.5
 			// C 10 for 10s, 4 for 10s = 140/20 = 7
 			// B .2 for 10s, .5 for 10s = 7/20 = 0.35
@@ -326,11 +326,11 @@ func (s *TestSuite) TestGetArithmeticTwap_ThreeAsset() {
 		},
 		// interpolate in time closer to second record
 		"(3 record) interpolate: get twap closer to second record": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
-				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC,
-				tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC},
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
+				tPlus10sp5ThreeAssetRecordAB, tPlus10sp5ThreeAssetRecordAC, tPlus10sp5ThreeAssetRecordBC,
+				tPlus20sp2ThreeAssetRecordAB, tPlus20sp2ThreeAssetRecordAC, tPlus20sp2ThreeAssetRecordBC},
 			ctxTime: tPlusOneMin,
-			input:   makeSimpleTapTwapInput(baseTime.Add(15*time.Second), baseTime.Add(30*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapInput(baseTime.Add(15*time.Second), baseTime.Add(30*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 5 for 5s, 2 for 10s = 45/15 = 3
 			// C 10 for 5s, 4 for 10s = 140/15 = 6
 			// B .2 for 5s, .5 for 10s = 7/15 = .4
@@ -531,20 +531,20 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod_ThreeAsset() {
 		expectError  error
 	}{
 		"(2 sets of 3 records); to now; with one directly at threshold, interpolated": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
 				recordBeforeKeepThresholdAB, recordBeforeKeepThresholdAC, recordBeforeKeepThresholdBC},
 			ctxTime: baseTimePlusKeepPeriod,
-			input:   makeSimpleTapTwapInput(baseTime, baseTimePlusKeepPeriod, baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapInput(baseTime, baseTimePlusKeepPeriod, baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 10 for 169200s, 30 for 3600s = 1800000/172800 = 10.416666
 			// C 20 for 169200s, 60 for 3600s = 100/172800 = 20.83333333
 			// B .1 for 169200s, .033 for 3600s = 17040/172800 = 0.0986111
 			expTwap: []sdk.Dec{sdk.MustNewDecFromStr("10.416666666666666666"), sdk.MustNewDecFromStr("20.833333333333333333"), sdk.MustNewDecFromStr("0.098611111111111111")},
 		},
 		"(2 sets of 3 records); with end time; with one before keep threshold, interpolated": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
 				recordBeforeKeepThresholdAB, recordBeforeKeepThresholdAC, recordBeforeKeepThresholdBC},
 			ctxTime: oneHourAfterKeepThreshold,
-			input:   makeSimpleTapTwapInput(baseTime, oneHourAfterKeepThreshold.Add(-time.Millisecond), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapInput(baseTime, oneHourAfterKeepThreshold.Add(-time.Millisecond), baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 10 for 169200000ms, 30 for 7199999ms = 1907999970/176399999 = 10.81632642
 			// C 20 for 169200000ms, 60 for 7199999ms = 3815999940/176399999 = 21.6326528
 			// B .1 for 169200000ms, .033 for 7199999ms = 17159999/176399999 = 0.09727891
@@ -672,8 +672,8 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 }
 
 func (s *TestSuite) TestGetArithmeticTwapToNow_ThreeAsset() {
-	makeSimpleTapTwapToNowInput := func(startTime time.Time, baseQuoteAB, baseQuoteAC, baseQuoteBC bool) []getTwapInput {
-		return makeSimpleTapTwapInput(startTime, startTime, baseQuoteAB, baseQuoteAC, baseQuoteBC)
+	makeSimpleThreeAssetTwapToNowInput := func(startTime time.Time, baseQuoteAB, baseQuoteAC, baseQuoteBC bool) []getTwapInput {
+		return makeSimpleThreeAssetTwapInput(startTime, startTime, baseQuoteAB, baseQuoteAC, baseQuoteBC)
 	}
 
 	tests := map[string]struct {
@@ -684,20 +684,20 @@ func (s *TestSuite) TestGetArithmeticTwapToNow_ThreeAsset() {
 		expectedError error
 	}{
 		"(2 pairs of 3 records) to now: start time = second record time": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
-				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC},
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
+				tPlus10sp5ThreeAssetRecordAB, tPlus10sp5ThreeAssetRecordAC, tPlus10sp5ThreeAssetRecordBC},
 			ctxTime: tPlusOneMin,
-			input:   makeSimpleTapTwapToNowInput(baseTime.Add(10*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapToNowInput(baseTime.Add(10*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 10 for 0s, 5 for 10s = 50/10 = 5
 			// C 20 for 0s, 10 for 10s = 100/10 = 10
 			// B .1 for 0s, .2 for 10s = 2/10 = 0.2
 			expTwap: []sdk.Dec{sdk.NewDec(5), sdk.NewDec(10), sdk.NewDecWithPrec(2, 1)}, // 10 for 0s, 5 for 10s
 		},
 		"(2 pairs of 3 records) first record time < start time < second record time": {
-			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
-				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC},
+			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,
+				tPlus10sp5ThreeAssetRecordAB, tPlus10sp5ThreeAssetRecordAC, tPlus10sp5ThreeAssetRecordBC},
 			ctxTime: baseTime.Add(20 * time.Second),
-			input:   makeSimpleTapTwapToNowInput(baseTime.Add(5*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			input:   makeSimpleThreeAssetTwapToNowInput(baseTime.Add(5*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
 			// A 10 for 5s, 5 for 10s = 100/15 = 6 + 2/3 = 6.66666666
 			// C 20 for 5s, 10 for 10s = 200/15 = 13 + 1/3 = 13.333333
 			// B .1 for 5s, .2 for 10s = 2.5/15 = 0.1666666

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -54,7 +54,11 @@ var (
 		OneSec.MulInt64(3))          // accum B
 
 	tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
-		baseTime.Add(20*time.Second), sdk.NewDec(2), OneSec.MulInt64(10*10+5*10), OneSec.MulInt64(3), OneSec.MulInt64(20*10+10*10))
+		baseTime.Add(20*time.Second),
+		sdk.NewDec(2),                // spot price 0
+		OneSec.MulInt64(10*10+5*10),  // accum A
+		OneSec.MulInt64(3),           // accum B
+		OneSec.MulInt64(20*10+10*10)) // accum C
 )
 
 func (s *TestSuite) TestGetBeginBlockAccumulatorRecord() {

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -47,7 +47,7 @@ var (
 	// accumulators updated from tPlus10sp5Record with
 	// t = baseTime + 20
 	// spA = 2, spB = 0.5, spC = 4
-	tPlus20sp2Record = newTwapRecordWithDefaults(
+	tPlus20sp2Record = newTwoAssetPoolTwapRecordWithDefaults(
 		baseTime.Add(20*time.Second),
 		sdk.NewDec(2),               // spot price 0
 		OneSec.MulInt64(10*10+5*10), // accum A

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -124,9 +124,11 @@ type getTwapInput struct {
 }
 
 func makeSimpleTwapInput(startTime time.Time, endTime time.Time, isQuoteTokenA bool) getTwapInput {
-	var twapInput []getTwapInput
-	formatSimpleTwapInput(twapInput, startTime, endTime, isQuoteTokenA, denom0, denom1, 1)
-	return twapInput[0]
+	quoteAssetDenom, baseAssetDenom := denom0, denom1
+	if isQuoteTokenA {
+		baseAssetDenom, quoteAssetDenom = quoteAssetDenom, baseAssetDenom
+	}
+	return getTwapInput{1, quoteAssetDenom, baseAssetDenom, startTime, endTime}
 }
 
 func makeSimpleTapTwapInput(startTime time.Time, endTime time.Time, baseQuoteAB, baseQuoteCA, baseQuoteBC bool) []getTwapInput {

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -691,7 +691,7 @@ func (s *TestSuite) TestGetArithmeticTwapToNow_ThreeAsset() {
 			// A 10 for 0s, 5 for 10s = 50/10 = 5
 			// C 20 for 0s, 10 for 10s = 100/10 = 10
 			// B .1 for 0s, .2 for 10s = 2/10 = 0.2
-			expTwap: []sdk.Dec{sdk.NewDec(5), sdk.NewDec(10), sdk.NewDecWithPrec(2, 1)}, // 10 for 0s, 5 for 10s
+			expTwap: []sdk.Dec{sdk.NewDec(5), sdk.NewDec(10), sdk.NewDecWithPrec(2, 1)},
 		},
 		"(2 pairs of 3 records) first record time < start time < second record time": {
 			recordsToSet: []types.TwapRecord{threeAssetRecordAB, threeAssetRecordAC, threeAssetRecordBC,

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -24,7 +24,11 @@ var (
 	baseRecord types.TwapRecord = newTwapRecordWithDefaults(baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec())
 
 	tapRecordAB, tapRecordAC, tapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
-		baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+		baseTime,
+		sdk.NewDec(10), // spot price 0
+		sdk.ZeroDec(),  // accum A
+		sdk.ZeroDec(),  // accum B
+		sdk.ZeroDec())  // accum C
 
 	// accumA = 10 seconds * (spot price = 10) = OneSec * 10 * 10
 	// accumB = 10 seconds * (spot price = 0.1) = OneSec

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -21,7 +21,7 @@ var (
 	ThreePlusOneThird sdk.Dec = sdk.MustNewDecFromStr("3.333333333333333333")
 
 	// base record is a record with t=baseTime, sp0=10(sp1=0.1) accumulators set to 0
-	baseRecord types.TwapRecord = newTwapRecordWithDefaults(baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec())
+	baseRecord types.TwapRecord = newTwoAssetPoolTwapRecordWithDefaults(baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec())
 
 	tapRecordAB, tapRecordAC, tapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
 		baseTime,
@@ -38,7 +38,7 @@ var (
 	// accumulators updated from baseRecord with
 	// t = baseTime + 10
 	// spA = 5, spB = 0.2, spC = 10
-	tPlus10sp5Record = newTwapRecordWithDefaults(
+	tPlus10sp5Record = newTwoAssetPoolTwapRecordWithDefaults(
 		baseTime.Add(10*time.Second), sdk.NewDec(5), accumA, accumB)
 
 	tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
@@ -387,7 +387,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 		periodBetweenBaseAndOneHourBeforeThreshold           = (defaultRecordHistoryKeepPeriod.Milliseconds() - time.Hour.Milliseconds())
 		accumBeforeKeepThreshold0, accumBeforeKeepThreshold1 = sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10), sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10)
 		// recordBeforeKeepThreshold is a record with t=baseTime+keepPeriod-1h, sp0=30(sp1=0.3) accumulators set relative to baseRecord
-		recordBeforeKeepThreshold types.TwapRecord = newTwapRecordWithDefaults(oneHourBeforeKeepThreshold, sdk.NewDec(30), accumBeforeKeepThreshold0, accumBeforeKeepThreshold1)
+		recordBeforeKeepThreshold types.TwapRecord = newTwoAssetPoolTwapRecordWithDefaults(oneHourBeforeKeepThreshold, sdk.NewDec(30), accumBeforeKeepThreshold0, accumBeforeKeepThreshold1)
 	)
 
 	// N.B.: when ctxTime = end time, we trigger the "TWAP to now path".

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -11,26 +11,43 @@ import (
 )
 
 var (
+	// when creating twap inputs, we use a function that, when set to true, returns the
+	// base asset as the lexicographically smaller denom and the quote as the larger. When
+	// set to false, this order is switched. These constants are provided to understand the
+	// base/quote asset for every test at a glance rather than a raw boolean value.
+	baseQuoteAB, baseQuoteCA, baseQuoteBC = true, true, true
+	baseQuoteBA, baseQuoteAC, baseQuoteCB = false, false, false
+
 	ThreePlusOneThird sdk.Dec = sdk.MustNewDecFromStr("3.333333333333333333")
 
 	// base record is a record with t=baseTime, sp0=10(sp1=0.1) accumulators set to 0
 	baseRecord types.TwapRecord = newTwapRecordWithDefaults(baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec())
 
-	// accum0 = 10 seconds * (spot price = 10) = OneSec * 10 * 10
-	// accum1 = 10 seconds * (spot price = 0.1) = OneSec
-	accum0, accum1 sdk.Dec = OneSec.MulInt64(10 * 10), OneSec
+	tapRecordAB, tapRecordAC, tapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
+		baseTime, sdk.NewDec(10), sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+
+	// accumA = 10 seconds * (spot price = 10) = OneSec * 10 * 10
+	// accumB = 10 seconds * (spot price = 0.1) = OneSec
+	// accumC = 10 seconds * (spot price = 20) = OneSec * 10 * 20
+	accumA, accumB, accumC sdk.Dec = OneSec.MulInt64(10 * 10), OneSec, OneSec.MulInt64(10 * 20)
 
 	// accumulators updated from baseRecord with
 	// t = baseTime + 10
-	// sp0 = 5, sp1 = 0.2
+	// spA = 5, spB = 0.2, spC = 10
 	tPlus10sp5Record = newTwapRecordWithDefaults(
-		baseTime.Add(10*time.Second), sdk.NewDec(5), accum0, accum1)
+		baseTime.Add(10*time.Second), sdk.NewDec(5), accumA, accumB)
+
+	tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
+		baseTime.Add(10*time.Second), sdk.NewDec(5), accumA, accumB, accumC)
 
 	// accumulators updated from tPlus10sp5Record with
 	// t = baseTime + 20
-	// sp0 = 2, sp1 = 0.5
+	// spA = 2, spB = 0.5, spC = 4
 	tPlus20sp2Record = newTwapRecordWithDefaults(
 		baseTime.Add(20*time.Second), sdk.NewDec(2), OneSec.MulInt64(10*10+5*10), OneSec.MulInt64(3))
+
+	tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
+		baseTime.Add(20*time.Second), sdk.NewDec(2), OneSec.MulInt64(10*10+5*10), OneSec.MulInt64(3), OneSec.MulInt64(20*10+10*10))
 )
 
 func (s *TestSuite) TestGetBeginBlockAccumulatorRecord() {
@@ -103,13 +120,30 @@ func makeSimpleTwapInput(startTime time.Time, endTime time.Time, isQuoteTokenA b
 	return getTwapInput{1, quoteAssetDenom, baseAssetDenom, startTime, endTime}
 }
 
+func makeSimpleTapTwapInput(startTime time.Time, endTime time.Time, baseQuoteAB, baseQuoteCA, baseQuoteBC bool) []getTwapInput {
+	var twapInput []getTwapInput
+	quoteAssetDenom, baseAssetDenom := denom0, denom1
+	if baseQuoteAB {
+		baseAssetDenom, quoteAssetDenom = quoteAssetDenom, baseAssetDenom
+	}
+	twapInput = append(twapInput, getTwapInput{2, quoteAssetDenom, baseAssetDenom, startTime, endTime})
+	quoteAssetDenom, baseAssetDenom = denom2, denom0
+	if baseQuoteCA {
+		baseAssetDenom, quoteAssetDenom = quoteAssetDenom, baseAssetDenom
+	}
+	twapInput = append(twapInput, getTwapInput{2, quoteAssetDenom, baseAssetDenom, startTime, endTime})
+	quoteAssetDenom, baseAssetDenom = denom1, denom2
+	if baseQuoteBC {
+		baseAssetDenom, quoteAssetDenom = quoteAssetDenom, baseAssetDenom
+	}
+	twapInput = append(twapInput, getTwapInput{2, quoteAssetDenom, baseAssetDenom, startTime, endTime})
+	return twapInput
+}
+
 // TestGetArithmeticTwap tests if we get the expected twap value from `GetArithmeticTwap`.
 // We test the method directly by updating the accumulator and storing the twap records
 // manually in this test.
 func (s *TestSuite) TestGetArithmeticTwap() {
-	quoteAssetA := true
-	quoteAssetB := false
-
 	tests := map[string]struct {
 		recordsToSet []types.TwapRecord
 		ctxTime      time.Time
@@ -120,50 +154,50 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 		"(1 record) start and end point to same record": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, tPlusOne, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, tPlusOne, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record) start and end point to same record, use sp1": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, tPlusOne, quoteAssetB),
+			input:        makeSimpleTwapInput(baseTime, tPlusOne, baseQuoteBA),
 			expTwap:      sdk.NewDecWithPrec(1, 1),
 		},
 		"(1 record) start and end point to same record, end time = now": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, tPlusOneMin, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, tPlusOneMin, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(2 record) start and end point to same record": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, tPlusOne, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, tPlusOne, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(2 record) start and end exact, different records": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, baseTime.Add(10*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, baseTime.Add(10*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(2 record) start exact, end after second record": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, baseTime.Add(20*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, baseTime.Add(20*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDecWithPrec(75, 1), // 10 for 10s, 5 for 10s
 		},
 		"(2 record) start exact, end after second record, sp1": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime, baseTime.Add(20*time.Second), quoteAssetB),
+			input:        makeSimpleTwapInput(baseTime, baseTime.Add(20*time.Second), baseQuoteBA),
 			expTwap:      sdk.NewDecWithPrec(15, 2), // .1 for 10s, .2 for 10s
 		},
 		// start at 5 second after first twap record, end at 5 second after second twap record
 		"(2 record) start and end interpolated": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(5*time.Second), baseTime.Add(20*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(5*time.Second), baseTime.Add(20*time.Second), baseQuoteAB),
 			// 10 for 5s, 5 for 10s = 100/15 = 6 + 2/3 = 6.66666666
 			expTwap: ThreePlusOneThird.MulInt64(2),
 		},
@@ -171,39 +205,39 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 		"(3 record) start and end point to same record": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record, tPlus20sp2Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(10*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(10*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDec(5),
 		},
 		"(3 record) start and end exactly at record times, different records": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record, tPlus20sp2Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(20*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(20*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDec(5),
 		},
 		"(3 record) start at second record, end after third record": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record, tPlus20sp2Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDecWithPrec(35, 1), // 5 for 10s, 2 for 10s
 		},
 		"(3 record) start at second record, end after third record, sp1": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record, tPlus20sp2Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), quoteAssetB),
+			input:        makeSimpleTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), baseQuoteBA),
 			expTwap:      sdk.NewDecWithPrec(35, 2), // 0.2 for 10s, 0.5 for 10s
 		},
 		// start in middle of first and second record, end in middle of second and third record
 		"(3 record) interpolate: in between second and third record": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record, tPlus20sp2Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(15*time.Second), baseTime.Add(25*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(15*time.Second), baseTime.Add(25*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDecWithPrec(35, 1), // 5 for 5s, 2 for 5 = 35 / 10 = 3.5
 		},
 		// interpolate in time closer to second record
 		"(3 record) interpolate: get twap closer to second record": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record, tPlus20sp2Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapInput(baseTime.Add(15*time.Second), baseTime.Add(30*time.Second), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(15*time.Second), baseTime.Add(30*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDec(3), // 5 for 5s, 2 for 10s = 45 / 15 = 3
 		},
 
@@ -211,25 +245,25 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 		"end time in future": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
-			input:        makeSimpleTwapInput(baseTime, tPlusOne, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, tPlusOne, baseQuoteAB),
 			expectError:  types.EndTimeInFutureError{BlockTime: baseTime, EndTime: tPlusOne},
 		},
 		"start time after end time": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
-			input:        makeSimpleTwapInput(tPlusOne, baseTime, quoteAssetA),
+			input:        makeSimpleTwapInput(tPlusOne, baseTime, baseQuoteAB),
 			expectError:  types.StartTimeAfterEndTimeError{StartTime: tPlusOne, EndTime: baseTime},
 		},
 		"start time too old (end time = now)": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime,
-			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, baseQuoteAB),
 			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
 		"start time too old": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTime.Add(time.Second),
-			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(-time.Hour), baseTime, baseQuoteAB),
 			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
 	}
@@ -254,6 +288,71 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 	}
 }
 
+func (s *TestSuite) TestGetArithmeticTwap_ThreeAsset() {
+	tests := map[string]struct {
+		recordsToSet []types.TwapRecord
+		ctxTime      time.Time
+		input        []getTwapInput
+		expTwap      []sdk.Dec
+		expectError  error
+	}{
+		"(2 pairs of 3 records) start exact, end after second record": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC},
+			ctxTime: tPlusOneMin,
+			input:   makeSimpleTapTwapInput(baseTime, baseTime.Add(20*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 10 for 10s, 5 for 10s = 150/20 = 7.5
+			// C 20 for 10s, 10 for 10s = 300/20 = 15
+			// B .1 for 10s, .2 for 10s = 3/20 = 0.15
+			expTwap: []sdk.Dec{sdk.NewDecWithPrec(75, 1), sdk.NewDec(15), sdk.NewDecWithPrec(15, 2)},
+		},
+		"(3 pairs of 3 record) start at second record, end after third record": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC,
+				tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC},
+			ctxTime: tPlusOneMin,
+			input:   makeSimpleTapTwapInput(baseTime.Add(10*time.Second), baseTime.Add(30*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 5 for 10s, 2 for 10s = 70/20 = 3.5
+			// C 10 for 10s, 4 for 10s = 140/20 = 7
+			// B .2 for 10s, .5 for 10s = 7/20 = 0.35
+			expTwap: []sdk.Dec{sdk.NewDecWithPrec(35, 1), sdk.NewDec(7), sdk.NewDecWithPrec(35, 2)},
+		},
+		// interpolate in time closer to second record
+		"(3 record) interpolate: get twap closer to second record": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC,
+				tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC},
+			ctxTime: tPlusOneMin,
+			input:   makeSimpleTapTwapInput(baseTime.Add(15*time.Second), baseTime.Add(30*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 5 for 5s, 2 for 10s = 45/15 = 3
+			// C 10 for 5s, 4 for 10s = 140/15 = 6
+			// B .2 for 5s, .5 for 10s = 7/15 = .4
+			expTwap: []sdk.Dec{sdk.NewDec(3), sdk.NewDec(6), sdk.NewDecWithPrec(4, 1)}, // 5 for 5s, 2 for 10s = 45 / 15 = 3
+		},
+	}
+	for name, test := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+			s.preSetRecords(test.recordsToSet)
+			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
+
+			for i, record := range test.input {
+				twap, err := s.twapkeeper.GetArithmeticTwap(s.Ctx, record.poolId,
+					record.quoteAssetDenom, record.baseAssetDenom,
+					record.startTime, record.endTime)
+
+				if test.expectError != nil {
+					s.Require().Error(err)
+					s.Require().ErrorIs(err, test.expectError)
+					return
+				}
+				s.Require().NoError(err)
+				s.Require().Equal(test.expTwap[i], twap)
+			}
+		})
+	}
+}
+
 // TestGetArithmeticTwap_PruningRecordKeepPeriod is similar to TestGetArithmeticTwap.
 // It specifically focuses on testing edge cases related to the
 // pruning record keep period when interacting with GetArithmeticTwap.
@@ -262,8 +361,6 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 // This is conditional on the records being present in the store earlier than startTime.
 // If there is no such record, we expect an error.
 func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
-	const quoteAssetA = true
-
 	var (
 		defaultRecordHistoryKeepPeriod = types.DefaultParams().RecordHistoryKeepPeriod
 
@@ -295,88 +392,88 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 		"(1 record at keep threshold); to now; ctxTime = at keep threshold; start time = end time = base keep threshold": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
-			input:        makeSimpleTwapInput(baseTimePlusKeepPeriod, baseTimePlusKeepPeriod, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTimePlusKeepPeriod, baseTimePlusKeepPeriod, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record at keep threshold); with end time; ctxTime = at keep threshold; start time = end time = base keep threshold - 1ms": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
-			input:        makeSimpleTwapInput(baseTimePlusKeepPeriod.Add(-time.Millisecond), baseTimePlusKeepPeriod.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTimePlusKeepPeriod.Add(-time.Millisecond), baseTimePlusKeepPeriod.Add(-time.Millisecond), baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record younger than keep threshold); to now; ctxTime = start time = end time = after keep threshold": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourAfterKeepThreshold,
-			input:        makeSimpleTwapInput(oneHourAfterKeepThreshold, oneHourAfterKeepThreshold, quoteAssetA),
+			input:        makeSimpleTwapInput(oneHourAfterKeepThreshold, oneHourAfterKeepThreshold, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record younger than keep threshold); with end time; ctxTime = start time = end time = after keep threshold - 1ms": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourAfterKeepThreshold,
-			input:        makeSimpleTwapInput(oneHourAfterKeepThreshold.Add(-time.Millisecond), oneHourAfterKeepThreshold.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(oneHourAfterKeepThreshold.Add(-time.Millisecond), oneHourAfterKeepThreshold.Add(-time.Millisecond), baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record older than keep threshold); to now; ctxTime = baseTime, start time = end time = before keep threshold": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourBeforeKeepThreshold,
-			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourBeforeKeepThreshold, quoteAssetA),
+			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourBeforeKeepThreshold, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record older than keep threshold); with end time; ctxTime = baseTime, start time = end time = before keep threshold - 1ms": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourBeforeKeepThreshold,
-			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold.Add(-time.Millisecond), oneHourBeforeKeepThreshold.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold.Add(-time.Millisecond), oneHourBeforeKeepThreshold.Add(-time.Millisecond), baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record older than keep threshold); to now; ctxTime = after keep threshold, start time = before keep threshold; end time = after keep threshold": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourAfterKeepThreshold,
-			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourAfterKeepThreshold, quoteAssetA),
+			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourAfterKeepThreshold, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record older than keep threshold); with end time; ctxTime = after keep threshold, start time = before keep threshold; end time = after keep threshold - 1ms": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      oneHourAfterKeepThreshold,
-			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourAfterKeepThreshold.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(oneHourBeforeKeepThreshold, oneHourAfterKeepThreshold.Add(-time.Millisecond), baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record at keep threshold); to now; ctxTime = base keep threshold, start time = base time - 1ms (source of error); end time = base keep threshold; error": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
-			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod, baseQuoteAB),
 			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Millisecond)},
 		},
 		"(1 record at keep threshold); with end time; ctxTime = base keep threshold, start time = base time - 1ms (source of error); end time = base keep threshold - ms; error": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      baseTimePlusKeepPeriod,
-			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime.Add(-time.Millisecond), baseTimePlusKeepPeriod.Add(-time.Millisecond), baseQuoteAB),
 			expectError:  twap.TimeTooOldError{Time: baseTime.Add(-time.Millisecond)},
 		},
 		"(2 records); to now; with one directly at threshold, interpolated": {
 			recordsToSet: []types.TwapRecord{baseRecord, recordBeforeKeepThreshold},
 			ctxTime:      baseTimePlusKeepPeriod,
-			input:        makeSimpleTwapInput(baseTime, baseTimePlusKeepPeriod, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, baseTimePlusKeepPeriod, baseQuoteAB),
 			// expTwap: = (10 * (172800s - 3600s) + 30 * 3600s) / 172800s = 10.416666666666666666
 			expTwap: sdk.MustNewDecFromStr("10.416666666666666666"),
 		},
 		"(2 records); with end time; with one directly at threshold, interpolated": {
 			recordsToSet: []types.TwapRecord{baseRecord, recordBeforeKeepThreshold},
 			ctxTime:      baseTimePlusKeepPeriod.Add(time.Millisecond),
-			input:        makeSimpleTwapInput(baseTime, baseTimePlusKeepPeriod.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, baseTimePlusKeepPeriod.Add(-time.Millisecond), baseQuoteAB),
 			// expTwap: = (10 * (172800000ms - 3600000ms) + 30 * 3599999ms) / 172799999ms approx = 10.41666655333719
 			expTwap: sdk.MustNewDecFromStr("10.416666553337190702"),
 		},
 		"(2 records); to now; with one before keep threshold, interpolated": {
 			recordsToSet: []types.TwapRecord{baseRecord, recordBeforeKeepThreshold},
 			ctxTime:      oneHourAfterKeepThreshold,
-			input:        makeSimpleTwapInput(baseTime, oneHourAfterKeepThreshold, quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, oneHourAfterKeepThreshold, baseQuoteAB),
 			// expTwap: = (10 * (172800s - 3600s) + 30 * 3600s * 2) / (172800s + 3600s) approx = 10.816326530612244
 			expTwap: sdk.MustNewDecFromStr("10.816326530612244897"),
 		},
 		"(2 records); with end time; with one before keep threshold, interpolated": {
 			recordsToSet: []types.TwapRecord{baseRecord, recordBeforeKeepThreshold},
 			ctxTime:      oneHourAfterKeepThreshold,
-			input:        makeSimpleTwapInput(baseTime, oneHourAfterKeepThreshold.Add(-time.Millisecond), quoteAssetA),
+			input:        makeSimpleTwapInput(baseTime, oneHourAfterKeepThreshold.Add(-time.Millisecond), baseQuoteAB),
 			// expTwap: = (10 * (172800000ms - 3600000ms) + 30 * (3600000ms + 3599999ms)) / (172800000ms + 3599999ms) approx = 10.81632642186126
 			expTwap: sdk.MustNewDecFromStr("10.816326421861260894"),
 		},
@@ -406,6 +503,71 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 	}
 }
 
+func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod_ThreeAsset() {
+	var (
+		defaultRecordHistoryKeepPeriod = types.DefaultParams().RecordHistoryKeepPeriod
+		baseTimePlusKeepPeriod         = baseTime.Add(defaultRecordHistoryKeepPeriod)
+		oneHourBeforeKeepThreshold     = baseTimePlusKeepPeriod.Add(-time.Hour)
+		oneHourAfterKeepThreshold      = baseTimePlusKeepPeriod.Add(time.Hour)
+
+		periodBetweenBaseAndOneHourBeforeThreshold                                      = (defaultRecordHistoryKeepPeriod.Milliseconds() - time.Hour.Milliseconds())
+		accumBeforeKeepThresholdA, accumBeforeKeepThresholdB, accumBeforeKeepThresholdC = sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 10), sdk.NewDecWithPrec(1, 1).MulInt64(periodBetweenBaseAndOneHourBeforeThreshold), sdk.NewDec(periodBetweenBaseAndOneHourBeforeThreshold * 20)
+		// recordBeforeKeepThreshold is a record with t=baseTime+keepPeriod-1h, spA=30(spB=0.3)(spC=60) accumulators set relative to baseRecord
+		recordBeforeKeepThresholdAB, recordBeforeKeepThresholdAC, recordBeforeKeepThresholdBC = newThreeAssetPoolTwapRecordWithDefaults(oneHourBeforeKeepThreshold, sdk.NewDec(30), accumBeforeKeepThresholdA, accumBeforeKeepThresholdB, accumBeforeKeepThresholdC)
+	)
+
+	tests := map[string]struct {
+		recordsToSet []types.TwapRecord
+		ctxTime      time.Time
+		input        []getTwapInput
+		expTwap      []sdk.Dec
+		expectError  error
+	}{
+		"(2 sets of 3 records); to now; with one directly at threshold, interpolated": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				recordBeforeKeepThresholdAB, recordBeforeKeepThresholdAC, recordBeforeKeepThresholdBC},
+			ctxTime: baseTimePlusKeepPeriod,
+			input:   makeSimpleTapTwapInput(baseTime, baseTimePlusKeepPeriod, baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 10 for 169200s, 30 for 3600s = 1800000/172800 = 10.416666
+			// C 20 for 169200s, 60 for 3600s = 100/172800 = 20.83333333
+			// B .1 for 169200s, .033 for 3600s = 17040/172800 = 0.0986111
+			expTwap: []sdk.Dec{sdk.MustNewDecFromStr("10.416666666666666666"), sdk.MustNewDecFromStr("20.833333333333333333"), sdk.MustNewDecFromStr("0.098611111111111111")},
+		},
+		"(2 sets of 3 records); with end time; with one before keep threshold, interpolated": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				recordBeforeKeepThresholdAB, recordBeforeKeepThresholdAC, recordBeforeKeepThresholdBC},
+			ctxTime: oneHourAfterKeepThreshold,
+			input:   makeSimpleTapTwapInput(baseTime, oneHourAfterKeepThreshold.Add(-time.Millisecond), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 10 for 169200000ms, 30 for 7199999ms = 1907999970/176399999 = 10.81632642
+			// C 20 for 169200000ms, 60 for 7199999ms = 3815999940/176399999 = 21.6326528
+			// B .1 for 169200000ms, .033 for 7199999ms = 17159999/176399999 = 0.09727891
+			expTwap: []sdk.Dec{sdk.MustNewDecFromStr("10.816326421861260894"), sdk.MustNewDecFromStr("21.632652843722521789"), sdk.MustNewDecFromStr("0.097278911927129130")},
+		},
+	}
+
+	for name, test := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+			s.preSetRecords(test.recordsToSet)
+			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
+
+			for i, record := range test.input {
+				twap, err := s.twapkeeper.GetArithmeticTwap(s.Ctx, record.poolId,
+					record.quoteAssetDenom, record.baseAssetDenom,
+					record.startTime, record.endTime)
+
+				if test.expectError != nil {
+					s.Require().Error(err)
+					s.Require().ErrorIs(err, test.expectError)
+					return
+				}
+				s.Require().NoError(err)
+				s.Require().Equal(test.expTwap[i], twap)
+			}
+		})
+	}
+}
+
 // TODO: implement
 // func (s *TestSuite) TestGetArithmeticTwapWithErrorRecords() {
 // }
@@ -418,9 +580,6 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 		return makeSimpleTwapInput(startTime, startTime, isQuoteTokenA)
 	}
 
-	quoteAssetA := true
-	quoteAssetB := false
-
 	tests := map[string]struct {
 		recordsToSet  []types.TwapRecord
 		ctxTime       time.Time
@@ -431,37 +590,37 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 		"(1 record) start time = record time": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapToNowInput(baseTime, quoteAssetA),
+			input:        makeSimpleTwapToNowInput(baseTime, baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(1 record) start time = record time, use sp1": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapToNowInput(baseTime, quoteAssetB),
+			input:        makeSimpleTwapToNowInput(baseTime, baseQuoteBA),
 			expTwap:      sdk.NewDecWithPrec(1, 1),
 		},
 		"(1 record) to_now: start time > record time": {
 			recordsToSet: []types.TwapRecord{baseRecord},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapToNowInput(baseTime.Add(10*time.Second), quoteAssetA),
+			input:        makeSimpleTwapToNowInput(baseTime.Add(10*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDec(10),
 		},
 		"(2 record) to now: start time = second record time": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapToNowInput(baseTime.Add(10*time.Second), quoteAssetA),
+			input:        makeSimpleTwapToNowInput(baseTime.Add(10*time.Second), baseQuoteAB),
 			expTwap:      sdk.NewDec(5), // 10 for 0s, 5 for 10s
 		},
 		"(2 record) to now: start time = second record time, use sp1": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      tPlusOneMin,
-			input:        makeSimpleTwapToNowInput(baseTime.Add(10*time.Second), quoteAssetB),
+			input:        makeSimpleTwapToNowInput(baseTime.Add(10*time.Second), baseQuoteBA),
 			expTwap:      sdk.NewDecWithPrec(2, 1),
 		},
 		"(2 record) first record time < start time < second record time": {
 			recordsToSet: []types.TwapRecord{baseRecord, tPlus10sp5Record},
 			ctxTime:      baseTime.Add(20 * time.Second),
-			input:        makeSimpleTwapToNowInput(baseTime.Add(5*time.Second), quoteAssetA),
+			input:        makeSimpleTwapToNowInput(baseTime.Add(5*time.Second), baseQuoteAB),
 			// 10 for 5s, 5 for 10s = 100/15 = 6 + 2/3 = 6.66666666
 			expTwap: ThreePlusOneThird.MulInt64(2),
 		},
@@ -470,13 +629,13 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 		"start time too old": {
 			recordsToSet:  []types.TwapRecord{baseRecord},
 			ctxTime:       tPlusOne,
-			input:         makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), quoteAssetA),
+			input:         makeSimpleTwapToNowInput(baseTime.Add(-time.Hour), baseQuoteAB),
 			expectedError: twap.TimeTooOldError{Time: baseTime.Add(-time.Hour)},
 		},
 		"start time too new": {
 			recordsToSet:  []types.TwapRecord{baseRecord},
 			ctxTime:       tPlusOne,
-			input:         makeSimpleTwapToNowInput(baseTime.Add(time.Hour), quoteAssetA),
+			input:         makeSimpleTwapToNowInput(baseTime.Add(time.Hour), baseQuoteAB),
 			expectedError: types.StartTimeAfterEndTimeError{StartTime: baseTime.Add(time.Hour), EndTime: tPlusOne},
 		},
 	}
@@ -501,6 +660,62 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 			}
 			s.Require().NoError(err)
 			s.Require().Equal(test.expTwap, twap)
+		})
+	}
+}
+
+func (s *TestSuite) TestGetArithmeticTwapToNow_ThreeAsset() {
+	makeSimpleTapTwapToNowInput := func(startTime time.Time, baseQuoteAB, baseQuoteAC, baseQuoteBC bool) []getTwapInput {
+		return makeSimpleTapTwapInput(startTime, startTime, baseQuoteAB, baseQuoteAC, baseQuoteBC)
+	}
+
+	tests := map[string]struct {
+		recordsToSet  []types.TwapRecord
+		ctxTime       time.Time
+		input         []getTwapInput
+		expTwap       []sdk.Dec
+		expectedError error
+	}{
+		"(2 pairs of 3 records) to now: start time = second record time": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC},
+			ctxTime: tPlusOneMin,
+			input:   makeSimpleTapTwapToNowInput(baseTime.Add(10*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 10 for 0s, 5 for 10s = 50/10 = 5
+			// C 20 for 0s, 10 for 10s = 100/10 = 10
+			// B .1 for 0s, .2 for 10s = 2/10 = 0.2
+			expTwap: []sdk.Dec{sdk.NewDec(5), sdk.NewDec(10), sdk.NewDecWithPrec(2, 1)}, // 10 for 0s, 5 for 10s
+		},
+		"(2 pairs of 3 records) first record time < start time < second record time": {
+			recordsToSet: []types.TwapRecord{tapRecordAB, tapRecordAC, tapRecordBC,
+				tPlus10sp5TapRecordAB, tPlus10sp5TapRecordAC, tPlus10sp5TapRecordBC},
+			ctxTime: baseTime.Add(20 * time.Second),
+			input:   makeSimpleTapTwapToNowInput(baseTime.Add(5*time.Second), baseQuoteAB, baseQuoteCA, baseQuoteBC),
+			// A 10 for 5s, 5 for 10s = 100/15 = 6 + 2/3 = 6.66666666
+			// C 20 for 5s, 10 for 10s = 200/15 = 13 + 1/3 = 13.333333
+			// B .1 for 5s, .2 for 10s = 2.5/15 = 0.1666666
+			expTwap: []sdk.Dec{ThreePlusOneThird.MulInt64(2), sdk.MustNewDecFromStr("13.333333333333333333"), sdk.MustNewDecFromStr("0.166666666666666666")},
+		},
+	}
+	for name, test := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+			s.preSetRecords(test.recordsToSet)
+			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
+
+			for i, record := range test.input {
+				twap, err := s.twapkeeper.GetArithmeticTwapToNow(s.Ctx, record.poolId,
+					record.quoteAssetDenom, record.baseAssetDenom,
+					record.startTime)
+
+				if test.expectedError != nil {
+					s.Require().Error(err)
+					s.Require().ErrorIs(err, test.expectedError)
+					return
+				}
+				s.Require().NoError(err)
+				s.Require().Equal(test.expTwap[i], twap)
+			}
 		})
 	}
 }

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -338,7 +338,7 @@ func (s *TestSuite) TestGetArithmeticTwap_ThreeAsset() {
 			// A 5 for 5s, 2 for 10s = 45/15 = 3
 			// C 10 for 5s, 4 for 10s = 140/15 = 6
 			// B .2 for 5s, .5 for 10s = 7/15 = .4
-			expTwap: []sdk.Dec{sdk.NewDec(3), sdk.NewDec(6), sdk.NewDecWithPrec(4, 1)}, // 5 for 5s, 2 for 10s = 45 / 15 = 3
+			expTwap: []sdk.Dec{sdk.NewDec(3), sdk.NewDec(6), sdk.NewDecWithPrec(4, 1)},
 		},
 	}
 	for name, test := range tests {

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -48,7 +48,10 @@ var (
 	// t = baseTime + 20
 	// spA = 2, spB = 0.5, spC = 4
 	tPlus20sp2Record = newTwapRecordWithDefaults(
-		baseTime.Add(20*time.Second), sdk.NewDec(2), OneSec.MulInt64(10*10+5*10), OneSec.MulInt64(3))
+		baseTime.Add(20*time.Second),
+		sdk.NewDec(2),               // spot price 0
+		OneSec.MulInt64(10*10+5*10), // accum A
+		OneSec.MulInt64(3))          // accum B
 
 	tPlus20sp2TapRecordAB, tPlus20sp2TapRecordAC, tPlus20sp2TapRecordBC = newThreeAssetPoolTwapRecordWithDefaults(
 		baseTime.Add(20*time.Second), sdk.NewDec(2), OneSec.MulInt64(10*10+5*10), OneSec.MulInt64(3), OneSec.MulInt64(20*10+10*10))

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -359,7 +359,7 @@ func (s *TestSuite) createTestRecordsFromTimeInPool(t time.Time, poolId uint64) 
 	return min2SecRecord, min1SecRecord, baseRecord, plus1SecRecord
 }
 
-func newTwapRecordWithDefaults(t time.Time, sp0, accum0, accum1 sdk.Dec) types.TwapRecord {
+func newTwoAssetPoolTwapRecordWithDefaults(t time.Time, sp0, accum0, accum1 sdk.Dec) types.TwapRecord {
 	return types.TwapRecord{
 		PoolId:      1,
 		Time:        t,

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -359,6 +359,9 @@ func (s *TestSuite) createTestRecordsFromTimeInPool(t time.Time, poolId uint64) 
 	return min2SecRecord, min1SecRecord, baseRecord, plus1SecRecord
 }
 
+// newTwoAssetPoolTwapRecordWithDefaults creates a single twap records, mimicking what one would expect from a two asset pool.
+// given a spot price 0 (sp0), this spot price is assigned to denomA and sp0 is then created and assigned to denomB by
+// calculating (1 / spA).
 func newTwoAssetPoolTwapRecordWithDefaults(t time.Time, sp0, accum0, accum1 sdk.Dec) types.TwapRecord {
 	return types.TwapRecord{
 		PoolId:      1,
@@ -373,6 +376,9 @@ func newTwoAssetPoolTwapRecordWithDefaults(t time.Time, sp0, accum0, accum1 sdk.
 	}
 }
 
+// newThreeAssetPoolTwapRecordWithDefaults creates three twap records, mimicking what one would expect from a three asset pool.
+// given a spot price 0 (sp0), this spot price is assigned to denomA and referred to as spA. spB is then created and assigned by
+// calculating (1 / spA). Finally spC is created and assigned by calculating (2 * spA).
 func newThreeAssetPoolTwapRecordWithDefaults(t time.Time, sp0, accumA, accumB, accumC sdk.Dec) (types.TwapRecord, types.TwapRecord, types.TwapRecord) {
 	spA := sp0
 	spB := sdk.OneDec().Quo(sp0)

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -373,6 +373,33 @@ func newTwapRecordWithDefaults(t time.Time, sp0, accum0, accum1 sdk.Dec) types.T
 	}
 }
 
+func newThreeAssetPoolTwapRecordWithDefaults(t time.Time, sp0, accumA, accumB, accumC sdk.Dec) (types.TwapRecord, types.TwapRecord, types.TwapRecord) {
+	spA := sp0
+	spB := sdk.OneDec().Quo(sp0)
+	spC := sp0.Mul(sdk.NewDec(2))
+	twapAB := types.TwapRecord{
+		PoolId:      2,
+		Time:        t,
+		Asset0Denom: denom0,
+		Asset1Denom: denom1,
+
+		P0LastSpotPrice:             spA,
+		P1LastSpotPrice:             spB,
+		P0ArithmeticTwapAccumulator: accumA,
+		P1ArithmeticTwapAccumulator: accumB,
+	}
+	twapAC := twapAB
+	twapAC.Asset1Denom = denom2
+	twapAC.P1LastSpotPrice = spC
+	twapAC.P1ArithmeticTwapAccumulator = accumC
+	twapBC := twapAC
+	twapBC.Asset0Denom = denom1
+	twapBC.P0LastSpotPrice = spB
+	twapBC.P0ArithmeticTwapAccumulator = accumB
+
+	return twapAB, twapAC, twapBC
+}
+
 func newEmptyPriceRecord(poolId uint64, t time.Time, asset0 string, asset1 string) types.TwapRecord {
 	return types.TwapRecord{
 		PoolId:      poolId,

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -239,7 +239,7 @@ func TestRecordWithUpdatedAccumulators(t *testing.T) {
 }
 
 func (s *TestSuite) TestGetInterpolatedRecord() {
-	baseRecord := newTwapRecordWithDefaults(baseTime, sdk.OneDec(), sdk.OneDec(), sdk.OneDec())
+	baseRecord := newTwoAssetPoolTwapRecordWithDefaults(baseTime, sdk.OneDec(), sdk.OneDec(), sdk.OneDec())
 
 	// all tests occur with updateTime = base time + time.Unix(1, 0)
 	tests := map[string]struct {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2538

## What is the purpose of the change

PR #2604 attempted to combine current tests with three asset pool tests. This proved to be very messy and unclear. This PR is another attempt at implementing these tests in a separate and clearer manner. Additionally, more complex test cases are used (varying spot prices for all three assets) for every three asset pool test case along with comments explaining the math behind each expected twap.

Part one addresses api_test.go

Part two will address logic_test.go and store_test.go

## Brief Changelog

- Adds test cases for api_test.go
- Adds function in keeper_test.go to generate default three asset pools


## Testing and Verifying

This change is already covered by existing tests


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable