### PR TITLE
fix(stableswap): require sorted initial liquidity

### DIFF
--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -856,6 +856,8 @@ func NewStableSwapAdjustScalingFactorsMsg(clientCtx client.Context, txf tx.Facto
 	return txf, msg, nil
 }
 
+// ParseCoinsNoSort parses coins from coinsStr but does not sort them.
+// Returns error if parsing fails.
 func ParseCoinsNoSort(coinsStr string) (sdk.Coins, error) {
 	coinStrs := strings.Split(coinsStr, ",")
 	decCoins := make(sdk.DecCoins, len(coinStrs))

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -479,22 +479,22 @@ func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, txf tx.Factory, fs 
 
 // Apologies to whoever has to touch this next, this code is horrendous
 func NewBuildCreateStableswapPoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
-	pool, err := parseCreateStableswapPoolFlags(fs)
+	flags, err := parseCreateStableswapPoolFlags(fs)
 	if err != nil {
 		return txf, nil, fmt.Errorf("failed to parse pool: %w", err)
 	}
 
-	deposit, err := sdk.ParseCoinsNormalized(pool.InitialDeposit)
+	deposit, err := ParseCoinsNoSort(flags.InitialDeposit)
 	if err != nil {
 		return txf, nil, err
 	}
 
-	swapFee, err := sdk.NewDecFromStr(pool.SwapFee)
+	swapFee, err := sdk.NewDecFromStr(flags.SwapFee)
 	if err != nil {
 		return txf, nil, err
 	}
 
-	exitFee, err := sdk.NewDecFromStr(pool.ExitFee)
+	exitFee, err := sdk.NewDecFromStr(flags.ExitFee)
 	if err != nil {
 		return txf, nil, err
 	}
@@ -505,7 +505,7 @@ func NewBuildCreateStableswapPoolMsg(clientCtx client.Context, txf tx.Factory, f
 	}
 
 	scalingFactors := []uint64{}
-	trimmedSfString := strings.Trim(pool.ScalingFactors, "[] {}")
+	trimmedSfString := strings.Trim(flags.ScalingFactors, "[] {}")
 	if len(trimmedSfString) > 0 {
 		ints := strings.Split(trimmedSfString, ",")
 		for _, i := range ints {
@@ -525,8 +525,8 @@ func NewBuildCreateStableswapPoolMsg(clientCtx client.Context, txf tx.Factory, f
 		PoolParams:              poolParams,
 		InitialPoolLiquidity:    deposit,
 		ScalingFactors:          scalingFactors,
-		ScalingFactorController: pool.ScalingFactorController,
-		FuturePoolGovernor:      pool.FutureGovernor,
+		ScalingFactorController: flags.ScalingFactorController,
+		FuturePoolGovernor:      flags.FutureGovernor,
 	}
 
 	return txf, msg, nil
@@ -854,4 +854,18 @@ func NewStableSwapAdjustScalingFactorsMsg(clientCtx client.Context, txf tx.Facto
 	}
 
 	return txf, msg, nil
+}
+
+func ParseCoinsNoSort(coinsStr string) (sdk.Coins, error) {
+	coinStrs := strings.Split(coinsStr, ",")
+	decCoins := make(sdk.DecCoins, len(coinStrs))
+	for i, coinStr := range coinStrs {
+		coin, err := sdk.ParseDecCoin(coinStr)
+		if err != nil {
+			return sdk.Coins{}, err
+		}
+
+		decCoins[i] = coin
+	}
+	return sdk.NormalizeCoins(decCoins), nil
 }

--- a/x/gamm/client/cli/tx_test.go
+++ b/x/gamm/client/cli/tx_test.go
@@ -1,0 +1,71 @@
+package cli_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v12/x/gamm/client/cli"
+)
+
+func TestParseCoinsNoSort(t *testing.T) {
+	const (
+		a = "aaa"
+		b = "bbb"
+		c = "ccc"
+		d = "ddd"
+	)
+
+	var (
+		ten = sdk.NewInt(10)
+
+		coinA = sdk.NewCoin(a, ten)
+		coinB = sdk.NewCoin(b, ten)
+		coinC = sdk.NewCoin(c, ten)
+		coinD = sdk.NewCoin(d, ten)
+	)
+
+	tests := map[string]struct {
+		coinsStr      string
+		expectedCoins sdk.Coins
+	}{
+		"ascending": {
+			coinsStr: "10aaa,10bbb,10ccc,10ddd",
+			expectedCoins: sdk.Coins{
+				coinA,
+				coinB,
+				coinC,
+				coinD,
+			},
+		},
+		"descending": {
+			coinsStr: "10ddd,10ccc,10bbb,10aaa",
+			expectedCoins: sdk.Coins{
+				coinD,
+				coinC,
+				coinB,
+				coinA,
+			},
+		},
+		"mixed with different values.": {
+			coinsStr: "100ddd,20bbb,300aaa,40ccc",
+			expectedCoins: sdk.Coins{
+				sdk.NewCoin(d, sdk.NewInt(100)),
+				sdk.NewCoin(b, sdk.NewInt(20)),
+				sdk.NewCoin(a, sdk.NewInt(300)),
+				sdk.NewCoin(c, sdk.NewInt(40)),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			coins, err := cli.ParseCoinsNoSort(tc.coinsStr)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCoins, coins)
+		})
+	}
+}

--- a/x/gamm/pool-models/stableswap/msgs_test.go
+++ b/x/gamm/pool-models/stableswap/msgs_test.go
@@ -15,8 +15,8 @@ import (
 
 func baseCreatePoolMsgGen(sender sdk.AccAddress) *stableswap.MsgCreateStableswapPool {
 	testPoolAsset := sdk.Coins{
-		sdk.NewCoin("osmo", sdk.NewInt(100)),
 		sdk.NewCoin("atom", sdk.NewInt(100)),
+		sdk.NewCoin("osmo", sdk.NewInt(100)),
 	}
 
 	poolParams := &stableswap.PoolParams{
@@ -96,15 +96,15 @@ func TestMsgCreateStableswapPoolValidateBasic(t *testing.T) {
 			name: "have assets in excess of cap",
 			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
-					sdk.NewCoin("osmo", sdk.NewInt(100)),
-					sdk.NewCoin("atom", sdk.NewInt(100)),
-					sdk.NewCoin("usdt", sdk.NewInt(100)),
-					sdk.NewCoin("usdc", sdk.NewInt(100)),
-					sdk.NewCoin("juno", sdk.NewInt(100)),
 					sdk.NewCoin("akt", sdk.NewInt(100)),
-					sdk.NewCoin("regen", sdk.NewInt(100)),
+					sdk.NewCoin("atom", sdk.NewInt(100)),
 					sdk.NewCoin("band", sdk.NewInt(100)),
 					sdk.NewCoin("evmos", sdk.NewInt(100)),
+					sdk.NewCoin("juno", sdk.NewInt(100)),
+					sdk.NewCoin("osmo", sdk.NewInt(100)),
+					sdk.NewCoin("regen", sdk.NewInt(100)),
+					sdk.NewCoin("usdt", sdk.NewInt(100)),
+					sdk.NewCoin("usdc", sdk.NewInt(100)),
 				}
 				return msg
 			}),
@@ -200,10 +200,10 @@ func TestMsgCreateStableswapPoolValidateBasic(t *testing.T) {
 			name: "multi assets pool",
 			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
-					sdk.NewCoin("osmo", sdk.NewInt(100)),
 					sdk.NewCoin("atom", sdk.NewInt(100)),
-					sdk.NewCoin("usdt", sdk.NewInt(100)),
+					sdk.NewCoin("osmo", sdk.NewInt(100)),
 					sdk.NewCoin("usdc", sdk.NewInt(100)),
+					sdk.NewCoin("usdt", sdk.NewInt(100)),
 				}
 				msg.ScalingFactors = []uint64{1, 1, 1, 1}
 				return msg
@@ -228,14 +228,14 @@ func TestMsgCreateStableswapPoolValidateBasic(t *testing.T) {
 			name: "max asset amounts",
 			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
-					sdk.NewCoin("osmo", types.StableswapMaxScaledAmtPerAsset),
-					sdk.NewCoin("atom", types.StableswapMaxScaledAmtPerAsset),
-					sdk.NewCoin("usdt", types.StableswapMaxScaledAmtPerAsset),
-					sdk.NewCoin("usdc", types.StableswapMaxScaledAmtPerAsset),
-					sdk.NewCoin("juno", types.StableswapMaxScaledAmtPerAsset),
 					sdk.NewCoin("akt", types.StableswapMaxScaledAmtPerAsset),
-					sdk.NewCoin("regen", types.StableswapMaxScaledAmtPerAsset),
+					sdk.NewCoin("atom", types.StableswapMaxScaledAmtPerAsset),
 					sdk.NewCoin("band", types.StableswapMaxScaledAmtPerAsset),
+					sdk.NewCoin("juno", types.StableswapMaxScaledAmtPerAsset),
+					sdk.NewCoin("osmo", types.StableswapMaxScaledAmtPerAsset),
+					sdk.NewCoin("regen", types.StableswapMaxScaledAmtPerAsset),
+					sdk.NewCoin("usdc", types.StableswapMaxScaledAmtPerAsset),
+					sdk.NewCoin("usdt", types.StableswapMaxScaledAmtPerAsset),
 				}
 				msg.ScalingFactors = []uint64{1, 1, 1, 1, 1, 1, 1, 1}
 				return msg
@@ -264,14 +264,14 @@ func TestMsgCreateStableswapPoolValidateBasic(t *testing.T) {
 			name: "100B token 8-asset pool using large scaling factors (6 decimal precision per asset)",
 			msg: updateMsg(func(msg stableswap.MsgCreateStableswapPool) stableswap.MsgCreateStableswapPool {
 				msg.InitialPoolLiquidity = sdk.Coins{
-					sdk.NewCoin("osmo", sdk.NewInt(100_000_000_000_000_000)),
-					sdk.NewCoin("atom", sdk.NewInt(100_000_000_000_000_000)),
-					sdk.NewCoin("usdt", sdk.NewInt(100_000_000_000_000_000)),
-					sdk.NewCoin("usdc", sdk.NewInt(100_000_000_000_000_000)),
-					sdk.NewCoin("juno", sdk.NewInt(100_000_000_000_000_000)),
 					sdk.NewCoin("akt", sdk.NewInt(100_000_000_000_000_000)),
-					sdk.NewCoin("regen", sdk.NewInt(100_000_000_000_000_000)),
+					sdk.NewCoin("atom", sdk.NewInt(100_000_000_000_000_000)),
 					sdk.NewCoin("band", sdk.NewInt(100_000_000_000_000_000)),
+					sdk.NewCoin("juno", sdk.NewInt(100_000_000_000_000_000)),
+					sdk.NewCoin("osmo", sdk.NewInt(100_000_000_000_000_000)),
+					sdk.NewCoin("regen", sdk.NewInt(100_000_000_000_000_000)),
+					sdk.NewCoin("usdc", sdk.NewInt(100_000_000_000_000_000)),
+					sdk.NewCoin("usdt", sdk.NewInt(100_000_000_000_000_000)),
 				}
 				msg.ScalingFactors = []uint64{10000000, 10000000, 10000000, 10000000, 10000000, 10000000, 10000000, 10000000}
 				return msg


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently, the CLI auto-sorts the initial liquidity. As a result, denoms end up mismatching the desired scaling factor.

This PR  removes the sorting in CLI and adds the requirement in `ValidateBasic()` for initial liquidity coins to be sorted. Fails if not.

## Testing and Verifying

Tested on localnet. Summary: https://hackmd.io/40cR4cL5SBOuX7APZKTWIw?edit