### PR TITLE
chore: Fix local testnet scripts and cleanup

### DIFF
--- a/scripts/multinode-local-testnet.sh
+++ b/scripts/multinode-local-testnet.sh
@@ -20,7 +20,6 @@ osmosisd keys add validator1 --keyring-backend=test --home=$HOME/.osmosisd/valid
 osmosisd keys add validator2 --keyring-backend=test --home=$HOME/.osmosisd/validator2
 osmosisd keys add validator3 --keyring-backend=test --home=$HOME/.osmosisd/validator3
 
-# Function updates the config based on a jq argument as a string
 update_genesis () {    
     cat $HOME/.osmosisd/validator1/config/genesis.json | jq "$1" > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
 }

--- a/scripts/multinode-local-testnet.sh
+++ b/scripts/multinode-local-testnet.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-rm -rf $HOME/.osmosisd/
+set -e
 
+# always returns true so set -e doesn't exit if it is not running.
+killall osmosisd || true
+rm -rf $HOME/.osmosisd/
 
 # make four osmosis directories
 mkdir $HOME/.osmosisd
@@ -17,8 +20,13 @@ osmosisd keys add validator1 --keyring-backend=test --home=$HOME/.osmosisd/valid
 osmosisd keys add validator2 --keyring-backend=test --home=$HOME/.osmosisd/validator2
 osmosisd keys add validator3 --keyring-backend=test --home=$HOME/.osmosisd/validator3
 
+# Function updates the config based on a jq argument as a string
+update_genesis () {    
+    cat $HOME/.osmosisd/validator1/config/genesis.json | jq "$1" > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+}
+
 # change staking denom to uosmo
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["staking"]["params"]["bond_denom"]="uosmo"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["staking"]["params"]["bond_denom"]="uosmo"'
 
 # create validator node with tokens to transfer to the three other nodes
 osmosisd add-genesis-account $(osmosisd keys show validator1 -a --keyring-backend=test --home=$HOME/.osmosisd/validator1) 100000000000uosmo,100000000000stake --home=$HOME/.osmosisd/validator1
@@ -27,75 +35,79 @@ osmosisd collect-gentxs --home=$HOME/.osmosisd/validator1
 
 
 # update staking genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["staking"]["params"]["unbonding_time"]="240s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["staking"]["params"]["unbonding_time"]="240s"'
 
 # update crisis variable to uosmo
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom"]="uosmo"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["crisis"]["constant_fee"]["denom"]="uosmo"'
 
 # udpate gov genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="60s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="uosmo"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["gov"]["voting_params"]["voting_period"]="60s"'
+update_genesis '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="uosmo"'
 
 # update epochs genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["epochs"]["epochs"][1]["duration"]="60s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["epochs"]["epochs"][1]["duration"]="60s"'
 
 # update poolincentives genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["poolincentives"]["lockable_durations"][0]="120s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["poolincentives"]["lockable_durations"][1]="180s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["poolincentives"]["lockable_durations"][2]="240s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["poolincentives"]["params"]["minted_denom"]="uosmo"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["poolincentives"]["lockable_durations"][0]="120s"'
+update_genesis '.app_state["poolincentives"]["lockable_durations"][1]="180s"'
+update_genesis '.app_state["poolincentives"]["lockable_durations"][2]="240s"'
+update_genesis '.app_state["poolincentives"]["params"]["minted_denom"]="uosmo"'
 
 # update incentives genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][0]="1s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][1]="120s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][2]="180s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][3]="240s"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["incentives"]["params"]["distr_epoch_identifier"]="day"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["incentives"]["lockable_durations"][0]="1s"'
+update_genesis '.app_state["incentives"]["lockable_durations"][1]="120s"'
+update_genesis '.app_state["incentives"]["lockable_durations"][2]="180s"'
+update_genesis '.app_state["incentives"]["lockable_durations"][3]="240s"'
+update_genesis '.app_state["incentives"]["params"]["distr_epoch_identifier"]="day"'
 
 # update mint genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]="uosmo"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["mint"]["params"]["epoch_identifier"]="day"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["mint"]["params"]["mint_denom"]="uosmo"'
+update_genesis '.app_state["mint"]["params"]["epoch_identifier"]="day"'
 
 # update gamm genesis
-cat $HOME/.osmosisd/validator1/config/genesis.json | jq '.app_state["gamm"]["params"]["pool_creation_fee"][0]["denom"]="uosmo"' > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+update_genesis '.app_state["gamm"]["params"]["pool_creation_fee"][0]["denom"]="uosmo"'
 
 
 # port key (validator1 uses default ports)
 # validator1 1317, 9090, 9091, 26658, 26657, 26656, 6060
 # validator2 1316, 9088, 9089, 26655, 26654, 26653, 6061
 # validator3 1315, 9086, 9087, 26652, 26651, 26650, 6062
-# validator4 1314, 9084, 9085, 26649, 26648, 26647, 6063
 
 
 # change app.toml values
+VALIDATOR2_APP_TOML=$HOME/.osmosisd/validator2/config/app.toml
+VALIDATOR3_APP_TOML=$HOME/.osmosisd/validator3/config/app.toml
 
 # validator2
-sed -i -E 's|tcp://0.0.0.0:1317|tcp://0.0.0.0:1316|g' $HOME/.osmosisd/validator2/config/app.toml
-sed -i -E 's|0.0.0.0:9090|0.0.0.0:9088|g' $HOME/.osmosisd/validator2/config/app.toml
-sed -i -E 's|0.0.0.0:9091|0.0.0.0:9089|g' $HOME/.osmosisd/validator2/config/app.toml
+sed -i -E 's|tcp://0.0.0.0:1317|tcp://0.0.0.0:1316|g' $VALIDATOR2_APP_TOML
+sed -i -E 's|0.0.0.0:9090|0.0.0.0:9088|g' $VALIDATOR2_APP_TOML
+sed -i -E 's|0.0.0.0:9091|0.0.0.0:9089|g' $VALIDATOR2_APP_TOML
 
 # validator3
-sed -i -E 's|tcp://0.0.0.0:1317|tcp://0.0.0.0:1315|g' $HOME/.osmosisd/validator3/config/app.toml
-sed -i -E 's|0.0.0.0:9090|0.0.0.0:9086|g' $HOME/.osmosisd/validator3/config/app.toml
-sed -i -E 's|0.0.0.0:9091|0.0.0.0:9087|g' $HOME/.osmosisd/validator3/config/app.toml
+sed -i -E 's|tcp://0.0.0.0:1317|tcp://0.0.0.0:1315|g' $VALIDATOR3_APP_TOML
+sed -i -E 's|0.0.0.0:9090|0.0.0.0:9086|g' $VALIDATOR3_APP_TOML
+sed -i -E 's|0.0.0.0:9091|0.0.0.0:9087|g' $VALIDATOR3_APP_TOML
 
 
 # change config.toml values
+VALIDATOR1_CONFIG=$HOME/.osmosisd/validator1/config/config.toml
+VALIDATOR2_CONFIG=$HOME/.osmosisd/validator2/config/config.toml
+VALIDATOR3_CONFIG=$HOME/.osmosisd/validator3/config/config.toml
 
 # validator1
-sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $HOME/.osmosisd/validator1/config/config.toml
+sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $VALIDATOR1_CONFIG
 # validator2
-sed -i -E 's|tcp://127.0.0.1:26658|tcp://127.0.0.1:26655|g' $HOME/.osmosisd/validator2/config/config.toml
-sed -i -E 's|tcp://127.0.0.1:26657|tcp://127.0.0.1:26654|g' $HOME/.osmosisd/validator2/config/config.toml
-sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26653|g' $HOME/.osmosisd/validator2/config/config.toml
-sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26650|g' $HOME/.osmosisd/validator3/config/config.toml
-sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $HOME/.osmosisd/validator2/config/config.toml
+sed -i -E 's|tcp://127.0.0.1:26658|tcp://127.0.0.1:26655|g' $VALIDATOR2_CONFIG
+sed -i -E 's|tcp://127.0.0.1:26657|tcp://127.0.0.1:26654|g' $VALIDATOR2_CONFIG
+sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26653|g' $VALIDATOR2_CONFIG
+sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26650|g' $VALIDATOR2_CONFIG
+sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $VALIDATOR2_CONFIG
 # validator3
-sed -i -E 's|tcp://127.0.0.1:26658|tcp://127.0.0.1:26652|g' $HOME/.osmosisd/validator3/config/config.toml
-sed -i -E 's|tcp://127.0.0.1:26657|tcp://127.0.0.1:26651|g' $HOME/.osmosisd/validator3/config/config.toml
-sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26650|g' $HOME/.osmosisd/validator3/config/config.toml
-sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26650|g' $HOME/.osmosisd/validator3/config/config.toml
-sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $HOME/.osmosisd/validator3/config/config.toml
+sed -i -E 's|tcp://127.0.0.1:26658|tcp://127.0.0.1:26652|g' $VALIDATOR3_CONFIG
+sed -i -E 's|tcp://127.0.0.1:26657|tcp://127.0.0.1:26651|g' $VALIDATOR3_CONFIG
+sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26650|g' $VALIDATOR3_CONFIG
+sed -i -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26650|g' $VALIDATOR3_CONFIG
+sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $VALIDATOR3_CONFIG
 
 
 # copy validator1 genesis file to validator2-3
@@ -104,8 +116,8 @@ cp $HOME/.osmosisd/validator1/config/genesis.json $HOME/.osmosisd/validator3/con
 
 
 # copy tendermint node id of validator1 to persistent peers of validator2-3
-sed -i -E "s|persistent_peers = \"\"|persistent_peers = \"$(osmosisd tendermint show-node-id --home=$HOME/.osmosisd/validator1)@$(curl -4 icanhazip.com):26656\"|g" $HOME/.osmosisd/validator2/config/config.toml
-sed -i -E "s|persistent_peers = \"\"|persistent_peers = \"$(osmosisd tendermint show-node-id --home=$HOME/.osmosisd/validator1)@$(curl -4 icanhazip.com):26656\"|g" $HOME/.osmosisd/validator3/config/config.toml
+sed -i -E "s|persistent_peers = \"\"|persistent_peers = \"$(osmosisd tendermint show-node-id --home=$HOME/.osmosisd/validator1)@localhost:26656\"|g" $HOME/.osmosisd/validator2/config/config.toml
+sed -i -E "s|persistent_peers = \"\"|persistent_peers = \"$(osmosisd tendermint show-node-id --home=$HOME/.osmosisd/validator1)@localhost:26656\"|g" $HOME/.osmosisd/validator3/config/config.toml
 
 
 # start all three validators
@@ -115,13 +127,13 @@ tmux new -s validator3 -d osmosisd start --home=$HOME/.osmosisd/validator3
 
 
 # send uosmo from first validator to second validator
+echo "Waiting 7 seconds to send funds to validators 2 and 3..."
 sleep 7
-osmosisd tx bank send validator1 $(osmosisd keys show validator2 -a --keyring-backend=test --home=$HOME/.osmosisd/validator2) 500000000uosmo --keyring-backend=test --home=$HOME/.osmosisd/validator1 --chain-id=testing --yes
-sleep 7
-osmosisd tx bank send validator1 $(osmosisd keys show validator3 -a --keyring-backend=test --home=$HOME/.osmosisd/validator3) 400000000uosmo --keyring-backend=test --home=$HOME/.osmosisd/validator1 --chain-id=testing --yes
+osmosisd tx bank send validator1 $(osmosisd keys show validator2 -a --keyring-backend=test --home=$HOME/.osmosisd/validator2) 500000000uosmo --keyring-backend=test --home=$HOME/.osmosisd/validator1 --chain-id=testing --broadcast-mode block --node http://localhost:26657 --yes
+osmosisd tx bank send validator1 $(osmosisd keys show validator3 -a --keyring-backend=test --home=$HOME/.osmosisd/validator3) 400000000uosmo --keyring-backend=test --home=$HOME/.osmosisd/validator1 --chain-id=testing --broadcast-mode block --node http://localhost:26657 --yes
 
-# create second validator
-sleep 7
-osmosisd tx staking create-validator --amount=500000000uosmo --from=validator2 --pubkey=$(osmosisd tendermint show-validator --home=$HOME/.osmosisd/validator2) --moniker="validator2" --chain-id="testing" --commission-rate="0.1" --commission-max-rate="0.2" --commission-max-change-rate="0.05" --min-self-delegation="500000000" --keyring-backend=test --home=$HOME/.osmosisd/validator2 --yes
-sleep 7
-osmosisd tx staking create-validator --amount=400000000uosmo --from=validator3 --pubkey=$(osmosisd tendermint show-validator --home=$HOME/.osmosisd/validator3) --moniker="validator3" --chain-id="testing" --commission-rate="0.1" --commission-max-rate="0.2" --commission-max-change-rate="0.05" --min-self-delegation="400000000" --keyring-backend=test --home=$HOME/.osmosisd/validator3 --yes
+# create second & third validator
+osmosisd tx staking create-validator --amount=500000000uosmo --from=validator2 --pubkey=$(osmosisd tendermint show-validator --home=$HOME/.osmosisd/validator2) --moniker="validator2" --chain-id="testing" --commission-rate="0.1" --commission-max-rate="0.2" --commission-max-change-rate="0.05" --min-self-delegation="500000000" --keyring-backend=test --home=$HOME/.osmosisd/validator2 --broadcast-mode block --node http://localhost:26657 --yes
+osmosisd tx staking create-validator --amount=400000000uosmo --from=validator3 --pubkey=$(osmosisd tendermint show-validator --home=$HOME/.osmosisd/validator3) --moniker="validator3" --chain-id="testing" --commission-rate="0.1" --commission-max-rate="0.2" --commission-max-change-rate="0.05" --min-self-delegation="400000000" --keyring-backend=test --home=$HOME/.osmosisd/validator3 --broadcast-mode block --node http://localhost:26657 --yes
+
+echo "All 3 Validators are up and running!"

--- a/scripts/superfluid-test-startnode.sh
+++ b/scripts/superfluid-test-startnode.sh
@@ -10,35 +10,39 @@ osmosisd add-genesis-account $(osmosisd keys show validator -a --keyring-backend
 osmosisd gentx validator 500000000stake --keyring-backend=test --home=$HOME/.osmosisd --chain-id=testing
 osmosisd collect-gentxs --home=$HOME/.osmosisd
 
+update_genesis () {    
+    cat $HOME/.osmosisd/validator1/config/genesis.json | jq "$1" > $HOME/.osmosisd/validator1/config/tmp_genesis.json && mv $HOME/.osmosisd/validator1/config/tmp_genesis.json $HOME/.osmosisd/validator1/config/genesis.json
+}
+
 # update staking genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["staking"]["params"]["unbonding_time"]="120s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["staking"]["params"]["unbonding_time"]="120s"'
 
 # update governance genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="10s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["gov"]["voting_params"]["voting_period"]="10s"'
 
 # update epochs genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["epochs"]["epochs"][0]["identifier"]="min"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["epochs"]["epochs"][0]["duration"]="60s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["epochs"]["epochs"][0]["identifier"]="min"'
+update_genesis '.app_state["epochs"]["epochs"][0]["duration"]="60s"'
 
 # update poolincentives genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["poolincentives"]["lockable_durations"][0]="120s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["poolincentives"]["lockable_durations"][1]="180s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["poolincentives"]["lockable_durations"][2]="240s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["poolincentives"]["lockable_durations"][0]="120s"'
+update_genesis '.app_state["poolincentives"]["lockable_durations"][1]="180s"'
+update_genesis '.app_state["poolincentives"]["lockable_durations"][2]="240s"'
 
 # update incentives genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["incentives"]["params"]["distr_epoch_identifier"]="min"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][0]="1s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][1]="120s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][2]="180s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["incentives"]["lockable_durations"][3]="240s"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["incentives"]["params"]["distr_epoch_identifier"]="min"'
+update_genesis '.app_state["incentives"]["lockable_durations"][0]="1s"'
+update_genesis '.app_state["incentives"]["lockable_durations"][1]="120s"'
+update_genesis '.app_state["incentives"]["lockable_durations"][2]="180s"'
+update_genesis '.app_state["incentives"]["lockable_durations"][3]="240s"'
 
 # update mint genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["mint"]["params"]["epoch_identifier"]="min"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["mint"]["params"]["epoch_identifier"]="min"'
 
 # update gamm genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["gamm"]["params"]["pool_creation_fee"][0]["denom"]="stake"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["gamm"]["params"]["pool_creation_fee"][0]["denom"]="stake"'
 
 # update superfluid genesis
-cat $HOME/.osmosisd/config/genesis.json | jq '.app_state["superfluid"]["params"]["refresh_epoch_identifier"]="min"' > $HOME/.osmosisd/config/tmp_genesis.json && mv $HOME/.osmosisd/config/tmp_genesis.json $HOME/.osmosisd/config/genesis.json
+update_genesis '.app_state["superfluid"]["params"]["minimum_risk_factor"]="0.500000000000000000"'
 
 osmosisd start --home=$HOME/.osmosisd


### PR DESCRIPTION
## What is the purpose of the change
- Fixes multinode-local-testnet.sh script
- Cleans up redundant lines in multinode-local-testnet.sh & superfluid-test-startnode.sh

## Brief Changelog
- Fixes issue with validator2 being set with validator3 setting in config.toml
- Improve readability
- Reduces time to start by 21 seconds
- Adds error check
- Kills osmosisd locally when you run multinode-local-testnet

## Testing and Verifying
- Manually verified via running both scripts locally & checking tmux instances are working as intended. 
- queried each RPCs status

## Documentation and Release Note
  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable