### PR TITLE
fix: localosmosis build patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ mdlint:
 
 markdown:
 	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --fix
-	
+
 ###############################################################################
 ###                                Localnet                                 ###
 ###############################################################################
@@ -361,7 +361,7 @@ localnet-keys:
 	. tests/localosmosis/scripts/add_keys.sh
 
 localnet-build:
-	@docker-compose -f tests/localosmosis/docker-compose.yml build
+	@DOCKER_BUILDKIT=1 docker-compose -f tests/localosmosis/docker-compose.yml build
 
 localnet-build-state-export:
 	@docker build -t local:osmosis-se --build-arg ID=$(ID) -f tests/localosmosis/mainnet_state/Dockerfile-stateExport .

--- a/tests/localosmosis/scripts/add_keys.sh
+++ b/tests/localosmosis/scripts/add_keys.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "satisfy adjust timber high purchase tuition stool faith fine install that you unaware feed domain license impose boss human eager hat rent enjoy dawn" | osmosisd keys add lo-val --recover --keyring-backend test
+echo "bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort" | osmosisd keys add val --recover --keyring-backend test
 echo "notice oak worry limit wrap speak medal online prefer cluster roof addict wrist behave treat actual wasp year salad speed social layer crew genius" | osmosisd keys add lo-test1 --recover --keyring-backend test
 echo "quality vacuum heart guard buzz spike sight swarm shove special gym robust assume sudden deposit grid alcohol choice devote leader tilt noodle tide penalty" | osmosisd keys add lo-test2 --recover --keyring-backend test
 echo "symbol force gallery make bulk round subway violin worry mixture penalty kingdom boring survey tool fringe patrol sausage hard admit remember broken alien absorb" | osmosisd keys add lo-test3 --recover --keyring-backend test

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -5,7 +5,7 @@ OSMOSIS_HOME=$HOME/.osmosisd
 CONFIG_FOLDER=$OSMOSIS_HOME/config
 MONIKER=val
 
-MNEMONIC="satisfy adjust timber high purchase tuition stool faith fine install that you unaware feed domain license impose boss human eager hat rent enjoy dawn"
+MNEMONIC="bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort"
 
 install_prerequisites () {
     apk add dasel
@@ -40,7 +40,7 @@ edit_genesis () {
     dasel put string -f $GENESIS '.app_state.incentives.lockable_durations.[1]' "120s"
     dasel put string -f $GENESIS '.app_state.incentives.lockable_durations.[2]' "180s"
     dasel put string -f $GENESIS '.app_state.incentives.lockable_durations.[3]' "240s"
-    dasel put string -f $GENESIS '.app_state.incentives.params.distr_epoch_identifier' "day" 
+    dasel put string -f $GENESIS '.app_state.incentives.params.distr_epoch_identifier' "day"
 
     # Update mint module
     dasel put string -f $GENESIS '.app_state.mint.params.mint_denom' "uosmo"
@@ -51,11 +51,14 @@ edit_genesis () {
 
     # Update txfee basedenom
     dasel put string -f $GENESIS '.app_state.txfees.basedenom' "uosmo"
+
+    # Update wasm permission (Nobody or Everybody)
+    dasel put string -f $GENESIS '.app_state.wasm.params.code_upload_access.permission' "Nobody"
 }
 
 add_genesis_accounts () {
 
-    osmosisd add-genesis-account osmo1phaxpevm5wecex2jyaqty2a4v02qj7qmlmzk5a 100000000000uosmo,100000000000uion --home $OSMOSIS_HOME 
+    osmosisd add-genesis-account osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj 100000000000uosmo,100000000000uion --home $OSMOSIS_HOME 
     osmosisd add-genesis-account osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks 100000000000uosmo,100000000000uion --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo18s5lynnmx37hq4wlrw9gdn68sg2uxp5rgk26vv 100000000000uosmo,100000000000uion --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo1qwexv7c6sm95lwhzn9027vyu2ccneaqad4w8ka 100000000000uosmo,100000000000uion --home $OSMOSIS_HOME


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

After the introduction of docker buildkits, we did not add this required buildkit to localosmosis. This fixes this issue.

I also:
* Changed the val key so its the same between localosmosis and localosmosis with mainnet state
* Added a line to the setup script to make changing between permissioned and permissionless cosmwasm easier


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable