### PR TITLE
Use total Ordering for begin blockers and end blockers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -227,10 +227,10 @@ func NewOsmosisApp(
 	// NOTE: capability module's beginblocker must come before any modules using capabilities (e.g. IBC)
 
 	// Tell the app's module manager how to set the order of BeginBlockers, which are run at the beginning of every block.
-	app.mm.SetOrderBeginBlockers(orderBeginBlockers(app.mm.ModuleNames())...)
+	app.mm.SetOrderBeginBlockers(orderBeginBlockers()...)
 
 	// Tell the app's module manager how to set the order of EndBlockers, which are run at the end of every block.
-	app.mm.SetOrderEndBlockers(OrderEndBlockers(app.mm.ModuleNames())...)
+	app.mm.SetOrderEndBlockers(orderEndBlockers()...)
 
 	app.mm.SetOrderInitGenesis(OrderInitGenesis(app.mm.ModuleNames())...)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Uses Total Ordering for begin blocker and end blockers for `app.mm.SetOrderBeginBlockers` and `app.mm.SetOrderEndBlockers`

## Brief Changelog

- Use Total Ordering for Begin Blockers and End Blockers

