### PR TITLE
Replace deprecated `ioutil` imports with `os`

### DIFF
--- a/cmd/osmosisd/cmd/airdrop.go.history
+++ b/cmd/osmosisd/cmd/airdrop.go.history
@@ -6,7 +6,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -99,7 +98,7 @@ Example:
 			}
 			defer genesisJson.Close()
 
-			byteValue, _ := ioutil.ReadAll(genesisJson)
+			byteValue, _ := os.ReadAll(genesisJson)
 
 			var genStateV036 GenesisStateV036
 
@@ -239,7 +238,7 @@ Example:
 				return fmt.Errorf("failed to marshal snapshot: %w", err)
 			}
 
-			err = ioutil.WriteFile(snapshotOutput, snapshotJSON, 0644)
+			err = os.WriteFile(snapshotOutput, snapshotJSON, 0644)
 			return err
 		},
 	}

--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -127,7 +127,7 @@ func getGenStateFromPath(genesisFilePath string) (map[string]json.RawMessage, er
 	}
 	defer genesisFile.Close()
 
-	byteValue, _ := ioutil.ReadAll(genesisFile)
+	byteValue, _ := io.ReadAll(genesisFile)
 
 	var doc tmtypes.GenesisDoc
 	err = tmjson.Unmarshal(byteValue, &doc)
@@ -293,7 +293,7 @@ Example:
 				return fmt.Errorf("failed to marshal snapshot: %w", err)
 			}
 
-			err = ioutil.WriteFile(snapshotOutput, snapshotJSON, 0o644)
+			err = os.WriteFile(snapshotOutput, snapshotJSON, 0o644)
 			return err
 		},
 	}

--- a/cmd/querygen/templates/queryyml.go
+++ b/cmd/querygen/templates/queryyml.go
@@ -1,7 +1,7 @@
 package templates
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -40,7 +40,7 @@ type CliDescriptor struct {
 }
 
 func ReadYmlFile(filepath string) (QueryYml, error) {
-	content, err := ioutil.ReadFile(filepath) // the file is inside the local directory
+	content, err := os.ReadFile(filepath) // the file is inside the local directory
 	if err != nil {
 		return QueryYml{}, err
 	}

--- a/simulation/executor/event_stats.go
+++ b/simulation/executor/event_stats.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 // EventStats defines an object that keeps a tally of each event that has occurred
@@ -48,7 +48,7 @@ func (es EventStats) ExportJSON(path string) {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(path, bz, 0o600)
+	err = os.WriteFile(path, bz, 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/simulation/executor/legacyconfig.go
+++ b/simulation/executor/legacyconfig.go
@@ -3,7 +3,6 @@ package simulation
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -130,7 +129,7 @@ func SetupSimulation(dirPrefix, dbName string) (cfg Config, db dbm.DB, logger lo
 	}
 	logger = simlogger.NewSimLogger(logger)
 
-	dir, err := ioutil.TempDir("", dirPrefix)
+	dir, err := os.MkdirTemp("", dirPrefix)
 	if err != nil {
 		return Config{}, nil, nil, func() {}, err
 	}

--- a/simulation/simtypes/manager.go
+++ b/simulation/simtypes/manager.go
@@ -2,8 +2,8 @@ package simtypes
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"sort"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -82,7 +82,7 @@ func NewSimulationManager(manager module.Manager, overrideModules map[string]mod
 }
 
 func loadAppParamsForWasm(path string) simulation.AppParams {
-	bz, err := ioutil.ReadFile(path)
+	bz, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/store/legacy/v101/tree_test.go
+++ b/store/legacy/v101/tree_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -109,7 +109,7 @@ func extract(store sdk.KVStore) (res []kvPair) {
 }
 
 func readold() []kvPair {
-	bz, err := ioutil.ReadFile("./old_tree.json")
+	bz, err := os.ReadFile("./old_tree.json")
 	if err != nil {
 		panic(err)
 	}

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -233,7 +233,7 @@ func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir st
 func (m *Manager) RunChainInitResource(chainId string, chainVotingPeriod, chainExpeditedVotingPeriod int, validatorConfigBytes []byte, mountDir string, forkHeight int) (*dockertest.Resource, error) {
 	votingPeriodDuration := time.Duration(chainVotingPeriod * 1000000000)
 	// TODO: Uncomment this after v12 release
-	//expeditedVotingPeriodDuration := time.Duration(chainExpeditedVotingPeriod * 1000000000)
+	// expeditedVotingPeriodDuration := time.Duration(chainExpeditedVotingPeriod * 1000000000)
 
 	initResource, err := m.pool.RunWithOptions(
 		&dockertest.RunOptions{
@@ -247,7 +247,7 @@ func (m *Manager) RunChainInitResource(chainId string, chainVotingPeriod, chainE
 				fmt.Sprintf("--config=%s", validatorConfigBytes),
 				fmt.Sprintf("--voting-period=%v", votingPeriodDuration),
 				// TODO: Uncomment this after v12 release
-				//fmt.Sprintf("--expedited-voting-period=%v", expeditedVotingPeriodDuration),
+				// fmt.Sprintf("--expedited-voting-period=%v", expeditedVotingPeriodDuration),
 				fmt.Sprintf("--fork-height=%v", forkHeight),
 			},
 			User: "root:root",

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -38,7 +38,7 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferAndCreatePool() {
 
 // TestSuperfluidVoting tests that superfluid voting is functioning as expected.
 // It does so by doing the following:
-//- creating a pool
+// - creating a pool
 // - attempting to submit a proposal to enable superfluid voting in that pool
 // - voting yes on the proposal from the validator wallet
 // - voting no on the proposal from the delegator wallet
@@ -243,7 +243,7 @@ func (s *IntegrationTestSuite) TestStateSync() {
 		filepath.Join(runningNode.ConfigDir, "config", "genesis.json"),
 		stateSynchingNodeConfig,
 		time.Duration(chainA.VotingPeriod),
-		//time.Duration(chainA.ExpeditedVotingPeriod),
+		// time.Duration(chainA.ExpeditedVotingPeriod),
 		trustHeight,
 		trustHash,
 		stateSyncRPCServers,

--- a/tests/e2e/util/io.go
+++ b/tests/e2e/util/io.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -39,5 +38,5 @@ func WriteFile(path string, body []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, body, 0o600)
+	return os.WriteFile(path, body, 0o600)
 }

--- a/tests/simulator/genesis.go
+++ b/tests/simulator/genesis.go
@@ -3,11 +3,12 @@ package simapp
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
+	"os"
 
-	"github.com/osmosis-labs/osmosis/v12/app"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/osmosis-labs/osmosis/v12/app"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -18,7 +19,7 @@ import (
 // AppStateFromGenesisFileFn util function to generate the genesis AppState
 // from a genesis.json file.
 func AppStateFromGenesisFileFn(r io.Reader, cdc codec.JSONCodec, genesisFile string) (tmtypes.GenesisDoc, []simtypes.Account) {
-	bytes, err := ioutil.ReadFile(genesisFile)
+	bytes, err := os.ReadFile(genesisFile)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/simulator/state.go
+++ b/tests/simulator/state.go
@@ -2,9 +2,9 @@ package simapp
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/osmosis-labs/osmosis/v12/app"
@@ -54,7 +54,7 @@ func AppStateFn() osmosim.AppStateFn {
 
 		case config.ParamsFile != "":
 			appParams := make(simtypes.AppParams)
-			bz, err := ioutil.ReadFile(config.ParamsFile)
+			bz, err := os.ReadFile(config.ParamsFile)
 			if err != nil {
 				panic(err)
 			}

--- a/wasmbinding/test/custom_query_test.go
+++ b/wasmbinding/test/custom_query_test.go
@@ -3,7 +3,7 @@ package wasmbinding
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"testing"
 
@@ -299,7 +299,7 @@ func assertValidShares(t *testing.T, shares wasmvmtypes.Coin, poolID uint64) {
 
 func storeReflectCode(t *testing.T, ctx sdk.Context, osmosis *app.OsmosisApp, addr sdk.AccAddress) {
 	govKeeper := osmosis.GovKeeper
-	wasmCode, err := ioutil.ReadFile("../testdata/osmo_reflect.wasm")
+	wasmCode, err := os.ReadFile("../testdata/osmo_reflect.wasm")
 	require.NoError(t, err)
 
 	src := wasmtypes.StoreCodeProposalFixture(func(p *wasmtypes.StoreCodeProposal) {

--- a/wasmbinding/test/store_run_test.go
+++ b/wasmbinding/test/store_run_test.go
@@ -2,7 +2,7 @@ package wasmbinding
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +27,7 @@ func TestNoStorageWithoutProposal(t *testing.T) {
 	_, _, creator := keyPubAddr()
 
 	// upload reflect code
-	wasmCode, err := ioutil.ReadFile("../testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("../testdata/hackatom.wasm")
 	require.NoError(t, err)
 	_, err = contractKeeper.Create(ctx, creator, wasmCode, nil)
 	require.Error(t, err)
@@ -35,7 +35,7 @@ func TestNoStorageWithoutProposal(t *testing.T) {
 
 func storeCodeViaProposal(t *testing.T, ctx sdk.Context, osmosis *app.OsmosisApp, addr sdk.AccAddress) {
 	govKeeper := osmosis.GovKeeper
-	wasmCode, err := ioutil.ReadFile("../testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("../testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	src := types.StoreCodeProposalFixture(func(p *types.StoreCodeProposal) {
@@ -68,7 +68,7 @@ func TestStoreCodeProposal(t *testing.T) {
 
 	storedCode, err := wasmKeeper.GetByteCode(ctx, 1)
 	require.NoError(t, err)
-	wasmCode, err := ioutil.ReadFile("../testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("../testdata/hackatom.wasm")
 	require.NoError(t, err)
 	assert.Equal(t, wasmCode, storedCode)
 }

--- a/x/gamm/client/cli/parse.go
+++ b/x/gamm/client/cli/parse.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/pflag"
 )
@@ -38,7 +38,7 @@ func parseCreatePoolFlags(fs *pflag.FlagSet) (*createPoolInputs, error) {
 		return nil, fmt.Errorf("must pass in a pool json using the --%s flag", FlagPoolFile)
 	}
 
-	contents, err := ioutil.ReadFile(poolFile)
+	contents, err := os.ReadFile(poolFile)
 	if err != nil {
 		return nil, err
 	}

--- a/x/lockup/client/cli/query.go
+++ b/x/lockup/client/cli/query.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -785,7 +785,7 @@ $ %s query lockup output-all-locks <max lock ID>
 			if err != nil {
 				return err
 			}
-			err = ioutil.WriteFile("lock_export.json", bz, 0o777)
+			err = os.WriteFile("lock_export.json", bz, 0o777)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

`make format` was failing locally due to a deprecated import:
<img width="837" alt="Screen Shot 2022-09-10 at 10 12 57 AM" src="https://user-images.githubusercontent.com/62043214/189495079-aa6c57c1-a071-41a2-8d52-5effa5d40c2b.png">

This PR replaces the import with its updated version. cc: @ValarDragon since this mainly touches simulator code

## Brief Changelog

- Replace all uses of `io/ioutil` with `os`

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)