### PR TITLE
Stop double running gamm tests

### DIFF
--- a/x/gamm/keeper/msg_server_test.go
+++ b/x/gamm/keeper/msg_server_test.go
@@ -1,10 +1,7 @@
 package keeper_test
 
 import (
-	"testing"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/keeper"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
@@ -15,10 +12,6 @@ const (
 	// Max positive int64.
 	int64Max = int64(^uint64(0) >> 1)
 )
-
-func TestMsgServerTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
-}
 
 // TestSwapExactAmountIn_Events tests that events are correctly emitted
 // when calling SwapExactAmountIn.


### PR DESCRIPTION
## What is the purpose of the change

Caught this in re-reviewing all gamm changes for v12

Gamm keeper tests were getting double ran, due to:
```
keeper/keeper_test.go
23:	suite.Run(t, new(KeeperTestSuite))
```
and 
```
keeper/msg_server_test.go
20:	suite.Run(t, new(KeeperTestSuite))
```

This PR fixes this. 

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

Manually verified by doing `go test -v ./x/gamm/keeper/.` before and after this change.
