### PR TITLE
feat(lockup): NewExtendLockupByIDCmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 
 * [#2739](https://github.com/osmosis-labs/osmosis/pull/2739) Add pool type query
+* [#2974](https://github.com/osmosis-labs/osmosis/pull/2974) Add increase lockup duration tx
 
 ### Bug fixes
 


### PR DESCRIPTION
Closes: N/A
*(Partially completes a comment from issue #382, working on the rebonding from unbond next)*

## What is the purpose of the change
This PR finishes adds the ability for a user to change the lockup period for a given lockid from the CLI

## Brief Changelog
- Adds `func NewExtendLockupByIDCmd()` in `x/lockup/client/cli/tx.go`


## Testing and Verifying
This change is already covered by existing tests, in msg_server_test.go for MsgExtendLockup type in the keeper

Also manually verified via CLI + Mainnet
```bash
osmosisd tx gamm join-swap-extern-amount-in 100000uosmo 387035722592697287 --pool-id 1 --from osmotest --keyring-backend test --chain-id osmosis-1
# osmosisd q tx 125D45810E4298A007103849DCF1EE007E8E3A8151ABCA1BFAEC3D47AFA7B992

osmosisd tx lockup lock-tokens 1000000000000000000gamm/pool/1 --duration 24h --from osmotest --keyring-backend test --chain-id osmosis-1
# osmosisd q tx 57027B480F9B2E2306F4511AC9A992022FFB3AED1991596F6835FB13B30756D2 <- period_lock_id 1513271
# osmosisd q tx BD4A3A7D7EEEEB85E1028F82C7EE039B4E014D202E16CACB036A827C0EE80918 <- period_lock_id 1513275

# osmosisd q lockup lock-by-id 1513271 # old lock to test 
osmosisd q lockup lock-by-id 1513275
# lock:
#   ID: "1513275"
#   coins:
#   - amount: "1000000000000000000"
#     denom: gamm/pool/1
#   duration: 86400s
#   end_time: "0001-01-01T00:00:00Z"
#   owner: osmo1hj5fveer5cjtn4wd6wstzugjfdxzl0xpwhpz63

# lockup some id, then extend it - 24h, 168h, 336h
osmosisd tx lockup extend-lockup-by-id 1513275 --duration 168h --from osmotest --keyring-backend test --chain-id osmosis-1
# osmosisd q tx E37E9E4FF193EBF69154E05A473B3399EAC5066AB9295AB1FF3756CF3A7F158D # from 168h -> 168h [fails correctly], tested on 1513271
# osmosisd q tx CCAEB24DA38B238F838257AE46FAD9F1B0B1CC8EA4D7C8DB6C66D63926460712 # from 24h -> 168h

osmosisd q lockup lock-by-id 1513275
# lock:
#   ID: "1513275"
#   coins:
#   - amount: "1000000000000000000"
#     denom: gamm/pool/1
#   duration: 604800s
#   end_time: "0001-01-01T00:00:00Z"
#   owner: osmo1hj5fveer5cjtn4wd6wstzugjfdxzl0xpwhpz63
# lock increased successfully!
```


## Documentation and Release Note
  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not documented, just adding to CLI