### PR TITLE
Reduce memory consumption for state exports

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -29,7 +29,7 @@ func (app *OsmosisApp) ExportAppStateAndValidators(
 	}
 
 	genState := app.mm.ExportGenesisForModules(ctx, app.appCodec, modulesToExport)
-	appState, err := json.MarshalIndent(genState, "", "  ")
+	appState, err := json.Marshal(genState)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}

--- a/app/export.go
+++ b/app/export.go
@@ -18,14 +18,13 @@ import (
 func (app *OsmosisApp) ExportAppStateAndValidators(
 	forZeroHeight bool, jailAllowedAddrs []string, modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
-	// as if they could withdraw from the start of the next block
-	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
-
+	ctx := app.NewUncachedContext(true, tmproto.Header{Height: app.LastBlockHeight()})
 	// We export at last height + 1, because that's the height at which
 	// Tendermint will start InitChain.
 	height := app.LastBlockHeight() + 1
 	if forZeroHeight {
 		height = 0
+		ctx = app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
 		app.prepForZeroHeightGenesis(ctx, jailAllowedAddrs)
 	}
 
@@ -35,6 +34,7 @@ func (app *OsmosisApp) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
+	// despite name, does no writes
 	validators, err := staking.WriteValidators(ctx, *app.StakingKeeper)
 	return servertypes.ExportedApp{
 		AppState:        appState,

--- a/cmd/osmosisd/cmd/export2.go
+++ b/cmd/osmosisd/cmd/export2.go
@@ -1,0 +1,136 @@
+package cmd
+
+// DONTCOVER
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/config"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/server/types"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	FlagHeight           = "height"
+	FlagForZeroHeight    = "for-zero-height"
+	FlagJailAllowedAddrs = "jail-allowed-addrs"
+	FlagModulesToExport  = "modules-to-export"
+)
+
+func openDB(rootDir string) (dbm.DB, error) {
+	dataDir := filepath.Join(rootDir, "data")
+	return sdk.NewLevelDB("application", dataDir)
+}
+
+// FasterExportCmd dumps app state to JSON.
+func FasterExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export state to JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+
+			homeDir, _ := cmd.Flags().GetString(flags.FlagHome)
+			config.SetRoot(homeDir)
+
+			if _, err := os.Stat(config.GenesisFile()); os.IsNotExist(err) {
+				return err
+			}
+
+			height, _ := cmd.Flags().GetInt64(FlagHeight)
+			modulesToExport, _ := cmd.Flags().GetStringSlice(FlagModulesToExport)
+
+			return exportLogic(serverCtx.Logger, cmd, serverCtx.Viper, config, appExporter, height, modulesToExport)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	cmd.Flags().Int64(FlagHeight, -1, "Export state from a particular height (-1 means latest height)")
+	cmd.Flags().StringSlice(FlagModulesToExport, []string{}, "Comma-separated list of modules to export. If empty, will export all modules")
+
+	return cmd
+}
+
+type printer interface {
+	Println(i ...interface{})
+}
+
+func exportLogic(logger log.Logger, cmd printer, appOpts servertypes.AppOptions, config *config.Config, appExporter types.AppExporter, height int64, modulesToExport []string) error {
+	db, err := openDB(config.RootDir)
+	if err != nil {
+		return err
+	}
+
+	if appExporter == nil {
+		if _, err := fmt.Fprintln(os.Stderr, "WARNING: App exporter not defined. Returning genesis file."); err != nil {
+			return err
+		}
+
+		genesis, err := ioutil.ReadFile(config.GenesisFile())
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(genesis))
+		return nil
+	}
+
+	forZeroHeight := false
+	jailAllowedAddrs := []string{}
+
+	var dummy io.Writer
+	exported, err := appExporter(logger, db, dummy, height, forZeroHeight, jailAllowedAddrs, appOpts, modulesToExport)
+	if err != nil {
+		return fmt.Errorf("error exporting state: %v", err)
+	}
+
+	doc, err := tmtypes.GenesisDocFromFile(config.GenesisFile())
+	if err != nil {
+		return err
+	}
+
+	doc.AppState = exported.AppState
+	doc.Validators = exported.Validators
+	doc.InitialHeight = exported.Height
+	doc.ConsensusParams = &tmproto.ConsensusParams{
+		Block: tmproto.BlockParams{
+			MaxBytes:   exported.ConsensusParams.Block.MaxBytes,
+			MaxGas:     exported.ConsensusParams.Block.MaxGas,
+			TimeIotaMs: doc.ConsensusParams.Block.TimeIotaMs,
+		},
+		Evidence: tmproto.EvidenceParams{
+			MaxAgeNumBlocks: exported.ConsensusParams.Evidence.MaxAgeNumBlocks,
+			MaxAgeDuration:  exported.ConsensusParams.Evidence.MaxAgeDuration,
+			MaxBytes:        exported.ConsensusParams.Evidence.MaxBytes,
+		},
+		Validator: tmproto.ValidatorParams{
+			PubKeyTypes: exported.ConsensusParams.Validator.PubKeyTypes,
+		},
+	}
+
+	// NOTE: Tendermint uses a custom JSON decoder for GenesisDoc
+	// (except for stuff inside AppState). Inside AppState, we're free
+	// to encode as protobuf or amino.
+	encoded, err := tmjson.Marshal(doc)
+	if err != nil {
+		return err
+	}
+
+	cmd.Println(string(sdk.MustSortJSON(encoded)))
+	return nil
+}

--- a/cmd/osmosisd/cmd/export_bench_test.go
+++ b/cmd/osmosisd/cmd/export_bench_test.go
@@ -1,0 +1,25 @@
+// This file just benchmarks export on a live node.
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/simapp"
+	tmcfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+type basePrinter struct {
+}
+
+func (b basePrinter) Println(i ...interface{}) {
+	fmt.Println(i...)
+}
+
+func BenchmarkExport(b *testing.B) {
+	config := tmcfg.DefaultConfig()
+	for i := 0; i < b.N; i++ {
+		exportLogic(log.NewNopLogger(), basePrinter{}, simapp.EmptyAppOptions{}, config, createOsmosisAppAndExport, -1, []string{})
+	}
+}

--- a/cmd/osmosisd/cmd/export_bench_test.go
+++ b/cmd/osmosisd/cmd/export_bench_test.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/tendermint/tendermint/config"
 	tmcfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -17,9 +18,22 @@ func (b basePrinter) Println(i ...interface{}) {
 	fmt.Println(i...)
 }
 
+type localAppOpts struct {
+	config *config.Config
+}
+
+func (a localAppOpts) Get(o string) interface{} {
+	if o == flags.FlagHome {
+		return a.config.RootDir
+	}
+	return nil
+}
+
 func BenchmarkExport(b *testing.B) {
 	config := tmcfg.DefaultConfig()
+	// manually adjust this based on server your on
+	config.RootDir = "/root/.osmosisd"
 	for i := 0; i < b.N; i++ {
-		exportLogic(log.NewNopLogger(), basePrinter{}, simapp.EmptyAppOptions{}, config, createOsmosisAppAndExport, -1, []string{})
+		exportLogic(log.NewNopLogger(), basePrinter{}, localAppOpts{config}, config, createOsmosisAppAndExport, -1, []string{})
 	}
 }

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -293,15 +293,16 @@ func createOsmosisAppAndExport(
 ) (servertypes.ExportedApp, error) {
 	encCfg := osmosis.MakeEncodingConfig() // Ideally, we would reuse the one created by NewRootCmd.
 	encCfg.Marshaler = codec.NewProtoCodec(encCfg.InterfaceRegistry)
+	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	var app *osmosis.OsmosisApp
 	if height != -1 {
-		app = osmosis.NewOsmosisApp(logger, db, traceStore, false, map[int64]bool{}, "", uint(1), appOpts, osmosis.GetWasmEnabledProposals(), osmosis.EmptyWasmOpts)
+		app = osmosis.NewOsmosisApp(logger, db, traceStore, false, map[int64]bool{}, homeDir, uint(1), appOpts, osmosis.GetWasmEnabledProposals(), osmosis.EmptyWasmOpts)
 
 		if err := app.LoadHeight(height); err != nil {
 			return servertypes.ExportedApp{}, err
 		}
 	} else {
-		app = osmosis.NewOsmosisApp(logger, db, traceStore, true, map[int64]bool{}, "", uint(1), appOpts, osmosis.GetWasmEnabledProposals(), osmosis.EmptyWasmOpts)
+		app = osmosis.NewOsmosisApp(logger, db, traceStore, true, map[int64]bool{}, homeDir, uint(1), appOpts, osmosis.GetWasmEnabledProposals(), osmosis.EmptyWasmOpts)
 	}
 
 	return app.ExportAppStateAndValidators(forZeroHeight, jailWhiteList, modulesToExport)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We've recently been hitting memory consumption issues with state exports, as we maintain several caches during state export. (IAVL internal cache, a second IAVL cache within the SDK, CacheKV cache, exported values, JSON marshal overhead)

This eliminates the `CacheKV cache` which is itself some degree of memory amplification over the size of all state, thus hopefully meaningfully lowering our overall memory consumption. We need some more profiling to know for sure where the highest time/RAM overhead is. 

This still needs to be sanity tested for correctness, and that it actually speeds things up.

There are other actions we can do to reduce the overall RAM overhead. Will try to make an issue outlining this.

## Brief Changelog

Make state export not use CacheKV

## Testing and Verifying

I plan to manually verify by getting a state export from a node with and without this, and check sha-sum being the same (post sorting)

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? TODO
  - How is the feature or change documented? N/A