### PR TITLE
Change `lte` to `zeroToOne`

### DIFF
--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -79,8 +79,8 @@ func computeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaini
 	return sqrtPriceNext, amountIn, amountOut
 }
 
-func getNextSqrtPriceFromInput(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec, lte bool) (sqrtPriceNext sdk.Dec) {
-	if lte {
+func getNextSqrtPriceFromInput(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec, zeroForOne bool) (sqrtPriceNext sdk.Dec) {
+	if zeroForOne {
 		sqrtPriceNext = getNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining)
 	} else {
 		sqrtPriceNext = getNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amountRemaining)

--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -55,25 +55,25 @@ func calcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec) sdk.Dec {
 
 // computeSwapStep calculates the amountIn, amountOut, and the next sqrtPrice given current price, price target, tick liquidity, and amount available to swap
 // lte is reference to "less than or equal", which determines if we are moving left or right of the current price to find the next initialized tick with liquidity
-func computeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaining sdk.Dec, lte bool) (sqrtPriceNext, amountIn, amountOut sdk.Dec) {
-	if lte {
-		amountIn = calcAmount1Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent)
-	} else {
+func computeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaining sdk.Dec, zeroForOne bool) (sqrtPriceNext, amountIn, amountOut sdk.Dec) {
+	if zeroForOne {
 		amountIn = calcAmount0Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent)
+	} else {
+		amountIn = calcAmount1Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent)
 	}
 
 	if amountRemaining.GTE(amountIn) {
 		sqrtPriceNext = sqrtPriceTarget
 	} else {
-		sqrtPriceNext = getNextSqrtPriceFromInput(sqrtPriceCurrent, liquidity, amountRemaining, lte)
+		sqrtPriceNext = getNextSqrtPriceFromInput(sqrtPriceCurrent, liquidity, amountRemaining, zeroForOne)
 	}
 
-	if lte {
-		amountIn = calcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent)
-		amountOut = calcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent)
-	} else {
+	if zeroForOne {
 		amountIn = calcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent)
 		amountOut = calcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent)
+	} else {
+		amountIn = calcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent)
+		amountOut = calcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent)
 	}
 
 	return sqrtPriceNext, amountIn, amountOut
@@ -81,9 +81,9 @@ func computeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaini
 
 func getNextSqrtPriceFromInput(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec, lte bool) (sqrtPriceNext sdk.Dec) {
 	if lte {
-		sqrtPriceNext = getNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amountRemaining)
-	} else {
 		sqrtPriceNext = getNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining)
+	} else {
+		sqrtPriceNext = getNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amountRemaining)
 	}
 	return sqrtPriceNext
 }

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -72,54 +72,54 @@ func TestKeeper_NextInitializedTick(t *testing.T) {
 		k.setTickInfo(ctx, 1, t, TickInfo{})
 	}
 
-	t.Run("lte=false", func(t *testing.T) {
+	t.Run("lte=true", func(t *testing.T) {
 		t.Run("returns tick to right if at initialized tick", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 78, false)
+			n, initd := k.NextInitializedTick(ctx, 1, 78, true)
 			require.Equal(t, int64(84), n)
 			require.True(t, initd)
 		})
 		t.Run("returns tick to right if at initialized tick", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, -55, false)
+			n, initd := k.NextInitializedTick(ctx, 1, -55, true)
 			require.Equal(t, int64(-4), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the tick directly to the right", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 77, false)
+			n, initd := k.NextInitializedTick(ctx, 1, 77, true)
 			require.Equal(t, int64(78), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the tick directly to the right", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, -56, false)
+			n, initd := k.NextInitializedTick(ctx, 1, -56, true)
 			require.Equal(t, int64(-55), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the next words initialized tick if on the right boundary", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, -257, false)
+			n, initd := k.NextInitializedTick(ctx, 1, -257, true)
 			require.Equal(t, int64(-200), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the next initialized tick from the next word", func(t *testing.T) {
 			k.setTickInfo(ctx, 1, 340, TickInfo{})
 
-			n, initd := k.NextInitializedTick(ctx, 1, 328, false)
+			n, initd := k.NextInitializedTick(ctx, 1, 328, true)
 			require.Equal(t, int64(340), n)
 			require.True(t, initd)
 		})
 	})
 
-	t.Run("lte=true", func(t *testing.T) {
+	t.Run("lte=false", func(t *testing.T) {
 		t.Run("returns tick directly to the left of input tick if not initialized", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 79, true)
+			n, initd := k.NextInitializedTick(ctx, 1, 79, false)
 			require.Equal(t, int64(78), n)
 			require.True(t, initd)
 		})
 		t.Run("returns same tick if initialized", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 78, true)
+			n, initd := k.NextInitializedTick(ctx, 1, 78, false)
 			require.Equal(t, int64(78), n)
 			require.True(t, initd)
 		})
 		t.Run("returns next initialized tick far away", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 100, true)
+			n, initd := k.NextInitializedTick(ctx, 1, 100, false)
 			require.Equal(t, int64(84), n)
 			require.True(t, initd)
 		})

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -281,7 +281,7 @@ Couple ways to define JoinPool Exit Pool relation
 
 * Simulator integrations:
   * Pool creation
-  * JoinPool + ExitPool gives a token amount out that is lte input
+  * JoinPool + ExitPool gives a token amount out that is zeroForOne input
   * SingleTokenIn + ExitPool + Swap to base token gives a token amount that is less than input
   * CFMM k adjusting in the correct direction after every action
 * Fuzz test binary search algorithm, to see that it still works correctly across wide scale ranges


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Existing code base introduces a `lte` parameter, which was suppose to indicate if we're going down the tick or up the tick, depending on if we're setting the base asset as asset 0 or asset 1. 

The proposal is to change `lte` parameter to a varaiable `zeroToOne` to make the variable more clear and intuitive. 
ZeroToOne indicates that we're changing from asset zero to one if true. If false, changing asset one to zero