### PR TITLE
gamm: Use expectedErr fields with error types

### DIFF
--- a/x/gamm/client/cli/cli_test.go
+++ b/x/gamm/client/cli/cli_test.go
@@ -87,7 +87,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	testCases := []struct {
 		name         string
 		json         string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -101,7 +101,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": "0.001"
 			}
 			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
-			true, &sdk.TxResponse{}, 4,
+			types.ErrTooFewPoolAssets, &sdk.TxResponse{}, 4,
 		},
 		{
 			"two tokens pair pool",
@@ -113,7 +113,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": "0.001"
 			}
 			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 		{
 			"change order of json fields",
@@ -125,7 +125,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": "0.001"
 			}
 			`, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileWeights, cli.PoolFileExitFee),
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 		{ // --record-tokens=100.0stake2 --record-tokens=100.0stake --record-tokens-weight=5 --record-tokens-weight=5 --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
 			"three tokens pair pool - insufficient balance check",
@@ -137,7 +137,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": "0.001"
 			}
 			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
-			false, &sdk.TxResponse{}, 5,
+			nil, &sdk.TxResponse{}, 5,
 		},
 		{
 			"future governor address",
@@ -150,7 +150,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": "osmo1fqlr98d45v5ysqgp6h56kpujcj4cvsjnjq9nck"
 			}
 			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 		// Due to CI time concerns, we leave these CLI tests commented out, and instead guaranteed via
 		// the logic tests.
@@ -196,7 +196,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 		{
 			"not valid json",
 			"bad json",
-			true, &sdk.TxResponse{}, 0,
+			fmt.Errorf("failed to parse pool"), &sdk.TxResponse{}, 0,
 		},
 		{
 			"bad pool json - missing quotes around exit fee",
@@ -208,11 +208,11 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "%s": 0.001
 			}
 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
-			true, &sdk.TxResponse{}, 0,
+			fmt.Errorf("failed to parse pool"), &sdk.TxResponse{}, 0,
 		},
 		{
 			"empty pool json",
-			"", true, &sdk.TxResponse{}, 0,
+			"", fmt.Errorf("failed to parse pool"), &sdk.TxResponse{}, 0,
 		},
 		{
 			"smooth change params",
@@ -231,7 +231,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
 				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileDuration, cli.PoolFileTargetPoolWeights, cli.PoolFileStartTime,
 			),
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 		{
 			"smooth change params - no start time",
@@ -249,7 +249,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
 				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileDuration, cli.PoolFileTargetPoolWeights,
 			),
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 		{
 			"empty smooth change params",
@@ -264,7 +264,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
 				cli.PoolFileSmoothWeightChangeParams,
 			),
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 		{
 			"smooth change params wrong type",
@@ -279,7 +279,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
 				cli.PoolFileSmoothWeightChangeParams,
 			),
-			true, &sdk.TxResponse{}, 0,
+			fmt.Errorf("failed to parse pool"), &sdk.TxResponse{}, 0,
 		},
 		{
 			"smooth change params missing duration",
@@ -296,7 +296,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
 				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileTargetPoolWeights,
 			),
-			true, &sdk.TxResponse{}, 0,
+			fmt.Errorf("could not parse duration"), &sdk.TxResponse{}, 0,
 		},
 		{
 			"unknown fields in json",
@@ -309,7 +309,7 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			  "unknown": true,
 			}
 			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
-			true, &sdk.TxResponse{}, 0,
+			fmt.Errorf("failed to parse pool"), &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -333,8 +333,9 @@ func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 			}
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				err = clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType)
@@ -368,7 +369,7 @@ func (s IntegrationTestSuite) TestNewJoinPoolCmd() {
 	testCases := []struct {
 		name         string
 		args         []string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -384,7 +385,7 @@ func (s IntegrationTestSuite) TestNewJoinPoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 6,
+			nil, &sdk.TxResponse{}, 6,
 		},
 		{
 			"join pool with sufficient balance",
@@ -398,7 +399,7 @@ func (s IntegrationTestSuite) TestNewJoinPoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -410,8 +411,9 @@ func (s IntegrationTestSuite) TestNewJoinPoolCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -429,7 +431,7 @@ func (s IntegrationTestSuite) TestNewExitPoolCmd() {
 	testCases := []struct {
 		name         string
 		args         []string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -445,7 +447,7 @@ func (s IntegrationTestSuite) TestNewExitPoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 7,
+			nil, &sdk.TxResponse{}, 7,
 		},
 		{
 			"ask enough when exit",
@@ -459,7 +461,7 @@ func (s IntegrationTestSuite) TestNewExitPoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -471,8 +473,9 @@ func (s IntegrationTestSuite) TestNewExitPoolCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -507,7 +510,7 @@ func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
 		name string
 		args []string
 
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -523,7 +526,7 @@ func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -535,8 +538,9 @@ func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -570,7 +574,7 @@ func (s IntegrationTestSuite) TestNewJoinSwapExternAmountInCmd() {
 	testCases := []struct {
 		name         string
 		args         []string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -585,7 +589,7 @@ func (s IntegrationTestSuite) TestNewJoinSwapExternAmountInCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -597,8 +601,9 @@ func (s IntegrationTestSuite) TestNewJoinSwapExternAmountInCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -616,7 +621,7 @@ func (s IntegrationTestSuite) TestNewExitSwapExternAmountOutCmd() {
 	testCases := []struct {
 		name         string
 		args         []string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -631,7 +636,7 @@ func (s IntegrationTestSuite) TestNewExitSwapExternAmountOutCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -643,8 +648,9 @@ func (s IntegrationTestSuite) TestNewExitSwapExternAmountOutCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -678,7 +684,7 @@ func (s IntegrationTestSuite) TestNewJoinSwapShareAmountOutCmd() {
 	testCases := []struct {
 		name         string
 		args         []string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -693,7 +699,7 @@ func (s IntegrationTestSuite) TestNewJoinSwapShareAmountOutCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -705,8 +711,9 @@ func (s IntegrationTestSuite) TestNewJoinSwapShareAmountOutCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -724,7 +731,7 @@ func (s IntegrationTestSuite) TestNewExitSwapShareAmountInCmd() {
 	testCases := []struct {
 		name         string
 		args         []string
-		expectErr    bool
+		expectErr    error
 		respType     proto.Message
 		expectedCode uint32
 	}{
@@ -739,7 +746,7 @@ func (s IntegrationTestSuite) TestNewExitSwapShareAmountInCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
 			},
-			false, &sdk.TxResponse{}, 0,
+			nil, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -751,8 +758,9 @@ func (s IntegrationTestSuite) TestNewExitSwapShareAmountInCmd() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
@@ -770,14 +778,14 @@ func (s *IntegrationTestSuite) TestGetCmdPools() {
 	testCases := []struct {
 		name      string
 		args      []string
-		expectErr bool
+		expectErr error
 	}{
 		{
 			"query pools",
 			[]string{
 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
 			},
-			false,
+			nil,
 		},
 	}
 
@@ -789,8 +797,9 @@ func (s *IntegrationTestSuite) TestGetCmdPools() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				resp := types.QueryPoolsResponse{}
 				s.Require().NoError(err, out.String())
@@ -808,14 +817,14 @@ func (s *IntegrationTestSuite) TestGetCmdNumPools() {
 	testCases := []struct {
 		name      string
 		args      []string
-		expectErr bool
+		expectErr error
 	}{
 		{
 			"query num-pools",
 			[]string{
 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
 			},
-			false,
+			nil,
 		},
 	}
 
@@ -827,8 +836,9 @@ func (s *IntegrationTestSuite) TestGetCmdNumPools() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				resp := types.QueryNumPoolsResponse{}
 				s.Require().NoError(err, out.String())
@@ -846,7 +856,7 @@ func (s *IntegrationTestSuite) TestGetCmdPool() {
 	testCases := []struct {
 		name      string
 		args      []string
-		expectErr bool
+		expectErr error
 	}{
 		{
 			"query pool by id", // osmosisd query gamm pool 1
@@ -854,7 +864,7 @@ func (s *IntegrationTestSuite) TestGetCmdPool() {
 				"1",
 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
 			},
-			false,
+			nil,
 		},
 	}
 
@@ -866,8 +876,9 @@ func (s *IntegrationTestSuite) TestGetCmdPool() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				s.Require().NoError(err, out.String())
 
@@ -884,7 +895,7 @@ func (s *IntegrationTestSuite) TestGetCmdTotalShares() {
 	testCases := []struct {
 		name      string
 		args      []string
-		expectErr bool
+		expectErr error
 	}{
 		{
 			"query pool total share by id", // osmosisd query gamm total-share 1
@@ -892,7 +903,7 @@ func (s *IntegrationTestSuite) TestGetCmdTotalShares() {
 				"1",
 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
 			},
-			false,
+			nil,
 		},
 	}
 
@@ -904,7 +915,7 @@ func (s *IntegrationTestSuite) TestGetCmdTotalShares() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
 			} else {
 				resp := types.QueryTotalSharesResponse{}
@@ -921,14 +932,14 @@ func (s *IntegrationTestSuite) TestGetCmdTotalLiquidity() {
 	testCases := []struct {
 		name      string
 		args      []string
-		expectErr bool
+		expectErr error
 	}{
 		{
 			"query total liquidity", // osmosisd query gamm total-liquidity
 			[]string{
 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
 			},
-			false,
+			nil,
 		},
 	}
 
@@ -940,8 +951,9 @@ func (s *IntegrationTestSuite) TestGetCmdTotalLiquidity() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				resp := types.QueryTotalLiquidityResponse{}
 				s.Require().NoError(err, out.String())
@@ -957,7 +969,7 @@ func (s *IntegrationTestSuite) TestGetCmdSpotPrice() {
 	testCases := []struct {
 		name      string
 		args      []string
-		expectErr bool
+		expectErr error
 	}{
 		{
 			"query pool spot price", // osmosisd query gamm spot-price 1 stake node0token
@@ -965,7 +977,7 @@ func (s *IntegrationTestSuite) TestGetCmdSpotPrice() {
 				"1", "stake", "node0token",
 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
 			},
-			false,
+			nil,
 		},
 	}
 
@@ -977,8 +989,9 @@ func (s *IntegrationTestSuite) TestGetCmdSpotPrice() {
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.expectErr {
+			if tc.expectErr != nil {
 				s.Require().Error(err)
+				s.Require().ErrorAs(tc.expectErr, &err)
 			} else {
 				resp := types.QuerySpotPriceResponse{}
 				s.Require().NoError(err, out.String())

--- a/x/gamm/keeper/msg_server_test.go
+++ b/x/gamm/keeper/msg_server_test.go
@@ -252,9 +252,9 @@ func (suite *KeeperTestSuite) TestJoinPool_Events() {
 			poolId:         1,
 			shareOutAmount: sdk.NewInt(shareOut),
 			tokenInMaxs:    sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenInMaxAmount))),
-			expectError:    sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs is less than the needed LP liquidity to this JoinPoolNoSwap,"+
-			" upperbound: %v, needed %v", sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenInMaxAmount))), 
-			sdk.NewCoins(sdk.NewCoin("bar", sdk.OneInt()), sdk.NewCoin("baz", sdk.OneInt()), sdk.NewCoin("foo", sdk.OneInt()), sdk.NewCoin("uosmo", sdk.OneInt()))),
+			expectError: sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs is less than the needed LP liquidity to this JoinPoolNoSwap,"+
+				" upperbound: %v, needed %v", sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenInMaxAmount))),
+				sdk.NewCoins(sdk.NewCoin("bar", sdk.OneInt()), sdk.NewCoin("baz", sdk.OneInt()), sdk.NewCoin("foo", sdk.OneInt()), sdk.NewCoin("uosmo", sdk.OneInt()))),
 		},
 	}
 
@@ -319,7 +319,7 @@ func (suite *KeeperTestSuite) TestExitPool_Events() {
 			poolId:        1,
 			shareInAmount: sdk.NewInt(shareIn),
 			tokenOutMins:  sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenOutMinAmount))),
-			expectError:   sdkerrors.Wrapf(types.ErrLimitMinAmount,
+			expectError: sdkerrors.Wrapf(types.ErrLimitMinAmount,
 				"Exit pool returned %s , minimum tokens out specified as %s",
 				sdk.Coins{}, sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenOutMinAmount)))),
 		},

--- a/x/gamm/keeper/msg_server_test.go
+++ b/x/gamm/keeper/msg_server_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/keeper"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
@@ -251,7 +252,9 @@ func (suite *KeeperTestSuite) TestJoinPool_Events() {
 			poolId:         1,
 			shareOutAmount: sdk.NewInt(shareOut),
 			tokenInMaxs:    sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenInMaxAmount))),
-			expectError:    types.ErrLimitMaxAmount,
+			expectError:    sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs is less than the needed LP liquidity to this JoinPoolNoSwap,"+
+			" upperbound: %v, needed %v", sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenInMaxAmount))), 
+			sdk.NewCoins(sdk.NewCoin("bar", sdk.OneInt()), sdk.NewCoin("baz", sdk.OneInt()), sdk.NewCoin("foo", sdk.OneInt()), sdk.NewCoin("uosmo", sdk.OneInt()))),
 		},
 	}
 
@@ -316,7 +319,9 @@ func (suite *KeeperTestSuite) TestExitPool_Events() {
 			poolId:        1,
 			shareInAmount: sdk.NewInt(shareIn),
 			tokenOutMins:  sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenOutMinAmount))),
-			expectError:   types.ErrLimitMinAmount,
+			expectError:   sdkerrors.Wrapf(types.ErrLimitMinAmount,
+				"Exit pool returned %s , minimum tokens out specified as %s",
+				sdk.Coins{}, sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tokenOutMinAmount)))),
 		},
 	}
 

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -415,8 +415,8 @@ func (suite *KeeperTestSuite) TestJoinPoolNoSwap() {
 			name:            "join no swap with insufficient funds",
 			txSender:        suite.TestAccs[1],
 			sharesRequested: types.OneShare.MulRaw(100001),
-			tokenInMaxs: sdk.Coins{},
-			expectErr: sdkerrors.ErrInsufficientFunds,
+			tokenInMaxs:     sdk.Coins{},
+			expectErr:       sdkerrors.ErrInsufficientFunds,
 		},
 		{
 			name:            "join no swap with exact tokenInMaxs",

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -6,11 +6,11 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/osmosis-labs/osmosis/v12/app/apptesting/osmoassert"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/balancer"
 	balancertypes "github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var (
@@ -65,7 +65,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			name:        "create pool with no assets",
 			msg:         balancer.NewMsgCreateBalancerPool(testAccount, defaultPoolParams, defaultPoolAssets, defaultFutureGovernor),
 			emptySender: true,
-			expectErr:  sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, "%s is smaller than %s", sdk.Coin{Denom: "uosmo", Amount: sdk.NewInt(0)}, sdk.Coin{Denom: "uosmo", Amount: sdk.NewInt(1000000000)}),
+			expectErr:   sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, "%s is smaller than %s", sdk.Coin{Denom: "uosmo", Amount: sdk.NewInt(0)}, sdk.Coin{Denom: "uosmo", Amount: sdk.NewInt(1000000000)}),
 		}, {
 			name: "create a pool with negative swap fee",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -73,7 +73,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				ExitFee: sdk.NewDecWithPrec(1, 2),
 			}, defaultPoolAssets, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  types.ErrNegativeSwapFee,
+			expectErr:   types.ErrNegativeSwapFee,
 		}, {
 			name: "create a pool with negative exit fee",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -81,7 +81,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				ExitFee: sdk.NewDecWithPrec(-1, 2),
 			}, defaultPoolAssets, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  types.ErrNegativeExitFee,
+			expectErr:   types.ErrNegativeExitFee,
 		}, {
 			name: "create the pool with empty PoolAssets",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -89,7 +89,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				ExitFee: sdk.NewDecWithPrec(1, 2),
 			}, []balancertypes.PoolAsset{}, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  types.ErrTooFewPoolAssets,
+			expectErr:   types.ErrTooFewPoolAssets,
 		}, {
 			name: "create the pool with 0 weighted PoolAsset",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -103,7 +103,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				Token:  sdk.NewCoin("bar", sdk.NewInt(10000)),
 			}}, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  sdkerrors.Wrap(types.ErrNotPositiveWeight, sdk.NewInt(0).String()),
+			expectErr:   sdkerrors.Wrap(types.ErrNotPositiveWeight, sdk.NewInt(0).String()),
 		}, {
 			name: "create the pool with negative weighted PoolAsset",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -117,7 +117,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				Token:  sdk.NewCoin("bar", sdk.NewInt(10000)),
 			}}, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  sdkerrors.Wrap(types.ErrNotPositiveWeight, sdk.NewInt(-1).String()),
+			expectErr:   sdkerrors.Wrap(types.ErrNotPositiveWeight, sdk.NewInt(-1).String()),
 		}, {
 			name: "create the pool with 0 balance PoolAsset",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -131,7 +131,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				Token:  sdk.NewCoin("bar", sdk.NewInt(10000)),
 			}}, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, sdk.NewCoin("foo", sdk.NewInt(0)).String()),
+			expectErr:   sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, sdk.NewCoin("foo", sdk.NewInt(0)).String()),
 		}, {
 			name: "create the pool with negative balance PoolAsset",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -148,7 +148,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				Token:  sdk.NewCoin("bar", sdk.NewInt(10000)),
 			}}, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, sdk.Coin{ Denom:"foo", Amount: sdk.NewInt(-1)}.String()),
+			expectErr:   sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, sdk.Coin{Denom: "foo", Amount: sdk.NewInt(-1)}.String()),
 		}, {
 			name: "create the pool with duplicated PoolAssets",
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
@@ -162,7 +162,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 				Token:  sdk.NewCoin("foo", sdk.NewInt(10000)),
 			}}, defaultFutureGovernor),
 			emptySender: false,
-			expectErr:  sdkerrors.Wrapf(types.ErrTooFewPoolAssets, "pool asset %s already exists", "foo"),
+			expectErr:   sdkerrors.Wrapf(types.ErrTooFewPoolAssets, "pool asset %s already exists", "foo"),
 		},
 	}
 
@@ -235,7 +235,7 @@ func (suite *KeeperTestSuite) TestPoolCreationFee() {
 		name            string
 		poolCreationFee sdk.Coins
 		msg             balancertypes.MsgCreateBalancerPool
-		expectErr      error
+		expectErr       error
 	}{
 		{
 			name:            "no pool creation fee for default asset pool",
@@ -389,7 +389,7 @@ func (suite *KeeperTestSuite) TestJoinPoolNoSwap() {
 		txSender        sdk.AccAddress
 		sharesRequested sdk.Int
 		tokenInMaxs     sdk.Coins
-		expectErr      error
+		expectErr       error
 	}{
 		{
 			name:            "basic join no swap",
@@ -402,14 +402,14 @@ func (suite *KeeperTestSuite) TestJoinPoolNoSwap() {
 			txSender:        suite.TestAccs[1],
 			sharesRequested: sdk.NewInt(0),
 			tokenInMaxs:     sdk.Coins{},
-			expectErr:      sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
+			expectErr:       sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
 		},
 		{
 			name:            "join no swap with negative shares requested",
 			txSender:        suite.TestAccs[1],
 			sharesRequested: sdk.NewInt(-1),
 			tokenInMaxs:     sdk.Coins{},
-			expectErr:      sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
+			expectErr:       sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
 		},
 		{
 			name:            "join no swap with insufficient funds",
@@ -418,7 +418,7 @@ func (suite *KeeperTestSuite) TestJoinPoolNoSwap() {
 			tokenInMaxs: sdk.Coins{
 				sdk.NewCoin("bar", sdk.NewInt(4999)), sdk.NewCoin("foo", sdk.NewInt(4999)),
 			},
-			expectErr:      sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
+			expectErr: sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
 		},
 		{
 			name:            "join no swap with exact tokenInMaxs",
@@ -436,9 +436,9 @@ func (suite *KeeperTestSuite) TestJoinPoolNoSwap() {
 				fiveKFooAndBar[0], fiveKFooAndBar[1], sdk.NewCoin("baz", sdk.NewInt(5000)),
 			},
 			expectErr: sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, "TokenInMaxs includes tokens that are not part of the target pool,"+
-			" input tokens: %v, pool tokens %v", 
-			sdk.Coins{fiveKFooAndBar[0], fiveKFooAndBar[1], sdk.NewCoin("baz", sdk.NewInt(5000))}, 
-			sdk.Coins{fiveKFooAndBar[0], fiveKFooAndBar[1]}),
+				" input tokens: %v, pool tokens %v",
+				sdk.Coins{fiveKFooAndBar[0], fiveKFooAndBar[1], sdk.NewCoin("baz", sdk.NewInt(5000))},
+				sdk.Coins{fiveKFooAndBar[0], fiveKFooAndBar[1]}),
 		},
 	}
 
@@ -496,7 +496,7 @@ func (suite *KeeperTestSuite) TestExitPool() {
 		sharesIn     sdk.Int
 		tokenOutMins sdk.Coins
 		emptySender  bool
-		expectErr   error
+		expectErr    error
 	}{
 		{
 			name:         "attempt exit pool with no pool share balance",
@@ -504,7 +504,7 @@ func (suite *KeeperTestSuite) TestExitPool() {
 			sharesIn:     types.OneShare.MulRaw(50),
 			tokenOutMins: sdk.Coins{},
 			emptySender:  true,
-			expectErr:   sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, "%s is smaller than %s", sdk.Coin{Denom: "gamm/pool/1", Amount: sdk.NewInt(0)}, sdk.Coin{Denom: "gamm/pool/1", Amount: types.OneShare.MulRaw(50)}),
+			expectErr:    sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, "%s is smaller than %s", sdk.Coin{Denom: "gamm/pool/1", Amount: sdk.NewInt(0)}, sdk.Coin{Denom: "gamm/pool/1", Amount: types.OneShare.MulRaw(50)}),
 		},
 		{
 			name:         "exit half pool with correct pool share balance",
@@ -519,7 +519,7 @@ func (suite *KeeperTestSuite) TestExitPool() {
 			sharesIn:     sdk.NewInt(0),
 			tokenOutMins: sdk.Coins{},
 			emptySender:  false,
-			expectErr:   sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
+			expectErr:    sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
 		},
 		{
 			name:         "attempt exit pool requesting negative share amount",
@@ -527,7 +527,7 @@ func (suite *KeeperTestSuite) TestExitPool() {
 			sharesIn:     sdk.NewInt(-1),
 			tokenOutMins: sdk.Coins{},
 			emptySender:  false,
-			expectErr:   sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
+			expectErr:    sdkerrors.Wrapf(types.ErrInvalidMathApprox, "share ratio is zero or negative"),
 		},
 		{
 			name:     "attempt exit pool with tokenOutMins above actual output",
@@ -537,9 +537,9 @@ func (suite *KeeperTestSuite) TestExitPool() {
 				sdk.NewCoin("foo", sdk.NewInt(5001)),
 			},
 			emptySender: false,
-			expectErr:  sdkerrors.Wrapf(types.ErrLimitMinAmount,
+			expectErr: sdkerrors.Wrapf(types.ErrLimitMinAmount,
 				"Exit pool returned %s , minimum tokens out specified as %s",
-				fiveKFooAndBar, 
+				fiveKFooAndBar,
 				sdk.Coins{sdk.NewCoin("foo", sdk.NewInt(5001))}),
 		},
 		{

--- a/x/gamm/keeper/swap_test.go
+++ b/x/gamm/keeper/swap_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -8,11 +9,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/osmosis-labs/osmosis/v12/tests/mocks"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"errors"
 )
 
 var _ = suite.TestingSuite(nil)
@@ -26,8 +26,8 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountIn() {
 	}
 
 	tests := []struct {
-		name       string
-		param      param
+		name      string
+		param     param
 		expectErr error
 	}{
 		{
@@ -132,8 +132,8 @@ func (suite *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountOut() {
 	}
 
 	tests := []struct {
-		name       string
-		param      param
+		name      string
+		param     param
 		expectErr error
 	}{
 		{

--- a/x/gamm/pool-models/balancer/msgs_test.go
+++ b/x/gamm/pool-models/balancer/msgs_test.go
@@ -61,8 +61,8 @@ func TestMsgCreateBalancerPool(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        balancer.MsgCreateBalancerPool
+		name      string
+		msg       balancer.MsgCreateBalancerPool
 		expectErr error
 	}{
 		{
@@ -205,7 +205,7 @@ func TestMsgCreateBalancerPool(t *testing.T) {
 				msg.PoolAssets[0].Weight = sdk.NewInt(1 << 21)
 				return msg
 			}),
-			expectErr: sdkerrors.Wrap(types.ErrWeightTooLarge, sdk.NewInt(1 << 21).String()),
+			expectErr: sdkerrors.Wrap(types.ErrWeightTooLarge, sdk.NewInt(1<<21).String()),
 		},
 		// {
 		// 	name: "Create an LBP",

--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -1299,7 +1299,7 @@ func TestCalcJoinPoolNoSwapShares(t *testing.T) {
 			expNumShare:     sdk.NewIntFromUint64(0),
 			expTokensJoined: sdk.Coins{},
 			expPoolAssets:   balancerThreePoolAssets,
-			expectErr:      sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, "input denoms must already exist in the pool (%s)", "qux"),
+			expectErr:       sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, "input denoms must already exist in the pool (%s)", "qux"),
 		},
 		"single asset pool, no-swap join attempt with one asset": {
 			tokensIn: sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(sdk.MaxSortableDec.TruncateInt64()))),
@@ -1363,7 +1363,7 @@ func TestCalcJoinPoolNoSwapShares(t *testing.T) {
 				require.Equal(t, test.expPoolAssets, balancerPool.PoolAssets)
 				require.Equal(t, test.expNumShare, numShare)
 				require.Equal(t, test.expTokensJoined, tokensJoined)
-				
+
 			}
 		})
 	}

--- a/x/gamm/pool-models/stableswap/msgs_test.go
+++ b/x/gamm/pool-models/stableswap/msgs_test.go
@@ -56,8 +56,8 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        stableswap.MsgCreateStableswapPool
+		name      string
+		msg       stableswap.MsgCreateStableswapPool
 		expectErr error
 	}{
 		{

--- a/x/gamm/types/msgs_test.go
+++ b/x/gamm/types/msgs_test.go
@@ -51,8 +51,8 @@ func TestMsgSwapExactAmountIn(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgSwapExactAmountIn
+		name      string
+		msg       gammtypes.MsgSwapExactAmountIn
 		expectErr error
 	}{
 		{
@@ -184,8 +184,8 @@ func TestMsgSwapExactAmountOut(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgSwapExactAmountOut
+		name      string
+		msg       gammtypes.MsgSwapExactAmountOut
 		expectErr error
 	}{
 		{
@@ -309,8 +309,8 @@ func TestMsgJoinPool(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgJoinPool
+		name      string
+		msg       gammtypes.MsgJoinPool
 		expectErr error
 	}{
 		{
@@ -407,8 +407,8 @@ func TestMsgExitPool(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgExitPool
+		name      string
+		msg       gammtypes.MsgExitPool
 		expectErr error
 	}{
 		{
@@ -505,8 +505,8 @@ func TestMsgJoinSwapExternAmountIn(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgJoinSwapExternAmountIn
+		name      string
+		msg       gammtypes.MsgJoinSwapExternAmountIn
 		expectErr error
 	}{
 		{
@@ -606,8 +606,8 @@ func TestMsgJoinSwapShareAmountOut(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgJoinSwapShareAmountOut
+		name      string
+		msg       gammtypes.MsgJoinSwapShareAmountOut
 		expectErr error
 	}{
 		{
@@ -706,8 +706,8 @@ func TestMsgExitSwapExternAmountOut(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgExitSwapExternAmountOut
+		name      string
+		msg       gammtypes.MsgExitSwapExternAmountOut
 		expectErr error
 	}{
 		{
@@ -807,8 +807,8 @@ func TestMsgExitSwapShareAmountIn(t *testing.T) {
 	require.Equal(t, signers[0].String(), addr1)
 
 	tests := []struct {
-		name       string
-		msg        gammtypes.MsgExitSwapShareAmountIn
+		name      string
+		msg       gammtypes.MsgExitSwapShareAmountIn
 		expectErr error
 	}{
 		{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Partially closes: #2959

## What is the purpose of the change

> Update tests that are using expectPass or expectErr as the bool variable to the error type in the gamm module



## Brief Changelog

*(for example:)*
 
  - *Coverage gamm module*
  - *All tests pass*
  - *Commented at test cases where the error returned is not as expected*


