### PR TITLE
Ensure go v1.18 used in make build & make install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc Improvements
 
 * [#3611](https://github.com/osmosis-labs/osmosis/pull/3611) Introduce osmocli, to automate thousands of lines of CLI boilerplate
+* [#3634](https://github.com/osmosis-labs/osmosis/pull/3634) (Makefile) Ensure correct golang version in make build and make install. (Thank you @jhernandezb )
 
 ## v13.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ BUILDDIR ?= $(CURDIR)/build
 E2E_UPGRADE_VERSION := "v13"
 
 
+GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
+GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
+
 export GO111MODULE = on
 
 # process build tags
@@ -83,13 +86,20 @@ endif
 ###                                  Build                                  ###
 ###############################################################################
 
+check_version:
+	@echo "Go version: $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION)"
+ifneq ($(GO_MINOR_VERSION),18)
+	@echo "ERROR: Go version 1.18 is required for this version of Osmosis. Go 1.19 has changes that are believed to break consensus."
+	exit 1
+endif
+
 all: install lint test
 
 BUILD_TARGETS := build install
 
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
-$(BUILD_TARGETS): go.sum $(BUILDDIR)/
+$(BUILD_TARGETS): check_version go.sum $(BUILDDIR)/
 	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 
 $(BUILDDIR)/:

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ endif
 ###############################################################################
 
 check_version:
-	@echo "Go version: $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION)"
 ifneq ($(GO_MINOR_VERSION),18)
 	@echo "ERROR: Go version 1.18 is required for this version of Osmosis. Go 1.19 has changes that are believed to break consensus."
 	exit 1


### PR DESCRIPTION
## What is the purpose of the change

Go 1.19 had changes that are consensus breaking. Thank you to @jhernandezb for pointing this out. This applies his suggested patch to Makefiles to ensure that all binary builds are done with the same go minor release line.

## Brief Changelog

- Require go 1.18 installed for building the binary.

## Testing and Verifying

Try building the binary if you don't have go 1.18, or build being a success if you do have go 1.18.

I've tested both