### PR TITLE
Re-enable stableswap messages

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -224,6 +224,17 @@ func (s *KeeperTestHelper) EndBlock() {
 	s.App.EndBlocker(s.Ctx, reqEndBlock)
 }
 
+func (s *KeeperTestHelper) RunMsg(msg sdk.Msg) (*sdk.Result, error) {
+	// cursed that we have to copy this internal logic from SDK
+	router := s.App.GetBaseApp().MsgServiceRouter()
+	if handler := router.Handler(msg); handler != nil {
+		// ADR 031 request type routing
+		return handler(s.Ctx, msg)
+	}
+	s.FailNow("msg %v could not be ran", msg)
+	return nil, fmt.Errorf("msg %v could not be ran", msg)
+}
+
 // AllocateRewardsToValidator allocates reward tokens to a distribution module then allocates rewards to the validator address.
 func (s *KeeperTestHelper) AllocateRewardsToValidator(valAddr sdk.ValAddress, rewardAmt sdk.Int) {
 	validator, found := s.App.StakingKeeper.GetValidator(s.Ctx, valAddr)

--- a/x/gamm/keeper/msg_server.go
+++ b/x/gamm/keeper/msg_server.go
@@ -2,11 +2,13 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )
 
@@ -26,16 +28,16 @@ func NewBalancerMsgServerImpl(keeper *Keeper) balancer.MsgServer {
 	}
 }
 
-// func NewStableswapMsgServerImpl(keeper *Keeper) stableswap.MsgServer {
-// 	return &msgServer{
-// 		keeper: keeper,
-// 	}
-// }
+func NewStableswapMsgServerImpl(keeper *Keeper) stableswap.MsgServer {
+	return &msgServer{
+		keeper: keeper,
+	}
+}
 
 var (
-	_ types.MsgServer    = msgServer{}
-	_ balancer.MsgServer = msgServer{}
-	// _ stableswap.MsgServer = msgServer{}
+	_ types.MsgServer      = msgServer{}
+	_ balancer.MsgServer   = msgServer{}
+	_ stableswap.MsgServer = msgServer{}
 )
 
 // CreateBalancerPool is a create balancer pool message.
@@ -44,23 +46,31 @@ func (server msgServer) CreateBalancerPool(goCtx context.Context, msg *balancer.
 	return &balancer.MsgCreateBalancerPoolResponse{PoolID: poolId}, err
 }
 
-// func (server msgServer) CreateStableswapPool(goCtx context.Context, msg *stableswap.MsgCreateStableswapPool) (*stableswap.MsgCreateStableswapPoolResponse, error) {
-// 	poolId, err := server.CreatePool(goCtx, msg)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return &stableswap.MsgCreateStableswapPoolResponse{PoolID: poolId}, nil
-// }
+func (server msgServer) CreateStableswapPool(goCtx context.Context, msg *stableswap.MsgCreateStableswapPool) (*stableswap.MsgCreateStableswapPoolResponse, error) {
+	poolId, err := server.CreatePool(goCtx, msg)
+	if err != nil {
+		return nil, err
+	}
+	return &stableswap.MsgCreateStableswapPoolResponse{PoolID: poolId}, nil
+}
 
-// func (server msgServer) StableSwapAdjustScalingFactors(goCtx context.Context, msg *stableswap.MsgStableSwapAdjustScalingFactors) (*stableswap.MsgStableSwapAdjustScalingFactorsResponse, error) {
-// 	ctx := sdk.UnwrapSDKContext(goCtx)
+func (server msgServer) StableSwapAdjustScalingFactors(goCtx context.Context, msg *stableswap.MsgStableSwapAdjustScalingFactors) (*stableswap.MsgStableSwapAdjustScalingFactorsResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
 
-// 	if err := server.keeper.SetStableSwapScalingFactors(ctx, msg.ScalingFactors, msg.PoolID, msg.ScalingFactorGovernor); err != nil {
-// 		return nil, err
-// 	}
+	pool, err := server.keeper.GetPoolAndPoke(ctx, msg.PoolID)
+	if err != nil {
+		return nil, err
+	}
+	stableswapPool, ok := pool.(*stableswap.Pool)
+	if !ok {
+		return nil, fmt.Errorf("pool id %d is not of type stableswap pool", msg.PoolID)
+	}
+	if err := stableswapPool.SetScalingFactors(ctx, msg.ScalingFactors, msg.Sender); err != nil {
+		return nil, err
+	}
 
-// 	return &stableswap.MsgStableSwapAdjustScalingFactorsResponse{}, nil
-// }
+	return &stableswap.MsgStableSwapAdjustScalingFactorsResponse{}, nil
+}
 
 // CreatePool attempts to create a pool returning the newly created pool ID or an error upon failure.
 // The pool creation fee is used to fund the community pool.

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -124,8 +124,6 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 
 	// send pool creation fee to community pool
 	params := k.GetParams(ctx)
-	fmt.Println("balance")
-	fmt.Println(k.bankKeeper.GetAllBalances(ctx, sender))
 	if err := k.communityPoolKeeper.FundCommunityPool(ctx, params.PoolCreationFee, sender); err != nil {
 		return 0, err
 	}

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -124,6 +124,8 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 
 	// send pool creation fee to community pool
 	params := k.GetParams(ctx)
+	fmt.Println("balance")
+	fmt.Println(k.bankKeeper.GetAllBalances(ctx, sender))
 	if err := k.communityPoolKeeper.FundCommunityPool(ctx, params.PoolCreationFee, sender); err != nil {
 		return 0, err
 	}

--- a/x/gamm/module.go
+++ b/x/gamm/module.go
@@ -103,7 +103,7 @@ type AppModule struct {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(&am.keeper))
 	balancer.RegisterMsgServer(cfg.MsgServer(), keeper.NewBalancerMsgServerImpl(&am.keeper))
-	// stableswap.RegisterMsgServer(cfg.MsgServer(), keeper.NewStableswapMsgServerImpl(&am.keeper))
+	stableswap.RegisterMsgServer(cfg.MsgServer(), keeper.NewStableswapMsgServerImpl(&am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQuerier(am.keeper))
 }
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -279,6 +279,10 @@ Couple ways to define JoinPool Exit Pool relation
 
 ## Testing strategy
 
+* Unit tests for every pool interface method
+* Msg tests for custom messages
+  * CreatePool
+  * SetScalingFactors
 * Simulator integrations:
   * Pool creation
   * JoinPool + ExitPool gives a token amount out that is lte input

--- a/x/gamm/pool-models/stableswap/integration_test.go
+++ b/x/gamm/pool-models/stableswap/integration_test.go
@@ -34,7 +34,8 @@ func (s *TestSuite) TestSetScalingFactors() {
 	addr1 := sdk.AccAddress(pk1.Address())
 	nextPoolId := s.App.GAMMKeeper.GetNextPoolId(s.Ctx)
 	defaultCreatePoolMsg := *baseCreatePoolMsgGen(addr1)
-	defaultAdjustSFMsg := stableswap.NewMsgStableSwapAdjustScalingFactors(defaultCreatePoolMsg.Sender, nextPoolId)
+	defaultCreatePoolMsg.ScalingFactorController = defaultCreatePoolMsg.Sender
+	defaultAdjustSFMsg := stableswap.NewMsgStableSwapAdjustScalingFactors(defaultCreatePoolMsg.Sender, nextPoolId, []uint64{1, 1})
 
 	tests := map[string]struct {
 		createMsg  stableswap.MsgCreateStableswapPool
@@ -47,6 +48,9 @@ func (s *TestSuite) TestSetScalingFactors() {
 	for name, tc := range tests {
 		s.Run(name, func() {
 			s.SetupTest()
+			sender := tc.createMsg.GetSigners()[0]
+			s.FundAcc(sender, s.App.GAMMKeeper.GetParams(s.Ctx).PoolCreationFee)
+			s.FundAcc(sender, tc.createMsg.InitialPoolLiquidity.Sort())
 			_, err := s.RunMsg(&tc.createMsg)
 			s.Require().NoError(err)
 			_, err = s.RunMsg(&tc.setMsg)

--- a/x/gamm/pool-models/stableswap/integration_test.go
+++ b/x/gamm/pool-models/stableswap/integration_test.go
@@ -1,0 +1,56 @@
+// This file contains integration tests, using "true" messages.
+// We expect tests for:
+// * MsgCreatePool creating correct pool as expected
+// * MsgSetStableswapScalingFactors works as expected
+//
+package stableswap_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v12/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v12/x/gamm/pool-models/stableswap"
+)
+
+type TestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+func TestTestSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}
+
+func (suite *TestSuite) SetupTest() {
+	suite.Setup()
+}
+
+func (s *TestSuite) TestSetScalingFactors() {
+	s.SetupTest()
+	pk1 := ed25519.GenPrivKey().PubKey()
+	addr1 := sdk.AccAddress(pk1.Address())
+	nextPoolId := s.App.GAMMKeeper.GetNextPoolId(s.Ctx)
+	defaultCreatePoolMsg := *baseCreatePoolMsgGen(addr1)
+	defaultAdjustSFMsg := stableswap.NewMsgStableSwapAdjustScalingFactors(defaultCreatePoolMsg.Sender, nextPoolId)
+
+	tests := map[string]struct {
+		createMsg  stableswap.MsgCreateStableswapPool
+		setMsg     stableswap.MsgStableSwapAdjustScalingFactors
+		expectPass bool
+	}{
+		"valid_msg": {defaultCreatePoolMsg, defaultAdjustSFMsg, true},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+			_, err := s.RunMsg(&tc.createMsg)
+			s.Require().NoError(err)
+			_, err = s.RunMsg(&tc.setMsg)
+			s.Require().NoError(err)
+		})
+	}
+}

--- a/x/gamm/pool-models/stableswap/integration_test.go
+++ b/x/gamm/pool-models/stableswap/integration_test.go
@@ -1,7 +1,7 @@
 // This file contains integration tests, using "true" messages.
 // We expect tests for:
 // * MsgCreatePool creating correct pool as expected
-// * MsgSetStableswapScalingFactors works as expected
+// * MsgStableSwapAdjustScalingFactors works as expected
 //
 package stableswap_test
 

--- a/x/gamm/pool-models/stableswap/msgs.go
+++ b/x/gamm/pool-models/stableswap/msgs.go
@@ -119,10 +119,12 @@ var _ sdk.Msg = &MsgStableSwapAdjustScalingFactors{}
 func NewMsgStableSwapAdjustScalingFactors(
 	sender string,
 	poolID uint64,
+	scalingFactors []uint64,
 ) MsgStableSwapAdjustScalingFactors {
 	return MsgStableSwapAdjustScalingFactors{
-		Sender: sender,
-		PoolID: poolID,
+		Sender:         sender,
+		PoolID:         poolID,
+		ScalingFactors: scalingFactors,
 	}
 }
 

--- a/x/gamm/pool-models/stableswap/msgs_test.go
+++ b/x/gamm/pool-models/stableswap/msgs_test.go
@@ -13,44 +13,45 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )
 
-func TestMsgCreateStableswapPool(t *testing.T) {
-	appParams.SetAddressPrefixes()
-	pk1 := ed25519.GenPrivKey().PubKey()
-	addr1 := sdk.AccAddress(pk1.Address()).String()
-	invalidAddr := sdk.AccAddress("invalid")
-
-	createMsg := func(after func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
-		testPoolAsset := sdk.Coins{
-			sdk.NewCoin("osmo", sdk.NewInt(100)),
-			sdk.NewCoin("atom", sdk.NewInt(100)),
-		}
-
-		poolParams := &stableswap.PoolParams{
-			SwapFee: sdk.NewDecWithPrec(1, 2),
-			ExitFee: sdk.NewDecWithPrec(1, 2),
-		}
-
-		msg := &stableswap.MsgCreateStableswapPool{
-			Sender:               addr1,
-			PoolParams:           poolParams,
-			InitialPoolLiquidity: testPoolAsset,
-			ScalingFactors:       []uint64{1, 1},
-			FuturePoolGovernor:   "",
-		}
-
-		return after(*msg)
+func baseCreatePoolMsgGen(sender sdk.AccAddress) *stableswap.MsgCreateStableswapPool {
+	testPoolAsset := sdk.Coins{
+		sdk.NewCoin("osmo", sdk.NewInt(100)),
+		sdk.NewCoin("atom", sdk.NewInt(100)),
 	}
 
-	default_msg := createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
-		// Do nothing
-		return msg
-	})
+	poolParams := &stableswap.PoolParams{
+		SwapFee: sdk.NewDecWithPrec(1, 2),
+		ExitFee: sdk.NewDecWithPrec(1, 2),
+	}
+
+	msg := &stableswap.MsgCreateStableswapPool{
+		Sender:               sender.String(),
+		PoolParams:           poolParams,
+		InitialPoolLiquidity: testPoolAsset,
+		ScalingFactors:       []uint64{1, 1},
+		FuturePoolGovernor:   "",
+	}
+
+	return msg
+}
+
+func TestMsgCreateStableswapPoolValidateBasic(t *testing.T) {
+	appParams.SetAddressPrefixes()
+	pk1 := ed25519.GenPrivKey().PubKey()
+	addr1 := sdk.AccAddress(pk1.Address())
+	invalidAddr := sdk.AccAddress("invalid")
+
+	default_msg := baseCreatePoolMsgGen(addr1)
+	updateMsg := func(f func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+		m := *baseCreatePoolMsgGen(addr1)
+		return f(m)
+	}
 
 	require.Equal(t, default_msg.Route(), types.RouterKey)
 	require.Equal(t, default_msg.Type(), "create_stableswap_pool")
 	signers := default_msg.GetSigners()
 	require.Equal(t, len(signers), 1)
-	require.Equal(t, signers[0].String(), addr1)
+	require.Equal(t, signers[0].String(), addr1.String())
 
 	tests := []struct {
 		name       string
@@ -59,7 +60,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 	}{
 		{
 			name: "proper msg",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				// Do nothing
 				return msg
 			}),
@@ -67,7 +68,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "invalid sender",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.Sender = invalidAddr.String()
 				return msg
 			}),
@@ -75,7 +76,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "has nil InitialPoolLiquidity ",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = nil
 				return msg
 			}),
@@ -83,7 +84,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "has one coin in InitialPoolLiquidity",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
 					sdk.NewCoin("osmo", sdk.NewInt(100)),
 				}
@@ -93,7 +94,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "have assets in excess of cap",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
 					sdk.NewCoin("osmo", sdk.NewInt(100)),
 					sdk.NewCoin("atom", sdk.NewInt(100)),
@@ -111,7 +112,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "negative swap fee with zero exit fee",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.PoolParams = &stableswap.PoolParams{
 					SwapFee: sdk.NewDecWithPrec(-1, 2),
 					ExitFee: sdk.NewDecWithPrec(0, 0),
@@ -122,7 +123,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "scaling factors with invalid lenght",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.ScalingFactors = []uint64{1, 2, 3}
 				return msg
 			}),
@@ -130,7 +131,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "invalid governor",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = "invalid_cosmos_address"
 				return msg
 			}),
@@ -138,7 +139,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "invalid governor : len governor > 2",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = "lptoken,1000h,invalid_cosmos_address"
 				return msg
 			}),
@@ -146,7 +147,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "invalid governor : len governor > 2",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = "lptoken,1000h,invalid_cosmos_address"
 				return msg
 			}),
@@ -154,7 +155,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "valid governor: err when parse duration ",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = "lptoken, invalid_duration"
 				return msg
 			}),
@@ -162,7 +163,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "valid governor: just lock duration for pool token",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = "1000h"
 				return msg
 			}),
@@ -170,7 +171,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "valid governor: address",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = "osmo1fqlr98d45v5ysqgp6h56kpujcj4cvsjnjq9nck"
 				return msg
 			}),
@@ -178,7 +179,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "valid governor: address",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.FuturePoolGovernor = ""
 				return msg
 			}),
@@ -186,7 +187,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "zero swap fee, zero exit fee",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.PoolParams = &stableswap.PoolParams{
 					ExitFee: sdk.NewDecWithPrec(0, 0),
 					SwapFee: sdk.NewDecWithPrec(0, 0),
@@ -197,7 +198,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "multi assets pool",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
 					sdk.NewCoin("osmo", sdk.NewInt(100)),
 					sdk.NewCoin("atom", sdk.NewInt(100)),
@@ -211,7 +212,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "max asset amounts",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
 					sdk.NewCoin("osmo", sdk.NewInt(10_000_000_000)),
 					sdk.NewCoin("atom", sdk.NewInt(10_000_000_000)),
@@ -229,7 +230,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "greater than max post-scaled amount with regular scaling factors",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
 					sdk.NewCoin("osmo", sdk.NewInt(1+10_000_000_000)),
 					sdk.NewCoin("atom", sdk.NewInt(10_000_000_000)),
@@ -247,7 +248,7 @@ func TestMsgCreateStableswapPool(t *testing.T) {
 		},
 		{
 			name: "100B token 8-asset pool using large scaling factors",
-			msg: createMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
+			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
 					sdk.NewCoin("osmo", sdk.NewInt(100_000_000_000_000_000)),
 					sdk.NewCoin("atom", sdk.NewInt(100_000_000_000_000_000)),

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -357,7 +357,7 @@ func (p Pool) CalcExitPoolCoinsFromShares(ctx sdk.Context, exitingShares sdk.Int
 	return cfmm_common.CalcExitPool(ctx, &p, exitingShares, exitFee)
 }
 
-// SetStableSwapScalingFactors sets scaling factors for pool to the given amount
+// SetScalingFactors sets scaling factors for pool to the given amount
 // It should only be able to be successfully called by the pool's ScalingFactorGovernor
 // TODO: move commented test for this function from x/gamm/keeper/pool_service_test.go once a pool_test.go file has been created for stableswap
 func (p *Pool) SetScalingFactors(ctx sdk.Context, scalingFactors []uint64, sender string) error {

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -360,7 +360,7 @@ func (p Pool) CalcExitPoolCoinsFromShares(ctx sdk.Context, exitingShares sdk.Int
 // SetStableSwapScalingFactors sets scaling factors for pool to the given amount
 // It should only be able to be successfully called by the pool's ScalingFactorGovernor
 // TODO: move commented test for this function from x/gamm/keeper/pool_service_test.go once a pool_test.go file has been created for stableswap
-func (p *Pool) SetStableSwapScalingFactors(ctx sdk.Context, scalingFactors []uint64, sender string) error {
+func (p *Pool) SetScalingFactors(ctx sdk.Context, scalingFactors []uint64, sender string) error {
 	if sender != p.ScalingFactorController {
 		return types.ErrNotScalingFactorGovernor
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Re-enables stableswap messages, and adds validation for them working. Test currently failing right now, which means the message enabling likely hasn't been fixed.

Soundness cases needed to be added as well. Will be done in this PR


## Brief Changelog

  - Re-enable stableswap messages
  - Add suite.RunMsg
  - Start Stableswap message integration testing

## Testing and Verifying

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)