### PR TITLE
fix: e2e flakiness

### DIFF
--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -126,7 +126,8 @@ func (c *Config) WaitUntilHeight(height int64) {
 func (c *Config) WaitForNumHeights(heightsToWait int64) {
 	node, err := c.GetDefaultNode()
 	require.NoError(c.t, err)
-	currentHeight := node.QueryCurrentHeight()
+	currentHeight, err := node.QueryCurrentHeight()
+	require.NoError(c.t, err)
 	c.WaitUntilHeight(currentHeight + heightsToWait)
 }
 

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -64,7 +64,9 @@ func (n *NodeConfig) Run() error {
 		n.t,
 		func() bool {
 			// This fails if unsuccessful.
-			n.QueryCurrentHeight()
+			if _, err := n.QueryCurrentHeight(); err != nil {
+				return false
+			}
 			n.t.Logf("started node container: %s", n.Name)
 			return true
 		},

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -224,10 +224,12 @@ func (n *NodeConfig) QueryHashFromBlock(height int64) (string, error) {
 }
 
 // QueryCurrentHeight returns the current block height of the node or error.
-func (n *NodeConfig) QueryCurrentHeight() int64 {
+func (n *NodeConfig) QueryCurrentHeight() (int64, error) {
 	status, err := n.rpcClient.Status(context.Background())
-	require.NoError(n.t, err)
-	return status.SyncInfo.LatestBlockHeight
+	if err != nil {
+		return 0, err
+	}
+	return status.SyncInfo.LatestBlockHeight, nil
 }
 
 // QueryLatestBlockTime returns the latest block time.

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -159,7 +159,10 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 	for _, chainConfig := range uc.chainConfigs {
 		for validatorIdx, node := range chainConfig.NodeConfigs {
 			if validatorIdx == 0 {
-				currentHeight := node.QueryCurrentHeight()
+				currentHeight, err := node.QueryCurrentHeight()
+				if err != nil {
+					return err
+				}
 				chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
 				node.SubmitUpgradeProposal(uc.upgradeVersion, chainConfig.UpgradePropHeight, sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(config.InitialMinDeposit)))
 				chainConfig.LatestProposalNumber += 1

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -342,7 +342,8 @@ func (s *IntegrationTestSuite) TestStateSync() {
 	stateSyncRPCServers := []string{stateSyncHostPort, stateSyncHostPort}
 
 	// get trust height and trust hash.
-	trustHeight := runningNode.QueryCurrentHeight()
+	trustHeight, err := runningNode.QueryCurrentHeight()
+	s.Require().NoError(err)
 
 	trustHash, err := runningNode.QueryHashFromBlock(trustHeight)
 	s.Require().NoError(err)
@@ -404,8 +405,8 @@ func (s *IntegrationTestSuite) TestStateSync() {
 
 	// ensure that the state synching node cathes up to the running node.
 	s.Require().Eventually(func() bool {
-		stateSyncNodeHeight := stateSynchingNode.QueryCurrentHeight()
-		runningNodeHeight := runningNode.QueryCurrentHeight()
+		stateSyncNodeHeight, _ := stateSynchingNode.QueryCurrentHeight()
+		runningNodeHeight, _ := runningNode.QueryCurrentHeight()
 		return stateSyncNodeHeight == runningNodeHeight
 	},
 		3*time.Minute,

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -405,8 +405,14 @@ func (s *IntegrationTestSuite) TestStateSync() {
 
 	// ensure that the state synching node cathes up to the running node.
 	s.Require().Eventually(func() bool {
-		stateSyncNodeHeight, _ := stateSynchingNode.QueryCurrentHeight()
-		runningNodeHeight, _ := runningNode.QueryCurrentHeight()
+		stateSyncNodeHeight, err := stateSynchingNode.QueryCurrentHeight()
+		if err != nil {
+			return false
+		}
+		runningNodeHeight, err := runningNode.QueryCurrentHeight()
+		if err != nil {
+			return false
+		}
 		return stateSyncNodeHeight == runningNodeHeight
 	},
 		3*time.Minute,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Without these checks, e2e fails locally sometimes
