### PR TITLE
specific error in test for mint module

### DIFF
--- a/x/mint/keeper/hooks_test.go
+++ b/x/mint/keeper/hooks_test.go
@@ -398,7 +398,6 @@ func (suite *KeeperTestSuite) TestAfterEpochEnd() {
 			if tc.expectedError != nil {
 				suite.Require().Error(err)
 				suite.Require().ErrorAs(err, &tc.expectedError)
-				println(tc.expectedError.Error())
 			} else {
 				suite.Require().NoError(err)
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2959

## What is the purpose of the change

Update tests that are using expectPass or expectErr as the bool variable to the error type in the mint module


## Brief Changelog

- Coverage mint module
- All tests pass
- Commented at test cases where the error returned is not as expected
