### PR TITLE
feat(CL): swaprouter cli, queries, module and keeper stubs (part 3 - no state breaks)

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -37,6 +37,7 @@ import (
 	ibchooks "github.com/osmosis-labs/osmosis/v13/x/ibc-hooks"
 	ibcratelimit "github.com/osmosis-labs/osmosis/v13/x/ibc-rate-limit"
 	ibcratelimittypes "github.com/osmosis-labs/osmosis/v13/x/ibc-rate-limit/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
 
 	icahost "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host"
 	icahostkeeper "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/keeper"
@@ -120,6 +121,8 @@ type AppKeepers struct {
 	ContractKeeper               *wasmkeeper.PermissionedKeeper
 	TokenFactoryKeeper           *tokenfactorykeeper.Keeper
 	ValidatorSetPreferenceKeeper *valsetpref.Keeper
+	// Note: DO NOT USE. This is not yet initialized
+	SwapRouterKeeper *swaprouter.Keeper
 
 	// IBC modules
 	// transfer module

--- a/x/swaprouter/client/cli/cli_test.go
+++ b/x/swaprouter/client/cli/cli_test.go
@@ -1,0 +1,598 @@
+package cli_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+	swaprouterqueryproto "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	swaproutertestutil "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/testutil"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	cfg     network.Config
+	network *network.Network
+}
+
+func (s *IntegrationTestSuite) SetupSuite() {
+	s.T().Log("setting up integration test suite")
+
+	s.cfg = app.DefaultConfig()
+	s.cfg.GenesisState = swaproutertestutil.UpdateTxFeeDenom(s.cfg.Codec, s.cfg.BondDenom)
+
+	s.network = network.New(s.T(), s.cfg)
+
+	_, err := s.network.WaitForHeight(1)
+	s.Require().NoError(err)
+
+	val := s.network.Validators[0]
+
+	// create a new pool
+	_, err = swaproutertestutil.MsgCreatePool(s.T(), val.ClientCtx, val.Address, "5stake,5node0token", "100stake,100node0token", "0.01", "0.01", "")
+	s.Require().NoError(err)
+
+	s.T().Log("test")
+
+	_, err = s.network.WaitForHeight(1)
+	s.Require().NoError(err)
+}
+
+func (s *IntegrationTestSuite) TearDownSuite() {
+	s.T().Log("tearing down integration test suite")
+	s.network.Cleanup()
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+
+	// TODO: re-enable this once swaprouter is fully merged.
+	t.SkipNow()
+
+	suite.Run(t, new(IntegrationTestSuite))
+}
+
+func (s IntegrationTestSuite) TestNewSwapExactAmountOutCmd() {
+	val := s.network.Validators[0]
+
+	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewSwapExactAmountOut",
+		keyring.English, sdk.FullFundraiserPath, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+	s.Require().NoError(err)
+
+	newAddr := sdk.AccAddress(info.GetPubKey().Address())
+
+	_, err = banktestutil.MsgSendExec(
+		val.ClientCtx,
+		val.Address,
+		newAddr,
+		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		osmoutils.DefaultFeeString(s.cfg),
+	)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		args []string
+
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"swap exact amount out", // osmosisd tx swaprouter swap-exact-amount-out 10stake 20 --swap-route-pool-ids=1 --swap-route-denoms=node0token --from=validator --keyring-backend=test --chain-id=testing --yes
+			[]string{
+				"10stake", "20",
+				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.NewSwapExactAmountOutCmd()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err, out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
+		})
+	}
+}
+
+// func (s *IntegrationTestSuite) TestGetCmdEstimateSwapExactAmountIn() {
+// 	val := s.network.Validators[0]
+
+// 	testCases := []struct {
+// 		name      string
+// 		args      []string
+// 		expectErr bool
+// 	}{
+// 		{
+// 			"query pool estimate swap exact amount in", // osmosisd query gamm estimate-swap-exact-amount-in 1 cosmos1n8skk06h3kyh550ad9qketlfhc2l5dsdevd3hq 10.0stake --swap-route-pool-ids=1 --swap-route-denoms=node0token
+// 			[]string{
+// 				"1",
+// 				"cosmos1n8skk06h3kyh550ad9qketlfhc2l5dsdevd3hq",
+// 				"10.0stake",
+// 				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+// 				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+// 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
+// 			},
+// 			false,
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		tc := tc
+
+// 		s.Run(tc.name, func() {
+// 			cmd := cli.GetCmdEstimateSwapExactAmountIn()
+// 			clientCtx := val.ClientCtx
+
+// 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+// 			if tc.expectErr {
+// 				s.Require().Error(err)
+// 			} else {
+// 				resp := types.QuerySwapExactAmountInResponse{}
+// 				s.Require().NoError(err, out.String())
+// 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+// 			}
+// 		})
+// 	}
+// }
+
+// func (s *IntegrationTestSuite) TestGetCmdEstimateSwapExactAmountOut() {
+// 	val := s.network.Validators[0]
+
+// 	testCases := []struct {
+// 		name      string
+// 		args      []string
+// 		expectErr bool
+// 	}{
+// 		{
+// 			"query pool estimate swap exact amount in", // osmosisd query gamm estimate-swap-exact-amount-in 1 cosmos1n8skk06h3kyh550ad9qketlfhc2l5dsdevd3hq 10.0stake --swap-route-pool-ids=1 --swap-route-denoms=node0token
+// 			[]string{
+// 				"1",
+// 				val.Address.String(),
+// 				"10.0stake",
+// 				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+// 				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+// 				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
+// 			},
+// 			false,
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		tc := tc
+
+// 		s.Run(tc.name, func() {
+// 			cmd := cli.GetCmdEstimateSwapExactAmountOut()
+// 			clientCtx := val.ClientCtx
+
+// 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+// 			if tc.expectErr {
+// 				s.Require().Error(err)
+// 			} else {
+// 				resp := types.QuerySwapExactAmountOutResponse{}
+// 				s.Require().NoError(err, out.String())
+// 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+// 			}
+// 		})
+// 	}
+// }
+
+func (s IntegrationTestSuite) TestNewSwapExactAmountInCmd() {
+	val := s.network.Validators[0]
+
+	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewSwapExactAmountIn",
+		keyring.English, sdk.FullFundraiserPath, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+	s.Require().NoError(err)
+
+	newAddr := sdk.AccAddress(info.GetPubKey().Address())
+
+	_, err = banktestutil.MsgSendExec(
+		val.ClientCtx,
+		val.Address,
+		newAddr,
+		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 20000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		osmoutils.DefaultFeeString(s.cfg),
+	)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		args []string
+
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"swap exact amount in", // osmosisd tx swaprouter swap-exact-amount-in 10stake 3 --swap-route-pool-ids=1 --swap-route-denoms=node0token --from=validator --keyring-backend=test --chain-id=testing --yes
+			[]string{
+				"10stake", "3",
+				fmt.Sprintf("--%s=%d", cli.FlagSwapRoutePoolIds, 1),
+				fmt.Sprintf("--%s=%s", cli.FlagSwapRouteDenoms, "node0token"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.NewSwapExactAmountInCmd()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err, out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestGetCmdNumPools() {
+	val := s.network.Validators[0]
+
+	testCases := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			"query num-pools",
+			[]string{
+				fmt.Sprintf("--%s=%s", tmcli.OutputFlag, "json"),
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.GetCmdNumPools() // osmosisd query swaprouter num-pools
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				resp := swaprouterqueryproto.NumPoolsResponse{}
+				s.Require().NoError(err, out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+
+				s.Require().Greater(resp.NumPools, uint64(0), out.String())
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
+	val := s.network.Validators[0]
+
+	info, _, err := val.ClientCtx.Keyring.NewMnemonic("NewCreatePoolAddr",
+		keyring.English, sdk.FullFundraiserPath, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+	s.Require().NoError(err)
+
+	newAddr := sdk.AccAddress(info.GetPubKey().Address())
+
+	_, err = banktestutil.MsgSendExec(
+		val.ClientCtx,
+		val.Address,
+		newAddr,
+		sdk.NewCoins(sdk.NewInt64Coin(s.cfg.BondDenom, 200000000), sdk.NewInt64Coin("node0token", 20000)), fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		osmoutils.DefaultFeeString(s.cfg),
+	)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name         string
+		json         string
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"one token pair pool",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token",
+			  "%s": "100node0token",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			true, &sdk.TxResponse{}, 4,
+		},
+		{
+			"two tokens pair pool",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"change order of json fields",
+			fmt.Sprintf(`
+			{
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "1node0token,3stake",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileWeights, cli.PoolFileExitFee),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{ // --record-tokens=100.0stake2 --record-tokens=100.0stake --record-tokens-weight=5 --record-tokens-weight=5 --swap-fee=0.01 --exit-fee=0.01 --from=validator --keyring-backend=test --chain-id=testing --yes
+			"three tokens pair pool - insufficient balance check",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,1stake,2btc",
+			  "%s": "100node0token,100stake,100btc",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			false, &sdk.TxResponse{}, 5,
+		},
+		{
+			"future governor address",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": "0.001",
+			  "%s": "osmo1fqlr98d45v5ysqgp6h56kpujcj4cvsjnjq9nck"
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+			false, &sdk.TxResponse{}, 0,
+		},
+		// Due to CI time concerns, we leave these CLI tests commented out, and instead guaranteed via
+		// the logic tests.
+		// {
+		// 	"future governor time",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "2h"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	false, &sdk.TxResponse{}, 0,
+		// },
+		// {
+		// 	"future governor token + time",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "token,1000h"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	false, &sdk.TxResponse{}, 0,
+		// },
+		// {
+		// 	"invalid future governor",
+		// 	fmt.Sprintf(`
+		// 	{
+		// 	  "%s": "1node0token,3stake",
+		// 	  "%s": "100node0token,100stake",
+		// 	  "%s": "0.001",
+		// 	  "%s": "0.001",
+		// 	  "%s": "validdenom,invalidtime"
+		// 	}
+		// 	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee, cli.PoolFileFutureGovernor),
+		// 	true, &sdk.TxResponse{}, 7,
+		// },
+		{
+			"not valid json",
+			"bad json",
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"bad pool json - missing quotes around exit fee",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token,3stake",
+			  "%s": "100node0token,100stake",
+			  "%s": "0.001",
+			  "%s": 0.001
+			}
+	`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"empty pool json",
+			"", true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {
+						"%s": "864h",
+						"%s": "2node0token,1stake",
+						"%s": "2006-01-02T15:04:05Z"
+					}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileDuration, cli.PoolFileTargetPoolWeights, cli.PoolFileStartTime,
+			),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params - no start time",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {
+						"%s": "864h",
+						"%s": "2node0token,1stake"
+					}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileDuration, cli.PoolFileTargetPoolWeights,
+			),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"empty smooth change params",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams,
+			),
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params wrong type",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": "invalid string"
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams,
+			),
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"smooth change params missing duration",
+			fmt.Sprintf(`
+				{
+					"%s": "1node0token,3stake",
+					"%s": "100node0token,100stake",
+					"%s": "0.001",
+					"%s": "0.001",
+					"%s": {
+						"%s": "2node0token,1stake"
+					}
+				}
+				`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee,
+				cli.PoolFileSmoothWeightChangeParams, cli.PoolFileTargetPoolWeights,
+			),
+			true, &sdk.TxResponse{}, 0,
+		},
+		{
+			"unknown fields in json",
+			fmt.Sprintf(`
+			{
+			  "%s": "1node0token",
+			  "%s": "100node0token",
+			  "%s": "0.001",
+			  "%s": "0.001"
+			  "unknown": true,
+			}
+			`, cli.PoolFileWeights, cli.PoolFileInitialDeposit, cli.PoolFileSwapFee, cli.PoolFileExitFee),
+			true, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.NewCreatePoolCmd()
+			clientCtx := val.ClientCtx
+
+			jsonFile := testutil.WriteToNewTempFile(s.T(), tc.json)
+
+			args := []string{
+				fmt.Sprintf("--%s=%s", cli.FlagPoolFile, jsonFile.Name()),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, newAddr),
+				// common args
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				osmoutils.DefaultFeeString(s.cfg),
+				fmt.Sprintf("--%s=%s", flags.FlagGas, fmt.Sprint(400000)),
+			}
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err, out.String())
+				err = clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType)
+				s.Require().NoError(err, out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
+		})
+	}
+}

--- a/x/swaprouter/client/cli/common.go
+++ b/x/swaprouter/client/cli/common.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"errors"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+func swapAmountInRoutes(fs *flag.FlagSet) ([]types.SwapAmountInRoute, error) {
+	swapRoutePoolIds, err := fs.GetStringArray(FlagSwapRoutePoolIds)
+	if err != nil {
+		return nil, err
+	}
+
+	swapRouteDenoms, err := fs.GetStringArray(FlagSwapRouteDenoms)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(swapRoutePoolIds) != len(swapRouteDenoms) {
+		return nil, errors.New("swap route pool ids and denoms mismatch")
+	}
+
+	routes := []types.SwapAmountInRoute{}
+	for index, poolIDStr := range swapRoutePoolIds {
+		pID, err := strconv.Atoi(poolIDStr)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, types.SwapAmountInRoute{
+			PoolId:        uint64(pID),
+			TokenOutDenom: swapRouteDenoms[index],
+		})
+	}
+	return routes, nil
+}
+
+func swapAmountOutRoutes(fs *flag.FlagSet) ([]types.SwapAmountOutRoute, error) {
+	swapRoutePoolIds, err := fs.GetStringArray(FlagSwapRoutePoolIds)
+	if err != nil {
+		return nil, err
+	}
+
+	swapRouteDenoms, err := fs.GetStringArray(FlagSwapRouteDenoms)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(swapRoutePoolIds) != len(swapRouteDenoms) {
+		return nil, errors.New("swap route pool ids and denoms mismatch")
+	}
+
+	routes := []types.SwapAmountOutRoute{}
+	for index, poolIDStr := range swapRoutePoolIds {
+		pID, err := strconv.Atoi(poolIDStr)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, types.SwapAmountOutRoute{
+			PoolId:       uint64(pID),
+			TokenInDenom: swapRouteDenoms[index],
+		})
+	}
+	return routes, nil
+}

--- a/x/swaprouter/client/cli/flags.go
+++ b/x/swaprouter/client/cli/flags.go
@@ -1,0 +1,71 @@
+package cli
+
+import flag "github.com/spf13/pflag"
+
+const (
+	// Names of fields in pool json file.
+	PoolFileWeights        = "weights"
+	PoolFileInitialDeposit = "initial-deposit"
+	PoolFileSwapFee        = "swap-fee"
+	PoolFileExitFee        = "exit-fee"
+	PoolFileFutureGovernor = "future-governor"
+
+	PoolFileSmoothWeightChangeParams = "lbp-params"
+	PoolFileStartTime                = "start-time"
+	PoolFileDuration                 = "duration"
+	PoolFileTargetPoolWeights        = "target-pool-weights"
+
+	// Will be parsed to string.
+	FlagPoolFile = "pool-file"
+	// Will be parsed to uint64.
+	FlagSwapRoutePoolIds = "swap-route-pool-ids"
+	// Will be parsed to []string.
+	FlagSwapRouteDenoms = "swap-route-denoms"
+)
+
+type createBalancerPoolInputs struct {
+	Weights                  string                         `json:"weights"`
+	InitialDeposit           string                         `json:"initial-deposit"`
+	SwapFee                  string                         `json:"swap-fee"`
+	ExitFee                  string                         `json:"exit-fee"`
+	FutureGovernor           string                         `json:"future-governor"`
+	SmoothWeightChangeParams smoothWeightChangeParamsInputs `json:"lbp-params"`
+}
+
+type createStableswapPoolInputs struct {
+	InitialDeposit          string `json:"initial-deposit"`
+	SwapFee                 string `json:"swap-fee"`
+	ExitFee                 string `json:"exit-fee"`
+	FutureGovernor          string `json:"future-governor"`
+	ScalingFactorController string `json:"scaling-factor-controller"`
+	ScalingFactors          string `json:"scaling-factors"`
+}
+
+type smoothWeightChangeParamsInputs struct {
+	StartTime         string `json:"start-time"`
+	Duration          string `json:"duration"`
+	TargetPoolWeights string `json:"target-pool-weights"`
+}
+
+func FlagSetQuerySwapRoutes() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	fs.StringArray(FlagSwapRoutePoolIds, []string{""}, "swap route pool id")
+	fs.StringArray(FlagSwapRouteDenoms, []string{""}, "swap route amount")
+	return fs
+}
+
+func FlagSetSwapAmountOutRoutes() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	fs.StringArray(FlagSwapRoutePoolIds, []string{""}, "swap route pool ids")
+	fs.StringArray(FlagSwapRouteDenoms, []string{""}, "swap route denoms")
+	return fs
+}
+
+func FlagSetCreatePool() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	fs.String(FlagPoolFile, "", "Pool json file path (if this path is given, other create pool flags should not be used)")
+	return fs
+}

--- a/x/swaprouter/client/cli/parse.go
+++ b/x/swaprouter/client/cli/parse.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// TODO: move these to exported types within an internal package
+type XCreatePoolInputs createBalancerPoolInputs
+
+type XCreatePoolInputsExceptions struct {
+	XCreatePoolInputs
+	Other *string // Other won't raise an error
+}
+
+type XCreateStableswapPoolInputs createStableswapPoolInputs
+
+type XCreateStableswapPoolInputsExceptions struct {
+	XCreateStableswapPoolInputs
+	Other *string // Other won't raise an error
+}
+
+// UnmarshalJSON should error if there are fields unexpected.
+func (release *createBalancerPoolInputs) UnmarshalJSON(data []byte) error {
+	var createPoolE XCreatePoolInputsExceptions
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields() // Force
+
+	if err := dec.Decode(&createPoolE); err != nil {
+		return err
+	}
+
+	*release = createBalancerPoolInputs(createPoolE.XCreatePoolInputs)
+	return nil
+}
+
+func parseCreateBalancerPoolFlags(fs *pflag.FlagSet) (*createBalancerPoolInputs, error) {
+	pool := &createBalancerPoolInputs{}
+	poolFile, _ := fs.GetString(FlagPoolFile)
+
+	if poolFile == "" {
+		return nil, fmt.Errorf("must pass in a pool json using the --%s flag", FlagPoolFile)
+	}
+
+	contents, err := os.ReadFile(poolFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// make exception if unknown field exists
+	err = pool.UnmarshalJSON(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}
+
+// UnmarshalJSON should error if there are fields unexpected.
+func (release *createStableswapPoolInputs) UnmarshalJSON(data []byte) error {
+	var createPoolE XCreateStableswapPoolInputsExceptions
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields() // Force
+
+	if err := dec.Decode(&createPoolE); err != nil {
+		return err
+	}
+
+	*release = createStableswapPoolInputs(createPoolE.XCreateStableswapPoolInputs)
+	return nil
+}
+
+func parseCreateStableswapPoolFlags(fs *pflag.FlagSet) (*createStableswapPoolInputs, error) {
+	pool := &createStableswapPoolInputs{}
+	poolFile, _ := fs.GetString(FlagPoolFile)
+
+	if poolFile == "" {
+		return nil, fmt.Errorf("must pass in a pool json using the --%s flag", FlagPoolFile)
+	}
+
+	contents, err := os.ReadFile(poolFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// make exception if unknown field exists
+	err = pool.UnmarshalJSON(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}

--- a/x/swaprouter/client/cli/query.go
+++ b/x/swaprouter/client/cli/query.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/spf13/cobra"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// GetQueryCmd returns the cli query commands for this module.
+func GetQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		GetCmdEstimateSwapExactAmountIn(),
+		GetCmdEstimateSwapExactAmountOut(),
+		GetCmdNumPools(),
+	)
+
+	return cmd
+}
+
+// GetCmdEstimateSwapExactAmountIn returns estimation of output coin when amount of x token input.
+func GetCmdEstimateSwapExactAmountIn() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "estimate-swap-exact-amount-in <poolID> <sender> <tokenIn>",
+		Short: "Query estimate-swap-exact-amount-in",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query estimate-swap-exact-amount-in.
+Example:
+$ %s query swaprouter estimate-swap-exact-amount-in 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := queryproto.NewQueryClient(clientCtx)
+
+			poolID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			routes, err := swapAmountInRoutes(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.EstimateSwapExactAmountIn(cmd.Context(), &queryproto.EstimateSwapExactAmountInRequest{
+				Sender:  args[1],        // TODO: where sender is used?
+				PoolId:  uint64(poolID), // TODO: is this poolId used?
+				TokenIn: args[2],
+				Routes:  routes,
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetQuerySwapRoutes())
+	flags.AddQueryFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+// GetCmdEstimateSwapExactAmountOut returns estimation of input coin to get exact amount of x token output.
+func GetCmdEstimateSwapExactAmountOut() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "estimate-swap-exact-amount-out <poolID> <sender> <tokenOut>",
+		Short: "Query estimate-swap-exact-amount-out",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query estimate-swap-exact-amount-out.
+Example:
+$ %s query swaprouter estimate-swap-exact-amount-out 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := queryproto.NewQueryClient(clientCtx)
+
+			poolID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			routes, err := swapAmountOutRoutes(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.EstimateSwapExactAmountOut(cmd.Context(), &queryproto.EstimateSwapExactAmountOutRequest{
+				Sender:   args[1],        // TODO: where sender is used?
+				PoolId:   uint64(poolID), // TODO: is this poolId used?
+				Routes:   routes,
+				TokenOut: args[2],
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetQuerySwapRoutes())
+	flags.AddQueryFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+// GetCmdNumPools return number of pools available.
+func GetCmdNumPools() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "num-pools",
+		Short: "Query number of pools",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query number of pools.
+Example:
+$ %s query swaprouter num-pools
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := queryproto.NewQueryClient(clientCtx)
+
+			res, err := queryClient.NumPools(cmd.Context(), &queryproto.NumPoolsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/swaprouter/client/cli/query_test.go
+++ b/x/swaprouter/client/cli/query_test.go
@@ -1,0 +1,58 @@
+package cli_test
+
+import (
+	gocontext "context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
+	swaprouterqueryproto "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+)
+
+type QueryTestSuite struct {
+	apptesting.KeeperTestHelper
+	queryClient swaprouterqueryproto.QueryClient
+}
+
+func (s *QueryTestSuite) SetupSuite() {
+	s.Setup()
+	s.queryClient = swaprouterqueryproto.NewQueryClient(s.QueryHelper)
+	// create a new pool
+	s.PrepareBalancerPool()
+	s.Commit()
+}
+
+func (s *QueryTestSuite) TestQueriesNeverAlterState() {
+	testCases := []struct {
+		name   string
+		query  string
+		input  interface{}
+		output interface{}
+	}{
+		{
+			"Query num pools",
+			"/osmosis.swaprouter.v1beta1.Query/NumPools",
+			&swaprouterqueryproto.NumPoolsRequest{},
+			&swaprouterqueryproto.NumPoolsResponse{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		s.Run(tc.name, func() {
+			s.SetupSuite()
+			err := s.QueryHelper.Invoke(gocontext.Background(), tc.query, tc.input, tc.output)
+			s.Require().NoError(err)
+			s.StateNotAltered()
+		})
+	}
+}
+
+func TestQueryTestSuite(t *testing.T) {
+
+	// TODO: re-enable this once swaprouter is fully merged.
+	t.SkipNow()
+
+	suite.Run(t, new(QueryTestSuite))
+}

--- a/x/swaprouter/client/cli/tx.go
+++ b/x/swaprouter/client/cli/tx.go
@@ -1,0 +1,360 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+func NewTxCmd() *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Swap transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	txCmd.AddCommand(
+		NewCreatePoolCmd(),
+		NewSwapExactAmountInCmd(),
+		NewSwapExactAmountOutCmd(),
+	)
+
+	return txCmd
+}
+
+func NewSwapExactAmountInCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "swap-exact-amount-in [token-in] [token-out-min-amount]",
+		Short: "swap exact amount in",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewBuildSwapExactAmountInMsg(clientCtx, args[0], args[1], txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetQuerySwapRoutes())
+	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+func NewSwapExactAmountOutCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "swap-exact-amount-out [token-out] [token-in-max-amount]",
+		Short: "swap exact amount out",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewBuildSwapExactAmountOutMsg(clientCtx, args[0], args[1], txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetSwapAmountOutRoutes())
+	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.MarkFlagRequired(FlagSwapRoutePoolIds)
+	_ = cmd.MarkFlagRequired(FlagSwapRouteDenoms)
+
+	return cmd
+}
+
+func NewBuildSwapExactAmountInMsg(clientCtx client.Context, tokenInStr, tokenOutMinAmtStr string, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	routes, err := swapAmountInRoutes(fs)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenIn, err := sdk.ParseCoinNormalized(tokenInStr)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenOutMinAmt, ok := sdk.NewIntFromString(tokenOutMinAmtStr)
+	if !ok {
+		return txf, nil, fmt.Errorf("invalid token out min amount, %s", tokenOutMinAmtStr)
+	}
+	msg := &types.MsgSwapExactAmountIn{
+		Sender:            clientCtx.GetFromAddress().String(),
+		Routes:            routes,
+		TokenIn:           tokenIn,
+		TokenOutMinAmount: tokenOutMinAmt,
+	}
+
+	return txf, msg, nil
+}
+
+func NewBuildSwapExactAmountOutMsg(clientCtx client.Context, tokenOutStr, tokenInMaxAmountStr string, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	routes, err := swapAmountOutRoutes(fs)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenOut, err := sdk.ParseCoinNormalized(tokenOutStr)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	tokenInMaxAmount, ok := sdk.NewIntFromString(tokenInMaxAmountStr)
+	if !ok {
+		return txf, nil, errors.New("invalid token in max amount")
+	}
+	msg := &types.MsgSwapExactAmountOut{
+		Sender:           clientCtx.GetFromAddress().String(),
+		Routes:           routes,
+		TokenInMaxAmount: tokenInMaxAmount,
+		TokenOut:         tokenOut,
+	}
+
+	return txf, msg, nil
+}
+
+func NewCreatePoolCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-pool [flags]",
+		Short: "create a new pool and provide the liquidity to it",
+		Long:  `Must provide path to a pool JSON file (--pool-file) describing the pool to be created`,
+		Example: `Sample pool JSON file contents:
+{
+	"weights": "4uatom,4osmo,2uakt",
+	"initial-deposit": "100uatom,5osmo,20uakt",
+	"swap-fee": "0.01",
+	"exit-fee": "0.01",
+	"future-governor": "168h"
+}
+`,
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewBuildCreateBalancerPoolMsg(clientCtx, txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetCreatePool())
+	flags.AddTxFlagsToCmd(cmd)
+
+	_ = cmd.MarkFlagRequired(FlagPoolFile)
+
+	return cmd
+}
+
+func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	pool, err := parseCreateBalancerPoolFlags(fs)
+	if err != nil {
+		return txf, nil, fmt.Errorf("failed to parse pool: %w", err)
+	}
+
+	deposit, err := sdk.ParseCoinsNormalized(pool.InitialDeposit)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	poolAssetCoins, err := sdk.ParseDecCoins(pool.Weights)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	if len(deposit) != len(poolAssetCoins) {
+		return txf, nil, errors.New("deposit tokens and token weights should have same length")
+	}
+
+	swapFee, err := sdk.NewDecFromStr(pool.SwapFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	exitFee, err := sdk.NewDecFromStr(pool.ExitFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	var poolAssets []balancer.PoolAsset
+	for i := 0; i < len(poolAssetCoins); i++ {
+		if poolAssetCoins[i].Denom != deposit[i].Denom {
+			return txf, nil, errors.New("deposit tokens and token weights should have same denom order")
+		}
+
+		poolAssets = append(poolAssets, balancer.PoolAsset{
+			Weight: poolAssetCoins[i].Amount.RoundInt(),
+			Token:  deposit[i],
+		})
+	}
+
+	poolParams := &balancer.PoolParams{
+		SwapFee: swapFee,
+		ExitFee: exitFee,
+	}
+
+	msg := &balancer.MsgCreateBalancerPool{
+		Sender:             clientCtx.GetFromAddress().String(),
+		PoolParams:         poolParams,
+		PoolAssets:         poolAssets,
+		FuturePoolGovernor: pool.FutureGovernor,
+	}
+
+	if (pool.SmoothWeightChangeParams != smoothWeightChangeParamsInputs{}) {
+		duration, err := time.ParseDuration(pool.SmoothWeightChangeParams.Duration)
+		if err != nil {
+			return txf, nil, fmt.Errorf("could not parse duration: %w", err)
+		}
+
+		targetPoolAssetCoins, err := sdk.ParseDecCoins(pool.SmoothWeightChangeParams.TargetPoolWeights)
+		if err != nil {
+			return txf, nil, err
+		}
+
+		var targetPoolAssets []balancer.PoolAsset
+		for i := 0; i < len(targetPoolAssetCoins); i++ {
+			if targetPoolAssetCoins[i].Denom != poolAssetCoins[i].Denom {
+				return txf, nil, errors.New("initial pool weights and target pool weights should have same denom order")
+			}
+
+			targetPoolAssets = append(targetPoolAssets, balancer.PoolAsset{
+				Weight: targetPoolAssetCoins[i].Amount.RoundInt(),
+				Token:  deposit[i],
+				// TODO: This doesn't make sense. Should only use denom, not an sdk.Coin
+			})
+		}
+
+		smoothWeightParams := balancer.SmoothWeightChangeParams{
+			Duration:           duration,
+			InitialPoolWeights: poolAssets,
+			TargetPoolWeights:  targetPoolAssets,
+		}
+
+		if pool.SmoothWeightChangeParams.StartTime != "" {
+			startTime, err := time.Parse(time.RFC3339, pool.SmoothWeightChangeParams.StartTime)
+			if err != nil {
+				return txf, nil, fmt.Errorf("could not parse time: %w", err)
+			}
+
+			smoothWeightParams.StartTime = startTime
+		}
+
+		msg.PoolParams.SmoothWeightChangeParams = &smoothWeightParams
+	}
+
+	return txf, msg, nil
+}
+
+// Apologies to whoever has to touch this next, this code is horrendous
+func NewBuildCreateStableswapPoolMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	flags, err := parseCreateStableswapPoolFlags(fs)
+	if err != nil {
+		return txf, nil, fmt.Errorf("failed to parse pool: %w", err)
+	}
+
+	deposit, err := ParseCoinsNoSort(flags.InitialDeposit)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	swapFee, err := sdk.NewDecFromStr(flags.SwapFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	exitFee, err := sdk.NewDecFromStr(flags.ExitFee)
+	if err != nil {
+		return txf, nil, err
+	}
+
+	poolParams := &stableswap.PoolParams{
+		SwapFee: swapFee,
+		ExitFee: exitFee,
+	}
+
+	scalingFactors := []uint64{}
+	trimmedSfString := strings.Trim(flags.ScalingFactors, "[] {}")
+	if len(trimmedSfString) > 0 {
+		ints := strings.Split(trimmedSfString, ",")
+		for _, i := range ints {
+			u, err := strconv.ParseUint(i, 10, 64)
+			if err != nil {
+				return txf, nil, err
+			}
+			scalingFactors = append(scalingFactors, u)
+		}
+		if len(scalingFactors) != len(deposit) {
+			return txf, nil, fmt.Errorf("number of scaling factors doesn't match number of assets")
+		}
+	}
+
+	msg := &stableswap.MsgCreateStableswapPool{
+		Sender:                  clientCtx.GetFromAddress().String(),
+		PoolParams:              poolParams,
+		InitialPoolLiquidity:    deposit,
+		ScalingFactors:          scalingFactors,
+		ScalingFactorController: flags.ScalingFactorController,
+		FuturePoolGovernor:      flags.FutureGovernor,
+	}
+
+	return txf, msg, nil
+}
+
+// ParseCoinsNoSort parses coins from coinsStr but does not sort them.
+// Returns error if parsing fails.
+func ParseCoinsNoSort(coinsStr string) (sdk.Coins, error) {
+	coinStrs := strings.Split(coinsStr, ",")
+	decCoins := make(sdk.DecCoins, len(coinStrs))
+	for i, coinStr := range coinStrs {
+		coin, err := sdk.ParseDecCoin(coinStr)
+		if err != nil {
+			return sdk.Coins{}, err
+		}
+
+		decCoins[i] = coin
+	}
+	return sdk.NormalizeCoins(decCoins), nil
+}

--- a/x/swaprouter/client/cli/tx_test.go
+++ b/x/swaprouter/client/cli/tx_test.go
@@ -1,0 +1,71 @@
+package cli_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+)
+
+func TestParseCoinsNoSort(t *testing.T) {
+	const (
+		a = "aaa"
+		b = "bbb"
+		c = "ccc"
+		d = "ddd"
+	)
+
+	var (
+		ten = sdk.NewInt(10)
+
+		coinA = sdk.NewCoin(a, ten)
+		coinB = sdk.NewCoin(b, ten)
+		coinC = sdk.NewCoin(c, ten)
+		coinD = sdk.NewCoin(d, ten)
+	)
+
+	tests := map[string]struct {
+		coinsStr      string
+		expectedCoins sdk.Coins
+	}{
+		"ascending": {
+			coinsStr: "10aaa,10bbb,10ccc,10ddd",
+			expectedCoins: sdk.Coins{
+				coinA,
+				coinB,
+				coinC,
+				coinD,
+			},
+		},
+		"descending": {
+			coinsStr: "10ddd,10ccc,10bbb,10aaa",
+			expectedCoins: sdk.Coins{
+				coinD,
+				coinC,
+				coinB,
+				coinA,
+			},
+		},
+		"mixed with different values.": {
+			coinsStr: "100ddd,20bbb,300aaa,40ccc",
+			expectedCoins: sdk.Coins{
+				sdk.NewCoin(d, sdk.NewInt(100)),
+				sdk.NewCoin(b, sdk.NewInt(20)),
+				sdk.NewCoin(a, sdk.NewInt(300)),
+				sdk.NewCoin(c, sdk.NewInt(40)),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			coins, err := cli.ParseCoinsNoSort(tc.coinsStr)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCoins, coins)
+		})
+	}
+}

--- a/x/swaprouter/client/query_proto_wrap.go
+++ b/x/swaprouter/client/query_proto_wrap.go
@@ -1,50 +1,81 @@
 package client
 
 import (
-	"math/big"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
 	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
 // This file should evolve to being code gen'd, off of `proto/swaprouter/v1beta/query.yml`
 
 type Querier struct {
-}
-
-// nolint: unused
-var sdkIntMaxValue = sdk.NewInt(0)
-
-func init() {
-	maxInt := big.NewInt(2)
-	maxInt = maxInt.Exp(maxInt, big.NewInt(256), nil)
-
-	_sdkIntMaxValue, ok := sdk.NewIntFromString(maxInt.Sub(maxInt, big.NewInt(1)).String())
-	if !ok {
-		panic("Failed to calculate the max value of sdk.Int")
-	}
-
-	sdkIntMaxValue = _sdkIntMaxValue
+	K swaprouter.Keeper
 }
 
 func (q Querier) Params(ctx sdk.Context,
 	req queryproto.ParamsRequest,
 ) (*queryproto.ParamsResponse, error) {
-	panic("not implemented")
+	params := q.K.GetParams(ctx)
+	return &queryproto.ParamsResponse{Params: params}, nil
 }
 
 // EstimateSwapExactAmountIn estimates input token amount for a swap.
 func (q Querier) EstimateSwapExactAmountIn(ctx sdk.Context, req queryproto.EstimateSwapExactAmountInRequest) (*queryproto.EstimateSwapExactAmountInResponse, error) {
-	panic("not implemented")
+	if req.TokenIn == "" {
+		return nil, status.Error(codes.InvalidArgument, "invalid token")
+	}
+
+	tokenIn, err := sdk.ParseCoinNormalized(req.TokenIn)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid token: %s", err.Error())
+	}
+
+	tokenOutAmount, err := q.K.MultihopEstimateOutGivenExactAmountIn(ctx, req.Routes, tokenIn)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &queryproto.EstimateSwapExactAmountInResponse{
+		TokenOutAmount: tokenOutAmount,
+	}, nil
 }
 
 // EstimateSwapExactAmountOut estimates token output amount for a swap.
 func (q Querier) EstimateSwapExactAmountOut(ctx sdk.Context, req queryproto.EstimateSwapExactAmountOutRequest) (*queryproto.EstimateSwapExactAmountOutResponse, error) {
-	panic("not implemented")
+	if req.Sender == "" {
+		return nil, status.Error(codes.InvalidArgument, "address cannot be empty")
+	}
+
+	if req.TokenOut == "" {
+		return nil, status.Error(codes.InvalidArgument, "invalid token")
+	}
+
+	if err := types.SwapAmountOutRoutes(req.Routes).Validate(); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	tokenOut, err := sdk.ParseCoinNormalized(req.TokenOut)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid token: %s", err.Error())
+	}
+
+	tokenInAmount, err := q.K.MultihopEstimateInGivenExactAmountOut(ctx, req.Routes, tokenOut)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &queryproto.EstimateSwapExactAmountOutResponse{
+		TokenInAmount: tokenInAmount,
+	}, nil
 }
 
 // NumPools returns total number of pools.
 func (q Querier) NumPools(ctx sdk.Context, _ queryproto.NumPoolsRequest) (*queryproto.NumPoolsResponse, error) {
-	panic("not implemented")
+	return &queryproto.NumPoolsResponse{
+		NumPools: q.K.GetNextPoolId(ctx) - 1,
+	}, nil
 }

--- a/x/swaprouter/client/testutil/test_helpers.go
+++ b/x/swaprouter/client/testutil/test_helpers.go
@@ -1,0 +1,82 @@
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/osmosis-labs/osmosis/v13/app"
+	swaproutercli "github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// commonArgs is args for CLI test commands.
+var commonArgs = []string{
+	fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+	fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+	fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10))).String()),
+}
+
+// MsgCreatePool broadcast a pool creation message.
+func MsgCreatePool(
+	t *testing.T,
+	clientCtx client.Context,
+	owner fmt.Stringer,
+	tokenWeights string,
+	initialDeposit string,
+	swapFee string,
+	exitFee string,
+	futureGovernor string,
+	extraArgs ...string,
+) (testutil.BufferWriter, error) {
+	args := []string{}
+
+	jsonFile := testutil.WriteToNewTempFile(t,
+		fmt.Sprintf(`
+		{
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s",
+		  "%s": "%s"
+		}
+		`, swaproutercli.PoolFileWeights,
+			tokenWeights,
+			swaproutercli.PoolFileInitialDeposit,
+			initialDeposit,
+			swaproutercli.PoolFileSwapFee,
+			swapFee,
+			swaproutercli.PoolFileExitFee,
+			exitFee,
+			swaproutercli.PoolFileExitFee,
+			exitFee,
+		),
+	)
+
+	args = append(args,
+		fmt.Sprintf("--%s=%s", swaproutercli.FlagPoolFile, jsonFile.Name()),
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, owner.String()),
+		fmt.Sprintf("--%s=%d", flags.FlagGas, 400000),
+	)
+
+	args = append(args, commonArgs...)
+	return clitestutil.ExecTestCLICmd(clientCtx, swaproutercli.NewCreatePoolCmd(), args)
+}
+
+// UpdateTxFeeDenom creates and modifies gamm genesis to pay fee with given denom.
+func UpdateTxFeeDenom(cdc codec.Codec, denom string) map[string]json.RawMessage {
+	// modification to pay fee with test bond denom "stake"
+	genesisState := app.ModuleBasics.DefaultGenesis(cdc)
+	swaprouterGen := swaproutertypes.DefaultGenesis()
+	swaprouterGen.Params.PoolCreationFee = sdk.Coins{sdk.NewInt64Coin(denom, 1000000)}
+	swaprouterGenJson := cdc.MustMarshalJSON(swaprouterGen)
+	genesisState[swaproutertypes.ModuleName] = swaprouterGenJson
+	return genesisState
+}

--- a/x/swaprouter/creator.go
+++ b/x/swaprouter/creator.go
@@ -1,0 +1,20 @@
+package swaprouter
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// CreatePool attempts to create a pool returning the newly created pool ID or
+// an error upon failure. The pool creation fee is used to fund the community
+// pool. It will create a dedicated module account for the pool and sends the
+// initial liquidity to the created module account.
+//
+// After the initial liquidity is sent to the pool's account, shares are minted
+// and sent to the pool creator. The shares are created using a denomination in
+// the form of <swap module name>/pool/{poolID}. In addition, the x/bank metadata is updated
+// to reflect the newly created GAMM share denomination.
+func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, error) {
+	panic("not implemented")
+}

--- a/x/swaprouter/events/emit.go
+++ b/x/swaprouter/events/emit.go
@@ -1,0 +1,58 @@
+package events
+
+import (
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+)
+
+func EmitSwapEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, input sdk.Coins, output sdk.Coins) {
+	ctx.EventManager().EmitEvents(sdk.Events{
+		newSwapEvent(sender, poolId, input, output),
+	})
+}
+
+func newSwapEvent(sender sdk.AccAddress, poolId uint64, input sdk.Coins, output sdk.Coins) sdk.Event {
+	return sdk.NewEvent(
+		types.TypeEvtTokenSwapped,
+		sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+		sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
+		sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+		sdk.NewAttribute(types.AttributeKeyTokensIn, input.String()),
+		sdk.NewAttribute(types.AttributeKeyTokensOut, output.String()),
+	)
+}
+
+func EmitAddLiquidityEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, liquidity sdk.Coins) {
+	ctx.EventManager().EmitEvents(sdk.Events{
+		newAddLiquidityEvent(sender, poolId, liquidity),
+	})
+}
+
+func newAddLiquidityEvent(sender sdk.AccAddress, poolId uint64, liquidity sdk.Coins) sdk.Event {
+	return sdk.NewEvent(
+		types.TypeEvtPoolJoined,
+		sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+		sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
+		sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+		sdk.NewAttribute(types.AttributeKeyTokensIn, liquidity.String()),
+	)
+}
+
+func EmitRemoveLiquidityEvent(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, liquidity sdk.Coins) {
+	ctx.EventManager().EmitEvents(sdk.Events{
+		newRemoveLiquidityEvent(sender, poolId, liquidity),
+	})
+}
+
+func newRemoveLiquidityEvent(sender sdk.AccAddress, poolId uint64, liquidity sdk.Coins) sdk.Event {
+	return sdk.NewEvent(
+		types.TypeEvtPoolExited,
+		sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+		sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
+		sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+		sdk.NewAttribute(types.AttributeKeyTokensOut, liquidity.String()),
+	)
+}

--- a/x/swaprouter/events/emit_test.go
+++ b/x/swaprouter/events/emit_test.go
@@ -1,0 +1,186 @@
+package events_test
+
+import (
+	"strconv"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/events"
+)
+
+type SwapRouterEventsTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+const (
+	addressString = "addr1---------------"
+	testDenomA    = "denoma"
+	testDenomB    = "denomb"
+	testDenomC    = "denomc"
+	testDenomD    = "denomd"
+)
+
+func TestSwapRouterEventsTestSuite(t *testing.T) {
+	suite.Run(t, new(SwapRouterEventsTestSuite))
+}
+
+func (suite *SwapRouterEventsTestSuite) TestEmitSwapEvent() {
+	testcases := map[string]struct {
+		ctx             sdk.Context
+		testAccountAddr sdk.AccAddress
+		poolId          uint64
+		tokensIn        sdk.Coins
+		tokensOut       sdk.Coins
+	}{
+		"basic valid": {
+			ctx:             suite.CreateTestContext(),
+			testAccountAddr: sdk.AccAddress([]byte(addressString)),
+			poolId:          1,
+			tokensIn:        sdk.NewCoins(sdk.NewCoin(testDenomA, sdk.NewInt(1234))),
+			tokensOut:       sdk.NewCoins(sdk.NewCoin(testDenomB, sdk.NewInt(5678))),
+		},
+		"valid with multiple tokens in and out": {
+			ctx:             suite.CreateTestContext(),
+			testAccountAddr: sdk.AccAddress([]byte(addressString)),
+			poolId:          200,
+			tokensIn:        sdk.NewCoins(sdk.NewCoin(testDenomA, sdk.NewInt(12)), sdk.NewCoin(testDenomB, sdk.NewInt(99))),
+			tokensOut:       sdk.NewCoins(sdk.NewCoin(testDenomC, sdk.NewInt(88)), sdk.NewCoin(testDenomD, sdk.NewInt(34))),
+		},
+	}
+
+	for name, tc := range testcases {
+		suite.Run(name, func() {
+			expectedEvents := sdk.Events{
+				sdk.NewEvent(
+					types.TypeEvtTokenSwapped,
+					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+					sdk.NewAttribute(sdk.AttributeKeySender, tc.testAccountAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(tc.poolId, 10)),
+					sdk.NewAttribute(types.AttributeKeyTokensIn, tc.tokensIn.String()),
+					sdk.NewAttribute(types.AttributeKeyTokensOut, tc.tokensOut.String()),
+				),
+			}
+
+			hasNoEventManager := tc.ctx.EventManager() == nil
+
+			// System under test.
+			events.EmitSwapEvent(tc.ctx, tc.testAccountAddr, tc.poolId, tc.tokensIn, tc.tokensOut)
+
+			// Assertions
+			if hasNoEventManager {
+				// If there is no event manager on context, this is a no-op.
+				return
+			}
+
+			eventManager := tc.ctx.EventManager()
+			actualEvents := eventManager.Events()
+			suite.Equal(expectedEvents, actualEvents)
+		})
+	}
+}
+
+func (suite *SwapRouterEventsTestSuite) TestEmitAddLiquidityEvent() {
+	testcases := map[string]struct {
+		ctx             sdk.Context
+		testAccountAddr sdk.AccAddress
+		poolId          uint64
+		tokensIn        sdk.Coins
+	}{
+		"basic valid": {
+			ctx:             suite.CreateTestContext(),
+			testAccountAddr: sdk.AccAddress([]byte(addressString)),
+			poolId:          1,
+			tokensIn:        sdk.NewCoins(sdk.NewCoin(testDenomA, sdk.NewInt(1234))),
+		},
+		"valid with multiple tokens in": {
+			ctx:             suite.CreateTestContext(),
+			testAccountAddr: sdk.AccAddress([]byte(addressString)),
+			poolId:          200,
+			tokensIn:        sdk.NewCoins(sdk.NewCoin(testDenomA, sdk.NewInt(12)), sdk.NewCoin(testDenomB, sdk.NewInt(99))),
+		},
+	}
+
+	for name, tc := range testcases {
+		suite.Run(name, func() {
+			expectedEvents := sdk.Events{
+				sdk.NewEvent(
+					types.TypeEvtPoolJoined,
+					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+					sdk.NewAttribute(sdk.AttributeKeySender, tc.testAccountAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(tc.poolId, 10)),
+					sdk.NewAttribute(types.AttributeKeyTokensIn, tc.tokensIn.String()),
+				),
+			}
+
+			hasNoEventManager := tc.ctx.EventManager() == nil
+
+			// System under test.
+			events.EmitAddLiquidityEvent(tc.ctx, tc.testAccountAddr, tc.poolId, tc.tokensIn)
+
+			// Assertions
+			if hasNoEventManager {
+				// If there is no event manager on context, this is a no-op.
+				return
+			}
+
+			eventManager := tc.ctx.EventManager()
+			actualEvents := eventManager.Events()
+			suite.Equal(expectedEvents, actualEvents)
+		})
+	}
+}
+
+func (suite *SwapRouterEventsTestSuite) TestEmitRemoveLiquidityEvent() {
+	testcases := map[string]struct {
+		ctx             sdk.Context
+		testAccountAddr sdk.AccAddress
+		poolId          uint64
+		tokensOut       sdk.Coins
+	}{
+		"basic valid": {
+			ctx:             suite.CreateTestContext(),
+			testAccountAddr: sdk.AccAddress([]byte(addressString)),
+			poolId:          1,
+			tokensOut:       sdk.NewCoins(sdk.NewCoin(testDenomA, sdk.NewInt(1234))),
+		},
+		"valid with multiple tokens out": {
+			ctx:             suite.CreateTestContext(),
+			testAccountAddr: sdk.AccAddress([]byte(addressString)),
+			poolId:          200,
+			tokensOut:       sdk.NewCoins(sdk.NewCoin(testDenomA, sdk.NewInt(12)), sdk.NewCoin(testDenomB, sdk.NewInt(99))),
+		},
+	}
+
+	for name, tc := range testcases {
+		suite.Run(name, func() {
+			expectedEvents := sdk.Events{
+				sdk.NewEvent(
+					types.TypeEvtPoolExited,
+					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+					sdk.NewAttribute(sdk.AttributeKeySender, tc.testAccountAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(tc.poolId, 10)),
+					sdk.NewAttribute(types.AttributeKeyTokensOut, tc.tokensOut.String()),
+				),
+			}
+
+			hasNoEventManager := tc.ctx.EventManager() == nil
+
+			// System under test.
+			events.EmitRemoveLiquidityEvent(tc.ctx, tc.testAccountAddr, tc.poolId, tc.tokensOut)
+
+			// Assertions
+			if hasNoEventManager {
+				// If there is no event manager on context, this is a no-op.
+				return
+			}
+
+			eventManager := tc.ctx.EventManager()
+			actualEvents := eventManager.Events()
+			suite.Equal(expectedEvents, actualEvents)
+		})
+	}
+}

--- a/x/swaprouter/export_test.go
+++ b/x/swaprouter/export_test.go
@@ -1,0 +1,14 @@
+package swaprouter
+
+import (
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// SetPoolRoutesUnsafe sets the given routes to the swaprouter keeper
+// to allow routing from a pool type to a certain swap module.
+// For example, balancer -> gamm.
+// This utility function is only exposed for testing and should not be moved
+// outside of the _test.go files.
+func (k *Keeper) SetPoolRoutesUnsafe(routes map[types.PoolType]types.SwapI) {
+	k.routes = routes
+}

--- a/x/swaprouter/keeper.go
+++ b/x/swaprouter/keeper.go
@@ -1,0 +1,103 @@
+package swaprouter
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogotypes "github.com/gogo/protobuf/types"
+
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+type Keeper struct {
+	storeKey sdk.StoreKey
+
+	gammKeeper           types.SwapI
+	concentratedKeeper   types.SwapI
+	poolIncentivesKeeper types.PoolIncentivesKeeperI
+	bankKeeper           types.BankI
+	accountKeeper        types.AccountI
+	communityPoolKeeper  types.CommunityPoolI
+
+	poolCreationListeners types.PoolCreationListeners
+
+	routes map[types.PoolType]types.SwapI
+
+	paramSpace paramtypes.Subspace
+}
+
+func NewKeeper(storeKey sdk.StoreKey, paramSpace paramtypes.Subspace, gammKeeper types.SwapI, concentratedKeeper types.SwapI, bankKeeper types.BankI, accountKeeper types.AccountI, communityPoolKeeper types.CommunityPoolI) *Keeper {
+	// set KeyTable if it has not already been set
+	if !paramSpace.HasKeyTable() {
+		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
+	}
+
+	routes := map[types.PoolType]types.SwapI{
+		types.Balancer:     gammKeeper,
+		types.StableSwap:   gammKeeper,
+		types.Concentrated: concentratedKeeper,
+	}
+
+	return &Keeper{storeKey: storeKey, paramSpace: paramSpace, gammKeeper: gammKeeper, concentratedKeeper: concentratedKeeper, bankKeeper: bankKeeper, accountKeeper: accountKeeper, communityPoolKeeper: communityPoolKeeper, routes: routes}
+}
+
+// GetParams returns the total set of swaprouter parameters.
+func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
+	k.paramSpace.GetParamSet(ctx, &params)
+	return params
+}
+
+// SetParams sets the total set of swaprouter parameters.
+func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
+	k.paramSpace.SetParamSet(ctx, &params)
+}
+
+// InitGenesis initializes the swaprouter module's state from a provided genesis
+// state.
+func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
+	k.SetNextPoolId(ctx, genState.NextPoolId)
+	if err := genState.Validate(); err != nil {
+		panic(err)
+	}
+
+	k.SetParams(ctx, genState.Params)
+}
+
+// ExportGenesis returns the swaprouter module's exported genesis.
+func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
+	return &types.GenesisState{
+		Params:     k.GetParams(ctx),
+		NextPoolId: k.GetNextPoolId(ctx),
+	}
+}
+
+// GetNextPoolId returns the next pool id.
+func (k Keeper) GetNextPoolId(ctx sdk.Context) uint64 {
+	store := ctx.KVStore(k.storeKey)
+	nextPoolId := gogotypes.UInt64Value{}
+	osmoutils.MustGet(store, types.KeyNextGlobalPoolId, &nextPoolId)
+	return nextPoolId.Value
+}
+
+// SetPoolCreationListeners sets the pool creation listeners.
+func (k *Keeper) SetPoolCreationListeners(listeners types.PoolCreationListeners) *Keeper {
+	if k.poolCreationListeners != nil {
+		panic("cannot set pool creation listeners twice")
+	}
+
+	k.poolCreationListeners = listeners
+
+	return k
+}
+
+// SetNextPoolId sets next pool Id.
+func (k Keeper) SetNextPoolId(ctx sdk.Context, poolId uint64) {
+	store := ctx.KVStore(k.storeKey)
+	osmoutils.MustSet(store, types.KeyNextGlobalPoolId, &gogotypes.UInt64Value{Value: poolId})
+}
+
+// SetPoolIncentivesKeeper sets pool incentives keeper
+func (k *Keeper) SetPoolIncentivesKeeper(poolIncentivesKeeper types.PoolIncentivesKeeperI) {
+	k.poolIncentivesKeeper = poolIncentivesKeeper
+}

--- a/x/swaprouter/keeper_test.go
+++ b/x/swaprouter/keeper_test.go
@@ -1,0 +1,56 @@
+package swaprouter_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+const testExpectedPoolId = 3
+
+var testPoolCreationFee = sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 1000_000_000)}
+
+func TestKeeperTestSuite(t *testing.T) {
+
+	// TODO: re-enable this once swaprouter is fully merged.
+	t.SkipNow()
+
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (suite *KeeperTestSuite) SetupTest() {
+	suite.Setup()
+}
+
+// createPoolFromType creates a basic pool of the given type for testing.
+func (suite *KeeperTestSuite) createPoolFromType(poolType types.PoolType) {
+	switch poolType {
+	case types.Balancer:
+		suite.PrepareBalancerPool()
+		return
+	case types.StableSwap:
+		// TODO
+		return
+	case types.Concentrated:
+		// TODO
+		return
+	}
+}
+
+// createBalancerPoolsFromCoins creates balancer pools from given sets of coins.
+// Where element 1 of the input corresponds to the first pool created,
+// element 2 to the second pool created, up until the last element.
+func (suite *KeeperTestSuite) createBalancerPoolsFromCoins(poolCoins []sdk.Coins) {
+	for _, curPoolCoins := range poolCoins {
+		suite.FundAcc(suite.TestAccs[0], curPoolCoins)
+		suite.PrepareBalancerPoolWithCoins(curPoolCoins...)
+	}
+}

--- a/x/swaprouter/module/module.go
+++ b/x/swaprouter/module/module.go
@@ -1,0 +1,154 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/osmosis-labs/osmosis/v13/simulation/simtypes"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/cli"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/client/queryproto"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+var (
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
+)
+
+type AppModuleBasic struct{}
+
+func (AppModuleBasic) Name() string { return types.ModuleName }
+
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+}
+
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	return cdc.MustMarshalJSON(types.DefaultGenesis())
+}
+
+// ValidateGenesis performs genesis state validation for the swaprouter module.
+func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
+	var genState types.GenesisState
+	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
+		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
+	}
+	return genState.Validate()
+}
+
+// ---------------------------------------
+// Interfaces.
+func (b AppModuleBasic) RegisterRESTRoutes(ctx client.Context, r *mux.Router) {
+}
+
+func (b AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+	if err := queryproto.RegisterQueryHandlerClient(context.Background(), mux, queryproto.NewQueryClient(clientCtx)); err != nil {
+		panic(err)
+	}
+}
+
+func (b AppModuleBasic) GetTxCmd() *cobra.Command {
+	return cli.NewTxCmd()
+}
+
+func (b AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}
+
+// RegisterInterfaces registers interfaces and implementations of the gamm module.
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+}
+
+type AppModule struct {
+	AppModuleBasic
+
+	k          swaprouter.Keeper
+	gammKeeper types.GammKeeper
+}
+
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+}
+
+func NewAppModule(swaprouterKeeper swaprouter.Keeper, gammKeeper types.GammKeeper) AppModule {
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{},
+		k:              swaprouterKeeper,
+		gammKeeper:     gammKeeper,
+	}
+}
+
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+}
+
+func (am AppModule) Route() sdk.Route {
+	return sdk.Route{}
+}
+
+// QuerierRoute returns the gamm module's querier route name.
+func (AppModule) QuerierRoute() string { return types.RouterKey }
+
+// LegacyQuerierHandler returns the x/gamm module's sdk.Querier.
+func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
+	return func(sdk.Context, []string, abci.RequestQuery) ([]byte, error) {
+		return nil, fmt.Errorf("legacy querier not supported for the x/%s module", types.ModuleName)
+	}
+}
+
+// InitGenesis performs genesis initialization for the swaprouter module.
+// no validator updates.
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState types.GenesisState
+
+	cdc.MustUnmarshalJSON(gs, &genesisState)
+
+	am.k.InitGenesis(ctx, &genesisState)
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis returns the exported genesis state as raw bytes for the swaprouter.
+// module.
+func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	genState := am.k.ExportGenesis(ctx)
+	return cdc.MustMarshalJSON(genState)
+}
+
+// BeginBlock performs a no-op.
+func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+
+// EndBlock performs a no-op.
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}
+
+// ConsensusVersion implements AppModule/ConsensusVersion.
+func (AppModule) ConsensusVersion() uint64 { return 1 }
+
+// **** simulation implementation ****
+// GenerateGenesisState creates a randomized GenState of the swaprouter module.
+// **** simulation implementation ****
+// GenerateGenesisState creates a randomized GenState of the gamm module.
+func (am AppModule) SimulatorGenesisState(simState *module.SimulationState, s *simtypes.SimCtx) {
+	swaprouterGen := types.DefaultGenesis()
+	// change the pool creation fee denom from uosmo to stake
+	// TODO: uncomment this once simulation is enabled.
+	// swaprouterGen.Params.PoolCreationFee = sdk.NewCoins(swaproutersimulation.PoolCreationFee)
+	DefaultGenJson := simState.Cdc.MustMarshalJSON(swaprouterGen)
+	simState.GenState[types.ModuleName] = DefaultGenJson
+}
+
+func (am AppModule) Actions() []simtypes.Action {
+	// TODO: uncomment this once simulation is enabled.
+	// return swaproutersimulation.DefaultActions(am.k, am.gammKeeper)
+	return nil
+}

--- a/x/swaprouter/msg_server.go
+++ b/x/swaprouter/msg_server.go
@@ -1,0 +1,99 @@
+package swaprouter
+
+import (
+	"context"
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+type msgServer struct {
+	keeper *Keeper
+}
+
+func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
+	return &msgServer{
+		keeper: keeper,
+	}
+}
+
+// CreatePool attempts to create a pool returning the newly created pool ID or an error upon failure.
+// The pool creation fee is used to fund the community pool.
+// It will create a dedicated module account for the pool and sends the initial liquidity to the created module account.
+func (server msgServer) CreatePool(goCtx context.Context, msg types.CreatePoolMsg) (poolId uint64, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	poolId, err = server.keeper.CreatePool(ctx, msg)
+	if err != nil {
+		return 0, err
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			gammtypes.TypeEvtPoolCreated,
+			sdk.NewAttribute(gammtypes.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+		),
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.PoolCreator().String()),
+		),
+	})
+
+	return poolId, nil
+}
+
+// TODO: spec and tests, including events
+func (server msgServer) SwapExactAmountIn(goCtx context.Context, msg *types.MsgSwapExactAmountIn) (*types.MsgSwapExactAmountInResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenOutAmount, err := server.keeper.RouteExactAmountIn(ctx, sender, msg.Routes, msg.TokenIn, msg.TokenOutMinAmount)
+	if err != nil {
+		return nil, err
+	}
+
+	// Swap event is handled elsewhere
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+		),
+	})
+
+	return &types.MsgSwapExactAmountInResponse{TokenOutAmount: tokenOutAmount}, nil
+}
+
+// TODO: spec and tests, including events
+func (server msgServer) SwapExactAmountOut(goCtx context.Context, msg *types.MsgSwapExactAmountOut) (*types.MsgSwapExactAmountOutResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenInAmount, err := server.keeper.RouteExactAmountOut(ctx, sender, msg.Routes, msg.TokenInMaxAmount, msg.TokenOut)
+	if err != nil {
+		return nil, err
+	}
+
+	// Swap event is handled elsewhere
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+		),
+	})
+
+	return &types.MsgSwapExactAmountOutResponse{TokenInAmount: tokenInAmount}, nil
+}

--- a/x/swaprouter/router.go
+++ b/x/swaprouter/router.go
@@ -1,0 +1,48 @@
+package swaprouter
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+// RouteExactAmountIn defines the input denom and input amount for the first pool,
+// the output of the first pool is chained as the input for the next routed pool
+// transaction succeeds when final amount out is greater than tokenOutMinAmount defined.
+func (k Keeper) RouteExactAmountIn(
+	ctx sdk.Context,
+	sender sdk.AccAddress,
+	routes []types.SwapAmountInRoute,
+	tokenIn sdk.Coin,
+	tokenOutMinAmount sdk.Int) (tokenOutAmount sdk.Int, err error) {
+	panic("not implemented")
+}
+
+func (k Keeper) MultihopEstimateOutGivenExactAmountIn(
+	ctx sdk.Context,
+	routes []types.SwapAmountInRoute,
+	tokenIn sdk.Coin,
+) (tokenOutAmount sdk.Int, err error) {
+	panic("not implemented")
+}
+
+// MultihopSwapExactAmountOut defines the output denom and output amount for the last pool.
+// Calculation starts by providing the tokenOutAmount of the final pool to calculate the required tokenInAmount
+// the calculated tokenInAmount is used as defined tokenOutAmount of the previous pool, calculating in reverse order of the swap
+// Transaction succeeds if the calculated tokenInAmount of the first pool is less than the defined tokenInMaxAmount defined.
+func (k Keeper) RouteExactAmountOut(ctx sdk.Context,
+	sender sdk.AccAddress,
+	routes []types.SwapAmountOutRoute,
+	tokenInMaxAmount sdk.Int,
+	tokenOut sdk.Coin,
+) (tokenInAmount sdk.Int, err error) {
+	panic("not implemented")
+}
+
+func (k Keeper) MultihopEstimateInGivenExactAmountOut(
+	ctx sdk.Context,
+	routes []types.SwapAmountOutRoute,
+	tokenOut sdk.Coin,
+) (tokenInAmount sdk.Int, err error) {
+	panic("not implemented")
+}

--- a/x/swaprouter/router_test.go
+++ b/x/swaprouter/router_test.go
@@ -1,0 +1,314 @@
+package swaprouter_test
+
+import (
+	"reflect"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gamm "github.com/osmosis-labs/osmosis/v13/x/gamm/keeper"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/v13/x/pool-incentives/types"
+	"github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
+)
+
+const (
+	foo   = "foo"
+	bar   = "bar"
+	baz   = "baz"
+	uosmo = "uosmo"
+)
+
+var (
+	defaultInitPoolAmount = sdk.NewInt(1000000000000)
+	defaultPoolSwapFee    = sdk.NewDecWithPrec(1, 2) // 1% pool swap fee default
+	defaultSwapAmount     = sdk.NewInt(1000000)
+	gammKeeperType        = reflect.TypeOf(&gamm.Keeper{})
+)
+
+// TestEstimateMultihopSwapExactAmountIn tests that the estimation done via `EstimateSwapExactAmountIn`
+// results in the same amount of token out as the actual swap.
+func (suite *KeeperTestSuite) TestEstimateMultihopSwapExactAmountIn() {
+	type param struct {
+		routes            []types.SwapAmountInRoute
+		estimateRoutes    []types.SwapAmountInRoute
+		tokenIn           sdk.Coin
+		tokenOutMinAmount sdk.Int
+	}
+
+	tests := []struct {
+		name              string
+		param             param
+		expectPass        bool
+		reducedFeeApplied bool
+	}{
+		{
+			name: "Proper swap - foo -> bar(pool 1) - bar(pool 2) -> baz",
+			param: param{
+				routes: []types.SwapAmountInRoute{
+					{
+						PoolId:        1,
+						TokenOutDenom: bar,
+					},
+					{
+						PoolId:        2,
+						TokenOutDenom: baz,
+					},
+				},
+				estimateRoutes: []types.SwapAmountInRoute{
+					{
+						PoolId:        3,
+						TokenOutDenom: bar,
+					},
+					{
+						PoolId:        4,
+						TokenOutDenom: baz,
+					},
+				},
+				tokenIn:           sdk.NewCoin(foo, sdk.NewInt(100000)),
+				tokenOutMinAmount: sdk.NewInt(1),
+			},
+			expectPass: true,
+		},
+		{
+			name: "Swap - foo -> uosmo(pool 1) - uosmo(pool 2) -> baz with a half fee applied",
+			param: param{
+				routes: []types.SwapAmountInRoute{
+					{
+						PoolId:        1,
+						TokenOutDenom: uosmo,
+					},
+					{
+						PoolId:        2,
+						TokenOutDenom: baz,
+					},
+				},
+				estimateRoutes: []types.SwapAmountInRoute{
+					{
+						PoolId:        3,
+						TokenOutDenom: uosmo,
+					},
+					{
+						PoolId:        4,
+						TokenOutDenom: baz,
+					},
+				},
+				tokenIn:           sdk.NewCoin(foo, sdk.NewInt(100000)),
+				tokenOutMinAmount: sdk.NewInt(1),
+			},
+			reducedFeeApplied: true,
+			expectPass:        true,
+		},
+	}
+
+	for _, test := range tests {
+		// Init suite for each test.
+		suite.SetupTest()
+
+		suite.Run(test.name, func() {
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+			poolDefaultSwapFee := sdk.NewDecWithPrec(1, 2) // 1%
+
+			// Prepare 4 pools,
+			// Two pools for calculating `MultihopSwapExactAmountIn`
+			// and two pools for calculating `EstimateMultihopSwapExactAmountIn`
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+
+			firstEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			secondEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+
+			firstEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			// calculate token out amount using `MultihopSwapExactAmountIn`
+			multihopTokenOutAmount, err := swaprouterKeeper.RouteExactAmountIn(
+				suite.Ctx,
+				suite.TestAccs[0],
+				test.param.routes,
+				test.param.tokenIn,
+				test.param.tokenOutMinAmount)
+			suite.Require().NoError(err)
+
+			// calculate token out amount using `EstimateMultihopSwapExactAmountIn`
+			estimateMultihopTokenOutAmount, err := swaprouterKeeper.MultihopEstimateOutGivenExactAmountIn(
+				suite.Ctx,
+				test.param.estimateRoutes,
+				test.param.tokenIn)
+			suite.Require().NoError(err)
+
+			// ensure that the token out amount is same
+			suite.Require().Equal(multihopTokenOutAmount, estimateMultihopTokenOutAmount)
+
+			// ensure that pool state has not been altered after estimation
+			firstEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(firstEstimatePool, firstEstimatePoolAfterSwap)
+			suite.Require().Equal(secondEstimatePool, secondEstimatePoolAfterSwap)
+		})
+	}
+}
+
+// TestEstimateMultihopSwapExactAmountOut tests that the estimation done via `EstimateSwapExactAmountOut`
+// results in the same amount of token in as the actual swap.
+func (suite *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
+	type param struct {
+		routes           []types.SwapAmountOutRoute
+		estimateRoutes   []types.SwapAmountOutRoute
+		tokenInMaxAmount sdk.Int
+		tokenOut         sdk.Coin
+	}
+
+	tests := []struct {
+		name              string
+		param             param
+		expectPass        bool
+		reducedFeeApplied bool
+	}{
+		{
+			name: "Proper swap: foo -> bar (pool 1), bar -> baz (pool 2)",
+			param: param{
+				routes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       1,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       2,
+						TokenInDenom: bar,
+					},
+				},
+				estimateRoutes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       3,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       4,
+						TokenInDenom: bar,
+					},
+				},
+				tokenInMaxAmount: sdk.NewInt(90000000),
+				tokenOut:         sdk.NewCoin(baz, sdk.NewInt(100000)),
+			},
+			expectPass: true,
+		},
+		{
+			name: "Swap - foo -> uosmo(pool 1) - uosmo(pool 2) -> baz with a half fee applied",
+			param: param{
+				routes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       1,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       2,
+						TokenInDenom: uosmo,
+					},
+				},
+				estimateRoutes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       3,
+						TokenInDenom: foo,
+					},
+					{
+						PoolId:       4,
+						TokenInDenom: uosmo,
+					},
+				},
+				tokenInMaxAmount: sdk.NewInt(90000000),
+				tokenOut:         sdk.NewCoin(baz, sdk.NewInt(100000)),
+			},
+			expectPass:        true,
+			reducedFeeApplied: true,
+		},
+	}
+
+	for _, test := range tests {
+		// Init suite for each test.
+		suite.SetupTest()
+
+		suite.Run(test.name, func() {
+			swaprouterKeeper := suite.App.SwapRouterKeeper
+			poolDefaultSwapFee := sdk.NewDecWithPrec(1, 2) // 1%
+
+			// Prepare 4 pools,
+			// Two pools for calculating `MultihopSwapExactAmountOut`
+			// and two pools for calculating `EstimateMultihopSwapExactAmountOut`
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee, // 1%
+				ExitFee: sdk.NewDec(0),
+			})
+			suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			firstEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee, // 1%
+				ExitFee: sdk.NewDec(0),
+			})
+			secondEstimatePoolId := suite.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
+				SwapFee: poolDefaultSwapFee,
+				ExitFee: sdk.NewDec(0),
+			})
+			firstEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			multihopTokenInAmount, err := swaprouterKeeper.RouteExactAmountOut(
+				suite.Ctx,
+				suite.TestAccs[0],
+				test.param.routes,
+				test.param.tokenInMaxAmount,
+				test.param.tokenOut)
+			suite.Require().NoError(err, "test: %v", test.name)
+
+			estimateMultihopTokenInAmount, err := swaprouterKeeper.MultihopEstimateInGivenExactAmountOut(
+				suite.Ctx,
+				test.param.estimateRoutes,
+				test.param.tokenOut)
+			suite.Require().NoError(err, "test: %v", test.name)
+
+			suite.Require().Equal(multihopTokenInAmount, estimateMultihopTokenInAmount)
+
+			// ensure that pool state has not been altered after estimation
+			firstEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, firstEstimatePoolId)
+			suite.Require().NoError(err)
+			secondEstimatePoolAfterSwap, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, secondEstimatePoolId)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(firstEstimatePool, firstEstimatePoolAfterSwap)
+			suite.Require().Equal(secondEstimatePool, secondEstimatePoolAfterSwap)
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) makeGaugesIncentivized(incentivizedGauges []uint64) {
+	var records []poolincentivestypes.DistrRecord
+	totalWeight := sdk.NewInt(int64(len(incentivizedGauges)))
+	for _, gauge := range incentivizedGauges {
+		records = append(records, poolincentivestypes.DistrRecord{GaugeId: gauge, Weight: sdk.OneInt()})
+	}
+	distInfo := poolincentivestypes.DistrInfo{
+		TotalWeight: totalWeight,
+		Records:     records,
+	}
+	suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, distInfo)
+}

--- a/x/swaprouter/types/msgs_test.go
+++ b/x/swaprouter/types/msgs_test.go
@@ -276,7 +276,7 @@ func TestMsgSwapExactAmountOut(t *testing.T) {
 // Test authz serialize and de-serializes for swaprouter msg.
 func TestAuthzMsg(t *testing.T) {
 
-	// TODO: uncomment when types are registered.
+	// TODO: remove when types are registered.
 	t.SkipNow()
 
 	pk1 := ed25519.GenPrivKey().PubKey()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We would like to drop `concentrated-liquidity-main` branch to avoid branch synching overhead. As part of that, we are going to be incrementally merging the current concentrated liquidity feature state to `main`.

All this logic has already been given a round of reviews since we treated `concentrated-liqudiity-main` branch as `main` with appropriate review processes.

This particular PR does the following:
- ports all cli and query logic while disabling tests
- ports swaprouter's `module` package w/o registering types
- ports all message server logic
- ports all keeper stubs but not the implementations, tests are disabled.
- adds a `SwapRouterKeeper` in `app/keepers/keepers.go` to let tests build. However, it does not initialize the keeper 

There should be no state or API breaks in this PR. Reviewer, please confirm.

For the latest state of the feature that we are merging, see: https://github.com/osmosis-labs/osmosis/tree/concentrated-liquidity-main

See spec: https://github.com/osmosis-labs/osmosis/pull/3052/files