### PR TITLE
feat: user defined modules to export

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -16,7 +16,7 @@ import (
 // ExportAppStateAndValidators exports the state of the application for a genesis
 // file.
 func (app *OsmosisApp) ExportAppStateAndValidators(
-	forZeroHeight bool, jailAllowedAddrs []string,
+	forZeroHeight bool, jailAllowedAddrs []string, modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
 	// as if they could withdraw from the start of the next block
 	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
@@ -29,7 +29,7 @@ func (app *OsmosisApp) ExportAppStateAndValidators(
 		app.prepForZeroHeightGenesis(ctx, jailAllowedAddrs)
 	}
 
-	genState := app.mm.ExportGenesis(ctx, app.appCodec)
+	genState := app.mm.ExportGenesis(ctx, app.appCodec, modulesToExport)
 	appState, err := json.MarshalIndent(genState, "", "  ")
 	if err != nil {
 		return servertypes.ExportedApp{}, err

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -288,7 +288,7 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts serverty
 // createOsmosisAppAndExport creates and exports the new Osmosis app, returns the state of the new Osmosis app for a genesis file.
 func createOsmosisAppAndExport(
 	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailWhiteList []string,
-	appOpts servertypes.AppOptions,
+	appOpts servertypes.AppOptions, modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
 	encCfg := osmosis.MakeEncodingConfig() // Ideally, we would reuse the one created by NewRootCmd.
 	encCfg.Marshaler = codec.NewProtoCodec(encCfg.InterfaceRegistry)
@@ -303,5 +303,5 @@ func createOsmosisAppAndExport(
 		app = osmosis.NewOsmosisApp(logger, db, traceStore, true, map[int64]bool{}, "", uint(1), appOpts, osmosis.GetWasmEnabledProposals(), osmosis.EmptyWasmOpts)
 	}
 
-	return app.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+	return app.ExportAppStateAndValidators(forZeroHeight, jailWhiteList, modulesToExport)
 }

--- a/go.mod
+++ b/go.mod
@@ -293,8 +293,8 @@ require (
 replace (
 	// branch: v0.28.0x-osmo-v12, current tag: v0.28.0-osmo-v12.1
 	github.com/CosmWasm/wasmd => github.com/osmosis-labs/wasmd v0.28.0-osmo-v12.1
-	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: osmosis-main. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5c9a51c277d067e0ec5cf48df30a85fae95bcd14
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220921135931-3c4d30596acc
+	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: osmosis-main. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/6849de6cf9f5ecffef88996063cbd7c489e89986
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221001190416-6849de6cf9f5
 	// Use Osmosis fast iavl
 	github.com/cosmos/iavl => github.com/osmosis-labs/iavl v0.17.3-osmo-v7
 	// use cosmos-compatible protobufs

--- a/go.sum
+++ b/go.sum
@@ -876,8 +876,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.9.1 h1:v4dkG+dlu76goxMiTT2j8zV7s4oPPEppKT8K8p2f1kY=
 github.com/ory/dockertest/v3 v3.9.1/go.mod h1:42Ir9hmvaAPm0Mgibk6mBPi7SFvTXxEcnztDYOJ//uM=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220921135931-3c4d30596acc h1:WPsgSEDb4RsdUxhy7qmKU++kZ07mMHFVMeSl8Hp808w=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20220921135931-3c4d30596acc/go.mod h1:uUkGXyCWol+CHoaMxZA0nKglvlN5uHBCMbMSsZoGSAs=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221001190416-6849de6cf9f5 h1:viSp1i2QEuUXx+yh/dy9YOxrTWqbcMFdTTcpHgzU3c4=
+github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221001190416-6849de6cf9f5/go.mod h1:HbTqN2YeBd0fpofiJQRNzhyEJS8ibUW/I44o3B/NsZQ=
 github.com/osmosis-labs/go-mutesting v0.0.0-20220811235203-65a53b4ea8e3 h1:/imbKy8s1I+z7wx4FbRHOXK2v82xesUCz2EPUqfBDIg=
 github.com/osmosis-labs/go-mutesting v0.0.0-20220811235203-65a53b4ea8e3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/iavl v0.17.3-osmo-v7 h1:6KcADC/WhL7yDmNQxUIJt2XmzNt4FfRmq9gRke45w74=

--- a/osmoutils/cache_ctx.go
+++ b/osmoutils/cache_ctx.go
@@ -30,8 +30,6 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	} else {
 		// no error, write the output of f
 		write()
-		// Temporary, should be removed once: https://github.com/cosmos/cosmos-sdk/issues/12912
-		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	}
 	return err
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

As part of the Merkle-drop contract, we wanted a way to provide quick exports of only the data we need. As it stands, we are required to export the entire state which takes up to an hour and a large amount of RAM. With this feature, the user can provide a comma separated list of desired modules to export. In our case, we just need to export bank which only takes ~45 seconds.


## Brief Changelog

- Updates sdk fork to current osmosis-main
- Adds modulesToExport string array to export app
- Adds --modulesToExport flag to export command


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable