### PR TITLE
feat: add gamm state to localosmosis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,16 +367,22 @@ localnet-build-state-export:
 	@docker build -t local:osmosis-se --build-arg ID=$(ID) -f tests/localosmosis/mainnet_state/Dockerfile-stateExport .
 
 localnet-start:
-	@docker-compose -f tests/localosmosis/docker-compose.yml up
+	@STATE="" docker-compose -f tests/localosmosis/docker-compose.yml up
+
+localnet-start-with-state:
+	@STATE=-s docker-compose -f tests/localosmosis/docker-compose.yml up
 
 localnet-startd:
-	@docker-compose -f tests/localosmosis/docker-compose.yml up -d
+	@STATE="" docker-compose -f tests/localosmosis/docker-compose.yml up -d
+
+localnet-startd-with-state:
+	@STATE=-s docker-compose -f tests/localosmosis/docker-compose.yml up -d
 
 localnet-start-state-export:
 	@docker-compose -f tests/localosmosis/mainnet_state/docker-compose-state-export.yml up
 
 localnet-stop:
-	@docker-compose -f tests/localosmosis/docker-compose.yml down
+	@STATE="" docker-compose -f tests/localosmosis/docker-compose.yml down
 
 localnet-remove: localnet-stop
 	rm -rf $(PWD)/tests/localosmosis/.osmosisd

--- a/tests/localosmosis/docker-compose.yml
+++ b/tests/localosmosis/docker-compose.yml
@@ -11,10 +11,14 @@ services:
         RUNNER_IMAGE: alpine:3.16
         GO_VERSION: 1.18
     volumes:
+      - ../e2e/scripts/nativeDenomPool.json:/osmosis/nativeDenomPool.json
+      - ../e2e/scripts/nativeDenomThreeAssetPool.json:/osmosis/nativeDenomThreeAssetPool.json
       - ./scripts/setup.sh:/osmosis/setup.sh
       - ./.osmosisd/:/osmosis/.osmosisd/
     entrypoint:
       - /osmosis/setup.sh
+    command:
+      - $STATE
     ports:
       - 26657:26657
       - 1317:1317

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -95,23 +95,33 @@ edit_config () {
 create_two_asset_pool () {
     # Create default pool
     substring='code: 0'
-    string=$(osmosisd tx gamm create-pool --pool-file=nativeDenomPool.json --from $MONIKER --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --yes  2>&1)
-    if [ "$string" != "${string%"$substring"*}" ]; then
-        echo "create two asset pool: successful"
-    else
-        create_two_asset_pool
-    fi
+    COUNTER=0
+    while [ $COUNTER -lt 15 ]; do
+        string=$(osmosisd tx gamm create-pool --pool-file=nativeDenomPool.json --from $MONIKER --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --yes  2>&1)
+        if [ "$string" != "${string%"$substring"*}" ]; then
+            echo "create two asset pool: successful"
+            break
+        else
+            let COUNTER=COUNTER+1
+            sleep 0.5
+        fi
+    done
 }
 
 create_three_asset_pool () {
     # Create three asset pool
     substring='code: 0'
-    string=$(osmosisd tx gamm create-pool --pool-file=nativeDenomThreeAssetPool.json --from $MONIKER --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --yes 2>&1)
-    if [ "$string" != "${string%"$substring"*}" ]; then
-        echo "create three asset pool: successful"
-    else
-        create_three_asset_pool
-    fi
+    COUNTER=0
+    while [ $COUNTER -lt 15 ]; do
+        string=$(osmosisd tx gamm create-pool --pool-file=nativeDenomThreeAssetPool.json --from $MONIKER --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --yes 2>&1)
+        if [ "$string" != "${string%"$substring"*}" ]; then
+            echo "create three asset pool: successful"
+            break
+        else
+            let COUNTER=COUNTER+1
+            sleep 0.5
+        fi
+    done
 }
 
 if [[ ! -d $CONFIG_FOLDER ]]

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -4,8 +4,16 @@ CHAIN_ID=localosmosis
 OSMOSIS_HOME=$HOME/.osmosisd
 CONFIG_FOLDER=$OSMOSIS_HOME/config
 MONIKER=val
+STATE='false'
 
 MNEMONIC="bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort"
+
+while getopts s flag
+do
+    case "${flag}" in
+        s) STATE='true';;
+    esac
+done
 
 install_prerequisites () {
     apk add dasel
@@ -58,7 +66,7 @@ edit_genesis () {
 
 add_genesis_accounts () {
 
-    osmosisd add-genesis-account osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME 
+    osmosisd add-genesis-account osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo18s5lynnmx37hq4wlrw9gdn68sg2uxp5rgk26vv 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo1qwexv7c6sm95lwhzn9027vyu2ccneaqad4w8ka 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
@@ -84,6 +92,28 @@ edit_config () {
     dasel put string -f $CONFIG_FOLDER/config.toml '.rpc.laddr' "tcp://0.0.0.0:26657"
 }
 
+create_two_asset_pool () {
+    # Create default pool
+    substring='code: 0'
+    string=$(osmosisd tx gamm create-pool --pool-file=nativeDenomPool.json --from $MONIKER --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --yes  2>&1)
+    if [ "$string" != "${string%"$substring"*}" ]; then
+        echo "create two asset pool: successful"
+    else
+        create_two_asset_pool
+    fi
+}
+
+create_three_asset_pool () {
+    # Create three asset pool
+    substring='code: 0'
+    string=$(osmosisd tx gamm create-pool --pool-file=nativeDenomThreeAssetPool.json --from $MONIKER --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --yes 2>&1)
+    if [ "$string" != "${string%"$substring"*}" ]; then
+        echo "create three asset pool: successful"
+    else
+        create_three_asset_pool
+    fi
+}
+
 if [[ ! -d $CONFIG_FOLDER ]]
 then
     echo $MNEMONIC | osmosisd init -o --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --recover $MONIKER
@@ -93,4 +123,11 @@ then
     edit_config
 fi
 
-osmosisd start --home $OSMOSIS_HOME
+osmosisd start --home $OSMOSIS_HOME &
+
+if [[ $STATE == 'true' ]]
+then
+    create_two_asset_pool
+    create_three_asset_pool
+fi
+wait


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

After discussion with @p0mvn, we agreed it would be very useful to provide an option (non-default) for LocalOsmosis to start with some pre-loaded state. This MVP allows a user to start their LocalOsmosis instance with `make localnet-start-with-state` and have two pools automatically created (one two asset pool and one three asset pool).


## Brief Changelog

- Adds state flag to setup.sh, when set:
  - Creates a two asset pool
  - Creates a three asset pool 


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable