### PR TITLE
refactor: begin unlock event with uses split lock on partial unlock

### DIFF
--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -235,6 +235,10 @@ func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Co
 		k.hooks.OnStartUnlock(ctx, lock.OwnerAddress(), lock.ID, lock.Coins, lock.Duration, lock.EndTime)
 	}
 
+	ctx.EventManager().EmitEvents(sdk.Events{
+		createBeginUnlockEvent(&lock),
+	})
+
 	return nil
 }
 

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -96,14 +96,7 @@ func (server msgServer) BeginUnlocking(goCtx context.Context, msg *types.MsgBegi
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
 
-	lock, err = server.keeper.GetLockByID(ctx, msg.ID)
-	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
-	}
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		createBeginUnlockEvent(lock),
-	})
+	// N.B. begin unlock event is emitted downstream in the keeper method.
 
 	return &types.MsgBeginUnlockingResponse{}, nil
 }

--- a/x/lockup/keeper/msg_server_test.go
+++ b/x/lockup/keeper/msg_server_test.go
@@ -172,8 +172,8 @@ func (suite *KeeperTestSuite) TestMsgBeginUnlocking() {
 		suite.FundAcc(test.param.lockOwner, test.param.coinsInOwnerAddress)
 
 		msgServer := keeper.NewMsgServerImpl(suite.App.LockupKeeper)
-		c := sdk.WrapSDKContext(suite.Ctx)
-		resp, err := msgServer.LockTokens(c, types.NewMsgLockTokens(test.param.lockOwner, test.param.duration, test.param.coinsToLock))
+		goCtx := sdk.WrapSDKContext(suite.Ctx)
+		resp, err := msgServer.LockTokens(goCtx, types.NewMsgLockTokens(test.param.lockOwner, test.param.duration, test.param.coinsToLock))
 		suite.Require().NoError(err)
 
 		if test.param.isSyntheticLockup {
@@ -181,12 +181,14 @@ func (suite *KeeperTestSuite) TestMsgBeginUnlocking() {
 			suite.Require().NoError(err)
 		}
 
-		_, err = msgServer.BeginUnlocking(c, types.NewMsgBeginUnlocking(test.param.lockOwner, resp.ID, test.param.coinsToUnlock))
+		_, err = msgServer.BeginUnlocking(goCtx, types.NewMsgBeginUnlocking(test.param.lockOwner, resp.ID, test.param.coinsToUnlock))
 
 		if test.expectPass {
 			suite.Require().NoError(err)
+			suite.AssertEventEmitted(suite.Ctx, types.TypeEvtBeginUnlock, 1)
 		} else {
 			suite.Require().Error(err)
+			suite.AssertEventEmitted(suite.Ctx, types.TypeEvtBeginUnlock, 0)
 		}
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2993

Context: https://github.com/osmosis-labs/osmosis/issues/2993

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable