### PR TITLE
refactor(txfees): remove redundant keeper fields and constructor params

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -266,8 +266,6 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.keys[txfeestypes.StoreKey],
 		appKeepers.GAMMKeeper,
 		appKeepers.GAMMKeeper,
-		txfeestypes.FeeCollectorName,
-		txfeestypes.NonNativeFeeCollectorName,
 	)
 	appKeepers.TxFeesKeeper = &txFeesKeeper
 

--- a/x/txfees/keeper/keeper.go
+++ b/x/txfees/keeper/keeper.go
@@ -14,12 +14,10 @@ import (
 type Keeper struct {
 	storeKey sdk.StoreKey
 
-	accountKeeper             types.AccountKeeper
-	bankKeeper                types.BankKeeper
-	gammKeeper                types.GammKeeper
-	spotPriceCalculator       types.SpotPriceCalculator
-	feeCollectorName          string
-	nonNativeFeeCollectorName string
+	accountKeeper       types.AccountKeeper
+	bankKeeper          types.BankKeeper
+	gammKeeper          types.GammKeeper
+	spotPriceCalculator types.SpotPriceCalculator
 }
 
 var _ types.TxFeesKeeper = (*Keeper)(nil)
@@ -30,17 +28,13 @@ func NewKeeper(
 	storeKey sdk.StoreKey,
 	gammKeeper types.GammKeeper,
 	spotPriceCalculator types.SpotPriceCalculator,
-	feeCollectorName string,
-	nonNativeFeeCollectorName string,
 ) Keeper {
 	return Keeper{
-		accountKeeper:             accountKeeper,
-		bankKeeper:                bankKeeper,
-		storeKey:                  storeKey,
-		gammKeeper:                gammKeeper,
-		spotPriceCalculator:       spotPriceCalculator,
-		feeCollectorName:          feeCollectorName,
-		nonNativeFeeCollectorName: nonNativeFeeCollectorName,
+		accountKeeper:       accountKeeper,
+		bankKeeper:          bankKeeper,
+		storeKey:            storeKey,
+		gammKeeper:          gammKeeper,
+		spotPriceCalculator: spotPriceCalculator,
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Removed obsolete:
- `feeCollectorName
- `nonNativeFeeCollectorName`

These are defined globals in `types`. The keeper fields were left unused