### PR TITLE
fix: initialize last gauge ID in init gen

### DIFF
--- a/x/incentives/keeper/genesis.go
+++ b/x/incentives/keeper/genesis.go
@@ -17,6 +17,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 			panic(err)
 		}
 	}
+	k.SetLastGaugeID(ctx, genState.LastGaugeId)
 }
 
 // ExportGenesis returns the x/incentives module's exported genesis.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We forget to initialize LastGaugeID despite properly exporting it. This properly initializes it with the exported param.
