### PR TITLE
(chore) Remove unused versions in mergify backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -38,14 +38,6 @@ pull_request_rules:
       backport:
         branches:
           - v4.x
-  - name: backport patches to v5.x branch
-    conditions:
-      - base=main
-      - label=A:backport/v5.x
-    actions:
-      backport:
-        branches:
-          - v5.x
   - name: backport patches to v6.x branch
     conditions:
       - base=main
@@ -54,14 +46,6 @@ pull_request_rules:
       backport:
         branches:
           - v6.x
-  - name: backport patches to v7.x branch
-    conditions:
-      - base=main
-      - label=A:backport/v7.x
-    actions:
-      backport:
-        branches:
-          - v7.x
   - name: backport patches to v8.x branch
     conditions:
       - base=main
@@ -70,14 +54,6 @@ pull_request_rules:
       backport:
         branches:
           - v8.x
-  - name: backport patches to v9.x branch
-    conditions:
-      - base=main
-      - label=A:backport/v9.x
-    actions:
-      backport:
-        branches:
-          - v9.x
   - name: backport patches to v10.x branch
     conditions:
       - base=main


### PR DESCRIPTION
## What is the purpose of the change

This PR removes unused osmosis versions from mergify backporting candidates.
This is not strictly necessary but it helps to avoid some confusion. Recently I had to backport a state-compatibility check PR to all *working*  osmosis versions and I backported it to versions that shouldn't be used (e.g. https://github.com/osmosis-labs/osmosis/pull/3026).

## Brief Changelog

- Remove unused versions in mergify.yml

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable