### PR TITLE
[CI] Align check-state-compatibility workflow on v8

### DIFF
--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -37,13 +37,12 @@ env:
   GOLANG_VERSION: 1.18
   GENESIS_URL: https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
   ADDRBOOK_URL: https://dl2.quicksync.io/json/addrbook.osmosis.json
-  SNAPSHOT_BUCKET: https://osmosis-snapshot.sfo3.cdn.digitaloceanspaces.com
+  SNAPSHOT_BUCKET: https://snapshots.osmosis.zone
   RPC_ENDPOINT: https://rpc.osmosis.zone
   LCD_ENDPOINT: https://lcd.osmosis.zone
   DELTA_HALT_HEIGHT: 50
- 
-jobs:
 
+jobs:
   check_state_compatibility:
     # DO NOT CHANGE THIS: please read the note above
     if: ${{ github.event.pull_request.head.repo.full_name == 'osmosis-labs/osmosis' }}
@@ -73,7 +72,7 @@ jobs:
           # Download genesis file if not present
           mkdir -p /mnt/data/genesis/osmosis-1/
           if [ ! -f "/mnt/data/genesis/osmosis-1/genesis.json" ]; then
-            wget -O /mnt/data/genesis/osmosis-1/genesis.json ${{ env.GENESIS_URL }}
+            wget -q -O /mnt/data/genesis/osmosis-1/genesis.json ${{ env.GENESIS_URL }}
           fi
 
           # Copy genesis to config folder
@@ -82,23 +81,12 @@ jobs:
         name: ⏬ Download last pre-epoch snapshot
         run:  |
           REPO_MAJOR_VERSION=$(echo $(git describe --tags) | cut -f 1 -d '.') # with v prefix
-
-          # Find current major version via rpc.osmosis.zone/abci_info
-          RPC_ABCI_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" ${{ env.RPC_ENDPOINT }}/abci_info)
-          CHAIN_MAJOR_VERSION=$(echo $RPC_ABCI_INFO | dasel --plain -r json  'result.response.version' | cut -f 1 -d '.') # no v prefix
-
-          # Get correct url to fetch snapshot comparing versions
-          if [ $REPO_MAJOR_VERSION == v$CHAIN_MAJOR_VERSION ]; then
-            # I'm in the latest major
-            SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/osmosis.json
-          else
-            SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/$REPO_MAJOR_VERSION/osmosis.json
-          fi
+          SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/$REPO_MAJOR_VERSION/snapshots.json
 
           # Get the latest pre-epoch snapshot information from bucket
           SNAPSHOT_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" $SNAPSHOT_INFO_URL)
-          SNAPSHOT_URL=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).url')
-          SNAPSHOT_ID=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).filename' | cut -f 1 -d '.')
+          SNAPSHOT_URL=$(echo $SNAPSHOT_INFO | jq -r '.[] | select(.type == "pre-epoch").url')
+          SNAPSHOT_ID=$(echo $SNAPSHOT_INFO |  jq -r '.[] | select(.type == "pre-epoch").filename' | cut -f 1 -d '.')
 
           # Download snapshot if not already present
           mkdir -p /mnt/data/snapshots/$REPO_MAJOR_VERSION/
@@ -129,9 +117,9 @@ jobs:
             # I'm in a previous major, calculate the epoch height from the snapshot height
             # (Snapshot is taken 100 blocks before epoch)
 
-            SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/v$REPO_MAJOR_VERSION/osmosis.json
+            SNAPSHOT_INFO_URL=${{ env.SNAPSHOT_BUCKET }}/v$REPO_MAJOR_VERSION/snapshots.json
             SNAPSHOT_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" $SNAPSHOT_INFO_URL)
-            SNAPSHOT_BLOCK_HEIGHT=$(echo $SNAPSHOT_INFO | dasel --plain -r json  '(file=osmosis-1-pre-epoch).height')
+            SNAPSHOT_BLOCK_HEIGHT=$(echo $SNAPSHOT_INFO | jq -r '.[] | select(.type == "pre-epoch").height')
             LAST_EPOCH_BLOCK_HEIGHT=$(($SNAPSHOT_BLOCK_HEIGHT + 100))
           fi
 
@@ -152,7 +140,7 @@ jobs:
           dasel put string -f $CONFIG_FOLDER/app.toml '.state-sync.snapshot-interval' 0
 
           # Download addrbook
-          wget -O $CONFIG_FOLDER/addrbook.json ${{ env.ADDRBOOK_URL }}
+          wget -q -O $CONFIG_FOLDER/addrbook.json ${{ env.ADDRBOOK_URL }}
       -
         name: 🧪 Start Osmosis Node
         run: build/osmosisd start


### PR DESCRIPTION
## What is the purpose of the change

This is a manual backport of the correct `check-state-compatibility` workflow.
We had different workflows on different branches created by cherry-picking commits while backporting. This PR aligns all `vY.x` branches to use the same workflow.

## Brief Changelog

- Align check-state-compatibility workflow on all branches

## Testing and Verifying

N.A.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? no
 