### PR TITLE
fix: fix multihop gamm cli

### DIFF
--- a/x/gamm/client/cli/flags.go
+++ b/x/gamm/client/cli/flags.go
@@ -67,16 +67,16 @@ type smoothWeightChangeParamsInputs struct {
 func FlagSetQuerySwapRoutes() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.StringArray(FlagSwapRoutePoolIds, []string{""}, "swap route pool id")
-	fs.StringArray(FlagSwapRouteDenoms, []string{""}, "swap route amount")
+	fs.String(FlagSwapRoutePoolIds, "", "swap route pool id")
+	fs.String(FlagSwapRouteDenoms, "", "swap route amount")
 	return fs
 }
 
 func FlagSetSwapAmountOutRoutes() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.StringArray(FlagSwapRoutePoolIds, []string{""}, "swap route pool ids")
-	fs.StringArray(FlagSwapRouteDenoms, []string{""}, "swap route denoms")
+	fs.String(FlagSwapRoutePoolIds, "", "swap route pool ids")
+	fs.String(FlagSwapRouteDenoms, "", "swap route denoms")
 	return fs
 }
 

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -583,12 +583,14 @@ func NewBuildExitPoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.Flag
 }
 
 func swapAmountInRoutes(fs *flag.FlagSet) ([]types.SwapAmountInRoute, error) {
-	swapRoutePoolIds, err := fs.GetStringArray(FlagSwapRoutePoolIds)
+	swapRoutePoolIds, err := fs.GetString(FlagSwapRoutePoolIds)
+	swapRoutePoolIdsArray := strings.Split(swapRoutePoolIds, ",")
 	if err != nil {
 		return nil, err
 	}
 
-	swapRouteDenoms, err := fs.GetStringArray(FlagSwapRouteDenoms)
+	swapRouteDenoms, err := fs.GetString(FlagSwapRouteDenoms)
+	swapRouteDenomsArray := strings.Split(swapRouteDenoms, ",")
 	if err != nil {
 		return nil, err
 	}
@@ -598,14 +600,14 @@ func swapAmountInRoutes(fs *flag.FlagSet) ([]types.SwapAmountInRoute, error) {
 	}
 
 	routes := []types.SwapAmountInRoute{}
-	for index, poolIDStr := range swapRoutePoolIds {
+	for index, poolIDStr := range swapRoutePoolIdsArray {
 		pID, err := strconv.Atoi(poolIDStr)
 		if err != nil {
 			return nil, err
 		}
 		routes = append(routes, types.SwapAmountInRoute{
 			PoolId:        uint64(pID),
-			TokenOutDenom: swapRouteDenoms[index],
+			TokenOutDenom: swapRouteDenomsArray[index],
 		})
 	}
 	return routes, nil

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -614,29 +614,31 @@ func swapAmountInRoutes(fs *flag.FlagSet) ([]types.SwapAmountInRoute, error) {
 }
 
 func swapAmountOutRoutes(fs *flag.FlagSet) ([]types.SwapAmountOutRoute, error) {
-	swapRoutePoolIds, err := fs.GetStringArray(FlagSwapRoutePoolIds)
+	swapRoutePoolIds, err := fs.GetString(FlagSwapRoutePoolIds)
+	swapRoutePoolIdsArray := strings.Split(swapRoutePoolIds, ",")
 	if err != nil {
 		return nil, err
 	}
 
-	swapRouteDenoms, err := fs.GetStringArray(FlagSwapRouteDenoms)
+	swapRouteDenoms, err := fs.GetString(FlagSwapRouteDenoms)
+	swapRouteDenomsArray := strings.Split(swapRouteDenoms, ",")
 	if err != nil {
 		return nil, err
 	}
 
-	if len(swapRoutePoolIds) != len(swapRouteDenoms) {
+	if len(swapRoutePoolIdsArray) != len(swapRouteDenomsArray) {
 		return nil, errors.New("swap route pool ids and denoms mismatch")
 	}
 
 	routes := []types.SwapAmountOutRoute{}
-	for index, poolIDStr := range swapRoutePoolIds {
+	for index, poolIDStr := range swapRoutePoolIdsArray {
 		pID, err := strconv.Atoi(poolIDStr)
 		if err != nil {
 			return nil, err
 		}
 		routes = append(routes, types.SwapAmountOutRoute{
 			PoolId:       uint64(pID),
-			TokenInDenom: swapRouteDenoms[index],
+			TokenInDenom: swapRouteDenomsArray[index],
 		})
 	}
 	return routes, nil

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -595,7 +595,7 @@ func swapAmountInRoutes(fs *flag.FlagSet) ([]types.SwapAmountInRoute, error) {
 		return nil, err
 	}
 
-	if len(swapRoutePoolIds) != len(swapRouteDenoms) {
+	if len(swapRoutePoolIdsArray) != len(swapRouteDenomsArray) {
 		return nil, errors.New("swap route pool ids and denoms mismatch")
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When testing osmosis multihop discount, I found that utilizing multiple pool ids and denoms in the cli was not getting parsed correctly. This fixes that issue
