### PR TITLE
[stableswap]: Wire up binary search solvers to core stableswap logic

### DIFF
--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -49,123 +49,7 @@ func cfmmConstantMulti(xReserve, yReserve, uReserve, vSumSquares osmomath.BigDec
 // So we solve the following expression for `a`
 // xy(x^2 + y^2) = (x - a)(y + b)((x - a)^2 + (y + b)^2)
 func solveCfmm(xReserve, yReserve, yIn osmomath.BigDec) osmomath.BigDec {
-	if !xReserve.IsPositive() || !yReserve.IsPositive() || !yIn.IsPositive() {
-		panic("invalid input: reserves and input must be positive")
-	}
-
-	// use the following wolfram alpha link to solve the equation
-	// https://www.wolframalpha.com/input?i=solve+for+a%2C+xy%28x%5E2+%2B+y%5E2%29+%3D+%28x+-+a%29%28y+%2B+b%29%28%28x+-+a%29%5E2+%2B+%28y+%2Bb%29%5E2%29+
-	// This returns (copied from wolfram):
-	// assuming (correctly) that b + y!=0
-	// a = (-27 b^2 x^3 y - 27 b^2 x y^3 + sqrt((-27 b^2 x^3 y - 27 b^2 x y^3 - 54 b x^3 y^2 - 54 b x y^4 - 27 x^3 y^3 - 27 x y^5)^2 + 4 (3 b^4 + 12 b^3 y + 18 b^2 y^2 + 12 b y^3 + 3 y^4)^3) - 54 b x^3 y^2 - 54 b x y^4 - 27 x^3 y^3 - 27 x y^5)^(1/3)/(3 2^(1/3) (b + y)) - (2^(1/3) (3 b^4 + 12 b^3 y + 18 b^2 y^2 + 12 b y^3 + 3 y^4))/(3 (b + y) (-27 b^2 x^3 y - 27 b^2 x y^3 + sqrt((-27 b^2 x^3 y - 27 b^2 x y^3 - 54 b x^3 y^2 - 54 b x y^4 - 27 x^3 y^3 - 27 x y^5)^2 + 4 (3 b^4 + 12 b^3 y + 18 b^2 y^2 + 12 b y^3 + 3 y^4)^3) - 54 b x^3 y^2 - 54 b x y^4 - 27 x^3 y^3 - 27 x y^5)^(1/3)) + (b x + x y)/(b + y) and b + y!=0
-	// We simplify and separate out terms to get that its the following:
-	// The key substitutions are that 3(b+y)^4 = 3 b^4 + 12 b^3 y + 18 b^2 y^2 + 12 b y^3 + 3 y^4
-	// and -27 x y (b + y)^2 (x^2 + y^2) = -27 b^2 x^3 y - 27 b^2 x y^3 - 54 b x^3 y^2 - 54 b x y^4 - 27 x^3 y^3 - 27 x y^5
-	// I added {} myself, making better distinctions between entirely distinct terms.
-	// a = {(-27 x y (b + y)^2 (x^2 + y^2)
-	//			+ sqrt(
-	//				(-27 x y (b + y)^2 (x^2 + y^2))^2
-	//				+ 108 ((b+y)^4)^3
-	// 			)^(1/3)
-	// 		  / (3 2^(1/3) (b + y))}
-	//		- {(2^(1/3) (3 (b + y)^4))
-	//		  /(3 (b + y)
-	// 			(-27 x y (b + y)^2 (x^2 + y^2)
-	// 				+ sqrt(
-	//					(-27 x y (b + y)^2 (x^2 + y^2))^2
-	//					+ 108 ((b+y)^4)^3)
-	// 			)^(1/3))}
-	//      + {(b x + x y)/(b + y)}
-	// we further simplify, and call:
-	// foo = (-27 x y (b + y)^2 (x^2 + y^2)
-	// 			+ sqrt(
-	//				(-27 x y (b + y)^2 (x^2 + y^2))^2
-	//				+ 108 ((b+y)^4)^3)
-	//		 )^(1/3)
-	// Thus, a is then:
-	// a = {foo / (3 2^(1/3) (b + y))}
-	//		- {(3 * 2^(1/3) (b+y)^4)
-	//		  /(3 (b + y) foo)}
-	//      + {(b x + x y)/(b + y)}
-	// Let:
-	// term1 = {foo / (3 2^(1/3) (b + y))}
-	// term2 = {(3 * 2^(1/3) (b+y)^4) /(3 (b + y) foo)} =  2^(1/3) (b+y)^3 / foo
-	// term3 = {(b x + x y)/(b + y)}
-
-	// prelude, compute all the xy cross terms. Consider keeping these precomputed in the struct,
-	// and maybe in state.
-	x := xReserve
-	y := yReserve
-	x2py2 := x.Mul(x).Add(y.Mul(y))
-
-	xy := x.Mul(y)
-
-	b := yIn
-
-	bpy := b.Add(y)
-	bpy2 := bpy.Mul(bpy)
-	bpy3 := bpy2.Mul(bpy)
-	bpy4 := bpy2.Mul(bpy2)
-
-	// TODO: Come back and optimize alot of the calculations
-
-	// Now we compute foo
-	// foo = (-27 x y (b + y)^2 (x^2 + y^2)
-	// 			+ sqrt(
-	//				(-27 x y (b + y)^2 (x^2 + y^2))^2
-	//				+ 108 ((b+y)^4)^3)
-	//		 )^(1/3)
-	// This has a y^12 term in it, which is unappealing, so we spend some energy reducing this max bitlen.
-	// foo = (-27 x y (b + y)^2 (x^2 + y^2)
-	// 			+ (b + y)^2 sqrt(
-	//				729 (x y (x^2 + y^2))^2
-	//				+ 108 (b+y)^8)
-	//		 )^(1/3)
-	// let e = x y (x^2 + y^2))
-	// foo = (-27 (b + y)^2 e
-	// 			+ (b + y)^2 sqrt(
-	//				729 e^2 + 108 (b+y)^8)
-	//		 )^(1/3)
-
-	e := xy.Mul(x2py2) // xy(x^2 + y^2)
-
-	// t1 = -27 (b + y)^2 e
-	t1 := e.Mul(bpy2).MulInt64(-27)
-
-	// compute d = (b + y)^2 sqrt(729 e^2 + 108 (b+y)^8)
-	bpy8 := bpy4.Mul(bpy4)
-	sqrt_inner := e.Mul(e).MulInt64(729).Add(bpy8.MulInt64(108)) // 729 e^2 + 108 (b+y)^8
-	sqrt, err := sqrt_inner.ApproxSqrt()
-	if err != nil {
-		panic(err)
-	}
-	d := sqrt.Mul(bpy2)
-
-	// foo = (t1 + d)^(1/3)
-	foo3 := t1.Add(d)
-	foo, _ := foo3.ApproxRoot(3)
-
-	// a = {foo / (3 2^(1/3) (b + y))}
-	//		- {(2^(1/3) banana) / (3 (b + y) foo}
-	//      + {(b x + x y)/(b + y)}
-
-	// term1 := {foo / (3 2^(1/3) (b + y))}
-	term1Denominator := threeCubeRootTwo.Mul(bpy)
-	term1 := foo.Quo(term1Denominator)
-	// term2 := {(2^(1/3) (b+y)^3) / (foo}
-	term2 := cubeRootTwo.Mul(bpy3)
-	term2 = term2.Quo(foo)
-	// term3 := {(b x + x y)/(b + y)}
-	term3Numerator := b.Mul(x).Add(xy)
-	term3 := term3Numerator.Quo(bpy)
-
-	a := term1.Sub(term2).Add(term3)
-
-	if a.GTE(xReserve) {
-		panic("invalid output: greater than full pool reserves")
-	}
-
-	return a
+	return solveCFMMBinarySearch(cfmmConstant)(xReserve, yReserve, yIn)
 }
 
 // Our multi-asset CFMM is xyz(x^2 + y^2 + w) = k
@@ -173,108 +57,8 @@ func solveCfmm(xReserve, yReserve, yIn osmomath.BigDec) osmomath.BigDec {
 // how many units `a` of x do we get out.
 // So we solve the following expression for `a`
 // xyz(x^2 + y^2 + w) = (x - a)(y + b)z((x - a)^2 + (y + b)^2 + w)
-func solveCfmmMulti(xReserve, yReserve, wSumSquares, yIn osmomath.BigDec) osmomath.BigDec {
-	if !xReserve.IsPositive() || !yReserve.IsPositive() || !yIn.IsPositive() {
-		panic("invalid input: reserves and input must be positive")
-	}
-
-	// Use the following wolfram alpha link to solve the equation
-	// https://www.wolframalpha.com/input?i=solve+for+a%2C+xyz%28x%5E2+%2B+y%5E2+%2B+w%29+%3D+%28x+-+a%29%28y+%2B+b%29z%28%28x+-+a%29%5E2+%2B+%28y+%2Bb%29%5E2+%2B+w%29
-	// This returns (copied from wolfram):
-	// assuming (correctly) that b + y!=0
-	// a = (-27 b^2 w x y - 27 b^2 x^3 y - 27 b^2 x y^3 + sqrt((-27 b^2 w x y - 27 b^2 x^3 y - 27 b^2 x y^3 - 54 b w x y^2 - 54 b x^3 y^2 - 54 b x y^4 - 27 w x y^3 - 27 x^3 y^3 - 27 x y^5)^2 + 4 (3 b^4 + 12 b^3 y + 3 b^2 w + 18 b^2 y^2 + 6 b w y + 12 b y^3 + 3 w y^2 + 3 y^4)^3) - 54 b w x y^2 - 54 b x^3 y^2 - 54 b x y^4 - 27 w x y^3 - 27 x^3 y^3 - 27 x y^5)^(1/3)/(3 2^(1/3) (b + y)) - (2^(1/3) (3 b^4 + 12 b^3 y + 3 b^2 w + 18 b^2 y^2 + 6 b w y + 12 b y^3 + 3 w y^2 + 3 y^4))/(3 (b + y) (-27 b^2 w x y - 27 b^2 x^3 y - 27 b^2 x y^3 + sqrt((-27 b^2 w x y - 27 b^2 x^3 y - 27 b^2 x y^3 - 54 b w x y^2 - 54 b x^3 y^2 - 54 b x y^4 - 27 w x y^3 - 27 x^3 y^3 - 27 x y^5)^2 + 4 (3 b^4 + 12 b^3 y + 3 b^2 w + 18 b^2 y^2 + 6 b w y + 12 b y^3 + 3 w y^2 + 3 y^4)^3) - 54 b w x y^2 - 54 b x^3 y^2 - 54 b x y^4 - 27 w x y^3 - 27 x^3 y^3 - 27 x y^5)^(1/3)) + (b x + x y)/(b + y) and b + y!=0
-	//
-	// The key substitutions are (where w represents the sum of the squares as represented in the multi-asset CFMM function):
-	// 1. S1: 3 (b + y)^2 (b^2 + 2 b y + y^2 + w) = 3 b^4 + 12 b^3 y + 3b^2w + 18 b^2 y^2 + 6bwy + 12 b y^3 + 3wy^2 + 3 y^4
-	// 2. S2: -27 x y (b + y)^2 (x^2 + y^2 + w) = -27b^2xyw - 27b^2x^3y - 27b^2xy^3 - 54bxy^2w - 54bx^3y^2 - 54bxy^4 - 27xy^3w - 27x^3y^3 - 27xy^5
-	//
-	// This is the simplified version using the substitutions above, to be expanded afterwards below:
-	// a = (1 / [3 * 2^(1/3) * (b + y)])
-	// 			* [S2 + sqrt(S2^2 + 4*(S1^3))]^(1/3)
-	//			- {2^(1/3) * S1 /
-	// 				[3 * (b + y) * (S2 + sqrt(S2^2 + 4*(S1^3)))^(1/3)]}
-	// 			+ [(bx + xy) / (b + y)]
-	//
-	// To further simplify, let:
-	// foo = (S2 + sqrt(S2^2 + 4*(S1^3)))^(1/3)
-	// bpy = (b + y)
-	//
-	// Thus, a further simplifies to:
-	// a = (foo / (3 * 2^(1/3) * bpy))
-	//			- (2^(1/3) * S1 / (3 * bpy * foo))
-	// 			+ ((bx + xy) / bpy)
-	//
-	// Finally, let:
-	// term1 = (foo / (3 * 2^(1/3) * bpy))
-	// term2 = (2^(1/3) * S1 / (3 * bpy * foo))
-	// term3 = ((bx + xy) / bpy)
-	//
-	// The final result should be:
-	// a = term1 - term2 + term3
-
-	// Prelude, compute all the xy cross terms. Consider keeping these precomputed in the struct,
-	// and maybe in state.
-
-	x := xReserve
-	x2 := x.Mul(x)
-	y := yReserve
-	y2 := y.Mul(y)
-	w := wSumSquares
-	b := yIn
-
-	xy := x.Mul(y)
-
-	bpy := b.Add(y)
-	bpy2 := bpy.Mul(bpy)
-	// bpy3 := bpy2.Mul(bpy)
-	// bpy4 := bpy2.Mul(bpy2)
-
-	// S1 = 3 (b + y)^2 (b^2 + 2 b y + y^2 + w)
-	s1_inner := bpy2.Add(w) // (b^2 + 2 b y + y^2 + w) = (b+y)^2 + w
-	s1 := bpy2.MulInt64(3).Mul(s1_inner)
-	// S2 = -27 x y (b + y)^2 (x^2 + y^2 + w)
-	s2_inner := x2.Add(y2).Add(w) // (x^2 + y^2 + w)
-	s2 := bpy2.MulInt64(-27).Mul(xy).Mul(s2_inner)
-
-	// Calculating foo directly causes an integer overflow due to having a y^12 term, so we expand and factor to reduce its max bitlen:
-	// Original foo = (S2 + sqrt(S2^2 + 4*(S1^3)))^(1/3)
-	// Expand:
-	// foo = (S2 + sqrt((-27 x y (b + y)^2 (x^2 + y^2 + w))^2 +
-	// 					4*(3 (b + y)^2 (b^2 + 2 b y + y^2 + w))^3)
-	// 		 )^(1/3)
-	// Factor (b+y)^2 out from within the square root:
-	// foo = (S2 + (b + y)^2
-	// 			* sqrt((-27 x y (x^2 + y^2 + w))^2 +
-	// 					4 * ((b + y)^2) * (3 (b^2 + 2 b y + y^2 + w))^3)
-	// 		 )^(1/3)
-	sqrt_inner_term1 := xy.MulInt64(-27).Mul(s2_inner)                // (-27 x y (x^2 + y^2 + w))
-	sqrt_inner_term1_2 := sqrt_inner_term1.Mul(sqrt_inner_term1)      // sqrt_inner_term1^2
-	s1_inner_3 := (s1_inner).Mul(s1_inner).Mul(s1_inner).MulInt64(27) // (3 (b^2 + 2 b y + y^2 + w))^3 = 27 s1_inner^3
-	sqrt_inner_term2 := s1_inner_3.MulInt64(4).Mul(bpy2)              // 4 * ((b + y)^2) * s1_inner_3
-	sqrt_inner := sqrt_inner_term1_2.Add(sqrt_inner_term2)            // sqrt_inner_term1 + sqrt_inner_term2
-	sqrt, err := sqrt_inner.ApproxSqrt()
-	if err != nil {
-		panic(err)
-	}
-	foo3 := s2.Add(bpy2.Mul(sqrt))
-	foo, _ := foo3.ApproxRoot(3)
-
-	// term1 = (foo / (3 * 2^(1/3) * bar))
-	term1Denominator := threeCubeRootTwo.Mul(bpy) // 3 * 2^(1/3) * (b + y)
-	term1 := foo.Quo(term1Denominator)
-	// term2 = (2^(1/3) * S1 / (3 * bar * foo))
-	term2 := (cubeRootTwo.Mul(s1)).Quo(foo.Mul(bpy).MulInt64(3))
-	// term3 = ((bx + xy) / bpy)
-	term3Numerator := b.Mul(x).Add(xy)
-	term3 := term3Numerator.Quo(bpy)
-
-	a := term1.Sub(term2).Add(term3)
-
-	if a.GTE(xReserve) {
-		panic("invalid output: greater than full pool reserves")
-	}
-
-	return a
+func solveCfmmMulti(xReserve, yReserve, uReserve, wSumSquares, yIn osmomath.BigDec) osmomath.BigDec {
+	return solveCFMMBinarySearchMulti(cfmmConstantMulti)(xReserve, yReserve, uReserve, wSumSquares, yIn)
 }
 
 func approxDecEqual(a, b, tol osmomath.BigDec) bool {
@@ -324,7 +108,7 @@ func solveCFMMBinarySearch(constantFunction func(osmomath.BigDec, osmomath.BigDe
 // added for future extension
 func solveCFMMBinarySearchMulti(constantFunction func(osmomath.BigDec, osmomath.BigDec, osmomath.BigDec, osmomath.BigDec) osmomath.BigDec) func(osmomath.BigDec, osmomath.BigDec, osmomath.BigDec, osmomath.BigDec, osmomath.BigDec) osmomath.BigDec {
 	return func(xReserve, yReserve, uReserve, wSumSquares, yIn osmomath.BigDec) osmomath.BigDec {
-		if !xReserve.IsPositive() || !yReserve.IsPositive() || wSumSquares.IsNegative() || !yIn.IsPositive() {
+		if !xReserve.IsPositive() || !yReserve.IsPositive() || !uReserve.IsPositive() || wSumSquares.IsNegative() || !yIn.IsPositive() {
 			panic("invalid input: reserves and input must be positive")
 		} else if yIn.GTE(yReserve) {
 			panic("cannot input more than pool reserves")

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -420,8 +420,7 @@ type StableSwapTestSuite struct {
 func TestCFMMInvariantTwoAssets(t *testing.T) {
 	kErrTolerance := osmomath.OneDec()
 
-	// TODO: switch solveCfmm to binary search and replace this with test case suite
-	tests := map[string]twoAssetCFMMTestCase{}
+	tests := twoAssetCFMMTestCases
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -437,7 +436,7 @@ func TestCFMMInvariantTwoAssets(t *testing.T) {
 				// using multi-asset cfmm (should be equivalent with u = 1, w = 0)
 				k2 := cfmmConstantMulti(test.xReserve, test.yReserve, osmomath.OneDec(), osmomath.ZeroDec())
 				osmomath.DecApproxEq(t, k2, k0, kErrTolerance)
-				xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, osmomath.ZeroDec(), test.yIn)
+				xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, osmomath.OneDec(), osmomath.ZeroDec(), test.yIn)
 				k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), osmomath.OneDec(), osmomath.ZeroDec())
 				osmomath.DecApproxEq(t, k2, k3, kErrTolerance)
 			}
@@ -473,7 +472,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 	kErrTolerance := osmomath.OneDec()
 
 	// TODO: switch solveCfmmMulti to binary search and replace this with test case suite
-	tests := map[string]multiAssetCFMMTestCase{}
+	tests := multiAssetCFMMTestCases
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -481,7 +480,7 @@ func TestCFMMInvariantMultiAssets(t *testing.T) {
 			sut := func() {
 				// using multi-asset cfmm
 				k2 := cfmmConstantMulti(test.xReserve, test.yReserve, test.uReserve, test.wSumSquares)
-				xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, test.wSumSquares, test.yIn)
+				xOut2 := solveCfmmMulti(test.xReserve, test.yReserve, test.uReserve, test.wSumSquares, test.yIn)
 				k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), test.uReserve, test.wSumSquares)
 				osmomath.DecApproxEq(t, k2, k3, kErrTolerance)
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1341, #2702, #2826

## What is the purpose of the change

This PR wires up our new binary search solvers to core stableswap logic through `solveCfmm` and `solveCfmmMulti`.

Note: majority of the diff is branched from #2825 – this PR makes minimal core logic changes and is meant mainly to tie up loose ends at the CFMM level so we can start thoroughly cleaning up and testing pool-level logic.

## Brief Changelog

- Wires up `solveCfmm` and `solveCfmmMulti` to use our new `BigDec` binary search solvers

## Testing and Verifying

- The existing suite of test cases for two-asset and multi-asset CFMMs is applied to both solvers in `amm_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)