### PR TITLE
Add custom parser support for osmocli

### DIFF
--- a/osmoutils/osmocli/flag_advice.go
+++ b/osmoutils/osmocli/flag_advice.go
@@ -1,13 +1,53 @@
 package osmocli
 
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
 type FlagAdvice struct {
 	HasPagination bool
 
 	// Map of FieldName -> FlagName
 	CustomFlagOverrides map[string]string
+	CustomFieldParsers  map[string]CustomFieldParserFn
 
 	// Tx sender value
 	IsTx              bool
 	TxSenderFieldName string
 	FromValue         string
+}
+
+type FieldReadLocation = bool
+
+const (
+	UsedArg  FieldReadLocation = true
+	UsedFlag FieldReadLocation = false
+)
+
+// CustomFieldParser function.
+type CustomFieldParserFn = func(arg string, flags *pflag.FlagSet) (valueToSet any, usedArg FieldReadLocation, err error)
+
+func (f FlagAdvice) Sanitize() FlagAdvice {
+	// map CustomFlagOverrides & CustomFieldParser keys to lower-case
+	// initialize if uninitialized
+	newFlagOverrides := make(map[string]string, len(f.CustomFlagOverrides))
+	for k, v := range f.CustomFlagOverrides {
+		newFlagOverrides[strings.ToLower(k)] = v
+	}
+	f.CustomFlagOverrides = newFlagOverrides
+	newFlagParsers := make(map[string]CustomFieldParserFn, len(f.CustomFieldParsers))
+	for k, v := range f.CustomFieldParsers {
+		newFlagParsers[strings.ToLower(k)] = v
+	}
+	f.CustomFieldParsers = newFlagParsers
+	return f
+}
+
+func FlagOnlyParser[v any](f func(fs *pflag.FlagSet) (v, error)) CustomFieldParserFn {
+	return func(_arg string, fs *pflag.FlagSet) (any, FieldReadLocation, error) {
+		t, err := f(fs)
+		return t, UsedFlag, err
+	}
 }

--- a/osmoutils/osmocli/parsers.go
+++ b/osmoutils/osmocli/parsers.go
@@ -83,6 +83,15 @@ func ParseField(v reflect.Value, t reflect.Type, fieldIndex int, arg string, fla
 	fType := t.Field(fieldIndex)
 	// fmt.Printf("Field %d: %s %s %s\n", fieldIndex, fType.Name, fType.Type, fType.Type.Kind())
 
+	lowercaseFieldNameStr := strings.ToLower(fType.Name)
+	if parseFn, ok := flagAdvice.CustomFieldParsers[lowercaseFieldNameStr]; ok {
+		v, usedArg, err := parseFn(arg, flags)
+		if err == nil {
+			fVal.Set(reflect.ValueOf(v))
+		}
+		return usedArg, err
+	}
+
 	parsedFromFlag, err := ParseFieldFromFlag(fVal, fType, flagAdvice, flags)
 	if err != nil {
 		return false, err

--- a/osmoutils/osmocli/query_cmd_wrap.go
+++ b/osmoutils/osmocli/query_cmd_wrap.go
@@ -37,13 +37,10 @@ func SimpleQueryFromDescriptor[reqP proto.Message, querier any](desc QueryDescri
 	if desc.HasPagination {
 		numArgs = numArgs - 1
 	}
-	if len(desc.CustomFlagOverrides) == 0 {
-		desc.CustomFlagOverrides = map[string]string{}
-	}
 	flagAdvice := FlagAdvice{
 		HasPagination:       desc.HasPagination,
 		CustomFlagOverrides: desc.CustomFlagOverrides,
-	}
+	}.Sanitize()
 	cmd := &cobra.Command{
 		Use:   desc.Use,
 		Short: desc.Short,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Cref: #3641 

## What is the purpose of the change

Adds custom parser support to osmocli. Lets us continue deletion of more CLI items.
I've tested the changes manually (plus we have cli tests) for:

* SwapExactAmountIn
* JoinPool
* ExitPool

## Testing and Verifying

Covered by existing tests + manually verified

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? ToDo to add osmocli docs