### PR TITLE
feat(ci/e2e): create a CI job to test e2e related makefile steps on merge to main

### DIFF
--- a/.github/workflows/test-e2e-makefile.yml
+++ b/.github/workflows/test-e2e-makefile.yml
@@ -55,5 +55,16 @@ jobs:
         name: Build e2e init chain image
         run: make docker-build-e2e-init-chain
       -
+        name: Build e2e image
+        uses: docker/build-push-action@v3
+        with:
+          load: true
+          context: .
+          tags: osmosis:debug
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BASE_IMG_TAG=debug
+      -
         name: Test e2e short
         run: make test-e2e-short

--- a/.github/workflows/test-e2e-makefile.yml
+++ b/.github/workflows/test-e2e-makefile.yml
@@ -1,0 +1,59 @@
+name: Test-E2E-Makefile
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "main"
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      -
+        name: Setup Go
+        uses: actions/setup-go@v2.2.0
+        with:
+          go-version: 1.18
+      -
+        name: Check out repository code
+        uses: actions/checkout@v2
+      -
+        name: Get git diff
+        uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
+      -
+        name: Get data from build cache
+        uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build e2e init chain image
+        run: make docker-build-e2e-init-chain
+      -
+        name: Test e2e short
+        run: make test-e2e-short


### PR DESCRIPTION
Closes: #3208 

## What is the purpose of the change

> Create a CI job to test e2e related makefile steps on merge to main

## Brief Changelog

  - *Run make docker-build-e2e-init-chain on merge to main*
  - *Run make test-e2e-short on merge to main*
