### PR TITLE
fix: MsgBeginUnlocking bug

### DIFF
--- a/x/lockup/types/msgs.go
+++ b/x/lockup/types/msgs.go
@@ -111,8 +111,8 @@ func (m MsgBeginUnlocking) ValidateBasic() error {
 		return fmt.Errorf("invalid lockup ID, got %v", m.ID)
 	}
 
-	// only allow unlocks with a single denom or nil
-	if m.Coins.Len() > 1 {
+	// only allow unlocks with a single denom or empty
+	if m.Coins.Len() != 1 || !m.Coins.Empty() {
 		return fmt.Errorf("can only unlock one denom per lock ID, got %v", m.Coins)
 	}
 

--- a/x/lockup/types/msgs.go
+++ b/x/lockup/types/msgs.go
@@ -112,11 +112,11 @@ func (m MsgBeginUnlocking) ValidateBasic() error {
 	}
 
 	// only allow unlocks with a single denom or empty
-	if m.Coins.Len() != 1 || !m.Coins.Empty() {
+	if m.Coins.Len() > 1 {
 		return fmt.Errorf("can only unlock one denom per lock ID, got %v", m.Coins)
 	}
 
-	if !m.Coins.IsAllPositive() {
+	if !m.Coins.Empty() && !m.Coins.IsAllPositive() {
 		return fmt.Errorf("cannot unlock a zero or negative amount")
 	}
 

--- a/x/lockup/types/msgs.go
+++ b/x/lockup/types/msgs.go
@@ -111,8 +111,8 @@ func (m MsgBeginUnlocking) ValidateBasic() error {
 		return fmt.Errorf("invalid lockup ID, got %v", m.ID)
 	}
 
-	// only allow unlocks with a single denom
-	if m.Coins.Len() != 1 {
+	// only allow unlocks with a single denom or nil
+	if m.Coins.Len() > 1 {
 		return fmt.Errorf("can only unlock one denom per lock ID, got %v", m.Coins)
 	}
 

--- a/x/lockup/types/msgs_test.go
+++ b/x/lockup/types/msgs_test.go
@@ -197,7 +197,6 @@ func TestMsgBeginUnlocking(t *testing.T) {
 				require.Equal(t, signers[0].String(), addr1)
 			} else {
 				require.Error(t, test.msg.ValidateBasic(), "test: %v", test.name)
-
 			}
 		})
 	}

--- a/x/lockup/types/msgs_test.go
+++ b/x/lockup/types/msgs_test.go
@@ -167,12 +167,22 @@ func TestMsgBeginUnlocking(t *testing.T) {
 			},
 		},
 		{
-			name: "not positive coins amount",
+			name: "zero coins (same as nil)",
 			msg: types.MsgBeginUnlocking{
 				Owner: addr1,
 				ID:    1,
 				Coins: sdk.NewCoins(sdk.NewCoin("test1", sdk.NewInt(0))),
 			},
+			expectPass: true,
+		},
+		{
+			name: "nil coins (unlock by ID)",
+			msg: types.MsgBeginUnlocking{
+				Owner: addr1,
+				ID:    1,
+				Coins: sdk.NewCoins(),
+			},
+			expectPass: true,
 		},
 	}
 
@@ -187,6 +197,7 @@ func TestMsgBeginUnlocking(t *testing.T) {
 				require.Equal(t, signers[0].String(), addr1)
 			} else {
 				require.Error(t, test.msg.ValidateBasic(), "test: %v", test.name)
+
 			}
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

As discovered on the v12 integrator testnet, attempting a begin-unlock-by-id (MsgBeginUnlocking) results in an error. This is because we pass a nil Coins object to MsgBeginUnlocking when we unlock by id, and the newly added ValidateBasic requires a length of 1 (which would be used if we are unlocking a specific subset of the lock)


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable