### PR TITLE
auto: code-gen upgrade handler v

### DIFF
--- a/.github/workflows/gen-upgrade-on-manual-input.yml
+++ b/.github/workflows/gen-upgrade-on-manual-input.yml
@@ -1,13 +1,17 @@
-# When new major release is created this workflow will be triggered and will do 3 things:
+# When user trigger this workflow with custom version input, this action will do 3 things:
 # 1) it will create a directory with an empty upgrade handler in app/upgrades folder
 # 2) will increase an E2E_UPGRADE_VERSION variable in Makefile
-# 3) create a pull request with these changes to main 
+# 3) create a pull request with these changes to main
 
-name: On Release Auto Upgrade
+name: On Manual Input Auto Upgrade
 
 on:
-  release: 
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Major vesrion to generate. Default value (v1) will ignore the action. Example format: v13'
+        required: true
+        default: 'v1'
 
 jobs:
   post_release:
@@ -17,11 +21,11 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Run version script
-        run: bash ./scripts/check_release.sh ${{ github.event.release.tag_name }}
+        run: bash ./scripts/check_release.sh ${{ inputs.version }}
 
       - name: Run post release script
-        if: env.MAJOR == 1    # 1 means vX of existing upgrade handler is smaller than A in tag vA.B.C 
-        run: bash ./scripts/empty_upgrade_handler_gen.sh 
+        if: env.MAJOR == 1    # 1 means vX of existing upgrade handler is smaller than A in tag vA.B.C
+        run: bash ./scripts/empty_upgrade_handler_gen.sh ${{ inputs.version }}
 
       - name: Create PR
         if: env.MAJOR == 1

--- a/.github/workflows/gen-upgrade-on-manual-input.yml
+++ b/.github/workflows/gen-upgrade-on-manual-input.yml
@@ -9,12 +9,12 @@ on:
   release: 
     types: [published]
 
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Major vesrion to generate. Default value (v1) will ignore the action. Example format: v13'
-        required: true
-        default: 'v1'
+  # workflow_dispatch:
+  #   inputs:
+  #     version:
+  #       description: 'Major vesrion to generate. Default value (v1) will ignore the action. Example format: v13'
+  #       required: true
+  #       default: 'v1'
 
 jobs:
   post_release:

--- a/.github/workflows/gen-upgrade-on-manual-input.yml
+++ b/.github/workflows/gen-upgrade-on-manual-input.yml
@@ -6,15 +6,15 @@
 name: On Manual Input Auto Upgrade
 
 on:
+  release: 
+    types: [published]
+
   workflow_dispatch:
     inputs:
       version:
         description: 'Major vesrion to generate. Default value (v1) will ignore the action. Example format: v13'
         required: true
         default: 'v1'
-  
-  release: 
-    types: [published]
 
 jobs:
   post_release:

--- a/.github/workflows/gen-upgrade-on-manual-input.yml
+++ b/.github/workflows/gen-upgrade-on-manual-input.yml
@@ -12,6 +12,9 @@ on:
         description: 'Major vesrion to generate. Default value (v1) will ignore the action. Example format: v13'
         required: true
         default: 'v1'
+  
+  release: 
+    types: [published]
 
 jobs:
   post_release:

--- a/scripts/empty_upgrade_handler_gen.sh
+++ b/scripts/empty_upgrade_handler_gen.sh
@@ -18,8 +18,8 @@
         latest_version=$num_version
      fi
  done
- version_create=$((latest_version+1))
- new_file=./app/upgrades/v${version_create}
+ version_create=$1
+ new_file=./app/upgrades/${version_create}
 
  mkdir $new_file
  CONSTANTS_FILE=$new_file/constants.go
@@ -33,8 +33,8 @@
 
  bracks='"'
  # set packages
- echo -e "package v${version_create}\n" >> $CONSTANTS_FILE
- echo -e "package v${version_create}\n" >> $UPGRADES_FILE
+ echo -e "package ${version_create}\n" >> $CONSTANTS_FILE
+ echo -e "package ${version_create}\n" >> $UPGRADES_FILE
 
  # imports
  echo "import (" >> $CONSTANTS_FILE
@@ -56,8 +56,8 @@
  echo -e ")\n" >> $CONSTANTS_FILE
  
  # constants.go logic
- echo "// UpgradeName defines the on-chain upgrade name for the Osmosis v$version_create upgrade." >> $CONSTANTS_FILE
- echo "const UpgradeName = ${bracks}v$version_create$bracks" >> $CONSTANTS_FILE
+ echo "// UpgradeName defines the on-chain upgrade name for the Osmosis $version_create upgrade." >> $CONSTANTS_FILE
+ echo "const UpgradeName = ${bracks}$version_create$bracks" >> $CONSTANTS_FILE
  echo "
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
@@ -81,12 +81,12 @@ func CreateUpgradeHandler(
   # change app/app.go file
  app_file=./app/app.go
  UPGRADES_LINE=$(grep -F upgrades.Upgrade{ $app_file)
- UPGRADES_LINE="${UPGRADES_LINE%?}, v${version_create}.Upgrade}"
+ UPGRADES_LINE="${UPGRADES_LINE%?}, ${version_create}.Upgrade}"
  sed -i "s|.*upgrades.Upgrade{.*|$UPGRADES_LINE|" $app_file 
 
  PREV_IMPORT="v$latest_version $module/app/upgrades/v$latest_version$bracks"
- NEW_IMPORT="v$version_create $module/app/upgrades/v$version_create$bracks"
+ NEW_IMPORT="$version_create $module/app/upgrades/$version_create$bracks"
  sed -i "s|.*$PREV_IMPORT.*|\t$PREV_IMPORT\n\t$NEW_IMPORT|" $app_file
 
  # change e2e version in makefile
- sed -i "s/E2E_UPGRADE_VERSION := ${bracks}v$latest_version$bracks/E2E_UPGRADE_VERSION := ${bracks}v$version_create$bracks/" ./Makefile
+ sed -i "s/E2E_UPGRADE_VERSION := ${bracks}v$latest_version$bracks/E2E_UPGRADE_VERSION := ${bracks}$version_create$bracks/" ./Makefile


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3495

## What is the purpose of the change

> Add a description of the overall background and high-level changes that this PR introduces

This changes the upgrade handler workflow from being triggered by public releases to being triggered manually with version input as suggested in #3495.

## Brief Changelog

 - `scripts/empty_upgrade_handler_gen.sh`
     - This will read version input from the workflow.
 - `.github/workflows/gen-upgrade-on-manual-input.yml`
     - Renamed the file and the workflow so that people can easily identify.
     - Change the trigger method and add a custom input field
     - Still keep workflow running on public release trigger