### PR TITLE
CI: Fix import path

### DIFF
--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -23,8 +23,9 @@ files=$(find ./ -type f -and -not \( -path "./vendor*" -or -path "./.git*" -or -
 
 echo "Updating all files"
 for file in $files; do
-    echo $file
-    replace_paths ${file}
+    if test -f "$file"; then
+        replace_paths $file
+    fi
 done
 
 echo "Updating go.mod and vendoring"

--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -23,6 +23,7 @@ files=$(find ./ -type f -and -not \( -path "./vendor*" -or -path "./.git*" -or -
 
 echo "Updating all files"
 for file in $files; do
+    echo $file
     replace_paths ${file}
 done
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3399

For some reason this [line](https://github.com/osmosis-labs/osmosis/blob/main/scripts/replace_import_paths.sh#L22) with normal paths returned `./x/twap/TWAP` file which does not exist. 

`Changes`: just added if statement that checks if a file exists when iterating them.

`Checks`: [successful action run](https://github.com/RusAkh/osmosis-fork/actions/runs/3476923028/jobs/5812582037)
Note that in this run I removed pull request job