### PR TITLE
[CI] Use fixed addrbook in state compatibility check

### DIFF
--- a/.github/workflows/state-compatibility-check.yml
+++ b/.github/workflows/state-compatibility-check.yml
@@ -36,6 +36,7 @@ on:
 env:
   GOLANG_VERSION: 1.18
   GENESIS_URL: https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
+  ADDRBOOK_URL: https://dl2.quicksync.io/json/addrbook.osmosis.json
   SNAPSHOT_BUCKET: https://osmosis-snapshot.sfo3.cdn.digitaloceanspaces.com
   RPC_ENDPOINT: https://rpc.osmosis.zone
   LCD_ENDPOINT: https://lcd.osmosis.zone
@@ -147,6 +148,9 @@ jobs:
           dasel put string -f $CONFIG_FOLDER/app.toml '.halt-height' $HALT_HEIGHT
           dasel put string -f $CONFIG_FOLDER/app.toml '.pruning' everything
           dasel put string -f $CONFIG_FOLDER/app.toml '.state-sync.snapshot-interval' 0
+
+          # Download addrbook
+          wget -O $CONFIG_FOLDER/addrbook.json ${{ env.ADDRBOOK_URL }}
       -
         name: 🧪 Start Osmosis Node
         run: build/osmosisd start


### PR DESCRIPTION
## What is the purpose of the change

This PR allows the possibility to use a default addrbook when running the state compatibility check.
For now, the default addrbook is the chainlayer one but the plan is to migrate to our own.

## Brief Changelog

- Use fixed addrbook in state compatibility check

## Testing and Verifying

Change tested in the `osmosis-ci` repo: https://github.com/osmosis-labs/osmosis-ci/actions/runs/3201062369

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable