### PR TITLE
[x/gamm][stableswap]: Deprecate two-asset binary search solver in favor of multi-asset one

### DIFF
--- a/x/gamm/pool-models/stableswap/amm_bench_test.go
+++ b/x/gamm/pool-models/stableswap/amm_bench_test.go
@@ -14,12 +14,6 @@ func BenchmarkCFMM(b *testing.B) {
 	}
 }
 
-func BenchmarkBinarySearchTwoAsset(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		runCalcTwoAsset(solveCFMMBinarySearch(cfmmConstant))
-	}
-}
-
 func BenchmarkBinarySearchMultiAsset(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		runCalcMultiAsset(solveCFMMBinarySearchMulti)

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -406,28 +406,6 @@ func TestCFMMInvariantTwoAssets(t *testing.T) {
 	}
 }
 
-func TestCFMMInvariantTwoAssetsBinarySearch(t *testing.T) {
-	kErrTolerance := osmomath.OneDec()
-
-	tests := twoAssetCFMMTestCases
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			// system under test
-			sut := func() {
-				// using two-asset binary search cfmm solver
-				k0 := cfmmConstant(test.xReserve, test.yReserve)
-				xOut := solveCFMMBinarySearch(cfmmConstant)(test.xReserve, test.yReserve, test.yIn)
-
-				k1 := cfmmConstant(test.xReserve.Sub(xOut), test.yReserve.Add(test.yIn))
-				osmomath.DecApproxEq(t, k0, k1, kErrTolerance)
-			}
-
-			osmoassert.ConditionalPanic(t, test.expectPanic, sut)
-		})
-	}
-}
-
 func TestCFMMInvariantTwoAssetsDirect(t *testing.T) {
 	kErrTolerance := osmomath.OneDec()
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3083

## What is the purpose of the change

This PR deprecates all uses of the two-asset binary search solver as it is no longer necessary after the recent optimizations to our multi-asset solver.

## Brief Changelog

- Remove `solveCFMMBinarySearch` from under `solveCfmm`
- Delete `solveCFMMBinarySearch` and related tests (all other two-asset tests already accounted for the generalization to multi-asset solver)

## Testing and Verifying

- The final `solveCfmm` function passes against our full CFMM test suite in `amm_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)