### PR TITLE
chore: fix import paths CI vendoring failure

### DIFF
--- a/scripts/replace_import_paths.sh
+++ b/scripts/replace_import_paths.sh
@@ -37,5 +37,9 @@ go mod vendor >/dev/null
 # N.B.: This must be run after go mod vendor.
 echo "running make proto-gen"
 make proto-gen >/dev/null
+
+echo "Run go mod vendor after proto-gen to avoid vendoring issues"
+go mod vendor >/dev/null
+
 echo "running make run-querygen"
 make run-querygen >/dev/null


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

In some cases `make proto-gen` modifies `go,mod`. As a result, that causes subsequent query-gen step to fail:
https://github.com/osmosis-labs/osmosis/actions/runs/3518190249/jobs/5896827173

Therefore, we should revendor after running proto-gen

## Testing and Verifying

Tested the script locally