### PR TITLE
Remove 'V' term from stableswap multi-asset eq's

### DIFF
--- a/x/gamm/pool-models/stableswap/amm_bench_test.go
+++ b/x/gamm/pool-models/stableswap/amm_bench_test.go
@@ -22,7 +22,7 @@ func BenchmarkBinarySearchTwoAsset(b *testing.B) {
 
 func BenchmarkBinarySearchMultiAsset(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		runCalcMultiAsset(solveCFMMBinarySearchMulti(cfmmConstantMulti))
+		runCalcMultiAsset(solveCFMMBinarySearchMulti)
 	}
 }
 
@@ -40,13 +40,12 @@ func runCalcTwoAsset(solve func(osmomath.BigDec, osmomath.BigDec, osmomath.BigDe
 	solve(xReserve, yReserve, yIn)
 }
 
-func runCalcMultiAsset(solve func(osmomath.BigDec, osmomath.BigDec, osmomath.BigDec, osmomath.BigDec, osmomath.BigDec) osmomath.BigDec) {
+func runCalcMultiAsset(solve func(osmomath.BigDec, osmomath.BigDec, osmomath.BigDec, osmomath.BigDec) osmomath.BigDec) {
 	xReserve := osmomath.NewBigDec(rand.Int63n(100000) + 50000)
 	yReserve := osmomath.NewBigDec(rand.Int63n(100000) + 50000)
 	mReserve := osmomath.NewBigDec(rand.Int63n(100000) + 50000)
 	nReserve := osmomath.NewBigDec(rand.Int63n(100000) + 50000)
-	u := mReserve.Mul(nReserve)
 	w := mReserve.Mul(mReserve).Add(nReserve.Mul(nReserve))
 	yIn := osmomath.NewBigDec(rand.Int63n(100000))
-	solve(xReserve, yReserve, u, w, yIn)
+	solve(xReserve, yReserve, w, yIn)
 }

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -326,14 +326,6 @@ var (
 			yIn:         osmomath.NewBigDec(1),
 			expectPanic: true,
 		},
-		"negative remReserve": {
-			xReserve: osmomath.NewBigDec(100),
-			yReserve: osmomath.NewBigDec(100),
-			// represents a 4-asset pool with 100 in each reserve
-			remReserves: []osmomath.BigDec{osmomath.NewBigDec(-100), osmomath.NewBigDec(100)},
-			yIn:         osmomath.NewBigDec(1),
-			expectPanic: true,
-		},
 		"input greater than pool reserves (even 4-asset pool)": {
 			xReserve:    osmomath.NewBigDec(100),
 			yReserve:    osmomath.NewBigDec(100),
@@ -491,13 +483,12 @@ func TestCFMMInvariantMultiAssetsBinarySearch(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// system under test
 			sut := func() {
-				uReserve := calcUReserve(test.remReserves)
 				wSumSquares := calcWSumSquares(test.remReserves)
 
 				// using multi-asset cfmm
-				k2 := cfmmConstantMulti(test.xReserve, test.yReserve, uReserve, wSumSquares)
-				xOut2 := solveCFMMBinarySearchMulti(cfmmConstantMulti)(test.xReserve, test.yReserve, uReserve, wSumSquares, test.yIn)
-				k3 := cfmmConstantMulti(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), uReserve, wSumSquares)
+				k2 := cfmmConstantMultiNoV(test.xReserve, test.yReserve, wSumSquares)
+				xOut2 := solveCFMMBinarySearchMulti(test.xReserve, test.yReserve, wSumSquares, test.yIn)
+				k3 := cfmmConstantMultiNoV(test.xReserve.Sub(xOut2), test.yReserve.Add(test.yIn), wSumSquares)
 				osmomath.DecApproxEq(t, k2, k3, kErrTolerance)
 			}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Remove "V" term from stableswap multi-asset equations, significantly lowering precision issues and improving computational overhead.

This is an accordance with the spec.

## Testing and Verifying


This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? Stableswap spec