### PR TITLE
fix: remove interchain accounts from state export in testnetify.py

### DIFF
--- a/tests/localosmosis/state_export/scripts/testnetify.py
+++ b/tests/localosmosis/state_export/scripts/testnetify.py
@@ -369,6 +369,11 @@ def main():
                 print("\tUpdate total uosmo supply from {} to {}".format(supply["amount"], str(int(supply["amount"]) + 2000000000000000 - DISTRIBUTION_MODULE_OFFSET)))
             supply["amount"] = str(int(supply["amount"]) + 2000000000000000 - DISTRIBUTION_MODULE_OFFSET)
             break
+
+    # State export bug
+    INTERCHAIN_ACCOUNT_TYPE = "/ibc.applications.interchain_accounts.v1.InterchainAccount"
+    genesis['app_state']['auth']["accounts"] = [account for account in genesis['app_state']['auth']["accounts"] if account['@type'] != INTERCHAIN_ACCOUNT_TYPE]
+
     
     print("📝 Writing {}... (it may take a while)".format(args.output_genesis))
     with open(args.output_genesis, 'w') as f:


### PR DESCRIPTION
Related to: https://github.com/osmosis-labs/osmosis/issues/2940

## What is the purpose of the change

This PR implements the quick fix suggested by @ValarDragon to circumvent the issue related to re-starting a chain from a mainnet state export:

```bash
10:49PM INF ABCI Replay Blocks appHeight=0 module=consensus stateHeight=0 storeHeight=0
10:50PM INF initializing blockchain state from genesis.json
10:50PM INF running initialization for module module=capability
10:50PM INF running initialization for module module=auth
panic: unable to resolve type URL /ibc.applications.interchain_accounts.v1.InterchainAccount
```

The fix removes from the `state_export.json` all accounts of type `/ibc.applications.interchain_accounts.v1.InterchainAccount` present in the `auth` module.

## Brief Changelog

- Fix`testnetify.py`

## Testing and Verifying

Run state-exported localosmosis as usual/

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable