### PR TITLE
Properly fix lints

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.65.0
           override: true
           components: rustfmt, clippy
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/lib.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 // Contract
 pub mod contract;
 mod error;


### PR DESCRIPTION

## What is the purpose of the change

Cosmwasm lints periodically fail due to rust versions being updated too often. Pinning the rust version to 1.65.0 and we can update it manually later. 

## Brief Changelog

 * Add an allow directive to ignore an unnecessary lint
 * Ping rust version on the workflow to 1.65.0

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)