### PR TITLE
[twap] Sort denoms in ascending order

### DIFF
--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -6,31 +6,28 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/osmosis-labs/osmosis/v12/osmoutils"
 )
 
 var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
 
 // GetAllUniqueDenomPairs returns all unique pairs of denoms, where for every pair
-// (X, Y), X > Y.
+// (X, Y), X < Y.
 // The pair (X,Y) should only appear once in the list
 // Panics if finds duplicate pairs.
 //
 // NOTE: Sorts the input denoms slice.
 func GetAllUniqueDenomPairs(denoms []string) ([]string, []string) {
-	// get denoms in descending order
+	// get denoms in ascending order
 	sort.Strings(denoms)
-	reverseDenoms := osmoutils.ReverseSlice(denoms)
 
 	numPairs := len(denoms) * (len(denoms) - 1) / 2
 	pairGT := make([]string, 0, numPairs)
 	pairLT := make([]string, 0, numPairs)
 
-	for i := 0; i < len(reverseDenoms); i++ {
-		for j := i + 1; j < len(reverseDenoms); j++ {
-			pairGT = append(pairGT, reverseDenoms[i])
-			pairLT = append(pairLT, reverseDenoms[j])
+	for i := 0; i < len(denoms); i++ {
+		for j := i + 1; j < len(denoms); j++ {
+			pairGT = append(pairGT, denoms[i])
+			pairLT = append(pairLT, denoms[j])
 		}
 	}
 	// sanity check

--- a/x/twap/types/utils_test.go
+++ b/x/twap/types/utils_test.go
@@ -21,11 +21,11 @@ func TestGetAllUniqueDenomPairs(t *testing.T) {
 		wantedPairLT []string
 		panics       bool
 	}{
-		"basic":    {[]string{"A", "B"}, []string{"B"}, []string{"A"}, false},
-		"basicRev": {[]string{"B", "A"}, []string{"B"}, []string{"A"}, false},
+		"basic":    {[]string{"A", "B"}, []string{"A"}, []string{"B"}, false},
+		"basicRev": {[]string{"B", "A"}, []string{"A"}, []string{"B"}, false},
 		// AB > A
-		"prefixed": {[]string{"A", "AB"}, []string{"AB"}, []string{"A"}, false},
-		"basic-3":  {[]string{"A", "B", "C"}, []string{"C", "C", "B"}, []string{"B", "A", "A"}, false},
+		"prefixed": {[]string{"A", "AB"}, []string{"A"}, []string{"AB"}, false},
+		"basic-3":  {[]string{"A", "B", "C"}, []string{"A", "A", "B"}, []string{"B", "C", "C"}, false},
 		"panics":   {[]string{"A", "A"}, []string{}, []string{}, true},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/2751

What is the purpose of the change

Solve 2751: types.GetAllUniqueDenomPairs returns pairs in increasing order so newTwapRecord doesn't have to perform unnecessary swaps

Brief Changelog

Denoms are sorted in lexicographically increasing order. tests changed

Testing and Verifying

This change is already covered by existing tests, such as "TestGetAllUniqueDenomPairs"

Documentation and Release Note

Does this pull request introduce a new feature or user-facing behavior changes? no
Is a relevant changelog entry added to the Unreleased section in CHANGELOG.md? no
How is the feature or change documented? not documented