### PR TITLE
deprecate `SwapExactAmountInDefaultSwapFee` in gamm

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -302,13 +302,18 @@ func (s *KeeperTestHelper) SwapAndSetSpotPrice(poolId uint64, fromAsset sdk.Coin
 	coins := sdk.Coins{sdk.NewInt64Coin(fromAsset.Denom, 100000000000000)}
 	s.FundAcc(acc1, coins)
 
-	_, err := s.App.GAMMKeeper.SwapExactAmountOutDefaultSwapFee(
+	pool, err := s.App.GAMMKeeper.GetPool(s.Ctx, poolId)
+	s.Require().NoError(err)
+	swapFee := pool.GetSwapFee(s.Ctx)
+
+	_, err = s.App.GAMMKeeper.SwapExactAmountOut(
 		s.Ctx,
 		acc1,
-		poolId,
+		pool,
 		fromAsset.Denom,
 		fromAsset.Amount,
 		sdk.NewCoin(toAsset.Denom, toAsset.Amount.Quo(sdk.NewInt(4))),
+		swapFee,
 	)
 	s.Require().NoError(err)
 

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -399,11 +399,18 @@ func (k Keeper) ExitSwapShareAmountIn(
 		return sdk.Int{}, err
 	}
 	tokenOutAmount = exitCoins.AmountOf(tokenOutDenom)
+
+	pool, err := k.GetPool(ctx, poolId)
+	if err != nil {
+		return sdk.Int{}, err
+	}
+	swapFee := pool.GetSwapFee(ctx)
+
 	for _, coin := range exitCoins {
 		if coin.Denom == tokenOutDenom {
 			continue
 		}
-		swapOut, err := k.SwapExactAmountInDefaultSwapFee(ctx, sender, poolId, coin, tokenOutDenom, sdk.ZeroInt())
+		swapOut, err := k.SwapExactAmountIn(ctx, sender, pool, coin, tokenOutDenom, sdk.ZeroInt(), swapFee)
 		if err != nil {
 			return sdk.Int{}, err
 		}

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -10,30 +10,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )
 
-// SwapExactAmountInDefaultSwapFee attempts to swap one asset, tokenIn, for another asset
-// denominated via tokenOutDenom through a pool denoted by poolId specifying that
-// tokenOutMinAmount must be returned in the resulting asset returning an error
-// upon failure. Upon success, the resulting tokens swapped for are returned. A
-// swap fee is applied determined by the pool's parameters.
-// TODO: remove this method:
-// https://github.com/osmosis-labs/osmosis/issues/3129
-func (k Keeper) SwapExactAmountInDefaultSwapFee(
-	ctx sdk.Context,
-	sender sdk.AccAddress,
-	poolId uint64,
-	tokenIn sdk.Coin,
-	tokenOutDenom string,
-	tokenOutMinAmount sdk.Int,
-) (sdk.Int, error) {
-	pool, err := k.getPoolForSwap(ctx, poolId)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-
-	swapFee := pool.GetSwapFee(ctx)
-	return k.SwapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
-}
-
 // swapExactAmountIn is an internal method for swapping an exact amount of tokens
 // as input to a pool, using the provided swapFee. This is intended to allow
 // different swap fees as determined by multi-hops, or when recovering from
@@ -78,22 +54,6 @@ func (k Keeper) SwapExactAmountIn(
 	}
 
 	return tokenOutAmount, nil
-}
-
-func (k Keeper) SwapExactAmountOutDefaultSwapFee(
-	ctx sdk.Context,
-	sender sdk.AccAddress,
-	poolId uint64,
-	tokenInDenom string,
-	tokenInMaxAmount sdk.Int,
-	tokenOut sdk.Coin,
-) (tokenInAmount sdk.Int, err error) {
-	pool, err := k.getPoolForSwap(ctx, poolId)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-	swapFee := pool.GetSwapFee(ctx)
-	return k.SwapExactAmountOut(ctx, sender, pool, tokenInDenom, tokenInMaxAmount, tokenOut, swapFee)
 }
 
 // swapExactAmountIn is a method for swapping to get an exact number of tokens out of a pool,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3129 

## What is the purpose of the change
Deprecates `SwapExactAmountInDefaultSwapFee` and `SwapExactAmountOutDefaultSwapFee` and ports existing test cases to use `SwapExactAmountIn` `SwapExactAmountOut`
