### PR TITLE
Add p2p.archive.osmosis.zone as a persistent peer

### DIFF
--- a/.github/workflows/state-compatibility-check.yml
+++ b/.github/workflows/state-compatibility-check.yml
@@ -131,6 +131,8 @@ jobs:
 
           # Edit config.toml
           dasel put string -f $CONFIG_FOLDER/config.toml '.tx_index.indexer' null
+          dasel put string -f $CONFIG_FOLDER/config.toml '.p2p.persistent_peers' 'b59016320a74525f92dbc3348521c64f2bf3f006@p2p.archive.osmosis.zone:26656'
+          dasel put string -f $CONFIG_FOLDER/config.toml 'seeds' ''
 
           # Edit app.toml
           dasel put string -f $CONFIG_FOLDER/app.toml '.halt-height' $HALT_HEIGHT


### PR DESCRIPTION
## Issue

State-compatibility check for old osmosis versions ( < `v10.x` ) stalls because the node is not able to fetch old blocks from peers. Example: https://github.com/osmosis-labs/osmosis/actions/runs/3411823601/jobs/5676521439

## What is the purpose of the change

This PR adds osmosis archive node as a persistent peer to fetch blocks for previous osmosis versions.

## Brief Changelog

Add `p2p.archive.osmosis.zone` as a persistent peer 

## Testing and Verifying

Tested in `osmosis-ci` with `v8.x`: https://github.com/osmosis-labs/osmosis-ci/actions/runs/3412517099/jobs/5678132884

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no 
  - How is the feature or change documented? not applicable