### PR TITLE
Allow to unset rate limiting contract param

### DIFF
--- a/x/ibc-rate-limit/contracts/rate-limiter/src/packet.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/packet.rs
@@ -471,4 +471,12 @@ pub mod tests {
             _ => panic!("parsed into wrong variant"),
         }
     }
+
+    #[test]
+    fn packet_with_memo() {
+        // extra fields (like memo) get ignored.
+        let json = r#"{"recv_packet":{"packet":{"sequence":1,"source_port":"transfer","source_channel":"channel-0","destination_port":"transfer","destination_channel":"channel-0","data":{"denom":"stake","amount":"1","sender":"osmo177uaalkhra6wth6hc9hu79f72eq903kwcusx4r","receiver":"osmo1fj6yt4pwfea4865z763fvhwktlpe020ef93dlq","memo":"some info"},"timeout_height":{"revision_height":100}}}}"#;
+        let _parsed: SudoMsg = serde_json_wasm::from_str(json).unwrap();
+        //println!("{parsed:?}");
+    }
 }

--- a/x/ibc-rate-limit/ibc_middleware_test.go
+++ b/x/ibc-rate-limit/ibc_middleware_test.go
@@ -506,5 +506,6 @@ func (suite *MiddlewareTestSuite) TestUnsetRateLimitingContract() {
 	osmosisApp := suite.chainA.GetOsmosisApp()
 	paramSpace, ok := osmosisApp.AppKeepers.ParamsKeeper.GetSubspace(types.ModuleName)
 	suite.Require().True(ok)
+        // N.B.: this panics if validation fails.
 	paramSpace.SetParamSet(suite.chainA.GetContext(), &params)
 }

--- a/x/ibc-rate-limit/ibc_middleware_test.go
+++ b/x/ibc-rate-limit/ibc_middleware_test.go
@@ -493,3 +493,18 @@ func (suite *MiddlewareTestSuite) TestFailedSendTransfer() {
 	// We should be able to send again because the packet that exceeded the quota failed and has been reverted
 	suite.AssertSend(true, suite.MessageFromAToB(sdk.DefaultBondDenom, sdk.NewInt(1)))
 }
+
+func (suite *MiddlewareTestSuite) TestUnsetRateLimitingContract() {
+	// Setup contract
+	suite.chainA.StoreContractCode(&suite.Suite, "./bytecode/rate_limiter.wasm")
+	addr := suite.chainA.InstantiateRLContract(&suite.Suite, "")
+	suite.chainA.RegisterRateLimitingContract(addr)
+
+	// Unset the contract param
+	params, err := types.NewParams("")
+	suite.Require().NoError(err)
+	osmosisApp := suite.chainA.GetOsmosisApp()
+	paramSpace, ok := osmosisApp.AppKeepers.ParamsKeeper.GetSubspace(types.ModuleName)
+	suite.Require().True(ok)
+	paramSpace.SetParamSet(suite.chainA.GetContext(), &params)
+}

--- a/x/ibc-rate-limit/types/params.go
+++ b/x/ibc-rate-limit/types/params.go
@@ -53,6 +53,12 @@ func validateContractAddress(i interface{}) error {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
+	// Empty strings are valid for unsetting the param
+	if v == "" {
+		return nil
+	}
+
+	// Checks that the contract address is valid
 	bech32, err := sdk.AccAddressFromBech32(v)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

We weren't allowing the unset of the rate limiting contract param by setting the contract address to `""`


## Brief Changelog

An empty string is now a valid contract address for rate limits


## Testing and Verifying

Added a test for this.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)