### PR TITLE
Make gamm pools override addr already exists

### DIFF
--- a/osmoutils/module_account.go
+++ b/osmoutils/module_account.go
@@ -1,0 +1,67 @@
+package osmoutils
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+)
+
+type AccountKeeper interface {
+	NewAccount(sdk.Context, authtypes.AccountI) authtypes.AccountI
+
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
+}
+
+// CanCreateModuleAccountAtAddr tells us if we can safely make a module account at
+// a given address. By collision resistance of the addr, we assume that
+// TODO: This is generally an SDK design flaw
+// code based off wasmd code: https://github.com/CosmWasm/wasmd/pull/996
+func CanCreateModuleAccountAtAddr(ctx sdk.Context, ak AccountKeeper, addr sdk.AccAddress) error {
+	existingAcct := ak.GetAccount(ctx, addr)
+	if existingAcct == nil {
+		return nil
+	}
+	if existingAcct.GetSequence() != 0 || existingAcct.GetPubKey() != nil {
+		return fmt.Errorf("cannot create module account %s, "+
+			"due to an account at that address already existing & having sent txs", addr)
+	}
+	var overrideAccountTypes = map[reflect.Type]struct{}{
+		reflect.TypeOf(&authtypes.BaseAccount{}):                 {},
+		reflect.TypeOf(&vestingtypes.DelayedVestingAccount{}):    {},
+		reflect.TypeOf(&vestingtypes.ContinuousVestingAccount{}): {},
+		reflect.TypeOf(&vestingtypes.BaseVestingAccount{}):       {},
+		reflect.TypeOf(&vestingtypes.PeriodicVestingAccount{}):   {},
+		reflect.TypeOf(&vestingtypes.PermanentLockedAccount{}):   {},
+		reflect.TypeOf(&vestingtypes.ClawbackVestingAccount{}):   {},
+	}
+	if _, clear := overrideAccountTypes[reflect.TypeOf(existingAcct)]; clear {
+		return nil
+	}
+	return errors.New("cannot create module account %s, " +
+		"due to an account at that address already existing & not being an overrideable type")
+}
+
+// CreateModuleAccount creates a module account at the provided address.
+// It overrides an account if it exists at that address, with a non-zero sequence number & pubkey
+// Contract: addr is derived from `address.Module(ModuleName, key)`
+func CreateModuleAccount(ctx sdk.Context, ak AccountKeeper, addr sdk.AccAddress) error {
+	err := CanCreateModuleAccountAtAddr(ctx, ak, addr)
+	if err != nil {
+		return err
+	}
+
+	acc := ak.NewAccount(
+		ctx,
+		authtypes.NewModuleAccount(
+			authtypes.NewBaseAccountWithAddress(addr),
+			addr.String(),
+		),
+	)
+	ak.SetAccount(ctx, acc)
+	return nil
+}

--- a/osmoutils/module_account_test.go
+++ b/osmoutils/module_account_test.go
@@ -1,6 +1,7 @@
 package osmoutils_test
 
 import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -15,9 +16,14 @@ func (s *TestSuite) TestCreateModuleAccount() {
 		acc.SetAddress(addr)
 		return acc
 	}
-	userAcc := func(addr sdk.AccAddress) authtypes.AccountI {
+	userAccViaSeqnum := func(addr sdk.AccAddress) authtypes.AccountI {
 		base := baseWithAddr(addr)
 		base.SetSequence(2)
+		return base
+	}
+	userAccViaPubkey := func(addr sdk.AccAddress) authtypes.AccountI {
+		base := baseWithAddr(addr)
+		base.SetPubKey(secp256k1.GenPrivKey().PubKey())
 		return base
 	}
 	defaultModuleAccAddr := address.Module("dummy module", []byte{1})
@@ -36,8 +42,13 @@ func (s *TestSuite) TestCreateModuleAccount() {
 			moduleAccAddr: defaultModuleAccAddr,
 			expErr:        false,
 		},
-		"prior user acc at addr": {
-			priorAccounts: []authtypes.AccountI{userAcc(defaultModuleAccAddr)},
+		"prior user acc at addr (sequence)": {
+			priorAccounts: []authtypes.AccountI{userAccViaSeqnum(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        true,
+		},
+		"prior user acc at addr (pubkey)": {
+			priorAccounts: []authtypes.AccountI{userAccViaPubkey(defaultModuleAccAddr)},
 			moduleAccAddr: defaultModuleAccAddr,
 			expErr:        true,
 		},

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -20,6 +20,11 @@ type TestSuite struct {
 	store sdk.KVStore
 }
 
+func (suite *TestSuite) SetupTest() {
+	suite.Setup()
+
+}
+
 const (
 	keyA               = "a"
 	keyB               = "b"

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -5,10 +5,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/osmosis-labs/osmosis/v12/osmomath"
+	"github.com/osmosis-labs/osmosis/v12/osmoutils"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )
 
@@ -101,10 +101,6 @@ func (k Keeper) validateCreatedPool(
 		return sdkerrors.Wrapf(types.ErrInvalidPool,
 			"Pool was attempted to be created with incorrect number of initial shares.")
 	}
-	acc := k.accountKeeper.GetAccount(ctx, pool.GetAddress())
-	if acc != nil {
-		return sdkerrors.Wrapf(types.ErrPoolAlreadyExist, "pool %d already exist", poolId)
-	}
 	return nil
 }
 
@@ -143,14 +139,9 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 	}
 
 	// create and save the pool's module account to the account keeper
-	acc := k.accountKeeper.NewAccount(
-		ctx,
-		authtypes.NewModuleAccount(
-			authtypes.NewBaseAccountWithAddress(pool.GetAddress()),
-			pool.GetAddress().String(),
-		),
-	)
-	k.accountKeeper.SetAccount(ctx, acc)
+	if err := osmoutils.CreateModuleAccount(ctx, k.accountKeeper, pool.GetAddress()); err != nil {
+		return 0, fmt.Errorf("creating pool module account for id %d: %w", poolId, err)
+	}
 
 	// send initial liquidity to the pool
 	err = k.bankKeeper.SendCoins(ctx, sender, pool.GetAddress(), initialPoolLiquidity)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Make gamm pools still creatable if the underlying account already exists

## Brief Changelog

- Add helper methods for creating module accounts, to override underlying ones. This is safe because module accounts as long created via the correct constructors, have domain separation and collision resistance from other addresses.
- Apply change to AMM module

## Testing and Verifying

This change added tests and can be verified as follows:

- added unit tests that validate the new method works with prior addresses existing

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no*
  - How is the feature or change documented? code comments