### PR TITLE
[x/gamm][stableswap]: Fix swap fee charge on single asset joins

### DIFF
--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -442,17 +442,17 @@ func (p *Pool) calcSingleAssetJoinShares(tokenIn sdk.Coin, swapFee sdk.Dec) (sdk
 	}
 
 	// Find the portion of the pool made up by non-input assets
-	sumScalingFactors := int64(0)
+	sumScalingFactors := uint64(0)
 	for _, scalingFactor := range p.ScalingFactors {
 		sumScalingFactors += int64(scalingFactor)
 	}
 
 	// We ensure that uint64 -> int64 conversions are safe in scaling factor validation logic
 	liquidityIndexes := p.getLiquidityIndexMap()
-	inputScalingFactor := int64(p.GetScalingFactorByLiquidityIndex(liquidityIndexes[tokenIn.Denom]))
+	inputScalingFactor := p.GetScalingFactorByLiquidityIndex(liquidityIndexes[tokenIn.Denom])
 
 	// Round the ratio up to overestimate the charged fee
-	nonInputRatio := (sdk.NewDec(sumScalingFactors).Sub(sdk.NewDec(inputScalingFactor))).Quo(sdk.NewDec(sumScalingFactors)).Ceil()
+	nonInputRatio := (sdk.NewDecFromInt(sdk.NewIntFromUint64(sumScalingFactors)).Sub(sdk.NewDec(inputScalingFactor))).Quo(sdk.NewDecFromInt(sdk.NewIntFromUint64(sumScalingFactors))).Ceil()
 
 	// Find amount charged in swap fee on non-input assets and subtract from total
 	chargedSwapFee := (nonInputRatio.Mul(tokenIn.Amount.ToDec())).Mul(swapFee)

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -688,10 +688,10 @@ func (suite *StableSwapTestSuite) Test_StableSwap_CalculateAmountOutAndIn_Invers
 			scalingFactors := []uint64{}
 			for j := 0; j < c; j++ {
 				coins = coins.Add(sdkrand.RandExponentialCoin(r, sdk.NewCoin(fmt.Sprintf("token%d", j), coinMax)))
-				sf := sdkrand.RandIntBetween(r, 1, 1<<60)
+				sf := sdkrand.RandIntBetween(r, 1, 1<<(61-types.MaxPoolAssets))
 				scalingFactors = append(scalingFactors, uint64(sf))
 			}
-			initialCalcOut := sdkrand.RandIntBetween(r, 1, 1<<60)
+			initialCalcOut := sdkrand.RandIntBetween(r, 1, 1<<(61-types.MaxPoolAssets))
 			testcases[fmt.Sprintf("rand_case_%d_coins_%d", c, i)] = testcase{
 				denomIn:        coins[0].Denom,
 				denomOut:       coins[1].Denom,
@@ -727,7 +727,8 @@ func (suite *StableSwapTestSuite) Test_StableSwap_CalculateAmountOutAndIn_Invers
 				pool := createTestPool(suite.T(), tc.poolLiquidity, swapFeeDec, exitFeeDec, tc.scalingFactors)
 				suite.Require().NotNil(pool)
 				errTolerance := osmoutils.ErrTolerance{
-					AdditiveTolerance: sdk.Int{}, MultiplicativeTolerance: sdk.NewDecWithPrec(1, 12)}
+					AdditiveTolerance: sdk.Int{}, MultiplicativeTolerance: sdk.NewDecWithPrec(1, 12),
+				}
 				test_helpers.TestCalculateAmountOutAndIn_InverseRelationship(suite.T(), ctx, pool, tc.denomIn, tc.denomOut, tc.initialCalcOut, swapFeeDec, errTolerance)
 			})
 		}

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -442,7 +442,7 @@ func validateScalingFactors(scalingFactors []uint64, numAssets int) error {
 	}
 
 	for _, scalingFactor := range scalingFactors {
-		if scalingFactor == 0 || int64(scalingFactor) <= 0 {
+		if scalingFactor == 0 || scalingFactor >= (1<<(62-types.MaxPoolAssets)) {
 			return types.ErrInvalidScalingFactors
 		}
 	}

--- a/x/gamm/pool-models/stableswap/pool_test.go
+++ b/x/gamm/pool-models/stableswap/pool_test.go
@@ -208,10 +208,10 @@ func TestScaledSortedPoolReserves(t *testing.T) {
 		"max scaling factors": {
 			denoms:         [2]string{"foo", "bar"},
 			poolAssets:     twoEvenStablePoolAssets,
-			scalingFactors: []uint64{(1 << 62) / types.ScalingFactorMultiplier, (1 << 62) / types.ScalingFactorMultiplier},
+			scalingFactors: []uint64{(1 << (61 - types.MaxPoolAssets)) / types.ScalingFactorMultiplier, (1 << (61 - types.MaxPoolAssets)) / types.ScalingFactorMultiplier},
 			expReserves: []osmomath.BigDec{
-				(osmomath.NewBigDec(1000000000).Quo(osmomath.NewBigDec(types.ScalingFactorMultiplier))).Quo(osmomath.NewBigDec(int64(1<<62) / types.ScalingFactorMultiplier)),
-				(osmomath.NewBigDec(1000000000).Quo(osmomath.NewBigDec(types.ScalingFactorMultiplier))).Quo(osmomath.NewBigDec(int64(1<<62) / types.ScalingFactorMultiplier)),
+				(osmomath.NewBigDec(1000000000).Quo(osmomath.NewBigDec(types.ScalingFactorMultiplier))).Quo(osmomath.NewBigDec(int64(1<<(61-types.MaxPoolAssets)) / types.ScalingFactorMultiplier)),
+				(osmomath.NewBigDec(1000000000).Quo(osmomath.NewBigDec(types.ScalingFactorMultiplier))).Quo(osmomath.NewBigDec(int64(1<<(61-types.MaxPoolAssets)) / types.ScalingFactorMultiplier)),
 			},
 		},
 		"zero scaling factor": {

--- a/x/gamm/types/errors.go
+++ b/x/gamm/types/errors.go
@@ -51,7 +51,7 @@ var (
 	ErrNotStableSwapPool          = sdkerrors.Register(ModuleName, 61, "not stableswap pool")
 	ErrInvalidScalingFactorLength = sdkerrors.Register(ModuleName, 62, "pool liquidity and scaling factors must have same length")
 	ErrNotScalingFactorGovernor   = sdkerrors.Register(ModuleName, 63, "not scaling factor governor")
-	ErrInvalidScalingFactors      = sdkerrors.Register(ModuleName, 64, "scaling factors cannot be 0 or use more than 63 bits")
+	ErrInvalidScalingFactors      = sdkerrors.Register(ModuleName, 64, "scaling factors cannot be 0 or use more than 54 bits")
 	ErrHitMaxScaledAssets         = sdkerrors.Register(ModuleName, 65, "post-scaled pool assets can not exceed 10^34")
 	ErrHitMinScaledAssets         = sdkerrors.Register(ModuleName, 66, "post-scaled pool assets can not be less than 1")
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR fixes a bug where swap fees for single asset joins are charged on the full amount instead of just the portion that is "swapped."

## Brief Changelog

- Update single asset join share calculation to only charge swap fee on the portion of the input tokens made of non-input assets
- Update scaling factor validation logic to prevent edge case where individual scaling factors pass but the sum of scaling factors overflows or turns negative when converted to int64

## Testing and Verifying

This PR passes our single asset join test suite and inverse relation tests, which ensure that any errors favor the pool. The exact swap fee charged is not directly tested.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)