### PR TITLE
CI: undeprecate set-output

### DIFF
--- a/.github/workflows/mutest-issue-generate.yml
+++ b/.github/workflows/mutest-issue-generate.yml
@@ -39,7 +39,7 @@ jobs:
         name: Get today's date
         id: date
         run: |
-          echo "::set-output name=today::$(date "+%Y/%m/%d")"
+          echo "name=today::$(date "+%Y/%m/%d")" >> $GITHUB_STATE
       -
         name: Read mutation_test_txt file
         id: result


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3348

[Changes according to this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

However, there are still many actions which depend on other actions, which were not updated. It is fine for now, but will break `1st of June 2023` Example: https://github.com/osmosis-labs/osmosis/issues/3348#issuecomment-1316364643