### PR TITLE
[x/gamm][stableswap]: Update binary search upper bounds to reflect spec

### DIFF
--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -179,8 +179,8 @@ func solveCFMMBinarySearch(constantFunction func(osmomath.BigDec, osmomath.BigDe
 
 		if kRatio.LT(osmomath.OneDec()) {
 			// k_0 < k. Need to find an upperbound. Worst case assume a linear relationship, gives an upperbound
-    		// TODO: In the future, we can derive better bounds via reasoning about coefficients in the cubic
-    		// These are quite close when we are in the "stable" part of the curve though.
+			// TODO: In the future, we can derive better bounds via reasoning about coefficients in the cubic
+			// These are quite close when we are in the "stable" part of the curve though.
 			xHighEst = xReserve.Quo(kRatio).Ceil()
 		} else if kRatio.GT(osmomath.OneDec()) {
 			// need to find a lowerbound. We could use a cubic relation, but for now we just set it to 0.

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -170,11 +170,25 @@ func solveCFMMBinarySearch(constantFunction func(osmomath.BigDec, osmomath.BigDe
 		} else if yIn.Abs().GTE(yReserve) {
 			panic("cannot input more than pool reserves")
 		}
-		k := constantFunction(xReserve, yReserve)
+		xLowEst, xHighEst := xReserve, xReserve
 		yFinal := yReserve.Add(yIn)
-		xLowEst := osmomath.ZeroDec()
-		// we set upper bound at 2 * xReserve to accommodate negative yIns
-		xHighEst := xReserve.Mul(osmomath.NewBigDec(2))
+
+		k0 := constantFunction(xReserve, yFinal)
+		k := constantFunction(xReserve, yReserve)
+		kRatio := k0.Quo(k)
+
+		if kRatio.LT(osmomath.OneDec()) {
+			// k_0 < k. Need to find an upperbound. Worst case assume a linear relationship, gives an upperbound
+    		// TODO: In the future, we can derive better bounds via reasoning about coefficients in the cubic
+    		// These are quite close when we are in the "stable" part of the curve though.
+			xHighEst = xReserve.Quo(kRatio).Ceil()
+		} else if kRatio.GT(osmomath.OneDec()) {
+			// need to find a lowerbound. We could use a cubic relation, but for now we just set it to 0.
+			xLowEst = osmomath.ZeroDec()
+		} else {
+			// k remains unchanged, so xOut = 0
+			return osmomath.ZeroDec()
+		}
 		maxIterations := 256
 		errTolerance := osmoutils.ErrTolerance{AdditiveTolerance: sdk.OneInt(), MultiplicativeTolerance: sdk.Dec{}}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3007

## What is the purpose of the change

This PR updates binary search bounds for our stableswap CFMM to reflect what is described in our spec. It only includes changes for the two-asset solver – the multi-asset changes are tied into #3006 since there were prior important changes to the solver in that PR.

## Brief Changelog

- Update upper and lower bound guesses for two-asset binary search solver to reflect spec

## Testing and Verifying

- All existing binary search tests, solver tests, and inverse relation tests pass

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)