### PR TITLE
Use current tick instead of recomputing

### DIFF
--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -148,7 +148,7 @@ func (k Keeper) CalcOutAmtGivenIn(ctx sdk.Context,
 		amountSpecifiedRemaining: tokenAmountInAfterFee, // tokenIn
 		amountCalculated:         sdk.ZeroDec(),         // tokenOut
 		sqrtPrice:                curSqrtPrice,
-		tick:                     priceToTick(curSqrtPrice.Power(2)),
+		tick:                     p.CurrentTick,
 		liquidity:                p.Liquidity,
 	}
 
@@ -306,7 +306,7 @@ func (k Keeper) CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coin, tokenInDen
 		amountSpecifiedRemaining: tokenOutAmt,
 		amountCalculated:         sdk.ZeroDec(),
 		sqrtPrice:                curSqrtPrice,
-		tick:                     priceToTick(curSqrtPrice.Power(2)),
+		tick:                     p.CurrentTick,
 	}
 
 	// TODO: This should be GT 0 but some instances have very small remainder


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3291 

## What is the purpose of the change

Use `pool.currentTick` has been saved in the last `applySwap` instead of recalculating the new one