### PR TITLE
review(x/twap): minor post-review clean up (post v-12)

### DIFF
--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -116,8 +116,6 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 	if err != nil {
 		return err
 	}
-	// TODO: Add a safety assert, that # of records is as we expect, given # of denoms in the pool
-	// namely, that for `k` denoms in pool, there should be k * (k - 1) / 2 records
 
 	denoms, err := k.ammkeeper.GetPoolDenoms(ctx, poolId)
 	if err != nil {

--- a/x/twap/migrate.go
+++ b/x/twap/migrate.go
@@ -6,8 +6,8 @@ import (
 
 // MigrateExistingPools iterates through all pools and creates state entry for the twap module.
 func (k Keeper) MigrateExistingPools(ctx sdk.Context, latestPoolId uint64) error {
-	for i := 1; i <= int(latestPoolId); i++ {
-		err := k.afterCreatePool(ctx, uint64(i))
+	for i := uint64(1); i <= latestPoolId; i++ {
+		err := k.afterCreatePool(ctx, i)
 		if err != nil {
 			return err
 		}

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -20,6 +20,9 @@ func (e timeTooOldError) Error() string {
 		" Try storing the accumulator value. (requested time %s)", e.Time)
 }
 
+// just has to not be empty, for store to work / not register as a delete.
+var sentinelExistsValue = []byte{1}
+
 // trackChangedPool places an entry into a transient store,
 // to track that this pool changed this block.
 // This tracking is for use in EndBlock, to create new TWAP records.
@@ -27,8 +30,7 @@ func (k Keeper) trackChangedPool(ctx sdk.Context, poolId uint64) {
 	store := ctx.TransientStore(k.transientKey)
 	poolIdBz := make([]byte, 8)
 	binary.LittleEndian.PutUint64(poolIdBz, poolId)
-	// just has to not be empty, for store to work / not register as a delete.
-	sentinelExistsValue := []byte{1}
+
 	store.Set(poolIdBz, sentinelExistsValue)
 }
 

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -11,8 +11,9 @@ import (
 var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
 
 // GetAllUniqueDenomPairs returns all unique pairs of denoms, where for every pair
-// (X, Y), X >= Y.
+// (X, Y), X > Y.
 // The pair (X,Y) should only appear once in the list
+// Panics if finds duplicate pairs.
 //
 // NOTE: Sorts the input denoms slice.
 func GetAllUniqueDenomPairs(denoms []string) ([]string, []string) {

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v12/osmoutils"
 )
 
 var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
@@ -18,23 +20,23 @@ var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
 // NOTE: Sorts the input denoms slice.
 func GetAllUniqueDenomPairs(denoms []string) ([]string, []string) {
 	// get denoms in descending order
-	sort.Slice(denoms, func(i, j int) bool {
-		return denoms[i] > denoms[j]
-	})
+	sort.Strings(denoms)
+	reverseDenoms := osmoutils.ReverseSlice(denoms)
 
 	numPairs := len(denoms) * (len(denoms) - 1) / 2
 	pairGT := make([]string, 0, numPairs)
 	pairLT := make([]string, 0, numPairs)
 
-	for i := 0; i < len(denoms); i++ {
-		for j := i + 1; j < len(denoms); j++ {
-			pairGT = append(pairGT, denoms[i])
-			pairLT = append(pairLT, denoms[j])
-
-			// sanity check
-			if pairGT[i] == pairLT[i] {
-				panic("input had duplicated denom")
-			}
+	for i := 0; i < len(reverseDenoms); i++ {
+		for j := i + 1; j < len(reverseDenoms); j++ {
+			pairGT = append(pairGT, reverseDenoms[i])
+			pairLT = append(pairLT, reverseDenoms[j])
+		}
+	}
+	// sanity check
+	for i := 0; i < numPairs; i++ {
+		if pairGT[i] == pairLT[i] {
+			panic("input had duplicated denom")
 		}
 	}
 	return pairGT, pairLT

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/osmosis-labs/osmosis/v12/osmoutils"
 )
 
 var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
@@ -19,23 +17,23 @@ var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
 // NOTE: Sorts the input denoms slice.
 func GetAllUniqueDenomPairs(denoms []string) ([]string, []string) {
 	// get denoms in descending order
-	sort.Strings(denoms)
-	reverseDenoms := osmoutils.ReverseSlice(denoms)
+	sort.Slice(denoms, func(i, j int) bool {
+		return denoms[i] > denoms[j]
+	})
 
 	numPairs := len(denoms) * (len(denoms) - 1) / 2
 	pairGT := make([]string, 0, numPairs)
 	pairLT := make([]string, 0, numPairs)
 
-	for i := 0; i < len(reverseDenoms); i++ {
-		for j := i + 1; j < len(reverseDenoms); j++ {
-			pairGT = append(pairGT, reverseDenoms[i])
-			pairLT = append(pairLT, reverseDenoms[j])
-		}
-	}
-	// sanity check
-	for i := 0; i < numPairs; i++ {
-		if pairGT[i] == pairLT[i] {
-			panic("input had duplicated denom")
+	for i := 0; i < len(denoms); i++ {
+		for j := i + 1; j < len(denoms); j++ {
+			pairGT = append(pairGT, denoms[i])
+			pairLT = append(pairLT, denoms[j])
+
+			// sanity check
+			if pairGT[i] == pairLT[i] {
+				panic("input had duplicated denom")
+			}
 		}
 	}
 	return pairGT, pairLT


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

- Remove 2 redundant iterations from `GetAllUniqueDenomPairs`
- Obsolete comment in `updateRecords`
- Redundant casts in `MigrateExistingPools`
- Redundant allocation of `sentinelExistsValue` on every call


All changes are super minor. This is a drive-by change for best practices. None are state-breaking.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable