### PR TITLE
Concentrated Liquidity chore: Fix `CalcOutAmtGivenIn` to return correct amount of tokenIn

### DIFF
--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -122,12 +122,16 @@ func getNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amount
 // getLiquidityFromAmounts takes the current sqrtPrice and the sqrtPrice for the upper and lower ticks as well as the amounts of asset0 and asset1
 // in return, liquidity is calculated from these inputs
 func getLiquidityFromAmounts(sqrtPrice, sqrtPriceA, sqrtPriceB sdk.Dec, amount0, amount1 sdk.Int) (liquidity sdk.Dec) {
+	// we set sqrtPrice A as the smaller sqrt price and sqrtPrice B as the higher sqrt price
 	if sqrtPriceA.GT(sqrtPriceB) {
 		sqrtPriceA, sqrtPriceB = sqrtPriceB, sqrtPriceA
 	}
+
+	// if the given curr sqrt price is smaller than both given sqrt price,
 	if sqrtPrice.LTE(sqrtPriceA) {
 		liquidity = liquidity0(amount0, sqrtPrice, sqrtPriceB)
-	} else if sqrtPrice.LTE(sqrtPriceB) {
+	} else if sqrtPrice.LTE(sqrtPriceB) { // if given sqrt price is in between sqrt price A and sqrt price B,
+		// we calculate liquidity from both sides and take the smaller liquidity
 		liquidity0 := liquidity0(amount0, sqrtPrice, sqrtPriceB)
 		liquidity1 := liquidity1(amount1, sqrtPrice, sqrtPriceA)
 		liquidity = sdk.MinDec(liquidity0, liquidity1)

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -133,7 +133,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	// at first, we use the pool liquidity
 	swapState := SwapState{
 		amountSpecifiedRemaining: tokenAmountInAfterFee,
-		amountCalculated:         sdk.ZeroDec(),
+		amountCalculated:         tokenAmountInAfterFee,
 		sqrtPrice:                curSqrtPrice,
 		tick:                     priceToTick(curSqrtPrice.Power(2)),
 		liquidity:                p.Liquidity,

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -40,7 +40,7 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	swapFee := sdk.ZeroDec()
 	priceLimit := sdk.NewDec(5004)
 	tokenIn, tokenOut, updatedTick, updatedLiquidity, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(s.Ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
-	expectedTokenIn := sdk.NewCoin("usdc", sdk.NewInt(0))
+	expectedTokenIn := sdk.NewCoin("usdc", sdk.NewInt(42))
 	expectedTokenOut := sdk.NewCoin("eth", sdk.NewInt(42))
 
 	s.Require().NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Sub component of : #3178

## What is the purpose of the change
Previously we were returning the delta amount of token in from `CalcOutAmtGivenIn` , not the actual amount of token in. Instead, the case should have been that we return the token amount in, by doing the calculation of tokenInMin - delta amount. 

## Testing and Verifying
Changed existing tests to confirm correct calculation
