### PR TITLE
Using last spot price instead of zero on error in `getSpotPrices`

### DIFF
--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -72,17 +72,18 @@ func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.T
 	return recordWithUpdatedAccumulators(record, t)
 }
 
-func (k Keeper) NewTwapRecord(ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
-	return k.newTwapRecord(ctx, poolId, denom0, denom1)
+func (k Keeper) NewTwapRecord(ctx sdk.Context, ammI types.AmmInterface, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+	return k.newTwapRecord(ctx, ammI, poolId, denom0, denom1)
 }
 
 func (k Keeper) GetSpotPrices(
 	ctx sdk.Context,
+	ammI types.AmmInterface,
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
 ) (sp0 sdk.Dec, sp1 sdk.Dec, latestErrTime time.Time) {
-	return k.getSpotPrices(ctx, poolId, denom0, denom1, previousErrorTime)
+	return k.getSpotPrices(ctx, ammI, poolId, denom0, denom1, previousErrorTime)
 }
 
 func (k *Keeper) GetAmmInterface() types.AmmInterface {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -72,19 +72,17 @@ func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.T
 	return recordWithUpdatedAccumulators(record, t)
 }
 
-func NewTwapRecord(k types.AmmInterface, keeper Keeper, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
-	return newTwapRecord(k, keeper, ctx, poolId, denom0, denom1)
+func (k Keeper) NewTwapRecord(ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+	return k.newTwapRecord(ctx, poolId, denom0, denom1)
 }
 
-func GetSpotPrices(
+func (k Keeper) GetSpotPrices(
 	ctx sdk.Context,
-	k types.AmmInterface,
-	keeper Keeper,
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
 ) (sp0 sdk.Dec, sp1 sdk.Dec, latestErrTime time.Time) {
-	return getSpotPrices(ctx, k, keeper, poolId, denom0, denom1, previousErrorTime)
+	return k.getSpotPrices(ctx, poolId, denom0, denom1, previousErrorTime)
 }
 
 func (k *Keeper) GetAmmInterface() types.AmmInterface {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -72,18 +72,19 @@ func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.T
 	return recordWithUpdatedAccumulators(record, t)
 }
 
-func NewTwapRecord(k types.AmmInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
-	return newTwapRecord(k, ctx, poolId, denom0, denom1)
+func NewTwapRecord(k types.AmmInterface, keeper Keeper, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+	return newTwapRecord(k, keeper, ctx, poolId, denom0, denom1)
 }
 
 func GetSpotPrices(
 	ctx sdk.Context,
 	k types.AmmInterface,
+	keeper Keeper,
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
 ) (sp0 sdk.Dec, sp1 sdk.Dec, latestErrTime time.Time) {
-	return getSpotPrices(ctx, k, poolId, denom0, denom1, previousErrorTime)
+	return getSpotPrices(ctx, k, keeper, poolId, denom0, denom1, previousErrorTime)
 }
 
 func (k *Keeper) GetAmmInterface() types.AmmInterface {

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -49,7 +49,7 @@ func (s *TestSuite) TestAfterPoolCreatedHook() {
 			denomPairs0, denomPairs1 := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for i := 0; i < len(denomPairs0); i++ {
-				expectedRecord, err := s.twapkeeper.NewTwapRecord(s.Ctx, s.App.GAMMKeeper,poolId, denomPairs0[i], denomPairs1[i])
+				expectedRecord, err := s.twapkeeper.NewTwapRecord(s.Ctx, s.App.GAMMKeeper, poolId, denomPairs0[i], denomPairs1[i])
 				s.Require().NoError(err)
 				expectedRecords = append(expectedRecords, expectedRecord)
 			}

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -49,7 +49,7 @@ func (s *TestSuite) TestAfterPoolCreatedHook() {
 			denomPairs0, denomPairs1 := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for i := 0; i < len(denomPairs0); i++ {
-				expectedRecord, err := s.twapkeeper.NewTwapRecord(s.Ctx, poolId, denomPairs0[i], denomPairs1[i])
+				expectedRecord, err := s.twapkeeper.NewTwapRecord(s.Ctx, s.App.GAMMKeeper,poolId, denomPairs0[i], denomPairs1[i])
 				s.Require().NoError(err)
 				expectedRecords = append(expectedRecords, expectedRecord)
 			}

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -50,7 +50,7 @@ func (s *TestSuite) TestAfterPoolCreatedHook() {
 			denomPairs0, denomPairs1 := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for i := 0; i < len(denomPairs0); i++ {
-				expectedRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, s.Ctx, poolId, denomPairs0[i], denomPairs1[i])
+				expectedRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, *s.App.TwapKeeper, s.Ctx, poolId, denomPairs0[i], denomPairs1[i])
 				s.Require().NoError(err)
 				expectedRecords = append(expectedRecords, expectedRecord)
 			}

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -6,7 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v12/osmoutils"
-	"github.com/osmosis-labs/osmosis/v12/x/twap"
 	"github.com/osmosis-labs/osmosis/v12/x/twap/types"
 )
 
@@ -50,7 +49,7 @@ func (s *TestSuite) TestAfterPoolCreatedHook() {
 			denomPairs0, denomPairs1 := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for i := 0; i < len(denomPairs0); i++ {
-				expectedRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, *s.App.TwapKeeper, s.Ctx, poolId, denomPairs0[i], denomPairs1[i])
+				expectedRecord, err := s.twapkeeper.NewTwapRecord(s.Ctx, poolId, denomPairs0[i], denomPairs1[i])
 				s.Require().NoError(err)
 				expectedRecords = append(expectedRecords, expectedRecord)
 			}

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -10,13 +10,13 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/x/twap/types"
 )
 
-func newTwapRecord(k types.AmmInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+func newTwapRecord(k types.AmmInterface, keeper Keeper, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
 	denom0, denom1, err := types.LexicographicalOrderDenoms(denom0, denom1)
 	if err != nil {
 		return types.TwapRecord{}, err
 	}
 	previousErrorTime := time.Time{} // no previous error
-	sp0, sp1, lastErrorTime := getSpotPrices(ctx, k, poolId, denom0, denom1, previousErrorTime)
+	sp0, sp1, lastErrorTime := getSpotPrices(ctx, k, keeper, poolId, denom0, denom1, previousErrorTime)
 	return types.TwapRecord{
 		PoolId:                      poolId,
 		Asset0Denom:                 denom0,
@@ -39,6 +39,7 @@ func newTwapRecord(k types.AmmInterface, ctx sdk.Context, poolId uint64, denom0,
 func getSpotPrices(
 	ctx sdk.Context,
 	k types.AmmInterface,
+	keeper Keeper,
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
@@ -47,15 +48,21 @@ func getSpotPrices(
 	sp0, err0 := k.CalculateSpotPrice(ctx, poolId, denom0, denom1)
 	sp1, err1 := k.CalculateSpotPrice(ctx, poolId, denom1, denom0)
 	if err0 != nil || err1 != nil {
+		previousRecord, err := keeper.getRecordAtOrBeforeTime(ctx, poolId, previousErrorTime, denom0, denom1)
 		latestErrTime = ctx.BlockTime()
-		// In the event of an error, we just sanity replace empty values with zero values
-		// so that the numbers can be still be calculated within TWAPs over error values
-		// TODO: Should we be using the last spot price?
 		if (sp0 == sdk.Dec{}) {
-			sp0 = sdk.ZeroDec()
+			if err != nil {
+				sp0 = sdk.ZeroDec()
+			} else {
+				sp0 = previousRecord.P0LastSpotPrice
+			}
 		}
 		if (sp1 == sdk.Dec{}) {
-			sp1 = sdk.ZeroDec()
+			if err != nil {
+				sp1 = sdk.ZeroDec()
+			} else {
+				sp1 = previousRecord.P1LastSpotPrice
+			}
 		}
 	}
 	if sp0.GT(types.MaxSpotPrice) {
@@ -72,7 +79,7 @@ func (k Keeper) afterCreatePool(ctx sdk.Context, poolId uint64) error {
 	denoms, err := k.ammkeeper.GetPoolDenoms(ctx, poolId)
 	denomPairs0, denomPairs1 := types.GetAllUniqueDenomPairs(denoms)
 	for i := 0; i < len(denomPairs0); i++ {
-		record, err := newTwapRecord(k.ammkeeper, ctx, poolId, denomPairs0[i], denomPairs1[i])
+		record, err := newTwapRecord(k.ammkeeper, k, ctx, poolId, denomPairs0[i], denomPairs1[i])
 		// err should be impossible given GetAllUniqueDenomPairs guarantees
 		if err != nil {
 			return err
@@ -145,7 +152,7 @@ func (k Keeper) updateRecord(ctx sdk.Context, record types.TwapRecord) types.Twa
 	newRecord.Height = ctx.BlockHeight()
 
 	newSp0, newSp1, lastErrorTime := getSpotPrices(
-		ctx, k.ammkeeper, record.PoolId, record.Asset0Denom, record.Asset1Denom, record.LastErrorTime)
+		ctx, k.ammkeeper, k, record.PoolId, record.Asset0Denom, record.Asset1Denom, record.LastErrorTime)
 
 	// set last spot price to be last price of this block. This is what will get used in interpolation.
 	newRecord.P0LastSpotPrice = newSp0

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -10,13 +10,13 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/x/twap/types"
 )
 
-func(k Keeper) newTwapRecord(ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+func(k Keeper) newTwapRecord(ctx sdk.Context, ammI types.AmmInterface, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
 	denom0, denom1, err := types.LexicographicalOrderDenoms(denom0, denom1)
 	if err != nil {
 		return types.TwapRecord{}, err
 	}
 	previousErrorTime := time.Time{} // no previous error
-	sp0, sp1, lastErrorTime := k.getSpotPrices(ctx, poolId, denom0, denom1, previousErrorTime)
+	sp0, sp1, lastErrorTime := k.getSpotPrices(ctx, ammI, poolId, denom0, denom1, previousErrorTime)
 	return types.TwapRecord{
 		PoolId:                      poolId,
 		Asset0Denom:                 denom0,
@@ -38,29 +38,31 @@ func(k Keeper) newTwapRecord(ctx sdk.Context, poolId uint64, denom0, denom1 stri
 // if there is an error in getting spot prices, then the latest error time is ctx.Blocktime()
 func(k Keeper) getSpotPrices(
 	ctx sdk.Context,
+	ammI types.AmmInterface,
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
 ) (sp0 sdk.Dec, sp1 sdk.Dec, latestErrTime time.Time) {
 	latestErrTime = previousErrorTime
-	sp0, err0 := k.ammkeeper.CalculateSpotPrice(ctx, poolId, denom0, denom1)
-	sp1, err1 := k.ammkeeper.CalculateSpotPrice(ctx, poolId, denom1, denom0)
-	if err0 != nil || err1 != nil {
-		previousRecord, err := k.getRecordAtOrBeforeTime(ctx, poolId, previousErrorTime, denom0, denom1)
+	sp0, err0 := ammI.CalculateSpotPrice(ctx, poolId, denom0, denom1)
+	sp1, err1 := ammI.CalculateSpotPrice(ctx, poolId, denom1, denom0)
+	if err0 != nil {
 		latestErrTime = ctx.BlockTime()
-		if (sp0 == sdk.Dec{}) {
-			if err != nil {
-				sp0 = sdk.ZeroDec()
-			} else {
-				sp0 = previousRecord.P0LastSpotPrice
-			}
+		previousRecord, err := k.getRecordAtOrBeforeTime(ctx, poolId, ctx.BlockTime(), denom0, denom1)
+		// use zero if we fail to get previous record
+		if err != nil {
+			sp0 = sdk.ZeroDec()
+		} else {
+			sp0 = previousRecord.P0LastSpotPrice
 		}
-		if (sp1 == sdk.Dec{}) {
-			if err != nil {
-				sp1 = sdk.ZeroDec()
-			} else {
-				sp1 = previousRecord.P1LastSpotPrice
-			}
+	}
+	if err1 != nil {
+		latestErrTime = ctx.BlockTime()
+		previousRecord, err := k.getRecordAtOrBeforeTime(ctx, poolId, ctx.BlockTime(), denom0, denom1)
+		if err != nil {
+			sp1 = sdk.ZeroDec()
+		} else {
+			sp1 = previousRecord.P1LastSpotPrice
 		}
 	}
 	if sp0.GT(types.MaxSpotPrice) {
@@ -77,7 +79,7 @@ func (k Keeper) afterCreatePool(ctx sdk.Context, poolId uint64) error {
 	denoms, err := k.ammkeeper.GetPoolDenoms(ctx, poolId)
 	denomPairs0, denomPairs1 := types.GetAllUniqueDenomPairs(denoms)
 	for i := 0; i < len(denomPairs0); i++ {
-		record, err := k.newTwapRecord(ctx, poolId, denomPairs0[i], denomPairs1[i])
+		record, err := k.newTwapRecord(ctx, k.ammkeeper, poolId, denomPairs0[i], denomPairs1[i])
 		// err should be impossible given GetAllUniqueDenomPairs guarantees
 		if err != nil {
 			return err
@@ -150,7 +152,7 @@ func (k Keeper) updateRecord(ctx sdk.Context, record types.TwapRecord) types.Twa
 	newRecord.Height = ctx.BlockHeight()
 
 	newSp0, newSp1, lastErrorTime := k.getSpotPrices(
-		ctx, record.PoolId, record.Asset0Denom, record.Asset1Denom, record.LastErrorTime)
+		ctx, k.ammkeeper, record.PoolId, record.Asset0Denom, record.Asset1Denom, record.LastErrorTime)
 
 	// set last spot price to be last price of this block. This is what will get used in interpolation.
 	newRecord.P0LastSpotPrice = newSp0

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -10,7 +10,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/x/twap/types"
 )
 
-func(k Keeper) newTwapRecord(ctx sdk.Context, ammI types.AmmInterface, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+func (k Keeper) newTwapRecord(ctx sdk.Context, ammI types.AmmInterface, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
 	denom0, denom1, err := types.LexicographicalOrderDenoms(denom0, denom1)
 	if err != nil {
 		return types.TwapRecord{}, err
@@ -36,7 +36,7 @@ func(k Keeper) newTwapRecord(ctx sdk.Context, ammI types.AmmInterface, poolId ui
 // returns spot prices for both pairs of assets, and the 'latest error time'.
 // The latest error time is the previous time if there is no error in getting spot prices.
 // if there is an error in getting spot prices, then the latest error time is ctx.Blocktime()
-func(k Keeper) getSpotPrices(
+func (k Keeper) getSpotPrices(
 	ctx sdk.Context,
 	ammI types.AmmInterface,
 	poolId uint64,

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -46,7 +46,7 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"use last spot price on err": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			blockTime: 			   s.Ctx.BlockTime(),
+			blockTime:             s.Ctx.BlockTime(),
 			mockSp0:               sdk.ZeroDec(),
 			mockSp1:               sdk.ZeroDec(),
 			mockSp0Err:            fmt.Errorf("foo"),
@@ -58,7 +58,7 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"sp zero, when err & no previous record": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			blockTime: 			   currTime.Add(5 * time.Second),
+			blockTime:             currTime.Add(5 * time.Second),
 			mockSp0:               sdk.OneDec(),
 			mockSp1:               sdk.OneDec(),
 			mockSp0Err:            fmt.Errorf("foo"),
@@ -69,7 +69,7 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"exceeds max spot price": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			blockTime: 			   s.Ctx.BlockTime(),
+			blockTime:             s.Ctx.BlockTime(),
 			mockSp0:               types.MaxSpotPrice.Add(sdk.OneDec()),
 			mockSp1:               types.MaxSpotPrice.Add(sdk.OneDec()),
 			expectedSp0:           types.MaxSpotPrice,
@@ -79,7 +79,7 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"valid spot prices": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			blockTime: 			   s.Ctx.BlockTime(),
+			blockTime:             s.Ctx.BlockTime(),
 			mockSp0:               sdk.NewDecWithPrec(55, 2),
 			mockSp1:               sdk.NewDecWithPrec(6, 1),
 			expectedSp0:           sdk.NewDecWithPrec(55, 2),

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -77,7 +77,7 @@ func (s *TestSuite) TestGetSpotPrices() {
 			mockAMMI.ProgramPoolSpotPriceOverride(tc.poolID, denom0, denom1, tc.mockSp0, tc.mockSp0Err)
 			mockAMMI.ProgramPoolSpotPriceOverride(tc.poolID, denom1, denom0, tc.mockSp1, tc.mockSp1Err)
 
-			sp0, sp1, latestErrTime := twap.GetSpotPrices(ctx, mockAMMI, *s.App.TwapKeeper, tc.poolID, denom0, denom1, tc.prevErrTime)
+			sp0, sp1, latestErrTime := s.twapkeeper.GetSpotPrices(ctx, tc.poolID, denom0, denom1, tc.prevErrTime)
 			s.Require().Equal(tc.expectedSp0, sp0)
 			s.Require().Equal(tc.expectedSp1, sp1)
 			s.Require().Equal(tc.expectedLatestErrTime, latestErrTime)
@@ -127,7 +127,7 @@ func (s *TestSuite) TestNewTwapRecord() {
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
-			twapRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, *s.App.TwapKeeper, s.Ctx, test.poolId, test.denom0, test.denom1)
+			twapRecord, err := s.twapkeeper.NewTwapRecord(s.Ctx, test.poolId, test.denom0, test.denom1)
 
 			if test.expectedPanic {
 				s.Require().Equal(twapRecord.LastErrorTime, s.Ctx.BlockTime())

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -77,7 +77,7 @@ func (s *TestSuite) TestGetSpotPrices() {
 			mockAMMI.ProgramPoolSpotPriceOverride(tc.poolID, denom0, denom1, tc.mockSp0, tc.mockSp0Err)
 			mockAMMI.ProgramPoolSpotPriceOverride(tc.poolID, denom1, denom0, tc.mockSp1, tc.mockSp1Err)
 
-			sp0, sp1, latestErrTime := twap.GetSpotPrices(ctx, mockAMMI, tc.poolID, denom0, denom1, tc.prevErrTime)
+			sp0, sp1, latestErrTime := twap.GetSpotPrices(ctx, mockAMMI, *s.App.TwapKeeper, tc.poolID, denom0, denom1, tc.prevErrTime)
 			s.Require().Equal(tc.expectedSp0, sp0)
 			s.Require().Equal(tc.expectedSp1, sp1)
 			s.Require().Equal(tc.expectedLatestErrTime, latestErrTime)
@@ -127,7 +127,7 @@ func (s *TestSuite) TestNewTwapRecord() {
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
-			twapRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, s.Ctx, test.poolId, test.denom0, test.denom1)
+			twapRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, *s.App.TwapKeeper, s.Ctx, test.poolId, test.denom0, test.denom1)
 
 			if test.expectedPanic {
 				s.Require().Equal(twapRecord.LastErrorTime, s.Ctx.BlockTime())
@@ -961,7 +961,7 @@ func (s *TestSuite) TestUpdateRecords() {
 				// The new record added.
 				{
 					spotPriceA:    sdk.OneDec(),
-					spotPriceB:    sdk.ZeroDec(),
+					spotPriceB:    baseRecord.P1LastSpotPrice,
 					lastErrorTime: baseRecord.Time.Add(time.Second), // equals to block time
 					isMostRecent:  true,
 				},

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -961,7 +961,7 @@ func (s *TestSuite) TestUpdateRecords() {
 				// The new record added.
 				{
 					spotPriceA:    sdk.OneDec(),
-					spotPriceB:    baseRecord.P1LastSpotPrice,
+					spotPriceB:    baseRecord.P1LastSpotPrice,       // getSpotPrice failed, should equal to previous record LastSpotPrice
 					lastErrorTime: baseRecord.Time.Add(time.Second), // equals to block time
 					isMostRecent:  true,
 				},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2689 

## What is the purpose of the change

> Refer from #2689 . Instead of updating price=0 if `getSpotPrices` got error as it is. We will update the price with the previous record.

## Brief Changelog
 
  - *Update `getSpotPrices` logic*
  - *Update related function & test*
  - *Got a special case that needs to be discussed. What if the pair have no previous record? Should spot price = 0( Following this way in my code)*
