### PR TITLE
Release process: fix `make build-reproducible` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,13 @@ build-reproducible-amd64: go.sum $(BUILDDIR)/
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg GIT_VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(COMMIT) \
+		--build-arg RUNNER_IMAGE=alpine:3.16 \
 		--platform linux/amd64 \
-		-t osmosis-amd64 \
+		-t osmosis:local-amd64 \
 		--load \
 		-f Dockerfile .
 	$(DOCKER) rm -f osmobinary || true
-	$(DOCKER) create -ti --name osmobinary osmosis-amd64
+	$(DOCKER) create -ti --name osmobinary osmosis:local-amd64
 	$(DOCKER) cp osmobinary:/bin/osmosisd $(BUILDDIR)/osmosisd-linux-amd64
 	$(DOCKER) rm -f osmobinary
 
@@ -124,12 +125,13 @@ build-reproducible-arm64: go.sum $(BUILDDIR)/
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg GIT_VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(COMMIT) \
+		--build-arg RUNNER_IMAGE=alpine:3.16 \
 		--platform linux/arm64 \
-		-t osmosis-arm64 \
+		-t osmosis:local-arm64 \
 		--load \
 		-f Dockerfile .
 	$(DOCKER) rm -f osmobinary || true
-	$(DOCKER) create -ti --name osmobinary osmosis-arm64
+	$(DOCKER) create -ti --name osmobinary osmosis:local-arm64
 	$(DOCKER) cp osmobinary:/bin/osmosisd $(BUILDDIR)/osmosisd-linux-arm64
 	$(DOCKER) rm -f osmobinary
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ build-reproducible-amd64: go.sum $(BUILDDIR)/
 	$(DOCKER) buildx use osmobuilder
 	$(DOCKER) buildx build \
 		--build-arg GO_VERSION=$(GO_VERSION) \
+		--build-arg GIT_VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(COMMIT) \
 		--platform linux/amd64 \
 		-t osmosis-amd64 \
 		--load \
@@ -120,6 +122,8 @@ build-reproducible-arm64: go.sum $(BUILDDIR)/
 	$(DOCKER) buildx use osmobuilder
 	$(DOCKER) buildx build \
 		--build-arg GO_VERSION=$(GO_VERSION) \
+		--build-arg GIT_VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(COMMIT) \
 		--platform linux/arm64 \
 		-t osmosis-arm64 \
 		--load \


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug in the `make build-reproducible` command that caused the latest  `v12.2.1` and `v12.3.0` release binaries to have an empty version specified. 

## Brief Changelog

- Update `make build-reproducible` command

## Testing and Verifying

Build binaries:

- **amd64**   `make build-reproducible-amd64`
- **arm64**   `make build-reproducible-arm64`

Check that the version is set with `osmosisd version`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable