### PR TITLE
test(gamm): add stableswap tests for new stargate queries

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -37,6 +37,7 @@ var DefaultStableswapLiquidity = sdk.NewCoins(
 	sdk.NewCoin("foo", sdk.NewInt(10000000)),
 	sdk.NewCoin("bar", sdk.NewInt(10000000)),
 	sdk.NewCoin("baz", sdk.NewInt(10000000)),
+	sdk.NewCoin("uosmo", sdk.NewInt(10000000)),
 )
 
 // PrepareBalancerPoolWithCoins returns a balancer pool

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -56,7 +56,7 @@ func (suite *KeeperTestSuite) TestCalcExitPoolCoinsFromShares() {
 	}
 
 	// Test case shared by all pools to be tested.
-	allTestCases := mergeTestCases(validPools, sharedTestCases)
+	allTestCases := createTestCasesForGivenPools(validPools, sharedTestCases)
 
 	// Add individual test cases
 	allTestCases = append(allTestCases, &shareInTestCase{
@@ -138,7 +138,7 @@ func (suite *KeeperTestSuite) TestCalcJoinPoolNoSwapShares() {
 		},
 	}
 
-	allTestCases := mergeTestCases(validPools, sharedTestCases)
+	allTestCases := createTestCasesForGivenPools(validPools, sharedTestCases)
 
 	// Indiividual test cases where pool model does not matter.
 	nonExistentPoolId := validPools[len(validPools)-1].poolId + 1
@@ -381,7 +381,7 @@ func (suite *KeeperTestSuite) TestCalcJoinPoolShares() {
 		},
 	}
 
-	allTestCases := mergeTestCases(validPools, sharedTestCases)
+	allTestCases := createTestCasesForGivenPools(validPools, sharedTestCases)
 
 	// add inidividual test cases
 	nonExistentPoolId := validPools[len(validPools)-1].poolId + 1

--- a/x/gamm/keeper/keeper_test.go
+++ b/x/gamm/keeper/keeper_test.go
@@ -120,6 +120,8 @@ func (suite *KeeperTestSuite) fundAllAccountsWith(balances sdk.Coins) {
 	}
 }
 
+// initializeValidTestPools returns a list of all supported pool models.
+// Each pool model has a pool with id created and a name assigned.
 func (suite *KeeperTestSuite) initializeValidTestPools() []poolsCase {
 	return []poolsCase{
 		{
@@ -133,7 +135,10 @@ func (suite *KeeperTestSuite) initializeValidTestPools() []poolsCase {
 	}
 }
 
-func mergeTestCases[T testCaseI](validPools []poolsCase, sharedTestCases []T) []T {
+// createTestCasesForGivenPools creates a test case in sharedTestCases for each pool in validPools
+// and returns the final merged list of all test cases.
+// This helps to reduce code duplciation when testing the same logic for multiple pool models.
+func createTestCasesForGivenPools[T testCaseI](validPools []poolsCase, sharedTestCases []T) []T {
 	allTestCases := make([]T, 0)
 	for _, pool := range validPools {
 		curPool := pool

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -234,7 +234,7 @@ func ensureDenomInPool(poolAssetsByDenom map[string]PoolAsset, tokensIn sdk.Coin
 	for _, coin := range tokensIn {
 		_, ok := poolAssetsByDenom[coin.Denom]
 		if !ok {
-			return sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, invalidInputDenomsErrFormat, coin.Denom)
+			return types.ErrInputDenomsNotInPool
 		}
 	}
 

--- a/x/gamm/pool-models/balancer/amm_test.go
+++ b/x/gamm/pool-models/balancer/amm_test.go
@@ -79,13 +79,13 @@ func (suite *KeeperTestSuite) TestEnsureDenomInPool() {
 			poolAssets:  []balancer.PoolAsset{defaultOsmoPoolAsset, defaultAtomPoolAsset},
 			tokensIn:    sdk.NewCoins(sdk.NewCoin("uatom", sdk.OneInt()), sdk.NewCoin("foo", sdk.OneInt())),
 			expectPass:  false,
-			expectedErr: types.ErrDenomNotFoundInPool,
+			expectedErr: types.ErrInputDenomsNotInPool,
 		},
 		"none of tokensIn is in pool asset map": {
 			poolAssets:  []balancer.PoolAsset{defaultOsmoPoolAsset, defaultAtomPoolAsset},
 			tokensIn:    sdk.NewCoins(sdk.NewCoin("foo", sdk.OneInt())),
 			expectPass:  false,
-			expectedErr: types.ErrDenomNotFoundInPool,
+			expectedErr: types.ErrInputDenomsNotInPool,
 		},
 	}
 

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -1,8 +1,6 @@
 package stableswap
 
 import (
-	"errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v12/osmomath"
@@ -402,7 +400,7 @@ func (p *Pool) calcSingleAssetJoinShares(tokenIn sdk.Coin, swapFee sdk.Dec) (sdk
 // Eventually, we intend to switch this to a COW wrapped pa for better performance
 func (p *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, tokensJoined sdk.Coins, err error) {
 	if !tokensIn.DenomsSubsetOf(p.GetTotalPoolLiquidity(ctx)) {
-		return sdk.ZeroInt(), sdk.NewCoins(), errors.New("attempted joining pool with assets that do not exist in pool")
+		return sdk.ZeroInt(), sdk.NewCoins(), types.ErrInputDenomsNotInPool
 	}
 	if len(tokensIn) == 1 && tokensIn[0].Amount.GT(sdk.OneInt()) {
 		numShares, err = p.calcSingleAssetJoinShares(tokensIn[0], swapFee)
@@ -420,8 +418,7 @@ func (p *Pool) joinPoolSharesInternal(ctx sdk.Context, tokensIn sdk.Coins, swapF
 
 		return numShares, tokensJoined, nil
 	} else if len(tokensIn) != p.NumAssets() {
-		return sdk.ZeroInt(), sdk.NewCoins(), errors.New(
-			"stableswap pool only supports LP'ing with one asset, or all assets in pool")
+		return sdk.ZeroInt(), sdk.NewCoins(), types.ErrSwapInputTokenCountMismatch
 	}
 
 	// Add all exact coins we can (no swap). ctx arg doesn't matter for Stableswap

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -349,8 +349,11 @@ func (p *Pool) CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee s
 // If an all-asset join is not possible, returns an error.
 func (p Pool) CalcJoinPoolNoSwapShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, tokensJoined sdk.Coins, err error) {
 	// ensure that there aren't too many or too few assets in `tokensIn`
-	if tokensIn.Len() != p.NumAssets() || !tokensIn.DenomsSubsetOf(p.GetTotalPoolLiquidity(ctx)) {
-		return sdk.ZeroInt(), sdk.NewCoins(), errors.New("no-swap joins require LP'ing with all assets in pool")
+	if tokensIn.Len() != p.NumAssets() {
+		return sdk.ZeroInt(), sdk.NewCoins(), types.ErrNoSwapInputTokenCountMismatch
+	}
+	if !tokensIn.DenomsSubsetOf(p.GetTotalPoolLiquidity(ctx)) {
+		return sdk.ZeroInt(), sdk.NewCoins(), types.ErrInputDenomsNotInPool
 	}
 
 	// execute a no-swap join with as many tokens as possible given a perfect ratio:

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	fmt "fmt"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -13,6 +14,12 @@ type PoolDoesNotExistError struct {
 func (e PoolDoesNotExistError) Error() string {
 	return fmt.Sprintf("pool with ID %d does not exist", e.PoolId)
 }
+
+var (
+	ErrInputDenomsNotInPool          = errors.New("input denoms must already exist in the pool")
+	ErrNoSwapInputTokenCountMismatch = errors.New("no-swap joins require LP'ing with all assets in pool")
+	ErrSwapInputTokenCountMismatch   = errors.New("only allowed LPing with one asset or all assets in pool")
+)
 
 // x/gamm module sentinel errors.
 var (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Most of our query and other gamm tests only test balancer pool. It is safer to test any supported pool and make sure that the same outcome is returned given the same inputs. Asserting this might be particularly useful for stargate queries that smart contracts rely upon.

This PR extends existing tests with the stableswap pool model for new queries whitelisted here: https://github.com/osmosis-labs/osmosis/pull/3217

Some error checks are shifted around to make sure that both pool models return the same error.

The way we test both pool modes is by creating shared test cases and a list of pool model ids. For each pool id, we create a new shared test case. This allows to reduce code duplication and to reuse the same test cases.
See this function for details:
https://github.com/osmosis-labs/osmosis/blob/e16c8ee62f76e6f1613df6450c8dd2d461ebfad2/x/gamm/keeper/keeper_test.go#L138-L153

and this is how we merge tests:
https://github.com/osmosis-labs/osmosis/blob/e16c8ee62f76e6f1613df6450c8dd2d461ebfad2/x/gamm/keeper/grpc_query_test.go#L38-L59


In the future, we can refactor to extract common validation into the `types` package.

## State Breakage

This is state-breaking due to removing `sdkerrors` and shifting around error checks.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable