### PR TITLE
remove settings that configure state sync

### DIFF
--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -102,8 +102,6 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.P2P.MaxNumOutboundPeers = 40
 			config.Consensus.TimeoutCommit = 2 * time.Second
 			config.Mempool.Size = 10000
-			config.StateSync.TrustPeriod = 112 * time.Hour
-			config.FastSync.Version = "v0"
 
 			config.SetRoot(clientCtx.HomeDir)
 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -102,8 +102,6 @@ func initAppConfig() (string, interface{}) {
 	// server config.
 	srvCfg := serverconfig.DefaultConfig()
 	srvCfg.API.Enable = true
-	srvCfg.StateSync.SnapshotInterval = 1500
-	srvCfg.StateSync.SnapshotKeepRecent = 2
 	srvCfg.MinGasPrices = "0uosmo"
 
 	// 128MB IAVL cache


### PR DESCRIPTION
closes: #3517 

## Use default state sync configuration

This PR removes settings that should no longer need to be set, and maybe never should have been set.  Specifically, this PR relies more heavily on upstream defaults:

* using the default state sync trust period, instead of 112 hours
* taking a snapshot every 1000 blocks, instead of 1500 (iirc)
* disabling serving state sync snapshots by default





## Testing and Verifying

This change added tests and can be verified as follows:

* Manually verified the change by running a node with these settings, then state syncing to my desktop against it.

Script to reproduce the findings is here:

Working:
https://github.com/osmosis-labs/osmosis/blob/faddat/working-state-sync-example/scripts/statesync-resolution.bash

Not Working:
https://github.com/osmosis-labs/osmosis/blob/faddat/working-state-sync-example/scripts/statesync.bash



## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no) yes: 
   - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) yes
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)