### PR TITLE
allow 100 percent exit from pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
 ### Features
 
 * [#2788](https://github.com/osmosis-labs/osmosis/pull/2788) Add logarithm base 2 implementation.
@@ -62,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#2937](https://github.com/osmosis-labs/osmosis/pull/2937) End block ordering - staking after gov and module sorting.
 * [#2923](https://github.com/osmosis-labs/osmosis/pull/2923) TWAP calculation now errors if it uses records that have errored previously.
 * [#3312](https://github.com/osmosis-labs/osmosis/pull/3312) Add better panic catches within GAMM txs
+* [#3428](https://github.com/osmosis-labs/osmosis/pull/3428) Permit 100% exit from pool.
 
 ### Misc Improvements
 

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -16,7 +16,7 @@ const errMsgFormatSharesLargerThanMax = "%s resulted shares is larger than the m
 // CalcExitPool returns how many tokens should come out, when exiting k LP shares against a "standard" CFMM
 func CalcExitPool(ctx sdk.Context, pool types.PoolI, exitingShares sdk.Int, exitFee sdk.Dec) (sdk.Coins, error) {
 	totalShares := pool.GetTotalShares()
-	if exitingShares.GTE(totalShares) {
+	if exitingShares.GT(totalShares) {
 		return sdk.Coins{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, errMsgFormatSharesLargerThanMax, exitingShares, totalShares)
 	}
 
@@ -42,7 +42,7 @@ func CalcExitPool(ctx sdk.Context, pool types.PoolI, exitingShares sdk.Int, exit
 		if exitAmt.LTE(sdk.ZeroInt()) {
 			continue
 		}
-		if exitAmt.GTE(asset.Amount) {
+		if exitAmt.GT(asset.Amount) {
 			return sdk.Coins{}, errors.New("too many shares out")
 		}
 		exitedCoins = exitedCoins.Add(sdk.NewCoin(asset.Denom, exitAmt))

--- a/x/gamm/pool-models/internal/cfmm_common/lp_test.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp_test.go
@@ -86,13 +86,19 @@ func TestCalcExitPool(t *testing.T) {
 		expError      bool
 	}{
 		{
-			name:          "two-asset pool, exiting shares grater than total shares",
+			name:          "two-asset pool, exiting shares 100% of total shares",
+			pool:          &twoAssetPool,
+			exitingShares: twoAssetPool.GetTotalShares(),
+			expError:      false,
+		},
+		{
+			name:          "two-asset pool, exiting shares greater than total shares",
 			pool:          &twoAssetPool,
 			exitingShares: twoAssetPool.GetTotalShares().AddRaw(1),
 			expError:      true,
 		},
 		{
-			name:          "three-asset pool, exiting shares grater than total shares",
+			name:          "three-asset pool, exiting shares greater than total shares",
 			pool:          &threeAssetPool,
 			exitingShares: threeAssetPool.GetTotalShares().AddRaw(1),
 			expError:      true,


### PR DESCRIPTION
Closes: #3427

## What is the purpose of the change

This pull request allows the last user with liquidity in a pool to exit the pool with 100% of their shares.


## Brief Changelog

- Allow 100% exit from pool by using GT instead of GTE.

## Testing and Verifying

This change added tests and can be verified as follows:

  - Added unit test that validates 100% exit from pool

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not documented