### PR TITLE
CL: fix CalcOutAmtGivenIn and other logic

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -39,12 +39,12 @@ func GetNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amount
 	return getNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amountRemaining)
 }
 
-func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec) sdk.Dec {
-	return calcAmount0Delta(liq, sqrtPriceA, sqrtPriceB)
+func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec {
+	return calcAmount0Delta(liq, sqrtPriceA, sqrtPriceB, roundUp)
 }
 
-func CalcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec) sdk.Dec {
-	return calcAmount1Delta(liq, sqrtPriceA, sqrtPriceB)
+func CalcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec {
+	return calcAmount1Delta(liq, sqrtPriceA, sqrtPriceB, roundUp)
 }
 
 func ComputeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaining sdk.Dec, zeroForOne bool) (sqrtPriceNext, amountIn, amountOut sdk.Dec) {

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -67,7 +67,6 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		// this means position is solely made up of asset0
 		amtDenom0 = calcAmount0Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = sdk.ZeroInt()
-
 	} else if pool.CurrentTick.LT(sdk.NewInt(upperTick)) {
 		// outcome two: the current price falls within the position
 		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1
@@ -75,7 +74,6 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		amtDenom0 = calcAmount0Delta(liquidity, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = calcAmount1Delta(liquidity, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
 		pool.Liquidity = pool.Liquidity.Add(liquidity)
-
 	} else {
 		// outcome three: position is above current price
 		// this means position is solely made up of asset1

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -62,23 +62,23 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
 	}
 
-	// outcome one: position is below current price
-	// this means position is solely made up of asset0
 	if pool.CurrentTick.LT(sdk.NewInt(lowerTick)) {
+		// outcome one: position is below current price
+		// this means position is solely made up of asset0
 		amtDenom0 = calcAmount0Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = sdk.ZeroInt()
 
+	} else if pool.CurrentTick.LT(sdk.NewInt(upperTick)) {
 		// outcome two: the current price falls within the position
 		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1
 		// we also update the pool liquidity since the virtual liquidity is modified by this position's creation
-	} else if pool.CurrentTick.LT(sdk.NewInt(upperTick)) {
 		amtDenom0 = calcAmount0Delta(liquidity, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = calcAmount1Delta(liquidity, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
 		pool.Liquidity = pool.Liquidity.Add(liquidity)
 
+	} else {
 		// outcome three: position is above current price
 		// this means position is solely made up of asset1
-	} else {
 		amtDenom0 = sdk.ZeroInt()
 		amtDenom1 = calcAmount1Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
 	}

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -77,7 +77,7 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		pool.Liquidity = pool.Liquidity.Add(liquidity)
 
 		// outcome three: position is above current price
-		// tis means position is solely made up of asset1
+		// this means position is solely made up of asset1
 	} else {
 		amtDenom0 = sdk.ZeroInt()
 		amtDenom1 = calcAmount1Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -62,14 +62,22 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
 	}
 
-	// update pool state as well only if we're injecting liquidity at the current tick of the pool
+	// outcome one: position is below current price
+	// this means position is solely made up of asset0
 	if pool.CurrentTick.LT(sdk.NewInt(lowerTick)) {
 		amtDenom0 = calcAmount0Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = sdk.ZeroInt()
+
+		// outcome two: the current price falls within the position
+		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1
+		// we also update the pool liquidity since the virtual liquidity is modified by this position's creation
 	} else if pool.CurrentTick.LT(sdk.NewInt(upperTick)) {
 		amtDenom0 = calcAmount0Delta(liquidity, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = calcAmount1Delta(liquidity, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
 		pool.Liquidity = pool.Liquidity.Add(liquidity)
+
+		// outcome three: position is above current price
+		// tis means position is solely made up of asset1
 	} else {
 		amtDenom0 = sdk.ZeroInt()
 		amtDenom1 = calcAmount1Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -64,15 +64,15 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 
 	// update pool state as well only if we're injecting liquidity at the current tick of the pool
 	if pool.CurrentTick.LT(sdk.NewInt(lowerTick)) {
-		amtDenom0 = calcAmount0Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick).RoundInt()
+		amtDenom0 = calcAmount0Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
 		amtDenom1 = sdk.ZeroInt()
 	} else if pool.CurrentTick.LT(sdk.NewInt(upperTick)) {
-		amtDenom0 = calcAmount0Delta(liquidity, currentSqrtPrice, sqrtRatioUpperTick).RoundInt()
-		amtDenom1 = calcAmount1Delta(liquidity, currentSqrtPrice, sqrtRatioLowerTick).RoundInt()
+		amtDenom0 = calcAmount0Delta(liquidity, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
+		amtDenom1 = calcAmount1Delta(liquidity, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
 		pool.Liquidity = pool.Liquidity.Add(liquidity)
 	} else {
 		amtDenom0 = sdk.ZeroInt()
-		amtDenom1 = calcAmount1Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick).RoundInt()
+		amtDenom1 = calcAmount1Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
 	}
 
 	k.setPoolById(ctx, pool.Id, pool)

--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -62,8 +62,12 @@ func calcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	}
 	diff := sqrtPriceB.Sub(sqrtPriceA)
 	// if calculating for amountIn, we round up
-	// if calculating for amountOut, we don't round
+	// if calculating for amountOut, we don't round at all
 	// this is to prevent removing more from the pool than expected due to rounding
+	// example: we calculate 1000000.9999999 uusdc (~$1) amountIn and 2000000.999999 uosmo amountOut
+	// we would want the used to put in 1000001 uusdc rather than 1000000 uusdc to ensure we are charging enough for the amount they are removing
+	// additionally, without rounding, there exists cases where the swapState.amountSpecifiedRemaining.GT(sdk.ZeroDec()) for loop within
+	// the CalcOut/In functions never actually reach zero due to dust that would have never gotten counted towards the amount (numbers after the 10^6 place)
 	if roundUp {
 		return liq.Mul(diff).Ceil()
 	}

--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -39,6 +39,9 @@ func calcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	}
 	diff := sqrtPriceB.Sub(sqrtPriceA)
 	mult := liq
+	// if calculating for amountIn, we round up
+	// if calculating for amountOut, we don't round
+	// this is to prevent removing more from the pool than expected due to rounding
 	if roundUp {
 		return ((mult.Mul(diff)).QuoRoundUp(sqrtPriceB).QuoRoundUp(sqrtPriceA)).Ceil()
 	}
@@ -54,6 +57,9 @@ func calcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 		sqrtPriceA, sqrtPriceB = sqrtPriceB, sqrtPriceA
 	}
 	diff := sqrtPriceB.Sub(sqrtPriceA)
+	// if calculating for amountIn, we round up
+	// if calculating for amountOut, we don't round
+	// this is to prevent removing more from the pool than expected due to rounding
 	if roundUp {
 		return liq.Mul(diff).Ceil()
 	}
@@ -74,17 +80,11 @@ func computeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaini
 		sqrtPriceNext = getNextSqrtPriceFromInput(sqrtPriceCurrent, liquidity, amountRemaining, zeroForOne)
 	}
 
-	max := sqrtPriceNext.Equal(sqrtPriceTarget)
-
 	if zeroForOne {
-		if !max {
-			amountIn = calcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true)
-		}
+		amountIn = calcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true)
 		amountOut = calcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, false)
 	} else {
-		if !max {
-			amountIn = calcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true)
-		}
+		amountIn = calcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true)
 		amountOut = calcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, false)
 	}
 

--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -43,7 +43,7 @@ func calcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	// if calculating for amountOut, we don't round at all
 	// this is to prevent removing more from the pool than expected due to rounding
 	// example: we calculate 1000000.9999999 uusdc (~$1) amountIn and 2000000.999999 uosmo amountOut
-	// we would want the used to put in 1000001 uusdc rather than 1000000 uusdc to ensure we are charging enough for the amount they are removing
+	// we would want the user to put in 1000001 uusdc rather than 1000000 uusdc to ensure we are charging enough for the amount they are removing
 	// additionally, without rounding, there exists cases where the swapState.amountSpecifiedRemaining.GT(sdk.ZeroDec()) for loop within
 	// the CalcOut/In functions never actually reach zero due to dust that would have never gotten counted towards the amount (numbers after the 10^6 place)
 	if roundUp {

--- a/x/concentrated-liquidity/math.go
+++ b/x/concentrated-liquidity/math.go
@@ -40,8 +40,12 @@ func calcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	diff := sqrtPriceB.Sub(sqrtPriceA)
 	mult := liq
 	// if calculating for amountIn, we round up
-	// if calculating for amountOut, we don't round
+	// if calculating for amountOut, we don't round at all
 	// this is to prevent removing more from the pool than expected due to rounding
+	// example: we calculate 1000000.9999999 uusdc (~$1) amountIn and 2000000.999999 uosmo amountOut
+	// we would want the used to put in 1000001 uusdc rather than 1000000 uusdc to ensure we are charging enough for the amount they are removing
+	// additionally, without rounding, there exists cases where the swapState.amountSpecifiedRemaining.GT(sdk.ZeroDec()) for loop within
+	// the CalcOut/In functions never actually reach zero due to dust that would have never gotten counted towards the amount (numbers after the 10^6 place)
 	if roundUp {
 		return ((mult.Mul(diff)).QuoRoundUp(sqrtPriceB).QuoRoundUp(sqrtPriceA)).Ceil()
 	}

--- a/x/concentrated-liquidity/math_test.go
+++ b/x/concentrated-liquidity/math_test.go
@@ -18,11 +18,11 @@ func (suite *KeeperTestSuite) TestGetLiquidityFromAmounts() {
 	}{
 		{
 			"happy path",
-			sdk.MustNewDecFromStr("70.710678"),
-			sdk.MustNewDecFromStr("74.161984"),
-			sdk.MustNewDecFromStr("67.082039"),
-			sdk.NewInt(1),
-			sdk.NewInt(5000),
+			sdk.MustNewDecFromStr("70710678"),
+			sdk.MustNewDecFromStr("74161984"),
+			sdk.MustNewDecFromStr("67082039"),
+			sdk.NewInt(1000000),
+			sdk.NewInt(5000000000),
 			"1377.927096082029653542",
 		},
 	}
@@ -201,7 +201,7 @@ func (suite *KeeperTestSuite) TestCalcAmount0Delta() {
 		tc := tc
 
 		suite.Run(tc.name, func() {
-			amount0 := cl.CalcAmount0Delta(tc.liquidity, tc.sqrtPCurrent, tc.sqrtPUpper)
+			amount0 := cl.CalcAmount0Delta(tc.liquidity, tc.sqrtPCurrent, tc.sqrtPUpper, false)
 			suite.Require().Equal(tc.amount0Expected, amount0.TruncateInt().String())
 		})
 	}
@@ -233,7 +233,7 @@ func (suite *KeeperTestSuite) TestCalcAmount1Delta() {
 		tc := tc
 
 		suite.Run(tc.name, func() {
-			amount1 := cl.CalcAmount1Delta(tc.liquidity, tc.sqrtPCurrent, tc.sqrtPLower)
+			amount1 := cl.CalcAmount1Delta(tc.liquidity, tc.sqrtPCurrent, tc.sqrtPLower, false)
 			suite.Require().Equal(tc.amount1Expected, amount1.TruncateInt().String())
 		})
 	}
@@ -259,7 +259,7 @@ func (suite *KeeperTestSuite) TestComputeSwapState() {
 			sdk.NewDec(133700),
 			true,
 			"70.468932817327539027",
-			"66849.999999999999897227",
+			"66850.000000000000000000",
 			"333107267.266511136411924087",
 		},
 		{
@@ -270,7 +270,7 @@ func (suite *KeeperTestSuite) TestComputeSwapState() {
 			sdk.NewDec(4199999999),
 			false,
 			"73.758734487372429211",
-			"4199999998.999999999987594209",
+			"4199999999.000000000000000000",
 			"805287.266898087447354318",
 		},
 	}

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -93,8 +93,6 @@ type SwapState struct {
 	liquidity                sdk.Dec
 }
 
-// TODO: revisit tokenIn that is getting returned. Right now if we swapped 40eth -> 40 usdc, the return value for tokenIn would be 0,
-// since we're returning the delta amount, not the actual amounut of token in
 func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	tokenInMin sdk.Coin,
 	tokenOutDenom string,

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -140,7 +140,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	}
 
 	// had to reintroduce the dust check, we need to figure out a cleaner way to do this
-	for swapState.amountSpecifiedRemaining.GT(sdk.NewDecWithPrec(1, 8)) && !swapState.sqrtPrice.Equal(sqrtPriceLimit) {
+	for swapState.amountSpecifiedRemaining.GT(sdk.ZeroDec()) && !swapState.sqrtPrice.Equal(sqrtPriceLimit) {
 		sqrtPriceStart := swapState.sqrtPrice
 		nextTick, ok := k.NextInitializedTick(ctx, poolId, swapState.tick.Int64(), zeroForOne)
 		if !ok {

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -197,14 +197,12 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 		}
 	}
 
-	amt0 := tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining.Abs()).TruncateInt()
-	amt1 := swapState.amountCalculated.TruncateInt()
 	if zeroForOne {
-		tokenInDelta = amt1
-		tokenOutDelta = amt0
+		tokenInDelta = (swapState.amountCalculated).TruncateInt()
+		tokenOutDelta = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
 	} else {
-		tokenInDelta = amt0
-		tokenOutDelta = amt1
+		tokenInDelta = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
+		tokenOutDelta = swapState.amountCalculated.TruncateInt()
 	}
 
 	return tokenInDelta, tokenOutDelta, swapState.tick, swapState.liquidity, nil

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -197,14 +197,14 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 		}
 	}
 
-	//amt0 := tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining.Abs()).TruncateInt()
-	//amt1 := swapState.amountCalculated.TruncateInt()
+	amt0 := tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining.Abs()).TruncateInt()
+	amt1 := swapState.amountCalculated.TruncateInt()
 	if zeroForOne {
-		tokenInDelta = (swapState.amountCalculated).TruncateInt()
-		tokenOutDelta = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
+		tokenInDelta = amt1
+		tokenOutDelta = amt0
 	} else {
-		tokenInDelta = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
-		tokenOutDelta = swapState.amountCalculated.TruncateInt()
+		tokenInDelta = amt0
+		tokenOutDelta = amt1
 	}
 
 	return tokenInDelta, tokenOutDelta, swapState.tick, swapState.liquidity, nil

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -100,7 +100,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	tokenOutDenom string,
 	swapFee sdk.Dec,
 	priceLimit sdk.Dec,
-	poolId uint64) (tokenInDelta, tokenOutDelta sdk.Int, updatedTick sdk.Int, updatedLiquidity sdk.Dec, err error) {
+	poolId uint64) (tokenIn, tokenOut sdk.Int, updatedTick sdk.Int, updatedLiquidity sdk.Dec, err error) {
 	p := k.getPoolbyId(ctx, poolId)
 	asset0 := p.Token0
 	asset1 := p.Token1
@@ -198,14 +198,14 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	}
 
 	if zeroForOne {
-		tokenInDelta = (swapState.amountCalculated).TruncateInt()
-		tokenOutDelta = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
+		tokenIn = (swapState.amountCalculated).TruncateInt()
+		tokenOut = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
 	} else {
-		tokenInDelta = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
-		tokenOutDelta = swapState.amountCalculated.TruncateInt()
+		tokenIn = tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
+		tokenOut = swapState.amountCalculated.TruncateInt()
 	}
 
-	return tokenInDelta, tokenOutDelta, swapState.tick, swapState.liquidity, nil
+	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, nil
 }
 
 func (k *Keeper) SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec, minPrice, maxPrice sdk.Dec, poolId uint64) (tokenIn sdk.Coin, err error) {

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -196,8 +196,10 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 		}
 	}
 
+	// coin amounts require int values
+	// we truncate at last step to retain as much precision as possible
 	amt0 := tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
-	amt1 := (swapState.amountCalculated).TruncateInt()
+	amt1 := swapState.amountCalculated.TruncateInt()
 	if zeroForOne {
 		tokenIn = sdk.NewCoin(tokenInMin.Denom, amt1)
 		tokenOut = sdk.NewCoin(tokenOutDenom, amt0)

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -100,7 +100,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	tokenOutDenom string,
 	swapFee sdk.Dec,
 	priceLimit sdk.Dec,
-	poolId uint64) (tokenIn, tokenOut sdk.Int, updatedTick sdk.Int, updatedLiquidity sdk.Dec, err error) {
+	poolId uint64) (tokenIn, tokenOut sdk.Coin, updatedTick sdk.Int, updatedLiquidity sdk.Dec, err error) {
 	p := k.getPoolbyId(ctx, poolId)
 	asset0 := p.Token0
 	asset1 := p.Token1
@@ -112,22 +112,22 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	curSqrtPrice := p.CurrentSqrtPrice
 	sqrtPriceLimit, err := priceLimit.ApproxSqrt()
 	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("issue calculating square root of price limit")
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("issue calculating square root of price limit")
 	}
 	if (zeroForOne && (sqrtPriceLimit.GT(p.CurrentSqrtPrice) || sqrtPriceLimit.LT(cltypes.MinSqrtRatio))) ||
 		(!zeroForOne && (sqrtPriceLimit.LT(p.CurrentSqrtPrice) || sqrtPriceLimit.GT(cltypes.MaxSqrtRatio))) {
-		return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("invalid price limit (%s)", priceLimit.String())
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("invalid price limit (%s)", priceLimit.String())
 	}
 
 	// validation
 	if tokenInMin.Denom != asset0 && tokenInMin.Denom != asset1 {
-		return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) does not match any asset in pool", tokenInMin.Denom)
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) does not match any asset in pool", tokenInMin.Denom)
 	}
 	if tokenOutDenom != asset0 && tokenOutDenom != asset1 {
-		return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenOutDenom (%s) does not match any asset in pool", tokenOutDenom)
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenOutDenom (%s) does not match any asset in pool", tokenOutDenom)
 	}
 	if tokenInMin.Denom == tokenOutDenom {
-		return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) cannot be the same as tokenOut (%s)", tokenInMin.Denom, tokenOutDenom)
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) cannot be the same as tokenOut (%s)", tokenInMin.Denom, tokenOutDenom)
 	}
 
 	// at first, we use the pool liquidity
@@ -143,12 +143,12 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 		sqrtPriceStart := swapState.sqrtPrice
 		nextTick, ok := k.NextInitializedTick(ctx, poolId, swapState.tick.Int64(), zeroForOne)
 		if !ok {
-			return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("there are no more ticks initialized to fill the swap")
+			return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("there are no more ticks initialized to fill the swap")
 		}
 
 		nextSqrtPrice, err := k.tickToSqrtPrice(sdk.NewInt(nextTick))
 		if err != nil {
-			return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", sdk.NewInt(nextTick))
+			return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", sdk.NewInt(nextTick))
 		}
 
 		var sqrtPriceTarget sdk.Dec
@@ -175,7 +175,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 			liquidityDelta, err := k.crossTick(ctx, p.Id, nextTick)
 
 			if err != nil {
-				return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
+				return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, err
 			}
 			if zeroForOne {
 				liquidityDelta = liquidityDelta.Neg()
@@ -184,7 +184,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 			swapState.liquidity = swapState.liquidity.Add(liquidityDelta.ToDec())
 
 			if swapState.liquidity.LTE(sdk.ZeroDec()) || swapState.liquidity.IsNil() {
-				return sdk.Int{}, sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
+				return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, err
 			}
 			if zeroForOne {
 				swapState.tick = sdk.NewInt(nextTick - 1)
@@ -199,11 +199,11 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	amt0 := tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
 	amt1 := (swapState.amountCalculated).TruncateInt()
 	if zeroForOne {
-		tokenIn = amt1
-		tokenOut = amt0
+		tokenIn = sdk.NewCoin(tokenInMin.Denom, amt1)
+		tokenOut = sdk.NewCoin(tokenOutDenom, amt0)
 	} else {
-		tokenIn = amt0
-		tokenOut = amt1
+		tokenIn = sdk.NewCoin(tokenInMin.Denom, amt0)
+		tokenOut = sdk.NewCoin(tokenOutDenom, amt1)
 	}
 
 	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, nil

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -200,13 +200,9 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	// we truncate at last step to retain as much precision as possible
 	amt0 := tokenAmountInAfterFee.Add(swapState.amountSpecifiedRemaining).TruncateInt()
 	amt1 := swapState.amountCalculated.TruncateInt()
-	if zeroForOne {
-		tokenIn = sdk.NewCoin(tokenInMin.Denom, amt1)
-		tokenOut = sdk.NewCoin(tokenOutDenom, amt0)
-	} else {
-		tokenIn = sdk.NewCoin(tokenInMin.Denom, amt0)
-		tokenOut = sdk.NewCoin(tokenOutDenom, amt1)
-	}
+
+	tokenIn = sdk.NewCoin(tokenInMin.Denom, amt0)
+	tokenOut = sdk.NewCoin(tokenOutDenom, amt1)
 
 	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, nil
 }

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -54,16 +54,16 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	priceLimit := sdk.NewDec(5002)
 
 	// run calculation
-	tokenInDelta, tokenOutDelta, updatedTick, updatedLiquidity, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
+	tokenIn, tokenOut, updatedTick, updatedLiquidity, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
 	s.Require().NoError(err)
 
 	// we expect to put 42 usdc in and in return get .008398 eth back
-	expectedTokenIn := sdk.NewInt(42000000)
-	expectedTokenOut := sdk.NewInt(8398)
+	expectedTokenIn := sdk.NewCoin("usdc", sdk.NewInt(42000000))
+	expectedTokenOut := sdk.NewCoin("eth", sdk.NewInt(8398))
 
 	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenIn.String(), tokenInDelta.String())
-	s.Require().Equal(expectedTokenOut.String(), tokenOutDelta.String())
+	s.Require().Equal(expectedTokenIn.String(), tokenIn.String())
+	s.Require().Equal(expectedTokenOut.String(), tokenOut.String())
 
 	// check the new tick is at the expected value
 	s.Require().Equal(sdk.NewInt(85180).String(), updatedTick.String())
@@ -104,16 +104,16 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	priceLimit = sdk.NewDec(5004)
 
 	// run calculation
-	tokenInDelta, tokenOutDelta, updatedTick, updatedLiquidity, err = s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
+	tokenIn, tokenOut, updatedTick, updatedLiquidity, err = s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
 	s.Require().NoError(err)
 
 	// we expect to put 41999999 usdc in and in return get .008396 eth back
-	expectedTokenIn = sdk.NewInt(41999999)
-	expectedTokenOut = sdk.NewInt(8396)
+	expectedTokenIn = sdk.NewCoin("usdc", sdk.NewInt(41999999))
+	expectedTokenOut = sdk.NewCoin("eth", sdk.NewInt(8396))
 
 	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenIn.String(), tokenInDelta.String())
-	s.Require().Equal(expectedTokenOut.String(), tokenOutDelta.String())
+	s.Require().Equal(expectedTokenIn.String(), tokenIn.String())
+	s.Require().Equal(expectedTokenOut.String(), tokenOut.String())
 
 	// this is off by one (too large), I think it is the priceToTick func, try using ln PR from main
 	s.Require().Equal(sdk.NewInt(85184).String(), updatedTick.String())
@@ -167,16 +167,16 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	priceLimit = sdk.NewDec(6106)
 
 	// run calculation
-	tokenInDelta, tokenOutDelta, updatedTick, updatedLiquidity, err = s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
+	tokenIn, tokenOut, updatedTick, updatedLiquidity, err = s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
 	s.Require().NoError(err)
 
 	// we expect to put 999.99 usdc in and in return get 1.820536 eth back
-	expectedTokenIn = sdk.NewInt(9999999999)
-	expectedTokenOut = sdk.NewInt(1820536)
+	expectedTokenIn = sdk.NewCoin("usdc", sdk.NewInt(9999999999))
+	expectedTokenOut = sdk.NewCoin("eth", sdk.NewInt(1820536))
 
 	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenIn.String(), tokenInDelta.String())
-	s.Require().Equal(expectedTokenOut.String(), tokenOutDelta.String())
+	s.Require().Equal(expectedTokenIn.String(), tokenIn.String())
+	s.Require().Equal(expectedTokenOut.String(), tokenOut.String())
 
 	// this is off by one (too large), I think it is the priceToTick func, try using ln PR from main
 	s.Require().Equal(sdk.NewInt(87173).String(), updatedTick.String())

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -58,12 +58,12 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	s.Require().NoError(err)
 
 	// we expect to put 42 usdc in and in return get .008398 eth back
-	expectedTokenInDelta := sdk.NewInt(42000000)
-	expectedTokenOutDelta := sdk.NewInt(8398)
+	expectedTokenIn := sdk.NewInt(42000000)
+	expectedTokenOut := sdk.NewInt(8398)
 
 	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenInDelta.String(), tokenInDelta.String())
-	s.Require().Equal(expectedTokenOutDelta.String(), tokenOutDelta.String())
+	s.Require().Equal(expectedTokenIn.String(), tokenInDelta.String())
+	s.Require().Equal(expectedTokenOut.String(), tokenOutDelta.String())
 
 	// check the new tick is at the expected value
 	s.Require().Equal(sdk.NewInt(85180).String(), updatedTick.String())
@@ -108,12 +108,12 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	s.Require().NoError(err)
 
 	// we expect to put 41999999 usdc in and in return get .008396 eth back
-	expectedTokenInDelta = sdk.NewInt(41999999)
-	expectedTokenOutDelta = sdk.NewInt(8396)
+	expectedTokenIn = sdk.NewInt(41999999)
+	expectedTokenOut = sdk.NewInt(8396)
 
 	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenInDelta.String(), tokenInDelta.String())
-	s.Require().Equal(expectedTokenOutDelta.String(), tokenOutDelta.String())
+	s.Require().Equal(expectedTokenIn.String(), tokenInDelta.String())
+	s.Require().Equal(expectedTokenOut.String(), tokenOutDelta.String())
 
 	// this is off by one (too large), I think it is the priceToTick func, try using ln PR from main
 	s.Require().Equal(sdk.NewInt(85184).String(), updatedTick.String())
@@ -171,12 +171,12 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	s.Require().NoError(err)
 
 	// we expect to put 999.99 usdc in and in return get 1.820536 eth back
-	expectedTokenInDelta = sdk.NewInt(9999999999)
-	expectedTokenOutDelta = sdk.NewInt(1820536)
+	expectedTokenIn = sdk.NewInt(9999999999)
+	expectedTokenOut = sdk.NewInt(1820536)
 
 	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenInDelta.String(), tokenInDelta.String())
-	s.Require().Equal(expectedTokenOutDelta.String(), tokenOutDelta.String())
+	s.Require().Equal(expectedTokenIn.String(), tokenInDelta.String())
+	s.Require().Equal(expectedTokenOut.String(), tokenOutDelta.String())
 
 	// this is off by one (too large), I think it is the priceToTick func, try using ln PR from main
 	s.Require().Equal(sdk.NewInt(87173).String(), updatedTick.String())

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -10,12 +10,6 @@ import (
 )
 
 func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
-	ctx := s.Ctx
-
-	//
-	// TEST 1: two overlapping price ranges
-	//
-
 	currPrice := sdk.NewDec(5000)
 	currSqrtPrice, err := currPrice.ApproxSqrt() // 70.710678118654752440
 	s.Require().NoError(err)
@@ -27,167 +21,188 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 	s.Require().NoError(err)
 	upperTick := cl.PriceToTick(upperPrice) // 86129
 
-	// 1 eth 5000 usdc position
-	amount0 := sdk.NewInt(1000000)
-	amount1 := sdk.NewInt(5000000000)
+	defaultAmt0 := sdk.NewInt(1000000)
+	defaultAmt1 := sdk.NewInt(5000000000)
 
-	// create pool
-	pool, err := s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, 1, "eth", "usdc", currSqrtPrice, currTick)
-	s.Require().NoError(err)
-
-	// add first position
-	_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, pool.Id, s.TestAccs[0], amount0, amount1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
-	s.Require().NoError(err)
-
-	// add second position
-	_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, pool.Id, s.TestAccs[1], amount0, amount1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
-	s.Require().NoError(err)
-	pool = s.App.ConcentratedLiquidityKeeper.GetPoolbyId(ctx, 1)
-
-	// swapping parameters used for test
-	// swap in 42 usdc for some amount of eth
-	tokenIn := sdk.NewCoin("usdc", sdk.NewInt(42000000))
-	tokenOutDenom := "eth"
-	// set no swap fee
 	swapFee := sdk.ZeroDec()
-	// limit max price impact to 5002 usdc per eth
-	priceLimit := sdk.NewDec(5002)
 
-	// run calculation
-	tokenIn, tokenOut, updatedTick, updatedLiquidity, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
-	s.Require().NoError(err)
+	tests := map[string]struct {
+		positionAmount0  sdk.Int
+		positionAmount1  sdk.Int
+		addPositions     func(ctx sdk.Context, poolId uint64)
+		tokenIn          sdk.Coin
+		tokenOutDenom    string
+		priceLimit       sdk.Dec
+		expectedTokenIn  sdk.Coin
+		expectedTokenOut sdk.Coin
+		expectedTick     sdk.Int
+		newLowerPrice    sdk.Dec
+		newUpperPrice    sdk.Dec
+		poolLiqAmount0   sdk.Int
+		poolLiqAmount1   sdk.Int
+	}{
+		//  One price range
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		"single position within one tick: usdc -> eth": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(5004),
+			// we expect to put 42 usdc in and in return get .008398 eth back
+			// due to limited liquidity, we actually put in 41.99 usdc and in return get .008396 eth back
+			expectedTokenIn:  sdk.NewCoin("usdc", sdk.NewInt(41999999)),
+			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8396)),
+			expectedTick:     sdk.NewInt(85184),
+		},
+		"single position within one tick: eth -> usdc": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
+			tokenOutDenom: "usdc",
+			priceLimit:    sdk.NewDec(4993),
+			// we expect to put .01337 eth in and in return get 66.79 usdc back
+			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(13370)),
+			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(66790908)),
+			expectedTick:     sdk.NewInt(85163),
+		},
+		//  Two equal price ranges
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		//  4545 -----|----- 5500
+		"two positions within one tick: usdc -> eth": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
 
-	// we expect to put 42 usdc in and in return get .008398 eth back
-	expectedTokenIn := sdk.NewCoin("usdc", sdk.NewInt(42000000))
-	expectedTokenOut := sdk.NewCoin("eth", sdk.NewInt(8398))
+				// add second position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[1], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(5002),
+			// we expect to put 42 usdc in and in return get .008398 eth back
+			expectedTokenIn:  sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8398)),
+			expectedTick:     sdk.NewInt(85180),
+			// two positions with same liquidity entered
+			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
+			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
+		},
+		"two positions within one tick: eth -> usdc": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
 
-	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenIn.String(), tokenIn.String())
-	s.Require().Equal(expectedTokenOut.String(), tokenOut.String())
+				// add second position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[1], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
+			tokenOutDenom: "usdc",
+			priceLimit:    sdk.NewDec(4996),
+			// we expect to put .01337 eth in and in return get 66.79 eth back
+			// TODO: look into why we are returning 66.81 instead of 66.79 like the inverse of this test above
+			// sure, the above test only has 1 position while this has two positions, but shouldn't that effect the tokenIn as well?
+			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(13370)),
+			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(66811697)),
+			expectedTick:     sdk.NewInt(85169),
+			// two positions with same liquidity entered
+			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
+			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
+		},
+		//  Consecutive price ranges
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		//             5500 ----------- 6250
+		//
+		"two positions with consecutive price ranges": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
 
-	// check the new tick is at the expected value
-	s.Require().Equal(sdk.NewInt(85180).String(), updatedTick.String())
+				// create second position parameters
+				newLowerPrice := sdk.NewDec(5501)
+				s.Require().NoError(err)
+				newLowerTick := cl.PriceToTick(newLowerPrice) // 84222
+				newUpperPrice := sdk.NewDec(6250)
+				s.Require().NoError(err)
+				newUpperTick := cl.PriceToTick(newUpperPrice) // 87407
 
-	// check pool liquidity
-	lowerSqrtPrice, err := s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(lowerTick)
-	s.Require().NoError(err)
-	upperSqrtPrice, err := s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(upperTick)
-	s.Require().NoError(err)
-	expectedLiquidity := cl.GetLiquidityFromAmounts(currSqrtPrice, lowerSqrtPrice, upperSqrtPrice, amount0.Mul(sdk.NewInt(2)), amount1.Mul(sdk.NewInt(2)))
-	s.Require().Equal(expectedLiquidity.String(), updatedLiquidity.String())
+				// add position two with the new price range above
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[2], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(6106),
+			// we expect to put 10000 usdc in and in return get 1.820536 eth back
+			// TODO: see why we don't get 9938.148 usdc and 1.80615 eth
+			expectedTokenIn:  sdk.NewCoin("usdc", sdk.NewInt(9999999999)),
+			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(1820536)),
+			expectedTick:     sdk.NewInt(87173),
+			newLowerPrice:    sdk.NewDec(5501),
+			newUpperPrice:    sdk.NewDec(6250),
+		},
+	}
 
-	//
-	// TEST 2: one price range
-	//
+	for name, test := range tests {
+		s.Run(name, func() {
+			s.Setup()
+			// create pool
+			pool, err := s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(s.Ctx, 1, "eth", "usdc", currSqrtPrice, currTick)
+			s.Require().NoError(err)
 
-	// we use the same price range as above, but just with a single position instead of two
+			// add positions
+			test.addPositions(s.Ctx, pool.Id)
 
-	// 1 eth 5000 usdc position
-	amount0 = sdk.NewInt(1000000)
-	amount1 = sdk.NewInt(5000000000)
+			tokenIn, tokenOut, updatedTick, updatedLiquidity, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(
+				s.Ctx,
+				test.tokenIn, test.tokenOutDenom,
+				swapFee, test.priceLimit, pool.Id)
+			s.Require().NoError(err)
 
-	// create pool
-	pool, err = s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, 2, "eth", "usdc", currSqrtPrice, currTick)
-	s.Require().NoError(err)
+			s.Require().Equal(test.expectedTokenIn.String(), tokenIn.String())
+			s.Require().Equal(test.expectedTokenOut.String(), tokenOut.String())
+			s.Require().Equal(test.expectedTick.String(), updatedTick.String())
 
-	// add position
-	_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, pool.Id, s.TestAccs[1], amount0, amount1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
-	s.Require().NoError(err)
+			if test.newLowerPrice.IsNil() && test.newUpperPrice.IsNil() {
+				test.newLowerPrice = lowerPrice
+				test.newUpperPrice = upperPrice
+			}
 
-	// swapping parameters used for test
-	// swap in 42 usdc for some amount of eth
-	tokenIn = sdk.NewCoin("usdc", sdk.NewInt(42000000))
-	tokenOutDenom = "eth"
-	// set no swap fee
-	swapFee = sdk.ZeroDec()
-	// limit max price impact to 5004 usdc per eth
-	priceLimit = sdk.NewDec(5004)
+			newLowerTick := cl.PriceToTick(test.newLowerPrice)
+			newUpperTick := cl.PriceToTick(test.newUpperPrice)
 
-	// run calculation
-	tokenIn, tokenOut, updatedTick, updatedLiquidity, err = s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
-	s.Require().NoError(err)
+			lowerSqrtPrice, err := s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(newLowerTick)
+			s.Require().NoError(err)
+			upperSqrtPrice, err := s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(newUpperTick)
+			s.Require().NoError(err)
 
-	// we expect to put 41999999 usdc in and in return get .008396 eth back
-	expectedTokenIn = sdk.NewCoin("usdc", sdk.NewInt(41999999))
-	expectedTokenOut = sdk.NewCoin("eth", sdk.NewInt(8396))
+			if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
+				test.poolLiqAmount0 = defaultAmt0
+				test.poolLiqAmount1 = defaultAmt1
+			}
 
-	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenIn.String(), tokenIn.String())
-	s.Require().Equal(expectedTokenOut.String(), tokenOut.String())
+			expectedLiquidity := cl.GetLiquidityFromAmounts(currSqrtPrice, lowerSqrtPrice, upperSqrtPrice, test.poolLiqAmount0, test.poolLiqAmount1)
+			s.Require().Equal(expectedLiquidity.TruncateInt(), updatedLiquidity.TruncateInt())
+		})
 
-	// this is off by one (too large), I think it is the priceToTick func, try using ln PR from main
-	s.Require().Equal(sdk.NewInt(85184).String(), updatedTick.String())
-
-	// check pool liquidity
-	lowerSqrtPrice, err = s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(lowerTick)
-	s.Require().NoError(err)
-	upperSqrtPrice, err = s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(upperTick)
-	s.Require().NoError(err)
-	expectedLiquidity = cl.GetLiquidityFromAmounts(currSqrtPrice, lowerSqrtPrice, upperSqrtPrice, amount0, amount1)
-	s.Require().Equal(expectedLiquidity.String(), updatedLiquidity.String())
-
-	//
-	// TEST 3: two consecutive price ranges
-	//
-
-	// we use the same price range as above, but for the first position
-	// then for the second position, we use a new price range
-
-	// both are 1 eth 5000 usdc positions
-	amount0 = sdk.NewInt(1000000)
-	amount1 = sdk.NewInt(5000000000)
-
-	// create pool
-	pool, err = s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, 3, "eth", "usdc", currSqrtPrice, currTick)
-	s.Require().NoError(err)
-
-	// add position one (utilizing old price range)
-	_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, pool.Id, s.TestAccs[0], amount0, amount1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
-	s.Require().NoError(err)
-
-	// create second position parameters
-	lowerPrice = sdk.NewDec(5501)
-	s.Require().NoError(err)
-	lowerTick = cl.PriceToTick(lowerPrice) // 84222
-	upperPrice = sdk.NewDec(6250)
-	s.Require().NoError(err)
-	upperTick = cl.PriceToTick(upperPrice) // 87407
-
-	// add position two with the new price range above
-	_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, pool.Id, s.TestAccs[2], amount0, amount1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
-	s.Require().NoError(err)
-
-	// swapping parameters used for test
-	// swap in 10000000 usdc for some amount of eth
-	tokenIn = sdk.NewCoin("usdc", sdk.NewInt(10000000000))
-	tokenOutDenom = "eth"
-	// set no swap fee
-	swapFee = sdk.ZeroDec()
-	// limit max price impact to 6106 usdc per eth
-	priceLimit = sdk.NewDec(6106)
-
-	// run calculation
-	tokenIn, tokenOut, updatedTick, updatedLiquidity, err = s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.Id)
-	s.Require().NoError(err)
-
-	// we expect to put 999.99 usdc in and in return get 1.820536 eth back
-	expectedTokenIn = sdk.NewCoin("usdc", sdk.NewInt(9999999999))
-	expectedTokenOut = sdk.NewCoin("eth", sdk.NewInt(1820536))
-
-	// ensure tokenIn and tokenOut meet our expected values
-	s.Require().Equal(expectedTokenIn.String(), tokenIn.String())
-	s.Require().Equal(expectedTokenOut.String(), tokenOut.String())
-
-	// this is off by one (too large), I think it is the priceToTick func, try using ln PR from main
-	s.Require().Equal(sdk.NewInt(87173).String(), updatedTick.String())
-
-	// check pool liquidity
-	lowerSqrtPrice, err = s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(lowerTick)
-	s.Require().NoError(err)
-	upperSqrtPrice, err = s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(upperTick)
-	s.Require().NoError(err)
-	expectedLiquidity = cl.GetLiquidityFromAmounts(currSqrtPrice, lowerSqrtPrice, upperSqrtPrice, amount0, amount1)
-	s.Require().Equal(expectedLiquidity.TruncateInt().String(), updatedLiquidity.TruncateInt().String())
+	}
 }
 
 // func (s *KeeperTestSuite) TestCalcInAmtGivenOut() {

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -77,7 +77,7 @@ func (k Keeper) NextInitializedTick(ctx sdk.Context, poolId uint64, tickIndex in
 	prefixStore := prefix.NewStore(store, prefixBz)
 
 	var startKey []byte
-	if zeroForOne {
+	if !zeroForOne {
 		startKey = types.TickIndexToBytes(tickIndex)
 	} else {
 		// When looking to the left of the current tick, we need to evaluate the
@@ -87,7 +87,7 @@ func (k Keeper) NextInitializedTick(ctx sdk.Context, poolId uint64, tickIndex in
 	}
 
 	var iter db.Iterator
-	if zeroForOne {
+	if !zeroForOne {
 		iter = prefixStore.Iterator(startKey, nil)
 	} else {
 		iter = prefixStore.ReverseIterator(nil, startKey)
@@ -103,10 +103,10 @@ func (k Keeper) NextInitializedTick(ctx sdk.Context, poolId uint64, tickIndex in
 			panic(fmt.Errorf("invalid tick index (%s): %v", string(iter.Key()), err))
 		}
 
-		if zeroForOne && tick > tickIndex {
+		if !zeroForOne && tick > tickIndex {
 			return tick, true
 		}
-		if !zeroForOne && tick <= tickIndex {
+		if zeroForOne && tick <= tickIndex {
 			return tick, true
 		}
 	}

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -75,34 +75,34 @@ func TestKeeper_NextInitializedTick(t *testing.T) {
 
 	t.Run("lte=true", func(t *testing.T) {
 		t.Run("returns tick to right if at initialized tick", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 78, true)
+			n, initd := k.NextInitializedTick(ctx, 1, 78, false)
 			require.Equal(t, int64(84), n)
 			require.True(t, initd)
 		})
 		t.Run("returns tick to right if at initialized tick", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, -55, true)
+			n, initd := k.NextInitializedTick(ctx, 1, -55, false)
 			require.Equal(t, int64(-4), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the tick directly to the right", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 77, true)
+			n, initd := k.NextInitializedTick(ctx, 1, 77, false)
 			require.Equal(t, int64(78), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the tick directly to the right", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, -56, true)
+			n, initd := k.NextInitializedTick(ctx, 1, -56, false)
 			require.Equal(t, int64(-55), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the next words initialized tick if on the right boundary", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, -257, true)
+			n, initd := k.NextInitializedTick(ctx, 1, -257, false)
 			require.Equal(t, int64(-200), n)
 			require.True(t, initd)
 		})
 		t.Run("returns the next initialized tick from the next word", func(t *testing.T) {
 			k.SetTickInfo(ctx, 1, 340, cl.TickInfo{})
 
-			n, initd := k.NextInitializedTick(ctx, 1, 328, true)
+			n, initd := k.NextInitializedTick(ctx, 1, 328, false)
 			require.Equal(t, int64(340), n)
 			require.True(t, initd)
 		})
@@ -110,17 +110,17 @@ func TestKeeper_NextInitializedTick(t *testing.T) {
 
 	t.Run("lte=false", func(t *testing.T) {
 		t.Run("returns tick directly to the left of input tick if not initialized", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 79, false)
+			n, initd := k.NextInitializedTick(ctx, 1, 79, true)
 			require.Equal(t, int64(78), n)
 			require.True(t, initd)
 		})
 		t.Run("returns same tick if initialized", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 78, false)
+			n, initd := k.NextInitializedTick(ctx, 1, 78, true)
 			require.Equal(t, int64(78), n)
 			require.True(t, initd)
 		})
 		t.Run("returns next initialized tick far away", func(t *testing.T) {
-			n, initd := k.NextInitializedTick(ctx, 1, 100, false)
+			n, initd := k.NextInitializedTick(ctx, 1, 100, true)
 			require.Equal(t, int64(84), n)
 			require.True(t, initd)
 		})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This corrects faulty logic throughout the CL module, mostly within CalcOut and ComputeSwapStep

I think for now we should leave these tests as is, and have a subsequent issue convert it to a clean table driven test

This confirms OneToZero logic for CalcOut is good, I still need to check if ZeroToOne logic is sound (there is no reason why it shouldn't, but I didn't have time to check and wanted to get this merged to main ASAP)
