### PR TITLE
fix: skip unmarshaling of blank modules

### DIFF
--- a/cmd/osmosisd/cmd/balances_from_state_export.go
+++ b/cmd/osmosisd/cmd/balances_from_state_export.go
@@ -184,7 +184,9 @@ Example:
 			snapshotAccs := make(map[string]DerivedAccount)
 
 			bankGenesis := banktypes.GenesisState{}
-			clientCtx.Codec.MustUnmarshalJSON(genState["bank"], &bankGenesis)
+			if len(genState["bank"]) > 0 {
+				clientCtx.Codec.MustUnmarshalJSON(genState["bank"], &bankGenesis)
+			}
 			for _, balance := range bankGenesis.Balances {
 				address := balance.Address
 				acc, ok := snapshotAccs[address]
@@ -197,7 +199,9 @@ Example:
 			}
 
 			stakingGenesis := stakingtypes.GenesisState{}
-			clientCtx.Codec.MustUnmarshalJSON(genState["staking"], &stakingGenesis)
+			if len(genState["staking"]) > 0 {
+				clientCtx.Codec.MustUnmarshalJSON(genState["staking"], &stakingGenesis)
+			}
 			for _, unbonding := range stakingGenesis.UnbondingDelegations {
 				address := unbonding.DelegatorAddress
 				acc, ok := snapshotAccs[address]
@@ -238,7 +242,9 @@ Example:
 			}
 
 			lockupGenesis := lockuptypes.GenesisState{}
-			clientCtx.Codec.MustUnmarshalJSON(genState["lockup"], &lockupGenesis)
+			if len(genState["lockup"]) > 0 {
+				clientCtx.Codec.MustUnmarshalJSON(genState["lockup"], &lockupGenesis)
+			}
 			for _, lock := range lockupGenesis.Locks {
 				address := lock.Owner
 
@@ -252,7 +258,9 @@ Example:
 			}
 
 			gammGenesis := gammtypes.GenesisState{}
-			clientCtx.Codec.MustUnmarshalJSON(genState["gamm"], &gammGenesis)
+			if len(genState["gamm"]) > 0 {
+				clientCtx.Codec.MustUnmarshalJSON(genState["gamm"], &gammGenesis)
+			}
 
 			// collect gamm pools
 			pools := make(map[string]gammtypes.PoolI)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Now that we have introduced partial state exports, we have instances where we want to derive account balances for specific modules. For instance, if we just export the staking module, we dont want to error at deriving account bank balances because we expect this to be blank. This simply adds a check to see if the modules is blank, and if it is we do not require unmarshaling.


## Brief Changelog

- Checks length of module when exporting balances. If zero, don't force unmarshaling and go to next module.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable