### PR TITLE
Add cli support for new gamm queries

### DIFF
--- a/x/gamm/client/cli/query.go
+++ b/x/gamm/client/cli/query.go
@@ -6,8 +6,12 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -38,6 +42,8 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdEstimateSwapExactAmountIn(),
 		GetCmdEstimateSwapExactAmountOut(),
 		GetCmdTotalPoolLiquidity(),
+		GetCmdQueryPoolsWithFilter(),
+		GetCmdPoolType(),
 	)
 
 	return cmd
@@ -501,6 +507,110 @@ $ %s query gamm estimate-swap-exact-amount-out 1 osm11vmx8jtggpd9u7qr0t8vxclycz8
 	flags.AddQueryFlagsToCmd(cmd)
 	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
 	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+// GetCmdQueryPoolsWithFilter returns pool with filter
+func GetCmdQueryPoolsWithFilter() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pools-with-filter <min_liquidity> <pool_type>",
+		Short: "Query pools with filter",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query pools with filter. The possible filter options are:
+
+1. By Pool type: Either "Balancer" or "Stableswap"
+2. By min pool liquidity by providing min coins
+
+Note that if both filters are to be applied, "min_liquidity" always needs to be provided as the first argument.
+
+Example:
+$ %s query gamm pools-with-filter <min_liquidity> <pool_type> 
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			var min_liquidity sdk.Coins
+			var pool_type string
+			if len(args) == 1 {
+				coins, err := sdk.ParseCoinsNormalized(args[0])
+				if err != nil {
+					pool_type = args[0]
+				}
+				min_liquidity = coins
+			} else {
+				coins, err := sdk.ParseCoinsNormalized(args[0])
+				if err != nil {
+					return status.Errorf(codes.InvalidArgument, "invalid token: %s", err.Error())
+				}
+
+				min_liquidity = coins
+				pool_type = args[1]
+			}
+
+			res, err := queryClient.PoolsWithFilter(cmd.Context(), &types.QueryPoolsWithFilterRequest{
+				MinLiquidity: min_liquidity,
+				PoolType:     pool_type,
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdPoolType returns pool type given pool id.
+func GetCmdPoolType() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pool-type <pool_id>",
+		Short: "Query pool type",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query pool type
+Example:
+$ %s query gamm pool-type <pool_id>
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			poolID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.PoolType(cmd.Context(), &types.QueryPoolTypeRequest{
+				PoolId: uint64(poolID),
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR adds cli for the new gamm queries, namely the pool type query and the pool with filter query in the gamm module. 

The pool with filter query has extra logic from the other cli commands since it uses a range args not an exact args, so we need extra review on this part. 

## Brief Changelog

- Add cli support for new gamm queries
