### PR TITLE
Implement `BigDec` binary search in osmoutils

### DIFF
--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -132,8 +132,13 @@ func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
 	return sdk.Int{}, errors.New("hit maximum iterations, did not converge fast enough")
 }
 
-// Binary search BigDec inputs between [lowerbound, upperbound] to a monotonic increasing function f
-// We stop once f(found_input) meets the ErrTolerance constraints.
+// BinarySearchBigDec takes as input:
+// * an input range [lowerbound, upperbound] 
+// * an increasing function f
+// * a target output x
+// * max number of iterations (for gas control / handling does-not-converge cases)
+// 
+// It binary searches on the input range, until it finds an input y s.t. f(y) meets the err tolerance constraints for how close it is to x.
 // If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.
 func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	lowerbound osmomath.BigDec,

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -58,7 +58,7 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 	return 0
 }
 
-// CompareBigDec returns if actual is within errTolerance of expected.
+// CompareBigDec validates if actual is within errTolerance of expected.
 // returns 0 if it is
 // returns 1 if not, and expected > actual.
 // returns -1 if not, and expected < actual

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -120,7 +120,7 @@ func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
 		} else if compRes < 0 {
 			lowerbound = curEstimate
 		} else {
-			break
+			return curEstimate, nil
 		}
 		curEstimate = lowerbound.Add(upperbound).QuoRaw(2)
 		curOutput, err = f(curEstimate)
@@ -128,10 +128,8 @@ func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
 			return sdk.Int{}, err
 		}
 	}
-	if curIteration == maxIterations {
-		return sdk.Int{}, errors.New("hit maximum iterations, did not converge fast enough")
-	}
-	return curEstimate, nil
+
+	return sdk.Int{}, errors.New("hit maximum iterations, did not converge fast enough")
 }
 
 // Binary search BigDec inputs between [lowerbound, upperbound] to a monotonic increasing function f
@@ -158,7 +156,7 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 		} else if compRes < 0 {
 			lowerbound = curEstimate
 		} else {
-			break
+			return curEstimate, nil
 		}
 		curEstimate = lowerbound.Add(upperbound).Quo(osmomath.NewBigDec(2))
 		curOutput, err = f(curEstimate)
@@ -166,8 +164,6 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 			return osmomath.BigDec{}, err
 		}
 	}
-	if curIteration == maxIterations {
-		return osmomath.BigDec{}, errors.New("hit maximum iterations, did not converge fast enough")
-	}
-	return curEstimate, nil
+
+	return osmomath.BigDec{}, errors.New("hit maximum iterations, did not converge fast enough")
 }

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -2,7 +2,6 @@ package osmoutils
 
 import (
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -153,10 +152,6 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	}
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
-		fmt.Println("target: ", targetOutput)
-		fmt.Println("current: ", curOutput)
-		fmt.Println("iteration: ", curIteration)
-		fmt.Println()
 		compRes := errTolerance.CompareBigDec(curOutput, targetOutput)
 		if compRes > 0 {
 			upperbound = curEstimate

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -58,7 +58,7 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 	return 0
 }
 
-// Compare returns if actual is within errTolerance of expected.
+// CompareBigDec returns if actual is within errTolerance of expected.
 // returns 0 if it is
 // returns 1 if not, and expected > actual.
 // returns -1 if not, and expected < actual
@@ -134,7 +134,7 @@ func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
 	return curEstimate, nil
 }
 
-// Binary search inputs between [lowerbound, upperbound] to a monotonic increasing function f.
+// Binary search BigDec inputs between [lowerbound, upperbound] to a monotonic increasing function f
 // We stop once f(found_input) meets the ErrTolerance constraints.
 // If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.
 func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -2,6 +2,7 @@ package osmoutils
 
 import (
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -152,6 +153,10 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	}
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
+		fmt.Println("target: ", targetOutput)
+		fmt.Println("current: ", curOutput)
+		fmt.Println("iteration: ", curIteration)
+		fmt.Println()
 		compRes := errTolerance.CompareBigDec(curOutput, targetOutput)
 		if compRes > 0 {
 			upperbound = curEstimate

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v12/osmomath"
 )
 
 // ErrTolerance is used to define a compare function, which checks if two
@@ -56,6 +58,44 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 	return 0
 }
 
+// Compare returns if actual is within errTolerance of expected.
+// returns 0 if it is
+// returns 1 if not, and expected > actual.
+// returns -1 if not, and expected < actual
+func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.BigDec) int {
+	diff := expected.Sub(actual).Abs()
+
+	comparisonSign := 0
+	if expected.GT(actual) {
+		comparisonSign = 1
+	} else {
+		comparisonSign = -1
+	}
+
+	// Check additive tolerance equations
+	if !e.AdditiveTolerance.IsNil() {
+		// if no error accepted, do a direct compare.
+		if e.AdditiveTolerance.IsZero() {
+			if expected.Equal(actual) {
+				return 0
+			}
+		}
+
+		if diff.GT(osmomath.NewBigDec(e.AdditiveTolerance.Int64())) {
+			return comparisonSign
+		}
+	}
+	// Check multiplicative tolerance equations
+	if !e.MultiplicativeTolerance.IsNil() && !e.MultiplicativeTolerance.IsZero() {
+		errTerm := diff.Quo(osmomath.MinDec(expected, actual))
+		if errTerm.GT(osmomath.BigDecFromSDKDec(e.MultiplicativeTolerance)) {
+			return comparisonSign
+		}
+	}
+
+	return 0
+}
+
 // Binary search inputs between [lowerbound, upperbound] to a monotonic increasing function f.
 // We stop once f(found_input) meets the ErrTolerance constraints.
 // If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.
@@ -90,6 +130,44 @@ func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
 	}
 	if curIteration == maxIterations {
 		return sdk.Int{}, errors.New("hit maximum iterations, did not converge fast enough")
+	}
+	return curEstimate, nil
+}
+
+// Binary search inputs between [lowerbound, upperbound] to a monotonic increasing function f.
+// We stop once f(found_input) meets the ErrTolerance constraints.
+// If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.
+func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
+	lowerbound osmomath.BigDec,
+	upperbound osmomath.BigDec,
+	targetOutput osmomath.BigDec,
+	errTolerance ErrTolerance,
+	maxIterations int,
+) (osmomath.BigDec, error) {
+	// Setup base case of loop
+	curEstimate := lowerbound.Add(upperbound).Quo(osmomath.NewBigDec(2))
+	curOutput, err := f(curEstimate)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+	curIteration := 0
+	for ; curIteration < maxIterations; curIteration += 1 {
+		compRes := errTolerance.CompareBigDec(curOutput, targetOutput)
+		if compRes > 0 {
+			upperbound = curEstimate
+		} else if compRes < 0 {
+			lowerbound = curEstimate
+		} else {
+			break
+		}
+		curEstimate = lowerbound.Add(upperbound).Quo(osmomath.NewBigDec(2))
+		curOutput, err = f(curEstimate)
+		if err != nil {
+			return osmomath.BigDec{}, err
+		}
+	}
+	if curIteration == maxIterations {
+		return osmomath.BigDec{}, errors.New("hit maximum iterations, did not converge fast enough")
 	}
 	return curEstimate, nil
 }

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -81,7 +81,7 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 			}
 		}
 
-		if diff.GT(osmomath.NewBigDec(e.AdditiveTolerance.Int64())) {
+		if diff.GT(osmomath.BigDecFromSDKDec(e.AdditiveTolerance.ToDec())) {
 			return comparisonSign
 		}
 	}
@@ -133,11 +133,11 @@ func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
 }
 
 // BinarySearchBigDec takes as input:
-// * an input range [lowerbound, upperbound] 
+// * an input range [lowerbound, upperbound]
 // * an increasing function f
 // * a target output x
 // * max number of iterations (for gas control / handling does-not-converge cases)
-// 
+//
 // It binary searches on the input range, until it finds an input y s.t. f(y) meets the err tolerance constraints for how close it is to x.
 // If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.
 func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),

--- a/osmoutils/binary_search_test.go
+++ b/osmoutils/binary_search_test.go
@@ -15,7 +15,7 @@ func TestBinarySearch(t *testing.T) {
 	lineF := func(a sdk.Int) (sdk.Int, error) {
 		return a, nil
 	}
-	expF := func(a sdk.Int) (sdk.Int, error) {
+	cubicF := func(a sdk.Int) (sdk.Int, error) {
 		calculation := sdk.Dec(a)
 		result := calculation.Power(3)
 		output := sdk.Int(result)
@@ -45,14 +45,14 @@ func TestBinarySearch(t *testing.T) {
 	}{
 		"linear f, no err tolerance, converges": {lineF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), noErrTolerance, 51, sdk.NewInt(1 + (1 << 25)), false},
 		"linear f, no err tolerance, does not converge": {lineF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), noErrTolerance, 10, sdk.Int{}, true},
-		"exponential f, no err tolerance, converges": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), noErrTolerance, 51, sdk.NewInt(322539792367616), false},
-		"exponential f, no err tolerance, does not converge": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), noErrTolerance, 10, sdk.Int{}, true},
-		"exponential f, large additive err tolerance, converges": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 15)), testErrToleranceAdditive, 51, sdk.NewInt(1 << 46), false},
-		"exponential f, large additive err tolerance, does not converge": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 30)), testErrToleranceAdditive, 10, sdk.Int{}, true},
-		"exponential f, large multiplicative err tolerance, converges": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), testErrToleranceMultiplicative, 51, sdk.NewInt(322539792367616), false},
-		"exponential f, large multiplicative err tolerance, does not converge": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), testErrToleranceMultiplicative, 10, sdk.Int{}, true},
-		"exponential f, both err tolerances, converges": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 15)), testErrToleranceBoth, 51, sdk.NewInt(1 << 45), false},
-		"exponential f, both err tolerances, does not converge": {expF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 30)), testErrToleranceBoth, 10, sdk.Int{}, true},
+		"cubic f, no err tolerance, converges": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), noErrTolerance, 51, sdk.NewInt(322539792367616), false},
+		"cubic f, no err tolerance, does not converge": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), noErrTolerance, 10, sdk.Int{}, true},
+		"cubic f, large additive err tolerance, converges": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 15)), testErrToleranceAdditive, 51, sdk.NewInt(1 << 46), false},
+		"cubic f, large additive err tolerance, does not converge": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 30)), testErrToleranceAdditive, 10, sdk.Int{}, true},
+		"cubic f, large multiplicative err tolerance, converges": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), testErrToleranceMultiplicative, 51, sdk.NewInt(322539792367616), false},
+		"cubic f, large multiplicative err tolerance, does not converge": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt(1 + (1 << 25)), testErrToleranceMultiplicative, 10, sdk.Int{}, true},
+		"cubic f, both err tolerances, converges": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 15)), testErrToleranceBoth, 51, sdk.NewInt(1 << 45), false},
+		"cubic f, both err tolerances, does not converge": {cubicF, sdk.ZeroInt(), sdk.NewInt(1 << 50), sdk.NewInt((1 << 30)), testErrToleranceBoth, 10, sdk.Int{}, true},
 	}
 
 	for name, tc := range tests {
@@ -74,7 +74,7 @@ func TestBinarySearchBigDec(t *testing.T) {
 	lineF := func(a osmomath.BigDec) (osmomath.BigDec, error) {
 		return a, nil
 	}
-	expF := func(a osmomath.BigDec) (osmomath.BigDec, error) {
+	cubicF := func(a osmomath.BigDec) (osmomath.BigDec, error) {
 		// these precision shifts are done implicitly in the int binary search tests
 		// we keep them here to maintain parity between test cases across implementations
 		calculation := a.Quo(osmomath.NewBigDec(10).Power(18))
@@ -106,14 +106,14 @@ func TestBinarySearchBigDec(t *testing.T) {
 	}{
 		"linear f, no err tolerance, converges": {lineF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), lowErrTolerance, 51, osmomath.NewBigDec(1 + (1 << 25)), false},
 		"linear f, no err tolerance, does not converge": {lineF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), lowErrTolerance, 10, osmomath.BigDec{}, true},
-		"exponential f, no err tolerance, converges": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), lowErrTolerance, 51, osmomath.NewBigDec(322539792367616), false},
-		"exponential f, no err tolerance, does not converge": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), lowErrTolerance, 10, osmomath.BigDec{}, true},
-		"exponential f, large additive err tolerance, converges": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 15)), testErrToleranceAdditive, 51, osmomath.NewBigDec(1 << 46), false},
-		"exponential f, large additive err tolerance, does not converge": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 30)), testErrToleranceAdditive, 10, osmomath.BigDec{}, true},
-		"exponential f, large multiplicative err tolerance, converges": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), testErrToleranceMultiplicative, 51, osmomath.NewBigDec(322539792367616), false},
-		"exponential f, large multiplicative err tolerance, does not converge": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), testErrToleranceMultiplicative, 10, osmomath.BigDec{}, true},
-		"exponential f, both err tolerances, converges": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 15)), testErrToleranceBoth, 51, osmomath.NewBigDec(1 << 45), false},
-		"exponential f, both err tolerances, does not converge": {expF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 30)), testErrToleranceBoth, 10, osmomath.BigDec{}, true},
+		"cubic f, no err tolerance, converges": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), lowErrTolerance, 51, osmomath.NewBigDec(322539792367616), false},
+		"cubic f, no err tolerance, does not converge": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), lowErrTolerance, 10, osmomath.BigDec{}, true},
+		"cubic f, large additive err tolerance, converges": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 15)), testErrToleranceAdditive, 51, osmomath.NewBigDec(1 << 46), false},
+		"cubic f, large additive err tolerance, does not converge": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 30)), testErrToleranceAdditive, 10, osmomath.BigDec{}, true},
+		"cubic f, large multiplicative err tolerance, converges": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), testErrToleranceMultiplicative, 51, osmomath.NewBigDec(322539792367616), false},
+		"cubic f, large multiplicative err tolerance, does not converge": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec(1 + (1 << 25)), testErrToleranceMultiplicative, 10, osmomath.BigDec{}, true},
+		"cubic f, both err tolerances, converges": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 15)), testErrToleranceBoth, 51, osmomath.NewBigDec(1 << 45), false},
+		"cubic f, both err tolerances, does not converge": {cubicF, osmomath.ZeroDec(), osmomath.NewBigDec(1 << 50), osmomath.NewBigDec((1 << 30)), testErrToleranceBoth, 10, osmomath.BigDec{}, true},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: #2794 and #2702

## What is the purpose of the change

This PR implements a `BigDec` binary search function for our general osmoutils package.

## Brief Changelog

- Add `BinarySearchBigDec` to osmoutils
- Add `CompareBigDec` to osmoutils
- Refactor existing and new tests to be more readable (string map names, `t.Run` etc.)

## Testing and Verifying

This change added tests for both new functions in `osmoutils/binary_search_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)