### PR TITLE
changed lints to stable so they change less often

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
Lints should use the stable rust version instead of nightly. That way we ensure they change less often. 