### PR TITLE
feat(CL): core swaprouter logic and tests (merge to main 3)

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -57,6 +57,16 @@ func (s *KeeperTestHelper) PrepareBalancerPoolWithCoins(coins ...sdk.Coin) uint6
 	return s.PrepareBalancerPoolWithCoinsAndWeights(coins, weights)
 }
 
+// PrepareBalancerPoolWithCoinsAndSwapFee returns a balancer pool
+// consisted of given coins with equal weight set with provided swap fee.
+func (s *KeeperTestHelper) PrepareBalancerPoolWithCoinsAndSwapFee(swapFee sdk.Dec, coins ...sdk.Coin) uint64 {
+	weights := make([]int64, len(coins))
+	for i := 0; i < len(coins); i++ {
+		weights[i] = 1
+	}
+	return s.PrepareBalancerPoolWithCoinsWeightsAndSwapFee(coins, weights, swapFee)
+}
+
 // PrepareBalancerPoolWithCoins returns a balancer pool
 // PrepareBalancerPoolWithCoinsAndWeights returns a balancer pool
 // consisted of given coins with the specified weights.
@@ -71,6 +81,22 @@ func (s *KeeperTestHelper) PrepareBalancerPoolWithCoinsAndWeights(coins sdk.Coin
 	}
 
 	return s.PrepareBalancerPoolWithPoolAsset(poolAssets)
+}
+
+// PrepareBalancerPoolWithCoins returns a balancer pool
+// PrepareBalancerPoolWithCoinsWeightsAndSwapFee returns a balancer pool
+// consisted of given coins with the specified weights and swap fee.
+func (s *KeeperTestHelper) PrepareBalancerPoolWithCoinsWeightsAndSwapFee(coins sdk.Coins, weights []int64, swapFee sdk.Dec) uint64 {
+	var poolAssets []balancer.PoolAsset
+	for i, coin := range coins {
+		poolAsset := balancer.PoolAsset{
+			Weight: sdk.NewInt(weights[i]),
+			Token:  coin,
+		}
+		poolAssets = append(poolAssets, poolAsset)
+	}
+
+	return s.PrepareBalancerPoolWithPoolAssetAndSwapFee(poolAssets, swapFee)
 }
 
 // PrepareBalancerPool returns a Balancer pool's pool-ID with pool params set in PrepareBalancerPoolWithPoolParams.
@@ -150,6 +176,24 @@ func (s *KeeperTestHelper) PrepareBalancerPoolWithPoolAsset(assets []balancer.Po
 		ExitFee: sdk.ZeroDec(),
 	}, assets, "")
 	poolId, err := s.App.GAMMKeeper.CreatePool(s.Ctx, msg)
+	s.NoError(err)
+	return poolId
+}
+
+// PrepareBalancerPoolWithPoolAssetAndSwapFee sets up a Balancer pool with an array of assets and a set swap fee.
+func (s *KeeperTestHelper) PrepareBalancerPoolWithPoolAssetAndSwapFee(assets []balancer.PoolAsset, swapFee sdk.Dec) uint64 {
+	// Add coins for pool creation fee + coins needed to mint balances
+	fundCoins := sdk.Coins{sdk.NewCoin("uosmo", sdk.NewInt(10000000000))}
+	for _, a := range assets {
+		fundCoins = fundCoins.Add(a.Token)
+	}
+	s.FundAcc(s.TestAccs[0], fundCoins)
+
+	msg := balancer.NewMsgCreateBalancerPool(s.TestAccs[0], balancer.PoolParams{
+		SwapFee: swapFee,
+		ExitFee: sdk.ZeroDec(),
+	}, assets, "")
+	poolId, err := s.App.SwapRouterKeeper.CreatePool(s.Ctx, msg)
 	s.NoError(err)
 	return poolId
 }

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -124,6 +124,19 @@ func MustGet(store store.KVStore, key []byte, result proto.Message) {
 	}
 }
 
+// GetIfFound gets key from store
+// returns a boolean indicating whether value exists for the given key and error
+func GetIfFound(store store.KVStore, key []byte, result proto.Message) (found bool, err error) {
+	b := store.Get(key)
+	if b == nil {
+		return false, nil
+	}
+	if err := proto.Unmarshal(b, result); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
 // MustSetDec sets dec value to store at key. Panics on any error.
 func MustSetDec(store store.KVStore, key []byte, value sdk.Dec) {
 	MustSet(store, key, &sdk.DecProto{

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -811,6 +811,98 @@ func (s *TestSuite) TestMustGet() {
 	}
 }
 
+// TestMustGet tests that GetIfFound returns a boolean indicating 
+// whether value exists for the given key and error
+func (s *TestSuite) TestGetIfFound() {
+	tests := map[string]struct {
+		// keys and values to preset
+		preSetKeyValues map[string]proto.Message
+
+		// keys and values to attempt to get and validate
+		expectedGetKeyValues map[string]proto.Message
+
+		actualResultProto proto.Message
+
+		expectFound bool
+
+		expectErr bool
+	}{
+		"basic valid test": {
+			preSetKeyValues: map[string]proto.Message{
+				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
+				keyB: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
+				keyC: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
+			},
+
+			expectedGetKeyValues: map[string]proto.Message{
+				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
+				keyB: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
+				keyC: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
+			},
+
+			actualResultProto: &sdk.DecProto{},
+
+			expectFound: true,
+		},
+		"attempt to get non-existent key - not found & no err return": {
+			preSetKeyValues: map[string]proto.Message{
+				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
+				keyC: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
+			},
+
+			expectedGetKeyValues: map[string]proto.Message{
+				keyB: &sdk.DecProto{Dec: sdk.OneDec().Add(sdk.OneDec())},
+			},
+
+			actualResultProto: &sdk.DecProto{},
+
+			expectFound: false,
+
+			expectErr: false,
+		},
+		"invalid proto Dec vs TwapRecord - found but Unmarshal err": {
+			preSetKeyValues: map[string]proto.Message{
+				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
+			},
+
+			expectedGetKeyValues: map[string]proto.Message{
+				keyA: &sdk.DecProto{Dec: sdk.OneDec()},
+			},
+
+			actualResultProto: &twaptypes.TwapRecord{},
+
+			expectFound: true,
+
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+			s.SetupStoreWithBasePrefix()
+
+			// Setup
+			for key, value := range tc.preSetKeyValues {
+				osmoutils.MustSet(s.store, []byte(key), value)
+			}
+
+			for key, expectedValue := range tc.expectedGetKeyValues {
+				// System under test.
+				found, err := osmoutils.GetIfFound(s.store, []byte(key), tc.actualResultProto)
+				// Assertions.
+				s.Require().Equal(found, tc.expectFound)
+				if tc.expectErr {
+					s.Require().Error(err)
+				} 
+				// make sure found by key & Unmarshal successfully
+				if !tc.expectErr && tc.expectFound {
+					s.Require().Equal(expectedValue.String(), tc.actualResultProto.String())
+				}
+			}
+		})
+	}
+}
+
 // TestMustSet tests that MustSet updates the store correctly
 // and panics if an error is encountered.
 func (s *TestSuite) TestMustSet() {

--- a/osmoutils/store_helper_test.go
+++ b/osmoutils/store_helper_test.go
@@ -811,7 +811,7 @@ func (s *TestSuite) TestMustGet() {
 	}
 }
 
-// TestMustGet tests that GetIfFound returns a boolean indicating 
+// TestGetIfFound tests that GetIfFound returns a boolean indicating 
 // whether value exists for the given key and error
 func (s *TestSuite) TestGetIfFound() {
 	tests := map[string]struct {

--- a/x/gamm/pool-models/balancer/msgs.go
+++ b/x/gamm/pool-models/balancer/msgs.go
@@ -5,6 +5,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 const (
@@ -12,8 +13,8 @@ const (
 )
 
 var (
-	_ sdk.Msg             = &MsgCreateBalancerPool{}
-	_ types.CreatePoolMsg = &MsgCreateBalancerPool{}
+	_ sdk.Msg                       = &MsgCreateBalancerPool{}
+	_ swaproutertypes.CreatePoolMsg = &MsgCreateBalancerPool{}
 )
 
 func NewMsgCreateBalancerPool(
@@ -97,4 +98,8 @@ func (msg MsgCreateBalancerPool) InitialLiquidity() sdk.Coins {
 func (msg MsgCreateBalancerPool) CreatePool(ctx sdk.Context, poolID uint64) (types.PoolI, error) {
 	poolI, err := NewBalancerPool(poolID, *msg.PoolParams, msg.PoolAssets, msg.FuturePoolGovernor, ctx.BlockTime())
 	return &poolI, err
+}
+
+func (msg MsgCreateBalancerPool) GetPoolType() swaproutertypes.PoolType {
+	return swaproutertypes.Balancer
 }

--- a/x/gamm/pool-models/stableswap/msgs.go
+++ b/x/gamm/pool-models/stableswap/msgs.go
@@ -5,6 +5,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 const (
@@ -13,8 +14,8 @@ const (
 )
 
 var (
-	_ sdk.Msg             = &MsgCreateStableswapPool{}
-	_ types.CreatePoolMsg = &MsgCreateStableswapPool{}
+	_ sdk.Msg                       = &MsgCreateStableswapPool{}
+	_ swaproutertypes.CreatePoolMsg = &MsgCreateStableswapPool{}
 )
 
 func NewMsgCreateStableswapPool(
@@ -116,6 +117,10 @@ func (msg MsgCreateStableswapPool) CreatePool(ctx sdk.Context, poolId uint64) (t
 	}
 
 	return &stableswapPool, nil
+}
+
+func (msg MsgCreateStableswapPool) GetPoolType() swaproutertypes.PoolType {
+	return swaproutertypes.StableSwap
 }
 
 var _ sdk.Msg = &MsgStableSwapAdjustScalingFactors{}

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -11,9 +11,12 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/internal/cfmm_common"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
-var _ types.PoolI = &Pool{}
+var (
+	_ types.PoolI = &Pool{}
+)
 
 type unsortedPoolLiqError struct {
 	ActualLiquidity sdk.Coins
@@ -458,9 +461,9 @@ func validatePoolLiquidity(liquidity sdk.Coins, scalingFactors []uint64) error {
 		return liquidityAndScalingFactorCountMismatchError{LiquidityCount: liquidityCount, ScalingFactorCount: scalingFactorCount}
 	}
 
-	if liquidityCount < types.MinPoolAssets {
+	if liquidityCount < swaproutertypes.MinPoolAssets {
 		return types.ErrTooFewPoolAssets
-	} else if liquidityCount > types.MaxPoolAssets {
+	} else if liquidityCount > swaproutertypes.MaxPoolAssets {
 		return types.ErrTooManyPoolAssets
 	}
 

--- a/x/swaprouter/client/cli/cli_test.go
+++ b/x/swaprouter/client/cli/cli_test.go
@@ -1,0 +1,604 @@
+package cli_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+	swaprouterqueryproto "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	swaproutertestutil "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/testutil"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	cfg     network.Config
+	network *network.Network
+}
+
+func (s *IntegrationTestSuite) SetupSuite() {
+	s.T().Log("setting up integration test suite")
+
+	s.cfg = app.DefaultConfig()
+	s.cfg.GenesisState = swaproutertestutil.UpdateTxFeeDenom(s.cfg.Codec, s.cfg.BondDenom)
+
+	s.network = network.New(s.T(), s.cfg)
+
+	_, err := s.network.WaitForHeight(1)
+	s.Require().NoError(err)
+
+	val := s.network.Validators[0]
+
+	// create a new pool
+	_, err = swaproutertestutil.MsgCreatePool(s.T(), val.ClientCtx, val.Address, "5stake,5node0token", "100stake,100node0token", "0.01", "0.01", "")
+	s.Require().NoError(err)
+
+	s.T().Log("test")
+
+	_, err = s.network.WaitForHeight(1)
+	s.Require().NoError(err)
+}
+
+func (s *IntegrationTestSuite) TearDownSuite() {
+	s.T().Log("tearing down integration test suite")
+	s.network.Cleanup()
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+
+	// TODO: uncomment this once gamm refactor is merged from concentrated-liquidity-main
+	// suite.Run(t, new(IntegrationTestSuite))
+}
+
+func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
+	val := s.network.Validators[0]
+
+	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewSwapExactAmountOut",
+		keyring.English, sdk.FullFundraiserPath, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+	s.Require().NoError(err)
+
+	newAddr := sdk.AccAddress(info.GetPubKey().Address())
+
+	_, err = banktestutil.MsgSendExec(
+		val.ClientCtx,
+		val.Address,
+		newAddr,
+		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		osmoutils.DefaultFeeString(s.cfg),
+	)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		args []string
+
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"swap exact amount out", // osmosisd tx swaprouter swap-exact-amount-out 10stake 20 --swap-route-pool-ids=1 --swap-route-denoms=node0token --from=validator --keyring-backend=test --chain-id=testing --yes
+			[]string{
+				"10stake", "20",
+				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.NewSwapExactAmountOutCmd()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err, out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
+		})
+	}
+}
+
+// func (s *IntegrationTestSuite) TestGetCmdEstimateSwapExactAmountIn() {
+// 	val := s.network.Validators[0]
+
+// 	testCases := []struct {
+// 		name      string
+// 		args      []string
+// 		expectErr bool
+// 	}{
+// 		{
+// 			"query pool estimate swap exact amount in", // osmosisd query gamm estimate-swap-exact-amount-in 1 cosmos1n8skk06h3kyh550ad9qketlfhc2l5dsdevd3hq 10.0stake --swap-route-pool-ids=1 --swap-route-denoms=node0token
+// 			[]string{
+// 				"1",
+// 				"cosmos1n8skk06h3kyh550ad9qketlfhc2l5dsdevd3hq",
+// 				"10.0stake",
+// 				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+// 				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+// 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
+// 			},
+// 			false,
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		tc := tc
+
+// 		s.Run(tc.name, func() {
+// 			cmd := cli.GetCmdEstimateSwapExactAmountIn()
+// 			clientCtx := val.ClientCtx
+
+// 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+// 			if tc.expectErr {
+// 				s.Require().Error(err)
+// 			} else {
+// 				resp := types.QuerySwapExactAmountInResponse{}
+// 				s.Require().NoError(err, out.String())
+// 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+// 			}
+// 		})
+// 	}
+// }
+
+// func (s *IntegrationTestSuite) TestGetCmdEstimateSwapExactAmountOut() {
+// 	val := s.network.Validators[0]
+
+// 	testCases := []struct {
+// 		name      string
+// 		args      []string
+// 		expectErr bool
+// 	}{
+// 		{
+// 			"query pool estimate swap exact amount in", // osmosisd query gamm estimate-swap-exact-amount-in 1 cosmos1n8skk06h3kyh550ad9qketlfhc2l5dsdevd3hq 10.0stake --swap-route-pool-ids=1 --swap-route-denoms=node0token
+// 			[]string{
+// 				"1",
+// 				val.Address.String(),
+// 				"10.0stake",
+// 				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+// 				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+// 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
+// 			},
+// 			false,
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		tc := tc
+
+// 		s.Run(tc.name, func() {
+// 			cmd := cli.GetCmdEstimateSwapExactAmountOut()
+// 			clientCtx := val.ClientCtx
+
+// 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+// 			if tc.expectErr {
+// 				s.Require().Error(err)
+// 			} else {
+// 				resp := types.QuerySwapExactAmountOutResponse{}
+// 				s.Require().NoError(err, out.String())
+// 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+// 			}
+// 		})
+// 	}
+// }
+
+func (s IntegrationTestSuite) TestNewSwapExactAmountInCmd() {
+
+	// TODO: remove this once gamm refactor is merged from concentrated-liquidity-main
+	s.T().Skip()
+
+	val := s.network.Validators[0]
+
+	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewSwapExactAmountIn",
+		keyring.English, sdk.FullFundraiserPath, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+	s.Require().NoError(err)
+
+	newAddr := sdk.AccAddress(info.GetPubKey().Address())
+
+	_, err = banktestutil.MsgSendExec(
+		val.ClientCtx,
+		val.Address,
+		newAddr,
+		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		osmoutils.DefaultFeeString(s.cfg),
+	)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		args []string
+
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"swap exact amount in", // osmosisd tx swaprouter swap-exact-amount-in 10stake 3 --swap-route-pool-ids=1 --swap-route-denoms=node0token --from=validator --keyring-backend=test --chain-id=testing --yes
+			[]string{
+				"10stake", "3",
+				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.NewSwapExactAmountInCmd()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err, out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestGetCmdNumPools() {
+	val := s.network.Validators[0]
+
+	testCases := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			"query num-pools",
+			[]string{
+				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.GetCmdNumPools() // osmosisd query swaprouter num-pools
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				resp := swaprouterqueryproto.NumPoolsResponse{}
+				s.Require().NoError(err, out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+
+				s.Require().Greater(resp.NumPools, uint64(0), out.String())
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
+
+	// TODO: remove this once gamm refactor is merged from concentrated-liquidity-main
+	s.T().Skip()
+
+	val := s.network.Validators[0]
+
+	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewCreatePoolAddr",
+		keyring.English, sdk.FullFundraiserPath, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+	s.Require().NoError(err)
+
+	newAddr := sdk.AccAddress(info.GetPubKey().Address())
+
+	_, err = banktestutil.MsgSendExec(
+		val.ClientCtx,
+		val.Address,
+		newAddr,
+		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 200000000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		osmoutils.DefaultFeeString(s.cfg),
+	)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name         string
+		json         string
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"one token pair pool",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token",
+			  "%s": "100node0token",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			true, &sdk.TxResponse{}, 4,
+		},
+		{
+			"two tokens pair pool",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"change order of json fields",
+			fmt.Sprintf(`
+			{
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "1node0token,3stake",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileWeights, cli.PoolFileExitFee),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{ // --record-tokens=100.0stake2 --record-tokens=100.0stake --record-tokens-weight=5 --record-tokens-weight=5 --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
+			"three tokens pair pool - insufficient balance check",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,1stake,2btc",
+			  "%s": "100node0token,100stake,100btc",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			false, &sdk.TxResponse{}, 5,
+		},
+		{
+			"future governor address",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001",
+			  "%s": "osmo1fqlr98d45v5ysqgp6h56kpujcj4cvsjnjq9nck"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+			false, &sdk.TxResponse{}, 0,
+		},
+		// Due to CI time concerns, we leave these CLI tests commented out, and instead guaranteed via
+		// the logic tests.
+		// {
+		// 	"future governor time",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "2h"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	false, &sdk.TxResponse{}, 0,
+		// },
+		// {
+		// 	"future governor token + time",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "token,1000h"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	false, &sdk.TxResponse{}, 0,
+		// },
+		// {
+		// 	"invalid future governor",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "validdenom,invalidtime"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	true, &sdk.TxResponse{}, 7,
+		// },
+		{
+			"not valid json",
+			"bad json",
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"bad pool json - missing quotes around exit fee",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": 0.001
+			}
+	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"empty pool json",
+			"", true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {
+						"%s": "864h",
+						"%s": "2node0token,1stake",
+						"%s": "2006-01-02T15:04:05Z"
+					}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileDuration, cli.PoolFileTargetPoolWeights, cli.PoolFileStartTime,
+			),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params - no start time",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {
+						"%s": "864h",
+						"%s": "2node0token,1stake"
+					}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileDuration, cli.PoolFileTargetPoolWeights,
+			),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"empty smooth change params",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams,
+			),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params wrong type",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": "invalid string"
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams,
+			),
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params missing duration",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {
+						"%s": "2node0token,1stake"
+					}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileTargetPoolWeights,
+			),
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"unknown fields in json",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token",
+			  "%s": "100node0token",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			  "unknown": true,
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			true, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.NewCreatePoolCmd()
+			clientCtx := val.ClientCtx
+
+			jsonFile := testutil.WriteToNewTempFile(s.T(), tc.json)
+
+			args := []string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, jsonFile.Name()),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				osmoutils.DefaultFeeString(s.cfg),
+				fmt.Sprintf("--%s=%s", flags.FlagGas, fmt.Sprint(400000)),
+			}
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err, out.String())
+				err = clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType)
+				s.Require().NoError(err, out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
+		})
+	}
+}

--- a/x/swaprouter/client/cli/cli_test.go
+++ b/x/swaprouter/client/cli/cli_test.go
@@ -60,7 +60,6 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 }
 
 func TestIntegrationTestSuite(t *testing.T) {
-
 	// TODO: uncomment this once gamm refactor is merged from concentrated-liquidity-main
 	// suite.Run(t, new(IntegrationTestSuite))
 }
@@ -212,10 +211,6 @@ func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
 // }
 
 func (s IntegrationTestSuite) TestNewSwapExactAmountInCmd() {
-
-	// TODO: remove this once gamm refactor is merged from concentrated-liquidity-main
-	s.T().Skip()
-
 	val := s.network.Validators[0]
 
 	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewSwapExactAmountIn",
@@ -318,10 +313,6 @@ func (s *IntegrationTestSuite) TestGetCmdNumPools() {
 }
 
 func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
-
-	// TODO: remove this once gamm refactor is merged from concentrated-liquidity-main
-	s.T().Skip()
-
 	val := s.network.Validators[0]
 
 	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewCreatePoolAddr",

--- a/x/swaprouter/client/cli/common.go
+++ b/x/swaprouter/client/cli/common.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"errors"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+func swapAmountInRoutes(fs *flag.FlagSet) ([]types.SwapAmountInRoute, error) {
+	swapRoutePoolIds, err := fs.GetStringArray(FlagSwapRoutePoolIds)
+	if err != nil {
+		return nil, err
+	}
+
+	swapRouteDenoms, err := fs.GetStringArray(FlagSwapRouteDenoms)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(swapRoutePoolIds) != len(swapRouteDenoms) {
+		return nil, errors.New("swap route pool ids and denoms mismatch")
+	}
+
+	routes := []types.SwapAmountInRoute{}
+	for index, poolIDStr := range swapRoutePoolIds {
+		pID, err := strconv.Atoi(poolIDStr)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, types.SwapAmountInRoute{
+			PoolId:        uint64(pID),
+			TokenOutDenom: swapRouteDenoms[index],
+		})
+	}
+	return routes, nil
+}
+
+func swapAmountOutRoutes(fs *flag.FlagSet) ([]types.SwapAmountOutRoute, error) {
+	swapRoutePoolIds, err := fs.GetStringArray(FlagSwapRoutePoolIds)
+	if err != nil {
+		return nil, err
+	}
+
+	swapRouteDenoms, err := fs.GetStringArray(FlagSwapRouteDenoms)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(swapRoutePoolIds) != len(swapRouteDenoms) {
+		return nil, errors.New("swap route pool ids and denoms mismatch")
+	}
+
+	routes := []types.SwapAmountOutRoute{}
+	for index, poolIDStr := range swapRoutePoolIds {
+		pID, err := strconv.Atoi(poolIDStr)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, types.SwapAmountOutRoute{
+			PoolId:       uint64(pID),
+			TokenInDenom: swapRouteDenoms[index],
+		})
+	}
+	return routes, nil
+}

--- a/x/swaprouter/client/cli/flags.go
+++ b/x/swaprouter/client/cli/flags.go
@@ -1,0 +1,71 @@
+package cli
+
+import flag "github.com/spf13/pflag"
+
+const (
+	// Names of fields in pool json file.
+	PoolFileWeights        = "weights"
+	PoolFileInitialDeposit = "initial-deposit"
+	PoolFileSwapFee        = "swap-fee"
+	PoolFileExitFee        = "exit-fee"
+	PoolFileFutureGovernor = "future-governor"
+
+	PoolFileSmoothWeightChangeParams = "lbp-params"
+	PoolFileStartTime                = "start-time"
+	PoolFileDuration                 = "duration"
+	PoolFileTargetPoolWeights        = "target-pool-weights"
+
+	// Will be parsed to string.
+	FlagPoolFile = "pool-file"
+	// Will be parsed to uint64.
+	FlagSwapRoutePoolIds = "swap-route-pool-ids"
+	// Will be parsed to []string.
+	FlagSwapRouteDenoms = "swap-route-denoms"
+)
+
+type createBalancerPoolInputs struct {
+	Weights                  string                         `json:"weights"`
+	InitialDeposit           string                         `json:"initial-deposit"`
+	SwapFee                  string                         `json:"swap-fee"`
+	ExitFee                  string                         `json:"exit-fee"`
+	FutureGovernor           string                         `json:"future-governor"`
+	SmoothWeightChangeParams smoothWeightChangeParamsInputs `json:"lbp-params"`
+}
+
+type createStableswapPoolInputs struct {
+	InitialDeposit          string `json:"initial-deposit"`
+	SwapFee                 string `json:"swap-fee"`
+	ExitFee                 string `json:"exit-fee"`
+	FutureGovernor          string `json:"future-governor"`
+	ScalingFactorController string `json:"scaling-factor-controller"`
+	ScalingFactors          string `json:"scaling-factors"`
+}
+
+type smoothWeightChangeParamsInputs struct {
+	StartTime         string `json:"start-time"`
+	Duration          string `json:"duration"`
+	TargetPoolWeights string `json:"target-pool-weights"`
+}
+
+func FlagSetQuerySwapRoutes() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	fs.StringArray(FlagSwapRoutePoolIds, []string{""}, "swap route pool id")
+	fs.StringArray(FlagSwapRouteDenoms, []string{""}, "swap route amount")
+	return fs
+}
+
+func FlagSetSwapAmountOutRoutes() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	fs.StringArray(FlagSwapRoutePoolIds, []string{""}, "swap route pool ids")
+	fs.StringArray(FlagSwapRouteDenoms, []string{""}, "swap route denoms")
+	return fs
+}
+
+func FlagSetCreatePool() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	fs.String(FlagPoolFile, "", "Pool json file path (if this path is given, other create pool flags should not be used)")
+	return fs
+}

--- a/x/swaprouter/client/cli/parse.go
+++ b/x/swaprouter/client/cli/parse.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// TODO: move these to exported types within an internal package
+type XCreatePoolInputs createBalancerPoolInputs
+
+type XCreatePoolInputsExceptions struct {
+	XCreatePoolInputs
+	Other *string // Other won't raise an error
+}
+
+type XCreateStableswapPoolInputs createStableswapPoolInputs
+
+type XCreateStableswapPoolInputsExceptions struct {
+	XCreateStableswapPoolInputs
+	Other *string // Other won't raise an error
+}
+
+// UnmarshalJSON should error if there are fields unexpected.
+func (release *createBalancerPoolInputs) UnmarshalJSON(data []byte) error {
+	var createPoolE XCreatePoolInputsExceptions
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields() // Force
+
+	if err := dec.Decode(&createPoolE); err != nil {
+		return err
+	}
+
+	*release = createBalancerPoolInputs(createPoolE.XCreatePoolInputs)
+	return nil
+}
+
+func parseCreateBalancerPoolFlags(fs *pflag.FlagSet) (*createBalancerPoolInputs, error) {
+	pool := &createBalancerPoolInputs{}
+	poolFile, _ := fs.GetString(FlagPoolFile)
+
+	if poolFile == "" {
+		return nil, fmt.Errorf("must pass in a pool json using the --%s flag", FlagPoolFile)
+	}
+
+	contents, err := os.ReadFile(poolFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// make exception if unknown field exists
+	err = pool.UnmarshalJSON(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}
+
+// UnmarshalJSON should error if there are fields unexpected.
+func (release *createStableswapPoolInputs) UnmarshalJSON(data []byte) error {
+	var createPoolE XCreateStableswapPoolInputsExceptions
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields() // Force
+
+	if err := dec.Decode(&createPoolE); err != nil {
+		return err
+	}
+
+	*release = createStableswapPoolInputs(createPoolE.XCreateStableswapPoolInputs)
+	return nil
+}
+
+func parseCreateStableswapPoolFlags(fs *pflag.FlagSet) (*createStableswapPoolInputs, error) {
+	pool := &createStableswapPoolInputs{}
+	poolFile, _ := fs.GetString(FlagPoolFile)
+
+	if poolFile == "" {
+		return nil, fmt.Errorf("must pass in a pool json using the --%s flag", FlagPoolFile)
+	}
+
+	contents, err := os.ReadFile(poolFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// make exception if unknown field exists
+	err = pool.UnmarshalJSON(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}

--- a/x/swaprouter/client/cli/query.go
+++ b/x/swaprouter/client/cli/query.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/spf13/cobra"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// GetQueryCmd returns the cli query commands for this module.
+func GetQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		GetCmdEstimateSwapExactAmountIn(),
+		GetCmdEstimateSwapExactAmountOut(),
+		GetCmdNumPools(),
+	)
+
+	return cmd
+}
+
+// GetCmdEstimateSwapExactAmountIn returns estimation of output coin when amount of x token input.
+func GetCmdEstimateSwapExactAmountIn() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "estimate-swap-exact-amount-in <poolID> <sender> <tokenIn>",
+		Short: "Query estimate-swap-exact-amount-in",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query estimate-swap-exact-amount-in.
+Example:
+$ %s query swaprouter estimate-swap-exact-amount-in 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := queryproto.NewQueryClient(clientCtx)
+
+			poolID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			routes, err := swapAmountInRoutes(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.EstimateSwapExactAmountIn(cmd.Context(), &queryproto.EstimateSwapExactAmountInRequest{
+				Sender:  args[1],        // TODO: where sender is used?
+				PoolId:  uint64(poolID), // TODO: is this poolId used?
+				TokenIn: args[2],
+				Routes:  routes,
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetQuerySwapRoutes())
+	flags.AddQueryFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+// GetCmdEstimateSwapExactAmountOut returns estimation of input coin to get exact amount of x token output.
+func GetCmdEstimateSwapExactAmountOut() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "estimate-swap-exact-amount-out <poolID> <sender> <tokenOut>",
+		Short: "Query estimate-swap-exact-amount-out",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query estimate-swap-exact-amount-out.
+Example:
+$ %s query swaprouter estimate-swap-exact-amount-out 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := queryproto.NewQueryClient(clientCtx)
+
+			poolID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			routes, err := swapAmountOutRoutes(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.EstimateSwapExactAmountOut(cmd.Context(), &queryproto.EstimateSwapExactAmountOutRequest{
+				Sender:   args[1],        // TODO: where sender is used?
+				PoolId:   uint64(poolID), // TODO: is this poolId used?
+				Routes:   routes,
+				TokenOut: args[2],
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetQuerySwapRoutes())
+	flags.AddQueryFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+// GetCmdNumPools return number of pools available.
+func GetCmdNumPools() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "num-pools",
+		Short: "Query number of pools",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query number of pools.
+Example:
+$ %s query swaprouter num-pools
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := queryproto.NewQueryClient(clientCtx)
+
+			res, err := queryClient.NumPools(cmd.Context(), &queryproto.NumPoolsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/swaprouter/client/cli/query_test.go
+++ b/x/swaprouter/client/cli/query_test.go
@@ -1,0 +1,54 @@
+package cli_test
+
+import (
+	gocontext "context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
+	swaprouterqueryproto "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+)
+
+type QueryTestSuite struct {
+	apptesting.KeeperTestHelper
+	queryClient swaprouterqueryproto.QueryClient
+}
+
+func (s *QueryTestSuite) SetupSuite() {
+	s.Setup()
+	s.queryClient = swaprouterqueryproto.NewQueryClient(s.QueryHelper)
+	// create a new pool
+	s.PrepareBalancerPool()
+	s.Commit()
+}
+
+func (s *QueryTestSuite) TestQueriesNeverAlterState() {
+	testCases := []struct {
+		name   string
+		query  string
+		input  interface{}
+		output interface{}
+	}{
+		{
+			"Query num pools",
+			"/osmosis.gamm.v1beta1.Query/NumPools",
+			&swaprouterqueryproto.NumPoolsRequest{},
+			&swaprouterqueryproto.NumPoolsResponse{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		s.Run(tc.name, func() {
+			s.SetupSuite()
+			err := s.QueryHelper.Invoke(gocontext.Background(), tc.query, tc.input, tc.output)
+			s.Require().NoError(err)
+			s.StateNotAltered()
+		})
+	}
+}
+
+func TestQueryTestSuite(t *testing.T) {
+	suite.Run(t, new(QueryTestSuite))
+}

--- a/x/swaprouter/client/cli/query_test.go
+++ b/x/swaprouter/client/cli/query_test.go
@@ -4,8 +4,6 @@ import (
 	gocontext "context"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
 	swaprouterqueryproto "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
 )
@@ -32,7 +30,7 @@ func (s *QueryTestSuite) TestQueriesNeverAlterState() {
 	}{
 		{
 			"Query num pools",
-			"/osmosis.gamm.v1beta1.Query/NumPools",
+			"/osmosis.swaprouter.v1beta1.Query/NumPools",
 			&swaprouterqueryproto.NumPoolsRequest{},
 			&swaprouterqueryproto.NumPoolsResponse{},
 		},
@@ -50,5 +48,6 @@ func (s *QueryTestSuite) TestQueriesNeverAlterState() {
 }
 
 func TestQueryTestSuite(t *testing.T) {
-	suite.Run(t, new(QueryTestSuite))
+	// TODO: uncomment this once gamm refactor is merged from concentrated-liquidity-main
+	// suite.Run(t, new(QueryTestSuite))
 }

--- a/x/swaprouter/client/cli/tx.go
+++ b/x/swaprouter/client/cli/tx.go
@@ -1,0 +1,360 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+func NewTxCmd() *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Swap transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	txCmd.AddCommand(
+		NewCreatePoolCmd(),
+		NewSwapExactAmountInCmd(),
+		NewSwapExactAmountOutCmd(),
+	)
+
+	return txCmd
+}
+
+func NewSwapExactAmountInCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "swap-exact-amount-in [token-in] [token-out-min-amount]",
+		Short: "swap exact amount in",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewBuildSwapExactAmountInMsg(clientCtx, args[0], args[1], txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetQuerySwapRoutes())
+	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+func NewSwapExactAmountOutCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "swap-exact-amount-out [token-out] [token-in-max-amount]",
+		Short: "swap exact amount out",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewBuildSwapExactAmountOutMsg(clientCtx, args[0], args[1], txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetSwapAmountOutRoutes())
+	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+func NewBuildSwapExactAmountInMsg(clientCtx client.Context, tokenInStr, tokenOutMinAmtStr string, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	routes, err := swapAmountInRoutes(fs)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenIn, err := sdk.ParseCoinNormalized(tokenInStr)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenOutMinAmt, ok := sdk.NewIntFromString(tokenOutMinAmtStr)
+	if !ok {
+		return txf, nil, fmt.Errorf("invalid token out min amount, %s", tokenOutMinAmtStr)
+	}
+	msg := &types.MsgSwapExactAmountIn{
+		Sender:            clientCtx.GetFromAddress().String(),
+		Routes:            routes,
+		TokenIn:           tokenIn,
+		TokenOutMinAmount: tokenOutMinAmt,
+	}
+
+	return txf, msg, nil
+}
+
+func NewBuildSwapExactAmountOutMsg(clientCtx client.Context, tokenOutStr, tokenInMaxAmountStr string, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	routes, err := swapAmountOutRoutes(fs)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenOut, err := sdk.ParseCoinNormalized(tokenOutStr)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenInMaxAmount, ok := sdk.NewIntFromString(tokenInMaxAmountStr)
+	if !ok {
+		return txf, nil, errors.New("invalid token in max amount")
+	}
+	msg := &types.MsgSwapExactAmountOut{
+		Sender:           clientCtx.GetFromAddress().String(),
+		Routes:           routes,
+		TokenInMaxAmount: tokenInMaxAmount,
+		TokenOut:         tokenOut,
+	}
+
+	return txf, msg, nil
+}
+
+func NewCreatePoolCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-pool [flags]",
+		Short: "create a new pool and provide the liquidity to it",
+		Long:  `Must provide path to a pool JSON file (--pool-file) describing the pool to be created`,
+		Example: `Sample pool JSON file contents:
+{
+	"weights": "4uatom,4osmo,2uakt",
+	"initial-deposit": "100uatom,5osmo,20uakt",
+	"swap-fee": "0.01",
+	"exit-fee": "0.01",
+	"future-governor": "168h"
+}
+`,
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewBuildCreateBalancerPoolMsg(clientCtx, txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetCreatePool())
+	flags.AddTxFlagsToCmd(cmd)
+
+	_ = cmd.MarkFlagRequired(FlagPoolFile)
+
+	return cmd
+}
+
+func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	pool, err := parseCreateBalancerPoolFlags(fs)
+	if err != nil {
+		return txf, nil, fmt.Errorf("failed to parse pool: %w", err)
+	}
+
+	deposit, err := sdk.ParseCoinsNormalized(pool.InitialDeposit)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	poolAssetCoins, err := sdk.ParseDecCoins(pool.Weights)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	if len(deposit) != len(poolAssetCoins) {
+		return txf, nil, errors.New("deposit tokens and token weights should have same length")
+	}
+
+	swapFee, err := sdk.NewDecFromStr(pool.SwapFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	exitFee, err := sdk.NewDecFromStr(pool.ExitFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	var poolAssets []balancer.PoolAsset
+	for i := 0; i < len(poolAssetCoins); i++ {
+		if poolAssetCoins[i].Denom != deposit[i].Denom {
+			return txf, nil, errors.New("deposit tokens and token weights should have same denom order")
+		}
+
+		poolAssets = append(poolAssets, balancer.PoolAsset{
+			Weight: poolAssetCoins[i].Amount.RoundInt(),
+			Token:  deposit[i],
+		})
+	}
+
+	poolParams := &balancer.PoolParams{
+		SwapFee: swapFee,
+		ExitFee: exitFee,
+	}
+
+	msg := &balancer.MsgCreateBalancerPool{
+		Sender:             clientCtx.GetFromAddress().String(),
+		PoolParams:         poolParams,
+		PoolAssets:         poolAssets,
+		FuturePoolGovernor: pool.FutureGovernor,
+	}
+
+	if (pool.SmoothWeightChangeParams != smoothWeightChangeParamsInputs{}) {
+		duration, err := time.ParseDuration(pool.SmoothWeightChangeParams.Duration)
+		if err != nil {
+			return txf, nil, fmt.Errorf("could not parse duration: %w", err)
+		}
+
+		targetPoolAssetCoins, err := sdk.ParseDecCoins(pool.SmoothWeightChangeParams.TargetPoolWeights)
+		if err != nil {
+			return txf, nil, err
+		}
+
+		var targetPoolAssets []balancer.PoolAsset
+		for i := 0; i < len(targetPoolAssetCoins); i++ {
+			if targetPoolAssetCoins[i].Denom != poolAssetCoins[i].Denom {
+				return txf, nil, errors.New("initial pool weights and target pool weights should have same denom order")
+			}
+
+			targetPoolAssets = append(targetPoolAssets, balancer.PoolAsset{
+				Weight: targetPoolAssetCoins[i].Amount.RoundInt(),
+				Token:  deposit[i],
+				// TODO: This doesn't make sense. Should only use denom, not an sdk.Coin
+			})
+		}
+
+		smoothWeightParams := balancer.SmoothWeightChangeParams{
+			Duration:           duration,
+			InitialPoolWeights: poolAssets,
+			TargetPoolWeights:  targetPoolAssets,
+		}
+
+		if pool.SmoothWeightChangeParams.StartTime != "" {
+			startTime, err := time.Parse(time.RFC3339, pool.SmoothWeightChangeParams.StartTime)
+			if err != nil {
+				return txf, nil, fmt.Errorf("could not parse time: %w", err)
+			}
+
+			smoothWeightParams.StartTime = startTime
+		}
+
+		msg.PoolParams.SmoothWeightChangeParams = &smoothWeightParams
+	}
+
+	return txf, msg, nil
+}
+
+// Apologies to whoever has to touch this next, this code is horrendous
+func NewBuildCreateStableswapPoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	flags, err := parseCreateStableswapPoolFlags(fs)
+	if err != nil {
+		return txf, nil, fmt.Errorf("failed to parse pool: %w", err)
+	}
+
+	deposit, err := ParseCoinsNoSort(flags.InitialDeposit)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	swapFee, err := sdk.NewDecFromStr(flags.SwapFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	exitFee, err := sdk.NewDecFromStr(flags.ExitFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	poolParams := &stableswap.PoolParams{
+		SwapFee: swapFee,
+		ExitFee: exitFee,
+	}
+
+	scalingFactors := []uint64{}
+	trimmedSfString := strings.Trim(flags.ScalingFactors, "[] {}")
+	if len(trimmedSfString) > 0 {
+		ints := strings.Split(trimmedSfString, ",")
+		for _, i := range ints {
+			u, err := strconv.ParseUint(i, 10, 64)
+			if err != nil {
+				return txf, nil, err
+			}
+			scalingFactors = append(scalingFactors, u)
+		}
+		if len(scalingFactors) != len(deposit) {
+			return txf, nil, fmt.Errorf("number of scaling factors doesn't match number of assets")
+		}
+	}
+
+	msg := &stableswap.MsgCreateStableswapPool{
+		Sender:                  clientCtx.GetFromAddress().String(),
+		PoolParams:              poolParams,
+		InitialPoolLiquidity:    deposit,
+		ScalingFactors:          scalingFactors,
+		ScalingFactorController: flags.ScalingFactorController,
+		FuturePoolGovernor:      flags.FutureGovernor,
+	}
+
+	return txf, msg, nil
+}
+
+// ParseCoinsNoSort parses coins from coinsStr but does not sort them.
+// Returns error if parsing fails.
+func ParseCoinsNoSort(coinsStr string) (sdk.Coins, error) {
+	coinStrs := strings.Split(coinsStr, ",")
+	decCoins := make(sdk.DecCoins, len(coinStrs))
+	for i, coinStr := range coinStrs {
+		coin, err := sdk.ParseDecCoin(coinStr)
+		if err != nil {
+			return sdk.Coins{}, err
+		}
+
+		decCoins[i] = coin
+	}
+	return sdk.NormalizeCoins(decCoins), nil
+}

--- a/x/swaprouter/client/cli/tx_test.go
+++ b/x/swaprouter/client/cli/tx_test.go
@@ -1,0 +1,71 @@
+package cli_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+)
+
+func TestParseCoinsNoSort(t *testing.T) {
+	const (
+		a = "aaa"
+		b = "bbb"
+		c = "ccc"
+		d = "ddd"
+	)
+
+	var (
+		ten = sdk.NewInt(10)
+
+		coinA = sdk.NewCoin(a, ten)
+		coinB = sdk.NewCoin(b, ten)
+		coinC = sdk.NewCoin(c, ten)
+		coinD = sdk.NewCoin(d, ten)
+	)
+
+	tests := map[string]struct {
+		coinsStr      string
+		expectedCoins sdk.Coins
+	}{
+		"ascending": {
+			coinsStr: "10aaa,10bbb,10ccc,10ddd",
+			expectedCoins: sdk.Coins{
+				coinA,
+				coinB,
+				coinC,
+				coinD,
+			},
+		},
+		"descending": {
+			coinsStr: "10ddd,10ccc,10bbb,10aaa",
+			expectedCoins: sdk.Coins{
+				coinD,
+				coinC,
+				coinB,
+				coinA,
+			},
+		},
+		"mixed with different values.": {
+			coinsStr: "100ddd,20bbb,300aaa,40ccc",
+			expectedCoins: sdk.Coins{
+				sdk.NewCoin(d, sdk.NewInt(100)),
+				sdk.NewCoin(b, sdk.NewInt(20)),
+				sdk.NewCoin(a, sdk.NewInt(300)),
+				sdk.NewCoin(c, sdk.NewInt(40)),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			coins, err := cli.ParseCoinsNoSort(tc.coinsStr)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCoins, coins)
+		})
+	}
+}

--- a/x/swaprouter/client/query_proto_wrap.go
+++ b/x/swaprouter/client/query_proto_wrap.go
@@ -4,16 +4,20 @@ import (
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // This file should evolve to being code gen'd, off of `proto/swaprouter/v1beta/query.yml`
 
 type Querier struct {
+	K swaprouter.Keeper
 }
 
-// nolint: unused
 var sdkIntMaxValue = sdk.NewInt(0)
 
 func init() {
@@ -31,20 +35,81 @@ func init() {
 func (q Querier) Params(ctx sdk.Context,
 	req queryproto.ParamsRequest,
 ) (*queryproto.ParamsResponse, error) {
-	panic("not implemented")
+	params := q.K.GetParams(ctx)
+	return &queryproto.ParamsResponse{Params: params}, nil
 }
 
 // EstimateSwapExactAmountIn estimates input token amount for a swap.
 func (q Querier) EstimateSwapExactAmountIn(ctx sdk.Context, req queryproto.EstimateSwapExactAmountInRequest) (*queryproto.EstimateSwapExactAmountInResponse, error) {
-	panic("not implemented")
+	if req.Sender == "" {
+		return nil, status.Error(codes.InvalidArgument, "address cannot be empty")
+	}
+
+	if req.TokenIn == "" {
+		return nil, status.Error(codes.InvalidArgument, "invalid token")
+	}
+
+	if err := types.SwapAmountInRoutes(req.Routes).Validate(); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	sender, err := sdk.AccAddressFromBech32(req.Sender)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid address: %s", err.Error())
+	}
+
+	tokenIn, err := sdk.ParseCoinNormalized(req.TokenIn)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid token: %s", err.Error())
+	}
+
+	tokenOutAmount, err := q.K.RouteExactAmountIn(ctx, sender, req.Routes, tokenIn, sdk.NewInt(1))
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &queryproto.EstimateSwapExactAmountInResponse{
+		TokenOutAmount: tokenOutAmount,
+	}, nil
 }
 
 // EstimateSwapExactAmountOut estimates token output amount for a swap.
 func (q Querier) EstimateSwapExactAmountOut(ctx sdk.Context, req queryproto.EstimateSwapExactAmountOutRequest) (*queryproto.EstimateSwapExactAmountOutResponse, error) {
-	panic("not implemented")
+	if req.Sender == "" {
+		return nil, status.Error(codes.InvalidArgument, "address cannot be empty")
+	}
+
+	if req.TokenOut == "" {
+		return nil, status.Error(codes.InvalidArgument, "invalid token")
+	}
+
+	if err := types.SwapAmountOutRoutes(req.Routes).Validate(); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	sender, err := sdk.AccAddressFromBech32(req.Sender)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid address: %s", err.Error())
+	}
+
+	tokenOut, err := sdk.ParseCoinNormalized(req.TokenOut)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid token: %s", err.Error())
+	}
+
+	tokenInAmount, err := q.K.RouteExactAmountOut(ctx, sender, req.Routes, sdkIntMaxValue, tokenOut)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &queryproto.EstimateSwapExactAmountOutResponse{
+		TokenInAmount: tokenInAmount,
+	}, nil
 }
 
 // NumPools returns total number of pools.
 func (q Querier) NumPools(ctx sdk.Context, _ queryproto.NumPoolsRequest) (*queryproto.NumPoolsResponse, error) {
-	panic("not implemented")
+	return &queryproto.NumPoolsResponse{
+		NumPools: q.K.GetNextPoolId(ctx) - 1,
+	}, nil
 }

--- a/x/swaprouter/client/testutil/test_helpers.go
+++ b/x/swaprouter/client/testutil/test_helpers.go
@@ -1,0 +1,82 @@
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/osmosis-labs/osmosis/v13/app"
+	swaproutercli "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// commonArgs is args for CLI test commands.
+var commonArgs = []string{
+	fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+	fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+	fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+}
+
+// MsgCreatePool broadcast a pool creation message.
+func MsgCreatePool(
+	t *testing.T,
+	clientCtx client.Context,
+	owner fmt.Stringer,
+	tokenWeights string,
+	initialDeposit string,
+	swapFee string,
+	exitFee string,
+	futureGovernor string,
+	extraArgs ...string,
+) (testutil.BufferWriter, error) {
+	args := []string{}
+
+	jsonFile := testutil.WriteToNewTempFile(t,
+		fmt.Sprintf(`
+		{
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s"
+		}
+		`, swaproutercli.PoolFileWeights,
+			tokenWeights,
+			swaproutercli.PoolFileInitialDeposit,
+			initialDeposit,
+			swaproutercli.PoolFileSwapFee,
+			swapFee,
+			swaproutercli.PoolFileExitFee,
+			exitFee,
+			swaproutercli.PoolFileExitFee,
+			exitFee,
+		),
+	)
+
+	args = append(args,
+		fmt.Sprintf("--%s=%s", swaproutercli.FlagPoolFile, jsonFile.Name()),
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, owner.String()),
+		fmt.Sprintf("--%s=%d", flags.FlagGas, 400000),
+	)
+
+	args = append(args, commonArgs...)
+	return clitestutil.ExecTestCLICmd(clientCtx, swaproutercli.NewCreatePoolCmd(), args)
+}
+
+// UpdateTxFeeDenom creates and modifies gamm genesis to pay fee with given denom.
+func UpdateTxFeeDenom(cdc codec.Codec, denom string) map[string]json.RawMessage {
+	// modification to pay fee with test bond denom "stake"
+	genesisState := app.ModuleBasics.DefaultGenesis(cdc)
+	swaprouterGen := swaproutertypes.DefaultGenesis()
+	swaprouterGen.Params.PoolCreationFee = sdk.Coins{sdk.NewInt64Coin(denom, 1000000)}
+	swaprouterGenJson := cdc.MustMarshalJSON(swaprouterGen)
+	genesisState[swaproutertypes.ModuleName] = swaprouterGenJson
+	return genesisState
+}

--- a/x/swaprouter/creator.go
+++ b/x/swaprouter/creator.go
@@ -1,0 +1,127 @@
+package swaprouter
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
+
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// CreatePool attempts to create a pool returning the newly created pool ID or
+// an error upon failure. The pool creation fee is used to fund the community
+// pool. It will create a dedicated module account for the pool and sends the
+// initial liquidity to the created module account.
+//
+// After the initial liquidity is sent to the pool's account, shares are minted
+// and sent to the pool creator. The shares are created using a denomination in
+// the form of <swap module name>/pool/{poolID}. In addition, the x/bank metadata is updated
+// to reflect the newly created GAMM share denomination.
+func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, error) {
+	err := validateCreatePoolMsg(ctx, msg)
+	if err != nil {
+		return 0, err
+	}
+
+	sender := msg.PoolCreator()
+	initialPoolLiquidity := msg.InitialLiquidity()
+
+	// send pool creation fee to community pool
+	params := k.GetParams(ctx)
+	if err := k.communityPoolKeeper.FundCommunityPool(ctx, params.PoolCreationFee, sender); err != nil {
+		return 0, err
+	}
+
+	poolId := k.getNextPoolIdAndIncrement(ctx)
+	pool, err := msg.CreatePool(ctx, poolId)
+	if err != nil {
+		return 0, err
+	}
+
+	k.SetModuleRoute(ctx, poolId, msg.GetPoolType())
+
+	if err := k.validateCreatedPool(ctx, initialPoolLiquidity, poolId, pool); err != nil {
+		return 0, err
+	}
+
+	// create and save the pool's module account to the account keeper
+	if err := osmoutils.CreateModuleAccount(ctx, k.accountKeeper, pool.GetAddress()); err != nil {
+		return 0, fmt.Errorf("creating pool module account for id %d: %w", poolId, err)
+	}
+
+	swapModule := k.routes[msg.GetPoolType()]
+
+	if err := swapModule.InitializePool(ctx, pool, sender); err != nil {
+		return 0, err
+	}
+
+	// send initial liquidity to the pool
+	err = k.bankKeeper.SendCoins(ctx, sender, pool.GetAddress(), initialPoolLiquidity)
+	if err != nil {
+		return 0, err
+	}
+
+	k.poolCreationListeners.AfterPoolCreated(ctx, sender, pool.GetId())
+
+	return pool.GetId(), nil
+}
+
+func validateCreatePoolMsg(ctx sdk.Context, msg types.CreatePoolMsg) error {
+	err := msg.Validate(ctx)
+	if err != nil {
+		return err
+	}
+
+	initialPoolLiquidity := msg.InitialLiquidity()
+	numAssets := initialPoolLiquidity.Len()
+	if numAssets < types.MinPoolAssets {
+		return types.ErrTooFewPoolAssets
+	}
+	if numAssets > types.MaxPoolAssets {
+		return errors.Wrapf(
+			types.ErrTooManyPoolAssets,
+			"pool has too many PoolAssets (%d)", numAssets,
+		)
+	}
+	return nil
+}
+
+func (k Keeper) validateCreatedPool(
+	ctx sdk.Context,
+	initialPoolLiquidity sdk.Coins,
+	poolId uint64,
+	pool gammtypes.PoolI,
+) error {
+	if pool.GetId() != poolId {
+		return errors.Wrapf(types.ErrInvalidPool,
+			"Pool was attempted to be created with incorrect pool ID.")
+	}
+	if !pool.GetAddress().Equals(gammtypes.NewPoolAddress(poolId)) {
+		return errors.Wrapf(types.ErrInvalidPool,
+			"Pool was attempted to be created with incorrect pool address.")
+	}
+	// Notably we use the initial pool liquidity at the start of the messages definition
+	// just in case CreatePool was mutative.
+	if !pool.GetTotalPoolLiquidity(ctx).IsEqual(initialPoolLiquidity) {
+		return errors.Wrap(types.ErrInvalidPool,
+			"Pool was attempted to be created, with initial liquidity not equal to what was specified.")
+	}
+	// TODO: this check should be moved
+	// This check can be removed later, and replaced with a minimum.
+	if !pool.GetTotalShares().Equal(gammtypes.InitPoolSharesSupply) {
+		return errors.Wrap(types.ErrInvalidPool,
+			"Pool was attempted to be created with incorrect number of initial shares.")
+	}
+	return nil
+}
+
+// SetModuleRoute stores the mapping from poolId to the given pool type.
+// TODO: unexport after concentrated-liqudity upgrade. Currently, it is exported
+// for the upgrade handler logic and tests.
+func (k Keeper) SetModuleRoute(ctx sdk.Context, poolId uint64, poolType types.PoolType) {
+	store := ctx.KVStore(k.storeKey)
+	osmoutils.MustSet(store, types.FormatModuleRouteKey(poolId), &types.ModuleRoute{PoolType: poolType})
+}

--- a/x/swaprouter/creator.go
+++ b/x/swaprouter/creator.go
@@ -69,6 +69,13 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 	return pool.GetId(), nil
 }
 
+// getNextPoolIdAndIncrement returns the next pool Id, and increments the corresponding state entry.
+func (k Keeper) getNextPoolIdAndIncrement(ctx sdk.Context) uint64 {
+	nextPoolId := k.GetNextPoolId(ctx)
+	k.SetNextPoolId(ctx, nextPoolId+1)
+	return nextPoolId
+}
+
 func validateCreatePoolMsg(ctx sdk.Context, msg types.CreatePoolMsg) error {
 	err := msg.Validate(ctx)
 	if err != nil {

--- a/x/swaprouter/creator_test.go
+++ b/x/swaprouter/creator_test.go
@@ -11,13 +11,14 @@ import (
 
 // TestCreatePool tests that all possible pools are created correctly.
 func (suite *KeeperTestSuite) TestCreatePool() {
+
 	validBalancerPoolMsg := balancer.NewMsgCreateBalancerPool(suite.TestAccs[0], balancer.NewPoolParams(sdk.ZeroDec(), sdk.ZeroDec(), nil), []balancer.PoolAsset{
 		{
-			Token:  sdk.NewCoin(denomA, defaultInitPoolAmount),
+			Token:  sdk.NewCoin(foo, defaultInitPoolAmount),
 			Weight: sdk.NewInt(1),
 		},
 		{
-			Token:  sdk.NewCoin(denomB, defaultInitPoolAmount),
+			Token:  sdk.NewCoin(bar, defaultInitPoolAmount),
 			Weight: sdk.NewInt(1),
 		},
 	}, "")
@@ -31,13 +32,13 @@ func (suite *KeeperTestSuite) TestCreatePool() {
 	}{
 		{
 			name:               "first balancer pool - success",
-			creatorFundAmount:  sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(denomB, defaultInitPoolAmount.Mul(sdk.NewInt(2)))),
+			creatorFundAmount:  sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(bar, defaultInitPoolAmount.Mul(sdk.NewInt(2)))),
 			msg:                validBalancerPoolMsg,
 			expectedModuleType: gammKeeperType,
 		},
 		{
 			name:               "second balancer pool - success",
-			creatorFundAmount:  sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(denomB, defaultInitPoolAmount.Mul(sdk.NewInt(2)))),
+			creatorFundAmount:  sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(bar, defaultInitPoolAmount.Mul(sdk.NewInt(2)))),
 			msg:                validBalancerPoolMsg,
 			expectedModuleType: gammKeeperType,
 		},

--- a/x/swaprouter/creator_test.go
+++ b/x/swaprouter/creator_test.go
@@ -1,0 +1,76 @@
+package swaprouter_test
+
+import (
+	"reflect"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// TestCreatePool tests that all possible pools are created correctly.
+func (suite *KeeperTestSuite) TestCreatePool() {
+	validBalancerPoolMsg := balancer.NewMsgCreateBalancerPool(suite.TestAccs[0], balancer.NewPoolParams(sdk.ZeroDec(), sdk.ZeroDec(), nil), []balancer.PoolAsset{
+		{
+			Token:  sdk.NewCoin(denomA, defaultInitPoolAmount),
+			Weight: sdk.NewInt(1),
+		},
+		{
+			Token:  sdk.NewCoin(denomB, defaultInitPoolAmount),
+			Weight: sdk.NewInt(1),
+		},
+	}, "")
+
+	tests := []struct {
+		name               string
+		creatorFundAmount  sdk.Coins
+		msg                types.CreatePoolMsg
+		expectedModuleType reflect.Type
+		expectError        bool
+	}{
+		{
+			name:               "first balancer pool - success",
+			creatorFundAmount:  sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(denomB, defaultInitPoolAmount.Mul(sdk.NewInt(2)))),
+			msg:                validBalancerPoolMsg,
+			expectedModuleType: gammKeeperType,
+		},
+		{
+			name:               "second balancer pool - success",
+			creatorFundAmount:  sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(denomB, defaultInitPoolAmount.Mul(sdk.NewInt(2)))),
+			msg:                validBalancerPoolMsg,
+			expectedModuleType: gammKeeperType,
+		},
+		// TODO: add stableswap test
+		// TODO: add concentrated-liquidity rest
+		// TODO: cover errors and edge cases
+	}
+
+	for i, tc := range tests {
+		suite.Run(tc.name, func() {
+			tc := tc
+
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+			ctx := suite.Ctx
+
+			poolCreationFee := swaprouterKeeper.GetParams(suite.Ctx).PoolCreationFee
+			suite.FundAcc(suite.TestAccs[0], append(tc.creatorFundAmount, poolCreationFee...))
+
+			poolId, err := swaprouterKeeper.CreatePool(ctx, tc.msg)
+
+			if tc.expectError {
+				suite.Require().Error(err)
+				return
+			}
+
+			// Validate pool.
+			suite.Require().NoError(err)
+			suite.Require().Equal(uint64(i+1), poolId)
+
+			// Validate that mapping pool id -> module type has been persisted.
+			swapModule, err := swaprouterKeeper.GetSwapModule(ctx, poolId)
+			suite.Require().NoError(err)
+			suite.Require().Equal(tc.expectedModuleType, reflect.TypeOf(swapModule))
+		})
+	}
+}

--- a/x/swaprouter/export_test.go
+++ b/x/swaprouter/export_test.go
@@ -2,8 +2,24 @@ package swaprouter
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 func (k Keeper) GetNextPoolIdAndIncrement(ctx sdk.Context) uint64 {
 	return k.getNextPoolIdAndIncrement(ctx)
+}
+
+func (k Keeper) GetOsmoRoutedMultihopTotalSwapFee(ctx sdk.Context, route types.MultihopRoute) (
+	totalPathSwapFee sdk.Dec, sumOfSwapFees sdk.Dec, err error) {
+	return k.getOsmoRoutedMultihopTotalSwapFee(ctx, route)
+}
+
+// SetPoolRoutesUnsafe sets the given routes to the swaprouter keeper
+// to allow routing from a pool type to a certain swap module.
+// For example, balancer -> gamm.
+// This utility function is only exposed for testing and should not be moved
+// outside of the _test.go files.
+func (k *Keeper) SetPoolRoutesUnsafe(routes map[types.PoolType]types.SwapI) {
+	k.routes = routes
 }

--- a/x/swaprouter/keeper.go
+++ b/x/swaprouter/keeper.go
@@ -101,10 +101,3 @@ func (k Keeper) SetNextPoolId(ctx sdk.Context, poolId uint64) {
 func (k *Keeper) SetPoolIncentivesKeeper(poolIncentivesKeeper types.PoolIncentivesKeeperI) {
 	k.poolIncentivesKeeper = poolIncentivesKeeper
 }
-
-// getNextPoolIdAndIncrement returns the next pool Id, and increments the corresponding state entry.
-func (k Keeper) getNextPoolIdAndIncrement(ctx sdk.Context) uint64 {
-	nextPoolId := k.GetNextPoolId(ctx)
-	k.SetNextPoolId(ctx, nextPoolId+1)
-	return nextPoolId
-}

--- a/x/swaprouter/keeper.go
+++ b/x/swaprouter/keeper.go
@@ -103,7 +103,6 @@ func (k *Keeper) SetPoolIncentivesKeeper(poolIncentivesKeeper types.PoolIncentiv
 }
 
 // getNextPoolIdAndIncrement returns the next pool Id, and increments the corresponding state entry.
-// nolint: unused
 func (k Keeper) getNextPoolIdAndIncrement(ctx sdk.Context) uint64 {
 	nextPoolId := k.GetNextPoolId(ctx)
 	k.SetNextPoolId(ctx, nextPoolId+1)

--- a/x/swaprouter/keeper_test.go
+++ b/x/swaprouter/keeper_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
-	"github.com/stretchr/testify/suite"
 )
 
 type KeeperTestSuite struct {
@@ -18,11 +18,37 @@ const testExpectedPoolId = 3
 var testPoolCreationFee = sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 1000_000_000)}
 
 func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
+	// TODO: uncomment this once gamm refactor is merged from concentrated-liquidity-main
+	// suite.Run(t, new(KeeperTestSuite))
 }
 
 func (suite *KeeperTestSuite) SetupTest() {
 	suite.Setup()
+}
+
+// createPoolFromType creates a basic pool of the given type for testing.
+func (suite *KeeperTestSuite) createPoolFromType(poolType types.PoolType) {
+	switch poolType {
+	case types.Balancer:
+		suite.PrepareBalancerPool()
+		return
+	case types.StableSwap:
+		// TODO
+		return
+	case types.Concentrated:
+		// TODO
+		return
+	}
+}
+
+// createBalancerPoolsFromCoins creates balancer pools from given sets of coins.
+// Where element 1 of the input corresponds to the first pool created,
+// element 2 to the second pool created, up until the last element.
+func (suite *KeeperTestSuite) createBalancerPoolsFromCoins(poolCoins []sdk.Coins) {
+	for _, curPoolCoins := range poolCoins {
+		suite.FundAcc(suite.TestAccs[0], curPoolCoins)
+		suite.PrepareBalancerPoolWithCoins(curPoolCoins...)
+	}
 }
 
 func (suite *KeeperTestSuite) TestInitGenesis() {

--- a/x/swaprouter/keeper_test.go
+++ b/x/swaprouter/keeper_test.go
@@ -51,6 +51,16 @@ func (suite *KeeperTestSuite) createBalancerPoolsFromCoins(poolCoins []sdk.Coins
 	}
 }
 
+// createBalancerPoolsFromCoinsWithSwapFee creates balancer pools from given sets of coins and respective swap fees.
+// Where element 1 of the input corresponds to the first pool created,
+// element 2 to the second pool created, up until the last element.
+func (suite *KeeperTestSuite) createBalancerPoolsFromCoinsWithSwapFee(poolCoins []sdk.Coins, swapFee []sdk.Dec) {
+	for i, curPoolCoins := range poolCoins {
+		suite.FundAcc(suite.TestAccs[0], curPoolCoins)
+		suite.PrepareBalancerPoolWithCoinsAndSwapFee(swapFee[i], curPoolCoins...)
+	}
+}
+
 func (suite *KeeperTestSuite) TestInitGenesis() {
 	suite.Setup()
 

--- a/x/swaprouter/module/module.go
+++ b/x/swaprouter/module/module.go
@@ -15,8 +15,14 @@ import (
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	"github.com/osmosis-labs/osmosis/v13/simulation/simtypes"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
+	swaprouterclient "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/grpc"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	swaproutersimulation "github.com/osmosis-labs/osmosis/v13/x/swaprouter/simulation"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
@@ -58,11 +64,11 @@ func (b AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux 
 }
 
 func (b AppModuleBasic) GetTxCmd() *cobra.Command {
-	return nil
+	return cli.NewTxCmd()
 }
 
 func (b AppModuleBasic) GetQueryCmd() *cobra.Command {
-	return nil
+	return cli.GetQueryCmd()
 }
 
 // RegisterInterfaces registers interfaces and implementations of the gamm module.
@@ -78,6 +84,11 @@ type AppModule struct {
 }
 
 func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterMsgServer(cfg.MsgServer(), swaprouter.NewMsgServerImpl(&am.k))
+	balancer.RegisterMsgServer(cfg.MsgServer(), swaprouter.NewBalancerMsgServerImpl(&am.k))
+	// TODO: enable after gamm refactor is ported from `concentrated-liqudity-main`
+	// stableswap.RegisterMsgCreatorServer(cfg.MsgServer(), swaprouter.NewStableswapMsgServerImpl(&am.k))
+	queryproto.RegisterQueryServer(cfg.QueryServer(), grpc.Querier{Q: swaprouterclient.Querier{K: am.k}})
 }
 
 func NewAppModule(swaprouterKeeper swaprouter.Keeper, gammKeeper types.GammKeeper) AppModule {
@@ -133,3 +144,19 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 { return 1 }
+
+// **** simulation implementation ****
+// GenerateGenesisState creates a randomized GenState of the swaprouter module.
+// **** simulation implementation ****
+// GenerateGenesisState creates a randomized GenState of the gamm module.
+func (am AppModule) SimulatorGenesisState(simState *module.SimulationState, s *simtypes.SimCtx) {
+	swaprouterGen := types.DefaultGenesis()
+	// change the pool creation fee denom from uosmo to stake
+	swaprouterGen.Params.PoolCreationFee = sdk.NewCoins(swaproutersimulation.PoolCreationFee)
+	DefaultGenJson := simState.Cdc.MustMarshalJSON(swaprouterGen)
+	simState.GenState[types.ModuleName] = DefaultGenJson
+}
+
+func (am AppModule) Actions() []simtypes.Action {
+	return swaproutersimulation.DefaultActions(am.k, am.gammKeeper)
+}

--- a/x/swaprouter/msg_server.go
+++ b/x/swaprouter/msg_server.go
@@ -1,0 +1,147 @@
+package swaprouter
+
+import (
+	"context"
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+type msgServer struct {
+	keeper *Keeper
+}
+
+var (
+	_ balancer.MsgServer = (*msgServer)(nil)
+	// TODO: enable after gamm refactor is ported from `concentrated-liqudity-main`
+	// _ stableswap.MsgCreatorServer = (*msgServer)(nil)
+)
+
+func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
+	return &msgServer{
+		keeper: keeper,
+	}
+}
+
+func NewBalancerMsgServerImpl(keeper *Keeper) balancer.MsgServer {
+	return &msgServer{
+		keeper: keeper,
+	}
+}
+
+// TODO: enable after gamm refactor is ported from `concentrated-liqudity-main`
+// func NewStableswapMsgServerImpl(keeper *Keeper) stableswap.MsgCreatorServer {
+// 	return &msgServer{
+// 		keeper: keeper,
+// 	}
+// }
+
+// CreateBalancerPool is a create balancer pool message.
+func (server msgServer) CreateBalancerPool(goCtx context.Context, msg *balancer.MsgCreateBalancerPool) (*balancer.MsgCreateBalancerPoolResponse, error) {
+	poolId, err := server.CreatePool(goCtx, msg)
+	if err != nil {
+		return nil, err
+	}
+	return &balancer.MsgCreateBalancerPoolResponse{PoolID: poolId}, nil
+}
+
+func (server msgServer) CreateStableswapPool(goCtx context.Context, msg *stableswap.MsgCreateStableswapPool) (*stableswap.MsgCreateStableswapPoolResponse, error) {
+	poolId, err := server.CreatePool(goCtx, msg)
+	if err != nil {
+		return nil, err
+	}
+	return &stableswap.MsgCreateStableswapPoolResponse{PoolID: poolId}, nil
+}
+
+// func (server msgServer) StableSwapAdjustScalingFactors(goCtx context.Context, msg *stableswap.MsgStableSwapAdjustScalingFactors) (*stableswap.MsgStableSwapAdjustScalingFactorsResponse, error) {
+// 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+// 	if err := server.keeper.SetStableSwapScalingFactors(ctx, msg.ScalingFactors, msg.PoolID, msg.ScalingFactorGovernor); err != nil {
+// 		return nil, err
+// 	}
+
+// 	return &stableswap.MsgStableSwapAdjustScalingFactorsResponse{}, nil
+// }
+
+// CreatePool attempts to create a pool returning the newly created pool ID or an error upon failure.
+// The pool creation fee is used to fund the community pool.
+// It will create a dedicated module account for the pool and sends the initial liquidity to the created module account.
+func (server msgServer) CreatePool(goCtx context.Context, msg types.CreatePoolMsg) (poolId uint64, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	poolId, err = server.keeper.CreatePool(ctx, msg)
+	if err != nil {
+		return 0, err
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			gammtypes.TypeEvtPoolCreated,
+			sdk.NewAttribute(gammtypes.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+		),
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.PoolCreator().String()),
+		),
+	})
+
+	return poolId, nil
+}
+
+// TODO: spec and tests, including events
+func (server msgServer) SwapExactAmountIn(goCtx context.Context, msg *types.MsgSwapExactAmountIn) (*types.MsgSwapExactAmountInResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenOutAmount, err := server.keeper.RouteExactAmountIn(ctx, sender, msg.Routes, msg.TokenIn, msg.TokenOutMinAmount)
+	if err != nil {
+		return nil, err
+	}
+
+	// Swap event is handled elsewhere
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+		),
+	})
+
+	return &types.MsgSwapExactAmountInResponse{TokenOutAmount: tokenOutAmount}, nil
+}
+
+// TODO: spec and tests, including events
+func (server msgServer) SwapExactAmountOut(goCtx context.Context, msg *types.MsgSwapExactAmountOut) (*types.MsgSwapExactAmountOutResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenInAmount, err := server.keeper.RouteExactAmountOut(ctx, sender, msg.Routes, msg.TokenInMaxAmount, msg.TokenOut)
+	if err != nil {
+		return nil, err
+	}
+
+	// Swap event is handled elsewhere
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+		),
+	})
+
+	return &types.MsgSwapExactAmountOutResponse{TokenInAmount: tokenInAmount}, nil
+}

--- a/x/swaprouter/msg_server.go
+++ b/x/swaprouter/msg_server.go
@@ -58,16 +58,6 @@ func (server msgServer) CreateStableswapPool(goCtx context.Context, msg *stables
 	return &stableswap.MsgCreateStableswapPoolResponse{PoolID: poolId}, nil
 }
 
-// func (server msgServer) StableSwapAdjustScalingFactors(goCtx context.Context, msg *stableswap.MsgStableSwapAdjustScalingFactors) (*stableswap.MsgStableSwapAdjustScalingFactorsResponse, error) {
-// 	ctx := sdk.UnwrapSDKContext(goCtx)
-
-// 	if err := server.keeper.SetStableSwapScalingFactors(ctx, msg.ScalingFactors, msg.PoolID, msg.ScalingFactorGovernor); err != nil {
-// 		return nil, err
-// 	}
-
-// 	return &stableswap.MsgStableSwapAdjustScalingFactorsResponse{}, nil
-// }
-
 // CreatePool attempts to create a pool returning the newly created pool ID or an error upon failure.
 // The pool creation fee is used to fund the community pool.
 // It will create a dedicated module account for the pool and sends the initial liquidity to the created module account.

--- a/x/swaprouter/msg_server_test.go
+++ b/x/swaprouter/msg_server_test.go
@@ -1,0 +1,214 @@
+package swaprouter_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+const (
+	doesNotExistDenom = "nodenom"
+	// Max positive int64.
+	int64Max = int64(^uint64(0) >> 1)
+)
+
+// TestSwapExactAmountIn_Events tests that events are correctly emitted
+// when calling SwapExactAmountIn.
+func (suite *KeeperTestSuite) TestSwapExactAmountIn_Events() {
+	const (
+		tokenInMinAmount = 1
+		tokenIn          = 5
+	)
+
+	testcases := map[string]struct {
+		routes                []swaproutertypes.SwapAmountInRoute
+		tokenIn               sdk.Coin
+		tokenOutMinAmount     sdk.Int
+		expectError           bool
+		expectedSwapEvents    int
+		expectedMessageEvents int
+	}{
+		"zero hops": {
+			routes:            []swaproutertypes.SwapAmountInRoute{},
+			tokenIn:           sdk.NewCoin("foo", sdk.NewInt(tokenIn)),
+			tokenOutMinAmount: sdk.NewInt(tokenInMinAmount),
+			expectError:       true,
+		},
+		"one hop": {
+			routes: []swaproutertypes.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: "bar",
+				},
+			},
+			tokenIn:               sdk.NewCoin("foo", sdk.NewInt(tokenIn)),
+			tokenOutMinAmount:     sdk.NewInt(tokenInMinAmount),
+			expectedSwapEvents:    1,
+			expectedMessageEvents: 3, // 1 gamm + 2 events emitted by other keeper methods.
+		},
+		"two hops": {
+			routes: []swaproutertypes.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: "bar",
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: "baz",
+				},
+			},
+			tokenIn:               sdk.NewCoin("foo", sdk.NewInt(tokenIn)),
+			tokenOutMinAmount:     sdk.NewInt(tokenInMinAmount),
+			expectedSwapEvents:    2,
+			expectedMessageEvents: 5, // 1 gamm + 4 events emitted by other keeper methods.
+		},
+		"invalid - two hops, denom does not exist": {
+			routes: []swaproutertypes.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: "bar",
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: "baz",
+				},
+			},
+			tokenIn:           sdk.NewCoin(doesNotExistDenom, sdk.NewInt(tokenIn)),
+			tokenOutMinAmount: sdk.NewInt(tokenInMinAmount),
+			expectError:       true,
+		},
+	}
+
+	for name, tc := range testcases {
+		suite.Run(name, func() {
+			suite.Setup()
+			ctx := suite.Ctx
+
+			suite.PrepareBalancerPool()
+			suite.PrepareBalancerPool()
+
+			msgServer := swaprouter.NewMsgServerImpl(suite.App.SwapRouterKeeper)
+
+			// Reset event counts to 0 by creating a new manager.
+			ctx = ctx.WithEventManager(sdk.NewEventManager())
+			suite.Equal(0, len(ctx.EventManager().Events()))
+
+			response, err := msgServer.SwapExactAmountIn(sdk.WrapSDKContext(ctx), &types.MsgSwapExactAmountIn{
+				Sender:            suite.TestAccs[0].String(),
+				Routes:            tc.routes,
+				TokenIn:           tc.tokenIn,
+				TokenOutMinAmount: tc.tokenOutMinAmount,
+			})
+
+			if !tc.expectError {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(response)
+			}
+
+			suite.AssertEventEmitted(ctx, gammtypes.TypeEvtTokenSwapped, tc.expectedSwapEvents)
+			suite.AssertEventEmitted(ctx, sdk.EventTypeMessage, tc.expectedMessageEvents)
+		})
+	}
+}
+
+// TestSwapExactAmountOut_Events tests that events are correctly emitted
+// when calling SwapExactAmountOut.
+func (suite *KeeperTestSuite) TestSwapExactAmountOut_Events() {
+	const (
+		tokenInMaxAmount = int64Max
+		tokenOut         = 5
+	)
+
+	testcases := map[string]struct {
+		routes                []swaproutertypes.SwapAmountOutRoute
+		tokenOut              sdk.Coin
+		tokenInMaxAmount      sdk.Int
+		expectError           bool
+		expectedSwapEvents    int
+		expectedMessageEvents int
+	}{
+		"zero hops": {
+			routes:           []swaproutertypes.SwapAmountOutRoute{},
+			tokenOut:         sdk.NewCoin("foo", sdk.NewInt(tokenOut)),
+			tokenInMaxAmount: sdk.NewInt(tokenInMaxAmount),
+			expectError:      true,
+		},
+		"one hop": {
+			routes: []swaproutertypes.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: "bar",
+				},
+			},
+			tokenOut:              sdk.NewCoin("foo", sdk.NewInt(tokenOut)),
+			tokenInMaxAmount:      sdk.NewInt(tokenInMaxAmount),
+			expectedSwapEvents:    1,
+			expectedMessageEvents: 3, // 1 gamm + 2 events emitted by other keeper methods.
+		},
+		"two hops": {
+			routes: []swaproutertypes.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: "bar",
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: "baz",
+				},
+			},
+			tokenOut:              sdk.NewCoin("foo", sdk.NewInt(tokenOut)),
+			tokenInMaxAmount:      sdk.NewInt(tokenInMaxAmount),
+			expectedSwapEvents:    2,
+			expectedMessageEvents: 5, // 1 gamm + 4 events emitted by other keeper methods.
+		},
+		"invalid - two hops, denom does not exist": {
+			routes: []swaproutertypes.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: "bar",
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: "baz",
+				},
+			},
+			tokenOut:         sdk.NewCoin(doesNotExistDenom, sdk.NewInt(tokenOut)),
+			tokenInMaxAmount: sdk.NewInt(tokenInMaxAmount),
+			expectError:      true,
+		},
+	}
+
+	for name, tc := range testcases {
+		suite.Run(name, func() {
+			suite.Setup()
+			ctx := suite.Ctx
+
+			suite.PrepareBalancerPool()
+			suite.PrepareBalancerPool()
+
+			msgServer := swaprouter.NewMsgServerImpl(suite.App.SwapRouterKeeper)
+
+			// Reset event counts to 0 by creating a new manager.
+			ctx = ctx.WithEventManager(sdk.NewEventManager())
+			suite.Equal(0, len(ctx.EventManager().Events()))
+
+			response, err := msgServer.SwapExactAmountOut(sdk.WrapSDKContext(ctx), &swaproutertypes.MsgSwapExactAmountOut{
+				Sender:           suite.TestAccs[0].String(),
+				Routes:           tc.routes,
+				TokenOut:         tc.tokenOut,
+				TokenInMaxAmount: tc.tokenInMaxAmount,
+			})
+
+			if !tc.expectError {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(response)
+			}
+
+			suite.AssertEventEmitted(ctx, gammtypes.TypeEvtTokenSwapped, tc.expectedSwapEvents)
+			suite.AssertEventEmitted(ctx, sdk.EventTypeMessage, tc.expectedMessageEvents)
+		})
+	}
+}

--- a/x/swaprouter/router.go
+++ b/x/swaprouter/router.go
@@ -1,0 +1,424 @@
+package swaprouter
+
+import (
+	"errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	appparams "github.com/osmosis-labs/osmosis/v13/app/params"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// RouteExactAmountIn defines the input denom and input amount for the first pool,
+// the output of the first pool is chained as the input for the next routed pool
+// transaction succeeds when final amount out is greater than tokenOutMinAmount defined.
+func (k Keeper) RouteExactAmountIn(
+	ctx sdk.Context,
+	sender sdk.AccAddress,
+	routes []types.SwapAmountInRoute,
+	tokenIn sdk.Coin,
+	tokenOutMinAmount sdk.Int) (tokenOutAmount sdk.Int, err error) {
+	var (
+		isMultiHopRouted bool
+		routeSwapFee     sdk.Dec
+		sumOfSwapFees    sdk.Dec
+	)
+
+	route := types.SwapAmountInRoutes(routes)
+	if err := route.Validate(); err != nil {
+		return sdk.Int{}, err
+	}
+
+	// In this loop, we check if:
+	// - the route is of length 2
+	// - route 1 and route 2 don't trade via the same pool
+	// - route 1 contains uosmo
+	// - both route 1 and route 2 are incentivized pools
+	//
+	// If all of the above is true, then we collect the additive and max fee between the
+	// two pools to later calculate the following:
+	// total_swap_fee = total_swap_fee = max(swapfee1, swapfee2)
+	// fee_per_pool = total_swap_fee * ((pool_fee) / (swapfee1 + swapfee2))
+	if k.isOsmoRoutedMultihop(ctx, route, routes[0].TokenOutDenom, tokenIn.Denom) {
+		isMultiHopRouted = true
+		routeSwapFee, sumOfSwapFees, err = k.getOsmoRoutedMultihopTotalSwapFee(ctx, route)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+	}
+
+	for i, route := range routes {
+		// To prevent the multihop swap from being interrupted prematurely, we keep
+		// the minimum expected output at a very low number until the last pool
+		_outMinAmount := sdk.NewInt(1)
+		if len(routes)-1 == i {
+			_outMinAmount = tokenOutMinAmount
+		}
+
+		swapModule, err := k.GetSwapModule(ctx, route.PoolId)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+
+		// Execute the expected swap on the current routed pool
+		pool, poolErr := swapModule.GetPool(ctx, route.PoolId)
+		if poolErr != nil {
+			return sdk.Int{}, poolErr
+		}
+
+		swapFee := pool.GetSwapFee(ctx)
+
+		// If we determined the route is an osmo multi-hop and both routes are incentivized,
+		// we modify the swap fee accordingly.
+		if isMultiHopRouted {
+			swapFee = routeSwapFee.Mul((swapFee.Quo(sumOfSwapFees)))
+		}
+
+		tokenOutAmount, err = swapModule.SwapExactAmountIn(ctx, sender, pool, tokenIn, route.TokenOutDenom, _outMinAmount, swapFee)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+
+		// Chain output of current pool as the input for the next routed pool
+		tokenIn = sdk.NewCoin(route.TokenOutDenom, tokenOutAmount)
+	}
+	return tokenOutAmount, nil
+}
+
+func (k Keeper) MultihopEstimateOutGivenExactAmountIn(
+	ctx sdk.Context,
+	routes []types.SwapAmountInRoute,
+	tokenIn sdk.Coin,
+) (tokenOutAmount sdk.Int, err error) {
+	var (
+		isMultiHopRouted bool
+		routeSwapFee     sdk.Dec
+		sumOfSwapFees    sdk.Dec
+	)
+
+	route := types.SwapAmountInRoutes(routes)
+	if err := route.Validate(); err != nil {
+		return sdk.Int{}, err
+	}
+
+	if k.isOsmoRoutedMultihop(ctx, route, routes[0].TokenOutDenom, tokenIn.Denom) {
+		isMultiHopRouted = true
+		routeSwapFee, sumOfSwapFees, err = k.getOsmoRoutedMultihopTotalSwapFee(ctx, route)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+	}
+
+	for _, route := range routes {
+		swapModule, err := k.GetSwapModule(ctx, route.PoolId)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+
+		// Execute the expected swap on the current routed pool
+		pool, poolErr := swapModule.GetPool(ctx, route.PoolId)
+		if poolErr != nil {
+			return sdk.Int{}, poolErr
+		}
+
+		swapFee := pool.GetSwapFee(ctx)
+
+		// If we determined the route is an osmo multi-hop and both routes are incentivized,
+		// we modify the swap fee accordingly.
+		if isMultiHopRouted {
+			swapFee = routeSwapFee.Mul((swapFee.Quo(sumOfSwapFees)))
+		}
+
+		tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.Coins{tokenIn}, route.TokenOutDenom, swapFee)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+
+		tokenOutAmount = tokenOut.Amount
+		if !tokenOutAmount.IsPositive() {
+			return sdk.Int{}, errors.New("token amount must be positive")
+		}
+
+		// Chain output of current pool as the input for the next routed pool
+		tokenIn = sdk.NewCoin(route.TokenOutDenom, tokenOutAmount)
+	}
+	return tokenOutAmount, err
+}
+
+// MultihopSwapExactAmountOut defines the output denom and output amount for the last pool.
+// Calculation starts by providing the tokenOutAmount of the final pool to calculate the required tokenInAmount
+// the calculated tokenInAmount is used as defined tokenOutAmount of the previous pool, calculating in reverse order of the swap
+// Transaction succeeds if the calculated tokenInAmount of the first pool is less than the defined tokenInMaxAmount defined.
+func (k Keeper) RouteExactAmountOut(ctx sdk.Context,
+	sender sdk.AccAddress,
+	routes []types.SwapAmountOutRoute,
+	tokenInMaxAmount sdk.Int,
+	tokenOut sdk.Coin,
+) (tokenInAmount sdk.Int, err error) {
+	isMultiHopRouted, routeSwapFee, sumOfSwapFees := false, sdk.Dec{}, sdk.Dec{}
+	route := types.SwapAmountOutRoutes(routes)
+	if err := route.Validate(); err != nil {
+		return sdk.Int{}, err
+	}
+
+	// in this loop, we check if:
+	// - the route is of length 2
+	// - route 1 and route 2 don't trade via the same pool
+	// - route 1 contains uosmo
+	// - both route 1 and route 2 are incentivized pools
+	// if all of the above is true, then we collect the additive and max fee between the two pools to later calculate the following:
+	// total_swap_fee = total_swap_fee = max(swapfee1, swapfee2)
+	// fee_per_pool = total_swap_fee * ((pool_fee) / (swapfee1 + swapfee2))
+	if k.isOsmoRoutedMultihop(ctx, route, routes[0].TokenInDenom, tokenOut.Denom) {
+		isMultiHopRouted = true
+		routeSwapFee, sumOfSwapFees, err = k.getOsmoRoutedMultihopTotalSwapFee(ctx, route)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+	}
+
+	// Determine what the estimated input would be for each pool along the multi-hop route
+	// if we determined the route is an osmo multi-hop and both routes are incentivized,
+	// we utilize a separate function that calculates the discounted swap fees
+	var insExpected []sdk.Int
+	if isMultiHopRouted {
+		insExpected, err = k.createOsmoMultihopExpectedSwapOuts(ctx, routes, tokenOut, routeSwapFee, sumOfSwapFees)
+	} else {
+		insExpected, err = k.createMultihopExpectedSwapOuts(ctx, routes, tokenOut)
+	}
+	if err != nil {
+		return sdk.Int{}, err
+	}
+	if len(insExpected) == 0 {
+		return sdk.Int{}, nil
+	}
+
+	insExpected[0] = tokenInMaxAmount
+
+	// Iterates through each routed pool and executes their respective swaps. Note that all of the work to get the return
+	// value of this method is done when we calculate insExpected – this for loop primarily serves to execute the actual
+	// swaps on each pool.
+	for i, route := range routes {
+		swapModule, err := k.GetSwapModule(ctx, route.PoolId)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+
+		_tokenOut := tokenOut
+
+		// If there is one pool left in the route, set the expected output of the current swap
+		// to the estimated input of the final pool.
+		if i != len(routes)-1 {
+			_tokenOut = sdk.NewCoin(routes[i+1].TokenInDenom, insExpected[i+1])
+		}
+
+		// Execute the expected swap on the current routed pool
+		pool, poolErr := swapModule.GetPool(ctx, route.PoolId)
+		if poolErr != nil {
+			return sdk.Int{}, poolErr
+		}
+
+		swapFee := pool.GetSwapFee(ctx)
+		if isMultiHopRouted {
+			swapFee = routeSwapFee.Mul((swapFee.Quo(sumOfSwapFees)))
+		}
+
+		_tokenInAmount, swapErr := swapModule.SwapExactAmountOut(ctx, sender, pool, route.TokenInDenom, insExpected[i], _tokenOut, swapFee)
+		if swapErr != nil {
+			return sdk.Int{}, swapErr
+		}
+
+		// Sets the final amount of tokens that need to be input into the first pool. Even though this is the final return value for the
+		// whole method and will not change after the first iteration, we still iterate through the rest of the pools to execute their respective
+		// swaps.
+		if i == 0 {
+			tokenInAmount = _tokenInAmount
+		}
+	}
+
+	return tokenInAmount, nil
+}
+
+func (k Keeper) MultihopEstimateInGivenExactAmountOut(
+	ctx sdk.Context,
+	routes []types.SwapAmountOutRoute,
+	tokenOut sdk.Coin,
+) (tokenInAmount sdk.Int, err error) {
+	isMultiHopRouted, routeSwapFee, sumOfSwapFees := false, sdk.Dec{}, sdk.Dec{}
+	route := types.SwapAmountOutRoutes(routes)
+	if err := route.Validate(); err != nil {
+		return sdk.Int{}, err
+	}
+
+	if k.isOsmoRoutedMultihop(ctx, route, routes[0].TokenInDenom, tokenOut.Denom) {
+		isMultiHopRouted = true
+		routeSwapFee, sumOfSwapFees, err = k.getOsmoRoutedMultihopTotalSwapFee(ctx, route)
+		if err != nil {
+			return sdk.Int{}, err
+		}
+	}
+
+	// Determine what the estimated input would be for each pool along the multi-hop route
+	// if we determined the route is an osmo multi-hop and both routes are incentivized,
+	// we utilize a separate function that calculates the discounted swap fees
+	var insExpected []sdk.Int
+	if isMultiHopRouted {
+		insExpected, err = k.createOsmoMultihopExpectedSwapOuts(ctx, routes, tokenOut, routeSwapFee, sumOfSwapFees)
+	} else {
+		insExpected, err = k.createMultihopExpectedSwapOuts(ctx, routes, tokenOut)
+	}
+	if err != nil {
+		return sdk.Int{}, err
+	}
+	if len(insExpected) == 0 {
+		return sdk.Int{}, nil
+	}
+
+	return insExpected[0], nil
+}
+
+func (k Keeper) isOsmoRoutedMultihop(ctx sdk.Context, route types.MultihopRoute, inDenom, outDenom string) (isRouted bool) {
+	if route.Length() != 2 {
+		return false
+	}
+	intemediateDenoms := route.IntermediateDenoms()
+	if len(intemediateDenoms) != 1 || intemediateDenoms[0] != appparams.BaseCoinUnit {
+		return false
+	}
+	if inDenom == outDenom {
+		return false
+	}
+	poolIds := route.PoolIds()
+	if poolIds[0] == poolIds[1] {
+		return false
+	}
+
+	route0Incentivized := k.poolIncentivesKeeper.IsPoolIncentivized(ctx, poolIds[0])
+	route1Incentivized := k.poolIncentivesKeeper.IsPoolIncentivized(ctx, poolIds[1])
+
+	return route0Incentivized && route1Incentivized
+}
+
+func (k Keeper) getOsmoRoutedMultihopTotalSwapFee(ctx sdk.Context, route types.MultihopRoute) (
+	totalPathSwapFee sdk.Dec, sumOfSwapFees sdk.Dec, err error) {
+	additiveSwapFee := sdk.ZeroDec()
+	maxSwapFee := sdk.ZeroDec()
+
+	for _, poolId := range route.PoolIds() {
+		swapModule, err := k.GetSwapModule(ctx, poolId)
+		if err != nil {
+			return sdk.Dec{}, sdk.Dec{}, err
+		}
+
+		pool, poolErr := swapModule.GetPool(ctx, poolId)
+		if poolErr != nil {
+			return sdk.Dec{}, sdk.Dec{}, poolErr
+		}
+		swapFee := pool.GetSwapFee(ctx)
+		additiveSwapFee = additiveSwapFee.Add(swapFee)
+		maxSwapFee = sdk.MaxDec(maxSwapFee, swapFee)
+	}
+	averageSwapFee := additiveSwapFee.QuoInt64(2)
+	maxSwapFee = sdk.MaxDec(maxSwapFee, averageSwapFee)
+	return maxSwapFee, additiveSwapFee, nil
+}
+
+// createMultihopExpectedSwapOuts defines the output denom and output amount for the last pool in
+// the route of pools the caller is intending to hop through in a fixed-output multihop tx. It estimates the input
+// amount for this last pool and then chains that input as the output of the previous pool in the route, repeating
+// until the first pool is reached. It returns an array of inputs, each of which correspond to a pool ID in the
+// route of pools for the original multihop transaction.
+// TODO: test this.
+func (k Keeper) createMultihopExpectedSwapOuts(
+	ctx sdk.Context,
+	routes []types.SwapAmountOutRoute,
+	tokenOut sdk.Coin,
+) ([]sdk.Int, error) {
+	insExpected := make([]sdk.Int, len(routes))
+	for i := len(routes) - 1; i >= 0; i-- {
+		route := routes[i]
+
+		swapModule, err := k.GetSwapModule(ctx, route.PoolId)
+		if err != nil {
+			return nil, err
+		}
+
+		pool, err := swapModule.GetPool(ctx, route.PoolId)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenIn, err := pool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), route.TokenInDenom, pool.GetSwapFee(ctx))
+		if err != nil {
+			return nil, err
+		}
+
+		insExpected[i] = tokenIn.Amount
+		tokenOut = tokenIn
+	}
+
+	return insExpected, nil
+}
+
+// createOsmoMultihopExpectedSwapOuts does the same as createMultihopExpectedSwapOuts, however discounts the swap fee
+func (k Keeper) createOsmoMultihopExpectedSwapOuts(
+	ctx sdk.Context,
+	routes []types.SwapAmountOutRoute,
+	tokenOut sdk.Coin,
+	cumulativeRouteSwapFee, sumOfSwapFees sdk.Dec,
+) ([]sdk.Int, error) {
+	insExpected := make([]sdk.Int, len(routes))
+	for i := len(routes) - 1; i >= 0; i-- {
+		route := routes[i]
+
+		swapModule, err := k.GetSwapModule(ctx, route.PoolId)
+		if err != nil {
+			return nil, err
+		}
+
+		pool, err := swapModule.GetPool(ctx, route.PoolId)
+		if err != nil {
+			return nil, err
+		}
+
+		swapFee := pool.GetSwapFee(ctx)
+		tokenIn, err := pool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), route.TokenInDenom, cumulativeRouteSwapFee.Mul((swapFee.Quo(sumOfSwapFees))))
+		if err != nil {
+			return nil, err
+		}
+
+		insExpected[i] = tokenIn.Amount
+		tokenOut = tokenIn
+	}
+
+	return insExpected, nil
+}
+
+// GetSwapModule returns the swap module for the given pool ID.
+// Returns error if:
+// - any database error occurs.
+// - fails to find a pool with the given id.
+// - the swap module of the type corresponding to the pool id is not registered
+// in swaprouter's keeper constructor.
+// TODO: unexport after concentrated-liqudity upgrade. Currently, it is exported
+// for the upgrade handler logic and tests.
+func (k Keeper) GetSwapModule(ctx sdk.Context, poolId uint64) (types.SwapI, error) {
+	store := ctx.KVStore(k.storeKey)
+
+	moduleRoute := &types.ModuleRoute{}
+	found, err := osmoutils.GetIfFound(store, types.FormatModuleRouteKey(poolId), moduleRoute)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, types.FailedToFindRouteError{PoolId: poolId}
+	}
+
+	swapModule, routeExists := k.routes[moduleRoute.PoolType]
+	if !routeExists {
+		return nil, types.UndefinedRouteError{PoolType: moduleRoute.PoolType, PoolId: poolId}
+	}
+
+	return swapModule, nil
+}

--- a/x/swaprouter/router_test.go
+++ b/x/swaprouter/router_test.go
@@ -6,19 +6,22 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	gamm "github.com/osmosis-labs/osmosis/v13/x/gamm/keeper"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
 	poolincentivestypes "github.com/osmosis-labs/osmosis/v13/x/pool-incentives/types"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 const (
-	denomA = "denomA"
-	denomB = "denomB"
-	denomC = "denomC"
+	foo   = "foo"
+	bar   = "bar"
+	baz   = "baz"
+	uosmo = "uosmo"
 )
 
 var (
 	defaultInitPoolAmount = sdk.NewInt(1000000000000)
+	defaultPoolSwapFee    = sdk.NewDecWithPrec(1, 2) // 1% pool swap fee default
 	defaultSwapAmount     = sdk.NewInt(1000000)
 	gammKeeperType        = reflect.TypeOf(&gamm.Keeper{})
 )
@@ -29,53 +32,208 @@ var (
 // - over the right routes (hops)
 // This test does not actually validate the math behind the swaps.
 func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
+	type param struct {
+	}
+
 	tests := []struct {
-		name              string
-		poolCoins         []sdk.Coins
-		routes            []swaproutertypes.SwapAmountInRoute
-		tokenIn           sdk.Coin
-		tokenOutMinAmount sdk.Int
-		swapFee           sdk.Dec
-		expectError       bool
-		reducedFeeApplied bool
+		name                    string
+		poolCoins               []sdk.Coins
+		poolFee                 []sdk.Dec
+		routes                  []swaproutertypes.SwapAmountInRoute
+		incentivizedGauges      []uint64
+		tokenIn                 sdk.Coin
+		tokenOutMinAmount       sdk.Int
+		swapFee                 sdk.Dec
+		expectError             bool
+		expectReducedFeeApplied bool
 	}{
 		{
-			name:      "x/gamm - single route",
-			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount), sdk.NewCoin(denomB, defaultInitPoolAmount))},
+			name:      "One route: Swap - [foo -> bar], 1 percent fee",
+			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount))},
+			poolFee:   []sdk.Dec{defaultPoolSwapFee},
 			routes: []swaproutertypes.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: denomB,
+					TokenOutDenom: bar,
 				},
 			},
-			tokenIn:           sdk.NewCoin(denomA, sdk.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(foo, sdk.NewInt(100000)),
 			tokenOutMinAmount: sdk.NewInt(1),
 		},
 		{
-			name: "x/gamm - two routes",
+			name: "Two routes: Swap - [foo -> bar](pool 1) - [bar -> baz](pool 2), both pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount), sdk.NewCoin(denomB, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(denomB, defaultInitPoolAmount), sdk.NewCoin(denomC, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)), // pool 2.
 			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
 			routes: []swaproutertypes.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: denomB,
+					TokenOutDenom: bar,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: denomC,
+					TokenOutDenom: baz,
 				},
 			},
-			tokenIn:           sdk.NewCoin(denomA, sdk.NewInt(100000)),
-			tokenOutMinAmount: sdk.NewInt(1),
+			incentivizedGauges: []uint64{},
+			tokenIn:            sdk.NewCoin(foo, sdk.NewInt(100000)),
+			tokenOutMinAmount:  sdk.NewInt(1),
+		},
+		{
+			name: "Two routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) with a half fee applied, both pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: uosmo,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: baz,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenIn:                 sdk.NewCoin("foo", sdk.NewInt(100000)),
+			tokenOutMinAmount:       sdk.NewInt(1),
+			expectReducedFeeApplied: true,
+		},
+		{
+			name: "Two routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) with a half fee applied, (pool 1) 1 percent fee, (pool 2) 10 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, sdk.NewDecWithPrec(1, 1)},
+			routes: []types.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: uosmo,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: baz,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenIn:                 sdk.NewCoin(foo, sdk.NewInt(100000)),
+			tokenOutMinAmount:       sdk.NewInt(1),
+			expectReducedFeeApplied: true,
+		},
+		{
+			name: "Three routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)),   // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: uosmo,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: baz,
+				},
+				{
+					PoolId:        3,
+					TokenOutDenom: bar,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenIn:                 sdk.NewCoin(foo, sdk.NewInt(100000)),
+			tokenOutMinAmount:       sdk.NewInt(1),
+			expectReducedFeeApplied: false,
+		},
+		{
+			name: "Two routes: Swap between four asset pools - [foo -> bar](pool 1) - [bar -> baz](pool 2), all pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: bar,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: baz,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenIn:                 sdk.NewCoin(foo, sdk.NewInt(100000)),
+			tokenOutMinAmount:       sdk.NewInt(1),
+			expectReducedFeeApplied: false,
+		},
+		{
+			name: "Two routes: Swap between four asset pools - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2), with a half fee applied, both pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: uosmo,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: baz,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenIn:                 sdk.NewCoin(foo, sdk.NewInt(100000)),
+			tokenOutMinAmount:       sdk.NewInt(1),
+			expectReducedFeeApplied: true,
+		},
+		{
+			name: "Three routes: Swap between four asset pools - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 3.                                                                                      // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: uosmo,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: baz,
+				},
+				{
+					PoolId:        3,
+					TokenOutDenom: bar,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			tokenIn:                 sdk.NewCoin(foo, sdk.NewInt(100000)),
+			tokenOutMinAmount:       sdk.NewInt(1),
+			expectReducedFeeApplied: false,
 		},
 		// TODO:
 		// tests for concentrated liquidity
-		// test for multi-hop
-		// test for multi hop (osmo routes) -> reduces fee, add an assertion
 		// change values in and out to be different with each swap module type
-		// create more precise assertions on what the results are
+		// tests for stable-swap pools
 		// edge cases:
 		//   * invalid route length
 		//   * pool does not exist
@@ -85,30 +243,27 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
-
 			swaprouterKeeper := suite.App.SwapRouterKeeper
 
-			suite.createBalancerPoolsFromCoins(tc.poolCoins)
+			suite.createBalancerPoolsFromCoinsWithSwapFee(tc.poolCoins, tc.poolFee)
 
-			// if we expect a reduced fee to apply, we set both pools in DistrInfo to replicate it being an incentivized pool
-			// each pool has three gauges, hence 6 gauges for 2 pools
-			if tc.reducedFeeApplied {
-				test := poolincentivestypes.DistrInfo{
-					TotalWeight: sdk.NewInt(6),
-					Records: []poolincentivestypes.DistrRecord{
-						{GaugeId: 1, Weight: sdk.OneInt()}, {GaugeId: 2, Weight: sdk.OneInt()}, {GaugeId: 3, Weight: sdk.OneInt()},
-						{GaugeId: 4, Weight: sdk.OneInt()}, {GaugeId: 5, Weight: sdk.OneInt()}, {GaugeId: 6, Weight: sdk.OneInt()}},
-				}
-				suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, test)
+			// if test specifies incentivized gauges, set them here
+			if len(tc.incentivizedGauges) > 0 {
+				suite.makeGaugesIncentivized(tc.incentivizedGauges)
 			}
 
-			tokenOut, err := swaprouterKeeper.RouteExactAmountIn(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenIn, tc.tokenOutMinAmount)
-
 			if tc.expectError {
+				// execute the swap
+				_, err := swaprouterKeeper.RouteExactAmountIn(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenIn, tc.tokenOutMinAmount)
 				suite.Require().Error(err)
 			} else {
+				// calculate the swap as separate swaps with either the reduced swap fee or normal fee
+				expectedMultihopTokenOutAmount := suite.calcInAmountAsSeparateSwaps(tc.expectReducedFeeApplied, tc.routes, tc.tokenIn)
+				// execute the swap
+				multihopTokenOutAmount, err := swaprouterKeeper.RouteExactAmountIn(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenIn, tc.tokenOutMinAmount)
+				// compare the expected tokenOut to the actual tokenOut
 				suite.Require().NoError(err)
-				suite.Require().True(tokenOut.GTE(tc.tokenOutMinAmount))
+				suite.Require().Equal(expectedMultihopTokenOutAmount.Amount.String(), multihopTokenOutAmount.String())
 			}
 		})
 	}
@@ -120,34 +275,207 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 // - over the right routes (hops)
 // This test does not actually validate the math behind the swaps.
 func (suite *KeeperTestSuite) TestMultihopSwapExactAmountOut() {
+
 	tests := []struct {
-		name              string
-		poolCoins         []sdk.Coins
-		routes            []swaproutertypes.SwapAmountOutRoute
-		tokenOut          sdk.Coin
-		tokenInMaxAmount  sdk.Int
-		swapFee           sdk.Dec
-		expectError       bool
-		reducedFeeApplied bool
+		name                    string
+		poolCoins               []sdk.Coins
+		poolFee                 []sdk.Dec
+		routes                  []swaproutertypes.SwapAmountOutRoute
+		incentivizedGauges      []uint64
+		tokenOut                sdk.Coin
+		tokenInMaxAmount        sdk.Int
+		swapFee                 sdk.Dec
+		expectError             bool
+		expectReducedFeeApplied bool
 	}{
 		{
-			name:      "x/gamm - single route",
-			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount), sdk.NewCoin(denomB, defaultInitPoolAmount))},
+			name:      "One route: Swap - [foo -> bar], 1 percent fee",
+			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount))},
+			poolFee:   []sdk.Dec{defaultPoolSwapFee},
 			routes: []swaproutertypes.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: denomB,
+					TokenInDenom: bar,
 				},
 			},
-			tokenOut:         sdk.NewCoin(denomA, defaultSwapAmount),
-			tokenInMaxAmount: defaultSwapAmount.Mul(sdk.NewInt(2)), // the amount here is arbitrary
+			tokenInMaxAmount: sdk.NewInt(90000000),
+			tokenOut:         sdk.NewCoin(foo, defaultSwapAmount),
+		},
+		{
+			name: "Two routes: Swap - [foo -> bar](pool 1) - [bar -> baz](pool 2), both pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)), // pool 2.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: bar,
+				},
+			},
+			incentivizedGauges: []uint64{},
+
+			tokenInMaxAmount: sdk.NewInt(90000000),
+			tokenOut:         sdk.NewCoin(baz, sdk.NewInt(100000)),
+		},
+		{
+			name: "Two routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) with a half fee applied, both pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: uosmo,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenInMaxAmount:        sdk.NewInt(90000000),
+			tokenOut:                sdk.NewCoin(baz, sdk.NewInt(100000)),
+			expectReducedFeeApplied: true,
+		},
+		{
+			name: "Two routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) with a half fee applied, (pool 1) 1 percent fee, (pool 2) 10 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, sdk.NewDecWithPrec(1, 1)},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: uosmo,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenInMaxAmount:        sdk.NewInt(90000000),
+			tokenOut:                sdk.NewCoin(baz, sdk.NewInt(100000)),
+			expectReducedFeeApplied: true,
+		},
+		{
+			name: "Three routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)),   // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: uosmo,
+				},
+				{
+					PoolId:       3,
+					TokenInDenom: baz,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenInMaxAmount:        sdk.NewInt(90000000),
+			tokenOut:                sdk.NewCoin(bar, sdk.NewInt(100000)),
+			expectReducedFeeApplied: false,
+		},
+		{
+			name: "Two routes: Swap between four asset pools - [foo -> bar](pool 1) - [bar -> baz](pool 2), all pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: bar,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenOut:                sdk.NewCoin(baz, sdk.NewInt(100000)),
+			tokenInMaxAmount:        sdk.NewInt(90000000),
+			expectReducedFeeApplied: false,
+		},
+		{
+			name: "Two routes: Swap between four asset pools - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2), with a half fee applied, both pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: uosmo,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6},
+			tokenOut:                sdk.NewCoin(baz, sdk.NewInt(100000)),
+			tokenInMaxAmount:        sdk.NewInt(90000000),
+			expectReducedFeeApplied: true,
+		},
+		{
+			name: "Three routes: Swap between four asset pools - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
+					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 3.                                                                                    // pool 3.
+			},
+			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee, defaultPoolSwapFee},
+			routes: []types.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: foo,
+				},
+				{
+					PoolId:       2,
+					TokenInDenom: uosmo,
+				},
+				{
+					PoolId:       3,
+					TokenInDenom: baz,
+				},
+			},
+			incentivizedGauges:      []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			tokenOut:                sdk.NewCoin(bar, sdk.NewInt(100000)),
+			tokenInMaxAmount:        sdk.NewInt(90000000),
+			expectReducedFeeApplied: false,
 		},
 		// TODO:
 		// tests for concentrated liquidity
-		// test for multi-hop
-		// test for multi hop (osmo routes) -> reduces fee, add an assertion
+		// tests for stable-swap pools
 		// change values in and out to be different with each swap module type
-		// create more precise assertions on what the results are
 		// edge cases:
 		//   * invalid route length
 		//   * pool does not exist
@@ -157,30 +485,27 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountOut() {
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
-
 			swaprouterKeeper := suite.App.SwapRouterKeeper
 
-			suite.createBalancerPoolsFromCoins(tc.poolCoins)
+			suite.createBalancerPoolsFromCoinsWithSwapFee(tc.poolCoins, tc.poolFee)
 
-			// if we expect a reduced fee to apply, we set both pools in DistrInfo to replicate it being an incentivized pool
-			// each pool has three gauges, hence 6 gauges for 2 pools
-			if tc.reducedFeeApplied {
-				test := poolincentivestypes.DistrInfo{
-					TotalWeight: sdk.NewInt(2),
-					Records: []poolincentivestypes.DistrRecord{
-						{GaugeId: 1, Weight: sdk.OneInt()}, {GaugeId: 2, Weight: sdk.OneInt()}, {GaugeId: 3, Weight: sdk.OneInt()},
-						{GaugeId: 4, Weight: sdk.OneInt()}, {GaugeId: 5, Weight: sdk.OneInt()}, {GaugeId: 6, Weight: sdk.OneInt()}},
-				}
-				suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, test)
+			// if test specifies incentivized gauges, set them here
+			if len(tc.incentivizedGauges) > 0 {
+				suite.makeGaugesIncentivized(tc.incentivizedGauges)
 			}
 
-			tokenIn, err := swaprouterKeeper.RouteExactAmountOut(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenInMaxAmount, tc.tokenOut)
-
 			if tc.expectError {
+				// execute the swap
+				_, err := swaprouterKeeper.RouteExactAmountOut(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenInMaxAmount, tc.tokenOut)
 				suite.Require().Error(err)
 			} else {
+				// calculate the swap as separate swaps with either the reduced swap fee or normal fee
+				expectedMultihopTokenOutAmount := suite.calcOutAmountAsSeparateSwaps(tc.expectReducedFeeApplied, tc.routes, tc.tokenOut)
+				// execute the swap
+				multihopTokenOutAmount, err := swaprouterKeeper.RouteExactAmountOut(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenInMaxAmount, tc.tokenOut)
+				// compare the expected tokenOut to the actual tokenOut
 				suite.Require().NoError(err)
-				suite.Require().True(tokenIn.LTE(tc.tokenInMaxAmount))
+				suite.Require().Equal(expectedMultihopTokenOutAmount.Amount.String(), multihopTokenOutAmount.String())
 			}
 		})
 	}
@@ -248,5 +573,371 @@ func (suite *KeeperTestSuite) TestGetSwapModule() {
 
 			suite.Require().Equal(tc.expectedModule, reflect.TypeOf(swapModule))
 		})
+	}
+}
+
+// TestEstimateMultihopSwapExactAmountIn tests that the estimation done via `EstimateSwapExactAmountIn`
+// results in the same amount of token out as the actual swap.
+func (suite *KeeperTestSuite) TestEstimateMultihopSwapExactAmountIn() {
+	type param struct {
+		routes            []types.SwapAmountInRoute
+		estimateRoutes    []types.SwapAmountInRoute
+		tokenIn           sdk.Coin
+		tokenOutMinAmount sdk.Int
+	}
+
+	tests := []struct {
+		name              string
+		param             param
+		expectPass        bool
+		reducedFeeApplied bool
+	}{
+		{
+			name: "Proper swap - foo -> bar(pool 1) - bar(pool 2) -> baz",
+			param: param{
+				routes: []types.SwapAmountInRoute{
+					{
+						PoolId:        1,
+						TokenOutDenom: bar,
+					},
+					{
+						PoolId:        2,
+						TokenOutDenom: baz,
+					},
+				},
+				estimateRoutes: []types.SwapAmountInRoute{
+					{
+						PoolId:        3,
+						TokenOutDenom: bar,
+					},
+					{
+						PoolId:        4,
+						TokenOutDenom: baz,
+					},
+				},
+				tokenIn:           sdk.NewCoin(foo, sdk.NewInt(100000)),
+				tokenOutMinAmount: sdk.NewInt(1),
+			},
+			expectPass: true,
+		},
+		{
+			name: "Swap - foo -> uosmo(pool 1) - uosmo(pool 2) -> baz with a half fee applied",
+			param: param{
+				routes: []types.SwapAmountInRoute{
+					{
+						PoolId:        1,
+						TokenOutDenom: uosmo,
+					},
+					{
+						PoolId:        2,
+						TokenOutDenom: baz,
+					},
+				},
+				estimateRoutes: []types.SwapAmountInRoute{
+					{
+						PoolId:        3,
+						TokenOutDenom: uosmo,
+					},
+					{
+						PoolId:        4,
+						TokenOutDenom: baz,
+					},
+				},
+				tokenIn:           sdk.NewCoin(foo, sdk.NewInt(100000)),
+				tokenOutMinAmount: sdk.NewInt(1),
+			},
+			reducedFeeApplied: true,
+			expectPass:        true,
+		},
+	}
+
+	for _, test := range tests {
+		// Init suite for each test.
+		suite.SetupTest()
+
+		suite.Run(test.name, func() {
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+			poolDefaultSwapFee := sdk.NewDecWithPrec(1, 2) // 1%
+
+			// Prepare 4 pools,
+			// Two pools for calculating `MultihopSwapExactAmountIn`
+			// and two pools for calculating `EstimateMultihopSwapExactAmountIn`
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+
+			firstEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			secondEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+
+			firstEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			// calculate token out amount using `MultihopSwapExactAmountIn`
+			multihopTokenOutAmount, err := swaprouterKeeper.RouteExactAmountIn(
+				suite.Ctx,
+				suite.TestAccs[0],
+				test.param.routes,
+				test.param.tokenIn,
+				test.param.tokenOutMinAmount)
+			suite.Require().NoError(err)
+
+			// calculate token out amount using `EstimateMultihopSwapExactAmountIn`
+			estimateMultihopTokenOutAmount, err := swaprouterKeeper.MultihopEstimateOutGivenExactAmountIn(
+				suite.Ctx,
+				test.param.estimateRoutes,
+				test.param.tokenIn)
+			suite.Require().NoError(err)
+
+			// ensure that the token out amount is same
+			suite.Require().Equal(multihopTokenOutAmount, estimateMultihopTokenOutAmount)
+
+			// ensure that pool state has not been altered after estimation
+			firstEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(firstEstimatePool, firstEstimatePoolAfterSwap)
+			suite.Require().Equal(secondEstimatePool, secondEstimatePoolAfterSwap)
+		})
+	}
+}
+
+// TestEstimateMultihopSwapExactAmountOut tests that the estimation done via `EstimateSwapExactAmountOut`
+// results in the same amount of token in as the actual swap.
+func (suite *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
+	type param struct {
+		routes           []types.SwapAmountOutRoute
+		estimateRoutes   []types.SwapAmountOutRoute
+		tokenInMaxAmount sdk.Int
+		tokenOut         sdk.Coin
+	}
+
+	tests := []struct {
+		name              string
+		param             param
+		expectPass        bool
+		reducedFeeApplied bool
+	}{
+		{
+			name: "Proper swap: foo -> bar (pool 1), bar -> baz (pool 2)",
+			param: param{
+				routes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       1,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       2,
+						TokenInDenom: bar,
+					},
+				},
+				estimateRoutes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       3,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       4,
+						TokenInDenom: bar,
+					},
+				},
+				tokenInMaxAmount: sdk.NewInt(90000000),
+				tokenOut:         sdk.NewCoin(baz, sdk.NewInt(100000)),
+			},
+			expectPass: true,
+		},
+		{
+			name: "Swap - foo -> uosmo(pool 1) - uosmo(pool 2) -> baz with a half fee applied",
+			param: param{
+				routes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       1,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       2,
+						TokenInDenom: uosmo,
+					},
+				},
+				estimateRoutes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       3,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       4,
+						TokenInDenom: uosmo,
+					},
+				},
+				tokenInMaxAmount: sdk.NewInt(90000000),
+				tokenOut:         sdk.NewCoin(baz, sdk.NewInt(100000)),
+			},
+			expectPass:        true,
+			reducedFeeApplied: true,
+		},
+	}
+
+	for _, test := range tests {
+		// Init suite for each test.
+		suite.SetupTest()
+
+		suite.Run(test.name, func() {
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+			poolDefaultSwapFee := sdk.NewDecWithPrec(1, 2) // 1%
+
+			// Prepare 4 pools,
+			// Two pools for calculating `MultihopSwapExactAmountOut`
+			// and two pools for calculating `EstimateMultihopSwapExactAmountOut`
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee, // 1%
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			firstEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee, // 1%
+				ExitFee: sdk.NewDec(0),
+			})
+			secondEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			firstEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			multihopTokenInAmount, err := swaprouterKeeper.RouteExactAmountOut(
+				suite.Ctx,
+				suite.TestAccs[0],
+				test.param.routes,
+				test.param.tokenInMaxAmount,
+				test.param.tokenOut)
+			suite.Require().NoError(err, "test: %v", test.name)
+
+			estimateMultihopTokenInAmount, err := swaprouterKeeper.MultihopEstimateInGivenExactAmountOut(
+				suite.Ctx,
+				test.param.estimateRoutes,
+				test.param.tokenOut)
+			suite.Require().NoError(err, "test: %v", test.name)
+
+			suite.Require().Equal(multihopTokenInAmount, estimateMultihopTokenInAmount)
+
+			// ensure that pool state has not been altered after estimation
+			firstEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(firstEstimatePool, firstEstimatePoolAfterSwap)
+			suite.Require().Equal(secondEstimatePool, secondEstimatePoolAfterSwap)
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) makeGaugesIncentivized(incentivizedGauges []uint64) {
+	var records []poolincentivestypes.DistrRecord
+	totalWeight := sdk.NewInt(int64(len(incentivizedGauges)))
+	for _, gauge := range incentivizedGauges {
+		records = append(records, poolincentivestypes.DistrRecord{GaugeId: gauge, Weight: sdk.OneInt()})
+	}
+	distInfo := poolincentivestypes.DistrInfo{
+		TotalWeight: totalWeight,
+		Records:     records,
+	}
+	suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, distInfo)
+}
+
+func (suite *KeeperTestSuite) calcOutAmountAsSeparateSwaps(osmoFeeReduced bool, routes []swaproutertypes.SwapAmountOutRoute, tokenOut sdk.Coin) sdk.Coin {
+	cacheCtx, _ := suite.Ctx.CacheContext()
+	if osmoFeeReduced {
+		// extract route from swap
+		route := types.SwapAmountOutRoutes(routes)
+		// utilizing the extracted route, determine the routeSwapFee and sumOfSwapFees
+		// these two variables are used to calculate the overall swap fee utilizing the following formula
+		// swapFee = routeSwapFee * ((pool_fee) / (sumOfSwapFees))
+		routeSwapFee, sumOfSwapFees, err := suite.App.SwapRouterKeeper.GetOsmoRoutedMultihopTotalSwapFee(suite.Ctx, route)
+		suite.Require().NoError(err)
+		nextTokenOut := tokenOut
+		for i := len(routes) - 1; i >= 0; i-- {
+			hop := routes[i]
+			// extract the current pool's swap fee
+			hopPool, err := suite.App.GAMMKeeper.GetPoolAndPoke(cacheCtx, hop.PoolId)
+			suite.Require().NoError(err)
+			currentPoolSwapFee := hopPool.GetSwapFee(cacheCtx)
+			// utilize the routeSwapFee, sumOfSwapFees, and current pool swap fee to calculate the new reduced swap fee
+			swapFee := routeSwapFee.Mul((currentPoolSwapFee.Quo(sumOfSwapFees)))
+			// we then do individual swaps until we reach the end of the swap route
+			tokenOut, err := suite.App.GAMMKeeper.SwapExactAmountOut(cacheCtx, suite.TestAccs[0], hopPool, hop.TokenInDenom, sdk.NewInt(100000000), nextTokenOut, swapFee)
+			suite.Require().NoError(err)
+			nextTokenOut = sdk.NewCoin(hop.TokenInDenom, tokenOut)
+		}
+		return nextTokenOut
+	} else {
+		nextTokenOut := tokenOut
+		for i := len(routes) - 1; i >= 0; i-- {
+			hop := routes[i]
+			hopPool, err := suite.App.GAMMKeeper.GetPoolAndPoke(cacheCtx, hop.PoolId)
+			suite.Require().NoError(err)
+			updatedPoolSwapFee := hopPool.GetSwapFee(cacheCtx)
+			tokenOut, err := suite.App.GAMMKeeper.SwapExactAmountOut(cacheCtx, suite.TestAccs[0], hopPool, hop.TokenInDenom, sdk.NewInt(100000000), nextTokenOut, updatedPoolSwapFee)
+			suite.Require().NoError(err)
+			nextTokenOut = sdk.NewCoin(hop.TokenInDenom, tokenOut)
+		}
+		return nextTokenOut
+	}
+}
+
+func (suite *KeeperTestSuite) calcInAmountAsSeparateSwaps(osmoFeeReduced bool, routes []swaproutertypes.SwapAmountInRoute, tokenIn sdk.Coin) sdk.Coin {
+	cacheCtx, _ := suite.Ctx.CacheContext()
+	if osmoFeeReduced {
+		// extract route from swap
+		route := types.SwapAmountInRoutes(routes)
+		// utilizing the extracted route, determine the routeSwapFee and sumOfSwapFees
+		// these two variables are used to calculate the overall swap fee utilizing the following formula
+		// swapFee = routeSwapFee * ((pool_fee) / (sumOfSwapFees))
+		routeSwapFee, sumOfSwapFees, err := suite.App.SwapRouterKeeper.GetOsmoRoutedMultihopTotalSwapFee(suite.Ctx, route)
+		suite.Require().NoError(err)
+		nextTokenIn := tokenIn
+		for _, hop := range routes {
+			// extract the current pool's swap fee
+			hopPool, err := suite.App.GAMMKeeper.GetPoolAndPoke(cacheCtx, hop.PoolId)
+			suite.Require().NoError(err)
+			currentPoolSwapFee := hopPool.GetSwapFee(cacheCtx)
+			// utilize the routeSwapFee, sumOfSwapFees, and current pool swap fee to calculate the new reduced swap fee
+			swapFee := routeSwapFee.Mul((currentPoolSwapFee.Quo(sumOfSwapFees)))
+			// we then do individual swaps until we reach the end of the swap route
+			tokenOut, err := suite.App.GAMMKeeper.SwapExactAmountIn(cacheCtx, suite.TestAccs[0], hopPool, nextTokenIn, hop.TokenOutDenom, sdk.OneInt(), swapFee)
+			suite.Require().NoError(err)
+			nextTokenIn = sdk.NewCoin(hop.TokenOutDenom, tokenOut)
+		}
+		return nextTokenIn
+	} else {
+		nextTokenIn := tokenIn
+		for _, hop := range routes {
+			hopPool, err := suite.App.GAMMKeeper.GetPoolAndPoke(cacheCtx, hop.PoolId)
+			suite.Require().NoError(err)
+			updatedPoolSwapFee := hopPool.GetSwapFee(cacheCtx)
+			tokenOut, err := suite.App.GAMMKeeper.SwapExactAmountIn(cacheCtx, suite.TestAccs[0], hopPool, nextTokenIn, hop.TokenOutDenom, sdk.OneInt(), updatedPoolSwapFee)
+			suite.Require().NoError(err)
+			nextTokenIn = sdk.NewCoin(hop.TokenOutDenom, tokenOut)
+		}
+		return nextTokenIn
 	}
 }

--- a/x/swaprouter/router_test.go
+++ b/x/swaprouter/router_test.go
@@ -1,0 +1,252 @@
+package swaprouter_test
+
+import (
+	"reflect"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gamm "github.com/osmosis-labs/osmosis/v13/x/gamm/keeper"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/v13/x/pool-incentives/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+const (
+	denomA = "denomA"
+	denomB = "denomB"
+	denomC = "denomC"
+)
+
+var (
+	defaultInitPoolAmount = sdk.NewInt(1000000000000)
+	defaultSwapAmount     = sdk.NewInt(1000000)
+	gammKeeperType        = reflect.TypeOf(&gamm.Keeper{})
+)
+
+// TestMultihopSwapExactAmountIn tests that the swaps are routed correctly.
+// That is:
+// - to the correct module (concentrated-liquidity or gamm)
+// - over the right routes (hops)
+// This test does not actually validate the math behind the swaps.
+func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
+	tests := []struct {
+		name              string
+		poolCoins         []sdk.Coins
+		routes            []swaproutertypes.SwapAmountInRoute
+		tokenIn           sdk.Coin
+		tokenOutMinAmount sdk.Int
+		swapFee           sdk.Dec
+		expectError       bool
+		reducedFeeApplied bool
+	}{
+		{
+			name:      "x/gamm - single route",
+			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount), sdk.NewCoin(denomB, defaultInitPoolAmount))},
+			routes: []swaproutertypes.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: denomB,
+				},
+			},
+			tokenIn:           sdk.NewCoin(denomA, sdk.NewInt(100000)),
+			tokenOutMinAmount: sdk.NewInt(1),
+		},
+		{
+			name: "x/gamm - two routes",
+			poolCoins: []sdk.Coins{
+				sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount), sdk.NewCoin(denomB, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(denomB, defaultInitPoolAmount), sdk.NewCoin(denomC, defaultInitPoolAmount)), // pool 2.
+			},
+			routes: []swaproutertypes.SwapAmountInRoute{
+				{
+					PoolId:        1,
+					TokenOutDenom: denomB,
+				},
+				{
+					PoolId:        2,
+					TokenOutDenom: denomC,
+				},
+			},
+			tokenIn:           sdk.NewCoin(denomA, sdk.NewInt(100000)),
+			tokenOutMinAmount: sdk.NewInt(1),
+		},
+		// TODO:
+		// tests for concentrated liquidity
+		// test for multi-hop
+		// test for multi hop (osmo routes) -> reduces fee, add an assertion
+		// change values in and out to be different with each swap module type
+		// create more precise assertions on what the results are
+		// edge cases:
+		//   * invalid route length
+		//   * pool does not exist
+		//   * swap errors
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+
+			suite.createBalancerPoolsFromCoins(tc.poolCoins)
+
+			// if we expect a reduced fee to apply, we set both pools in DistrInfo to replicate it being an incentivized pool
+			// each pool has three gauges, hence 6 gauges for 2 pools
+			if tc.reducedFeeApplied {
+				test := poolincentivestypes.DistrInfo{
+					TotalWeight: sdk.NewInt(6),
+					Records: []poolincentivestypes.DistrRecord{
+						{GaugeId: 1, Weight: sdk.OneInt()}, {GaugeId: 2, Weight: sdk.OneInt()}, {GaugeId: 3, Weight: sdk.OneInt()},
+						{GaugeId: 4, Weight: sdk.OneInt()}, {GaugeId: 5, Weight: sdk.OneInt()}, {GaugeId: 6, Weight: sdk.OneInt()}},
+				}
+				suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, test)
+			}
+
+			tokenOut, err := swaprouterKeeper.RouteExactAmountIn(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenIn, tc.tokenOutMinAmount)
+
+			if tc.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().True(tokenOut.GTE(tc.tokenOutMinAmount))
+			}
+		})
+	}
+}
+
+// TestMultihopSwapExactAmountOut tests that the swaps are routed correctly.
+// That is:
+// - to the correct module (concentrated-liquidity or gamm)
+// - over the right routes (hops)
+// This test does not actually validate the math behind the swaps.
+func (suite *KeeperTestSuite) TestMultihopSwapExactAmountOut() {
+	tests := []struct {
+		name              string
+		poolCoins         []sdk.Coins
+		routes            []swaproutertypes.SwapAmountOutRoute
+		tokenOut          sdk.Coin
+		tokenInMaxAmount  sdk.Int
+		swapFee           sdk.Dec
+		expectError       bool
+		reducedFeeApplied bool
+	}{
+		{
+			name:      "x/gamm - single route",
+			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(denomA, defaultInitPoolAmount), sdk.NewCoin(denomB, defaultInitPoolAmount))},
+			routes: []swaproutertypes.SwapAmountOutRoute{
+				{
+					PoolId:       1,
+					TokenInDenom: denomB,
+				},
+			},
+			tokenOut:         sdk.NewCoin(denomA, defaultSwapAmount),
+			tokenInMaxAmount: defaultSwapAmount.Mul(sdk.NewInt(2)), // the amount here is arbitrary
+		},
+		// TODO:
+		// tests for concentrated liquidity
+		// test for multi-hop
+		// test for multi hop (osmo routes) -> reduces fee, add an assertion
+		// change values in and out to be different with each swap module type
+		// create more precise assertions on what the results are
+		// edge cases:
+		//   * invalid route length
+		//   * pool does not exist
+		//   * swap errors
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+
+			suite.createBalancerPoolsFromCoins(tc.poolCoins)
+
+			// if we expect a reduced fee to apply, we set both pools in DistrInfo to replicate it being an incentivized pool
+			// each pool has three gauges, hence 6 gauges for 2 pools
+			if tc.reducedFeeApplied {
+				test := poolincentivestypes.DistrInfo{
+					TotalWeight: sdk.NewInt(2),
+					Records: []poolincentivestypes.DistrRecord{
+						{GaugeId: 1, Weight: sdk.OneInt()}, {GaugeId: 2, Weight: sdk.OneInt()}, {GaugeId: 3, Weight: sdk.OneInt()},
+						{GaugeId: 4, Weight: sdk.OneInt()}, {GaugeId: 5, Weight: sdk.OneInt()}, {GaugeId: 6, Weight: sdk.OneInt()}},
+				}
+				suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, test)
+			}
+
+			tokenIn, err := swaprouterKeeper.RouteExactAmountOut(suite.Ctx, suite.TestAccs[0], tc.routes, tc.tokenInMaxAmount, tc.tokenOut)
+
+			if tc.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().True(tokenIn.LTE(tc.tokenInMaxAmount))
+			}
+		})
+	}
+}
+
+// TestGetSwapModule tests that the correct swap module is returned for a given pool id.
+// Additionally, validates that the expected errors are produced when expected.
+func (suite *KeeperTestSuite) TestGetSwapModule() {
+
+	tests := map[string]struct {
+		poolId            uint64
+		preCreatePoolType types.PoolType
+		routesOverwrite   map[types.PoolType]types.SwapI
+
+		expectedModule reflect.Type
+		expectError    error
+	}{
+		"valid balancer pool": {
+			preCreatePoolType: types.Balancer,
+			poolId:            1,
+			expectedModule:    gammKeeperType,
+		},
+		"non-existent pool": {
+			preCreatePoolType: types.Balancer,
+			poolId:            2,
+			expectedModule:    gammKeeperType,
+
+			expectError: types.FailedToFindRouteError{PoolId: 2},
+		},
+		"undefined route": {
+			preCreatePoolType: types.Balancer,
+			poolId:            1,
+			routesOverwrite: map[types.PoolType]types.SwapI{
+				types.StableSwap: &gamm.Keeper{}, // undefined for balancer.
+			},
+
+			expectError: types.UndefinedRouteError{PoolId: 1, PoolType: types.Balancer},
+		},
+		// TODO: valid stableswap test case.
+		// TODO: valid concentrated liquidity test case.
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+			suite.SetupTest()
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+
+			suite.createPoolFromType(tc.preCreatePoolType)
+
+			if len(tc.routesOverwrite) > 0 {
+				swaprouterKeeper.SetPoolRoutesUnsafe(tc.routesOverwrite)
+			}
+
+			swapModule, err := swaprouterKeeper.GetSwapModule(suite.Ctx, tc.poolId)
+
+			if tc.expectError != nil {
+				suite.Require().Error(err)
+				suite.Require().Nil(swapModule)
+				return
+			}
+
+			suite.Require().NoError(err)
+			suite.Require().NotNil(swapModule)
+
+			suite.Require().Equal(tc.expectedModule, reflect.TypeOf(swapModule))
+		})
+	}
+}

--- a/x/swaprouter/simulation/sim_msgs.go
+++ b/x/swaprouter/simulation/sim_msgs.go
@@ -1,0 +1,174 @@
+package swaproutersimulation
+
+import (
+	"errors"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	legacysimulationtype "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/v13/simulation/simtypes"
+	balancertypes "github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// simulationKeeper is a wrapper around swaprouter's keeper which makes it easy to wire new keepers
+type simulationKeeper struct {
+	keeper swaprouter.Keeper
+
+	gammKeeper types.GammKeeper
+}
+
+// PoolCreationFee denotes how much it costs to create a pool.
+var PoolCreationFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 10_000_000)
+
+// RandomSwapExactAmountIn utilizes a random pool and swaps and exact amount in for minimum of the secondary pool token
+// TODO: Improve this to swap through multiple pools
+func RandomSwapExactAmountIn(k simulationKeeper, sim *simtypes.SimCtx, ctx sdk.Context) (*types.MsgSwapExactAmountIn, error) {
+	// get random pool, randomly select one of the pool denoms to be the coinIn, other is coinOut
+	pool_id, pool, coinIn, coinOut, _, _, err := getRandPool(k, sim, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// set the swap route to use this pool
+	route := []types.SwapAmountInRoute{{
+		PoolId:        pool_id,
+		TokenOutDenom: coinOut.Denom,
+	}}
+
+	// find an address that has a balance of the coinIn
+	sender, accCoinIn, senderExists := sim.SelAddrWithDenom(ctx, coinIn.Denom)
+	if !senderExists {
+		return nil, fmt.Errorf("no sender with denom %s exists", coinIn.Denom)
+	}
+
+	// select a random amount that is upper-bound by the address's balance of coinIn
+	randomCoinSubset := sim.RandSubsetCoins(sdk.NewCoins(sdk.NewCoin(accCoinIn.Denom, accCoinIn.Amount)))
+
+	// calculate the minimum number of tokens received from input of tokenIn
+	tokenOutMin, err := pool.CalcOutAmtGivenIn(ctx, randomCoinSubset, coinOut.Denom, pool.GetSwapFee(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.MsgSwapExactAmountIn{
+		Sender:            sender.Address.String(),
+		Routes:            route,
+		TokenIn:           randomCoinSubset[0],
+		TokenOutMinAmount: tokenOutMin.Amount,
+	}, nil
+}
+
+// RandomSwapExactAmountOut utilizes a random pool and swaps a max amount amount in for an exact amount of the secondary pool token
+// TODO: Improve this to swap through multiple pools
+func RandomSwapExactAmountOut(k simulationKeeper, sim *simtypes.SimCtx, ctx sdk.Context) (*types.MsgSwapExactAmountOut, error) {
+	// get random pool, randomly select one of the pool denoms to be the coinIn, other is coinOut
+	pool_id, pool, coinIn, coinOut, _, _, err := getRandPool(k, sim, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// set the swap route to use this pool
+	route := []types.SwapAmountOutRoute{{
+		PoolId:       pool_id,
+		TokenInDenom: coinIn.Denom,
+	}}
+
+	// find an address that has a balance of the coinIn
+	senderAcc, accCoin, senderExists := sim.SelAddrWithDenom(ctx, coinIn.Denom)
+	if !senderExists {
+		return nil, fmt.Errorf("no sender with denom %s exists", coinIn.Denom)
+	}
+
+	// set the subset of coins to be upper-bound to the minimum between the address and the pool itself
+	randomCoinInSubset := osmoutils.MinCoins(sdk.NewCoins(coinIn), sdk.NewCoins(accCoin))
+
+	// utilize CalcOutAmtGivenIn to calculate tokenOut and use tokenOut to calculate tokenInMax
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, randomCoinInSubset, coinOut.Denom, pool.GetSwapFee(ctx))
+	if err != nil {
+		return nil, err
+	}
+	tokenInMax, err := pool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), coinIn.Denom, pool.GetSwapFee(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.MsgSwapExactAmountOut{
+		Sender:           senderAcc.Address.String(),
+		Routes:           route,
+		TokenInMaxAmount: tokenInMax.Amount,
+		TokenOut:         tokenOut,
+	}, nil
+}
+
+// RandomCreatePoolMsg attempts to find an account with two or more distinct denoms and attempts to send a
+// create pool message composed of those denoms
+func RandomCreateUniV2Msg(k swaprouter.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (*balancertypes.MsgCreateBalancerPool, error) {
+	var poolAssets []balancertypes.PoolAsset
+	// find an address with two or more distinct denoms in their wallet
+	sender, senderExists := sim.RandomSimAccountWithConstraint(createPoolRestriction(k, sim, ctx))
+	if !senderExists {
+		return nil, errors.New("no sender with two different denoms & pool creation fee exists")
+	}
+	poolCoins, ok := sim.GetRandSubsetOfKDenoms(ctx, sender, 2)
+	if !ok {
+		return nil, fmt.Errorf("provided sender with requested number of denoms does not exist")
+	}
+	if poolCoins.Add(PoolCreationFee).IsAnyGT(sim.BankKeeper().SpendableCoins(ctx, sender.Address)) {
+		return nil, errors.New("chose an account / creation amount that didn't pass fee bar")
+	}
+
+	// TODO: pseudo-randomly generate swap and exit fees
+	poolParams := &balancertypes.PoolParams{
+		SwapFee: sdk.NewDecWithPrec(1, 2),
+		ExitFee: sdk.ZeroDec(),
+	}
+
+	// from the above selected account, determine the token type and respective weight needed to make the pool
+	for i := 0; i < len(poolCoins); i++ {
+		poolAssets = append(poolAssets, balancertypes.PoolAsset{
+			Weight: sdk.OneInt(),
+			Token:  poolCoins[i],
+		})
+	}
+
+	return &balancertypes.MsgCreateBalancerPool{
+		Sender:     sender.Address.String(),
+		PoolParams: poolParams,
+		PoolAssets: poolAssets,
+	}, nil
+}
+
+func createPoolRestriction(k swaprouter.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) simtypes.SimAccountConstraint {
+	return func(acc legacysimulationtype.Account) bool {
+		accCoins := sim.BankKeeper().SpendableCoins(ctx, acc.Address)
+		hasTwoCoins := len(accCoins) >= 2
+		hasPoolCreationFee := accCoins.AmountOf("stake").GT(PoolCreationFee.Amount)
+		return hasTwoCoins && hasPoolCreationFee
+	}
+}
+
+func getRandPool(k simulationKeeper, sim *simtypes.SimCtx, ctx sdk.Context) (uint64, gammtypes.PoolI, sdk.Coin, sdk.Coin, []string, string, error) {
+	// select a pseudo-random pool ID, max bound by the upcoming pool ID
+	pool_id := simtypes.RandLTBound(sim, k.keeper.GetNextPoolId(ctx))
+	pool, err := k.gammKeeper.GetPoolAndPoke(ctx, pool_id)
+	if err != nil {
+		return 0, nil, sdk.NewCoin("denom", sdk.ZeroInt()), sdk.NewCoin("denom", sdk.ZeroInt()), []string{}, "", err
+	}
+	poolCoins := pool.GetTotalPoolLiquidity(ctx)
+
+	// TODO: Improve this, don't just assume two asset pools
+	// randomly select one of the pool denoms to be the coinIn and one to be the coinOut
+	r := sim.GetSeededRand("select random seed")
+	index := r.Intn(len(poolCoins) - 1)
+	coinIn := poolCoins[index]
+	poolCoins = simtypes.RemoveIndex(poolCoins, index)
+	coinOut := poolCoins[0]
+	poolDenoms := osmoutils.CoinsDenoms(pool.GetTotalPoolLiquidity(ctx))
+	gammDenom := gammtypes.GetPoolShareDenom(pool_id)
+	return pool_id, pool, coinIn, coinOut, poolDenoms, gammDenom, err
+}

--- a/x/swaprouter/simulation/sim_setup.go
+++ b/x/swaprouter/simulation/sim_setup.go
@@ -1,0 +1,19 @@
+package swaproutersimulation
+
+import (
+	"github.com/osmosis-labs/osmosis/v13/simulation/simtypes"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+func DefaultActions(keeper swaprouter.Keeper, gammKeeper types.GammKeeper) []simtypes.Action {
+	simKeeper := simulationKeeper{
+		keeper:     keeper,
+		gammKeeper: gammKeeper,
+	}
+	return []simtypes.Action{
+		simtypes.NewMsgBasedAction("SwapExactAmountIn", simKeeper, RandomSwapExactAmountIn),
+		simtypes.NewMsgBasedAction("SwapExactAmountOut", simKeeper, RandomSwapExactAmountOut),
+		simtypes.NewMsgBasedAction("CreateUniV2Msg", keeper, RandomCreateUniV2Msg).WithFrequency(simtypes.Frequent),
+	}
+}

--- a/x/swaprouter/types/routes.go
+++ b/x/swaprouter/types/routes.go
@@ -9,22 +9,22 @@ import (
 	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
-// AccountI defines the account contract that must be fulfilled when
-// creating a x/swaprouter keeper.
+// AccountKeeper defines the account contract that must be fulfilled when
+// creating a x/gamm keeper.
 type AccountI interface {
 	NewAccount(sdk.Context, authtypes.AccountI) authtypes.AccountI
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
 }
 
-// BankI defines the banking contract that must be fulfilled when
-// creating a x/swaprouter keeper.
+// BankKeeper defines the banking contract that must be fulfilled when
+// creating a x/gamm keeper.
 type BankI interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)
 }
 
-// CommunityPoolI defines the contract needed to be fulfilled for distribution keeper.
+// CommunityPoolKeeper defines the contract needed to be fulfilled for distribution keeper.
 type CommunityPoolI interface {
 	FundCommunityPool(ctx sdk.Context, amount sdk.Coins, sender sdk.AccAddress) error
 }
@@ -38,7 +38,7 @@ type SwapI interface {
 	SwapExactAmountIn(
 		ctx sdk.Context,
 		sender sdk.AccAddress,
-		pool gammtypes.PoolI,
+		poolId gammtypes.PoolI,
 		tokenIn sdk.Coin,
 		tokenOutDenom string,
 		tokenOutMinAmount sdk.Int,
@@ -48,7 +48,7 @@ type SwapI interface {
 	SwapExactAmountOut(
 		ctx sdk.Context,
 		sender sdk.AccAddress,
-		pool gammtypes.PoolI,
+		poolId gammtypes.PoolI,
 		tokenInDenom string,
 		tokenInMaxAmount sdk.Int,
 		tokenOut sdk.Coin,

--- a/x/swaprouter/types/routes.go
+++ b/x/swaprouter/types/routes.go
@@ -9,16 +9,16 @@ import (
 	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
-// AccountKeeper defines the account contract that must be fulfilled when
-// creating a x/gamm keeper.
+// AccountI defines the account contract that must be fulfilled when
+// creating a x/swaprouter keeper.
 type AccountI interface {
 	NewAccount(sdk.Context, authtypes.AccountI) authtypes.AccountI
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
 }
 
-// BankKeeper defines the banking contract that must be fulfilled when
-// creating a x/gamm keeper.
+// BankI defines the banking contract that must be fulfilled when
+// creating a x/swaprouter keeper.
 type BankI interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We would like to drop `concentrated-liquidity-main` branch to avoid branch synching overhead. As part of that, we are going to be incrementally merging the current concentrated liquidity feature state to `main`.

All this logic has already been given a round of reviews since we treated `concentrated-liqudiity-main` branch as `main` with appropriate review processes.

This particular PR does the following:
- fully merges `x/swaprouter` and its tests
- disables the failing tests that depend on gamm refactor
- inclides minor non-breaking API changes in GAMM

This is the final swaprouter PR. As soon as we merge gamm refactor, the swap router can be fully enabled.

For the latest state of the feature that we are merging, see: https://github.com/osmosis-labs/osmosis/tree/concentrated-liquidity-main

See spec: https://github.com/osmosis-labs/osmosis/pull/3052/files