### PR TITLE
Make stableswap error in terms of input size

### DIFF
--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -71,7 +71,7 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 	}
 	// Check multiplicative tolerance equations
 	if !e.MultiplicativeTolerance.IsNil() && !e.MultiplicativeTolerance.IsZero() {
-		errTerm := diff.ToDec().Quo(sdk.MinInt(expected, actual).ToDec())
+		errTerm := diff.ToDec().Quo(sdk.MinInt(expected.Abs(), actual.Abs()).ToDec())
 		if errTerm.GT(e.MultiplicativeTolerance) {
 			return comparisonSign
 		}
@@ -123,7 +123,7 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 	}
 	// Check multiplicative tolerance equations
 	if !e.MultiplicativeTolerance.IsNil() && !e.MultiplicativeTolerance.IsZero() {
-		errTerm := diff.Quo(osmomath.MinDec(expected.Abs(), actual.Abs())).Abs()
+		errTerm := diff.Quo(osmomath.MinDec(expected.Abs(), actual.Abs()))
 		// fmt.Printf("err term %v\n", errTerm)
 		if errTerm.GT(osmomath.BigDecFromSDKDec(e.MultiplicativeTolerance)) {
 			return comparisonSign

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -124,6 +124,7 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 	// Check multiplicative tolerance equations
 	if !e.MultiplicativeTolerance.IsNil() && !e.MultiplicativeTolerance.IsZero() {
 		errTerm := diff.Quo(osmomath.MinDec(expected.Abs(), actual.Abs())).Abs()
+		// fmt.Printf("err term %v\n", errTerm)
 		if errTerm.GT(osmomath.BigDecFromSDKDec(e.MultiplicativeTolerance)) {
 			return comparisonSign
 		}
@@ -198,6 +199,7 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	}
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
+		// fmt.Println("targetOutput, curOutput, curEstimate", targetOutput, curOutput, curEstimate)
 		compRes := errTolerance.CompareBigDec(targetOutput, curOutput)
 		if compRes < 0 {
 			upperbound = curEstimate

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -124,7 +124,6 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 	// Check multiplicative tolerance equations
 	if !e.MultiplicativeTolerance.IsNil() && !e.MultiplicativeTolerance.IsZero() {
 		errTerm := diff.Quo(osmomath.MinDec(expected.Abs(), actual.Abs())).Abs()
-		// fmt.Printf("err term %v\n", errTerm)
 		if errTerm.GT(osmomath.BigDecFromSDKDec(e.MultiplicativeTolerance)) {
 			return comparisonSign
 		}
@@ -199,7 +198,6 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	}
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
-		// fmt.Println("targetOutput, curOutput, curEstimate", targetOutput, curOutput, curEstimate)
 		compRes := errTolerance.CompareBigDec(targetOutput, curOutput)
 		if compRes < 0 {
 			upperbound = curEstimate

--- a/osmoutils/binary_search.go
+++ b/osmoutils/binary_search.go
@@ -85,15 +85,6 @@ func (e ErrTolerance) Compare(expected sdk.Int, actual sdk.Int) int {
 // returns 1 if not, and expected > actual.
 // returns -1 if not, and expected < actual
 func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.BigDec) int {
-	diff := expected.Sub(actual).Abs()
-
-	comparisonSign := 0
-	if expected.GT(actual) {
-		comparisonSign = 1
-	} else {
-		comparisonSign = -1
-	}
-
 	// Ensure that even if expected is within tolerance of actual, we don't count it as equal if its in the wrong direction.
 	// so if were supposed to round down, it must be that `expected >= actual`.
 	// likewise if were supposed to round up, it must be that `expected <= actual`.
@@ -106,6 +97,15 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 		if expected.GT(actual) {
 			return 1
 		}
+	}
+
+	diff := expected.Sub(actual).Abs()
+
+	comparisonSign := 0
+	if expected.GT(actual) {
+		comparisonSign = 1
+	} else {
+		comparisonSign = -1
 	}
 
 	// Check additive tolerance equations
@@ -123,7 +123,8 @@ func (e ErrTolerance) CompareBigDec(expected osmomath.BigDec, actual osmomath.Bi
 	}
 	// Check multiplicative tolerance equations
 	if !e.MultiplicativeTolerance.IsNil() && !e.MultiplicativeTolerance.IsZero() {
-		errTerm := diff.Quo(osmomath.MinDec(expected, actual))
+		errTerm := diff.Quo(osmomath.MinDec(expected.Abs(), actual.Abs())).Abs()
+		// fmt.Printf("err term %v\n", errTerm)
 		if errTerm.GT(osmomath.BigDecFromSDKDec(e.MultiplicativeTolerance)) {
 			return comparisonSign
 		}
@@ -198,7 +199,7 @@ func BinarySearchBigDec(f func(input osmomath.BigDec) (osmomath.BigDec, error),
 	}
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
-		// fmt.Println(targetOutput, curOutput)
+		// fmt.Println("targetOutput, curOutput, curEstimate", targetOutput, curOutput, curEstimate)
 		compRes := errTolerance.CompareBigDec(targetOutput, curOutput)
 		if compRes < 0 {
 			upperbound = curEstimate

--- a/osmoutils/binary_search_test.go
+++ b/osmoutils/binary_search_test.go
@@ -320,39 +320,51 @@ func TestBinarySearchRoundingBehavior(t *testing.T) {
 func TestErrTolerance_Compare(t *testing.T) {
 	ZeroErrTolerance := ErrTolerance{AdditiveTolerance: sdk.ZeroInt(), MultiplicativeTolerance: sdk.Dec{}}
 	NonZeroErrAdditive := ErrTolerance{AdditiveTolerance: sdk.NewInt(10), MultiplicativeTolerance: sdk.Dec{}}
-	NonZeroErrMultiplicative := ErrTolerance{AdditiveTolerance: sdk.ZeroInt(), MultiplicativeTolerance: sdk.NewDec(10)}
+	NonZeroErrMultiplicative := ErrTolerance{AdditiveTolerance: sdk.Int{}, MultiplicativeTolerance: sdk.NewDec(10)}
 	NonZeroErrBoth := ErrTolerance{AdditiveTolerance: sdk.NewInt(1), MultiplicativeTolerance: sdk.NewDec(10)}
 	tests := []struct {
 		name         string
 		tol          ErrTolerance
-		intInput     sdk.Int
-		intReference sdk.Int
-
-		bigDecInput     osmomath.BigDec
-		bigDecReference osmomath.BigDec
+		intInput     int64
+		intReference int64
 
 		expectedCompareResult int
 	}{
-		{"0 tolerance: <", ZeroErrTolerance, sdk.NewInt(1000), sdk.NewInt(1001), osmomath.NewBigDec(1000), osmomath.NewBigDec(1001), -1},
-		{"0 tolerance: =", ZeroErrTolerance, sdk.NewInt(1001), sdk.NewInt(1001), osmomath.NewBigDec(1001), osmomath.NewBigDec(1001), 0},
-		{"0 tolerance: >", ZeroErrTolerance, sdk.NewInt(1002), sdk.NewInt(1001), osmomath.NewBigDec(1002), osmomath.NewBigDec(1001), 1},
-		{"Nonzero additive tolerance: <", NonZeroErrAdditive, sdk.NewInt(420), sdk.NewInt(1001), osmomath.NewBigDec(420), osmomath.NewBigDec(1001), -1},
-		{"Nonzero additive tolerance: =", NonZeroErrAdditive, sdk.NewInt(1011), sdk.NewInt(1001), osmomath.NewBigDec(1011), osmomath.NewBigDec(1001), 0},
-		{"Nonzero additive tolerance: >", NonZeroErrAdditive, sdk.NewInt(1230), sdk.NewInt(1001), osmomath.NewBigDec(1230), osmomath.NewBigDec(1001), 1},
-		{"Nonzero multiplicative tolerance: <", NonZeroErrMultiplicative, sdk.NewInt(1000), sdk.NewInt(1001), osmomath.NewBigDec(1000), osmomath.NewBigDec(1001), -1},
-		{"Nonzero multiplicative tolerance: =", NonZeroErrMultiplicative, sdk.NewInt(1001), sdk.NewInt(1001), osmomath.NewBigDec(1001), osmomath.NewBigDec(1001), 0},
-		{"Nonzero multiplicative tolerance: >", NonZeroErrMultiplicative, sdk.NewInt(1002), sdk.NewInt(1001), osmomath.NewBigDec(1002), osmomath.NewBigDec(1001), 1},
-		{"Nonzero both tolerance: <", NonZeroErrBoth, sdk.NewInt(990), sdk.NewInt(1001), osmomath.NewBigDec(990), osmomath.NewBigDec(1001), -1},
-		{"Nonzero both tolerance: =", NonZeroErrBoth, sdk.NewInt(1002), sdk.NewInt(1001), osmomath.NewBigDec(1002), osmomath.NewBigDec(1001), 0},
-		{"Nonzero both tolerance: >", NonZeroErrBoth, sdk.NewInt(1011), sdk.NewInt(1001), osmomath.NewBigDec(1011), osmomath.NewBigDec(1001), 1},
+		{"0 tolerance: <", ZeroErrTolerance, 1000, 1001, -1},
+		{"0 tolerance: =", ZeroErrTolerance, 1001, 1001, 0},
+		{"0 tolerance: >", ZeroErrTolerance, 1002, 1001, 1},
+		{"Nonzero additive tolerance: <", NonZeroErrAdditive, 420, 1001, -1},
+		{"Nonzero additive tolerance: =", NonZeroErrAdditive, 1011, 1001, 0},
+		{"Nonzero additive tolerance: >", NonZeroErrAdditive, 1230, 1001, 1},
+		{"Nonzero multiplicative tolerance within bounds: <", NonZeroErrMultiplicative, 1000, 1001, 0},
+		{"Nonzero multiplicative tolerance within bounds: =", NonZeroErrMultiplicative, 1001, 1001, 0},
+		{"Nonzero multiplicative tolerance within bounds: >", NonZeroErrMultiplicative, 1002, 1001, 0},
+		{"Nonzero multiplicative tolerance out of bounds: <", NonZeroErrMultiplicative, 100000, 1001, 1},
+		{"Nonzero multiplicative tolerance out of bounds: =", NonZeroErrMultiplicative, 100100, 1001, 1},
+		{"Nonzero multiplicative tolerance out of bounds: >", NonZeroErrMultiplicative, 100200, 1001, 1},
+		{"multiplicative tolerance with negative: >", NonZeroErrMultiplicative,
+			-20020, -1001, -1},
+		{"Nonzero both tolerance: <", NonZeroErrBoth, 990, 1001, -1},
+		{"Nonzero both tolerance: =", NonZeroErrBoth, 1002, 1001, 0},
+		{"Nonzero both tolerance: >", NonZeroErrBoth, 1011, 1001, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.tol.Compare(tt.intInput, tt.intReference); got != tt.expectedCompareResult {
-				t.Errorf("ErrTolerance.Compare() = %v, want %v", got, tt.expectedCompareResult)
+			gotInt := tt.tol.Compare(sdk.NewInt(tt.intInput), sdk.NewInt(tt.intReference))
+			if gotInt != tt.expectedCompareResult {
+				t.Errorf("ErrTolerance.Compare() = %v, want %v", gotInt, tt.expectedCompareResult)
 			}
-			if got := tt.tol.CompareBigDec(tt.bigDecInput, tt.bigDecReference); got != tt.expectedCompareResult {
-				t.Errorf("ErrTolerance.CompareBigDec() = %v, want %v", got, tt.expectedCompareResult)
+			gotIntRev := tt.tol.Compare(sdk.NewInt(tt.intReference), sdk.NewInt(tt.intInput))
+			if gotIntRev != -tt.expectedCompareResult {
+				t.Errorf("ErrTolerance.Compare() = %v, want %v", gotIntRev, -tt.expectedCompareResult)
+			}
+			gotBigDec := tt.tol.CompareBigDec(osmomath.NewBigDec(tt.intInput), osmomath.NewBigDec(tt.intReference))
+			if gotBigDec != tt.expectedCompareResult {
+				t.Errorf("ErrTolerance.CompareBigDec() = %v, want %v", gotBigDec, tt.expectedCompareResult)
+			}
+			gotBigDecRev := tt.tol.CompareBigDec(osmomath.NewBigDec(tt.intReference), osmomath.NewBigDec(tt.intInput))
+			if gotBigDecRev != -tt.expectedCompareResult {
+				t.Errorf("ErrTolerance.CompareBigDec() = %v, want %v", gotBigDecRev, -tt.expectedCompareResult)
 			}
 		})
 	}

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -164,8 +164,8 @@ $$k_{iter}(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}
 So we can subtract this constant term `y_0 (x_f^2 + w) + y_0^3`, which for `y_out < y_0` is the dominant term in the expression!
 
 So lets define this as:
-$$target_k = \frac{x_0 y_0 (x_0^2 + y_0^2 + w)}{x_f} - (y_0 (x_f^2 + w) + y_0^3)$$
-$$iter_k(y_delta) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$$
+$$k_{target} = \frac{x_0 y_0 (x_0^2 + y_0^2 + w)}{x_f} - (y_0 (x_f^2 + w) + y_0^3)$$
+$$k_{iter}(y_delta) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$$
 
 We prove [here](#err_proof) that an error of a multiplicative `e` between `target_k` and `iter_k`, implies an error of less than a factor of `e` in `y_delta`.
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -350,6 +350,11 @@ We bound the right hand side, with the assistance of wolfram alpha. Let $a = y_{
     * $b > \frac{2}{3} a$, as $y_0$ is positive.
     * $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
 
+Tieing this all together, we have that 
+
+$$e_k > .01e_y$$
+
+So $e_y < 100 e_k$! QED.
 
 
 ### Spot Price

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -165,9 +165,9 @@ So we can subtract this constant term `y_0 (x_f^2 + w) + y_0^3`, which for `y_ou
 
 So lets define this as:
 $$k_{target} = \frac{x_0 y_0 (x_0^2 + y_0^2 + w)}{x_f} - (y_0 (x_f^2 + w) + y_0^3)$$
-$$k_{iter}(y_delta) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$$
+$$k_{iter}(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$$
 
-We prove [here](#err_proof) that an error of a multiplicative `e` between `target_k` and `iter_k`, implies an error of less than a factor of `e` in `y_delta`.
+We prove [here](#err_proof) that an error of a multiplicative `e` between `target_k` and `iter_k`, implies an error of less than a factor of `e` in `y_{out}`.
 
 ##### Combined pseudocode
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -251,6 +251,10 @@ And therefore we round up in both cases.
 
 
 
+##### Further optimization
+
+
+
 #### Using this in swap methods
 
 So now we put together the components discussed in prior sections to achieve pseudocode for the SwapExactAmountIn
@@ -317,8 +321,10 @@ We see correctness of the swap fee, by imagining what happens if we took this re
 
 </a>
 
-The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals. You can prove this, by seeing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary, and therefore has no local minima or maxima in the reals.
-Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via binary search, we solve for a value $y_{out}^{*}$ such that $\left|\frac{ k - k^{*} }{k}\right| < e_k$, where $k^{*} = f(y_{out}^{*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{*} }{y_{out}}\right|$ in relation to $e_k$.
+The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals.
+You can prove this, by seeing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary, and therefore has no local minima or maxima in the reals.
+Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$.
+Via binary search, we solve for a value $y_{out}^{\*}$ such that $\left|\frac{ k - k^{\*} }{k}\right| < e_k$, where $k^{\*} = f(y_{out}^{\*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{\*} }{y_{out}}\right|$ in relation to $e_k$.
 
 **Theorem**: $e_y < 100 e_k$ as long as $|y_{out}| <= .9y_0$.
 **Informal**, we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better. (Often better than $e_k$)
@@ -327,13 +333,13 @@ Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via bi
 Let $y_{out} - y_{out}^* = a_y$, we are going to assume that $a_y << y_{out}$, and will justify this later. But due to this, we treat $a_y^c = 0$ for $c > 1$. This then implies that $y_{out}^2 - y_{out}^{*2} = y_{out}^2 - (y_{out} - a_y)^2 \approx 2y_{out}a_y$, and similarly $y_{out}^3 - y_{out}^{*3} \approx 3y_{out}^2 a_y$
 
 Now we are prepared to start bounding this.
-$$k - k^{*} = -(y_{out}^3 - y_{out}^{3*}) + 3y_0(y_{out}^2 - y_{out}^{2*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^*)$$
-$$k - k^{*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
-$$k - k^{*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
+$$k - k^{\*} = -(y_{out}^3 - y_{out}^{3\*}) + 3y_0(y_{out}^2 - y_{out}^{2\*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^{\*})$$
+$$k - k^{\*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
+$$k - k^{\*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
 
 Rewrite $k = y_{out}(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))$
 
-$$e_k > \left|\frac{ k - k^{*} }{k}\right| = \left|\frac{a_y}{y_{out}} \frac{(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))}{(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))}\right|$$
+$$e_k > \left|\frac{ k - k^{\*} }{k}\right| = \left|\frac{a_y}{y_{out}} \frac{(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))}{(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))}\right|$$
 
 Notice that $\left|\frac{a_y}{y_{out}}\right| = e_y$! Therefore
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -317,10 +317,12 @@ We see correctness of the swap fee, by imagining what happens if we took this re
 
 </a>
 
-Theorem: $|e_y| < 100 |e_k|$ as long as $y_{out} <= y_0$.
-
 The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals. You can prove this, by seeing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary, and therefore has no local minima or maxima in the reals.
 Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via binary search, we solve for a value $y_{out}^{*}$ such that $\left|\frac{ k - k^{*} }{k}\right| < e_k$, where $k^{*} = f(y_{out}^{*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{*} }{y_{out}}\right|$ in relation to $e_k$.
+
+**Theorem**: $e_y < 100 e_k$ as long as $|y_{out}| <= .9y_0$.
+**Informal**, we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better. (Often better than $e_k$)
+
 
 Let $y_{out} - y_{out}^* = a_y$, we are going to assume that $a_y << y_{out}$, and will justify this later. But due to this, we treat $a_y^c = 0$ for $c > 1$. This then implies that $y_{out}^2 - y_{out}^{*2} = y_{out}^2 - (y_{out} - a_y)^2 \approx 2y_{out}a_y$, and similarly $y_{out}^3 - y_{out}^{*3} \approx 3y_{out}^2 a_y$
 
@@ -343,19 +345,18 @@ We bound the right hand side, with the assistance of wolfram alpha. Let $a = y_{
   * Use solution set: $a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$
     * $a > 0$ by definition.
     * $b > \frac{2}{3} a$, as thats equivalent to $y_0 > \frac{2}{3} y_{out}$. We already assume that $y_0 >= y_{out}$.
-    * If we take the max possible value of $a$, that $y_{out} = y_0$, then we'd have to show that $x_f^2 + w > \frac{1}{99}y_0^2$. so we just need to bound when the rhs is less than 0. Unfortunately, we either have to assume something stronger about $x_f$, or make a tighter bound on $y_{out}$ than it merely being less than $y_0$.
+    * Set $y_{out} = .9y_0$, per our theorem assumption. So $b = .9a$. Take $c = x^2 + w = 0$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $(-299a^2 + 597ab - 297b^2) < 0$ for all $a$. This completes the constraint set.
 * When $y_{out} < 0$
   * Use solution set: $a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$
     * $a < 0$ by definition.
     * $b > \frac{2}{3} a$, as $y_0$ is positive.
     * $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
 
-Tieing this all together, we have that 
+Tieing this all together, we have that $e_k > .01e_y$. Therefore $e_y < 100 e_k$, satisfying our theoerem!
 
-$$e_k > .01e_y$$
+To show the informal claims, the constraint that led to this 100x error blowup was trying to accomodate high $y_{out}$. When $y_{out}$ is smaller, the error is far lower. (Often to the case that $e_y < e_k$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha) When $y_{out}$ is bigger than $.9y_0$, we can rely on x_f^2 + w being much larger to lower this error. In these cases, the $x_f$ term must be large relative to $y_0$, which would yield a far better error bound.
 
-So $e_y < 100 e_k$! QED.
-
+TODO: Justify a_y << y_out. (This should be easy, assume its not, that leads to e_k being high. Ratio test probably easiest. Maybe just add a sentence to that effect)
 
 ### Spot Price
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -153,6 +153,7 @@ $$k_{iter}(y_0 - y_{out}) = h(x_f, y_0 - y_{out}, w) = x_f (y_0 - y_{out}) (x_f^
 But we can remove many of these terms! First notice that `x_f` is a constant factor in `k_iter`, so we can just divide `k_target` by `x_f` to remove that. Then we switch what we search over, from `y_f` to `y_out`, by fixing `y_0`, so were at:
 
 $$k_{target} = x_0 y_0 (x_0^2 + y_0^2 + w) / x_f$$
+
 $$k_{iter}(y_{out}) = (y_0 - y_{out}) (x_f^2 + (y_0 - y_{out})^2 + w) = (y_0 - y_{out}) (x_f^2 + w) + (y_0 - y_{out})^3$$
 
 So $k_{iter}(y_{out})$ is a cubic polynomial in $y_{out}$. Next we remove the terms that have no dependence on `y_{delta}` (the constant term in the polynomial). To do this first we rewrite this to make the polynomial clearer:

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -147,8 +147,8 @@ In the lowerbound case, we leave it as lower-bounded by $0$, otherwise we would 
 Great, we have a binary search to finding an input `new_y_reserve`, such that we get a value `k` within some error bound close to the true desired `k`! We can prove that an error by a factor of `e` in `k`, implies an error of a factor less than `e` in `new_y_reserve`. So we could set `e` to be close to some correctness bound we want. Except... `new_y_reserve >> y_in`, so we'd need an extremely high error tolerance for this to work. So we actually want to adapt the equations, to reduce the "common terms" in `k` that we need to binary search over, to help us search. To do this, we open up what are we doing again, and re-expose `y_out` as a variable we explicitly search over (and therefore get error terms in `k` implying error in `y_out`)
 
 What we are doing above in the binary search is setting `k_target` and searching over `y_f` until we get `k_iter` {within tolerance} to `k_target`. Sine we want to change to iterating over $y_{out}$, we unroll that $y_f = y_0 - y_{out}$ where they are defined as:
-$k_{target} = x_0 y_0 (x_0^2 + y_0^2 + w)$
-$k_{iter}(y_0 - y_{out}) = h(x_f, y_0 - y_{out}, w) = x_f (y_0 - y_{out}) (x_f^2 + (y_0 - y_{out})^2 + w)$
+$$k_{target} = x_0 y_0 (x_0^2 + y_0^2 + w)$$
+$$k_{iter}(y_0 - y_{out}) = h(x_f, y_0 - y_{out}, w) = x_f (y_0 - y_{out}) (x_f^2 + (y_0 - y_{out})^2 + w)$$
 
 But we can remove many of these terms! First notice that `x_f` is a constant factor in `k_iter`, so we can just divide `k_target` by `x_f` to remove that. Then we switch what we search over, from `y_f` to `y_out`, by fixing `y_0`, so were at:
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -210,6 +210,10 @@ def solve_y(x_0, y_0, w, x_in):
   return y_out
 ```
 
+##### Further optimization
+
+
+
 #### Using this in swap methods
 
 So now we put together the components discussed in prior sections to achieve pseudocode for the SwapExactAmountIn

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -249,8 +249,6 @@ And therefore we round up in both cases.
 
 ##### Further optimization
 
-
-
 #### Using this in swap methods
 
 So now we put together the components discussed in prior sections to achieve pseudocode for the SwapExactAmountIn
@@ -317,19 +315,19 @@ We see correctness of the swap fee, by imagining what happens if we took this re
 
 </a>
 
-The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals. You can prove this, by seeing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary, and therefore has no local minima or maxima in the reals.
-Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via binary search, we solve for a value $y_{out}^{*}$ such that $\left|\frac{ k - k^{*} }{k}\right| < e_k$, where $k^{*} = f(y_{out}^{*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{*} }{y_{out}}\right|$ in relation to $e_k$.
+The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals. You can prove this by showing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary and that therefore it has no local minima or maxima in the reals.
+
+Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via binary search, we solve for a value $y_{out}^{\*}$ such that $\left|\frac{ k - k^{\*} }{k}\right| < e_k$, where $k^{\*} = f(y_{out}^{\*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{*} }{y_{out}}\right|$ in relation to $e_k$.
 
 **Theorem**: $e_y < 100 e_k$ as long as $|y_{out}| <= .9y_0$.
-**Informal**, we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better. (Often better than $e_k$)
-
+**Informal**: we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better (often better than $e_k$).
 
 Let $y_{out} - y_{out}^* = a_y$, we are going to assume that $a_y << y_{out}$, and will justify this later. But due to this, we treat $a_y^c = 0$ for $c > 1$. This then implies that $y_{out}^2 - y_{out}^{*2} = y_{out}^2 - (y_{out} - a_y)^2 \approx 2y_{out}a_y$, and similarly $y_{out}^3 - y_{out}^{*3} \approx 3y_{out}^2 a_y$
 
 Now we are prepared to start bounding this.
-$$k - k^{*} = -(y_{out}^3 - y_{out}^{3*}) + 3y_0(y_{out}^2 - y_{out}^{2*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^*)$$
-$$k - k^{*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
-$$k - k^{*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
+$$k - k^{\*} = -(y_{out}^3 - y_{out}^{3\*}) + 3y_0(y_{out}^2 - y_{out}^{2\*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^\*)$$
+$$k - k^{\*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
+$$k - k^{\*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
 
 Rewrite $k = y_{out}(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))$
 
@@ -341,20 +339,20 @@ $$e_k > e_y\left|\frac{(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))}{(-y_{
 
 We bound the right hand side, with the assistance of wolfram alpha. Let $a = y_{out}, b = y_0, c = x_f^2 + w$. Then we see from [wolfram alpha here](https://www.wolframalpha.com/input?i=%7C%28-3a%5E2+%2B+6ab+-+%28c+%2B+3b%5E2%29%29+%2F+%28-a%5E2+%2B+3ab+-+%28c+%2B+3b%5E2%29%29+%7C+%3E+.01), that this right hand expression is provably greater than `.01` if some set of decisions hold. We describe the solution set that satisfies our use case here:
 
-* When $y_{out} > 0$
-  * Use solution set: $a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$
-    * $a > 0$ by definition.
-    * $b > \frac{2}{3} a$, as thats equivalent to $y_0 > \frac{2}{3} y_{out}$. We already assume that $y_0 >= y_{out}$.
-    * Set $y_{out} = .9y_0$, per our theorem assumption. So $b = .9a$. Take $c = x^2 + w = 0$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $(-299a^2 + 597ab - 297b^2) < 0$ for all $a$. This completes the constraint set.
-* When $y_{out} < 0$
-  * Use solution set: $a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$
-    * $a < 0$ by definition.
-    * $b > \frac{2}{3} a$, as $y_0$ is positive.
-    * $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
+- When $y_{out} > 0$
+  - Use solution set: $a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$
+    - $a > 0$ by definition.
+    - $b > \frac{2}{3} a$, as thats equivalent to $y_0 > \frac{2}{3} y_{out}$. We already assume that $y_0 >= y_{out}$.
+    - Set $y_{out} = .9y_0$, per our theorem assumption. So $b = .9a$. Take $c = x^2 + w = 0$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $(-299a^2 + 597ab - 297b^2) < 0$ for all $a$. This completes the constraint set.
+- When $y_{out} < 0$
+  - Use solution set: $a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$
+    - $a < 0$ by definition.
+    - $b > \frac{2}{3} a$, as $y_0$ is positive.
+    - $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
 
 Tieing this all together, we have that $e_k > .01e_y$. Therefore $e_y < 100 e_k$, satisfying our theoerem!
 
-To show the informal claims, the constraint that led to this 100x error blowup was trying to accomodate high $y_{out}$. When $y_{out}$ is smaller, the error is far lower. (Often to the case that $e_y < e_k$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha) When $y_{out}$ is bigger than $.9y_0$, we can rely on x_f^2 + w being much larger to lower this error. In these cases, the $x_f$ term must be large relative to $y_0$, which would yield a far better error bound.
+To show the informal claims, the constraint that led to this 100x error blowup was trying to accomodate high $y_{out}$. When $y_{out}$ is smaller, the error is far lower (often to the case that $e_y < e_k$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha). When $y_{out}$ is bigger than $.9y_0$, we can rely on the (x_f^2 + w) term being much larger to lower this error. In these cases, the $x_f$ term must be large relative to $y_0$, which would yield a far better error bound.
 
 TODO: Justify a_y << y_out. (This should be easy, assume its not, that leads to e_k being high. Ratio test probably easiest. Maybe just add a sentence to that effect)
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -159,13 +159,17 @@ $$k_{iter}(y_{out}) = (y_0 - y_{out}) (x_f^2 + (y_0 - y_{out})^2 + w) = (y_0 - y
 So $k_{iter}(y_{out})$ is a cubic polynomial in $y_{out}$. Next we remove the terms that have no dependence on `y_{delta}` (the constant term in the polynomial). To do this first we rewrite this to make the polynomial clearer:
 
 $$k_{iter}(y_{out}) = (y_0 - y_{out}) (x_f^2 + w) + y_0^3 - 3y_0^2 y_{out} + 3 y_0 y_{out}^2 - y_{out}^3$$
+
 $$k_{iter}(y_{out}) = y_0 (x_f^2 + w) - y_{out}(x_f^2 + w) + y_0^3 - 3y_0^2 y_{out} + 3 y_0 y_{out}^2 - y_{out}^3$$
+
 $$k_{iter}(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out} + (y_0 (x_f^2 + w) + y_0^3)$$
 
 So we can subtract this constant term `y_0 (x_f^2 + w) + y_0^3`, which for `y_out < y_0` is the dominant term in the expression!
 
 So lets define this as:
+
 $$k_{target} = \frac{x_0 y_0 (x_0^2 + y_0^2 + w)}{x_f} - (y_0 (x_f^2 + w) + y_0^3)$$
+
 $$k_{iter}(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$$
 
 We prove [here](#err_proof) that an error of a multiplicative `e` between `target_k` and `iter_k`, implies an error of less than a factor of `10e` in `y_{out}`, as long as `|y_{out}| < y_0`. (The proven bounds are actually better)
@@ -337,7 +341,9 @@ Let $y_{out} - y_{out}^* = a_y$, we are going to assume that $a_y << y_{out}$, a
 
 Now we are prepared to start bounding this.
 $$k - k^{\*} = -(y_{out}^3 - y_{out}^{3\*}) + 3y_0(y_{out}^2 - y_{out}^{2\*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^{\*})$$
+
 $$k - k^{\*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
+
 $$k - k^{\*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
 
 Rewrite $k = y_{out}(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))$

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -249,6 +249,8 @@ And therefore we round up in both cases.
 
 ##### Further optimization
 
+
+
 #### Using this in swap methods
 
 So now we put together the components discussed in prior sections to achieve pseudocode for the SwapExactAmountIn
@@ -315,19 +317,19 @@ We see correctness of the swap fee, by imagining what happens if we took this re
 
 </a>
 
-The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals. You can prove this by showing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary and that therefore it has no local minima or maxima in the reals.
-
-Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via binary search, we solve for a value $y_{out}^{\*}$ such that $\left|\frac{ k - k^{\*} }{k}\right| < e_k$, where $k^{\*} = f(y_{out}^{\*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{*} }{y_{out}}\right|$ in relation to $e_k$.
+The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals. You can prove this, by seeing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary, and therefore has no local minima or maxima in the reals.
+Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$. Via binary search, we solve for a value $y_{out}^{*}$ such that $\left|\frac{ k - k^{*} }{k}\right| < e_k$, where $k^{*} = f(y_{out}^{*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{*} }{y_{out}}\right|$ in relation to $e_k$.
 
 **Theorem**: $e_y < 100 e_k$ as long as $|y_{out}| <= .9y_0$.
-**Informal**: we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better (often better than $e_k$).
+**Informal**, we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better. (Often better than $e_k$)
+
 
 Let $y_{out} - y_{out}^* = a_y$, we are going to assume that $a_y << y_{out}$, and will justify this later. But due to this, we treat $a_y^c = 0$ for $c > 1$. This then implies that $y_{out}^2 - y_{out}^{*2} = y_{out}^2 - (y_{out} - a_y)^2 \approx 2y_{out}a_y$, and similarly $y_{out}^3 - y_{out}^{*3} \approx 3y_{out}^2 a_y$
 
 Now we are prepared to start bounding this.
-$$k - k^{\*} = -(y_{out}^3 - y_{out}^{3\*}) + 3y_0(y_{out}^2 - y_{out}^{2\*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^\*)$$
-$$k - k^{\*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
-$$k - k^{\*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
+$$k - k^{*} = -(y_{out}^3 - y_{out}^{3*}) + 3y_0(y_{out}^2 - y_{out}^{2*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^*)$$
+$$k - k^{*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^2)a_y$$
+$$k - k^{*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
 
 Rewrite $k = y_{out}(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))$
 
@@ -339,20 +341,20 @@ $$e_k > e_y\left|\frac{(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))}{(-y_{
 
 We bound the right hand side, with the assistance of wolfram alpha. Let $a = y_{out}, b = y_0, c = x_f^2 + w$. Then we see from [wolfram alpha here](https://www.wolframalpha.com/input?i=%7C%28-3a%5E2+%2B+6ab+-+%28c+%2B+3b%5E2%29%29+%2F+%28-a%5E2+%2B+3ab+-+%28c+%2B+3b%5E2%29%29+%7C+%3E+.01), that this right hand expression is provably greater than `.01` if some set of decisions hold. We describe the solution set that satisfies our use case here:
 
-- When $y_{out} > 0$
-  - Use solution set: $a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$
-    - $a > 0$ by definition.
-    - $b > \frac{2}{3} a$, as thats equivalent to $y_0 > \frac{2}{3} y_{out}$. We already assume that $y_0 >= y_{out}$.
-    - Set $y_{out} = .9y_0$, per our theorem assumption. So $b = .9a$. Take $c = x^2 + w = 0$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $(-299a^2 + 597ab - 297b^2) < 0$ for all $a$. This completes the constraint set.
-- When $y_{out} < 0$
-  - Use solution set: $a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$
-    - $a < 0$ by definition.
-    - $b > \frac{2}{3} a$, as $y_0$ is positive.
-    - $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
+* When $y_{out} > 0$
+  * Use solution set: $a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$
+    * $a > 0$ by definition.
+    * $b > \frac{2}{3} a$, as thats equivalent to $y_0 > \frac{2}{3} y_{out}$. We already assume that $y_0 >= y_{out}$.
+    * Set $y_{out} = .9y_0$, per our theorem assumption. So $b = .9a$. Take $c = x^2 + w = 0$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $(-299a^2 + 597ab - 297b^2) < 0$ for all $a$. This completes the constraint set.
+* When $y_{out} < 0$
+  * Use solution set: $a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$
+    * $a < 0$ by definition.
+    * $b > \frac{2}{3} a$, as $y_0$ is positive.
+    * $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
 
 Tieing this all together, we have that $e_k > .01e_y$. Therefore $e_y < 100 e_k$, satisfying our theoerem!
 
-To show the informal claims, the constraint that led to this 100x error blowup was trying to accomodate high $y_{out}$. When $y_{out}$ is smaller, the error is far lower (often to the case that $e_y < e_k$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha). When $y_{out}$ is bigger than $.9y_0$, we can rely on the (x_f^2 + w) term being much larger to lower this error. In these cases, the $x_f$ term must be large relative to $y_0$, which would yield a far better error bound.
+To show the informal claims, the constraint that led to this 100x error blowup was trying to accomodate high $y_{out}$. When $y_{out}$ is smaller, the error is far lower. (Often to the case that $e_y < e_k$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha) When $y_{out}$ is bigger than $.9y_0$, we can rely on x_f^2 + w being much larger to lower this error. In these cases, the $x_f$ term must be large relative to $y_0$, which would yield a far better error bound.
 
 TODO: Justify a_y << y_out. (This should be easy, assume its not, that leads to e_k being high. Ratio test probably easiest. Maybe just add a sentence to that effect)
 

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -281,16 +281,18 @@ func iterKCalculator(x0, w, yf osmomath.BigDec) func(osmomath.BigDec) (osmomath.
 	}
 }
 
-var zero = osmomath.ZeroDec()
-var one = osmomath.OneDec()
+var (
+	zero = osmomath.ZeroDec()
+	one  = osmomath.OneDec()
+)
 
 func deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal osmomath.BigDec) (
-	xFinalLowerbound, xFinalUpperbound osmomath.BigDec) {
+	xFinalLowerbound, xFinalUpperbound osmomath.BigDec,
+) {
 	xFinalLowerbound, xFinalUpperbound = xReserve, xReserve
 
 	k0 := cfmmConstantMultiNoV(xReserve, yFinal, wSumSquares)
 	k := cfmmConstantMultiNoV(xReserve, yReserve, wSumSquares)
-	// fmt.Println(k0, k)
 	if k0.Equal(zero) || k.Equal(zero) {
 		panic("k should never be zero")
 	}
@@ -303,10 +305,8 @@ func deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal
 	} else if kRatio.GT(one) {
 		// need to find a lowerbound. We could use a cubic relation, but for now we just set it to 0.
 		xFinalLowerbound = osmomath.ZeroDec()
-	} else {
-		// k remains unchanged.
-		// So we keep bounds equal to each other
 	}
+	// otherwise, k remains unchanged, so we keep bounds equal to each other
 	return xFinalLowerbound, xFinalUpperbound
 }
 
@@ -317,7 +317,6 @@ func solveCFMMBinarySearchMulti(xReserve, yReserve, wSumSquares, yIn osmomath.Bi
 	} else if yIn.Abs().GTE(yReserve) {
 		panic("cannot input more than pool reserves")
 	}
-	// fmt.Printf("solve cfmm xreserve %v, yreserve %v, w %v, yin %v\n", xReserve, yReserve, wSumSquares, yIn)
 	yFinal := yReserve.Add(yIn)
 	xLowEst, xHighEst := deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal)
 	targetK := targetKCalculator(xReserve, yReserve, wSumSquares, yFinal)
@@ -344,7 +343,6 @@ func solveCFMMBinarySearchMulti(xReserve, yReserve, wSumSquares, yIn osmomath.Bi
 	}
 
 	xOut := xReserve.Sub(xEst)
-	// fmt.Printf("xOut %v\n", xOut)
 
 	// We check the absolute value of the output against the xReserve amount to ensure that:
 	// 1. Swaps cannot more than double the input token's pool supply

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -303,10 +303,10 @@ func deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal
 	} else if kRatio.GT(one) {
 		// need to find a lowerbound. We could use a cubic relation, but for now we just set it to 0.
 		xFinalLowerbound = osmomath.ZeroDec()
-	} else {
-		// k remains unchanged.
-		// So we keep bounds equal to each other
 	}
+	// else
+	// k remains unchanged.
+	// So we keep bounds equal to each other
 	return xFinalLowerbound, xFinalUpperbound
 }
 

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -281,18 +281,16 @@ func iterKCalculator(x0, w, yf osmomath.BigDec) func(osmomath.BigDec) (osmomath.
 	}
 }
 
-var (
-	zero = osmomath.ZeroDec()
-	one  = osmomath.OneDec()
-)
+var zero = osmomath.ZeroDec()
+var one = osmomath.OneDec()
 
 func deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal osmomath.BigDec) (
-	xFinalLowerbound, xFinalUpperbound osmomath.BigDec,
-) {
+	xFinalLowerbound, xFinalUpperbound osmomath.BigDec) {
 	xFinalLowerbound, xFinalUpperbound = xReserve, xReserve
 
 	k0 := cfmmConstantMultiNoV(xReserve, yFinal, wSumSquares)
 	k := cfmmConstantMultiNoV(xReserve, yReserve, wSumSquares)
+	// fmt.Println(k0, k)
 	if k0.Equal(zero) || k.Equal(zero) {
 		panic("k should never be zero")
 	}
@@ -305,8 +303,10 @@ func deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal
 	} else if kRatio.GT(one) {
 		// need to find a lowerbound. We could use a cubic relation, but for now we just set it to 0.
 		xFinalLowerbound = osmomath.ZeroDec()
+	} else {
+		// k remains unchanged.
+		// So we keep bounds equal to each other
 	}
-	// otherwise, k remains unchanged, so we keep bounds equal to each other
 	return xFinalLowerbound, xFinalUpperbound
 }
 
@@ -317,6 +317,7 @@ func solveCFMMBinarySearchMulti(xReserve, yReserve, wSumSquares, yIn osmomath.Bi
 	} else if yIn.Abs().GTE(yReserve) {
 		panic("cannot input more than pool reserves")
 	}
+	// fmt.Printf("solve cfmm xreserve %v, yreserve %v, w %v, yin %v\n", xReserve, yReserve, wSumSquares, yIn)
 	yFinal := yReserve.Add(yIn)
 	xLowEst, xHighEst := deriveUpperLowerXFinalReserveBounds(xReserve, yReserve, wSumSquares, yFinal)
 	targetK := targetKCalculator(xReserve, yReserve, wSumSquares, yFinal)
@@ -343,6 +344,7 @@ func solveCFMMBinarySearchMulti(xReserve, yReserve, wSumSquares, yIn osmomath.Bi
 	}
 
 	xOut := xReserve.Sub(xEst)
+	// fmt.Printf("xOut %v\n", xOut)
 
 	// We check the absolute value of the output against the xReserve amount to ensure that:
 	// 1. Swaps cannot more than double the input token's pool supply

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -681,8 +681,9 @@ func (suite *StableSwapTestSuite) Test_StableSwap_CalculateAmountOutAndIn_Invers
 
 	swapFeeCases := []string{"0", "0.001", "0.1", "0.5", "0.99"}
 
-	getTestCaseName := func(tc testcase, swapFeeCase string) string {
-		return fmt.Sprintf("tokenOutInitial: %d, tokenInInitial: %d, initialOut: %d, swapFee: %s",
+	getTestCaseName := func(name string, tc testcase, swapFeeCase string) string {
+		return fmt.Sprintf("%s: tokenOutInitial: %d, tokenInInitial: %d, initialOut: %d, swapFee: %s",
+			name,
 			tc.initialPoolOut,
 			tc.initialPoolIn,
 			tc.initialCalcOut,
@@ -690,9 +691,9 @@ func (suite *StableSwapTestSuite) Test_StableSwap_CalculateAmountOutAndIn_Invers
 		)
 	}
 
-	for _, tc := range testcases {
+	for name, tc := range testcases {
 		for _, swapFee := range swapFeeCases {
-			suite.Run(getTestCaseName(tc, swapFee), func() {
+			suite.Run(getTestCaseName(name, tc, swapFee), func() {
 				ctx := suite.CreateTestContext()
 
 				poolLiquidityIn := sdk.NewInt64Coin(tc.denomIn, tc.initialPoolIn)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Changes our stableswap binary search to be searching for k, with only a dependence in `y_{out}` not `y_final`. This fixes the convergence bound problem before, where we wasted the accuracy on the already-known bits of `y_final`, rather than the lower order bits we need.

## Brief Changelog

- Make CFMM solving code cubic, rather than quartic. 
- Make it only cubic in the input amount
- Make big dec compare able to handle negatives

## Testing and Verifying

This change is already covered by existing tests, namely the hand worked out test vectors. Granted, we need more hand worked out test vectors for swaps. I'd not expect this to change things within the error tolerance bounds though.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? Stableswap Spec (Merge should be blocked until we've made the explanation clear)