### PR TITLE
feat: cli command to create csv for merkledrop

### DIFF
--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ import (
 )
 
 const FlagSelectPoolIds = "breakdown-by-pool-ids"
+const FlagMinimumStakeAmount = "minimum-stake-amount"
 
 type DeriveSnapshot struct {
 	NumberAccounts uint64                    `json:"num_accounts"`
@@ -300,6 +302,78 @@ Example:
 
 	cmd.Flags().String(FlagSelectPoolIds, "",
 		"Output a special breakdown for amount LP'd to the provided pools. Usage --breakdown-by-pool-ids=1,2,605")
+
+	return cmd
+}
+
+// BalancesToCSVCmd generates a airdrop.csv from a provided exported balances.json.
+func StakedToCSVCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "staked-to-csv [input-balances-file] [output-airdrop-csv]",
+		Short: "Export a airdrop csv from a provided balances export",
+		Long: `Export a airdrop csv from a provided balances export (from export-derive-balances)
+Example:
+	osmosisd staked-to-csv ../balances.json ../airdrop.csv
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+			config.SetRoot(clientCtx.HomeDir)
+
+			balancesFile := args[0]
+
+			snapshotOutput := args[1]
+
+			minStakeAmount, _ := cmd.Flags().GetInt64(FlagMinimumStakeAmount)
+
+			var deriveSnapshot DeriveSnapshot
+
+			sourceFile, err := os.Open(balancesFile)
+			if err != nil {
+				return err
+			}
+			// remember to close the file at the end of the function
+			defer sourceFile.Close()
+
+			// decode the balances json file into the struct array
+			if err := json.NewDecoder(sourceFile).Decode(&deriveSnapshot); err != nil {
+				return err
+			}
+
+			// create a new file to store CSV data
+			outputFile, err := os.Create(snapshotOutput)
+			if err != nil {
+				return err
+			}
+			defer outputFile.Close()
+
+			// write the header of the CSV file
+			writer := csv.NewWriter(outputFile)
+			defer writer.Flush()
+
+			header := []string{"address", "staked"}
+			if err := writer.Write(header); err != nil {
+				return err
+			}
+
+			// iterate through all accounts, leave out accounts that do not meet the user provided min stake amount
+			for _, r := range deriveSnapshot.Accounts {
+				var csvRow []string
+				if r.Staked.GT(sdk.NewInt(minStakeAmount)) {
+					csvRow = append(csvRow, r.Address, r.Staked.String())
+					if err := writer.Write(csvRow); err != nil {
+						return err
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64(FlagMinimumStakeAmount, 0, "Specify minimum amount (non inclusive) accounts must stake to be included in airdrop (default: 0)")
 
 	return cmd
 }

--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -306,7 +306,7 @@ Example:
 	return cmd
 }
 
-// BalancesToCSVCmd generates a airdrop.csv from a provided exported balances.json.
+// StakedToCSVCmd generates a airdrop.csv from a provided exported balances.json.
 func StakedToCSVCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "staked-to-csv [input-balances-file] [output-airdrop-csv]",

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -150,6 +150,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, osmosis.DefaultNodeHome),
 		genutilcli.MigrateGenesisCmd(),
 		ExportDeriveBalancesCmd(),
+		StakedToCSVCmd(),
 		AddGenesisAccountCmd(osmosis.DefaultNodeHome),
 		AddGenesisWasmMsgCmd(osmosis.DefaultNodeHome),
 		genutilcli.GenTxCmd(osmosis.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, osmosis.DefaultNodeHome),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The current flow is as follows:

1. Run `osmosisd export --modules-to-export="lockup,bank,gamm,staking" 2> export.json`. This gives you a state export of just those four modules (~40 seconds)
2. Run `osmosisd export-derive-balances export.json balances.json`. This gives you the balances
3. Finally, introduced in this PR, run `osmosisd staked-to-csv --minimum-stake-amount xxxxxxx balances.json airdrop.csv`

This final step gives you a csv of all accounts that have a minimum amount staked, which is then used in @p0mvn's merkledrop contract.

This staked-to-csv command should be expanded to cover many options that people may want to airdrop for (bonded gamm, holding certain assets, etc)


## Brief Changelog

- adds `staked-to-csv` cli command


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable