### PR TITLE
Delete unused binary search

### DIFF
--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -114,42 +114,6 @@ func (e ErrTolerance) CompareBigDecWithRoundingDirection(expected osmomath.BigDe
 	return e.CompareBigDec(expected, actual)
 }
 
-// Binary search inputs between [lowerbound, upperbound] to a monotonic increasing function f.
-// We stop once f(found_input) meets the ErrTolerance constraints.
-// If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.
-func BinarySearch(f func(input sdk.Int) (sdk.Int, error),
-	lowerbound sdk.Int,
-	upperbound sdk.Int,
-	targetOutput sdk.Int,
-	errTolerance ErrTolerance,
-	maxIterations int,
-) (sdk.Int, error) {
-	// Setup base case of loop
-	curEstimate := lowerbound.Add(upperbound).QuoRaw(2)
-	curOutput, err := f(curEstimate)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-	curIteration := 0
-	for ; curIteration < maxIterations; curIteration += 1 {
-		compRes := errTolerance.Compare(curOutput, targetOutput)
-		if compRes > 0 {
-			upperbound = curEstimate
-		} else if compRes < 0 {
-			lowerbound = curEstimate
-		} else {
-			return curEstimate, nil
-		}
-		curEstimate = lowerbound.Add(upperbound).QuoRaw(2)
-		curOutput, err = f(curEstimate)
-		if err != nil {
-			return sdk.Int{}, err
-		}
-	}
-
-	return sdk.Int{}, errors.New("hit maximum iterations, did not converge fast enough")
-}
-
 // SdkDec
 type SdkDec[D any] interface {
 	Add(SdkDec[D]) SdkDec[D]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Deletes deadcode for a binary search over sdk.Int, if we want this in the future we should do it via a generic.