### PR TITLE
twap: errors checked directly

### DIFF
--- a/x/twap/migrate_test.go
+++ b/x/twap/migrate_test.go
@@ -1,6 +1,7 @@
 package twap_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/osmosis-labs/osmosis/v12/x/twap/types"
@@ -62,5 +63,5 @@ func (s *TestSuite) TestMigrateExistingPoolsError() {
 	// should error when we try to migrate with pool ID that does not exist
 	latestPoolIdPlusOne := s.App.GAMMKeeper.GetNextPoolId(s.Ctx)
 	err := s.twapkeeper.MigrateExistingPools(s.Ctx, latestPoolIdPlusOne)
-	s.Require().Error(err)
+	s.Require().EqualError(fmt.Errorf("pool with ID %v does not exist", latestPoolIdPlusOne), err.Error())
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2959

checks directly for specific error. Other tests are already following ```expectErr           error ``` style in x/twap