### PR TITLE
refactor(CL): move PoolI to swaprouter; swaprouter only depends on PoolI

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -35,6 +35,7 @@ import (
 	lockupkeeper "github.com/osmosis-labs/osmosis/v13/x/lockup/keeper"
 	lockuptypes "github.com/osmosis-labs/osmosis/v13/x/lockup/types"
 	minttypes "github.com/osmosis-labs/osmosis/v13/x/mint/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 type KeeperTestHelper struct {
@@ -252,14 +253,14 @@ func (s *KeeperTestHelper) AllocateRewardsToValidator(valAddr sdk.ValAddress, re
 }
 
 // SetupGammPoolsWithBondDenomMultiplier uses given multipliers to set initial pool supply of bond denom.
-func (s *KeeperTestHelper) SetupGammPoolsWithBondDenomMultiplier(multipliers []sdk.Dec) []gammtypes.PoolI {
+func (s *KeeperTestHelper) SetupGammPoolsWithBondDenomMultiplier(multipliers []sdk.Dec) []swaproutertypes.PoolI {
 	bondDenom := s.App.StakingKeeper.BondDenom(s.Ctx)
 	// TODO: use sdk crypto instead of tendermint to generate address
 	acc1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address().Bytes())
 
 	params := s.App.SwapRouterKeeper.GetParams(s.Ctx)
 
-	pools := []gammtypes.PoolI{}
+	pools := []swaproutertypes.PoolI{}
 	for index, multiplier := range multipliers {
 		token := fmt.Sprintf("token%d", index)
 		uosmoAmount := gammtypes.InitPoolSharesSupply.ToDec().Mul(multiplier).RoundInt()

--- a/x/concentrated-liquidity/keeper.go
+++ b/x/concentrated-liquidity/keeper.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 type Keeper struct {
@@ -20,6 +20,6 @@ func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey) *Keeper {
 }
 
 // TODO: spec, tests, implementation
-func (k Keeper) InitializePool(ctx sdk.Context, pool gammtypes.PoolI, creatorAddress sdk.AccAddress) error {
+func (k Keeper) InitializePool(ctx sdk.Context, pool swaproutertypes.PoolI, creatorAddress sdk.AccAddress) error {
 	panic("not implemented")
 }

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -8,11 +8,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/internal/model"
 	types "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // GetPool returns a pool with a given id.
-func (k Keeper) GetPool(ctx sdk.Context, poolId uint64) (gammtypes.PoolI, error) {
+func (k Keeper) GetPool(ctx sdk.Context, poolId uint64) (swaproutertypes.PoolI, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -47,7 +47,7 @@ func (k Keeper) CreateNewConcentratedLiquidityPool(ctx sdk.Context, poolId uint6
 func (k Keeper) SwapExactAmountIn(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	poolId swaproutertypes.PoolI,
+	pool swaproutertypes.PoolI,
 	tokenIn sdk.Coin,
 	tokenOutDenom string,
 	tokenOutMinAmount sdk.Int,
@@ -59,7 +59,7 @@ func (k Keeper) SwapExactAmountIn(
 func (k Keeper) SwapExactAmountOut(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	poolId swaproutertypes.PoolI,
+	pool swaproutertypes.PoolI,
 	tokenInDenom string,
 	tokenInMaxAmount sdk.Int,
 	tokenOut sdk.Coin,

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/internal/model"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 type SwapState struct {
@@ -46,7 +47,7 @@ func (k Keeper) CreateNewConcentratedLiquidityPool(ctx sdk.Context, poolId uint6
 func (k Keeper) SwapExactAmountIn(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	poolId gammtypes.PoolI,
+	poolId swaproutertypes.PoolI,
 	tokenIn sdk.Coin,
 	tokenOutDenom string,
 	tokenOutMinAmount sdk.Int,
@@ -58,7 +59,7 @@ func (k Keeper) SwapExactAmountIn(
 func (k Keeper) SwapExactAmountOut(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	poolId gammtypes.PoolI,
+	poolId swaproutertypes.PoolI,
 	tokenInDenom string,
 	tokenInMaxAmount sdk.Int,
 	tokenOut sdk.Coin,

--- a/x/gamm/keeper/export_test.go
+++ b/x/gamm/keeper/export_test.go
@@ -3,10 +3,10 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // SetPool adds an existing pool to the keeper store.
-func (k Keeper) SetPool(ctx sdk.Context, pool types.PoolI) error {
+func (k Keeper) SetPool(ctx sdk.Context, pool swaproutertypes.PoolI) error {
 	return k.setPool(ctx, pool)
 }

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/v2types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 func (suite *KeeperTestSuite) TestCalcExitPoolCoinsFromShares() {
@@ -433,7 +434,7 @@ func (suite *KeeperTestSuite) TestQueryPool() {
 			PoolId: poolId,
 		})
 		suite.Require().NoError(err)
-		var pool types.PoolI
+		var pool swaproutertypes.PoolI
 		err = suite.App.InterfaceRegistry().UnpackAny(poolRes.Pool, &pool)
 		suite.Require().NoError(err)
 		suite.Require().Equal(poolId, pool.GetId())
@@ -450,7 +451,7 @@ func (suite *KeeperTestSuite) TestQueryPools() {
 			PoolId: poolId,
 		})
 		suite.Require().NoError(err)
-		var pool types.PoolI
+		var pool swaproutertypes.PoolI
 		err = suite.App.InterfaceRegistry().UnpackAny(poolRes.Pool, &pool)
 		suite.Require().NoError(err)
 		suite.Require().Equal(poolId, pool.GetId())
@@ -467,7 +468,7 @@ func (suite *KeeperTestSuite) TestQueryPools() {
 	suite.Require().NoError(err)
 	suite.Require().Equal(1, len(res.Pools))
 	for _, r := range res.Pools {
-		var pool types.PoolI
+		var pool swaproutertypes.PoolI
 		err = suite.App.InterfaceRegistry().UnpackAny(r, &pool)
 		suite.Require().NoError(err)
 		suite.Require().Equal(types.NewPoolAddress(uint64(1)).String(), pool.GetAddress().String())
@@ -484,7 +485,7 @@ func (suite *KeeperTestSuite) TestQueryPools() {
 	suite.Require().NoError(err)
 	suite.Require().Equal(5, len(res.Pools))
 	for i, r := range res.Pools {
-		var pool types.PoolI
+		var pool swaproutertypes.PoolI
 		err = suite.App.InterfaceRegistry().UnpackAny(r, &pool)
 		suite.Require().NoError(err)
 		suite.Require().Equal(types.NewPoolAddress(uint64(i+1)).String(), pool.GetAddress().String())

--- a/x/gamm/keeper/msg_server.go
+++ b/x/gamm/keeper/msg_server.go
@@ -13,18 +13,13 @@ type msgServer struct {
 	keeper *Keeper
 }
 
-var (
-	_ types.MsgServer                   = &msgServer{}
-	_ stableswap.MsgScalingFactorServer = &msgServer{}
-)
-
 func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
 	return &msgServer{
 		keeper: keeper,
 	}
 }
 
-func NewStableSwapScalingFactorSetterMsgServerImpl(keeper *Keeper) stableswap.MsgScalingFactorServer {
+func NewStableswapMsgScalingFactorModifierServerImpl(keeper *Keeper) stableswap.MsgScalingFactorServer {
 	return &msgServer{
 		keeper: keeper,
 	}

--- a/x/gamm/keeper/pool.go
+++ b/x/gamm/keeper/pool.go
@@ -12,10 +12,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // TODO spec and tests
-func (k Keeper) InitializePool(ctx sdk.Context, pool types.PoolI, creatorAddress sdk.AccAddress) error {
+func (k Keeper) InitializePool(ctx sdk.Context, pool swaproutertypes.PoolI, creatorAddress sdk.AccAddress) error {
 	traditionalPool, ok := pool.(types.TraditionalAmmInterface)
 	if !ok {
 		return fmt.Errorf("failed to create gamm pool. Could not cast to TraditionalAmmInterface")
@@ -57,7 +58,7 @@ func (k Keeper) InitializePool(ctx sdk.Context, pool types.PoolI, creatorAddress
 	return k.setPool(ctx, pool)
 }
 
-func (k Keeper) MarshalPool(pool types.PoolI) ([]byte, error) {
+func (k Keeper) MarshalPool(pool swaproutertypes.PoolI) ([]byte, error) {
 	return k.cdc.MarshalInterface(pool)
 }
 
@@ -67,7 +68,7 @@ func (k Keeper) UnmarshalPool(bz []byte) (types.TraditionalAmmInterface, error) 
 }
 
 // GetPool returns a pool with a given id.
-func (k Keeper) GetPool(ctx sdk.Context, poolId uint64) (types.PoolI, error) {
+func (k Keeper) GetPool(ctx sdk.Context, poolId uint64) (swaproutertypes.PoolI, error) {
 	return k.getPoolForSwap(ctx, poolId)
 }
 
@@ -134,7 +135,7 @@ func (k Keeper) GetPoolsAndPoke(ctx sdk.Context) (res []types.TraditionalAmmInte
 	return res, nil
 }
 
-func (k Keeper) setPool(ctx sdk.Context, pool types.PoolI) error {
+func (k Keeper) setPool(ctx sdk.Context, pool swaproutertypes.PoolI) error {
 	bz, err := k.MarshalPool(pool)
 	if err != nil {
 		return err

--- a/x/gamm/keeper/share.go
+++ b/x/gamm/keeper/share.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/keeper/internal/events"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
-func (k Keeper) applyJoinPoolStateChange(ctx sdk.Context, pool types.PoolI, joiner sdk.AccAddress, numShares sdk.Int, joinCoins sdk.Coins) error {
+func (k Keeper) applyJoinPoolStateChange(ctx sdk.Context, pool swaproutertypes.PoolI, joiner sdk.AccAddress, numShares sdk.Int, joinCoins sdk.Coins) error {
 	err := k.bankKeeper.SendCoins(ctx, joiner, pool.GetAddress(), joinCoins)
 	if err != nil {
 		return err
@@ -29,7 +30,7 @@ func (k Keeper) applyJoinPoolStateChange(ctx sdk.Context, pool types.PoolI, join
 	return nil
 }
 
-func (k Keeper) applyExitPoolStateChange(ctx sdk.Context, pool types.PoolI, exiter sdk.AccAddress, numShares sdk.Int, exitCoins sdk.Coins) error {
+func (k Keeper) applyExitPoolStateChange(ctx sdk.Context, pool swaproutertypes.PoolI, exiter sdk.AccAddress, numShares sdk.Int, exitCoins sdk.Coins) error {
 	err := k.bankKeeper.SendCoins(ctx, pool.GetAddress(), exiter, exitCoins)
 	if err != nil {
 		return err
@@ -54,7 +55,7 @@ func (k Keeper) applyExitPoolStateChange(ctx sdk.Context, pool types.PoolI, exit
 // MintPoolShareToAccount attempts to mint shares of a GAMM denomination to the
 // specified address returning an error upon failure. Shares are minted using
 // the x/gamm module account.
-func (k Keeper) MintPoolShareToAccount(ctx sdk.Context, pool types.PoolI, addr sdk.AccAddress, amount sdk.Int) error {
+func (k Keeper) MintPoolShareToAccount(ctx sdk.Context, pool swaproutertypes.PoolI, addr sdk.AccAddress, amount sdk.Int) error {
 	amt := sdk.NewCoins(sdk.NewCoin(types.GetPoolShareDenom(pool.GetId()), amount))
 
 	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, amt)
@@ -71,7 +72,7 @@ func (k Keeper) MintPoolShareToAccount(ctx sdk.Context, pool types.PoolI, addr s
 }
 
 // BurnPoolShareFromAccount burns `amount` of the given pools shares held by `addr`.
-func (k Keeper) BurnPoolShareFromAccount(ctx sdk.Context, pool types.PoolI, addr sdk.AccAddress, amount sdk.Int) error {
+func (k Keeper) BurnPoolShareFromAccount(ctx sdk.Context, pool swaproutertypes.PoolI, addr sdk.AccAddress, amount sdk.Int) error {
 	amt := sdk.Coins{
 		sdk.NewCoin(types.GetPoolShareDenom(pool.GetId()), amount),
 	}

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -72,7 +72,7 @@ func (k Keeper) SwapExactAmountIn(
 func (k Keeper) SwapExactAmountOut(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	poolI swaproutertypes.PoolI,
+	pool swaproutertypes.PoolI,
 	tokenInDenom string,
 	tokenInMaxAmount sdk.Int,
 	tokenOut sdk.Coin,
@@ -80,10 +80,6 @@ func (k Keeper) SwapExactAmountOut(
 ) (tokenInAmount sdk.Int, err error) {
 	if tokenInDenom == tokenOut.Denom {
 		return sdk.Int{}, errors.New("cannot trade same denomination in and out")
-	}
-	pool, ok := poolI.(types.TraditionalAmmInterface)
-	if !ok {
-		return sdk.Int{}, errors.New("given pool does not implement TraditionalAmmInterface")
 	}
 
 	defer func() {

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/keeper/internal/events"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // swapExactAmountIn is an internal method for swapping an exact amount of tokens
@@ -20,7 +21,7 @@ import (
 func (k Keeper) SwapExactAmountIn(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	pool types.PoolI,
+	pool swaproutertypes.PoolI,
 	tokenIn sdk.Coin,
 	tokenOutDenom string,
 	tokenOutMinAmount sdk.Int,
@@ -71,7 +72,7 @@ func (k Keeper) SwapExactAmountIn(
 func (k Keeper) SwapExactAmountOut(
 	ctx sdk.Context,
 	sender sdk.AccAddress,
-	poolI types.PoolI,
+	poolI swaproutertypes.PoolI,
 	tokenInDenom string,
 	tokenInMaxAmount sdk.Int,
 	tokenOut sdk.Coin,
@@ -131,7 +132,7 @@ func (k Keeper) SwapExactAmountOut(
 // sends the in tokens from the sender to the pool, and the out tokens from the pool to the sender.
 func (k Keeper) updatePoolForSwap(
 	ctx sdk.Context,
-	pool types.PoolI,
+	pool swaproutertypes.PoolI,
 	sender sdk.AccAddress,
 	tokenIn sdk.Coin,
 	tokenOut sdk.Coin,

--- a/x/gamm/module.go
+++ b/x/gamm/module.go
@@ -104,7 +104,7 @@ type AppModule struct {
 
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(&am.keeper))
-	stableswap.RegisterMsgScalingFactorServer(cfg.MsgServer(), keeper.NewStableSwapScalingFactorSetterMsgServerImpl(&am.keeper))
+	stableswap.RegisterMsgScalingFactorServer(cfg.MsgServer(), keeper.NewStableswapMsgScalingFactorModifierServerImpl(&am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQuerier(am.keeper))
 	v2types.RegisterQueryServer(cfg.QueryServer(), keeper.NewV2Querier(am.keeper))
 }

--- a/x/gamm/pool-models/balancer/codec.go
+++ b/x/gamm/pool-models/balancer/codec.go
@@ -2,6 +2,7 @@ package balancer
 
 import (
 	types "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -21,7 +22,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"osmosis.gamm.v1beta1.PoolI",
-		(*types.PoolI)(nil),
+		(*swaproutertypes.PoolI)(nil),
 		&Pool{},
 	)
 	registry.RegisterInterface(

--- a/x/gamm/pool-models/balancer/msgs.go
+++ b/x/gamm/pool-models/balancer/msgs.go
@@ -95,7 +95,7 @@ func (msg MsgCreateBalancerPool) InitialLiquidity() sdk.Coins {
 	return coins
 }
 
-func (msg MsgCreateBalancerPool) CreatePool(ctx sdk.Context, poolID uint64) (types.TraditionalAmmInterface, error) {
+func (msg MsgCreateBalancerPool) CreatePool(ctx sdk.Context, poolID uint64) (swaproutertypes.PoolI, error) {
 	poolI, err := NewBalancerPool(poolID, *msg.PoolParams, msg.PoolAssets, msg.FuturePoolGovernor, ctx.BlockTime())
 	return &poolI, err
 }

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/internal/cfmm_common"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 //nolint:deadcode
@@ -27,7 +28,7 @@ const (
 )
 
 var (
-	_ types.PoolI                   = &Pool{}
+	_ swaproutertypes.PoolI         = &Pool{}
 	_ types.PoolAmountOutExtension  = &Pool{}
 	_ types.WeightedPoolExtension   = &Pool{}
 	_ types.TraditionalAmmInterface = &Pool{}

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 const errMsgFormatSharesLargerThanMax = "%s resulted shares is larger than the max amount of %s"
@@ -168,7 +169,7 @@ func BinarySearchSingleAssetJoin(
 }
 
 // SwapAllCoinsToSingleAsset iterates through each token in the input set and trades it against the same pool sequentially
-func SwapAllCoinsToSingleAsset(pool types.PoolI, ctx sdk.Context, inTokens sdk.Coins, swapToDenom string,
+func SwapAllCoinsToSingleAsset(pool swaproutertypes.PoolI, ctx sdk.Context, inTokens sdk.Coins, swapToDenom string,
 	swapFee sdk.Dec) (sdk.Int, error) {
 	tokenOutAmt := inTokens.AmountOfNoDenomValidation(swapToDenom)
 	for _, coin := range inTokens {

--- a/x/gamm/pool-models/internal/cfmm_common/lp_test.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/internal/cfmm_common"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
 	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -149,14 +150,14 @@ func TestMaximalExactRatioJoin(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		pool        func() gammtypes.PoolI
+		pool        func() swaproutertypes.PoolI
 		tokensIn    sdk.Coins
 		expNumShare sdk.Int
 		expRemCoin  sdk.Coins
 	}{
 		{
 			name: "two asset pool, same tokenIn ratio",
-			pool: func() gammtypes.PoolI {
+			pool: func() swaproutertypes.PoolI {
 				balancerPool, err := balancer.NewBalancerPool(
 					1,
 					balancer.PoolParams{SwapFee: sdk.ZeroDec(), ExitFee: sdk.ZeroDec()},
@@ -173,7 +174,7 @@ func TestMaximalExactRatioJoin(t *testing.T) {
 		},
 		{
 			name: "two asset pool, different tokenIn ratio with pool",
-			pool: func() gammtypes.PoolI {
+			pool: func() swaproutertypes.PoolI {
 				balancerPool, err := balancer.NewBalancerPool(
 					1,
 					balancer.PoolParams{SwapFee: sdk.ZeroDec(), ExitFee: sdk.ZeroDec()},

--- a/x/gamm/pool-models/internal/test_helpers/test_helpers.go
+++ b/x/gamm/pool-models/internal/test_helpers/test_helpers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	sdkrand "github.com/osmosis-labs/osmosis/v13/simulation/simtypes/random"
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // CfmmCommonTestSuite is the common test suite struct of Constant Function Market Maker,
@@ -36,7 +36,7 @@ func (suite *CfmmCommonTestSuite) CreateTestContext() sdk.Context {
 func TestCalculateAmountOutAndIn_InverseRelationship(
 	t *testing.T,
 	ctx sdk.Context,
-	pool types.PoolI,
+	pool swaproutertypes.PoolI,
 	assetInDenom string,
 	assetOutDenom string,
 	initialCalcOut int64,
@@ -80,7 +80,7 @@ func TestSlippageRelationWithLiquidityIncrease(
 	testname string,
 	t *testing.T,
 	ctx sdk.Context,
-	createPoolWithLiquidity func(sdk.Context, sdk.Coins) types.PoolI,
+	createPoolWithLiquidity func(sdk.Context, sdk.Coins) swaproutertypes.PoolI,
 	initLiquidity sdk.Coins,
 ) {
 	TestSlippageRelationOutGivenIn(testname, t, ctx, createPoolWithLiquidity, initLiquidity)
@@ -91,7 +91,7 @@ func TestSlippageRelationOutGivenIn(
 	testname string,
 	t *testing.T,
 	ctx sdk.Context,
-	createPoolWithLiquidity func(sdk.Context, sdk.Coins) types.PoolI,
+	createPoolWithLiquidity func(sdk.Context, sdk.Coins) swaproutertypes.PoolI,
 	initLiquidity sdk.Coins,
 ) {
 	r := rand.New(rand.NewSource(100))
@@ -124,7 +124,7 @@ func TestSlippageRelationInGivenOut(
 	testname string,
 	t *testing.T,
 	ctx sdk.Context,
-	createPoolWithLiquidity func(sdk.Context, sdk.Coins) types.PoolI,
+	createPoolWithLiquidity func(sdk.Context, sdk.Coins) swaproutertypes.PoolI,
 	initLiquidity sdk.Coins,
 ) {
 	r := rand.New(rand.NewSource(100))
@@ -165,7 +165,7 @@ func TestSlippageRelationInGivenOut(
 }
 
 // returns true if the pool can accommodate an InGivenOut swap with `tokenOut` amount out, false otherwise
-func isWithinBounds(ctx sdk.Context, pool types.PoolI, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (b bool) {
+func isWithinBounds(ctx sdk.Context, pool swaproutertypes.PoolI, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (b bool) {
 	b = true
 	defer func() {
 		if r := recover(); r != nil {

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/internal/cfmm_common"
 	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/internal/test_helpers"
 	types "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // CFMMTestCase defines a testcase for stableswap pools
@@ -756,7 +757,7 @@ func (suite *StableSwapTestSuite) Test_StableSwap_Slippage_LiquidityRelation() {
 	swapFeeCases := []string{"0", "0.001", "0.1", "0.5", "0.99"}
 	for name, tc := range testcases {
 		for _, swapFee := range swapFeeCases {
-			createPoolFn := func(ctx sdk.Context, liq sdk.Coins) types.PoolI {
+			createPoolFn := func(ctx sdk.Context, liq sdk.Coins) swaproutertypes.PoolI {
 				return createTestPool(suite.T(), liq, sdk.MustNewDecFromStr(swapFee), sdk.ZeroDec(), tc.scalingFactors)
 			}
 			ctx := sdk.Context{}

--- a/x/gamm/pool-models/stableswap/codec.go
+++ b/x/gamm/pool-models/stableswap/codec.go
@@ -9,6 +9,7 @@ import (
 	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
 
 	types "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // RegisterLegacyAminoCodec registers the necessary x/gamm interfaces and concrete types
@@ -23,7 +24,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"osmosis.gamm.v1beta1.PoolI",
-		(*types.PoolI)(nil),
+		(*swaproutertypes.PoolI)(nil),
 		&Pool{},
 	)
 	registry.RegisterInterface(

--- a/x/gamm/pool-models/stableswap/msgs.go
+++ b/x/gamm/pool-models/stableswap/msgs.go
@@ -109,7 +109,7 @@ func (msg MsgCreateStableswapPool) InitialLiquidity() sdk.Coins {
 	return msg.InitialPoolLiquidity
 }
 
-func (msg MsgCreateStableswapPool) CreatePool(ctx sdk.Context, poolId uint64) (types.TraditionalAmmInterface, error) {
+func (msg MsgCreateStableswapPool) CreatePool(ctx sdk.Context, poolId uint64) (swaproutertypes.PoolI, error) {
 	stableswapPool, err := NewStableswapPool(poolId, *msg.PoolParams, msg.InitialPoolLiquidity,
 		msg.ScalingFactors, msg.ScalingFactorController, msg.FuturePoolGovernor)
 	if err != nil {

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	_ types.PoolI                   = &Pool{}
+	_ swaproutertypes.PoolI         = &Pool{}
 	_ types.TraditionalAmmInterface = &Pool{}
 )
 

--- a/x/gamm/pool-models/stableswap/util_test.go
+++ b/x/gamm/pool-models/stableswap/util_test.go
@@ -6,10 +6,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
-func createTestPool(t *testing.T, poolLiquidity sdk.Coins, swapFee, exitFee sdk.Dec, scalingFactors []uint64) types.PoolI {
+func createTestPool(t *testing.T, poolLiquidity sdk.Coins, swapFee, exitFee sdk.Dec, scalingFactors []uint64) swaproutertypes.PoolI {
 	pool, err := NewStableswapPool(1, PoolParams{
 		SwapFee: swapFee,
 		ExitFee: exitFee,

--- a/x/gamm/types/codec.go
+++ b/x/gamm/types/codec.go
@@ -11,7 +11,6 @@ import (
 // RegisterLegacyAminoCodec registers the necessary x/gamm interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterInterface((*PoolI)(nil), nil)
 	cdc.RegisterInterface((*TraditionalAmmInterface)(nil), nil)
 	cdc.RegisterConcrete(&MsgJoinPool{}, "osmosis/gamm/join-pool", nil)
 	cdc.RegisterConcrete(&MsgExitPool{}, "osmosis/gamm/exit-pool", nil)
@@ -22,10 +21,6 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {
-	registry.RegisterInterface(
-		"osmosis.gamm.v1beta1.PoolI",
-		(*PoolI)(nil),
-	)
 	registry.RegisterInterface(
 		"osmosis.gamm.v1beta1.TraditionalAmmInterface",
 		(*TraditionalAmmInterface)(nil),

--- a/x/gamm/types/msgs_test.go
+++ b/x/gamm/types/msgs_test.go
@@ -675,14 +675,6 @@ func TestAuthzMsg(t *testing.T) {
 				InitialPoolLiquidity: sdk.NewCoins(coin),
 			},
 		},
-		{
-			name: "MsgCreateStableswapPool",
-			gammMsg: &stableswap.MsgCreateStableswapPool{
-				Sender:               addr1,
-				PoolParams:           &stableswap.PoolParams{},
-				InitialPoolLiquidity: sdk.NewCoins(coin),
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/x/gamm/types/pool.go
+++ b/x/gamm/types/pool.go
@@ -3,60 +3,16 @@ package types
 import (
 	"time"
 
-	proto "github.com/gogo/protobuf/proto"
-
 	"github.com/cosmos/cosmos-sdk/types/address"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
-
-// PoolI defines an interface for pools that hold tokens.
-type PoolI interface {
-	proto.Message
-
-	GetAddress() sdk.AccAddress
-	String() string
-	GetId() uint64
-	// GetSwapFee returns the pool's swap fee, based on the current state.
-	// Pools may choose to make their swap fees dependent upon state
-	// (prior TWAPs, network downtime, other pool states, etc.)
-	// hence Context is provided as an argument.
-	GetSwapFee(ctx sdk.Context) sdk.Dec
-	// GetExitFee returns the pool's exit fee, based on the current state.
-	// Pools may choose to make their exit fees dependent upon state.
-	GetExitFee(ctx sdk.Context) sdk.Dec
-	// Returns whether the pool has swaps enabled at the moment
-	IsActive(ctx sdk.Context) bool
-	// GetTotalShares returns the total number of LP shares in the pool
-	GetTotalShares() sdk.Int
-
-	// SwapOutAmtGivenIn swaps 'tokenIn' against the pool, for tokenOutDenom, with the provided swapFee charged.
-	// Balance transfers are done in the keeper, but this method updates the internal pool state.
-	SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
-	// CalcOutAmtGivenIn returns how many coins SwapOutAmtGivenIn would return on these arguments.
-	// This does not mutate the pool, or state.
-	CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
-
-	// SwapInAmtGivenOut swaps exactly enough tokensIn against the pool, to get the provided tokenOut amount out of the pool.
-	// Balance transfers are done in the keeper, but this method updates the internal pool state.
-	SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
-	// CalcInAmtGivenOut returns how many coins SwapInAmtGivenOut would return on these arguments.
-	// This does not mutate the pool, or state.
-	CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
-
-	// Returns the spot price of the 'base asset' in terms of the 'quote asset' in the pool,
-	// errors if either baseAssetDenom, or quoteAssetDenom does not exist.
-	// For example, if this was a UniV2 50-50 pool, with 2 ETH, and 8000 UST
-	// pool.SpotPrice(ctx, "eth", "ust") = 4000.00
-	SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (sdk.Dec, error)
-}
 
 // TraditionalAmmInterface defines an interface for pools representing traditional AMM.
 type TraditionalAmmInterface interface {
-	PoolI
-
-	// GetTotalPoolLiquidity returns the coins in the pool owned by all LPs
-	GetTotalPoolLiquidity(ctx sdk.Context) sdk.Coins
+	swaproutertypes.PoolI
 
 	// JoinPool joins the pool using all of the tokensIn provided.
 	// The AMM swaps to the correct internal ratio should be and returns the number of shares created.

--- a/x/superfluid/keeper/twap_price.go
+++ b/x/superfluid/keeper/twap_price.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"github.com/gogo/protobuf/proto"
 
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v13/x/superfluid/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,7 +13,7 @@ import (
 // This function calculates the osmo equivalent worth of an LP share.
 // It is intended to eventually use the TWAP of the worth of an LP share
 // once that is exposed from the gamm module.
-func (k Keeper) calculateOsmoBackingPerShare(pool gammtypes.PoolI, osmoInPool sdk.Int) sdk.Dec {
+func (k Keeper) calculateOsmoBackingPerShare(pool swaproutertypes.PoolI, osmoInPool sdk.Int) sdk.Dec {
 	twap := osmoInPool.ToDec().Quo(pool.GetTotalShares().ToDec())
 	return twap
 }

--- a/x/swaprouter/creator.go
+++ b/x/swaprouter/creator.go
@@ -100,7 +100,7 @@ func (k Keeper) validateCreatedPool(
 	ctx sdk.Context,
 	initialPoolLiquidity sdk.Coins,
 	poolId uint64,
-	pool gammtypes.TraditionalAmmInterface,
+	pool types.PoolI,
 ) error {
 	if pool.GetId() != poolId {
 		return errors.Wrapf(types.ErrInvalidPool,

--- a/x/swaprouter/simulation/sim_msgs.go
+++ b/x/swaprouter/simulation/sim_msgs.go
@@ -152,10 +152,10 @@ func createPoolRestriction(k swaprouter.Keeper, sim *simtypes.SimCtx, ctx sdk.Co
 	}
 }
 
-func getRandPool(k simulationKeeper, sim *simtypes.SimCtx, ctx sdk.Context) (uint64, gammtypes.TraditionalAmmInterface, sdk.Coin, sdk.Coin, []string, string, error) {
+func getRandPool(k simulationKeeper, sim *simtypes.SimCtx, ctx sdk.Context) (uint64, types.PoolI, sdk.Coin, sdk.Coin, []string, string, error) {
 	// select a pseudo-random pool ID, max bound by the upcoming pool ID
 	pool_id := simtypes.RandLTBound(sim, k.keeper.GetNextPoolId(ctx))
-	pool, err := k.gammKeeper.GetPoolAndPoke(ctx, pool_id)
+	pool, err := k.gammKeeper.GetPool(ctx, pool_id)
 	if err != nil {
 		return 0, nil, sdk.NewCoin("denom", sdk.ZeroInt()), sdk.NewCoin("denom", sdk.ZeroInt()), []string{}, "", err
 	}

--- a/x/swaprouter/types/codec.go
+++ b/x/swaprouter/types/codec.go
@@ -11,11 +11,17 @@ import (
 // RegisterLegacyAminoCodec registers the necessary x/swaprouter interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterInterface((*PoolI)(nil), nil)
 	cdc.RegisterConcrete(&MsgSwapExactAmountIn{}, "osmosis/swaprouter/swap-exact-amount-in", nil)
 	cdc.RegisterConcrete(&MsgSwapExactAmountOut{}, "osmosis/swaprouter/swap-exact-amount-out", nil)
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterInterface(
+		"osmosis.swaprouter.v1beta1.PoolI",
+		(*PoolI)(nil),
+	)
+
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgSwapExactAmountIn{},

--- a/x/swaprouter/types/expected_keepers.go
+++ b/x/swaprouter/types/expected_keepers.go
@@ -2,13 +2,11 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 // GammKeeper defines the expected interface needed for swaprouter module
 type GammKeeper interface {
-	GetPoolAndPoke(ctx sdk.Context, poolId uint64) (gammtypes.TraditionalAmmInterface, error)
+	GetPool(ctx sdk.Context, poolId uint64) (PoolI, error)
 
 	GetNextPoolId(ctx sdk.Context) uint64
 }

--- a/x/swaprouter/types/msg_create_pool.go
+++ b/x/swaprouter/types/msg_create_pool.go
@@ -2,8 +2,6 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 // CreatePoolMsg defines an interface that every CreatePool transaction should implement.
@@ -19,5 +17,5 @@ type CreatePoolMsg interface {
 	// Initial Liquidity for the pool that the sender is required to send to the pool account
 	InitialLiquidity() sdk.Coins
 	// CreatePool creates a pool implementing PoolI, using data from the message.
-	CreatePool(ctx sdk.Context, poolID uint64) (gammtypes.TraditionalAmmInterface, error)
+	CreatePool(ctx sdk.Context, poolID uint64) (PoolI, error)
 }

--- a/x/swaprouter/types/pool.go
+++ b/x/swaprouter/types/pool.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	proto "github.com/gogo/protobuf/proto"
+)
+
+// PoolI defines an interface for pools that hold tokens.
+type PoolI interface {
+	proto.Message
+
+	GetAddress() sdk.AccAddress
+	String() string
+	GetId() uint64
+	// GetSwapFee returns the pool's swap fee, based on the current state.
+	// Pools may choose to make their swap fees dependent upon state
+	// (prior TWAPs, network downtime, other pool states, etc.)
+	// hence Context is provided as an argument.
+	GetSwapFee(ctx sdk.Context) sdk.Dec
+	// GetExitFee returns the pool's exit fee, based on the current state.
+	// Pools may choose to make their exit fees dependent upon state.
+	GetExitFee(ctx sdk.Context) sdk.Dec
+	// Returns whether the pool has swaps enabled at the moment
+	IsActive(ctx sdk.Context) bool
+	// GetTotalShares returns the total number of LP shares in the pool
+	GetTotalShares() sdk.Int
+	// GetTotalPoolLiquidity returns the coins in the pool owned by all LPs
+	GetTotalPoolLiquidity(ctx sdk.Context) sdk.Coins
+
+	// SwapOutAmtGivenIn swaps 'tokenIn' against the pool, for tokenOutDenom, with the provided swapFee charged.
+	// Balance transfers are done in the keeper, but this method updates the internal pool state.
+	SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
+	// CalcOutAmtGivenIn returns how many coins SwapOutAmtGivenIn would return on these arguments.
+	// This does not mutate the pool, or state.
+	CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
+
+	// SwapInAmtGivenOut swaps exactly enough tokensIn against the pool, to get the provided tokenOut amount out of the pool.
+	// Balance transfers are done in the keeper, but this method updates the internal pool state.
+	SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
+	// CalcInAmtGivenOut returns how many coins SwapInAmtGivenOut would return on these arguments.
+	// This does not mutate the pool, or state.
+	CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
+
+	// Returns the spot price of the 'base asset' in terms of the 'quote asset' in the pool,
+	// errors if either baseAssetDenom, or quoteAssetDenom does not exist.
+	// For example, if this was a UniV2 50-50 pool, with 2 ETH, and 8000 UST
+	// pool.SpotPrice(ctx, "eth", "ust") = 4000.00
+	SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (sdk.Dec, error)
+}

--- a/x/swaprouter/types/routes.go
+++ b/x/swaprouter/types/routes.go
@@ -7,7 +7,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-// AccountKeeper defines the account contract that must be fulfilled when
+// AccountI defines the account contract that must be fulfilled when
 // creating a x/gamm keeper.
 type AccountI interface {
 	NewAccount(sdk.Context, authtypes.AccountI) authtypes.AccountI
@@ -15,14 +15,14 @@ type AccountI interface {
 	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
 }
 
-// BankKeeper defines the banking contract that must be fulfilled when
+// BankI defines the banking contract that must be fulfilled when
 // creating a x/gamm keeper.
 type BankI interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)
 }
 
-// CommunityPoolKeeper defines the contract needed to be fulfilled for distribution keeper.
+// CommunityPoolI defines the contract needed to be fulfilled for distribution keeper.
 type CommunityPoolI interface {
 	FundCommunityPool(ctx sdk.Context, amount sdk.Coins, sender sdk.AccAddress) error
 }
@@ -36,7 +36,7 @@ type SwapI interface {
 	SwapExactAmountIn(
 		ctx sdk.Context,
 		sender sdk.AccAddress,
-		poolId PoolI,
+		pool PoolI,
 		tokenIn sdk.Coin,
 		tokenOutDenom string,
 		tokenOutMinAmount sdk.Int,
@@ -46,7 +46,7 @@ type SwapI interface {
 	SwapExactAmountOut(
 		ctx sdk.Context,
 		sender sdk.AccAddress,
-		poolId PoolI,
+		pool PoolI,
 		tokenInDenom string,
 		tokenInMaxAmount sdk.Int,
 		tokenOut sdk.Coin,

--- a/x/swaprouter/types/routes.go
+++ b/x/swaprouter/types/routes.go
@@ -5,8 +5,6 @@ import (
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 // AccountKeeper defines the account contract that must be fulfilled when
@@ -31,14 +29,14 @@ type CommunityPoolI interface {
 
 // TODO: godoc
 type SwapI interface {
-	InitializePool(ctx sdk.Context, pool gammtypes.PoolI, creatorAddress sdk.AccAddress) error
+	InitializePool(ctx sdk.Context, pool PoolI, creatorAddress sdk.AccAddress) error
 
-	GetPool(ctx sdk.Context, poolId uint64) (gammtypes.PoolI, error)
+	GetPool(ctx sdk.Context, poolId uint64) (PoolI, error)
 
 	SwapExactAmountIn(
 		ctx sdk.Context,
 		sender sdk.AccAddress,
-		poolId gammtypes.PoolI,
+		poolId PoolI,
 		tokenIn sdk.Coin,
 		tokenOutDenom string,
 		tokenOutMinAmount sdk.Int,
@@ -48,7 +46,7 @@ type SwapI interface {
 	SwapExactAmountOut(
 		ctx sdk.Context,
 		sender sdk.AccAddress,
-		poolId gammtypes.PoolI,
+		poolId PoolI,
 		tokenInDenom string,
 		tokenInMaxAmount sdk.Int,
 		tokenOut sdk.Coin,

--- a/x/txfees/keeper/hooks_test.go
+++ b/x/txfees/keeper/hooks_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 	"github.com/osmosis-labs/osmosis/v13/x/txfees/types"
 )
 
 var defaultPooledAssetAmount = int64(500)
 
-func (suite *KeeperTestSuite) preparePool(denom string) (poolID uint64, pool gammtypes.PoolI) {
+func (suite *KeeperTestSuite) preparePool(denom string) (poolID uint64, pool swaproutertypes.PoolI) {
 	baseDenom, _ := suite.App.TxFeesKeeper.GetBaseDenom(suite.Ctx)
 	poolID = suite.PrepareBalancerPoolWithCoins(
 		sdk.NewInt64Coin(baseDenom, defaultPooledAssetAmount),
@@ -42,7 +42,7 @@ func (suite *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 		coins      sdk.Coins
 		baseDenom  string
 		denoms     []string
-		poolTypes  []gammtypes.PoolI
+		poolTypes  []swaproutertypes.PoolI
 		swapFee    sdk.Dec
 		expectPass bool
 	}{
@@ -51,7 +51,7 @@ func (suite *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 			coins:     sdk.Coins{sdk.NewInt64Coin(uion, 10)},
 			baseDenom: baseDenom,
 			denoms:    []string{uion},
-			poolTypes: []gammtypes.PoolI{uionPool},
+			poolTypes: []swaproutertypes.PoolI{uionPool},
 			swapFee:   sdk.MustNewDecFromStr("0"),
 		},
 		{
@@ -59,7 +59,7 @@ func (suite *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 			coins:     sdk.Coins{sdk.NewInt64Coin(atom, 20), sdk.NewInt64Coin(ust, 30)},
 			baseDenom: baseDenom,
 			denoms:    []string{atom, ust},
-			poolTypes: []gammtypes.PoolI{atomPool, ustPool},
+			poolTypes: []swaproutertypes.PoolI{atomPool, ustPool},
 			swapFee:   sdk.MustNewDecFromStr("0"),
 		},
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

`PoolI` is the most general pool interface. Every pool implements it.

`x/swaprouter` is the module that deals with the most general pool logic. As a result, `PoolI` belongs there.

Additionally, there are currently several import cycles that are blocking #3525 . This PR needs to be merged to unblock mergin to `main`.

Lastly, `swaprouter` previously depended on the `gammtypes.TraditionalAmmInterface` when it shouldn't have. Now, all dependencies have been removed so that `x/swaprouter` is only concerned with the generalized `PoolI`.