### PR TITLE
CL: SwapOutGivenIn logic

### DIFF
--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -71,14 +71,13 @@ func (p Pool) GetTotalShares() sdk.Int {
 
 // TODO: implement this
 func (k Keeper) SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom string, swapFee sdk.Dec, priceLimit sdk.Dec, poolId uint64) (tokenOut sdk.Coin, err error) {
-	// tokenIn, tokenOut, newCurrentTick, newLiquidity, err := k.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, poolId)
-	// if err != nil {
-	// 	return sdk.Coin{}, err
-	// }
+	tokenIn, tokenOut, newCurrentTick, newLiquidity, newSqrtPrice, err := k.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, poolId)
+	if err != nil {
+		return sdk.Coin{}, err
+	}
+	k.applySwap(ctx, tokenIn, tokenOut, poolId, newLiquidity, newCurrentTick, newSqrtPrice)
 
-	// k.applySwap(ctx, tokenInCoin, tokenOut, poolId, newLiquidity, newCurrentTick, newCurrentSqrtPrice)
-
-	return sdk.Coin{}, nil
+	return tokenOut, nil
 }
 
 func (p Pool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (sdk.Dec, error) {
@@ -98,7 +97,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	tokenOutDenom string,
 	swapFee sdk.Dec,
 	priceLimit sdk.Dec,
-	poolId uint64) (tokenIn, tokenOut sdk.Coin, updatedTick sdk.Int, updatedLiquidity sdk.Dec, err error) {
+	poolId uint64) (tokenIn, tokenOut sdk.Coin, updatedTick sdk.Int, updatedLiquidity, updatedSqrtPrice sdk.Dec, err error) {
 	p := k.getPoolbyId(ctx, poolId)
 	asset0 := p.Token0
 	asset1 := p.Token1
@@ -110,22 +109,22 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	curSqrtPrice := p.CurrentSqrtPrice
 	sqrtPriceLimit, err := priceLimit.ApproxSqrt()
 	if err != nil {
-		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("issue calculating square root of price limit")
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("issue calculating square root of price limit")
 	}
 	if (zeroForOne && (sqrtPriceLimit.GT(p.CurrentSqrtPrice) || sqrtPriceLimit.LT(cltypes.MinSqrtRatio))) ||
 		(!zeroForOne && (sqrtPriceLimit.LT(p.CurrentSqrtPrice) || sqrtPriceLimit.GT(cltypes.MaxSqrtRatio))) {
-		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("invalid price limit (%s)", priceLimit.String())
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("invalid price limit (%s)", priceLimit.String())
 	}
 
 	// validation
 	if tokenInMin.Denom != asset0 && tokenInMin.Denom != asset1 {
-		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) does not match any asset in pool", tokenInMin.Denom)
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) does not match any asset in pool", tokenInMin.Denom)
 	}
 	if tokenOutDenom != asset0 && tokenOutDenom != asset1 {
-		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenOutDenom (%s) does not match any asset in pool", tokenOutDenom)
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("tokenOutDenom (%s) does not match any asset in pool", tokenOutDenom)
 	}
 	if tokenInMin.Denom == tokenOutDenom {
-		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) cannot be the same as tokenOut (%s)", tokenInMin.Denom, tokenOutDenom)
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("tokenIn (%s) cannot be the same as tokenOut (%s)", tokenInMin.Denom, tokenOutDenom)
 	}
 
 	// at first, we use the pool liquidity
@@ -141,12 +140,12 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 		sqrtPriceStart := swapState.sqrtPrice
 		nextTick, ok := k.NextInitializedTick(ctx, poolId, swapState.tick.Int64(), zeroForOne)
 		if !ok {
-			return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("there are no more ticks initialized to fill the swap")
+			return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("there are no more ticks initialized to fill the swap")
 		}
 
 		nextSqrtPrice, err := k.tickToSqrtPrice(sdk.NewInt(nextTick))
 		if err != nil {
-			return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", sdk.NewInt(nextTick))
+			return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", sdk.NewInt(nextTick))
 		}
 
 		var sqrtPriceTarget sdk.Dec
@@ -173,7 +172,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 			liquidityDelta, err := k.crossTick(ctx, p.Id, nextTick)
 
 			if err != nil {
-				return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, err
+				return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}
 			if zeroForOne {
 				liquidityDelta = liquidityDelta.Neg()
@@ -182,7 +181,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 			swapState.liquidity = swapState.liquidity.Add(liquidityDelta.ToDec())
 
 			if swapState.liquidity.LTE(sdk.ZeroDec()) || swapState.liquidity.IsNil() {
-				return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, err
+				return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}
 			if zeroForOne {
 				swapState.tick = sdk.NewInt(nextTick - 1)
@@ -202,7 +201,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 	tokenIn = sdk.NewCoin(tokenInMin.Denom, amt0)
 	tokenOut = sdk.NewCoin(tokenOutDenom, amt1)
 
-	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, nil
+	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, swapState.sqrtPrice, nil
 }
 
 func (k *Keeper) SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec, minPrice, maxPrice sdk.Dec, poolId uint64) (tokenIn sdk.Coin, err error) {

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -319,7 +319,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 		priceLimit       sdk.Dec
 		expectedTokenOut sdk.Coin
 		expectedTick     sdk.Int
-		zeroForOne       bool
 		newLowerPrice    sdk.Dec
 		newUpperPrice    sdk.Dec
 		poolLiqAmount0   sdk.Int
@@ -342,7 +341,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			// due to limited liquidity, we actually put in 41.99 usdc and in return get .008396 eth back
 			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8396)),
 			expectedTick:     sdk.NewInt(85184),
-			zeroForOne:       false,
 		},
 		"single position within one tick: eth -> usdc": {
 			addPositions: func(ctx sdk.Context, poolId uint64) {
@@ -356,7 +354,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			// we expect to put .01337 eth in and in return get 66.79 usdc back
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(66790908)),
 			expectedTick:     sdk.NewInt(85163),
-			zeroForOne:       true,
 		},
 		//  Two equal price ranges
 		//
@@ -379,7 +376,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			// we expect to put 42 usdc in and in return get .008398 eth back
 			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8398)),
 			expectedTick:     sdk.NewInt(85180),
-			zeroForOne:       false,
 			// two positions with same liquidity entered
 			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
 			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
@@ -402,7 +398,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			// sure, the above test only has 1 position while this has two positions, but shouldn't that effect the tokenIn as well?
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(66811697)),
 			expectedTick:     sdk.NewInt(85169),
-			zeroForOne:       true,
 			// two positions with same liquidity entered
 			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
 			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
@@ -438,7 +433,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			// TODO: see why we don't get 9938.148 usdc and 1.80615 eth
 			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(1820536)),
 			expectedTick:     sdk.NewInt(87173),
-			zeroForOne:       false,
 			newLowerPrice:    sdk.NewDec(5501),
 			newUpperPrice:    sdk.NewDec(6250),
 		},

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -1,8 +1,6 @@
 package concentrated_liquidity_test
 
 import (
-	fmt "fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cl "github.com/osmosis-labs/osmosis/v12/x/concentrated-liquidity"
@@ -170,7 +168,7 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 			// add positions
 			test.addPositions(s.Ctx, pool.Id)
 
-			tokenIn, tokenOut, updatedTick, updatedLiquidity, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(
+			tokenIn, tokenOut, updatedTick, updatedLiquidity, _, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(
 				s.Ctx,
 				test.tokenIn, test.tokenOutDenom,
 				swapFee, test.priceLimit, pool.Id)
@@ -296,38 +294,210 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 // }
 
 func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
-	ctx := s.Ctx
-	pool, err := s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, 1, "eth", "usdc", sdk.MustNewDecFromStr("70.710678"), sdk.NewInt(85176))
+	currPrice := sdk.NewDec(5000)
+	currSqrtPrice, err := currPrice.ApproxSqrt() // 70.710678118654752440
 	s.Require().NoError(err)
-	fmt.Printf("%v pool liq pre \n", pool.Liquidity)
-	lowerTick := int64(84222)
-	upperTick := int64(86129)
-	amount0Desired := sdk.NewInt(1)
-	amount1Desired := sdk.NewInt(5000)
+	currTick := cl.PriceToTick(currPrice) // 85176
+	lowerPrice := sdk.NewDec(4545)
+	s.Require().NoError(err)
+	lowerTick := cl.PriceToTick(lowerPrice) // 84222
+	upperPrice := sdk.NewDec(5500)
+	s.Require().NoError(err)
+	upperTick := cl.PriceToTick(upperPrice) // 86129
 
-	s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, pool.Id, s.TestAccs[0], amount0Desired, amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick, upperTick)
-	pool = s.App.ConcentratedLiquidityKeeper.GetPoolbyId(ctx, pool.Id)
-	fmt.Printf("%v pool liq post 1 \n", pool.Liquidity)
+	defaultAmt0 := sdk.NewInt(1000000)
+	defaultAmt1 := sdk.NewInt(5000000000)
 
-	// tokenIn := sdk.NewCoin("eth", sdk.NewInt(133700))
-	// tokenOutDenom := "usdc"
-	// swapFee := sdk.NewDec(0)
-	// minPrice := sdk.NewDec(4500)
-	// maxPrice := sdk.NewDec(5500)
+	swapFee := sdk.ZeroDec()
 
-	// this is a test case for swapping within the tick
-	// amountIn, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, minPrice, maxPrice, pool.Id)
-	// s.Require().NoError(err)
-	// fmt.Printf("%v amountIn \n", amountIn)
-	// pool = s.App.ConcentratedLiquidityKeeper.GetPoolbyId(ctx, pool.Id)
+	tests := map[string]struct {
+		positionAmount0  sdk.Int
+		positionAmount1  sdk.Int
+		addPositions     func(ctx sdk.Context, poolId uint64)
+		tokenIn          sdk.Coin
+		tokenOutDenom    string
+		priceLimit       sdk.Dec
+		expectedTokenOut sdk.Coin
+		expectedTick     sdk.Int
+		zeroForOne       bool
+		newLowerPrice    sdk.Dec
+		newUpperPrice    sdk.Dec
+		poolLiqAmount0   sdk.Int
+		poolLiqAmount1   sdk.Int
+	}{
+		//  One price range
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		"single position within one tick: usdc -> eth": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(5004),
+			// we expect to put 42 usdc in and in return get .008398 eth back
+			// due to limited liquidity, we actually put in 41.99 usdc and in return get .008396 eth back
+			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8396)),
+			expectedTick:     sdk.NewInt(85184),
+			zeroForOne:       false,
+		},
+		"single position within one tick: eth -> usdc": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
+			tokenOutDenom: "usdc",
+			priceLimit:    sdk.NewDec(4993),
+			// we expect to put .01337 eth in and in return get 66.79 usdc back
+			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(66790908)),
+			expectedTick:     sdk.NewInt(85163),
+			zeroForOne:       true,
+		},
+		//  Two equal price ranges
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		//  4545 -----|----- 5500
+		"two positions within one tick: usdc -> eth": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
 
-	// // calculation for this is tested in TestCalcOutAmtGivenInt
-	// s.Require().Equal(sdk.NewInt(666975610), amountIn.Amount)
+				// add second position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[1], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(5002),
+			// we expect to put 42 usdc in and in return get .008398 eth back
+			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8398)),
+			expectedTick:     sdk.NewInt(85180),
+			zeroForOne:       false,
+			// two positions with same liquidity entered
+			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
+			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
+		},
+		"two positions within one tick: eth -> usdc": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
 
-	// s.Require().Equal(sdk.MustNewDecFromStr("1517.818895638265328110"), pool.Liquidity)
-	// // curr sqrt price and tick remains the same
-	// s.Require().Equal(sdk.MustNewDecFromStr("70.710678000000000000"), pool.CurrentSqrtPrice)
-	// s.Require().Equal(sdk.NewInt(85176), pool.CurrentTick)
+				// add second position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[1], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
+			tokenOutDenom: "usdc",
+			priceLimit:    sdk.NewDec(4996),
+			// we expect to put .01337 eth in and in return get 66.79 eth back
+			// TODO: look into why we are returning 66.81 instead of 66.79 like the inverse of this test above
+			// sure, the above test only has 1 position while this has two positions, but shouldn't that effect the tokenIn as well?
+			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(66811697)),
+			expectedTick:     sdk.NewInt(85169),
+			zeroForOne:       true,
+			// two positions with same liquidity entered
+			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
+			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
+		},
+		//  Consecutive price ranges
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		//             5500 ----------- 6250
+		//
+		"two positions with consecutive price ranges": {
+			addPositions: func(ctx sdk.Context, poolId uint64) {
+				// add first position
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[0], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), lowerTick.Int64(), upperTick.Int64())
+				s.Require().NoError(err)
+
+				// create second position parameters
+				newLowerPrice := sdk.NewDec(5501)
+				s.Require().NoError(err)
+				newLowerTick := cl.PriceToTick(newLowerPrice) // 84222
+				newUpperPrice := sdk.NewDec(6250)
+				s.Require().NoError(err)
+				newUpperTick := cl.PriceToTick(newUpperPrice) // 87407
+
+				// add position two with the new price range above
+				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(ctx, poolId, s.TestAccs[2], defaultAmt0, defaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
+				s.Require().NoError(err)
+			},
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(6106),
+			// we expect to put 10000 usdc in and in return get 1.820536 eth back
+			// TODO: see why we don't get 9938.148 usdc and 1.80615 eth
+			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(1820536)),
+			expectedTick:     sdk.NewInt(87173),
+			zeroForOne:       false,
+			newLowerPrice:    sdk.NewDec(5501),
+			newUpperPrice:    sdk.NewDec(6250),
+		},
+	}
+
+	for name, test := range tests {
+		s.Run(name, func() {
+			s.Setup()
+			// create pool
+			pool, err := s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(s.Ctx, 1, "eth", "usdc", currSqrtPrice, currTick)
+			s.Require().NoError(err)
+
+			// add positions
+			test.addPositions(s.Ctx, pool.Id)
+
+			// execute internal swap function
+			tokenOut, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
+				s.Ctx,
+				test.tokenIn, test.tokenOutDenom,
+				swapFee, test.priceLimit, pool.Id)
+			s.Require().NoError(err)
+
+			pool = s.App.ConcentratedLiquidityKeeper.GetPoolbyId(s.Ctx, pool.Id)
+			s.Require().NoError(err)
+
+			// check that we produced the same token out from the swap function that we expected
+			s.Require().Equal(test.expectedTokenOut.String(), tokenOut.String())
+
+			// check that the pool's current tick was updated correctly
+			s.Require().Equal(test.expectedTick.String(), pool.CurrentTick.String())
+
+			// the following is needed to get the expected liquidity to later compare to what the pool was updated to
+			if test.newLowerPrice.IsNil() && test.newUpperPrice.IsNil() {
+				test.newLowerPrice = lowerPrice
+				test.newUpperPrice = upperPrice
+			}
+
+			newLowerTick := cl.PriceToTick(test.newLowerPrice)
+			newUpperTick := cl.PriceToTick(test.newUpperPrice)
+
+			lowerSqrtPrice, err := s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(newLowerTick)
+			s.Require().NoError(err)
+			upperSqrtPrice, err := s.App.ConcentratedLiquidityKeeper.TickToSqrtPrice(newUpperTick)
+			s.Require().NoError(err)
+
+			if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
+				test.poolLiqAmount0 = defaultAmt0
+				test.poolLiqAmount1 = defaultAmt1
+			}
+
+			expectedLiquidity := cl.GetLiquidityFromAmounts(currSqrtPrice, lowerSqrtPrice, upperSqrtPrice, test.poolLiqAmount0, test.poolLiqAmount1)
+			// check that the pools liquidity was updated correctly
+			s.Require().Equal(expectedLiquidity.TruncateInt(), pool.Liquidity.TruncateInt())
+
+			// TODO: need to figure out a good way to test that the currentSqrtPrice that the pool is set to makes sense
+			// right now we calculate this value through iterations, so unsure how to do this here / if its needed
+		})
+
+	}
 }
 
 func (s *KeeperTestSuite) TestOrderInitialPoolDenoms() {

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -53,7 +53,7 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn() {
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(5004),
 			// we expect to put 42 usdc in and in return get .008398 eth back
-			// due to limited liquidity, we actually put in 41.99 usdc and in return get .008396 eth back
+			// due to truncations and precision loss, we actually put in 41.99 usdc and in return get .008396 eth back
 			expectedTokenIn:  sdk.NewCoin("usdc", sdk.NewInt(41999999)),
 			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8396)),
 			expectedTick:     sdk.NewInt(85184),
@@ -338,7 +338,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(5004),
 			// we expect to put 42 usdc in and in return get .008398 eth back
-			// due to limited liquidity, we actually put in 41.99 usdc and in return get .008396 eth back
+			// due to truncations and precision loss, we actually put in 41.99 usdc and in return get .008396 eth back
 			expectedTokenOut: sdk.NewCoin("eth", sdk.NewInt(8396)),
 			expectedTick:     sdk.NewInt(85184),
 		},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Adds initial SwapOutGivenIn logic. The respective test essentially check if applySwap was done on the pool, ensuring that the pool state was actually changed.

Since SwapOutGivenIn is an internal method (used in conjunction with SwapExactAmountIn), no funds are actually sent between the pool and the user. That will come next.
