### PR TITLE
Fix Spot Price

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -48,6 +48,7 @@ func (s *KeeperTestHelper) PrepareBalancerPool() uint64 {
 		ExitFee: sdk.NewDec(0),
 	})
 
+	// note to reviewers: please double check if these are correct
 	spotPrice, err := s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, "foo", "bar")
 	s.NoError(err)
 	s.Equal(sdk.NewDec(2).String(), spotPrice.String())

--- a/proto/osmosis/twap/v1beta1/twap_record.proto
+++ b/proto/osmosis/twap/v1beta1/twap_record.proto
@@ -37,20 +37,20 @@ message TwapRecord {
 
   // We store the last spot prices in the struct, so that we can interpolate
   // accumulator values for times between when accumulator records are stored.
-  string p0_last_spot_price = 6 [
+  string p1_last_spot_price = 6 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable) = false
   ];
-  string p1_last_spot_price = 7 [
+  string p0_last_spot_price = 7 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable) = false
   ];
 
-  string p0_arithmetic_twap_accumulator = 8 [
+  string p1_arithmetic_twap_accumulator = 8 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable) = false
   ];
-  string p1_arithmetic_twap_accumulator = 9 [
+  string p0_arithmetic_twap_accumulator = 9 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable) = false
   ];

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -357,9 +357,9 @@ func (s *IntegrationTestSuite) TestTWAP() {
 	// Because we traded the same amount of all three assets, we expect the asset with the greatest
 	// initial value (B, or uion) to have a largest negative price impact,
 	// to the benefit (positive price impact) of the other two assets (A&C, or stake and uosmo)
-	s.Require().True(twapFromBeforeSwapToAfterSwapAB.GT(twapFromBeforeSwapToBeforeSwapOneAB))
-	s.Require().True(twapFromBeforeSwapToAfterSwapBC.LT(twapFromBeforeSwapToBeforeSwapOneBC))
-	s.Require().True(twapFromBeforeSwapToAfterSwapCA.GT(twapFromBeforeSwapToBeforeSwapOneCA))
+	s.Require().True(twapFromBeforeSwapToAfterSwapAB.LT(twapFromBeforeSwapToBeforeSwapOneAB))
+	s.Require().True(twapFromBeforeSwapToAfterSwapBC.GT(twapFromBeforeSwapToBeforeSwapOneBC))
+	s.Require().True(twapFromBeforeSwapToAfterSwapCA.LT(twapFromBeforeSwapToBeforeSwapOneCA))
 
 	s.T().Log("querying for the TWAP from after swap to now")
 	twapFromAfterToNowAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeAfterSwap)
@@ -370,9 +370,9 @@ func (s *IntegrationTestSuite) TestTWAP() {
 	s.Require().NoError(err)
 	// Because twapFromAfterToNow has a higher time weight for the after swap period,
 	// we expect the results to be flipped from the previous comparison to twapFromBeforeSwapToBeforeSwapOne
-	s.Require().True(twapFromBeforeSwapToAfterSwapAB.LT(twapFromAfterToNowAB))
-	s.Require().True(twapFromBeforeSwapToAfterSwapBC.GT(twapFromAfterToNowBC))
-	s.Require().True(twapFromBeforeSwapToAfterSwapCA.LT(twapFromAfterToNowCA))
+	s.Require().True(twapFromBeforeSwapToAfterSwapAB.GT(twapFromAfterToNowAB))
+	s.Require().True(twapFromBeforeSwapToAfterSwapBC.LT(twapFromAfterToNowBC))
+	s.Require().True(twapFromBeforeSwapToAfterSwapCA.GT(twapFromAfterToNowCA))
 
 	s.T().Log("querying for the TWAP from after swap to after swap + 10ms")
 	twapAfterSwapBeforePruning10MsAB, err := chainANode.QueryArithmeticTwap(poolId, denomA, denomB, timeAfterSwap, timeAfterSwap.Add(10*time.Millisecond))
@@ -383,9 +383,9 @@ func (s *IntegrationTestSuite) TestTWAP() {
 	s.Require().NoError(err)
 	// Again, because twapAfterSwapBeforePruning10Ms has a higher time weight for the after swap period between the two,
 	// we expect no change in the inequality
-	s.Require().True(twapFromBeforeSwapToAfterSwapAB.LT(twapAfterSwapBeforePruning10MsAB))
-	s.Require().True(twapFromBeforeSwapToAfterSwapBC.GT(twapAfterSwapBeforePruning10MsBC))
-	s.Require().True(twapFromBeforeSwapToAfterSwapCA.LT(twapAfterSwapBeforePruning10MsCA))
+	s.Require().True(twapFromBeforeSwapToAfterSwapAB.GT(twapAfterSwapBeforePruning10MsAB))
+	s.Require().True(twapFromBeforeSwapToAfterSwapBC.LT(twapAfterSwapBeforePruning10MsBC))
+	s.Require().True(twapFromBeforeSwapToAfterSwapCA.GT(twapAfterSwapBeforePruning10MsCA))
 
 	// These must be equal because they are calculated over time ranges with the stable and equal spot price.
 	// There are potential rounding errors requiring us to approximate the comparison.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -345,11 +345,11 @@ func (s *IntegrationTestSuite) TestTWAP() {
 	// TWAP "from before to after swap" should be different from "from before to before swap"
 	// because swap introduces a new record with a different spot price.
 	s.T().Log("querying for the TWAP from before swap to now after swap")
-	twapFromBeforeSwapToAfterSwapAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap)
+	twapFromBeforeSwapToAfterSwapAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomA, timeBeforeSwap)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToAfterSwapBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomC, timeBeforeSwap)
+	twapFromBeforeSwapToAfterSwapBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomB, timeBeforeSwap)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToAfterSwapCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap)
+	twapFromBeforeSwapToAfterSwapCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomC, timeBeforeSwap)
 	s.Require().NoError(err)
 	// We had a swap of 2000000stake for some amount of uion,
 	// 2000000uion for some amount of uosmo, and

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -345,11 +345,11 @@ func (s *IntegrationTestSuite) TestTWAP() {
 	// TWAP "from before to after swap" should be different from "from before to before swap"
 	// because swap introduces a new record with a different spot price.
 	s.T().Log("querying for the TWAP from before swap to now after swap")
-	twapFromBeforeSwapToAfterSwapAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomA, timeBeforeSwap)
+	twapFromBeforeSwapToAfterSwapAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToAfterSwapBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomB, timeBeforeSwap)
+	twapFromBeforeSwapToAfterSwapBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomC, timeBeforeSwap)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToAfterSwapCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomC, timeBeforeSwap)
+	twapFromBeforeSwapToAfterSwapCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap)
 	s.Require().NoError(err)
 	// We had a swap of 2000000stake for some amount of uion,
 	// 2000000uion for some amount of uosmo, and

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -23,8 +23,8 @@ import (
 func (k Keeper) CalculateSpotPrice(
 	ctx sdk.Context,
 	poolID uint64,
-	baseAssetDenom string,
 	quoteAssetDenom string,
+	baseAssetDenom string,
 ) (spotPrice sdk.Dec, err error) {
 	pool, err := k.GetPoolAndPoke(ctx, poolID)
 	if err != nil {
@@ -39,7 +39,7 @@ func (k Keeper) CalculateSpotPrice(
 		}
 	}()
 
-	spotPrice, err = pool.SpotPrice(ctx, baseAssetDenom, quoteAssetDenom)
+	spotPrice, err = pool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
 		return sdk.Dec{}, err
 	}

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -625,10 +625,12 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPric
 		return sdk.Dec{}, errors.New("pool is misconfigured, got 0 weight")
 	}
 
-	// spot_price = (Base_supply / Weight_base) / (Quote_supply / Weight_quote)
-	// spot_price = (weight_quote / weight_base) * (base_supply / quote_supply)
+	// spot_price = (Quote_supply / Weight_quote) / (base_supply / Weight_base)
+	// spot_price = (weight_base / weight_quote) * (quote_supply / base_supply)
 	invWeightRatio := base.Weight.ToDec().Quo(quote.Weight.ToDec())
 	supplyRatio := quote.Token.Amount.ToDec().Quo(base.Token.Amount.ToDec())
+	fmt.Println("invWeightRatio", invWeightRatio)
+	fmt.Println("supplyRatio", supplyRatio)
 	spotPrice = supplyRatio.Mul(invWeightRatio)
 
 	return spotPrice, err

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -629,8 +629,6 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPric
 	// spot_price = (weight_base / weight_quote) * (quote_supply / base_supply)
 	invWeightRatio := base.Weight.ToDec().Quo(quote.Weight.ToDec())
 	supplyRatio := quote.Token.Amount.ToDec().Quo(base.Token.Amount.ToDec())
-	fmt.Println("invWeightRatio", invWeightRatio)
-	fmt.Println("supplyRatio", supplyRatio)
 	spotPrice = supplyRatio.Mul(invWeightRatio)
 
 	return spotPrice, err

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -616,7 +616,7 @@ func (p *Pool) applySwap(ctx sdk.Context, tokensIn sdk.Coins, tokensOut sdk.Coin
 //
 // panics if the pool in state is incorrect, and has any weight that is 0.
 // TODO: Come back and improve docs for this.
-func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (spotPrice sdk.Dec, err error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPrice sdk.Dec, err error) {
 	quote, base, err := p.parsePoolAssetsByDenoms(quoteAsset, baseAsset)
 	if err != nil {
 		return sdk.Dec{}, err
@@ -627,8 +627,8 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAsset, quoteAsset string) (spotPric
 
 	// spot_price = (Base_supply / Weight_base) / (Quote_supply / Weight_quote)
 	// spot_price = (weight_quote / weight_base) * (base_supply / quote_supply)
-	invWeightRatio := quote.Weight.ToDec().Quo(base.Weight.ToDec())
-	supplyRatio := base.Token.Amount.ToDec().Quo(quote.Token.Amount.ToDec())
+	invWeightRatio := base.Weight.ToDec().Quo(quote.Weight.ToDec())
+	supplyRatio := quote.Token.Amount.ToDec().Quo(base.Token.Amount.ToDec())
 	spotPrice = supplyRatio.Mul(invWeightRatio)
 
 	return spotPrice, err

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -644,36 +644,36 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 200),
 			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("0.500000000000000000"),
-		},
-		{
-			name:                "2:1 ratio",
-			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
-			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
-			expectError:         false,
 			expectedOutput:      sdk.MustNewDecFromStr("2.000000000000000000"),
 		},
-		{
-			name:                "rounding after sigfig ratio",
-			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
-			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
-			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
-		},
-		{
-			name:                "check number of sig figs",
-			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
-			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
-			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("0.333333330000000000"),
-		},
-		{
-			name:                "check number of sig figs high sizes",
-			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
-			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
-			expectError:         false,
-			expectedOutput:      sdk.MustNewDecFromStr("0.000000000001840877"),
-		},
+		// {
+		// 	name:                "2:1 ratio",
+		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
+		// 	quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
+		// 	expectError:         false,
+		// 	expectedOutput:      sdk.MustNewDecFromStr("2.000000000000000000"),
+		// },
+		// {
+		// 	name:                "rounding after sigfig ratio",
+		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
+		// 	quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
+		// 	expectError:         false,
+		// 	expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
+		// },
+		// {
+		// 	name:                "check number of sig figs",
+		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
+		// 	quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
+		// 	expectError:         false,
+		// 	expectedOutput:      sdk.MustNewDecFromStr("0.333333330000000000"),
+		// },
+		// {
+		// 	name:                "check number of sig figs high sizes",
+		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
+		// 	quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
+		// 	expectError:         false,
+		// 	expectedOutput:      sdk.MustNewDecFromStr("0.000000000001840877"),
+		// },
 	}
 
 	for _, tc := range tests {
@@ -688,7 +688,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 
 			sut := func() {
 				spotPrice, err := suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx,
-					poolId, tc.baseDenomPoolInput.Denom, tc.quoteDenomPoolInput.Denom)
+					poolId, tc.quoteDenomPoolInput.Denom, tc.baseDenomPoolInput.Denom)
 
 				if tc.expectError {
 					suite.Require().Error(err, "test: %s", tc.name)

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -644,36 +644,36 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 200),
 			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("0.500000000000000000"),
+		},
+		{
+			name:                "2:1 ratio",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
+			expectError:         false,
 			expectedOutput:      sdk.MustNewDecFromStr("2.000000000000000000"),
 		},
-		// {
-		// 	name:                "2:1 ratio",
-		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
-		// 	quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
-		// 	expectError:         false,
-		// 	expectedOutput:      sdk.MustNewDecFromStr("2.000000000000000000"),
-		// },
-		// {
-		// 	name:                "rounding after sigfig ratio",
-		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
-		// 	quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
-		// 	expectError:         false,
-		// 	expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
-		// },
-		// {
-		// 	name:                "check number of sig figs",
-		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
-		// 	quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
-		// 	expectError:         false,
-		// 	expectedOutput:      sdk.MustNewDecFromStr("0.333333330000000000"),
-		// },
-		// {
-		// 	name:                "check number of sig figs high sizes",
-		// 	baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
-		// 	quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
-		// 	expectError:         false,
-		// 	expectedOutput:      sdk.MustNewDecFromStr("0.000000000001840877"),
-		// },
+		{
+			name:                "rounding after sigfig ratio",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
+		},
+		{
+			name:                "check number of sig figs",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
+			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("0.333333330000000000"),
+		},
+		{
+			name:                "check number of sig figs high sizes",
+			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
+			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, sdk.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
+			expectError:         false,
+			expectedOutput:      sdk.MustNewDecFromStr("0.000000000001840877"),
+		},
 	}
 
 	for _, tc := range tests {
@@ -688,7 +688,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPrice() {
 
 			sut := func() {
 				spotPrice, err := suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx,
-					poolId, tc.quoteDenomPoolInput.Denom, tc.baseDenomPoolInput.Denom)
+					poolId, tc.baseDenomPoolInput.Denom, tc.quoteDenomPoolInput.Denom)
 
 				if tc.expectError {
 					suite.Require().Error(err, "test: %s", tc.name)

--- a/x/gamm/types/pool.go
+++ b/x/gamm/types/pool.go
@@ -50,7 +50,7 @@ type PoolI interface {
 	// errors if either baseAssetDenom, or quoteAssetDenom does not exist.
 	// For example, if this was a UniV2 50-50 pool, with 2 ETH, and 8000 UST
 	// pool.SpotPrice(ctx, "eth", "ust") = 4000.00
-	SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (sdk.Dec, error)
+	SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (sdk.Dec, error)
 
 	// JoinPool joins the pool using all of the tokensIn provided.
 	// The AMM swaps to the correct internal ratio should be and returns the number of shares created.

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -164,7 +164,7 @@ func (s *TestSuite) TestEndBlock() {
 			}
 
 			// check if spot price has been correctly updated in twap record
-			asset0sp, err := s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, twapAfterBlock1.Asset0Denom, twapAfterBlock1.Asset1Denom)
+			asset0sp, err := s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, twapAfterBlock1.Asset1Denom, twapAfterBlock1.Asset0Denom)
 			s.Require().NoError(err)
 			s.Require().Equal(asset0sp, twapAfterBlock1.P0LastSpotPrice)
 
@@ -192,7 +192,7 @@ func (s *TestSuite) TestEndBlock() {
 			}
 
 			// check if spot price has been correctly updated in twap record
-			asset0sp, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, twapAfterBlock1.Asset0Denom, twapAfterBlock2.Asset1Denom)
+			asset0sp, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, twapAfterBlock2.Asset1Denom, twapAfterBlock1.Asset0Denom)
 			s.Require().NoError(err)
 			s.Require().Equal(asset0sp, twapAfterBlock2.P0LastSpotPrice)
 		})

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -44,8 +44,8 @@ func getSpotPrices(
 	previousErrorTime time.Time,
 ) (sp0 sdk.Dec, sp1 sdk.Dec, latestErrTime time.Time) {
 	latestErrTime = previousErrorTime
-	sp0, err0 := k.CalculateSpotPrice(ctx, poolId, denom0, denom1)
-	sp1, err1 := k.CalculateSpotPrice(ctx, poolId, denom1, denom0)
+	sp0, err0 := k.CalculateSpotPrice(ctx, poolId, denom1, denom0)
+	sp1, err1 := k.CalculateSpotPrice(ctx, poolId, denom0, denom1)
 	if err0 != nil || err1 != nil {
 		latestErrTime = ctx.BlockTime()
 		// In the event of an error, we just sanity replace empty values with zero values

--- a/x/twap/types/expected_interfaces.go
+++ b/x/twap/types/expected_interfaces.go
@@ -12,7 +12,7 @@ type AmmInterface interface {
 	CalculateSpotPrice(
 		ctx sdk.Context,
 		poolID uint64,
-		baseAssetDenom string,
 		quoteAssetDenom string,
+		baseAssetDenom string,
 	) (price sdk.Dec, err error)
 }

--- a/x/twap/types/twap_record.pb.go
+++ b/x/twap/types/twap_record.pb.go
@@ -51,10 +51,10 @@ type TwapRecord struct {
 	Time time.Time `protobuf:"bytes,5,opt,name=time,proto3,stdtime" json:"time" yaml:"record_time"`
 	// We store the last spot prices in the struct, so that we can interpolate
 	// accumulator values for times between when accumulator records are stored.
-	P0LastSpotPrice             github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,6,opt,name=p0_last_spot_price,json=p0LastSpotPrice,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p0_last_spot_price"`
-	P1LastSpotPrice             github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,7,opt,name=p1_last_spot_price,json=p1LastSpotPrice,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p1_last_spot_price"`
-	P0ArithmeticTwapAccumulator github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,8,opt,name=p0_arithmetic_twap_accumulator,json=p0ArithmeticTwapAccumulator,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p0_arithmetic_twap_accumulator"`
-	P1ArithmeticTwapAccumulator github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,9,opt,name=p1_arithmetic_twap_accumulator,json=p1ArithmeticTwapAccumulator,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p1_arithmetic_twap_accumulator"`
+	P1LastSpotPrice             github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,6,opt,name=p1_last_spot_price,json=p1LastSpotPrice,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p1_last_spot_price"`
+	P0LastSpotPrice             github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,7,opt,name=p0_last_spot_price,json=p0LastSpotPrice,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p0_last_spot_price"`
+	P1ArithmeticTwapAccumulator github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,8,opt,name=p1_arithmetic_twap_accumulator,json=p1ArithmeticTwapAccumulator,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p1_arithmetic_twap_accumulator"`
+	P0ArithmeticTwapAccumulator github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,9,opt,name=p0_arithmetic_twap_accumulator,json=p0ArithmeticTwapAccumulator,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"p0_arithmetic_twap_accumulator"`
 	// This field contains the time in which the last spot price error occured.
 	// It is used to alert the caller if they are getting a potentially erroneous
 	// TWAP, due to an unforeseen underlying error.
@@ -165,20 +165,20 @@ var fileDescriptor_dbf5c78678e601aa = []byte{
 	0xa8, 0x02, 0x37, 0x8d, 0xdb, 0x9d, 0xa1, 0xaa, 0x7c, 0xe9, 0xad, 0xb9, 0xbd, 0x58, 0x27, 0x5a,
 	0xef, 0x40, 0x5b, 0xcc, 0x60, 0xdf, 0xef, 0x1b, 0x83, 0xce, 0x71, 0xcf, 0x57, 0x03, 0xfa, 0xcb,
 	0x01, 0xfd, 0xd3, 0xe5, 0x80, 0x23, 0xe7, 0xaa, 0x71, 0x5b, 0x37, 0x8d, 0x6b, 0xad, 0xf1, 0x44,
-	0xb2, 0x77, 0xf9, 0xc3, 0x35, 0x62, 0xc9, 0xb1, 0x3e, 0x01, 0x8b, 0x86, 0xb0, 0x44, 0x8c, 0x43,
+	0xb2, 0x77, 0xf9, 0xc3, 0x35, 0x62, 0xc9, 0xb1, 0x3e, 0x01, 0x8b, 0x46, 0xb0, 0x44, 0x8c, 0x43,
 	0x46, 0x09, 0x87, 0xb4, 0x2e, 0x52, 0x6c, 0x9b, 0xa2, 0xf7, 0x91, 0x2f, 0x08, 0xdf, 0x1b, 0xf7,
 	0x30, 0x2f, 0xf8, 0x78, 0x9a, 0xf8, 0x29, 0xa9, 0xf4, 0xf1, 0xeb, 0xc7, 0x11, 0xcb, 0x3e, 0x07,
-	0x7c, 0x46, 0x31, 0xf3, 0x4f, 0x70, 0x1a, 0x1f, 0xd0, 0xf0, 0x2d, 0x62, 0xfc, 0x03, 0x25, 0xfc,
-	0xbd, 0xc0, 0x48, 0x78, 0xf4, 0x17, 0x7c, 0x77, 0x4b, 0x78, 0xb4, 0x0e, 0x67, 0xc0, 0xa1, 0x21,
+	0x7c, 0x46, 0x31, 0xf3, 0x4f, 0x70, 0x1a, 0x1f, 0xd0, 0xe8, 0x2d, 0x62, 0xfc, 0x03, 0x25, 0xfc,
+	0xbd, 0xc0, 0x48, 0x78, 0xf8, 0x17, 0x7c, 0x77, 0x4b, 0x78, 0xb8, 0x0e, 0x67, 0xc0, 0xa1, 0x11,
 	0x44, 0x75, 0xc1, 0xc7, 0x15, 0xe6, 0x45, 0x0a, 0xe5, 0x05, 0x44, 0x69, 0x3a, 0xad, 0xa6, 0x25,
-	0xe2, 0xa4, 0xb6, 0x1f, 0x6c, 0x55, 0xe8, 0x29, 0x0d, 0x87, 0x2b, 0xa8, 0xb8, 0x1b, 0xc3, 0x3f,
-	0x48, 0x59, 0x34, 0xfa, 0x6f, 0xd1, 0xbd, 0x2d, 0x8b, 0x46, 0xff, 0x2e, 0x7a, 0x06, 0x0e, 0xe4,
+	0xe2, 0xa4, 0xb6, 0x1f, 0x6c, 0x55, 0xe8, 0x29, 0x8d, 0x86, 0x2b, 0xa8, 0xb8, 0x1b, 0xc3, 0x3f,
+	0x48, 0x59, 0x34, 0xfc, 0x6f, 0xd1, 0xbd, 0x2d, 0x8b, 0x86, 0xff, 0x2e, 0x7a, 0x06, 0x0e, 0xe4,
 	0x19, 0xe2, 0xba, 0x26, 0xb5, 0xdc, 0xa0, 0xdd, 0xb9, 0x73, 0xfd, 0x9e, 0x5e, 0xff, 0x23, 0xb5,
 	0xfe, 0x0d, 0x80, 0xba, 0x02, 0xfb, 0xc2, 0xfb, 0x4a, 0x38, 0x45, 0xde, 0xe8, 0xcd, 0xd5, 0xdc,
 	0x31, 0xae, 0xe7, 0x8e, 0xf1, 0x73, 0xee, 0x18, 0x97, 0x0b, 0xa7, 0x75, 0xbd, 0x70, 0x5a, 0xdf,
 	0x16, 0x4e, 0xeb, 0x63, 0x78, 0x6b, 0x0c, 0xfd, 0x51, 0x1f, 0x95, 0x28, 0x61, 0x4b, 0x23, 0x38,
 	0x8f, 0x8e, 0x83, 0x2f, 0xea, 0x7f, 0x20, 0x87, 0x4a, 0x4c, 0xd9, 0xd2, 0x8b, 0xdf, 0x01, 0x00,
-	0x00, 0xff, 0xff, 0xdf, 0xff, 0x6c, 0x30, 0x2c, 0x04, 0x00, 0x00,
+	0x00, 0xff, 0xff, 0x6a, 0x8b, 0xe3, 0xd1, 0x2c, 0x04, 0x00, 0x00,
 }
 
 func (m *TwapRecord) Marshal() (dAtA []byte, err error) {
@@ -210,16 +210,6 @@ func (m *TwapRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i--
 	dAtA[i] = 0x5a
 	{
-		size := m.P1ArithmeticTwapAccumulator.Size()
-		i -= size
-		if _, err := m.P1ArithmeticTwapAccumulator.MarshalTo(dAtA[i:]); err != nil {
-			return 0, err
-		}
-		i = encodeVarintTwapRecord(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0x4a
-	{
 		size := m.P0ArithmeticTwapAccumulator.Size()
 		i -= size
 		if _, err := m.P0ArithmeticTwapAccumulator.MarshalTo(dAtA[i:]); err != nil {
@@ -228,11 +218,21 @@ func (m *TwapRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintTwapRecord(dAtA, i, uint64(size))
 	}
 	i--
+	dAtA[i] = 0x4a
+	{
+		size := m.P1ArithmeticTwapAccumulator.Size()
+		i -= size
+		if _, err := m.P1ArithmeticTwapAccumulator.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintTwapRecord(dAtA, i, uint64(size))
+	}
+	i--
 	dAtA[i] = 0x42
 	{
-		size := m.P1LastSpotPrice.Size()
+		size := m.P0LastSpotPrice.Size()
 		i -= size
-		if _, err := m.P1LastSpotPrice.MarshalTo(dAtA[i:]); err != nil {
+		if _, err := m.P0LastSpotPrice.MarshalTo(dAtA[i:]); err != nil {
 			return 0, err
 		}
 		i = encodeVarintTwapRecord(dAtA, i, uint64(size))
@@ -240,9 +240,9 @@ func (m *TwapRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i--
 	dAtA[i] = 0x3a
 	{
-		size := m.P0LastSpotPrice.Size()
+		size := m.P1LastSpotPrice.Size()
 		i -= size
-		if _, err := m.P0LastSpotPrice.MarshalTo(dAtA[i:]); err != nil {
+		if _, err := m.P1LastSpotPrice.MarshalTo(dAtA[i:]); err != nil {
 			return 0, err
 		}
 		i = encodeVarintTwapRecord(dAtA, i, uint64(size))
@@ -317,13 +317,13 @@ func (m *TwapRecord) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Time)
 	n += 1 + l + sovTwapRecord(uint64(l))
-	l = m.P0LastSpotPrice.Size()
-	n += 1 + l + sovTwapRecord(uint64(l))
 	l = m.P1LastSpotPrice.Size()
 	n += 1 + l + sovTwapRecord(uint64(l))
-	l = m.P0ArithmeticTwapAccumulator.Size()
+	l = m.P0LastSpotPrice.Size()
 	n += 1 + l + sovTwapRecord(uint64(l))
 	l = m.P1ArithmeticTwapAccumulator.Size()
+	n += 1 + l + sovTwapRecord(uint64(l))
+	l = m.P0ArithmeticTwapAccumulator.Size()
 	n += 1 + l + sovTwapRecord(uint64(l))
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.LastErrorTime)
 	n += 1 + l + sovTwapRecord(uint64(l))
@@ -502,40 +502,6 @@ func (m *TwapRecord) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field P0LastSpotPrice", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTwapRecord
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthTwapRecord
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthTwapRecord
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.P0LastSpotPrice.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 7:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field P1LastSpotPrice", wireType)
 			}
 			var stringLen uint64
@@ -568,9 +534,9 @@ func (m *TwapRecord) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 8:
+		case 7:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field P0ArithmeticTwapAccumulator", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field P0LastSpotPrice", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -598,11 +564,11 @@ func (m *TwapRecord) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.P0ArithmeticTwapAccumulator.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.P0LastSpotPrice.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
-		case 9:
+		case 8:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field P1ArithmeticTwapAccumulator", wireType)
 			}
@@ -633,6 +599,40 @@ func (m *TwapRecord) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.P1ArithmeticTwapAccumulator.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field P0ArithmeticTwapAccumulator", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTwapRecord
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTwapRecord
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTwapRecord
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.P0ArithmeticTwapAccumulator.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/twap/types/twapmock/amminterface.go
+++ b/x/twap/types/twapmock/amminterface.go
@@ -71,8 +71,8 @@ func (p *ProgrammedAmmInterface) GetPoolDenoms(ctx sdk.Context, poolId uint64) (
 
 func (p *ProgrammedAmmInterface) CalculateSpotPrice(ctx sdk.Context,
 	poolId uint64,
-	baseDenom,
-	quoteDenom string,
+	quoteDenom,
+	baseDenom string,
 ) (price sdk.Dec, err error) {
 	input := SpotPriceInput{poolId, baseDenom, quoteDenom}
 	if res, ok := p.programmedSpotPrice[input]; ok {

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"github.com/gogo/protobuf/proto"
+
 	"github.com/osmosis-labs/osmosis/v12/x/txfees/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

This PR fixes the current spot price API by switching the orders of the parameters for base asset and quote asset. This is done in both `PoolI` level and the pool model API level.

This PR also addresses the issue for the reversed accumulator stores and spot price store entry in the twap module, and this is done by simply switching the names of each state entry. This allows us to successfully have the correct states with the correct names without having the need to do separate migration for the existing states.


## Brief Changelog
- Fix Spot price to return with correct value given base asset and quote asset

## Testing and Verifying
Existing tests has been fixed if necessary, also added a new integration test case in the twap module.
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)