### PR TITLE
[CL]: Calculation for `MinSqrtRatio`

### DIFF
--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -23,7 +23,6 @@ var (
 
 // Calculates MinSqrtPrice = sqrt(1.0001^MinTick)
 func GetMinSqrtRatio() sdk.Dec {
-	minSqrtRatio := osmomath.MustNewDecFromStr(strconv.FormatFloat(math.Pow(1.0001, -887272 / 2), 'f', 36, 64))
-	fmt.Println(minSqrtRatio)
+	minSqrtRatio := osmomath.MustNewDecFromStr(strconv.FormatFloat(math.Pow(1.0001, -887272/2), 'f', 36, 64))
 	return minSqrtRatio.SDKDec()
 }

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -1,7 +1,13 @@
 package types
 
 import (
+	"fmt"
+	"math"
+	"strconv"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v12/osmomath"
 )
 
 // TODO: decide on the values for Max tick and Min tick
@@ -12,5 +18,12 @@ var (
 	MaxSqrtRatio = sdk.MustNewDecFromStr("18446050711097703529.7763428")
 	// TODO: this is a temp value, figure out math for this.
 	// we basically want getSqrtRatioAtTick(MIN_TICK)
-	MinSqrtRatio = sdk.MustNewDecFromStr("0")
+	MinSqrtRatio = GetMinSqrtRatio()
 )
+
+// Calculates MinSqrtPrice = sqrt(1.0001^MinTick)
+func GetMinSqrtRatio() sdk.Dec {
+	minSqrtRatio := osmomath.MustNewDecFromStr(strconv.FormatFloat(math.Pow(1.0001, -887272 / 2), 'f', 36, 64))
+	fmt.Println(minSqrtRatio)
+	return minSqrtRatio.SDKDec()
+}

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Sub component of : #3178

## What is the purpose of the change
Add a function to calculate `MinSqrtRatio` instead of using zero value.
I'm using `BigDec` to save value but limit 36 ​​numbers prec (a little confused at this point)
