### PR TITLE
feat(CL): implement `withdrawPosition`

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -31,7 +31,7 @@ func (k Keeper) SetTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64, tic
 	k.setTickInfo(ctx, poolId, tickIndex, tickInfo)
 }
 
-func (k Keeper) WithdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityAmount sdk.Int) (amtDenom0, amtDenom1 sdk.Int, err error) {
+func (k Keeper) WithdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityAmount sdk.Dec) (amtDenom0, amtDenom1 sdk.Int, err error) {
 	return k.withdrawPosition(ctx, poolId, owner, lowerTick, upperTick, liquidityAmount)
 }
 

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -71,6 +71,6 @@ func Liquidity1(amount sdk.Int, sqrtPriceA, sqrtPriceB sdk.Dec) sdk.Dec {
 	return liquidity1(amount, sqrtPriceA, sqrtPriceB)
 }
 
-func (k Keeper) GetPoolbyId(ctx sdk.Context, poolId uint64) Pool {
+func (k Keeper) GetPoolbyId(ctx sdk.Context, poolId uint64) (Pool, error) {
 	return k.getPoolbyId(ctx, poolId)
 }

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -31,6 +31,10 @@ func (k Keeper) SetTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64, tic
 	k.setTickInfo(ctx, poolId, tickIndex, tickInfo)
 }
 
+func (k Keeper) WithdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityAmount sdk.Int) (amtDenom0, amtDenom1 sdk.Int, err error) {
+	return k.withdrawPosition(ctx, poolId, owner, lowerTick, upperTick, liquidityAmount)
+}
+
 func GetNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext sdk.Dec) {
 	return getNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining)
 }

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -35,6 +35,14 @@ func (k Keeper) WithdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAd
 	return k.withdrawPosition(ctx, poolId, owner, lowerTick, upperTick, liquidityAmount)
 }
 
+func (k Keeper) GetPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) (*Position, error) {
+	return k.getPosition(ctx, poolId, owner, lowerTick, upperTick)
+}
+
+func (k Keeper) HasPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) bool {
+	return k.hasPosition(ctx, poolId, owner, lowerTick, upperTick)
+}
+
 func GetNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext sdk.Dec) {
 	return getNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining)
 }

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -42,7 +42,7 @@ func (s *KeeperTestSuite) validatePositionUpdate(ctx sdk.Context, poolId uint64,
 	s.Require().True(newPositionLiquidity.GTE(sdk.ZeroDec()))
 }
 
-// validateTickupdates validates that ticks with the given parameters have expectedRemainingLiquidity left.
+// validateTickUpdates validates that ticks with the given parameters have expectedRemainingLiquidity left.
 func (s *KeeperTestSuite) validateTickUpdates(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, expectedRemainingLiquidity sdk.Dec) {
 	lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, poolId, lowerTick)
 	s.Require().NoError(err)

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -33,7 +33,7 @@ func (s *KeeperTestSuite) SetupPosition(poolId uint64) {
 	s.Require().Equal(amount1Desired.String(), asset1.String())
 }
 
-// validatePositionUpdate validates that positive with given parameters has expectedRemainingLiquidity left.
+// validatePositionUpdate validates that position with given parameters has expectedRemainingLiquidity left.
 func (s *KeeperTestSuite) validatePositionUpdate(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, expectedRemainingLiquidity sdk.Dec) {
 	position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(ctx, poolId, owner, lowerTick, upperTick)
 	s.Require().NoError(err)

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -32,3 +32,23 @@ func (s *KeeperTestSuite) SetupPosition(poolId uint64) {
 	s.Require().Equal(amount0Desired.String(), asset0.String())
 	s.Require().Equal(amount1Desired.String(), asset1.String())
 }
+
+func (s *KeeperTestSuite) validatePositionUpdate(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, expectedRemainingLiquidity sdk.Dec) {
+	position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(ctx, poolId, owner, lowerTick, upperTick)
+	s.Require().NoError(err)
+	newPositionLiquidity := position.Liquidity
+	s.Require().Equal(expectedRemainingLiquidity.String(), newPositionLiquidity.String())
+	s.Require().True(newPositionLiquidity.GTE(sdk.ZeroDec()))
+}
+
+func (s *KeeperTestSuite) validateTickUpdates(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, expectedRemainingLiquidity sdk.Dec) {
+	lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, poolId, lowerTick)
+	s.Require().NoError(err)
+	s.Require().Equal(expectedRemainingLiquidity.String(), lowerTickInfo.LiquidityGross.String())
+	s.Require().Equal(expectedRemainingLiquidity.String(), lowerTickInfo.LiquidityNet.String())
+
+	upperTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, poolId, upperTick)
+	s.Require().NoError(err)
+	s.Require().Equal(expectedRemainingLiquidity.String(), upperTickInfo.LiquidityGross.String())
+	s.Require().Equal(expectedRemainingLiquidity.Neg().String(), upperTickInfo.LiquidityNet.String())
+}

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -33,6 +33,7 @@ func (s *KeeperTestSuite) SetupPosition(poolId uint64) {
 	s.Require().Equal(amount1Desired.String(), asset1.String())
 }
 
+// validatePositionUpdate validates that positive with given parameters has expectedRemainingLiquidity left.
 func (s *KeeperTestSuite) validatePositionUpdate(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, expectedRemainingLiquidity sdk.Dec) {
 	position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(ctx, poolId, owner, lowerTick, upperTick)
 	s.Require().NoError(err)
@@ -41,6 +42,7 @@ func (s *KeeperTestSuite) validatePositionUpdate(ctx sdk.Context, poolId uint64,
 	s.Require().True(newPositionLiquidity.GTE(sdk.ZeroDec()))
 }
 
+// validateTickupdates validates that ticks with the given parameters have expectedRemainingLiquidity left.
 func (s *KeeperTestSuite) validateTickUpdates(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, expectedRemainingLiquidity sdk.Dec) {
 	lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, poolId, lowerTick)
 	s.Require().NoError(err)

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -129,6 +129,7 @@ func (k Keeper) updatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 
 // calcActualAmounts calculates and returns actual amounts based on where the current tick is located relative to position's
 // lower and upper ticks.
+// The returned amounts are rounded down to avoid returning more to clients than they actually deposited.
 // There are 3 possible cases:
 // -The position is active ( lowerTick <= p.CurrentTick < upperTick).
 //    * The provided liqudity is distributed in both tokens.
@@ -145,18 +146,18 @@ func (p Pool) calcActualAmounts(ctx sdk.Context, lowerTick, upperTick int64, sqr
 		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1
 		// we also update the pool liquidity since the virtual liquidity is modified by this position's creation
 		currentSqrtPrice := p.CurrentSqrtPrice
-		actualAmountDenom0 = calcAmount0Delta(liquidityDelta, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
-		actualAmountDenom1 = calcAmount1Delta(liquidityDelta, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
+		actualAmountDenom0 = calcAmount0Delta(liquidityDelta, currentSqrtPrice, sqrtRatioUpperTick, false).TruncateInt()
+		actualAmountDenom1 = calcAmount1Delta(liquidityDelta, currentSqrtPrice, sqrtRatioLowerTick, false).TruncateInt()
 	} else if p.CurrentTick.LT(sdk.NewInt(lowerTick)) {
 		// outcome two: position is below current price
 		// this means position is solely made up of asset0
 		actualAmountDenom1 = sdk.ZeroInt()
-		actualAmountDenom0 = calcAmount0Delta(liquidityDelta, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
+		actualAmountDenom0 = calcAmount0Delta(liquidityDelta, sqrtRatioLowerTick, sqrtRatioUpperTick, false).TruncateInt()
 	} else {
 		// outcome three: position is above current price
 		// this means position is solely made up of asset1
 		actualAmountDenom0 = sdk.ZeroInt()
-		actualAmountDenom1 = calcAmount1Delta(liquidityDelta, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
+		actualAmountDenom1 = calcAmount1Delta(liquidityDelta, sqrtRatioLowerTick, sqrtRatioUpperTick, false).TruncateInt()
 	}
 
 	return actualAmountDenom0, actualAmountDenom1

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -48,13 +48,12 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	return actualAmount0, actualAmount1, liquidityDelta, nil
 }
 
-// withdrawPosition withdraws a concentrated liquidity position from the given pool id in the given tick range and liquidityAmount.
-// On success, returns an amount of each token withdrawn.
+// withdrawPosition attempts to withdraw liquidityAmount from a position with the given pool id in the given tick range.
+// On success, returns an positive amount of each token withdrawn.
 // Returns error if
 // - there is no position in the given tick ranges
 // - if tick ranges are invalid
-// - if attempts to withdraw an amount higher than originally provided in createPosition for a given range
-// TODO: implement and table-driven tests
+// - if attempts to withdraw an amount higher than originally provided in createPosition for a given range.
 func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, requestedLiqudityAmountToWithdraw sdk.Dec) (amtDenom0, amtDenom1 sdk.Int, err error) {
 	if err := validateTickRangeIsValid(lowerTick, upperTick); err != nil {
 		return sdk.Int{}, sdk.Int{}, err

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -17,7 +17,7 @@ import (
 // Returns error if:
 // TODO: list error cases
 // TODO: table-driven tests
-func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, amount0Desired, amount1Desired, amount0Min, amount1Min sdk.Int, lowerTick, upperTick int64) (amtDenom0, amtDenom1 sdk.Int, liquidityCreated sdk.Dec, err error) {
+func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, amount0Desired, amount1Desired, amount0Min, amount1Min sdk.Int, lowerTick, upperTick int64) (sdk.Int, sdk.Int, sdk.Dec, error) {
 	// ensure types.MinTick <= lowerTick < types.MaxTick
 	// TODO (bez): Add unit tests.
 	if lowerTick < types.MinTick || lowerTick >= types.MaxTick {
@@ -30,66 +30,27 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("invalid upper tick: %d", upperTick)
 	}
 
+	sqrtPriceLowerTick, sqrtPriceUpperTick, err := ticksToSqrtPrice(lowerTick, upperTick)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
+	}
+
 	// now calculate amount for token0 and token1
 	pool := k.getPoolbyId(ctx, poolId)
 
-	currentSqrtPrice := pool.CurrentSqrtPrice
-	sqrtRatioUpperTick, err := tickToSqrtPrice(sdk.NewInt(upperTick))
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
-	}
-	sqrtRatioLowerTick, err := tickToSqrtPrice(sdk.NewInt(lowerTick))
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
+	liquidityDelta := getLiquidityFromAmounts(pool.CurrentSqrtPrice, sqrtPriceLowerTick, sqrtPriceUpperTick, amount0Desired, amount1Desired)
+	if liquidityDelta.IsZero() {
+		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("liquidity delta zero")
 	}
 
-	liquidity := getLiquidityFromAmounts(currentSqrtPrice, sqrtRatioLowerTick, sqrtRatioUpperTick, amount0Desired, amount1Desired)
-	if liquidity.IsZero() {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, fmt.Errorf("token in amount is zero")
-	}
-
-	// update tickInfo state
-	// TODO: come back to sdk.Int vs sdk.Dec state & truncation
-	err = k.initOrUpdateTick(ctx, poolId, lowerTick, liquidity, false)
+	actualAmount0, actualAmount1, err := k.updatePosition(ctx, poolId, owner, lowerTick, upperTick, liquidityDelta)
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
 	}
 
-	// TODO: come back to sdk.Int vs sdk.Dec state & truncation
-	err = k.initOrUpdateTick(ctx, poolId, upperTick, liquidity, true)
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
-	}
+	// TODO: handle amount0Min, amount1Min
 
-	// update position state
-	// TODO: come back to sdk.Int vs sdk.Dec state & truncation
-	err = k.initOrUpdatePosition(ctx, poolId, owner, lowerTick, upperTick, liquidity)
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
-	}
-
-	if pool.CurrentTick.LT(sdk.NewInt(lowerTick)) {
-		// outcome one: position is below current price
-		// this means position is solely made up of asset0
-		amtDenom0 = calcAmount0Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
-		amtDenom1 = sdk.ZeroInt()
-	} else if pool.CurrentTick.LT(sdk.NewInt(upperTick)) {
-		// outcome two: the current price falls within the position
-		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1
-		// we also update the pool liquidity since the virtual liquidity is modified by this position's creation
-		amtDenom0 = calcAmount0Delta(liquidity, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
-		amtDenom1 = calcAmount1Delta(liquidity, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
-		pool.Liquidity = pool.Liquidity.Add(liquidity)
-	} else {
-		// outcome three: position is above current price
-		// this means position is solely made up of asset1
-		amtDenom0 = sdk.ZeroInt()
-		amtDenom1 = calcAmount1Delta(liquidity, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
-	}
-
-	k.setPoolById(ctx, pool.Id, pool)
-
-	return amtDenom0, amtDenom1, liquidity, nil
+	return actualAmount0, actualAmount1, liquidityDelta, nil
 }
 
 // withdrawPosition withdraws a concentrated liquidity position from the given pool id in the given tick range and liquidityAmount.
@@ -99,6 +60,134 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 // - if tick ranges are invalid
 // - if attempts to withdraw an amount higher than originally provided in createPosition for a given range
 // TODO: implement and table-driven tests
-func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityAmount sdk.Int) (amtDenom0, amtDenom1 sdk.Int, err error) {
-	panic("not implemented")
+func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, requestedLiqudityAmountToWithdraw sdk.Int) (amtDenom0, amtDenom1 sdk.Int, err error) {
+
+	// check if requested liquidiyt matches available
+
+	position, err := k.GetPosition(ctx, poolId, owner, lowerTick, upperTick)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	availableLiquidity := position.Liquidity
+
+	if requestedLiqudityAmountToWithdraw.ToDec().GT(availableLiquidity) {
+		// TODO: format error correctly.
+		return sdk.Int{}, sdk.Int{}, fmt.Errorf("cannot withdraw more than available")
+	}
+
+	liquidityDelta := availableLiquidity.Sub(requestedLiqudityAmountToWithdraw.ToDec())
+
+	actualAmount0, actualAmount1, err := k.updatePosition(ctx, poolId, owner, lowerTick, upperTick, liquidityDelta)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	return actualAmount0, actualAmount1, nil
+}
+
+// TODO: spec and tests.
+func (k Keeper) updatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityDelta sdk.Dec) (sdk.Int, sdk.Int, error) {
+
+	// update tickInfo state
+	// TODO: come back to sdk.Int vs sdk.Dec state & truncation
+	err := k.initOrUpdateTick(ctx, poolId, lowerTick, liquidityDelta, false)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	// TODO: come back to sdk.Int vs sdk.Dec state & truncation
+	err = k.initOrUpdateTick(ctx, poolId, upperTick, liquidityDelta, true)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	// update position state
+	// TODO: come back to sdk.Int vs sdk.Dec state & truncation
+	err = k.initOrUpdatePosition(ctx, poolId, owner, lowerTick, upperTick, liquidityDelta)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	// now calculate amount for token0 and token1
+	pool := k.getPoolbyId(ctx, poolId)
+
+	sqrtPriceLowerTick, sqrtPriceUpperTick, err := ticksToSqrtPrice(lowerTick, upperTick)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	actualAmount0, actualAmount1 := pool.calcActualAmounts(ctx, lowerTick, upperTick, sqrtPriceLowerTick, sqrtPriceUpperTick, liquidityDelta)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	pool.updateLiquidityIfActivePosition(ctx, lowerTick, upperTick, liquidityDelta)
+
+	k.setPoolById(ctx, pool.Id, pool)
+
+	return actualAmount0, actualAmount1, nil
+}
+
+// calcActualAmounts calculates and returns actual amounts based on where the current tick is located relative to position's
+// lower and upper ticks.
+// There are 3 possible cases:
+// -The position is active ( lowerTick <= p.CurrentTick < upperTick).
+//    * The provided liqudity is distributed in both tokens.
+//    * Actual amounts might differ from desired because we recalculate them from liquidity delta and sqrt price.
+//      the calculations lead to amounts being off. // TODO: confirm logic is correct
+// - Current tick is below the position ( p.CurrentTick < lowerTick).
+//    * The provided liquidity is distributed in token0 only.
+// - Current tick is above the position ( p.CurrentTick >= p.upperTick ).
+//    * The provided liquidity is distributed in token1 only.
+// TODO: add tests.
+func (p Pool) calcActualAmounts(ctx sdk.Context, lowerTick, upperTick int64, sqrtRatioLowerTick, sqrtRatioUpperTick sdk.Dec, liquidityDelta sdk.Dec) (actualAmountDenom0 sdk.Int, actualAmountDenom1 sdk.Int) {
+
+	if p.isPositionActive(lowerTick, upperTick) {
+		// outcome one: the current price falls within the position
+		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1
+		// we also update the pool liquidity since the virtual liquidity is modified by this position's creation
+		currentSqrtPrice := p.CurrentSqrtPrice
+		actualAmountDenom0 = calcAmount0Delta(liquidityDelta, currentSqrtPrice, sqrtRatioUpperTick, false).RoundInt()
+		actualAmountDenom1 = calcAmount1Delta(liquidityDelta, currentSqrtPrice, sqrtRatioLowerTick, false).RoundInt()
+	} else if p.CurrentTick.LT(sdk.NewInt(lowerTick)) {
+		// outcome two: position is below current price
+		// this means position is solely made up of asset0
+		actualAmountDenom1 = sdk.ZeroInt()
+		actualAmountDenom0 = calcAmount0Delta(liquidityDelta, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
+	} else {
+		// outcome three: position is above current price
+		// this means position is solely made up of asset1
+		actualAmountDenom0 = sdk.ZeroInt()
+		actualAmountDenom1 = calcAmount1Delta(liquidityDelta, sqrtRatioLowerTick, sqrtRatioUpperTick, false).RoundInt()
+	}
+
+	return actualAmountDenom0, actualAmountDenom1
+}
+
+// TODO: add tests.
+func (p Pool) isPositionActive(lowerTick, upperTick int64) bool {
+	return p.CurrentTick.GTE(sdk.NewInt(lowerTick)) && p.CurrentTick.LT(sdk.NewInt(upperTick))
+}
+
+// TODO: add tests.
+func (p *Pool) updateLiquidityIfActivePosition(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) bool {
+	if p.isPositionActive(lowerTick, upperTick) {
+		p.Liquidity = p.Liquidity.Add(liquidityDelta)
+		return true
+	}
+	return false
+}
+
+// TODO: spec and tests
+func ticksToSqrtPrice(lowerTick, upperTick int64) (sdk.Dec, sdk.Dec, error) {
+	sqrtPriceUpperTick, err := tickToSqrtPrice(sdk.NewInt(upperTick))
+	if err != nil {
+		return sdk.Dec{}, sdk.Dec{}, err
+	}
+	sqrtPriceLowerTick, err := tickToSqrtPrice(sdk.NewInt(lowerTick))
+	if err != nil {
+		return sdk.Dec{}, sdk.Dec{}, err
+	}
+	return sqrtPriceLowerTick, sqrtPriceUpperTick, nil
 }

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -83,7 +83,7 @@ func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAd
 // updatePosition updates the position in the given pool id and in the given tick range and liquidityAmount.
 // Negative liquidityDelta implies withdrawing liquidity.
 // Positive liquidityDelta implies adding liquidity.
-// Updates ticks and poo, liquidity. Returns how much of each token is either added or removed.
+// Updates ticks and pool liquidity. Returns how much of each token is either added or removed.
 // Negative returned amounts imply that tokens are removed from the pool.
 // Positive returned amounts imply that tokens are added to the pool.
 // TODO: tests.

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -68,8 +68,7 @@ func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAd
 	availableLiquidity := position.Liquidity
 
 	if requestedLiqudityAmountToWithdraw.GT(availableLiquidity) {
-		// TODO: format error correctly.
-		return sdk.Int{}, sdk.Int{}, fmt.Errorf("cannot withdraw more than available")
+		return sdk.Int{}, sdk.Int{}, types.InsufficientLiquidityError{Actual: requestedLiqudityAmountToWithdraw, Available: availableLiquidity}
 	}
 
 	liquidityDelta := requestedLiqudityAmountToWithdraw.Neg()
@@ -141,7 +140,6 @@ func (k Keeper) updatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 //    * The provided liquidity is distributed in token1 only.
 // TODO: add tests.
 func (p Pool) calcActualAmounts(ctx sdk.Context, lowerTick, upperTick int64, sqrtRatioLowerTick, sqrtRatioUpperTick sdk.Dec, liquidityDelta sdk.Dec) (actualAmountDenom0 sdk.Int, actualAmountDenom1 sdk.Int) {
-
 	if p.isPositionActive(lowerTick, upperTick) {
 		// outcome one: the current price falls within the position
 		// if this is the case, we attempt to provide liquidity evenly between asset0 and asset1

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -49,7 +49,7 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 }
 
 // withdrawPosition attempts to withdraw liquidityAmount from a position with the given pool id in the given tick range.
-// On success, returns an positive amount of each token withdrawn.
+// On success, returns a positive amount of each token withdrawn.
 // Returns error if
 // - there is no position in the given tick ranges
 // - if tick ranges are invalid

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -36,7 +36,10 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	}
 
 	// now calculate amount for token0 and token1
-	pool := k.getPoolbyId(ctx, poolId)
+	pool, err := k.getPoolbyId(ctx, poolId)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
+	}
 
 	liquidityDelta := getLiquidityFromAmounts(pool.CurrentSqrtPrice, sqrtPriceLowerTick, sqrtPriceUpperTick, amount0Desired, amount1Desired)
 	if liquidityDelta.IsZero() {
@@ -107,7 +110,10 @@ func (k Keeper) updatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	}
 
 	// now calculate amount for token0 and token1
-	pool := k.getPoolbyId(ctx, poolId)
+	pool, err := k.getPoolbyId(ctx, poolId)
+	if err != nil {
+		return sdk.Int{}, sdk.Int{}, err
+	}
 
 	sqrtPriceLowerTick, sqrtPriceUpperTick, err := ticksToSqrtPrice(lowerTick, upperTick)
 	if err != nil {

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -61,7 +61,7 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 // - if attempts to withdraw an amount higher than originally provided in createPosition for a given range
 // TODO: implement and table-driven tests
 func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, requestedLiqudityAmountToWithdraw sdk.Dec) (amtDenom0, amtDenom1 sdk.Int, err error) {
-	position, err := k.GetPosition(ctx, poolId, owner, lowerTick, upperTick)
+	position, err := k.getPosition(ctx, poolId, owner, lowerTick, upperTick)
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, err
 	}

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -65,3 +65,68 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 
 	}
 }
+
+// func (s *KeeperTestSuite) TestWithdrawPosition() {
+
+// 	tests := map[string]struct {
+// 		poolId       uint64
+// 		denom0       string
+// 		denom1       string
+// 		currentSqrtP sdk.Dec
+// 		currentTick  sdk.Int
+
+// 		amount0Desired sdk.Int
+// 		amount1Desired sdk.Int
+
+// 		owner           sdk.AccAddress
+// 		lowerTick       int64
+// 		upperTick       int64
+// 		liquidityAmount sdk.Int
+
+// 		expectedAmount0 sdk.Int
+// 		expectedAmount1 sdk.Int
+// 		expectError     bool
+// 	}{
+// 		"example test": {
+// 			poolId: 1,
+// 			denom0: "eth",
+// 			denom1: "usdc",
+
+// 			currentSqrtP: sdk.MustNewDecFromStr("70.710678"),
+// 			currentTick:  sdk.NewInt(85176),
+
+// 			amount0Desired: sdk.NewInt(1),
+// 			amount1Desired: sdk.NewInt(5000),
+
+// 			lowerTick: int64(84222),
+// 			upperTick: int64(86129),
+// 		},
+// 	}
+
+// 	for name, tc := range tests {
+// 		s.Run(name, func() {
+// 			s.SetupTest()
+// 			ctx := s.Ctx
+// 			concentratedLiquidityKeeper := s.App.ConcentratedLiquidityKeeper
+
+// 			// Setup.
+// 			_, err := concentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, tc.poolId, tc.denom0, tc.denom1, tc.currentSqrtP, tc.currentTick)
+// 			s.Require().NoError(err)
+
+// 			_, _, _, err = concentratedLiquidityKeeper.CreatePosition(ctx, tc.poolId, s.TestAccs[0], tc.amount0Desired, tc.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), tc.lowerTick, tc.upperTick)
+// 			s.Require().NoError(err)
+
+// 			// System under test.
+// 			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, tc.liquidityAmount)
+
+// 			if tc.expectError {
+// 				s.Require().Error(err)
+// 				return
+// 			}
+
+// 			s.Require().NoError(err)
+// 			s.Require().Equal(tc.expectedAmount0, amtDenom0)
+// 			s.Require().Equal(tc.expectedAmount1, amtDenom1)
+// 		})
+// 	}
+// }

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -46,7 +46,7 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 			expectedError: types.InvalidTickError{Tick: types.MaxTick + 1, IsLower: true},
 		},
 		// TODO: add more tests
-		// custom hand-picked values
+		// - custom hand-picked values
 		// - error edge cases
 		// - think of overflows
 		// - think of truncations

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -111,7 +111,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			},
 		},
 		"withdraw partial liqudity amount": {
-			// setup parameters for creation a pool and position.
+			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
 
 			// system under test parameters

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -4,33 +4,40 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestCreatePosition() {
-	denom0 := "eth"
-	denom1 := "usdc"
+type lpTest struct {
+	poolId          uint64
+	owner           sdk.AccAddress
+	currentTick     sdk.Int
+	lowerTick       int64
+	upperTick       int64
+	currentSqrtP    sdk.Dec
+	amount0Desired  sdk.Int
+	amount0Expected sdk.Int
+	amount1Desired  sdk.Int
+	amount1Expected sdk.Int
+	liquidityAmount sdk.Dec
+	expectedError   error
+}
 
-	tests := map[string]struct {
-		poolId            uint64
-		currentTick       sdk.Int
-		lowerTick         int64
-		upperTick         int64
-		currentSqrtP      sdk.Dec
-		amount0Desired    sdk.Int
-		amount0Expected   sdk.Int
-		amount1Desired    sdk.Int
-		amount1Expected   sdk.Int
-		expectedLiquidity sdk.Dec
-	}{
+var (
+	denom0 = "eth"
+	denom1 = "usdc"
+)
+
+func (s *KeeperTestSuite) TestCreatePosition() {
+
+	tests := map[string]lpTest{
 		"happy path": {
-			poolId:            1,
-			currentTick:       sdk.NewInt(85176),
-			lowerTick:         int64(84222),
-			upperTick:         int64(86129),
-			currentSqrtP:      sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-			amount0Desired:    sdk.NewInt(1000000),                            // 1 eth
-			amount0Expected:   sdk.NewInt(998587),                             // 0.998587 eth
-			amount1Desired:    sdk.NewInt(5000000000),                         // 5000 usdc
-			amount1Expected:   sdk.NewInt(5000000000),                         // 5000 usdc
-			expectedLiquidity: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
+			poolId:          1,
+			currentTick:     sdk.NewInt(85176),
+			lowerTick:       int64(84222),
+			upperTick:       int64(86129),
+			currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			amount0Desired:  sdk.NewInt(1000000),                            // 1 eth
+			amount0Expected: sdk.NewInt(998587),                             // 0.998587 eth
+			amount1Desired:  sdk.NewInt(5000000000),                         // 5000 usdc
+			amount1Expected: sdk.NewInt(5000000000),                         // 5000 usdc
+			liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
 		},
 	}
 
@@ -44,23 +51,23 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 			s.Require().NoError(err)
 			s.Require().Equal(tc.amount0Expected.String(), asset0.String())
 			s.Require().Equal(tc.amount1Expected.String(), asset1.String())
-			s.Require().Equal(tc.expectedLiquidity.String(), liquidityCreated.String())
+			s.Require().Equal(tc.liquidityAmount.String(), liquidityCreated.String())
 
 			// check position state
 			position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(s.Ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick)
 			s.Require().NoError(err)
-			s.Require().Equal(tc.expectedLiquidity.String(), position.Liquidity.String())
+			s.Require().Equal(tc.liquidityAmount.String(), position.Liquidity.String())
 
 			// check tick state
 			lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, tc.poolId, tc.lowerTick)
 			s.Require().NoError(err)
-			s.Require().Equal(tc.expectedLiquidity.String(), lowerTickInfo.LiquidityGross.String())
-			s.Require().Equal(tc.expectedLiquidity.String(), lowerTickInfo.LiquidityNet.String())
+			s.Require().Equal(tc.liquidityAmount.String(), lowerTickInfo.LiquidityGross.String())
+			s.Require().Equal(tc.liquidityAmount.String(), lowerTickInfo.LiquidityNet.String())
 
 			upperTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, tc.poolId, tc.upperTick)
 			s.Require().NoError(err)
-			s.Require().Equal(tc.expectedLiquidity.String(), upperTickInfo.LiquidityGross.String())
-			s.Require().Equal(tc.expectedLiquidity.Neg().String(), upperTickInfo.LiquidityNet.String())
+			s.Require().Equal(tc.liquidityAmount.String(), upperTickInfo.LiquidityGross.String())
+			s.Require().Equal(tc.liquidityAmount.Neg().String(), upperTickInfo.LiquidityNet.String())
 		})
 
 	}
@@ -68,43 +75,60 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 
 func (s *KeeperTestSuite) TestWithdrawPosition() {
 
+	// mergeConfigs merges every desired non-zero field from overwrite
+	// into dst. dst is mutated due to being a pointer.
+	mergeConfigs := func(dst *lpTest, overwrite *lpTest) {
+		if overwrite != nil {
+			if overwrite.poolId != 0 {
+				dst.poolId = overwrite.poolId
+			}
+			if overwrite.lowerTick != 0 {
+				dst.lowerTick = overwrite.lowerTick
+			}
+			if overwrite.upperTick != 0 {
+				dst.upperTick = overwrite.upperTick
+			}
+			if !overwrite.liquidityAmount.IsNil() {
+				dst.liquidityAmount = overwrite.liquidityAmount
+			}
+			if !overwrite.amount0Expected.IsNil() {
+				dst.amount0Expected = overwrite.amount0Expected
+			}
+			if !overwrite.amount1Expected.IsNil() {
+				dst.amount1Expected = overwrite.amount1Expected
+			}
+			if overwrite.expectedError != nil {
+				dst.expectedError = overwrite.expectedError
+			}
+		}
+	}
+
 	tests := map[string]struct {
-		poolId       uint64
-		denom0       string
-		denom1       string
-		currentSqrtP sdk.Dec
-		currentTick  sdk.Int
-
-		amount0Desired sdk.Int
-		amount1Desired sdk.Int
-
-		owner           sdk.AccAddress
-		lowerTick       int64
-		upperTick       int64
-		liquidityAmount sdk.Dec
-
-		expectedAmount0 sdk.Int
-		expectedAmount1 sdk.Int
-		expectError     bool
+		setupConfig lpTest
+		// when this is set, it ovewrites the setupConfig
+		// and gives the overwritten configuration to
+		// the system under test.
+		sutConfigOverwrite *lpTest
 	}{
 		"basic test for active position": {
-			poolId: 1,
-			denom0: "eth",
-			denom1: "usdc",
+			// setup parameters for creation a pool and position.
+			setupConfig: lpTest{
+				poolId:          1,
+				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+				currentTick:     sdk.NewInt(85176),
+				lowerTick:       int64(84222),
+				upperTick:       int64(86129),
+				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
+				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
+				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
+			},
 
-			currentSqrtP: sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-			currentTick:  sdk.NewInt(85176),
-
-			amount0Desired: sdk.NewInt(1000000),    // 1 eth,
-			amount1Desired: sdk.NewInt(5000000000), // 5000 usdc
-
-			lowerTick: int64(84222),
-			upperTick: int64(86129),
-
-			liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-
-			expectedAmount0: sdk.NewInt(998587),     // 0.998587 eth
-			expectedAmount1: sdk.NewInt(5000000000), // 5000 usdc
+			// system under test parameters
+			// for withdrawing a position.
+			sutConfigOverwrite: &lpTest{
+				amount0Expected: sdk.NewInt(998587),     // 0.998587 eth
+				amount1Expected: sdk.NewInt(5000000000), // 5000 usdc
+			},
 		},
 		// no position created
 		// invalid pool id
@@ -116,28 +140,34 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 
 	for name, tc := range tests {
 		s.Run(name, func() {
+			tc := tc
 			s.SetupTest()
 			ctx := s.Ctx
 			concentratedLiquidityKeeper := s.App.ConcentratedLiquidityKeeper
 
+			owner := s.TestAccs[0]
+
 			// Setup.
-			_, err := concentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, tc.poolId, tc.denom0, tc.denom1, tc.currentSqrtP, tc.currentTick)
+			_, err := concentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, tc.setupConfig.poolId, denom0, denom1, tc.setupConfig.currentSqrtP, tc.setupConfig.currentTick)
 			s.Require().NoError(err)
 
-			_, _, _, err = concentratedLiquidityKeeper.CreatePosition(ctx, tc.poolId, s.TestAccs[0], tc.amount0Desired, tc.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), tc.lowerTick, tc.upperTick)
+			_, _, _, err = concentratedLiquidityKeeper.CreatePosition(ctx, tc.setupConfig.poolId, owner, tc.setupConfig.amount0Desired, tc.setupConfig.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), tc.setupConfig.lowerTick, tc.setupConfig.upperTick)
 			s.Require().NoError(err)
+
+			config := tc.setupConfig
+			mergeConfigs(&config, tc.sutConfigOverwrite)
 
 			// System under test.
-			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, tc.liquidityAmount)
+			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, config.poolId, owner, config.lowerTick, config.upperTick, config.liquidityAmount)
 
-			if tc.expectError {
+			if config.expectedError != nil {
 				s.Require().Error(err)
 				return
 			}
 
 			s.Require().NoError(err)
-			s.Require().Equal(tc.expectedAmount0.String(), amtDenom0.String())
-			s.Require().Equal(tc.expectedAmount1.String(), amtDenom1.String())
+			s.Require().Equal(config.amount0Expected.String(), amtDenom0.String())
+			s.Require().Equal(config.amount1Expected.String(), amtDenom1.String())
 		})
 	}
 }

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -22,25 +22,26 @@ type lpTest struct {
 }
 
 var (
-	denom0 = "eth"
-	denom1 = "usdc"
+	denom0   = "eth"
+	denom1   = "usdc"
+	baseCase = &lpTest{
+		poolId:          1,
+		currentTick:     sdk.NewInt(85176),
+		lowerTick:       int64(84222),
+		upperTick:       int64(86129),
+		currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+		amount0Desired:  sdk.NewInt(1000000),                            // 1 eth
+		amount0Expected: sdk.NewInt(998587),                             // 0.998587 eth
+		amount1Desired:  sdk.NewInt(5000000000),                         // 5000 usdc
+		amount1Expected: sdk.NewInt(5000000000),                         // 5000 usdc
+		liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
+	}
 )
 
 func (s *KeeperTestSuite) TestCreatePosition() {
 
 	tests := map[string]lpTest{
-		"happy path": {
-			poolId:          1,
-			currentTick:     sdk.NewInt(85176),
-			lowerTick:       int64(84222),
-			upperTick:       int64(86129),
-			currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-			amount0Desired:  sdk.NewInt(1000000),                            // 1 eth
-			amount0Expected: sdk.NewInt(998587),                             // 0.998587 eth
-			amount1Desired:  sdk.NewInt(5000000000),                         // 5000 usdc
-			amount1Expected: sdk.NewInt(5000000000),                         // 5000 usdc
-			liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-		},
+		"happy path": *baseCase,
 	}
 
 	for name, tc := range tests {
@@ -111,18 +112,9 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		// the system under test.
 		sutConfigOverwrite *lpTest
 	}{
-		"withdraw full liqudity amount": {
+		"base case: withdraw full liqudity amount": {
 			// setup parameters for creation a pool and position.
-			setupConfig: &lpTest{
-				poolId:          1,
-				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-				currentTick:     sdk.NewInt(85176),
-				lowerTick:       int64(84222),
-				upperTick:       int64(86129),
-				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
-				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-			},
+			setupConfig: baseCase,
 
 			// system under test parameters
 			// for withdrawing a position.
@@ -133,38 +125,20 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		},
 		"withdraw partial liqudity amount": {
 			// setup parameters for creation a pool and position.
-			setupConfig: &lpTest{
-				poolId:          1,
-				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-				currentTick:     sdk.NewInt(85176),
-				lowerTick:       int64(84222),
-				upperTick:       int64(86129),
-				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
-				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-			},
+			setupConfig: baseCase,
 
 			// system under test parameters
 			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519").QuoInt64(2),
+				liquidityAmount: baseCase.liquidityAmount.QuoInt64(2),
 
-				amount0Expected: sdk.NewInt(998587).QuoRaw(2), // 0.998587 eth
-				amount1Expected: sdk.NewInt(5000000000/2 - 1), // 2499 usdc, one is lost due to truncation
+				amount0Expected: baseCase.amount0Expected.QuoRaw(2),                   // 0.998587 eth
+				amount1Expected: baseCase.amount1Expected.QuoRaw(2).Sub(sdk.OneInt()), // 2499 usdc, one is lost due to truncation
 			},
 		},
 		"error: no position created": {
 			// setup parameters for creation a pool and position.
-			setupConfig: &lpTest{
-				poolId:          1,
-				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-				currentTick:     sdk.NewInt(85176),
-				lowerTick:       int64(84222),
-				upperTick:       int64(86129),
-				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
-				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-			},
+			setupConfig: baseCase,
 
 			// system under test parameters
 			// for withdrawing a position.
@@ -175,16 +149,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		},
 		"error: pool id for pool that does not exist": {
 			// setup parameters for creation a pool and position.
-			setupConfig: &lpTest{
-				poolId:          1,
-				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-				currentTick:     sdk.NewInt(85176),
-				lowerTick:       int64(84222),
-				upperTick:       int64(86129),
-				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
-				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-			},
+			setupConfig: baseCase,
 
 			// system under test parameters
 			// for withdrawing a position.
@@ -195,16 +160,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		},
 		"error: invalid tick given": {
 			// setup parameters for creation a pool and position.
-			setupConfig: &lpTest{
-				poolId:          1,
-				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-				currentTick:     sdk.NewInt(85176),
-				lowerTick:       int64(84222),
-				upperTick:       int64(86129),
-				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
-				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-			},
+			setupConfig: baseCase,
 
 			// system under test parameters
 			// for withdrawing a position.
@@ -215,33 +171,26 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		},
 		"error: insufficient liqudity": {
 			// setup parameters for creation a pool and position.
-			setupConfig: &lpTest{
-				poolId:          1,
-				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-				currentTick:     sdk.NewInt(85176),
-				lowerTick:       int64(84222),
-				upperTick:       int64(86129),
-				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
-				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
-			},
+			setupConfig: baseCase,
 
 			// system under test parameters
 			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
-				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519").Add(sdk.OneDec()), // 1 more than available
-				expectedError:   types.InsufficientLiquidityError{Actual: sdk.MustNewDecFromStr("1517818840.967515822610790519").Add(sdk.OneDec()), Available: sdk.MustNewDecFromStr("1517818840.967515822610790519")},
+				liquidityAmount: baseCase.liquidityAmount.Add(sdk.OneDec()), // 1 more than available
+				expectedError:   types.InsufficientLiquidityError{Actual: baseCase.liquidityAmount.Add(sdk.OneDec()), Available: baseCase.liquidityAmount},
 			},
 		},
+		// TODO: test with custom amounts that potentially lead to truncations.
 	}
 
 	for name, tc := range tests {
 		s.Run(name, func() {
 			tc := tc
+			config := *tc.setupConfig
+			sutConfigOverwrite := *tc.sutConfigOverwrite
 			s.SetupTest()
 			ctx := s.Ctx
 			concentratedLiquidityKeeper := s.App.ConcentratedLiquidityKeeper
-			config := tc.setupConfig
 
 			owner := s.TestAccs[0]
 
@@ -254,7 +203,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				s.Require().NoError(err)
 			}
 
-			mergeConfigs(config, tc.sutConfigOverwrite)
+			mergeConfigs(&config, &sutConfigOverwrite)
 
 			// System under test.
 			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, config.poolId, owner, config.lowerTick, config.upperTick, config.liquidityAmount)

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -57,22 +57,11 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 			s.Require().Equal(tc.liquidityAmount.String(), liquidityCreated.String())
 
 			// check position state
-			position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(s.Ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick)
-			s.Require().NoError(err)
-			s.Require().Equal(tc.liquidityAmount.String(), position.Liquidity.String())
+			s.validatePositionUpdate(s.Ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, tc.liquidityAmount)
 
 			// check tick state
-			lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, tc.poolId, tc.lowerTick)
-			s.Require().NoError(err)
-			s.Require().Equal(tc.liquidityAmount.String(), lowerTickInfo.LiquidityGross.String())
-			s.Require().Equal(tc.liquidityAmount.String(), lowerTickInfo.LiquidityNet.String())
-
-			upperTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, tc.poolId, tc.upperTick)
-			s.Require().NoError(err)
-			s.Require().Equal(tc.liquidityAmount.String(), upperTickInfo.LiquidityGross.String())
-			s.Require().Equal(tc.liquidityAmount.Neg().String(), upperTickInfo.LiquidityNet.String())
+			s.validateTickUpdates(s.Ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, tc.liquidityAmount)
 		})
-
 	}
 }
 
@@ -229,22 +218,10 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			s.Require().Equal(config.amount1Expected.String(), amtDenom1.String())
 
 			// Check that the position was updated.
-			position, err := concentratedLiquidityKeeper.GetPosition(ctx, config.poolId, owner, config.lowerTick, config.upperTick)
-			s.Require().NoError(err)
-			newPositionLiquidity := position.Liquidity
-			s.Require().Equal(expectedRemainingLiquidity.String(), newPositionLiquidity.String())
-			s.Require().True(newPositionLiquidity.GTE(sdk.ZeroDec()))
+			s.validatePositionUpdate(ctx, config.poolId, owner, config.lowerTick, config.upperTick, expectedRemainingLiquidity)
 
 			// check tick state
-			lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, config.poolId, config.lowerTick)
-			s.Require().NoError(err)
-			s.Require().Equal(expectedRemainingLiquidity.String(), lowerTickInfo.LiquidityGross.String())
-			s.Require().Equal(expectedRemainingLiquidity.String(), lowerTickInfo.LiquidityNet.String())
-
-			upperTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, config.poolId, config.upperTick)
-			s.Require().NoError(err)
-			s.Require().Equal(expectedRemainingLiquidity.String(), upperTickInfo.LiquidityGross.String())
-			s.Require().Equal(expectedRemainingLiquidity.Neg().String(), upperTickInfo.LiquidityNet.String())
+			s.validateTickUpdates(ctx, config.poolId, owner, config.lowerTick, config.upperTick, expectedRemainingLiquidity)
 		})
 	}
 }

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -100,7 +100,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		sutConfigOverwrite *lpTest
 	}{
 		"base case: withdraw full liquidity amount": {
-			// setup parameters for creation a pool and position.
+			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
 
 			// system under test parameters

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -135,7 +135,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			},
 		},
 		"error: pool id for pool that does not exist": {
-			// setup parameters for creation a pool and position.
+			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
 
 			// system under test parameters

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -157,7 +157,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			},
 		},
 		"error: insufficient liqudity": {
-			// setup parameters for creation a pool and position.
+			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
 
 			// system under test parameters

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -110,7 +110,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				amount1Expected: baseCase.amount1Expected, // 5000 usdc
 			},
 		},
-		"withdraw partial liqudity amount": {
+		"withdraw partial liquidity amount": {
 			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
 

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -172,7 +172,26 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				expectedError: types.PoolNotFoundError{PoolId: 2},
 			},
 		},
-		// invalid ticks
+		"invalid tick given": {
+			// setup parameters for creation a pool and position.
+			setupConfig: &lpTest{
+				poolId:          1,
+				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+				currentTick:     sdk.NewInt(85176),
+				lowerTick:       int64(84222),
+				upperTick:       int64(86129),
+				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
+				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
+				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
+			},
+
+			// system under test parameters
+			// for withdrawing a position.
+			sutConfigOverwrite: &lpTest{
+				lowerTick:     types.MaxTick + 1, // invalid tick
+				expectedError: types.InvalidTickError{Tick: types.MaxTick + 1, IsLower: true},
+			},
+		},
 		// liquidityAmount higher than available
 		// full liquidity amount
 		// liquidity amount lower than available

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -130,7 +130,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			// system under test parameters
 			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
-				lowerTick:     -1, // valid tick at which no position does not exist
+				lowerTick:     -1, // valid tick at which no position exists
 				expectedError: types.PositionNotFoundError{PoolId: 1, LowerTick: -1, UpperTick: 86129},
 			},
 		},

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -66,67 +66,78 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 	}
 }
 
-// func (s *KeeperTestSuite) TestWithdrawPosition() {
+func (s *KeeperTestSuite) TestWithdrawPosition() {
 
-// 	tests := map[string]struct {
-// 		poolId       uint64
-// 		denom0       string
-// 		denom1       string
-// 		currentSqrtP sdk.Dec
-// 		currentTick  sdk.Int
+	tests := map[string]struct {
+		poolId       uint64
+		denom0       string
+		denom1       string
+		currentSqrtP sdk.Dec
+		currentTick  sdk.Int
 
-// 		amount0Desired sdk.Int
-// 		amount1Desired sdk.Int
+		amount0Desired sdk.Int
+		amount1Desired sdk.Int
 
-// 		owner           sdk.AccAddress
-// 		lowerTick       int64
-// 		upperTick       int64
-// 		liquidityAmount sdk.Int
+		owner           sdk.AccAddress
+		lowerTick       int64
+		upperTick       int64
+		liquidityAmount sdk.Dec
 
-// 		expectedAmount0 sdk.Int
-// 		expectedAmount1 sdk.Int
-// 		expectError     bool
-// 	}{
-// 		"example test": {
-// 			poolId: 1,
-// 			denom0: "eth",
-// 			denom1: "usdc",
+		expectedAmount0 sdk.Int
+		expectedAmount1 sdk.Int
+		expectError     bool
+	}{
+		"basic test for active position": {
+			poolId: 1,
+			denom0: "eth",
+			denom1: "usdc",
 
-// 			currentSqrtP: sdk.MustNewDecFromStr("70.710678"),
-// 			currentTick:  sdk.NewInt(85176),
+			currentSqrtP: sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			currentTick:  sdk.NewInt(85176),
 
-// 			amount0Desired: sdk.NewInt(1),
-// 			amount1Desired: sdk.NewInt(5000),
+			amount0Desired: sdk.NewInt(1000000),    // 1 eth,
+			amount1Desired: sdk.NewInt(5000000000), // 5000 usdc
 
-// 			lowerTick: int64(84222),
-// 			upperTick: int64(86129),
-// 		},
-// 	}
+			lowerTick: int64(84222),
+			upperTick: int64(86129),
 
-// 	for name, tc := range tests {
-// 		s.Run(name, func() {
-// 			s.SetupTest()
-// 			ctx := s.Ctx
-// 			concentratedLiquidityKeeper := s.App.ConcentratedLiquidityKeeper
+			liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
 
-// 			// Setup.
-// 			_, err := concentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, tc.poolId, tc.denom0, tc.denom1, tc.currentSqrtP, tc.currentTick)
-// 			s.Require().NoError(err)
+			expectedAmount0: sdk.NewInt(998587),     // 0.998587 eth
+			expectedAmount1: sdk.NewInt(5000000000), // 5000 usdc
+		},
+		// no position created
+		// invalid pool id
+		// invalid ticks
+		// liquidityAmount higher than available
+		// full liquidity amount
+		// liquidity amount lower than available
+	}
 
-// 			_, _, _, err = concentratedLiquidityKeeper.CreatePosition(ctx, tc.poolId, s.TestAccs[0], tc.amount0Desired, tc.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), tc.lowerTick, tc.upperTick)
-// 			s.Require().NoError(err)
+	for name, tc := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+			ctx := s.Ctx
+			concentratedLiquidityKeeper := s.App.ConcentratedLiquidityKeeper
 
-// 			// System under test.
-// 			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, tc.liquidityAmount)
+			// Setup.
+			_, err := concentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(ctx, tc.poolId, tc.denom0, tc.denom1, tc.currentSqrtP, tc.currentTick)
+			s.Require().NoError(err)
 
-// 			if tc.expectError {
-// 				s.Require().Error(err)
-// 				return
-// 			}
+			_, _, _, err = concentratedLiquidityKeeper.CreatePosition(ctx, tc.poolId, s.TestAccs[0], tc.amount0Desired, tc.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), tc.lowerTick, tc.upperTick)
+			s.Require().NoError(err)
 
-// 			s.Require().NoError(err)
-// 			s.Require().Equal(tc.expectedAmount0, amtDenom0)
-// 			s.Require().Equal(tc.expectedAmount1, amtDenom1)
-// 		})
-// 	}
-// }
+			// System under test.
+			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, tc.liquidityAmount)
+
+			if tc.expectError {
+				s.Require().Error(err)
+				return
+			}
+
+			s.Require().NoError(err)
+			s.Require().Equal(tc.expectedAmount0.String(), amtDenom0.String())
+			s.Require().Equal(tc.expectedAmount1.String(), amtDenom1.String())
+		})
+	}
+}

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -152,7 +152,26 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				expectedError: types.PositionNotFoundError{PoolId: 1, LowerTick: -1, UpperTick: 86129},
 			},
 		},
-		// invalid pool id
+		"pool id for pool that does not exist": {
+			// setup parameters for creation a pool and position.
+			setupConfig: &lpTest{
+				poolId:          1,
+				currentSqrtP:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+				currentTick:     sdk.NewInt(85176),
+				lowerTick:       int64(84222),
+				upperTick:       int64(86129),
+				amount0Desired:  sdk.NewInt(1000000),    // 1 eth,
+				amount1Desired:  sdk.NewInt(5000000000), // 5000 usdc
+				liquidityAmount: sdk.MustNewDecFromStr("1517818840.967515822610790519"),
+			},
+
+			// system under test parameters
+			// for withdrawing a position.
+			sutConfigOverwrite: &lpTest{
+				poolId:        2, // does not exist
+				expectedError: types.PoolNotFoundError{PoolId: 2},
+			},
+		},
 		// invalid ticks
 		// liquidityAmount higher than available
 		// full liquidity amount

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -99,7 +99,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		// the system under test.
 		sutConfigOverwrite *lpTest
 	}{
-		"base case: withdraw full liqudity amount": {
+		"base case: withdraw full liquidity amount": {
 			// setup parameters for creation a pool and position.
 			setupConfig: baseCase,
 

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -119,7 +119,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			sutConfigOverwrite: &lpTest{
 				liquidityAmount: baseCase.liquidityAmount.QuoInt64(2),
 
-				amount0Expected: baseCase.amount0Expected.QuoRaw(2),                   // 0.998587 eth
+				amount0Expected: baseCase.amount0Expected.QuoRaw(2),                   // 0.4992935 / 2 eth
 				amount1Expected: baseCase.amount1Expected.QuoRaw(2).Sub(sdk.OneInt()), // 2499 usdc, one is lost due to truncation
 			},
 		},

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -146,7 +146,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			},
 		},
 		"error: invalid tick given": {
-			// setup parameters for creation a pool and position.
+			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
 
 			// system under test parameters

--- a/x/concentrated-liquidity/msg_server.go
+++ b/x/concentrated-liquidity/msg_server.go
@@ -64,7 +64,7 @@ func (server msgServer) WithdrawPosition(goCtx context.Context, msg *types.MsgWi
 		return nil, err
 	}
 
-	amount0, amount1, err := server.keeper.withdrawPosition(ctx, msg.PoolId, sender, msg.LowerTick, msg.UpperTick, msg.LiquidityAmount)
+	amount0, amount1, err := server.keeper.withdrawPosition(ctx, msg.PoolId, sender, msg.LowerTick, msg.UpperTick, msg.LiquidityAmount.ToDec())
 	if err != nil {
 		return nil, err
 	}

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -100,6 +100,24 @@ func (p Pool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom 
 	return sdk.Dec{}, nil
 }
 
+// isCurrentTickInRange returns true if pool's current tick is within
+// the range of the lower and upper ticks. False otherwise.
+// TODO: add tests.
+func (p Pool) isCurrentTickInRange(lowerTick, upperTick int64) bool {
+	return p.CurrentTick.GTE(sdk.NewInt(lowerTick)) && p.CurrentTick.LT(sdk.NewInt(upperTick))
+}
+
+// updateLiquidityIfActivePosition updates the pool's liquidity if the position is active.
+// Returns true if updated, false otherwise.
+// TODO: add tests.
+func (p *Pool) updateLiquidityIfActivePosition(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) bool {
+	if p.isCurrentTickInRange(lowerTick, upperTick) {
+		p.Liquidity = p.Liquidity.Add(liquidityDelta)
+		return true
+	}
+	return false
+}
+
 // CalcOutAmtGivenIn calculates tokens to be swapped out given the provided amount and fee deducted. It also returns
 // what the updated tick, liquidity, and currentSqrtPrice for the pool would be after this swap.
 // Note this method is non-mutative, so the values returned by CalcOutAmtGivenIn do not get stored

--- a/x/concentrated-liquidity/pool_store.go
+++ b/x/concentrated-liquidity/pool_store.go
@@ -7,12 +7,18 @@ import (
 	types "github.com/osmosis-labs/osmosis/v12/x/concentrated-liquidity/types"
 )
 
-func (k Keeper) getPoolbyId(ctx sdk.Context, poolId uint64) Pool {
+func (k Keeper) getPoolbyId(ctx sdk.Context, poolId uint64) (Pool, error) {
 	store := ctx.KVStore(k.storeKey)
 	pool := Pool{}
 	key := types.KeyPool(poolId)
-	osmoutils.MustGet(store, key, &pool)
-	return pool
+	found, err := osmoutils.GetIfFound(store, key, &pool)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		return Pool{}, types.PoolNotFoundError{PoolId: poolId}
+	}
+	return pool, nil
 }
 
 func (k Keeper) setPoolById(ctx sdk.Context, poolId uint64, pool Pool) {

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -468,6 +468,45 @@ func (suite *KeeperTestSuite) TestPriceToTick() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestGetLiquidityFromAmounts() {
+	testCases := map[string]struct {
+		currentSqrtP      sdk.Dec
+		sqrtPHigh         sdk.Dec
+		sqrtPLow          sdk.Dec
+		amount0Desired    sdk.Int
+		amount1Desired    sdk.Int
+		expectedLiquidity string
+	}{
+		"happy path": {
+			currentSqrtP:      sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			sqrtPHigh:         sdk.MustNewDecFromStr("74.161984870956629487"), // 5500
+			sqrtPLow:          sdk.MustNewDecFromStr("67.416615162732695594"), // 4545
+			amount0Desired:    sdk.NewInt(1000000),
+			amount1Desired:    sdk.NewInt(5000000000),
+			expectedLiquidity: "1517882343.751510418088349649",
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+
+		suite.Run(name, func() {
+			// CASE A: if the currentSqrtP is less than the sqrtPLow, all the liquidity is in asset0, so GetLiquidityFromAmounts returns the liquidity of asset0
+			// CASE B: if the currentSqrtP is less than the sqrtPHigh but greater than sqrtPLow, the liquidity is split between asset0 and asset1,
+			// so GetLiquidityFromAmounts returns the smaller liquidity of asset0 and asset1
+			// CASE C: if the currentSqrtP is greater than the sqrtPHigh, all the liquidity is in asset1, so GetLiquidityFromAmounts returns the liquidity of asset1
+			liquidity := cl.GetLiquidityFromAmounts(tc.currentSqrtP, tc.sqrtPLow, tc.sqrtPHigh, tc.amount0Desired, tc.amount1Desired)
+			suite.Require().Equal(tc.expectedLiquidity, liquidity.String())
+			// TODO: this check works for CASE B but needs to get reworked when CASE A and CASE C are tested
+			liq0 := cl.Liquidity0(tc.amount0Desired, tc.currentSqrtP, tc.sqrtPHigh)
+			liq1 := cl.Liquidity1(tc.amount1Desired, tc.currentSqrtP, tc.sqrtPLow)
+			liq := sdk.MinDec(liq0, liq1)
+			suite.Require().Equal(liq.String(), liquidity.String())
+
+		})
+	}
+}
+
 // func (s *KeeperTestSuite) TestCalcInAmtGivenOut() {
 // 	ctx := s.Ctx
 // 	pool, err := s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(s.Ctx, 1, "eth", "usdc", sdk.MustNewDecFromStr("70.710678"), sdk.NewInt(85176))

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -911,6 +911,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(5300000000)),
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(6000),
+			expectedTick:  currTick,
 			expectErr:     true,
 		},
 		"single position within one tick, trade does not complete due to lack of liquidity: eth -> usdc": {
@@ -921,6 +922,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 			},
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(1100000)),
 			tokenOutDenom: "usdc",
+			expectedTick:  currTick,
 			priceLimit:    sdk.NewDec(4000),
 			expectErr:     true,
 		},
@@ -928,6 +930,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 
 	for name, test := range tests {
 		s.Run(name, func() {
+			test := test
 			s.Setup()
 			// create pool
 			pool, err := s.App.ConcentratedLiquidityKeeper.CreateNewConcentratedLiquidityPool(s.Ctx, 1, "eth", "usdc", currSqrtPrice, currTick)

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -390,7 +390,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn() {
 				swapFee, test.priceLimit, pool.Id)
 			s.Require().NoError(err)
 
-			pool = s.App.ConcentratedLiquidityKeeper.GetPoolbyId(s.Ctx, pool.Id)
+			pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolbyId(s.Ctx, pool.Id)
 			s.Require().NoError(err)
 
 			// check that we produced the same token out from the swap function that we expected

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -45,6 +45,8 @@ func (k Keeper) initOrUpdatePosition(
 
 	position.Liquidity = liquidityAfter
 
+	// TODO: consider deleting position if liquidity becomes zero
+
 	k.setPosition(ctx, poolId, owner, lowerTick, upperTick, position)
 	return nil
 }

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -7,13 +7,32 @@ import (
 	types "github.com/osmosis-labs/osmosis/v12/x/concentrated-liquidity/types"
 )
 
-func (k Keeper) initOrUpdatePosition(ctx sdk.Context,
+// TODO: test
+func (k Keeper) getOrInitPosition(
+	ctx sdk.Context,
+	poolId uint64,
+	owner sdk.AccAddress,
+	lowerTick, upperTick int64,
+	liquidityDelta sdk.Dec,
+) (*Position, error) {
+	if k.hasPosition(ctx, poolId, owner, lowerTick, upperTick) {
+		position, err := k.getPosition(ctx, poolId, owner, lowerTick, upperTick)
+		if err != nil {
+			return nil, err
+		}
+		return position, nil
+	}
+	return &Position{Liquidity: sdk.ZeroDec()}, nil
+}
+
+func (k Keeper) initOrUpdatePosition(
+	ctx sdk.Context,
 	poolId uint64,
 	owner sdk.AccAddress,
 	lowerTick, upperTick int64,
 	liquidityDelta sdk.Dec,
 ) (err error) {
-	position, err := k.GetPosition(ctx, poolId, owner, lowerTick, upperTick)
+	position, err := k.getOrInitPosition(ctx, poolId, owner, lowerTick, upperTick, liquidityDelta)
 	if err != nil {
 		return err
 	}
@@ -30,18 +49,24 @@ func (k Keeper) initOrUpdatePosition(ctx sdk.Context,
 	return nil
 }
 
-func (k Keeper) GetPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) (position Position, err error) {
+func (k Keeper) hasPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) bool {
 	store := ctx.KVStore(k.storeKey)
-	positionStruct := Position{}
+	key := types.KeyPosition(poolId, owner, lowerTick, upperTick)
+	return store.Has(key)
+}
+
+func (k Keeper) getPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) (*Position, error) {
+	store := ctx.KVStore(k.storeKey)
+	positionStruct := &Position{}
 	key := types.KeyPosition(poolId, owner, lowerTick, upperTick)
 
-	found, err := osmoutils.GetIfFound(store, key, &positionStruct)
-	// return 0 values if key has not been initialized
-	if !found {
-		return Position{Liquidity: sdk.ZeroDec()}, nil
-	}
+	found, err := osmoutils.GetIfFound(store, key, positionStruct)
 	if err != nil {
-		return positionStruct, err
+		return nil, err
+	}
+
+	if !found {
+		return nil, types.PositionNotFoundError{PoolId: poolId, LowerTick: lowerTick, UpperTick: upperTick}
 	}
 
 	return positionStruct, nil
@@ -52,9 +77,9 @@ func (k Keeper) setPosition(ctx sdk.Context,
 	poolId uint64,
 	owner sdk.AccAddress,
 	lowerTick, upperTick int64,
-	position Position,
+	position *Position,
 ) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.KeyPosition(poolId, owner, lowerTick, upperTick)
-	osmoutils.MustSet(store, key, &position)
+	osmoutils.MustSet(store, key, position)
 }

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -154,6 +154,7 @@ func tickToSqrtPrice(tickIndex sdk.Int) (sdk.Dec, error) {
 // That is, both lower and upper ticks are within types.MinTick and types.MaxTick.
 // Also, lower tick must be less than upper tick.
 // Returns error if validation fails. Otherwise, nil.
+// TODO: test
 func validateTickRangeIsValid(lowerTick int64, upperTick int64) error {
 	// ensure types.MinTick <= lowerTick < types.MaxTick
 	if lowerTick < types.MinTick || lowerTick >= types.MaxTick {

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -140,6 +140,7 @@ func ticksToSqrtPrice(lowerTick, upperTick int64) (sdk.Dec, sdk.Dec, error) {
 
 // tickToSqrtPrice takes the tick index and returns the corresponding sqrt of the price.
 // Returns error if fails to calculate sqrt price. Otherwise, the computed value and nil.
+// TODO: test
 func tickToSqrtPrice(tickIndex sdk.Int) (sdk.Dec, error) {
 	sqrtPrice, err := sdk.NewDecWithPrec(10001, 4).Power(tickIndex.Uint64()).ApproxSqrt()
 	if err != nil {

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -12,21 +12,6 @@ import (
 	types "github.com/osmosis-labs/osmosis/v12/x/concentrated-liquidity/types"
 )
 
-// tickToSqrtPrice takes the tick index and returns the corresponding sqrt of the price
-func tickToSqrtPrice(tickIndex sdk.Int) (sdk.Dec, error) {
-	sqrtPrice, err := sdk.NewDecWithPrec(10001, 4).Power(tickIndex.Uint64()).ApproxSqrt()
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-
-	return sqrtPrice, nil
-}
-
-// TODO: implement this
-// func (k Keeper) getTickAtSqrtRatio(sqrtPrice sdk.Dec) sdk.Int {
-// 	return sdk.Int{}
-// }
-
 func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, tickIndex int64, liquidityIn sdk.Dec, upper bool) (err error) {
 	tickInfo, err := k.GetTickInfo(ctx, poolId, tickIndex)
 	if err != nil {
@@ -136,4 +121,49 @@ func (k Keeper) setTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64, tic
 	store := ctx.KVStore(k.storeKey)
 	key := types.KeyTick(poolId, tickIndex)
 	osmoutils.MustSet(store, key, &tickInfo)
+}
+
+// ticksToSqrtPrice returns the sqrt price for the lower and upper ticks.
+// Returns error if fails to calculate sqrt price.
+// TODO: spec and tests
+func ticksToSqrtPrice(lowerTick, upperTick int64) (sdk.Dec, sdk.Dec, error) {
+	sqrtPriceUpperTick, err := tickToSqrtPrice(sdk.NewInt(upperTick))
+	if err != nil {
+		return sdk.Dec{}, sdk.Dec{}, err
+	}
+	sqrtPriceLowerTick, err := tickToSqrtPrice(sdk.NewInt(lowerTick))
+	if err != nil {
+		return sdk.Dec{}, sdk.Dec{}, err
+	}
+	return sqrtPriceLowerTick, sqrtPriceUpperTick, nil
+}
+
+// tickToSqrtPrice takes the tick index and returns the corresponding sqrt of the price.
+// Returns error if fails to calculate sqrt price. Otherwise, the computed value and nil.
+func tickToSqrtPrice(tickIndex sdk.Int) (sdk.Dec, error) {
+	sqrtPrice, err := sdk.NewDecWithPrec(10001, 4).Power(tickIndex.Uint64()).ApproxSqrt()
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+
+	return sqrtPrice, nil
+}
+
+// validateTickInRangeIsValid validates that given ticks are valid.
+// That is, both lower and upper ticks are within types.MinTick and types.MaxTick.
+// Also, lower tick must be less than upper tick.
+// Returns error if validation fails. Otherwise, nil.
+func validateTickRangeIsValid(lowerTick int64, upperTick int64) error {
+	// ensure types.MinTick <= lowerTick < types.MaxTick
+	if lowerTick < types.MinTick || lowerTick >= types.MaxTick {
+		return types.InvalidTickError{Tick: lowerTick, IsLower: true}
+	}
+	// ensure types.MaxTick < upperTick <= types.MinTick
+	if upperTick > types.MaxTick || upperTick <= types.MinTick {
+		return types.InvalidTickError{Tick: upperTick, IsLower: false}
+	}
+	if lowerTick >= upperTick {
+		return types.InvalidLowerUpperTickError{LowerTick: lowerTick, UpperTick: upperTick}
+	}
+	return nil
 }

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -47,3 +47,11 @@ type PositionNotFoundError struct {
 func (e PositionNotFoundError) Error() string {
 	return fmt.Sprintf("position not found. pool id (%d), lower tick (%d), upper tick (%d)", e.PoolId, e.LowerTick, e.UpperTick)
 }
+
+type PoolNotFoundError struct {
+	PoolId uint64
+}
+
+func (e PoolNotFoundError) Error() string {
+	return fmt.Sprintf("pool not found. pool id (%d)", e.PoolId)
+}

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -79,3 +79,17 @@ type InsufficientLiquidityError struct {
 func (e InsufficientLiquidityError) Error() string {
 	return fmt.Sprintf("insufficient liqudity requested to withdraw. Actual: (%s). Available (%s)", e.Actual, e.Available)
 }
+
+type InsufficientLiquidityCreatedError struct {
+	Actual      sdk.Int
+	Minimum     sdk.Int
+	IsTokenZero bool
+}
+
+func (e InsufficientLiquidityCreatedError) Error() string {
+	tokenNum := uint8(0)
+	if !e.IsTokenZero {
+		tokenNum = 1
+	}
+	return fmt.Sprintf("insufficient amount of token%d created. Actual: (%s). Minimum (%s)", tokenNum, e.Actual, e.Minimum)
+}

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	fmt "fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // x/concentrated-liquidity module sentinel errors.
@@ -67,4 +69,13 @@ func (e InvalidTickError) Error() string {
 		tickStr = "lower"
 	}
 	return fmt.Sprintf("%s tick (%d) is invalid, Must be >= %d and <= %d", tickStr, e.Tick, MinTick, MaxTick)
+}
+
+type InsufficientLiquidityError struct {
+	Actual    sdk.Dec
+	Available sdk.Dec
+}
+
+func (e InsufficientLiquidityError) Error() string {
+	return fmt.Sprintf("insufficient liqudity requested to withdraw. Actual: (%s). Available (%s)", e.Actual, e.Available)
 }

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -55,3 +55,16 @@ type PoolNotFoundError struct {
 func (e PoolNotFoundError) Error() string {
 	return fmt.Sprintf("pool not found. pool id (%d)", e.PoolId)
 }
+
+type InvalidTickError struct {
+	Tick    int64
+	IsLower bool
+}
+
+func (e InvalidTickError) Error() string {
+	tickStr := "upper"
+	if e.IsLower {
+		tickStr = "lower"
+	}
+	return fmt.Sprintf("%s tick (%d) is invalid, Must be >= %d and <= %d", tickStr, e.Tick, MinTick, MaxTick)
+}

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -37,3 +37,13 @@ type NotPositiveRequireAmountError struct {
 func (e NotPositiveRequireAmountError) Error() string {
 	return fmt.Sprintf("Required amount should be positive. Got: %s", e.Amount)
 }
+
+type PositionNotFoundError struct {
+	PoolId    uint64
+	LowerTick int64
+	UpperTick int64
+}
+
+func (e PositionNotFoundError) Error() string {
+	return fmt.Sprintf("position not found. pool id (%d), lower tick (%d), upper tick (%d)", e.PoolId, e.LowerTick, e.UpperTick)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3143

## What is the purpose of the change

Implemented the core functionality for removing liquidity in the concentrated liquidity module. The method is called `withdrawPosition`.

It shares a lot of the logic with `createPosition` that adds liquidity. 

In fact, a new method called `updateLiqudity` was refactored out of `createPosition`. It takes `liqudityDelta`. If the liquidity delta is negative, `updatePosition` assumes we remove liquidity. If positive, it assumes the addition of liquidity.

Please follow the method and function specs for more information on the details of the implementation.

I ended up extracting several smaller helper functions. While I have tested the high-level APIs in-detail, I still need to add tests for the helper functions. They are marked with TODOs and are tracked.