### PR TITLE
Fix swapfee for single asset joins

### DIFF
--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -151,7 +151,7 @@ func BinarySearchSingleAssetJoin(
 			return sdk.Int{}, err
 		}
 
-		return SwapAllCoinsToSingleAsset(poolWithUpdatedLiquidity, ctx, exitedCoins, swapToDenom)
+		return SwapAllCoinsToSingleAsset(poolWithUpdatedLiquidity, ctx, exitedCoins, swapToDenom, sdk.ZeroDec())
 	}
 
 	// We accept an additive tolerance of 1 LP share error and round down
@@ -168,8 +168,8 @@ func BinarySearchSingleAssetJoin(
 }
 
 // SwapAllCoinsToSingleAsset iterates through each token in the input set and trades it against the same pool sequentially
-func SwapAllCoinsToSingleAsset(pool types.PoolI, ctx sdk.Context, inTokens sdk.Coins, swapToDenom string) (sdk.Int, error) {
-	swapFee := sdk.ZeroDec()
+func SwapAllCoinsToSingleAsset(pool types.PoolI, ctx sdk.Context, inTokens sdk.Coins, swapToDenom string,
+	swapFee sdk.Dec) (sdk.Int, error) {
 	tokenOutAmt := inTokens.AmountOfNoDenomValidation(swapToDenom)
 	for _, coin := range inTokens {
 		if coin.Denom == swapToDenom {

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -398,7 +398,26 @@ The JoinPool API only supports JoinPoolNoSwap if
 
 #### Join pool single asset in
 
-Couple ways to define JoinPool Exit Pool relation
+There are a couple ways to define `JoinPoolSingleAssetIn`. The simplest way is to define it from its intended relation from the CFMM, with Exit pool. We describe this below under the zero swap fee case.
+
+Let `pool_{L, S}` represent a pool with liquidity `L`, and `S` total LP shares.
+If we call `pool_{L, S}.JoinPoolSingleAssetIn(tokensIn) -> (N, pool_{L + tokensIn, S + N})`, or in others we get out `N` new LP shares, and a pool with with tokensIn added to liquidity. 
+It must then be the case that `pool_{L+tokensIn, S+N}.ExitPool(N) -> (tokensExited, pool_{L + tokensIn - tokensExited, S})`.
+Then if we swap all of `tokensExited` back to tokensIn, under 0 swap fee, we should get back to `pool_{L, S}` under the CFMM property.
+
+In other words, if we single asset join pool, and then exit pool, we should return back to the same CFMM `k` value we started with. Then if we swap back to go entirely back into our input asset, we should have exactly many tokens as we started with, under 0 swap fee.
+
+We can solve this relation with a binary search over the amount of LP shares to give!
+
+Thus we are left with how to account swap fee. We currently account for swap fee, by considering the asset ratio in the pool. If post scaling factors, the pool liquidity is say 60:20:20, where 60 is the asset were bringing in, then we consider "only (1 - 60%) = 40%" of the input as getting swapped. So we charge the swap fee on 40% of our single asset join in input. So the pseudocode for this is roughly:
+
+```python
+def JoinPoolSingleAssetIn(pool, tokenIn):
+  swapFeeApplicableFraction = 1 -(pool.ScaledLiquidityOf(tokenIn.Denom) / pool.SumOfAllScaledLiquidity())
+  effectiveSwapFee = pool.SwapFee * swapFeeApplicableFraction
+  effectiveTokenIn = RoundDown(tokenIn * (1 - effectiveSwapFee))
+  return BinarySearchSingleJoinLpShares(pool, effectiveTokenIn)
+```
 
 ## Code structure
 

--- a/x/gamm/pool-models/stableswap/README.md
+++ b/x/gamm/pool-models/stableswap/README.md
@@ -413,11 +413,15 @@ Thus we are left with how to account swap fee. We currently account for swap fee
 
 ```python
 def JoinPoolSingleAssetIn(pool, tokenIn):
-  swapFeeApplicableFraction = 1 -(pool.ScaledLiquidityOf(tokenIn.Denom) / pool.SumOfAllScaledLiquidity())
+  swapFeeApplicableFraction = 1 - (pool.ScaledLiquidityOf(tokenIn.Denom) / pool.SumOfAllScaledLiquidity())
   effectiveSwapFee = pool.SwapFee * swapFeeApplicableFraction
   effectiveTokenIn = RoundDown(tokenIn * (1 - effectiveSwapFee))
   return BinarySearchSingleJoinLpShares(pool, effectiveTokenIn)
 ```
+
+We leave the rounding mode for the scaling factor division unspecified.
+This is because its expected to be tiny (as the denominator is larger than the numerator, and we are operating in BigDec),
+and it should be dominated by the later step of rounding down.
 
 ## Code structure
 

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -1003,6 +1003,8 @@ func TestJoinPoolSharesInternal(t *testing.T) {
 }
 
 func TestSingleAssetJoinSwapFeeRatio(t *testing.T) {
+	largeInt, ok := sdk.NewIntFromString("123456789012345678")
+	require.True(t, ok)
 	type testcase struct {
 		poolLiquidity  sdk.Coins
 		scalingFactors []uint64
@@ -1033,6 +1035,16 @@ func TestSingleAssetJoinSwapFeeRatio(t *testing.T) {
 			scalingFactors: []uint64{40, 20},
 			tokenInDenom:   "tokenA",
 			expectedRatio:  sdk.MustNewDecFromStr("0.333333333333333334"),
+		},
+		"60:40:40, large numbers": {
+			poolLiquidity: sdk.NewCoins(
+				sdk.NewCoin("tokenA", largeInt.MulRaw(6)),
+				sdk.NewCoin("tokenB", largeInt.MulRaw(4)),
+				sdk.NewCoin("tokenC", largeInt.MulRaw(4))),
+			scalingFactors: []uint64{1, 1, 1},
+			tokenInDenom:   "tokenA",
+			// 1 - (6 / 14) = 8/14 = 4/7 ~= 0.571428571428571429
+			expectedRatio: sdk.MustNewDecFromStr("0.571428571428571429"),
 		},
 	}
 	for name, tc := range tests {

--- a/x/gamm/pool-models/stableswap/pool_test.go
+++ b/x/gamm/pool-models/stableswap/pool_test.go
@@ -808,7 +808,6 @@ func TestInverseJoinPoolExitPool(t *testing.T) {
 		unevenJoinedTokens sdk.Coins
 		scalingFactors     []uint64
 		swapFee            sdk.Dec
-		expectPass         bool
 	}
 
 	tests := map[string]testcase{
@@ -817,70 +816,60 @@ func TestInverseJoinPoolExitPool(t *testing.T) {
 			poolAssets:     twoEvenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 		"[single asset join] uneven two asset pool, no swap fee": {
 			tokensIn:       hundredFoo,
 			poolAssets:     twoUnevenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 		"[single asset join] even 3-asset pool, no swap fee": {
 			tokensIn:       thousandAssetA,
 			poolAssets:     threeEvenStablePoolAssets,
 			scalingFactors: defaultThreeAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 		"[single asset join] uneven 3-asset pool, no swap fee": {
 			tokensIn:       thousandAssetA,
 			poolAssets:     threeUnevenStablePoolAssets,
 			scalingFactors: defaultThreeAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 		"[single asset join] even two asset pool, default swap fee": {
 			tokensIn:       hundredFoo,
 			poolAssets:     twoEvenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        defaultSwapFee,
-			expectPass:     true,
 		},
 		"[single asset join] uneven two asset pool, default swap fee": {
 			tokensIn:       hundredFoo,
 			poolAssets:     twoUnevenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        defaultSwapFee,
-			expectPass:     true,
 		},
 		"[single asset join] even 3-asset pool, default swap fee": {
 			tokensIn:       thousandAssetA,
 			poolAssets:     threeEvenStablePoolAssets,
 			scalingFactors: defaultThreeAssetScalingFactors,
 			swapFee:        defaultSwapFee,
-			expectPass:     true,
 		},
 		"[single asset join] uneven 3-asset pool, default swap fee": {
 			tokensIn:       thousandAssetA,
 			poolAssets:     threeUnevenStablePoolAssets,
 			scalingFactors: defaultThreeAssetScalingFactors,
 			swapFee:        defaultSwapFee,
-			expectPass:     true,
 		},
 		"[single asset join] even 3-asset pool, 0.03 swap fee": {
 			tokensIn:       thousandAssetA,
 			poolAssets:     threeEvenStablePoolAssets,
 			scalingFactors: defaultThreeAssetScalingFactors,
 			swapFee:        sdk.MustNewDecFromStr("0.03"),
-			expectPass:     true,
 		},
 		"[single asset join] uneven 3-asset pool, 0.03 swap fee": {
 			tokensIn:       thousandAssetA,
 			poolAssets:     threeUnevenStablePoolAssets,
 			scalingFactors: defaultThreeAssetScalingFactors,
 			swapFee:        sdk.MustNewDecFromStr("0.03"),
-			expectPass:     true,
 		},
 
 		"[all asset join] even two asset pool, same tokenIn ratio": {
@@ -888,28 +877,24 @@ func TestInverseJoinPoolExitPool(t *testing.T) {
 			poolAssets:     twoEvenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 		"[all asset join] even two asset pool, different tokenIn ratio with pool": {
 			tokensIn:       sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tenPercentOfTwoPoolRaw)), sdk.NewCoin("bar", sdk.NewInt(10+tenPercentOfTwoPoolRaw))),
 			poolAssets:     twoEvenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 		"[all asset join] even two asset pool, different tokenIn ratio with pool, nonzero swap fee": {
 			tokensIn:       sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(tenPercentOfTwoPoolRaw)), sdk.NewCoin("bar", sdk.NewInt(10+tenPercentOfTwoPoolRaw))),
 			poolAssets:     twoEvenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        defaultSwapFee,
-			expectPass:     true,
 		},
 		"[all asset join] even two asset pool, no tokens in": {
 			tokensIn:       sdk.NewCoins(),
 			poolAssets:     twoEvenStablePoolAssets,
 			scalingFactors: defaultTwoAssetScalingFactors,
 			swapFee:        sdk.ZeroDec(),
-			expectPass:     true,
 		},
 	}
 
@@ -918,32 +903,40 @@ func TestInverseJoinPoolExitPool(t *testing.T) {
 			ctx := sdk.Context{}
 			p := poolStructFromAssets(tc.poolAssets, tc.scalingFactors)
 
+			// only for single asset join case
+			var swapRatio sdk.Dec
+			var err error
+			if len(tc.tokensIn) == 1 {
+				swapRatio, err = p.singleAssetJoinSwapFeeRatio(tc.tokensIn[0].Denom)
+				require.NoError(t, err)
+			}
+
 			// we join then exit the pool
 			shares, err := p.JoinPool(ctx, tc.tokensIn, tc.swapFee)
 			tokenOut, err := p.ExitPool(ctx, shares, defaultExitFee)
 
 			// if single asset join, we swap output tokens to input denom to test the full inverse relationship
 			if len(tc.tokensIn) == 1 {
-				tokenOutAmt, err := cfmm_common.SwapAllCoinsToSingleAsset(&p, ctx, tokenOut, tc.tokensIn[0].Denom)
+				tokenOutAmt, err := cfmm_common.SwapAllCoinsToSingleAsset(&p, ctx, tokenOut, tc.tokensIn[0].Denom, sdk.ZeroDec())
 				require.NoError(t, err)
 				tokenOut = sdk.NewCoins(sdk.NewCoin(tc.tokensIn[0].Denom, tokenOutAmt))
 			}
 
-			// if single asset join, we expect output token swapped into the input denom to be input minus swap fee
+			// if single asset join, we expect output token swapped into the input denom
+			// to be smaller by swap ratio * 2
 			var expectedTokenOut sdk.Coins
 			if len(tc.tokensIn) == 1 {
-				expectedAmt := (tc.tokensIn[0].Amount.ToDec().Mul(sdk.OneDec().Sub(tc.swapFee))).TruncateInt()
+				oneMinusSingleSwapFee := sdk.OneDec().Sub((swapRatio.Mul(tc.swapFee)))
+				expectedAmt := (tc.tokensIn[0].Amount.ToDec().Mul(oneMinusSingleSwapFee)).TruncateInt()
 				expectedTokenOut = sdk.NewCoins(sdk.NewCoin(tc.tokensIn[0].Denom, expectedAmt))
 			} else {
 				expectedTokenOut = tc.tokensIn
 			}
 
-			if tc.expectPass {
-				finalPoolLiquidity := p.GetTotalPoolLiquidity(ctx)
-				require.True(t, tokenOut.IsAllLTE(expectedTokenOut))
-				require.True(t, finalPoolLiquidity.IsAllGTE(tc.poolAssets))
-			}
-			osmoassert.ConditionalError(t, !tc.expectPass, err)
+			finalPoolLiquidity := p.GetTotalPoolLiquidity(ctx)
+			require.True(t, tokenOut.IsAllLTE(expectedTokenOut), "token out %v, expected <= %v", tokenOut, expectedTokenOut)
+			require.True(t, finalPoolLiquidity.IsAllGTE(tc.poolAssets))
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

We were accidentally over-charging swap fee for single asset joins. This PR causes us to no longer significantly over-charge. We now charge swapfee at `swapfee * fraction of pool ratio that is not the token your joining`. This is a slight over-charge, as your swap does change this ratio itself, but this is quite low. (Namely bips on the % change in liquidity ratio itself)

## Brief Changelog

Reduce the amount of stableswap singleassetjoin swap fee

## Testing and Verifying

* Updates the test that ensures that we don't over-return funds on exit.
* Added tests that we return what is expected from the new internal function.

We should add more tests that:
* we don't return an insufficient amount, but I have spot-checked manually that this is tightly-close to the intended bound.
* Increase coverage of the join use case
* Split out single asset join test setup from multi-asset joins

But I leave those to future PR's.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? Spec