### PR TITLE
fix: don't increment code ID in e2e before running

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -133,10 +133,6 @@ func copyFile(a, b string) error {
 }
 
 func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
-
-	// TODO: need to upload the contract in setup for this test to work.
-	s.T().Skip("Skipping IBC rate limiting tests")
-
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -165,8 +161,7 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
 	fmt.Println(wd, projectDir)
 	err = copyFile(projectDir+"/x/ibc-rate-limit/bytecode/rate_limiter.wasm", wd+"/scripts/rate_limiter.wasm")
 	s.NoError(err)
-	// set LatestCodeId to 1 since we upload a contract in the upgrade handler for v13
-	chainA.LatestCodeId = 1
+
 	node.StoreWasmCode("rate_limiter.wasm", initialization.ValidatorWalletName)
 	chainA.LatestCodeId += 1
 	node.InstantiateWasmContract(

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -163,7 +163,7 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
 	s.NoError(err)
 
 	node.StoreWasmCode("rate_limiter.wasm", initialization.ValidatorWalletName)
-	chainA.LatestCodeId += 1
+	chainA.LatestCodeId = 1
 	node.InstantiateWasmContract(
 		strconv.Itoa(chainA.LatestCodeId),
 		fmt.Sprintf(`{"gov_module": "%s", "ibc_module": "%s", "paths": [{"channel_id": "channel-0", "denom": "%s", "quotas": [{"name":"testQuota", "duration": 86400, "send_recv": [1, 1]}] } ] }`, node.PublicAddress, node.PublicAddress, initialization.OsmoToken.Denom),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Roman had to disable the IBC rate limiter test due to an unknown bug. This fixes that bug and re-enables that e2e test.

The reason we incremented this before is because the contract was uploaded in the upgrade handler, and this was a prior workaround to test this within e2e itself. 


## Brief Changelog

- Removed code ID increment prior to contract upload
- Re-enabled IBC test
