### PR TITLE
Speedup CI tests

### DIFF
--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -29,7 +29,7 @@ func getDefaultGenesisStateBytes() []byte {
 // Setup initializes a new OsmosisApp.
 func Setup(isCheckTx bool) *OsmosisApp {
 	db := dbm.NewMemDB()
-	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
+	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, simapp.EmptyAppOptions{}, GetWasmEnabledProposals(), EmptyWasmOpts)
 	if !isCheckTx {
 		stateBytes := getDefaultGenesisStateBytes()
 

--- a/x/ibc-hooks/ibc_middleware_test.go
+++ b/x/ibc-hooks/ibc_middleware_test.go
@@ -3,8 +3,9 @@ package ibc_hooks_test
 import (
 	"encoding/json"
 	"fmt"
-	ibc_hooks "github.com/osmosis-labs/osmosis/v13/x/ibc-hooks"
 	"testing"
+
+	ibc_hooks "github.com/osmosis-labs/osmosis/v13/x/ibc-hooks"
 
 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 
@@ -45,6 +46,10 @@ func (suite *HooksTestSuite) SetupTest() {
 	suite.chainB = &osmosisibctesting.TestChain{
 		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(2)),
 	}
+	err := suite.chainA.MoveEpochsToTheFuture()
+	suite.Require().NoError(err)
+	err = suite.chainB.MoveEpochsToTheFuture()
+	suite.Require().NoError(err)
 	suite.path = NewTransferPath(suite.chainA, suite.chainB)
 	suite.coordinator.Setup(suite.path)
 }

--- a/x/ibc-rate-limit/ibc_middleware_test.go
+++ b/x/ibc-rate-limit/ibc_middleware_test.go
@@ -15,10 +15,11 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
-	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
-	"github.com/osmosis-labs/osmosis/v13/x/ibc-rate-limit/testutil"
-	"github.com/osmosis-labs/osmosis/v13/x/ibc-rate-limit/types"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
+	osmosisibctesting "github.com/osmosis-labs/osmosis/v13/x/ibc-rate-limit/testutil"
+	"github.com/osmosis-labs/osmosis/v13/x/ibc-rate-limit/types"
 )
 
 type MiddlewareTestSuite struct {
@@ -54,11 +55,14 @@ func (suite *MiddlewareTestSuite) SetupTest() {
 		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(1)),
 	}
 	// Remove epochs to prevent  minting
-	suite.chainA.MoveEpochsToTheFuture()
+	err := suite.chainA.MoveEpochsToTheFuture()
+	suite.Require().NoError(err)
 	suite.chainB = &osmosisibctesting.TestChain{
 		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(2)),
 	}
 	suite.path = NewTransferPath(suite.chainA, suite.chainB)
+	err = suite.chainB.MoveEpochsToTheFuture()
+	suite.Require().NoError(err)
 	suite.coordinator.Setup(suite.path)
 }
 
@@ -506,6 +510,6 @@ func (suite *MiddlewareTestSuite) TestUnsetRateLimitingContract() {
 	osmosisApp := suite.chainA.GetOsmosisApp()
 	paramSpace, ok := osmosisApp.AppKeepers.ParamsKeeper.GetSubspace(types.ModuleName)
 	suite.Require().True(ok)
-        // N.B.: this panics if validation fails.
+	// N.B.: this panics if validation fails.
 	paramSpace.SetParamSet(suite.chainA.GetContext(), &params)
 }

--- a/x/ibc-rate-limit/testutil/chain.go
+++ b/x/ibc-rate-limit/testutil/chain.go
@@ -10,9 +10,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	"github.com/cosmos/ibc-go/v3/testing/simapp/helpers"
-	"github.com/osmosis-labs/osmosis/v13/app"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/osmosis-labs/osmosis/v13/app"
 )
 
 type TestChain struct {
@@ -85,14 +86,18 @@ func SignAndDeliver(
 }
 
 // Move epochs to the future to avoid issues with minting
-func (chain *TestChain) MoveEpochsToTheFuture() {
+func (chain *TestChain) MoveEpochsToTheFuture() error {
 	epochsKeeper := chain.GetOsmosisApp().EpochsKeeper
 	ctx := chain.GetContext()
 	for _, epoch := range epochsKeeper.AllEpochInfos(ctx) {
 		epoch.StartTime = ctx.BlockTime().Add(time.Hour * 24 * 30)
 		epochsKeeper.DeleteEpochInfo(chain.GetContext(), epoch.Identifier)
-		_ = epochsKeeper.AddEpochInfo(ctx, epoch)
+		err := epochsKeeper.AddEpochInfo(ctx, epoch)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // GetOsmosisApp returns the current chain's app as an OsmosisApp

--- a/x/incentives/keeper/hooks.go
+++ b/x/incentives/keeper/hooks.go
@@ -27,8 +27,11 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			}
 		}
 
+		if len(gauges) > 10 {
+			ctx.EventManager().IncreaseCapacity(2e6)
+		}
+
 		// distribute due to epoch event
-		ctx.EventManager().IncreaseCapacity(2e6)
 		gauges = k.GetActiveGauges(ctx)
 		// only distribute to active gauges that are for native denoms
 		// or non-perpetual and for synthetic denoms.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Does basic changes to speedup tests, driven by `x/ibc-rate-limit`, but should have more broad impact.

Locally `13.943s -> 2.670s`, CI: `86.922s -> 10.370s`. As a side effect:
IBC-hooks `107.357s -> 3.827s`

- Disable epochs on both chains in ibc-rate-limit tests (big win)
- Make epochs not allocate high amounts of RAM for events unless theres at least 10 gauges (small win)
- Remove invariants from our testing setups (small win, across many tests)

## Testing and Verifying

All tests still pass.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? (not applicable   /   specification N/A