### PR TITLE
build: generalize Dockerfiles and reuse common build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILDER_VERSION="v1"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
-FROM osmosis-builder:${BUILDER_VERSION} as builder
+FROM osmolabs/osmosis-builder:${BUILDER_VERSION} as builder
 
 # --------------------------------------------------------
 # Runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,10 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+# Rebuild with make docker-build-builder
+ARG BUILDER_VERSION="v1"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
-# --------------------------------------------------------
-# Builder
-# --------------------------------------------------------
-
-FROM golang:${GO_VERSION}-alpine as builder
-
-RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-headers
-
-# Download go dependencies
-WORKDIR /osmosis
-COPY go.* .
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/root/go/pkg/mod \
-    go mod download
-
-# Cosmwasm - download correct libwasmvm version
-RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
-      -O /lib/libwasmvm_muslc.a
-
-# Cosmwasm - verify checksum
-RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/checksums.txt -O /tmp/checksums.txt && \
-    sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep $(uname -m) | cut -d ' ' -f 1)
-
-# Copy the remaining files
-COPY . .
-
-# Build osmosisd binary
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/root/go/pkg/mod \
-    VERSION=$(echo $(git describe --tags) | sed 's/^v//') && \
-    COMMIT=$(git log -1 --format='%H') && \
-    go build \
-      -mod=readonly \
-      -tags "netgo,ledger,muslc" \
-      -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name="osmosis" \
-              -X github.com/cosmos/cosmos-sdk/version.AppName="osmosisd" \
-              -X github.com/cosmos/cosmos-sdk/version.Version=$VERSION \
-              -X github.com/cosmos/cosmos-sdk/version.Commit=$COMMIT \
-              -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,ledger,muslc' \
-              -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
-      -trimpath \
-      -o /osmosis/build/ \
-      ./...
+FROM osmosis-builder:${BUILDER_VERSION} as builder
 
 # --------------------------------------------------------
 # Runner

--- a/Makefile
+++ b/Makefile
@@ -311,16 +311,6 @@ build-e2e-script:
 	mkdir -p $(BUILDDIR)
 	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
-docker-build-debug:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug -f Dockerfile .
-	@DOCKER_BUILDKIT=1 docker tag osmosis:${COMMIT} osmosis:debug
-
-docker-build-e2e-init-chain:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-chain:debug --build-arg E2E_SCRIPT_NAME=chain -f tests/e2e/initialization/init.Dockerfile .
-
-docker-build-e2e-init-node:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-node:debug --build-arg E2E_SCRIPT_NAME=node -f tests/e2e/initialization/init.Dockerfile .
-
 e2e-setup: e2e-check-image-sha e2e-remove-resources
 	@echo Finished e2e environment setup, ready to start the test
 
@@ -331,6 +321,29 @@ e2e-remove-resources:
 	tests/e2e/scripts/run/remove_stale_resources.sh
 
 .PHONY: test-mutation
+
+
+###############################################################################
+###                                 Docker Utils                            ###
+###############################################################################
+
+OSMOSIS_COMMON_VERSION=v1
+
+docker-build-setup:
+	@DOCKER_BUILDKIT=1 docker build -t osmosis-setup:${OSMOSIS_COMMON_VERSION} -f images/setup.Dockerfile .
+
+docker-build-builder:
+	@DOCKER_BUILDKIT=1 docker build -t osmosis-builder:${OSMOSIS_COMMON_VERSION} --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} -f images/builder.Dockerfile .
+
+docker-build-debug:
+	@DOCKER_BUILDKIT=1 docker build -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug -f Dockerfile .
+	@DOCKER_BUILDKIT=1 docker tag osmosis:${COMMIT} osmosis:debug
+
+docker-build-e2e-init-chain:
+	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-chain:debug --build-arg E2E_SCRIPT_NAME=chain --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} -f tests/e2e/initialization/init.Dockerfile .
+
+docker-build-e2e-init-node:
+	@DOCKER_BUILDKIT=1 docker build -t osmosis-e2e-init-node:debug --build-arg E2E_SCRIPT_NAME=node --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} -f tests/e2e/initialization/init.Dockerfile .
 
 ###############################################################################
 ###                                Linting                                  ###

--- a/Makefile
+++ b/Makefile
@@ -330,10 +330,10 @@ e2e-remove-resources:
 OSMOSIS_COMMON_VERSION=v1
 
 docker-build-setup:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis-setup:${OSMOSIS_COMMON_VERSION} -f images/setup.Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build -t osmolabs/osmosis-setup:${OSMOSIS_COMMON_VERSION} -f images/setup.Dockerfile .
 
 docker-build-builder:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis-builder:${OSMOSIS_COMMON_VERSION} --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} -f images/builder.Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build -t osmolabs/osmosis-builder:${OSMOSIS_COMMON_VERSION} --build-arg SETUP_VERSION=${OSMOSIS_COMMON_VERSION} -f images/builder.Dockerfile .
 
 docker-build-debug:
 	@DOCKER_BUILDKIT=1 docker build -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug -f Dockerfile .

--- a/images/builder.Dockerfile
+++ b/images/builder.Dockerfile
@@ -8,7 +8,7 @@ ARG SETUP_VERSION
 # Builder
 # --------------------------------------------------------
 
-FROM osmosis-setup:${SETUP_VERSION}
+FROM osmolabs/osmosis-setup:${SETUP_VERSION}
 
 # Copy the remaining files
 COPY . .

--- a/images/builder.Dockerfile
+++ b/images/builder.Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+ARG RUNNER_IMAGE="gcr.io/distroless/static"
+# Rebuild with make docker-build-setup
+ARG SETUP_VERSION
+
+# --------------------------------------------------------
+# Builder
+# --------------------------------------------------------
+
+FROM osmosis-setup:${SETUP_VERSION}
+
+# Copy the remaining files
+COPY . .
+
+# Build osmosisd binary
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    VERSION=$(echo $(git describe --tags) | sed 's/^v//') && \
+    COMMIT=$(git log -1 --format='%H') && \
+    go build \
+      -mod=readonly \
+      -tags "netgo,ledger,muslc" \
+      -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name="osmosis" \
+              -X github.com/cosmos/cosmos-sdk/version.AppName="osmosisd" \
+              -X github.com/cosmos/cosmos-sdk/version.Version=$VERSION \
+              -X github.com/cosmos/cosmos-sdk/version.Commit=$COMMIT \
+              -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,ledger,muslc' \
+              -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
+      -trimpath \
+      -o /osmosis/build/ \
+      ./...

--- a/images/setup.Dockerfile
+++ b/images/setup.Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION="1.18"
+
+# --------------------------------------------------------
+# Pre-build Setup
+# --------------------------------------------------------
+
+FROM golang:${GO_VERSION}-alpine
+
+RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-headers
+
+# Download go dependencies
+WORKDIR /osmosis
+COPY go.* .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    go mod download
+
+# Cosmwasm - download correct libwasmvm version
+RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
+      -O /lib/libwasmvm_muslc.a
+
+# Cosmwasm - verify checksum
+RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/checksums.txt -O /tmp/checksums.txt && \
+    sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep $(uname -m) | cut -d ' ' -f 1)

--- a/tests/e2e/initialization/init.Dockerfile
+++ b/tests/e2e/initialization/init.Dockerfile
@@ -1,28 +1,14 @@
 # syntax=docker/dockerfile:1
 
+ARG SETUP_VERSION
+
 ## Build Image
-FROM golang:1.18.2-alpine3.15 as build
+FROM osmosis-setup:${SETUP_VERSION} as builder
 
 ARG E2E_SCRIPT_NAME
 
-RUN set -eux; apk add --no-cache ca-certificates build-base;
-
-RUN apk add git
-
-# needed by github.com/zondax/hid
-RUN apk add linux-headers
-
 WORKDIR /osmosis
 COPY . /osmosis
-
-# CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
-
-# CosmWasm: copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
-RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 RUN BUILD_TAGS=muslc LINK_STATICALLY=true E2E_SCRIPT_NAME=${E2E_SCRIPT_NAME} make build-e2e-script
 
@@ -32,7 +18,7 @@ FROM ubuntu
 # Args only last for a single build stage - renew
 ARG E2E_SCRIPT_NAME
 
-COPY --from=build /osmosis/build/${E2E_SCRIPT_NAME} /bin/${E2E_SCRIPT_NAME}
+COPY --from=builder /osmosis/build/${E2E_SCRIPT_NAME} /bin/${E2E_SCRIPT_NAME}
 
 ENV HOME /osmosis
 WORKDIR $HOME

--- a/tests/localosmosis/mainnet_state/Dockerfile-stateExport
+++ b/tests/localosmosis/mainnet_state/Dockerfile-stateExport
@@ -5,35 +5,17 @@
 # Build
 # --------------------------------------------------------
 
-FROM golang:1.18.2-alpine3.15 as build
+ARG BUILDER_VERSION="v1"
+ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
-RUN set -eux; apk add --no-cache ca-certificates build-base;
-RUN apk add git
-# Needed by github.com/zondax/hid
-RUN apk add linux-headers
-
-WORKDIR /osmosis
-COPY . /osmosis
-
-
-# CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
-
-# CosmWasm: copy the right library according to architecture. The final location will be found by the linker flag `-lwasmvm_muslc`
-RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
-
-RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build
+FROM osmosis-builder:${BUILDER_VERSION} as builder
 
 # --------------------------------------------------------
 # Runner
 # --------------------------------------------------------
 
 FROM ubuntu
-
-COPY --from=build /osmosis/build/osmosisd /bin/osmosisd
+COPY --from=builder /osmosis/build/osmosisd /bin/osmosisd
 COPY /tests/localosmosis/mainnet_state/statesync.sh /osmosis/statesync.sh
 COPY /tests/localosmosis/mainnet_state/testnetify.py /osmosis/testnetify.py
 COPY /tests/localosmosis/testnet_genesis.json /osmosis/testnet_genesis.json

--- a/tests/localosmosis/mainnet_state/Dockerfile-stateExport
+++ b/tests/localosmosis/mainnet_state/Dockerfile-stateExport
@@ -8,7 +8,7 @@
 ARG BUILDER_VERSION="v1"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
-FROM osmosis-builder:${BUILDER_VERSION} as builder
+FROM osmolabs/osmosis-builder:${BUILDER_VERSION} as builder
 
 # --------------------------------------------------------
 # Runner


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1685

## What is the purpose of the change

Reuse common Docker build steps across all Dockerfiles

## Testing and Verifying

Tested by:
```
docker image rm -f $(docker image ls -aq)

make docker-build-setup

make docker-build-builder

make docker-build-debug

make docker-build-e2e-init-chain

make docker-build-e2e-init-node
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable