### PR TITLE
Add servers to openapi.yaml swagger file

### DIFF
--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -40,6 +40,10 @@ yarn install
 yarn combine
 yarn convert
 yarn build
+
+#Add public servers to spec file for Osmosis testnet and mainnet
+yq -i '."servers"+=[{"url":"https://lcd.osmosis.zone","description":"Osmosis mainnet node"},{"url":"https://lcd-test.osmosis.zone","description":"Osmosis testnet node"}]' static/openapi/openapi.yaml
+
 cd ../../
 
 # clean swagger files


### PR DESCRIPTION
This change on the codegen scripts allows adding default servers on this openapi swagger file which will be used on the official docs. 

closes #2979