### PR TITLE
fix/test: misplaced assets in twap tests

### DIFF
--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -119,7 +119,7 @@ func (qp QueryPlugin) ArithmeticTwap(ctx sdk.Context, arithmeticTwap *bindings.A
 	startTime := time.UnixMilli(arithmeticTwap.StartTime)
 	endTime := time.UnixMilli(arithmeticTwap.EndTime)
 
-	twap, err := qp.twapKeeper.GetArithmeticTwap(ctx, poolId, quoteAssetDenom, baseAssetDenom, startTime, endTime)
+	twap, err := qp.twapKeeper.GetArithmeticTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime)
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "gamm arithmetic twap")
 	}

--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -119,7 +119,7 @@ func (qp QueryPlugin) ArithmeticTwap(ctx sdk.Context, arithmeticTwap *bindings.A
 	startTime := time.UnixMilli(arithmeticTwap.StartTime)
 	endTime := time.UnixMilli(arithmeticTwap.EndTime)
 
-	twap, err := qp.twapKeeper.GetArithmeticTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime)
+	twap, err := qp.twapKeeper.GetArithmeticTwap(ctx, poolId, quoteAssetDenom, baseAssetDenom, startTime, endTime)
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "gamm arithmetic twap")
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2962

## What is the purpose of the change

This is a continuation of #3564 that fixes twap test asset misplace. There are no state-breaking changes here