### PR TITLE
[stableswap]: Add checks for invalid cfmm inputs

### DIFF
--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -18,24 +18,25 @@ type StableSwapTestSuite struct {
 func TestCFMMInvariantTwoAssets(t *testing.T) {
 	kErrTolerance := sdk.OneDec()
 
-	tests := []struct {
+	tests := map[string]struct {
 		xReserve    sdk.Dec
 		yReserve    sdk.Dec
 		yIn         sdk.Dec
 		expectPanic bool
 	}{
-		{
+		"small pool small input": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			sdk.NewDec(1),
 			false,
 		},
-		{
+		"small pool large input": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			sdk.NewDec(1000),
 			false,
 		},
+		// This test fails due to a bug in our original solver
 		// {
 		// 	sdk.NewDec(100000),
 		// 	sdk.NewDec(100000),
@@ -43,19 +44,19 @@ func TestCFMMInvariantTwoAssets(t *testing.T) {
 		// },
 
 		// panic catching
-		{ // xReserve negative
+		"xReserve negative": {
 			sdk.NewDec(-100),
 			sdk.NewDec(100),
 			sdk.NewDec(1),
 			true,
 		},
-		{ // yReserve negative
+		"yReserve negative": {
 			sdk.NewDec(100),
 			sdk.NewDec(-100),
 			sdk.NewDec(1),
 			true,
 		},
-		{ // yIn negative
+		"yIn negative": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			sdk.NewDec(-1),
@@ -63,33 +64,34 @@ func TestCFMMInvariantTwoAssets(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		// system under test
-		sut := func() {
-			// using two-asset cfmm
-			k0 := cfmmConstant(test.xReserve, test.yReserve)
-			xOut := solveCfmm(test.xReserve, test.yReserve, test.yIn)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// system under test
+			sut := func() {
+				// using two-asset cfmm
+				k0 := cfmmConstant(test.xReserve, test.yReserve)
+				xOut := solveCfmm(test.xReserve, test.yReserve, test.yIn)
 
-			k1 := cfmmConstant(test.xReserve.Sub(xOut), test.yReserve.Add(test.yIn))
-			osmoassert.DecApproxEq(t, k0, k1, kErrTolerance)
+				k1 := cfmmConstant(test.xReserve.Sub(xOut), test.yReserve.Add(test.yIn))
+				osmoassert.DecApproxEq(t, k0, k1, kErrTolerance)
 
-			// using multi-asset cfmm (should be equivalent with u = 1, w = 0)
-			k2 := cfmmConstantMulti(test.xReserve, test.yReserve, sdk.OneDec(), sdk.ZeroDec())
-			osmoassert.DecApproxEq(t, k2, k0, kErrTolerance)
-			xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, sdk.ZeroDec(), test.yIn)
-			fmt.Println(xOut2)
-			k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), sdk.OneDec(), sdk.ZeroDec())
-			osmoassert.DecApproxEq(t, k2, k3, kErrTolerance)
-		}
+				// using multi-asset cfmm (should be equivalent with u = 1, w = 0)
+				k2 := cfmmConstantMulti(test.xReserve, test.yReserve, sdk.OneDec(), sdk.ZeroDec())
+				osmoassert.DecApproxEq(t, k2, k0, kErrTolerance)
+				xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, sdk.ZeroDec(), test.yIn)
+				k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), sdk.OneDec(), sdk.ZeroDec())
+				osmoassert.DecApproxEq(t, k2, k3, kErrTolerance)
+			}
 
-		osmoassert.ConditionalPanic(t, test.expectPanic, sut)
+			osmoassert.ConditionalPanic(t, test.expectPanic, sut)
+		})
 	}
 }
 
 func TestCFMMInvariantMultiAssets(t *testing.T) {
 	kErrTolerance := sdk.OneDec()
 
-	tests := []struct {
+	tests := map[string]struct {
 		xReserve    sdk.Dec
 		yReserve    sdk.Dec
 		uReserve    sdk.Dec
@@ -97,7 +99,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 		yIn         sdk.Dec
 		expectPanic bool
 	}{
-		{
+		"4-asset pool, small input": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			// represents a 4-asset pool with 100 in each reserve
@@ -106,7 +108,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sdk.NewDec(1),
 			false,
 		},
-		{
+		"4-asset pool, large input": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			sdk.NewDec(200),
@@ -114,14 +116,15 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sdk.NewDec(1000),
 			false,
 		},
-		// {
+		// This test fails due to a bug in our original solver
+		// "large pool, large input": {
 		// 	sdk.NewDec(100000),
 		// 	sdk.NewDec(100000),
 		// 	sdk.NewDec(10000),
 		// },
 
 		// panic catching
-		{ // negative xReserve
+		"negative xReserve": {
 			sdk.NewDec(-100),
 			sdk.NewDec(100),
 			// represents a 4-asset pool with 100 in each reserve
@@ -130,7 +133,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sdk.NewDec(1),
 			true,
 		},
-		{ // negative yReserve
+		"negative yReserve": {
 			sdk.NewDec(100),
 			sdk.NewDec(-100),
 			// represents a 4-asset pool with 100 in each reserve
@@ -139,7 +142,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sdk.NewDec(1),
 			true,
 		},
-		{ // negative uReserve
+		"negative uReserve": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			// represents a 4-asset pool with 100 in each reserve
@@ -148,7 +151,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sdk.NewDec(1),
 			true,
 		},
-		{ // negative sumSquares
+		"negative sumSquares": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			// represents a 4-asset pool with 100 in each reserve
@@ -157,7 +160,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sdk.NewDec(1),
 			true,
 		},
-		{ // negative yIn
+		"negative yIn": {
 			sdk.NewDec(100),
 			sdk.NewDec(100),
 			// represents a 4-asset pool with 100 in each reserve
@@ -168,17 +171,19 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		// system under test
-		sut := func() {
-			// using multi-asset cfmm
-			k2 := cfmmConstantMulti(test.xReserve, test.yReserve, test.uReserve, test.wSumSquares)
-			xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, test.wSumSquares, test.yIn)
-			k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), test.uReserve, test.wSumSquares)
-			osmoassert.DecApproxEq(t, k2, k3, kErrTolerance)
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// system under test
+			sut := func() {
+				// using multi-asset cfmm
+				k2 := cfmmConstantMulti(test.xReserve, test.yReserve, test.uReserve, test.wSumSquares)
+				xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, test.wSumSquares, test.yIn)
+				k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), test.uReserve, test.wSumSquares)
+				osmoassert.DecApproxEq(t, k2, k3, kErrTolerance)
+			}
 
-		osmoassert.ConditionalPanic(t, test.expectPanic, sut)
+			osmoassert.ConditionalPanic(t, test.expectPanic, sut)
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2694 

## What is the purpose of the change

From issue:

> While testing our stableswap CFMMs (both two-asset and multi), I noticed that given their complexity it is possible for certain really weird inputs to get passed into the solvers that go completely uncaught. Both for security reasons and for more time-effective testing/bug squashing, I think we should implement validity checks for inputs to (and outputs of) the CFMM solvers.

This PR adds these validity checks.

## Brief Changelog

- Ensure inputs and outputs of CFMM functions are checked for basic validity (not negative, outputs not greater than reserves etc.)

## Testing and Verifying

This change added tests that verify negative input checks in `stableswap/amm_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)