### PR TITLE
fix: change proto go templates 

### DIFF
--- a/cmd/querygen/templates/grpc_template.tmpl
+++ b/cmd/querygen/templates/grpc_template.tmpl
@@ -20,7 +20,8 @@ type Querier struct {
 
 var _ queryproto.QueryServer = Querier{}
 
-{{range .Queries -}} 
+{{- range .Queries }}
+
 func (q Querier) {{.QueryName}}(grpcCtx context.Context,
 	req *queryproto.{{.QueryName}}Request,
 ) (*queryproto.{{.QueryName}}Response, error) {
@@ -30,4 +31,5 @@ func (q Querier) {{.QueryName}}(grpcCtx context.Context,
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.{{.QueryName}}(ctx, *req)
 }
-{{end -}} 
+
+{{- end }}

--- a/cmd/querygen/templates/grpc_template.tmpl
+++ b/cmd/querygen/templates/grpc_template.tmpl
@@ -1,4 +1,4 @@
-package grpc 
+package grpc
 
 // THIS FILE IS GENERATED CODE, DO NOT EDIT
 // SOURCE AT `{{.ProtoPath}}`

--- a/cmd/querygen/templates/query_proto_wrap.tmpl
+++ b/cmd/querygen/templates/query_proto_wrap.tmpl
@@ -18,7 +18,8 @@ type Querier struct {
 	K {{.KeeperStruct}}
 }
 
-{{range .Queries -}} 
+{{- range .Queries }}
+
 func (q Querier) {{.QueryName}}(ctx sdk.Context,
 	req queryproto.{{.QueryName}}Request,
 ) (*queryproto.{{.QueryName}}Response, error) {
@@ -28,4 +29,5 @@ func (q Querier) {{.QueryName}}(ctx sdk.Context,
 
 	return &queryproto.GetArithmeticTwapResponse{ArithmeticTwap: twap}, nil
 }
-{{end -}} 
+
+{{- end }}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the `check-proto` CI (https://github.com/osmosis-labs/osmosis/actions/workflows/check-generated.yml) that fails by fixing the go templates used to generate the protos.

## Brief Changelog

- Change Go templates

## Testing and Verifying

You can check by running the same scripts that the CI runs:

```bash
./scrips/ci/check-generated.sh
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 