### PR TITLE
[CI] Add GitHub Action to push development docker images

### DIFF
--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -1,0 +1,80 @@
+# This workflow pushes new osmosis docker images on:
+#
+# 1. Every new tag containing a release candidate (e.g. `v1.2.3-rc4`).
+#     `osmolabs/osmosis-dev:1.2.3-rc4` is pushed.      
+# 2. Every new commit to the main branch
+#     `osmolabs/osmosis-dev:main-{SHORT_SHA}-$(date +%s)` is pushed.
+# 3. Every new commit to a development branch vN.x (e.g. `v1.x`)
+#     `osmolabs/osmosis-dev-v1.x:{SHORT_SHA}-$(date +%s)` is pushed.
+#
+# Note: $(date +%s) is used to sort the tags in the docker registry.
+#
+# All the images above have support for linux/amd64 (not linux/arm64).
+# All the images are based on an alpine image for easy debugging.
+
+name: Push Development Docker Images 
+
+on:
+  push:
+    tags:
+    - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+    branches:
+    - main
+    - v[0-9]+.x
+  
+env:
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.16
+  DOCKER_IMAGE_REPOSITORY: osmolabs/osmosis-dev
+
+jobs:
+  docker:
+    runs-on: self-hosted
+    steps:
+    - 
+      name: Check out repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - 
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - 
+      name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    -
+      name: Find go version
+      run: |
+        GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+        echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV          
+    - 
+      name: Create Docker Image Tag for release candidate
+      if:   startsWith(github.ref, 'refs/tags/v')
+      run:  |
+        GITHUB_TAG=${{ github.ref_name }}
+        echo "DOCKER_IMAGE_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
+        echo "OSMOSIS_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+    - 
+      name: Create Docker Image Tag for vN.x branch
+      if:   "!startsWith(github.ref, 'refs/tags/v')"
+      run:  |
+        SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)
+        echo "DOCKER_IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
+        echo "OSMOSIS_VERSION=${{ github.ref_name }}-$SHORT_SHA" >> $GITHUB_ENV
+    - 
+      name: Build and Push Docker Images
+      uses: docker/build-push-action@v3
+      with:
+        file: Dockerfile
+        context: .
+        push: true
+        platforms: linux/amd64
+        build-args: |
+          GO_VERSION=${{ env.GO_VERSION }}
+          RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_ALPINE }}
+          GIT_VERSION=${{ env.OSMOSIS_VERSION }}
+          GIT_COMMIT=${{ github.sha }}
+        tags: |
+          ${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}


### PR DESCRIPTION
## What is the purpose of the change

This PR creates a GitHub Action to push development docker images on:

1. Every new tag containing a release candidate (e.g. `v1.2.3-rc4`).
    `osmolabs/osmosis-dev:1.2.3-rc4` is pushed.

2. Every new commit to the main branch
    `osmolabs/osmosis-dev:main-{SHORT_SHA}-$(date +%s)` is pushed.

3. Every new commit to a development branch vN.x (e.g. `v1.x`)
    `osmolabs/osmosis-dev-v1.x:{SHORT_SHA}-$(date +%s)` is pushed.

> Note: $(date +%s) will be used later as an index to sort the tags chronologically in the docker registry to get the latest one.

All the images above support only `linux/amd64` (not `linux/arm64`) so they can be built a lot faster.
All the images are based on an alpine image for easy debugging (you would always have a shell to exec inside the container)

### Context

This is the first step for the automatic creation of devnets. 
On every new commit to a `vN.x` branch, a new vanilla (or state-exported) testnet will be launched.

## Brief Changelog

- Add GitHub Action to push development docker images

## Testing and Verifying

Ran a test on the [osmosis-ci-repo](https://github.com/osmosis-labs/osmosis-ci/actions/runs/3535881003/jobs/5934373564).

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no 
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 