### PR TITLE
refactor: end block ordering - staking after gov and module sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#2803](https://github.com/osmosis-labs/osmosis/pull/2803) Fix total pool liquidity CLI query.
 * [#2914](https://github.com/osmosis-labs/osmosis/pull/2914) Remove out of gas panics from node logs
+* [#2937](https://github.com/osmosis-labs/osmosis/pull/2937) End block ordering - staking after gov and module sorting.
 
 ### Misc Improvements
 

--- a/app/modules.go
+++ b/app/modules.go
@@ -167,7 +167,9 @@ func orderBeginBlockers(allModuleNames []string) []string {
 func OrderEndBlockers(allModuleNames []string) []string {
 	ord := partialord.NewPartialOrdering(allModuleNames)
 
-	ord.After(stakingtypes.ModuleName, govtypes.ModuleName)
+	// Staking must be after gov.
+	ord.FirstElements(govtypes.ModuleName)
+	ord.LastElements(stakingtypes.ModuleName)
 
 	// only Osmosis modules with endblock code are: twap, crisis, govtypes, staking
 	// we don't care about the relative ordering between them.

--- a/app/modules.go
+++ b/app/modules.go
@@ -166,6 +166,9 @@ func orderBeginBlockers(allModuleNames []string) []string {
 // OrderEndBlockers returns EndBlockers (crisis, govtypes, staking) with no relative order.
 func OrderEndBlockers(allModuleNames []string) []string {
 	ord := partialord.NewPartialOrdering(allModuleNames)
+
+	ord.After(stakingtypes.ModuleName, govtypes.ModuleName)
+
 	// only Osmosis modules with endblock code are: twap, crisis, govtypes, staking
 	// we don't care about the relative ordering between them.
 	return ord.TotalOrdering()

--- a/app/modules_test.go
+++ b/app/modules_test.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	dbm "github.com/tendermint/tm-db"
+)
+
+func TestOrderEndBlockers_Determinism(t *testing.T) {
+	db := dbm.NewMemDB()
+	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
+
+	for i := 0; i < 1000; i++ {
+		a := OrderEndBlockers(app.mm.ModuleNames())
+		b := OrderEndBlockers(app.mm.ModuleNames())
+		require.True(t, reflect.DeepEqual(a, b))
+	}
+}

--- a/osmoutils/partialord/partialord.go
+++ b/osmoutils/partialord/partialord.go
@@ -21,7 +21,7 @@ func NewPartialOrdering(elements []string) PartialOrdering {
 	copy(elementsCopy, elements)
 	sort.Strings(elementsCopy)
 	return PartialOrdering{
-		dag:         dag.NewDAG(elements),
+		dag:         dag.NewDAG(elementsCopy),
 		firstSealed: false,
 		lastSealed:  false,
 	}

--- a/osmoutils/partialord/partialord_test.go
+++ b/osmoutils/partialord/partialord_test.go
@@ -26,7 +26,7 @@ func TestAPI(t *testing.T) {
 	totalOrd := beginBlockOrd.TotalOrdering()
 	expTotalOrd := []string{
 		"upgrades", "epochs", "capabilities",
-		"bank", "staking", "mint", "ibc", "distribution", "ibctransfers",
+		"bank", "ibc", "mint", "staking", "ibctransfers", "distribution",
 		"auth", "authz", "wasm",
 	}
 	require.Equal(t, expTotalOrd, totalOrd)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

`ModuleNames()` function returns modules in non-deterministic order due to a map iteration. Our DAG took those modules to construct total order from a partial order. Although we tried to sort the module names to prevent non-determinism, we ended up erroneously providing the unsorted copy.

Additionally, there was no ordering constraint for the staking `EndBlock` to go after the gov `EndBlock`. The constraint is added here.

It seems that the DAG ordering problems haven't been causing issues since they were added. The ordering between stake and gov modules only matters in some edge cases. In our case, the following proposal has led to the dependency being fatal: https://www.mintscan.io/osmosis/proposals/337

Lastly, @alexanderbez created a test to make sure that the ordering is deterministic.


## Testing and Verifying

This change added tests.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable