### PR TITLE
move rounding direction into error tolerance

### DIFF
--- a/osmomath/rounding_direction.go
+++ b/osmomath/rounding_direction.go
@@ -10,9 +10,10 @@ import (
 type RoundingDirection int
 
 const (
-	RoundUp      RoundingDirection = 1
-	RoundDown    RoundingDirection = 2
-	RoundBankers RoundingDirection = 3
+	RoundUnconstrained RoundingDirection = 0
+	RoundUp            RoundingDirection = 1
+	RoundDown          RoundingDirection = 2
+	RoundBankers       RoundingDirection = 3
 )
 
 func DivIntByU64ToBigDec(i sdk.Int, u uint64, round RoundingDirection) (BigDec, error) {

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -18,6 +18,7 @@ import (
 type ErrTolerance struct {
 	AdditiveTolerance       sdk.Int
 	MultiplicativeTolerance sdk.Dec
+	RoundingDir             osmomath.RoundingDirection
 }
 
 // Compare returns if actual is within errTolerance of expected.
@@ -72,6 +73,20 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 		comparisonSign = -1
 	}
 
+	// Ensure that even if expected is within tolerance of actual, we don't count it as equal if its in the wrong direction.
+	// so if were supposed to round down, it must be that `expected >= actual`.
+	// likewise if were supposed to round up, it must be that `expected <= actual`.
+	// If neither of the above, then rounding direction does not enforce a constraint.
+	if e.RoundingDir == osmomath.RoundDown {
+		if expected.LT(actual) {
+			return -1
+		}
+	} else if e.RoundingDir == osmomath.RoundUp {
+		if expected.GT(actual) {
+			return 1
+		}
+	}
+
 	// Check additive tolerance equations
 	if !e.AdditiveTolerance.IsNil() {
 		// if no error accepted, do a direct compare.
@@ -94,24 +109,6 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 	}
 
 	return 0
-}
-
-// Compares big decimal's, using the error tolerance for defining equality in one direction.
-func (e ErrTolerance) CompareBigDecWithRoundingDirection(expected osmomath.BigDec, actual osmomath.BigDec,
-	dir osmomath.RoundingDirection) int {
-	// Ensure that even if expected is within tolerance of actual, we don't count it as equal if its in the wrong direction.
-	// so if were supposed to round down, it must be that `expected >= actual`.
-	// likewise if were supposed to round up, it must be that `expected <= actual`
-	if dir == osmomath.RoundDown {
-		if expected.LT(actual) {
-			return -1
-		}
-	} else if dir == osmomath.RoundUp {
-		if expected.GT(actual) {
-			return 1
-		}
-	}
-	return e.CompareBigDec(expected, actual)
 }
 
 // Binary search inputs between [lowerbound, upperbound] to a monotonic increasing function f.
@@ -170,7 +167,6 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	upperbound osmomath.BigDec,
 	targetOutput osmomath.BigDec,
 	errTolerance ErrTolerance,
-	roundingDirection osmomath.RoundingDirection,
 	maxIterations int,
 ) (osmomath.BigDec, error) {
 	// Setup base case of loop
@@ -182,7 +178,7 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
 		// fmt.Println(targetOutput, curOutput)
-		compRes := errTolerance.CompareBigDecWithRoundingDirection(targetOutput, curOutput, roundingDirection)
+		compRes := errTolerance.CompareBigDec(targetOutput, curOutput)
 		if compRes < 0 {
 			upperbound = curEstimate
 		} else if compRes > 0 {

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -9,11 +9,18 @@ import (
 )
 
 // ErrTolerance is used to define a compare function, which checks if two
-// ints are within a certain error tolerance of one another.
+// ints are within a certain error tolerance of one another,
+// and (optionally) that they are rounding in the correct direction.
 // ErrTolerance.Compare(a, b) returns true iff:
-// |a - b| <= AdditiveTolerance
-// |a - b| / min(a, b) <= MultiplicativeTolerance
-// Each check is respectively ignored if the entry is nil (sdk.Dec{}, sdk.Int{})
+// * RoundingMode = RoundUp, then b >= a
+// * RoundingMode = RoundDown, then b <= a
+// * |a - b| <= AdditiveTolerance
+// * |a - b| / min(a, b) <= MultiplicativeTolerance
+//
+// Each check is respectively ignored if the entry is nil.
+// So AdditiveTolerance = sdk.Int{} or sdk.ZeroInt()
+// MultiplicativeTolerance = sdk.Dec{}
+// RoundingDir = RoundUnconstrained.
 // Note that if AdditiveTolerance == 0, then this is equivalent to a standard compare.
 type ErrTolerance struct {
 	AdditiveTolerance       sdk.Int

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -279,8 +279,9 @@ func solveCFMMBinarySearchMulti(xReserve, yReserve, wSumSquares, yIn osmomath.Bi
 	// This means rounding x_final up, to give us a larger negative.
 	// Therefore we always round up.
 	roundingDirection := osmomath.RoundUp
+	errTolerance.RoundingDir = roundingDirection
 
-	xEst, err := osmoutils.BinarySearchBigDec(computeFromEst, xLowEst, xHighEst, k, errTolerance, roundingDirection, maxIterations)
+	xEst, err := osmoutils.BinarySearchBigDec(computeFromEst, xLowEst, xHighEst, k, errTolerance, maxIterations)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Move rounding direction into error tolerance, rather than being another argument to binary search.

## Testing and Verifying

This change is already covered by existing binary search tests.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? Code comments