### PR TITLE
fix joining mainnet link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For the most up to date documentation please visit
 ## Joining the Mainnet
 
 [Please visit the official instructions on how to join the Mainnet
-here.](https://docs.osmosis.zone/developing/network/join-mainnet.html#install-osmosis-binary)
+here.](https://docs.osmosis.zone/networks/join-mainnet)
 
 Thank you for supporting a healthy blockchain network and community by
 running an Osmosis node!


### PR DESCRIPTION
The link for join mainnet was directing to a no longer found page, updated with current docs location.