### PR TITLE
x/incentives: gauge method patch

### DIFF
--- a/x/incentives/types/gauge.go
+++ b/x/incentives/types/gauge.go
@@ -31,12 +31,12 @@ func NewGauge(id uint64, isPerpetual bool, distrTo lockuptypes.QueryCondition, c
 
 // IsUpcomingGauge returns true if the gauge's distribution start time is after the provided time.
 func (gauge Gauge) IsUpcomingGauge(curTime time.Time) bool {
-	return curTime.After(gauge.StartTime)
+	return curTime.Before(gauge.StartTime) || curTime.Equal(gauge.StartTime)
 }
 
 // IsActiveGauge returns true if the gauge is in an active state during the provided time.
 func (gauge Gauge) IsActiveGauge(curTime time.Time) bool {
-	if curTime.Before(gauge.StartTime) && (gauge.IsPerpetual || gauge.FilledEpochs < gauge.NumEpochsPaidOver) {
+	if curTime.After(gauge.StartTime) && (gauge.IsPerpetual || gauge.FilledEpochs < gauge.NumEpochsPaidOver) {
 		return true
 	}
 	return false


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2757

## What is the purpose of the change

When running state exported testnets, we ran into an issue where upcoming gauges would begin distributing after the first epoch post state export. It turns out the method we were using to determine Active or Upcoming was incorrect.


## Brief Changelog

- Fixes IsActive and IsUpcoming


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable