### PR TITLE
chore: localosmosis in $HOME/.osmosisd-local folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ localnet-stop:
 	@STATE="" docker-compose -f tests/localosmosis/docker-compose.yml down
 
 localnet-clean:
-	@rm -rfI $(HOME)/.osmosisd/
+	@rm -rfI $(HOME)/.osmosisd-local/
 
 localnet-state-export-init: localnet-state-export-clean localnet-state-export-build 
 

--- a/tests/localosmosis/docker-compose.yml
+++ b/tests/localosmosis/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./scripts/nativeDenomPoolB.json:/osmosis/nativeDenomPoolB.json
       - ./scripts/nativeDenomThreeAssetPool.json:/osmosis/nativeDenomThreeAssetPool.json
       - ./scripts/setup.sh:/osmosis/setup.sh
-      - $HOME/.osmosisd2/:/osmosis/.osmosisd-local/
+      - $HOME/.osmosisd-local/:/osmosis/.osmosisd/
     entrypoint:
       - /osmosis/setup.sh
     command:

--- a/tests/localosmosis/docker-compose.yml
+++ b/tests/localosmosis/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./scripts/nativeDenomPoolB.json:/osmosis/nativeDenomPoolB.json
       - ./scripts/nativeDenomThreeAssetPool.json:/osmosis/nativeDenomThreeAssetPool.json
       - ./scripts/setup.sh:/osmosis/setup.sh
-      - $HOME/.osmosisd/:/osmosis/.osmosisd/
+      - $HOME/.osmosisd2/:/osmosis/.osmosisd-local/
     entrypoint:
       - /osmosis/setup.sh
     command:

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CHAIN_ID=localosmosis
-OSMOSIS_HOME=$HOME/.osmosisd
+OSMOSIS_HOME=$HOME/.osmosisd-local
 CONFIG_FOLDER=$OSMOSIS_HOME/config
 MONIKER=val
 STATE='false'

--- a/tests/localosmosis/state_export/docker-compose.yml
+++ b/tests/localosmosis/state_export/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./scripts/start.sh:/osmosis/start.sh
       - ./scripts/testnetify.py:/osmosis/testnetify.py
       - ./state_export.json:/osmosis/state_export.json
-      - $HOME/.osmosisd/:/osmosis/.osmosisd/
+      - $HOME/.osmosisd-local/:/osmosis/.osmosisd/
     entrypoint:
       - /osmosis/start.sh
     environment:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Moved localosmosis directory. Having it in the regular location, always overwrites my CLI settings for querying other RPC nodes. Additionally, it causes permission issues in the future since localosmosis is run as root in Linux with the conventional Docker setup.


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.