### PR TITLE
testnet: prune script

### DIFF
--- a/tests/localosmosis/mainnet_state/stateprune.py
+++ b/tests/localosmosis/mainnet_state/stateprune.py
@@ -1,0 +1,34 @@
+import json
+
+test_gen = open("testnet_genesis.json", "r+")
+read_test_gen = json.loads(test_gen.read())
+
+#remove everything from channel_genesis except next_channel_sequence
+for elem in list(read_test_gen['app_state']['ibc']['channel_genesis']):
+    if elem == 'next_channel_sequence':
+        continue
+    else:
+        del read_test_gen['app_state']['ibc']['channel_genesis'][elem]
+
+#remove everything from client_genesis except create_localhost, params, and next_client_sequence
+for elem in list(read_test_gen['app_state']['ibc']['client_genesis']):
+    if elem == 'create_localhost' or elem == 'params' or elem == 'next_client_sequence':
+        continue
+    else:
+        del read_test_gen['app_state']['ibc']['client_genesis'][elem]
+
+#remove everything from distribution except params, fee_pool, outstanding_rewards, and previous_proposer
+for elem in list(read_test_gen['app_state']['distribution']):
+    if elem == 'params' or elem == 'fee_pool' or elem == 'outstanding_rewards' or elem == 'previous_proposer':
+        continue
+    else:
+        del read_test_gen['app_state']['distribution'][elem]
+
+
+print("Please wait while file writes over itself, this may take 60 seconds or more")
+#go back to begining of file, write over with new values
+test_gen.seek(0)
+json.dump(read_test_gen, test_gen)
+
+#delete remainder in case new data is shorter than old
+test_gen.truncate()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Whenever we run a testnet with mainnet state, we normally have to wait ~2 hours to process the first block. Running this script reduces the time to wait to around 10 minutes.


## Brief Changelog

- Removes ibc state
- Removes incentives state


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable