### PR TITLE
[ValSet-Pref] UnDelegate tokens from val-set using MsgUnDelegateFromValidatorSet

### DIFF
--- a/x/valset-pref/README.md
+++ b/x/valset-pref/README.md
@@ -1,20 +1,20 @@
-# validator-set Preference
+# validator-set Preference 
 
-## Abstract
+## Abstract 
 
-Validator-Set preference is a new module which gives users and contracts a
+Validator-Set preference is a new module which gives users and contracts a 
 better UX for staking to a set of validators. For example: a one click button
-that delegates to multiple validators. Then the user can set (or realistically a frontend provides)
+that delegates to multiple validators. Then the user can set (or realistically a frontend provides) 
 a list of recommended defaults (Ex: active governors, relayers, core stack contributors etc).
-Currently this can be done on-chain with frontends, but having a preference list stored locally
-eases frontend code burden.
+Currently this can be done on-chain with frontends, but having a preference list stored locally 
+eases frontend code burden. 
 
-## Design
+## Design 
 
-How does this module work?
+How does this module work? 
 
 - Allow a user to set a list of {val-addr, weight} in the state, called their validator-set preference.
-- Allow a user to update a list of {val-addr, weight} in the state, then do the following;
+- Allow a user to update a list of {val-addr, weight} in the state, then do the following; 
   - Unstake the existing tokens (run the same unbond logic as cosmos-sdk staking).
   - Update the validator distribution weights.
   - Stake the tokens based on the new weights.
@@ -27,21 +27,21 @@ How does this module work?
 
 ## Calculations
 
-Staking Calculation
+Staking Calculation 
 
 - The user provides an amount to delegate and our `MsgDelegateToValidatorSet` divides the amount based on validator weight distribution.
   For example: Stake 100osmo with validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}
-  our delegate logic will attempt to delegate (100 _ 0.5) 50osmo for ValA , (100 _ 0.3) 30osmo from ValB and (100 \* 0.2) 20osmo from ValC.
+  our delegate logic will attempt to delegate (100 * 0.5) 50osmo for ValA , (100 * 0.3) 30osmo from ValB and (100 * 0.2) 20osmo from ValC.
 
-UnStaking Calculation
+UnStaking Calculation 
 
 - The user provides an amount to undelegate and our `MsgUnDelegateToValidatorSet` divides the amount based on validator weight distribution.
-- Here, the user can either undelegate the entire amount or partial amount
+- Here, the user can either undelegate the entire amount or partial amount 
   - Entire amount unstaking: UnStake 100osmo from validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2},
     our undelegate logic will attempt to undelegate 50osmo from ValA , 30osmo from ValB, 20osmo from ValC
-  - Partial amount unstaking: UnStake 27osmo from validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2},
-    our undelegate logic will attempt to undelegate (27 _ 0.5) 13.5osmos from ValA, (27 _ 0.3), 8.1osmo from ValB,
-    and (50 \* 0.2) 5.4smo from ValC where 13.5osmo + 8.1osmo + 5.4osmo = 27osmo
+  - Partial amount unstaking: UnStake 27osmo from validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}, 
+    our undelegate logic will attempt to undelegate (27 * 0.5) 13.5osmos from ValA, (27 * 0.3), 8.1osmo from ValB, 
+    and (50 * 0.2) 5.4smo from ValC where 13.5osmo + 8.1osmo + 5.4osmo = 27osmo
   - The user will then have 73osmo remaining with unchanged weights {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2},
 
 ## Messages
@@ -62,16 +62,16 @@ and preferences. The weights are in decimal format from 0 to 1 and must add up t
 **State Modifications:**
 
 - Safety Checks
-  - check if the user already has a validator-set created.
+  - check if the user already has a validator-set created. 
   - check if the validator exist and is valid.
   - check if the validator-set add up to 1.
-- Add owner address to the `KVStore`, where a state of validator-set is stored.
+- Add owner address to the `KVStore`, where a state of validator-set is stored. 
 
 ### UpdateValidatorSetPreference
 
 Updates a validator-set of `{valAddr, Weight}` given the delegator address
 and existing preferences. The weights calculations follow the same rule as `CreateValidatorSetPreference`.
-If a user changes their preferences list, the unstaking logic will run from the old set and
+If a user changes their preferences list, the unstaking logic will run from the old set and 
 restaking to a new set is going to happen behind the scenes.
 
 ```go
@@ -86,14 +86,12 @@ restaking to a new set is going to happen behind the scenes.
 
 - Follows the same rule as `CreateValidatorSetPreference` for weights checks.
 - Update the `KVStore` value for the specific owner address key.
-- Run the undelegate logic and restake the tokens with updated weights.
+- Run the undelegate logic and restake the tokens with updated weights. 
 
-### DelegateToValidateSet
+### DelegateToValidatorSet
 
-Gets the existing validator-set of the delegator and delegates the given amount. The given amount
-will be divided based on the weights distributed to the validators. The weights will be unchanged!
-Shares per Token = validator.TotalShares() / validator.Tokens()
-Tokens per Share = validator.Tokens() / validatorShares()
+Gets the existing validator-set of the delegator and delegates the given amount. The given amount 
+will be divided based on the weights distributed to the validators. The weights will be unchanged 
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
@@ -105,16 +103,16 @@ Tokens per Share = validator.Tokens() / validatorShares()
 
 **State Modifications:**
 
-- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`.
-- Safety Checks
+- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`. 
+- Safety Checks 
   - check if the user has enough funds to delegate.
   - check overflow/underflow since `Delegate` method takes `sdk.Int` as tokenAmount.
-- use the [Delegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation.
+- use the [Delegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation. 
 
 ### UnStakeFromValidatorSet
 
 Gets the existing validator-set of the delegator and undelegate the given amount. The amount to undelegate will
-will be divided based on the weights distributed to the validators. The weights will be unchanged!
+will be divided based on the weights distributed to the validators. The weights will be unchanged! 
 
 The given amount will be divided based on the weights distributed to the validators.
 
@@ -128,30 +126,30 @@ The given amount will be divided based on the weights distributed to the validat
 
 **State Modifications:**
 
-- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`.
-- The unbonding logic will be follow the `UnDelegate` logic from the cosmos-sdk.
-- Safety Checks
+- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`. 
+- The unbonding logic will be follow the `UnDelegate` logic from the cosmos-sdk. 
+- Safety Checks 
   - check that the amount of funds to undelegate is <= to the funds the user has in the address.
   - `UnDelegate` method takes `sdk.Dec` as tokenAmount, so check if overflow/underflow case is relevant.
-- use the [UnDelegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation.
+- use the [UnDelegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation. 
 
 ### WithdrawDelegationRewards
 
-Allows the user to claim rewards based from the existing validator-set. The user can claim rewards from all the validators at once.
+Allows the user to claim rewards based from the existing validator-set. The user can claim rewards from all the validators at once. 
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
 ```
 
-## Code Layout
+## Code Layout 
 
 The Code Layout is very similar to TWAP module.
 
-- client/\* - Implementation of GRPC and CLI queries
-- types/\* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
+- client/* - Implementation of GRPC and CLI queries
+- types/* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
 - twapmodule/validatorsetpreference.go - SDK AppModule interface implementation.
 - api.go - Public API, that other users / modules can/should depend on
-- listeners.go - Defines hooks & calls to logic.go, for triggering actions on
+- listeners.go - Defines hooks & calls to logic.go, for triggering actions on 
 - keeper.go - generic SDK boilerplate (defining a wrapper for store keys + params)
-- msg_server.go - handle messages request from client and process responses.
+- msg_server.go - handle messages request from client and process responses. 
 - store.go - Managing logic for getting and setting things to underlying stores (KVStore)

--- a/x/valset-pref/README.md
+++ b/x/valset-pref/README.md
@@ -1,20 +1,20 @@
-# validator-set Preference 
+# validator-set Preference
 
-## Abstract 
+## Abstract
 
-Validator-Set preference is a new module which gives users and contracts a 
+Validator-Set preference is a new module which gives users and contracts a
 better UX for staking to a set of validators. For example: a one click button
-that delegates to multiple validators. Then the user can set (or realistically a frontend provides) 
+that delegates to multiple validators. Then the user can set (or realistically a frontend provides)
 a list of recommended defaults (Ex: active governors, relayers, core stack contributors etc).
-Currently this can be done on-chain with frontends, but having a preference list stored locally 
-eases frontend code burden. 
+Currently this can be done on-chain with frontends, but having a preference list stored locally
+eases frontend code burden.
 
-## Design 
+## Design
 
-How does this module work? 
+How does this module work?
 
 - Allow a user to set a list of {val-addr, weight} in the state, called their validator-set preference.
-- Allow a user to update a list of {val-addr, weight} in the state, then do the following; 
+- Allow a user to update a list of {val-addr, weight} in the state, then do the following;
   - Unstake the existing tokens (run the same unbond logic as cosmos-sdk staking).
   - Update the validator distribution weights.
   - Stake the tokens based on the new weights.
@@ -27,21 +27,21 @@ How does this module work?
 
 ## Calculations
 
-Staking Calculation 
+Staking Calculation
 
-- The user provides an amount to delegate and our `MsgStakeToValidatorSet` divides the amount based on validator weight distribution.
+- The user provides an amount to delegate and our `MsgDelegateToValidatorSet` divides the amount based on validator weight distribution.
   For example: Stake 100osmo with validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}
-  our delegate logic will attempt to delegate (100 * 0.5) 50osmo for ValA , (100 * 0.3) 30osmo from ValB and (100 * 0.2) 20osmo from ValC.
+  our delegate logic will attempt to delegate (100 _ 0.5) 50osmo for ValA , (100 _ 0.3) 30osmo from ValB and (100 \* 0.2) 20osmo from ValC.
 
-UnStaking Calculation 
+UnStaking Calculation
 
-- The user provides an amount to undelegate and our `MsgUnStakeFromValidatorSet` divides the amount based on validator weight distribution.
-- Here, the user can either undelegate the entire amount or partial amount 
+- The user provides an amount to undelegate and our `MsgUnDelegateToValidatorSet` divides the amount based on validator weight distribution.
+- Here, the user can either undelegate the entire amount or partial amount
   - Entire amount unstaking: UnStake 100osmo from validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2},
     our undelegate logic will attempt to undelegate 50osmo from ValA , 30osmo from ValB, 20osmo from ValC
-  - Partial amount unstaking: UnStake 27osmo from validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}, 
-    our undelegate logic will attempt to undelegate (27 * 0.5) 13.5osmos from ValA, (27 * 0.3), 8.1osmo from ValB, 
-    and (50 * 0.2) 5.4smo from ValC where 13.5osmo + 8.1osmo + 5.4osmo = 27osmo
+  - Partial amount unstaking: UnStake 27osmo from validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2},
+    our undelegate logic will attempt to undelegate (27 _ 0.5) 13.5osmos from ValA, (27 _ 0.3), 8.1osmo from ValB,
+    and (50 \* 0.2) 5.4smo from ValC where 13.5osmo + 8.1osmo + 5.4osmo = 27osmo
   - The user will then have 73osmo remaining with unchanged weights {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2},
 
 ## Messages
@@ -62,16 +62,16 @@ and preferences. The weights are in decimal format from 0 to 1 and must add up t
 **State Modifications:**
 
 - Safety Checks
-  - check if the user already has a validator-set created. 
+  - check if the user already has a validator-set created.
   - check if the validator exist and is valid.
   - check if the validator-set add up to 1.
-- Add owner address to the `KVStore`, where a state of validator-set is stored. 
+- Add owner address to the `KVStore`, where a state of validator-set is stored.
 
 ### UpdateValidatorSetPreference
 
 Updates a validator-set of `{valAddr, Weight}` given the delegator address
 and existing preferences. The weights calculations follow the same rule as `CreateValidatorSetPreference`.
-If a user changes their preferences list, the unstaking logic will run from the old set and 
+If a user changes their preferences list, the unstaking logic will run from the old set and
 restaking to a new set is going to happen behind the scenes.
 
 ```go
@@ -86,12 +86,14 @@ restaking to a new set is going to happen behind the scenes.
 
 - Follows the same rule as `CreateValidatorSetPreference` for weights checks.
 - Update the `KVStore` value for the specific owner address key.
-- Run the undelegate logic and restake the tokens with updated weights. 
+- Run the undelegate logic and restake the tokens with updated weights.
 
-### StakeToValidatorSet
+### DelegateToValidateSet
 
-Gets the existing validator-set of the delegator and delegates the given amount. The given amount 
-will be divided based on the weights distributed to the validators. The weights will be unchanged! 
+Gets the existing validator-set of the delegator and delegates the given amount. The given amount
+will be divided based on the weights distributed to the validators. The weights will be unchanged!
+Shares per Token = validator.TotalShares() / validator.Tokens()
+Tokens per Share = validator.Tokens() / validatorShares()
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
@@ -103,16 +105,16 @@ will be divided based on the weights distributed to the validators. The weights 
 
 **State Modifications:**
 
-- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`. 
-- Safety Checks 
+- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`.
+- Safety Checks
   - check if the user has enough funds to delegate.
   - check overflow/underflow since `Delegate` method takes `sdk.Int` as tokenAmount.
-- use the [Delegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation. 
+- use the [Delegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation.
 
 ### UnStakeFromValidatorSet
 
 Gets the existing validator-set of the delegator and undelegate the given amount. The amount to undelegate will
-will be divided based on the weights distributed to the validators. The weights will be unchanged! 
+will be divided based on the weights distributed to the validators. The weights will be unchanged!
 
 The given amount will be divided based on the weights distributed to the validators.
 
@@ -126,30 +128,30 @@ The given amount will be divided based on the weights distributed to the validat
 
 **State Modifications:**
 
-- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`. 
-- The unbonding logic will be follow the `UnDelegate` logic from the cosmos-sdk. 
-- Safety Checks 
+- Check if the user has a validator-set and if so, get the users validator-set from `KVStore`.
+- The unbonding logic will be follow the `UnDelegate` logic from the cosmos-sdk.
+- Safety Checks
   - check that the amount of funds to undelegate is <= to the funds the user has in the address.
   - `UnDelegate` method takes `sdk.Dec` as tokenAmount, so check if overflow/underflow case is relevant.
-- use the [UnDelegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation. 
+- use the [UnDelegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation.
 
 ### WithdrawDelegationRewards
 
-Allows the user to claim rewards based from the existing validator-set. The user can claim rewards from all the validators at once. 
+Allows the user to claim rewards based from the existing validator-set. The user can claim rewards from all the validators at once.
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
 ```
 
-## Code Layout 
+## Code Layout
 
 The Code Layout is very similar to TWAP module.
 
-- client/* - Implementation of GRPC and CLI queries
-- types/* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
+- client/\* - Implementation of GRPC and CLI queries
+- types/\* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
 - twapmodule/validatorsetpreference.go - SDK AppModule interface implementation.
 - api.go - Public API, that other users / modules can/should depend on
-- listeners.go - Defines hooks & calls to logic.go, for triggering actions on 
+- listeners.go - Defines hooks & calls to logic.go, for triggering actions on
 - keeper.go - generic SDK boilerplate (defining a wrapper for store keys + params)
-- msg_server.go - handle messages request from client and process responses. 
+- msg_server.go - handle messages request from client and process responses.
 - store.go - Managing logic for getting and setting things to underlying stores (KVStore)

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -24,7 +24,7 @@ var _ types.MsgServer = msgServer{}
 func (server msgServer) SetValidatorSetPreference(goCtx context.Context, msg *types.MsgSetValidatorSetPreference) (*types.MsgSetValidatorSetPreferenceResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	err := server.keeper.SetupValidatorSetPreference(ctx, msg.Delegator, msg.Preferences)
+	err := server.keeper.SetValidatorSetPreference(ctx, msg.Delegator, msg.Preferences)
 	if err != nil {
 		return nil, err
 	}

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -47,7 +47,15 @@ func (server msgServer) DelegateToValidatorSet(goCtx context.Context, msg *types
 
 	return &types.MsgDelegateToValidatorSetResponse{}, nil
 }
+
 func (server msgServer) UndelegateFromValidatorSet(goCtx context.Context, msg *types.MsgUndelegateFromValidatorSet) (*types.MsgUndelegateFromValidatorSetResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	err := server.keeper.UndelegateFromValidatorSet(ctx, msg.Delegator, msg.Coin)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.MsgUndelegateFromValidatorSetResponse{}, nil
 }
 

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -38,9 +38,15 @@ func (server msgServer) SetValidatorSetPreference(goCtx context.Context, msg *ty
 }
 
 func (server msgServer) DelegateToValidatorSet(goCtx context.Context, msg *types.MsgDelegateToValidatorSet) (*types.MsgDelegateToValidatorSetResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	err := server.keeper.DelegateToValidatorSet(ctx, msg.Delegator, msg.Coin)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.MsgDelegateToValidatorSetResponse{}, nil
 }
-
 func (server msgServer) UndelegateFromValidatorSet(goCtx context.Context, msg *types.MsgUndelegateFromValidatorSet) (*types.MsgUndelegateFromValidatorSetResponse, error) {
 	return &types.MsgUndelegateFromValidatorSetResponse{}, nil
 }

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -215,22 +215,22 @@ func (suite *KeeperTestSuite) TestUnDelegateFromValidatorSet() {
 		{
 			name:          "Unstake from a validator Set",
 			delegator:     sdk.AccAddress([]byte("addr1---------------")),
-			coinToStake:   sdk.NewCoin("stake", sdk.NewInt(20)),
-			coinToUnStake: sdk.NewCoin("stake", sdk.NewInt(10_000_000)),
+			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+			coinToUnStake: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
 			expectPass:    true,
 		},
 		{
 			name:          "Unstake everything",
 			delegator:     sdk.AccAddress([]byte("addr2---------------")),
-			coinToStake:   sdk.NewCoin("stake", sdk.NewInt(20)),
-			coinToUnStake: sdk.NewCoin("stake", sdk.NewInt(20_000_000)),
+			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+			coinToUnStake: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
 			expectPass:    true,
 		},
 		{
 			name:          "Unstake more amount than the staked amount",
 			delegator:     sdk.AccAddress([]byte("addr3---------------")),
-			coinToStake:   sdk.NewCoin("stake", sdk.NewInt(20)),
-			coinToUnStake: sdk.NewCoin("stake", sdk.NewInt(40_000_000)),
+			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+			coinToUnStake: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(40_000_000)),
 			expectPass:    false,
 		},
 	}

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -213,23 +213,23 @@ func (suite *KeeperTestSuite) TestUnDelegateFromValidatorSet() {
 		expectPass    bool
 	}{
 		{
-			name:          "Unstake from a validator Set",
+			name:          "Unstake x amount from a validator Set",
 			delegator:     sdk.AccAddress([]byte("addr1---------------")),
-			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
 			coinToUnStake: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
 			expectPass:    true,
 		},
 		{
 			name:          "Unstake everything",
 			delegator:     sdk.AccAddress([]byte("addr2---------------")),
-			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
 			coinToUnStake: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
 			expectPass:    true,
 		},
 		{
 			name:          "Unstake more amount than the staked amount",
 			delegator:     sdk.AccAddress([]byte("addr3---------------")),
-			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+			coinToStake:   sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
 			coinToUnStake: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(40_000_000)),
 			expectPass:    false,
 		},

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -142,14 +142,14 @@ func (suite *KeeperTestSuite) TestDelegateToValidatorSet() {
 		{
 			name:           "Delegate to valid validators!",
 			delegator:      sdk.AccAddress([]byte("addr1---------------")),
-			coin:           sdk.NewCoin("stake", sdk.NewInt(10)),                                           // amount to delegate
+			coin:           sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),                      // amount to delegate
 			expectedShares: []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)}, // expected shares after delegation
 			expectPass:     true,
 		},
 		{
 			name:           "Delegate more tokens to existing validator-set",
 			delegator:      sdk.AccAddress([]byte("addr1---------------")),
-			coin:           sdk.NewCoin("stake", sdk.NewInt(10)),                                            // amount to delegate
+			coin:           sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),                       // amount to delegate
 			expectedShares: []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)}, // expected shares after delegation
 			expectPass:     true,
 			valSetExists:   true,
@@ -157,14 +157,14 @@ func (suite *KeeperTestSuite) TestDelegateToValidatorSet() {
 		{
 			name:           "Delegate Decimal Amounts",
 			delegator:      sdk.AccAddress([]byte("addr2---------------")),
-			coin:           sdk.NewCoin("stake", sdk.NewInt(25)),                                            // amount to delegate
+			coin:           sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(25_000_000)),                       // amount to delegate
 			expectedShares: []sdk.Dec{sdk.NewDec(12_500_000), sdk.NewDec(7_500_000), sdk.NewDec(5_000_000)}, // expected shares after delegation
 			expectPass:     true,
 		},
 		{
 			name:       "User doesnot have enough tokens to stake",
 			delegator:  sdk.AccAddress([]byte("addr3---------------")),
-			coin:       sdk.NewCoin("stake", sdk.NewInt(200)), // amount to delegate
+			coin:       sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(200_000_000)), // amount to delegate
 			expectPass: false,
 		},
 	}

--- a/x/valset-pref/types/msgs.go
+++ b/x/valset-pref/types/msgs.go
@@ -74,7 +74,7 @@ const (
 var _ sdk.Msg = &MsgDelegateToValidatorSet{}
 
 // NewMsgMsgStakeToValidatorSet creates a msg to stake to a validator set.
-func NewMsgMsgStakeToValidatorSet(delegator sdk.AccAddress, coin sdk.Coin) *MsgDelegateToValidatorSet {
+func NewMsgDelegateToValidatorSet(delegator sdk.AccAddress, coin sdk.Coin) *MsgDelegateToValidatorSet {
 	return &MsgDelegateToValidatorSet{
 		Delegator: delegator.String(),
 		Coin:      coin,

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -67,6 +67,51 @@ func (k Keeper) DelegateToValidatorSet(ctx sdk.Context, delegatorAddr string, co
 	return nil
 }
 
+// UndelegateFromValidatorSet undelegates {coin} amount from the validator set.
+// For ex: userA has staked 10tokens with weight {Val->0.5, ValB->0.3, ValC->0.2}
+// undelegate 6osmo with validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}
+// our undelegate logic would attempt to undelegate 3osmo from A , 1.8osmo from B, 1.2osmo from C
+func (k Keeper) UndelegateFromValidatorSet(ctx sdk.Context, delegatorAddr string, coin sdk.Coin) error {
+	// get the existing validator set preference
+	existingSet, found := k.GetValidatorSetPreference(ctx, delegatorAddr)
+	if !found {
+		return fmt.Errorf("user %s doesn't have validator set", delegatorAddr)
+	}
+
+	delegator, err := sdk.AccAddressFromBech32(delegatorAddr)
+	if err != nil {
+		return err
+	}
+
+	// the total amount the user wants to undelegate
+	tokenAmt := sdk.NewDec(coin.Amount.Int64())
+
+	totalAmountFromWeights := sdk.NewDec(0)
+	for _, val := range existingSet.Preferences {
+		// Calculate the amount to undelegate based on the existing weights
+		amountToUnDelegate := val.Weight.Mul(tokenAmt)
+
+		// ValidateValidator gurantees that this exist
+		valAddr, err := sdk.ValAddressFromBech32(val.ValOperAddress)
+		if err != nil {
+			return err
+		}
+
+		_, err = k.stakingKeeper.Undelegate(ctx, delegator, valAddr, amountToUnDelegate)
+		if err != nil {
+			return err
+		}
+
+		totalAmountFromWeights = totalAmountFromWeights.Add(amountToUnDelegate)
+	}
+
+	if !totalAmountFromWeights.Equal(tokenAmt) {
+		return fmt.Errorf("The undelegate total donot add up with the amount calculated from weights expected %s got %s", tokenAmt, totalAmountFromWeights)
+	}
+
+	return nil
+}
+
 // GetValAddrAndVal checks if the validator address is valid and the validator provided exists on chain.
 func (k Keeper) getValAddrAndVal(ctx sdk.Context, valOperAddress string) (sdk.ValAddress, stakingtypes.Validator, error) {
 	valAddr, err := sdk.ValAddressFromBech32(valOperAddress)

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -97,7 +97,17 @@ func (k Keeper) UndelegateFromValidatorSet(ctx sdk.Context, delegatorAddr string
 			return err
 		}
 
-		_, err = k.stakingKeeper.Undelegate(ctx, delegator, valAddr, amountToUnDelegate)
+		validator, found := k.stakingKeeper.GetValidator(ctx, valAddr)
+		if !found {
+			return fmt.Errorf("validator %s not found", valAddr)
+		}
+
+		sharesAmt, err := validator.SharesFromTokens(amountToUnDelegate.RoundInt())
+		if err != nil {
+			return err
+		}
+
+		_, err = k.stakingKeeper.Undelegate(ctx, delegator, valAddr, sharesAmt) // this has to be shares amount
 		if err != nil {
 			return err
 		}

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v12/x/valset-pref/types"
 )
 
-// TODO: If a user has delegated and wants to change the weights. Currently, the state weight changes. We should restrict that
 func (k Keeper) SetValidatorSetPreference(ctx sdk.Context, delegator string, preferences []types.ValidatorPreference) error {
 	// check if a user already has a validator-set created
 	existingValidators, found := k.GetValidatorSetPreference(ctx, delegator)

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -29,6 +29,43 @@ func (k Keeper) SetupValidatorSetPreference(ctx sdk.Context, delegator string, p
 	return nil
 }
 
+// TODO MAYBE: Check if there are any banned assets and ways to handle them
+// DelegateToValidatorSet delegates to a delegators existing validator-set.
+// For ex: delegate 10osmo with validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}
+// our delegate logic would attempt to delegate 5osmo to A , 2osmo to B, 3osmo to C
+func (k Keeper) DelegateToValidatorSet(ctx sdk.Context, delegatorAddr string, coin sdk.Coin) error {
+	// get the existing validator set preference from store
+	existingSet, found := k.GetValidatorSetPreference(ctx, delegatorAddr)
+	if !found {
+		return fmt.Errorf("user %s doesn't have validator set", delegatorAddr)
+	}
+
+	delegator, err := sdk.AccAddressFromBech32(delegatorAddr)
+	if err != nil {
+		return err
+	}
+
+	tokenAmt := sdk.NewDec(coin.Amount.Int64())
+
+	// loop through the validatorSetPreference and delegate the proportion of the tokens based on weights
+	for _, val := range existingSet.Preferences {
+		_, validator, err := k.getValAddrAndVal(ctx, val.ValOperAddress)
+		if err != nil {
+			return err
+		}
+
+		// amount to delegate, calculated by {val_distribution_weight * tokenAmt}
+		amountToStake := val.Weight.Mul(tokenAmt).RoundInt()
+
+		_, err = k.stakingKeeper.Delegate(ctx, delegator, amountToStake, stakingtypes.Unbonded, validator, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // GetValAddrAndVal checks if the validator address is valid and the validator provided exists on chain.
 func (k Keeper) getValAddrAndVal(ctx sdk.Context, valOperAddress string) (sdk.ValAddress, stakingtypes.Validator, error) {
 	valAddr, err := sdk.ValAddressFromBech32(valOperAddress)

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -53,13 +53,12 @@ func (k Keeper) DelegateToValidatorSet(ctx sdk.Context, delegatorAddr string, co
 		}
 
 		// tokenAmt takes the amount to delegate, calculated by {val_distribution_weight * tokenAmt}
-		// amountToDelegate tokenAmt takes the smallest denom so, 1 usmo = 10^6 osmo
-		tokenAmt := val.Weight.Mul(coin.Amount.ToDec())
-		amountToDelegate := tokenAmt.Mul(sdk.NewDec(1000000)).RoundInt()
+		// expect tokenAmt to be in the smallest denom for ex, 1 usmo = 10^6 osmo
+		tokenAmt := val.Weight.Mul(coin.Amount.ToDec()).RoundInt()
 
 		// TODO: What happens here if validator is jailed, tombstoned, or unbonding
 		// Delegate the unbonded tokens
-		_, err = k.stakingKeeper.Delegate(ctx, delegator, amountToDelegate, stakingtypes.Unbonded, validator, true)
+		_, err = k.stakingKeeper.Delegate(ctx, delegator, tokenAmt, stakingtypes.Unbonded, validator, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of : https://github.com/osmosis-labs/osmosis/issues/2579
Merge https://github.com/osmosis-labs/osmosis/pull/3260 first 

## What is the purpose of the change

`UndelegateFromValidatorSet` undelegates {coin} amount from the validator set.
For ex: userA has staked 10tokens with weight {Val->0.5, ValB->0.3, ValC->0.2}
undelegate 6osmo with validator-set {ValA -> 0.5, ValB -> 0.3, ValC -> 0.2}
our undelegate logic would attempt to undelegate 3osmo from A , 1.8osmo from B, 1.2osmo from C
## Brief Changelog

## Testing and Verifying

Added tests for TestUnDelegateFromValidatorSet

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)