### PR TITLE
[x/gamm][stableswap]: Clean up rounding for single-asset joins

### DIFF
--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -115,10 +115,6 @@ func MaximalExactRatioJoin(p types.PoolI, ctx sdk.Context, tokensIn sdk.Coins) (
 	return numShares, remCoins, nil
 }
 
-// Need to get something that makes the result correct within 1 LP share.
-// If we fail to reach it within maxIterations, we return an error.
-var singleAssetJoinAdditive = sdk.NewInt(1)
-
 // We binary search a number of LP shares, s.t. if we exited the pool with the updated liquidity,
 // and swapped all the tokens back to the input denom, we'd get the same amount. (under 0 swap fee)
 // Thanks to CFMM path-independence, we can estimate slippage with these swaps to be sure to get the right numbers here.
@@ -158,7 +154,7 @@ func BinarySearchSingleAssetJoin(
 	}
 
 	// We accept an additive tolerance of 1 LP share error and round down
-	errTolerance := osmoutils.ErrTolerance{AdditiveTolerance: singleAssetJoinAdditive, MultiplicativeTolerance: sdk.Dec{}, RoundingDir: osmomath.RoundDown}
+	errTolerance := osmoutils.ErrTolerance{AdditiveTolerance: sdk.OneInt(), MultiplicativeTolerance: sdk.Dec{}, RoundingDir: osmomath.RoundDown}
 
 	numLPShares, err = osmoutils.BinarySearch(
 		estimateCoinOutGivenShares,

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	"github.com/osmosis-labs/osmosis/v12/osmomath"
 	"github.com/osmosis-labs/osmosis/v12/osmoutils"
 	"github.com/osmosis-labs/osmosis/v12/x/gamm/types"
 )
@@ -116,7 +117,7 @@ func MaximalExactRatioJoin(p types.PoolI, ctx sdk.Context, tokensIn sdk.Coins) (
 
 // Need to get something that makes the result correct within 1 LP share.
 // If we fail to reach it within maxIterations, we return an error.
-var singleAssetJoinCorrectnessThreshold = sdk.NewInt(1)
+var singleAssetJoinAdditive = sdk.NewInt(1)
 
 // We binary search a number of LP shares, s.t. if we exited the pool with the updated liquidity,
 // and swapped all the tokens back to the input denom, we'd get the same amount. (under 0 swap fee)
@@ -156,14 +157,17 @@ func BinarySearchSingleAssetJoin(
 		return SwapAllCoinsToSingleAsset(poolWithUpdatedLiquidity, ctx, exitedCoins, swapToDenom)
 	}
 
-	errTolerance := osmoutils.ErrTolerance{AdditiveTolerance: singleAssetJoinCorrectnessThreshold, MultiplicativeTolerance: sdk.OneDec()}
+	// We accept an additive tolerance of 1 LP share error and round down
+	errTolerance := osmoutils.ErrTolerance{AdditiveTolerance: singleAssetJoinAdditive, MultiplicativeTolerance: sdk.Dec{}, RoundingDir: osmomath.RoundDown}
 
-	// we set the target at input amount minus additive tolerance so we never output more tokens than were passed in
 	numLPShares, err = osmoutils.BinarySearch(
 		estimateCoinOutGivenShares,
-		LPShareLowerBound, LPShareUpperBound, tokenIn.Amount.Sub(singleAssetJoinCorrectnessThreshold), errTolerance, maxIterations)
+		LPShareLowerBound, LPShareUpperBound, tokenIn.Amount, errTolerance, maxIterations)
+	if err != nil {
+		return sdk.Int{}, err
+	}
 
-	return numLPShares, err
+	return numLPShares, nil
 }
 
 // SwapAllCoinsToSingleAsset iterates through each token in the input set and trades it against the same pool sequentially


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3355

## What is the purpose of the change

This PR adds rounding support to our basic error tolerance `Compare` and cleans up rounding behavior for single asset joins

## Brief Changelog

- Add rounding logic to `ErrTolerance`'s `CompareRounding` function as is implemented in `CompareBigDec`
- Fix binary search to properly compare expected and target (was backwards leading to odd rounding)
- Remove the subtraction by 1 on the input to `BinarySearchSingleAssetJoin`
- Remove additive error tolerance var and pass `sdk.OneInt()` in directly for `ErrTolerance` passed into `BinarySearchSingleAssetJoin`

## Testing and Verifying

- All binary search and single asset join tests pass

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)