### PR TITLE
test(osmomath): log tests around max spot price

### DIFF
--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 type decimalTestSuite struct {
@@ -720,6 +721,17 @@ func (s *decimalTestSuite) TestLog2() {
 			initialValue: MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+912648174127941279170121098210.92821920190204131121+38+digits
 			expected: MustNewDecFromStr("99.525973560175362367047484597337715868"),
+		},
+		"log_2{Max Spot Price} = 128": {
+			initialValue: BigDecFromSDKDec(gammtypes.MaxSpotPrice), // 2^128 - 1
+			// From: https://www.wolframalpha.com/input?i=log+base+2+of+%28%282%5E128%29+-+1%29+38+digits
+			expected: MustNewDecFromStr("128"),
+		},
+		// The value tested below is: gammtypes.MaxSpotPrice * 0.99 = (2^128 - 1) * 0.99
+		"log_2{336879543251729078828740861357450529340.45} = 127.98550043030488492336620207564264562": {
+			initialValue: MustNewDecFromStr("336879543251729078828740861357450529340.45"),
+			// From: https://www.wolframalpha.com/input?i=log+base+2+of+%28%28%282%5E128%29+-+1%29*0.99%29++38+digits
+			expected: MustNewDecFromStr("127.98550043030488492336620207564264562"),
 		},
 	}
 

--- a/osmomath/log2_bench_test.go
+++ b/osmomath/log2_bench_test.go
@@ -3,6 +3,8 @@ package osmomath
 import (
 	"math/rand"
 	"testing"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 func BenchmarkLog2(b *testing.B) {
@@ -13,6 +15,8 @@ func BenchmarkLog2(b *testing.B) {
 		NewBigDec(2048 * 2048 * 2048 * 2048 * 2048),
 		MustNewDecFromStr("999999999999999999999999999999999999999999999999999999.9122181273612911"),
 		MustNewDecFromStr("0.563289239121902491248219047129047129"),
+		BigDecFromSDKDec(gammtypes.MaxSpotPrice),                        // 2^128 - 1
+		MustNewDecFromStr("336879543251729078828740861357450529340.45"), // (2^128 - 1) * 0.99
 	}
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is related to: https://github.com/osmosis-labs/osmosis/issues/3540

Upon adding tests around max spot price for geometric twap, overflows started to occur.

To eliminate the possibility of log function being at fault, the tests around max spot price values are added directly to the log. Benchmark is also added to ensure that large values do not inflate the time it takes to run the log. The difference was indeed negligible.