### PR TITLE
txfees: expectedErr directly checks specific error 

### DIFF
--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
@@ -34,7 +35,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 		minGasPrices sdk.DecCoins
 		gasRequested uint64
 		isCheckTx    bool
-		expectPass   bool
+		expectErr    error
 		baseDenomGas bool
 	}{
 		{
@@ -43,7 +44,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: true,
 		},
 		{
@@ -52,7 +53,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(),
 			gasRequested: 10000,
 			isCheckTx:    false,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: true,
 		},
 		{
@@ -62,7 +63,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				sdk.MustNewDecFromStr("0.1"))),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: true,
 		},
 		{
@@ -72,7 +73,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				sdk.MustNewDecFromStr("0.1"))),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   false,
+			expectErr:    sdkerrors.ErrInsufficientFee,
 			baseDenomGas: true,
 		},
 		{
@@ -82,7 +83,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				sdk.MustNewDecFromStr("0.1"))),
 			gasRequested: 10000,
 			isCheckTx:    false,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: true,
 		},
 		{
@@ -92,7 +93,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				sdk.MustNewDecFromStr("0.1"))),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: false,
 		},
 		{
@@ -102,7 +103,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				sdk.MustNewDecFromStr("0.1"))),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   false,
+			expectErr:    sdkerrors.ErrInsufficientFee,
 			baseDenomGas: false,
 		},
 		{
@@ -112,7 +113,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				sdk.MustNewDecFromStr("0.1"))),
 			gasRequested: 10000,
 			isCheckTx:    false,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: false,
 		},
 		{
@@ -121,7 +122,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   false,
+			expectErr:    types.ErrTooManyFeeCoins,
 			baseDenomGas: false,
 		},
 		{
@@ -130,7 +131,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(),
 			gasRequested: 10000,
 			isCheckTx:    false,
-			expectPass:   false,
+			expectErr:    types.ErrTooManyFeeCoins,
 			baseDenomGas: false,
 		},
 		{
@@ -139,7 +140,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(),
 			gasRequested: 10000,
 			isCheckTx:    false,
-			expectPass:   false,
+			expectErr:    types.ErrInvalidFeeToken,
 			baseDenomGas: false,
 		},
 		{
@@ -148,7 +149,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(sdk.NewInt64DecCoin(uion, 1)),
 			gasRequested: 10000,
 			isCheckTx:    true,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: false,
 		},
 		{
@@ -157,7 +158,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(sdk.NewInt64DecCoin(uion, 1)),
 			gasRequested: mempoolFeeOpts.MaxGasWantedPerTx + 1,
 			isCheckTx:    true,
-			expectPass:   false,
+			expectErr:    sdkerrors.ErrOutOfGas,
 			baseDenomGas: false,
 		},
 		{
@@ -166,7 +167,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(sdk.NewInt64DecCoin(uion, 1)),
 			gasRequested: mempoolFeeOpts.HighGasTxThreshold,
 			isCheckTx:    true,
-			expectPass:   false,
+			expectErr:    sdkerrors.ErrInsufficientFee,
 			baseDenomGas: false,
 		},
 		{
@@ -175,7 +176,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			minGasPrices: sdk.NewDecCoins(sdk.NewInt64DecCoin(uion, 1)),
 			gasRequested: mempoolFeeOpts.HighGasTxThreshold,
 			isCheckTx:    true,
-			expectPass:   true,
+			expectErr:    nil,
 			baseDenomGas: false,
 		},
 	}
@@ -225,7 +226,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			antehandlerMFD := sdk.ChainAnteDecorators(mfd, dfd)
 			_, err := antehandlerMFD(suite.Ctx, tx, false)
 
-			if tc.expectPass {
+			if tc.expectErr == nil {
 				if tc.baseDenomGas && !tc.txFee.IsZero() {
 					moduleAddr := suite.App.AccountKeeper.GetModuleAddress(types.FeeCollectorName)
 					suite.Require().Equal(tc.txFee[0], suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, baseDenom), tc.name)
@@ -235,7 +236,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 				}
 				suite.Require().NoError(err, "test: %s", tc.name)
 			} else {
-				suite.Require().Error(err, "test: %s", tc.name)
+				suite.Require().ErrorIs(err, tc.expectErr)
 			}
 		})
 	}

--- a/x/txfees/keeper/hooks_test.go
+++ b/x/txfees/keeper/hooks_test.go
@@ -38,13 +38,12 @@ func (suite *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 	_, ustPool := suite.preparePool(ust)
 
 	tests := []struct {
-		name       string
-		coins      sdk.Coins
-		baseDenom  string
-		denoms     []string
-		poolTypes  []gammtypes.PoolI
-		swapFee    sdk.Dec
-		expectPass bool
+		name      string
+		coins     sdk.Coins
+		baseDenom string
+		denoms    []string
+		poolTypes []gammtypes.PoolI
+		swapFee   sdk.Dec
 	}{
 		{
 			name:      "One non-osmo fee token (uion): TxFees AfterEpochEnd",
@@ -67,8 +66,6 @@ func (suite *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 	finalOutputAmount := sdk.NewInt(0)
 
 	for _, tc := range tests {
-		tc := tc
-
 		suite.Run(tc.name, func() {
 			for i, coin := range tc.coins {
 				// Get the output amount in osmo denom


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes partially: #2959

txfees' tests now have expectedErr fields check for specific error