### PR TITLE
Protorev Basic Keeper + Epoch Hook

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -578,6 +578,7 @@ func (appKeepers *AppKeepers) SetupHooks() {
 			appKeepers.SuperfluidKeeper.Hooks(),
 			appKeepers.IncentivesKeeper.Hooks(),
 			appKeepers.MintKeeper.Hooks(),
+			appKeepers.ProtoRevKeeper.EpochHooks(),
 		),
 	)
 

--- a/x/protorev/genesis.go
+++ b/x/protorev/genesis.go
@@ -24,7 +24,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 	// Init all of the searcher routes
 	for _, tokenPairArbRoutes := range genState.TokenPairs {
-		_, err := k.SetTokenPairArbRoutes(ctx, tokenPairArbRoutes.TokenIn, tokenPairArbRoutes.TokenOut, &tokenPairArbRoutes)
+		err := tokenPairArbRoutes.Validate()
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = k.SetTokenPairArbRoutes(ctx, tokenPairArbRoutes.TokenIn, tokenPairArbRoutes.TokenOut, &tokenPairArbRoutes)
 		if err != nil {
 			panic(err)
 		}

--- a/x/protorev/genesis.go
+++ b/x/protorev/genesis.go
@@ -16,6 +16,19 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 	// Init module parameters
 	k.SetParams(ctx, genState.Params)
+
+	// Update the pools on genesis
+	if err := k.UpdatePools(ctx); err != nil {
+		panic(err)
+	}
+
+	// Init all of the searcher routes
+	for _, tokenPairArbRoutes := range genState.TokenPairs {
+		_, err := k.SetTokenPairArbRoutes(ctx, tokenPairArbRoutes.TokenIn, tokenPairArbRoutes.TokenOut, &tokenPairArbRoutes)
+		if err != nil {
+			panic(err)
+		}
+	}
 }
 
 // ExportGenesis returns the module's exported genesis

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -30,7 +30,8 @@ func (h EpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, ep
 	return nil
 }
 
-// AfterEpochEnd is the epoch end hook.
+// AfterEpochEnd is the epoch end hook. The module will update all of the pools in the store that are
+// used for trading.
 func (h EpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	switch epochIdentifier {
 	case "week":

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -91,12 +91,12 @@ func (k Keeper) GetHighestLiquidityPools(ctx sdk.Context) (map[string]LiquidityP
 			}
 
 			// Check if there is a match with osmo
-			if otherDenom, match := types.CheckMatchAndReturnOther(tokenA.Denom, tokenB.Denom, types.OsmosisDenomination); match {
+			if otherDenom, match := types.CheckOsmoAtomDenomMatch(tokenA.Denom, tokenB.Denom, types.OsmosisDenomination); match {
 				k.updateHighestLiquidityPool(otherDenom, osmoPools, newPool)
 			}
 
 			// Check if there is a match with atom
-			if otherDenom, match := types.CheckMatchAndReturnOther(tokenA.Denom, tokenB.Denom, types.AtomDenomination); match {
+			if otherDenom, match := types.CheckOsmoAtomDenomMatch(tokenA.Denom, tokenB.Denom, types.AtomDenomination); match {
 				k.updateHighestLiquidityPool(otherDenom, atomPools, newPool)
 			}
 		}

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -45,6 +45,7 @@ func (h EpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epoch
 	return nil
 }
 
+// Update pools requests the highest liquidity pools from the gamm module and updates the pools in the store
 func (k Keeper) UpdatePools(ctx sdk.Context) error {
 	// Get the highest liquidity pools
 	osmoPools, atomPools, err := k.GetHighestLiquidityPools(ctx)

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -92,27 +92,26 @@ func (k Keeper) GetHighestLiquidityPools(ctx sdk.Context) (map[string]LiquidityP
 
 			// Check if there is a match with osmo
 			if otherDenom, match := types.CheckMatchAndReturnOther(tokenA.Denom, tokenB.Denom, types.OsmosisDenomination); match {
-				if currPool, ok := osmoPools[otherDenom]; !ok {
-					osmoPools[otherDenom] = newPool
-				} else {
-					if newPool.Liquidity.GT(currPool.Liquidity) {
-						osmoPools[otherDenom] = newPool
-					}
-				}
+				k.updateHighestLiquidityPool(otherDenom, osmoPools, newPool)
 			}
 
 			// Check if there is a match with atom
 			if otherDenom, match := types.CheckMatchAndReturnOther(tokenA.Denom, tokenB.Denom, types.AtomDenomination); match {
-				if currPool, ok := atomPools[otherDenom]; !ok {
-					atomPools[otherDenom] = newPool
-				} else {
-					if newPool.Liquidity.GT(currPool.Liquidity) {
-						atomPools[otherDenom] = newPool
-					}
-				}
+				k.updateHighestLiquidityPool(otherDenom, atomPools, newPool)
 			}
 		}
 	}
 
 	return osmoPools, atomPools, nil
+}
+
+// updateHighestLiquidityPool updates the pool with the highest liquidity for either osmo or atom
+func (k Keeper) updateHighestLiquidityPool(denom string, pool map[string]LiquidityPoolStruct, newPool LiquidityPoolStruct) {
+	if currPool, ok := pool[denom]; !ok {
+		pool[denom] = newPool
+	} else {
+		if newPool.Liquidity.GT(currPool.Liquidity) {
+			pool[denom] = newPool
+		}
+	}
 }

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -35,10 +35,6 @@ func (h EpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, ep
 func (h EpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	switch epochIdentifier {
 	case "week":
-		// Reset the pools in the store
-		h.k.DeleteAllAtomPools(ctx)
-		h.k.DeleteAllOsmoPools(ctx)
-
 		// Update the pools in the store
 		return h.k.UpdatePools(ctx)
 	}
@@ -47,6 +43,10 @@ func (h EpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epoch
 
 // Update pools requests the highest liquidity pools from the gamm module and updates the pools in the store
 func (k Keeper) UpdatePools(ctx sdk.Context) error {
+	// Reset the pools in the store
+	k.DeleteAllAtomPools(ctx)
+	k.DeleteAllOsmoPools(ctx)
+
 	// Get the highest liquidity pools
 	osmoPools, atomPools, err := k.GetHighestLiquidityPools(ctx)
 	if err != nil {

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -1,0 +1,116 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	epochstypes "github.com/osmosis-labs/osmosis/v13/x/epochs/types"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+type EpochHooks struct {
+	k Keeper
+}
+
+// Struct used to track the pool with the highest liquidity
+type LiquidityPoolStruct struct {
+	Liquidity sdk.Int
+	PoolId    uint64
+}
+
+var (
+	_ epochstypes.EpochHooks = EpochHooks{}
+)
+
+func (k Keeper) EpochHooks() epochstypes.EpochHooks {
+	return EpochHooks{k}
+}
+
+// BeforeEpochStart is the epoch start hook.
+func (h EpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return nil
+}
+
+// AfterEpochEnd is the epoch end hook.
+func (h EpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	switch epochIdentifier {
+	case "week":
+		// Reset the pools in the store
+		h.k.DeleteAllAtomPools(ctx)
+		h.k.DeleteAllOsmoPools(ctx)
+
+		// Update the pools in the store
+		return h.k.UpdatePools(ctx)
+	}
+	return nil
+}
+
+func (k Keeper) UpdatePools(ctx sdk.Context) error {
+	// Get the highest liquidity pools
+	osmoPools, atomPools, err := k.GetHighestLiquidityPools(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Update the pools in the store
+	for token, poolInfo := range osmoPools {
+		k.SetOsmoPool(ctx, token, poolInfo.PoolId)
+	}
+	for token, poolInfo := range atomPools {
+		k.SetAtomPool(ctx, token, poolInfo.PoolId)
+	}
+
+	return nil
+}
+
+// GetHighestLiquidityPools returns the highest liquidity pools for pools that have Osmo or Atom
+// and Osmo/Atom
+func (k Keeper) GetHighestLiquidityPools(ctx sdk.Context) (map[string]LiquidityPoolStruct, map[string]LiquidityPoolStruct, error) {
+	// Get all pools
+	pools, err := k.gammKeeper.GetPoolsAndPoke(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	osmoPools := make(map[string]LiquidityPoolStruct)
+	atomPools := make(map[string]LiquidityPoolStruct)
+
+	// Iterate through all pools and find valid matches
+	for _, pool := range pools {
+		coins := pool.GetTotalPoolLiquidity(ctx)
+
+		// Pool must be active and the number of coins must be 2
+		if pool.IsActive(ctx) && len(coins) == 2 {
+			tokenA := coins[0]
+			tokenB := coins[1]
+
+			newPool := LiquidityPoolStruct{
+				PoolId:    pool.GetId(),
+				Liquidity: tokenA.Amount.Mul(tokenB.Amount),
+			}
+
+			// Check if there is a match with osmo
+			if otherDenom, match := types.CheckMatchAndReturnOther(tokenA.Denom, tokenB.Denom, types.OsmosisDenomination); match {
+				if currPool, ok := osmoPools[otherDenom]; !ok {
+					osmoPools[otherDenom] = newPool
+				} else {
+					if newPool.Liquidity.GT(currPool.Liquidity) {
+						osmoPools[otherDenom] = newPool
+					}
+				}
+			}
+
+			// Check if there is a match with atom
+			if otherDenom, match := types.CheckMatchAndReturnOther(tokenA.Denom, tokenB.Denom, types.AtomDenomination); match {
+				if currPool, ok := atomPools[otherDenom]; !ok {
+					atomPools[otherDenom] = newPool
+				} else {
+					if newPool.Liquidity.GT(currPool.Liquidity) {
+						atomPools[otherDenom] = newPool
+					}
+				}
+			}
+		}
+	}
+
+	return osmoPools, atomPools, nil
+}

--- a/x/protorev/keeper/epoch_hook_test.go
+++ b/x/protorev/keeper/epoch_hook_test.go
@@ -54,7 +54,7 @@ func (suite *KeeperTestSuite) TestEpochHook() {
 	for _, pool := range expectedToSee {
 		foundEitherOne := false
 		// Check if there is a match with osmo
-		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.OsmosisDenomination); match {
+		if otherDenom, match := types.CheckOsmoAtomDenomMatch(pool.Asset1, pool.Asset2, types.OsmosisDenomination); match {
 			poolId, err := suite.App.AppKeepers.ProtoRevKeeper.GetOsmoPool(suite.Ctx, otherDenom)
 
 			// pool ID must exist
@@ -65,7 +65,7 @@ func (suite *KeeperTestSuite) TestEpochHook() {
 		}
 
 		// Check if there is a match with atom
-		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.AtomDenomination); match {
+		if otherDenom, match := types.CheckOsmoAtomDenomMatch(pool.Asset1, pool.Asset2, types.AtomDenomination); match {
 			poolId, err := suite.App.AppKeepers.ProtoRevKeeper.GetAtomPool(suite.Ctx, otherDenom)
 
 			// pool ID must exist

--- a/x/protorev/keeper/epoch_hook_test.go
+++ b/x/protorev/keeper/epoch_hook_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
 )
 
+// TestEpochHook tests that the epoch hook is correctly setting the pool IDs for the osmo and atom pools.
+// The epoch hook is run after the pools are set and committed in keeper_test.go. All of the pools are initialized in the setup function in keeper_test.go
+// and are available in the suite.pools variable. The pools are filtered to only include the pools that
+// have osmo or atom as one of the assets. The pools are then filtered again to only include the pools that
+// have the highest liquidity. The pools are then checked to see if the pool IDs are correctly set in the
+// osmo and atom stores.
 func (suite *KeeperTestSuite) TestEpochHook() {
 	// All of the pools initialized in the setup function are available in keeper_test.go
 	// akash <-> types.OsmosisDenomination

--- a/x/protorev/keeper/epoch_hook_test.go
+++ b/x/protorev/keeper/epoch_hook_test.go
@@ -1,0 +1,74 @@
+package keeper_test
+
+import (
+	"fmt"
+
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+func (suite *KeeperTestSuite) TestEpochHook() {
+	// All of the pools initialized in the setup function are available in keeper_test.go
+	// akash <-> types.OsmosisDenomination
+	// juno <-> types.OsmosisDenomination
+	// ethereum <-> types.OsmosisDenomination
+	// bitcoin <-> types.OsmosisDenomination
+	// canto <-> types.OsmosisDenomination
+	// and so on...
+	expectedToSee := make(map[string]Pool)
+	for _, pool := range suite.pools {
+
+		// Module currently limited to two asset pools
+		// Instantiate asset and amounts for the pool
+		if len(pool.PoolAssets) == 2 {
+			pool.Asset1 = pool.PoolAssets[0].Token.Denom
+			pool.Amount1 = pool.PoolAssets[0].Token.Amount
+			pool.Asset2 = pool.PoolAssets[1].Token.Denom
+			pool.Amount2 = pool.PoolAssets[1].Token.Amount
+		}
+
+		if pool.Asset1 == types.OsmosisDenomination || pool.Asset2 == types.OsmosisDenomination || pool.Asset1 == types.AtomDenomination || pool.Asset2 == types.AtomDenomination {
+			// create a key that is a combination of asset1 and asset2 in alphabetical order
+			key := fmt.Sprintf("%s-%s", pool.Asset1, pool.Asset2)
+			if pool.Asset1 > pool.Asset2 {
+				key = fmt.Sprintf("%s-%s", pool.Asset2, pool.Asset1)
+			}
+
+			if storedPool, ok := expectedToSee[key]; !ok {
+				expectedToSee[key] = pool
+			} else {
+				liquidity := pool.Amount1.Mul(pool.Amount2)
+				if liquidity.GT(storedPool.Amount1.Mul(storedPool.Amount2)) {
+					expectedToSee[key] = pool
+				}
+			}
+		}
+	}
+
+	// The epoch hook is run after the pools are set and committed so all that must be done is the stores must be checked if they are correctly set
+	for _, pool := range expectedToSee {
+		foundEitherOne := false
+		// Check if there is a match with osmo
+		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.OsmosisDenomination); match {
+			poolId, err := suite.App.AppKeepers.ProtoRevKeeper.GetOsmoPool(suite.Ctx, otherDenom)
+
+			// pool ID must exist
+			suite.Require().NoError(err)
+			suite.Require().Equal(pool.PoolId, poolId)
+
+			foundEitherOne = true
+		}
+
+		// Check if there is a match with atom
+		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.AtomDenomination); match {
+			poolId, err := suite.App.AppKeepers.ProtoRevKeeper.GetAtomPool(suite.Ctx, otherDenom)
+
+			// pool ID must exist
+			suite.Require().NoError(err)
+			suite.Require().Equal(poolId, poolId)
+
+			foundEitherOne = true
+		}
+
+		suite.Require().True(foundEitherOne)
+	}
+}

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -81,7 +81,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 		sdk.NewCoin("busd", sdk.NewInt(9000000000000000000)),
 		sdk.NewCoin("ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293", sdk.NewInt(9000000000000000000)),
 	)
-
 	suite.fundAllAccountsWith()
 	suite.Commit()
 

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -1,0 +1,711 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	balancertypes "github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/pool-models/stableswap"
+
+	osmosisapp "github.com/osmosis-labs/osmosis/v13/app"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+
+	clientCtx   client.Context
+	queryClient types.QueryClient
+
+	pools              []Pool
+	stableSwapPools    []StableSwapPool
+	balances           sdk.Coins
+	tokenPairArbRoutes []*types.TokenPairArbRoutes
+	adminAccount       sdk.AccAddress
+}
+
+type Pool struct {
+	PoolAssets []balancertypes.PoolAsset
+	Asset1     string
+	Asset2     string
+	Amount1    sdk.Int
+	Amount2    sdk.Int
+	SwapFee    sdk.Dec
+	ExitFee    sdk.Dec
+	PoolId     uint64
+}
+
+type StableSwapPool struct {
+	initialLiquidity sdk.Coins
+	poolParams       stableswap.PoolParams
+	scalingFactors   []uint64
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (suite *KeeperTestSuite) SetupTest() {
+	suite.Setup()
+
+	encodingConfig := osmosisapp.MakeEncodingConfig()
+	suite.clientCtx = client.Context{}.
+		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
+		WithTxConfig(encodingConfig.TxConfig).
+		WithLegacyAmino(encodingConfig.Amino).
+		WithJSONCodec(encodingConfig.Marshaler)
+
+	// Set default configuration for testing
+	suite.balances = sdk.NewCoins(
+		sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin(types.AtomDenomination, sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("akash", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("bitcoin", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("canto", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("ethereum", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("juno", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE", sdk.NewIntFromBigInt(big.NewInt(1).Mul(big.NewInt(9000000000000000000), big.NewInt(10000)))),
+		sdk.NewCoin("ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("usdc", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("usdt", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("busd", sdk.NewInt(9000000000000000000)),
+		sdk.NewCoin("ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293", sdk.NewInt(9000000000000000000)),
+	)
+
+	suite.fundAllAccountsWith()
+	suite.Commit()
+
+	// Init pools
+	suite.setUpPools()
+	suite.Commit()
+
+	// Init search routes
+	suite.setUpTokenPairRoutes()
+	suite.Commit()
+}
+
+// setUpPools sets up the pools needed for testing
+// This creates several assets and pools between most of them (used in testing throughout the module)
+// akash <-> types.OsmosisDenomination
+// juno <-> types.OsmosisDenomination
+// ethereum <-> types.OsmosisDenomination
+// bitcoin <-> types.OsmosisDenomination
+// canto <-> types.OsmosisDenomination
+// and so on....
+func (suite *KeeperTestSuite) setUpPools() {
+	// Create any necessary sdk.Ints that require string conversion
+	pool28Amount1, ok := sdk.NewIntFromString("6170367464346955818920")
+	suite.Require().True(ok)
+
+	// Init pools
+	suite.pools = []Pool{
+		{ // Pool 1
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  1,
+		},
+		{ // Pool 2
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  2,
+		},
+		{ // Pool 3
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  3,
+		},
+		{ // Pool 4
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  4,
+		},
+		{ // Pool 5
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  5,
+		},
+		{ // Pool 6
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  6,
+		},
+		{ // Pool 7
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  7,
+		},
+		{ // Pool 8
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  8,
+		},
+		{ // Pool 9
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  9,
+		},
+		{ // Pool 10
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  10,
+		},
+		{ // Pool 11
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  11,
+		},
+		{ // Pool 12
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  12,
+		},
+		{ // Pool 13
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  13,
+		},
+		{ // Pool 14
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  14,
+		},
+		{ // Pool 15
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  15,
+		},
+		{ // Pool 16
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  16,
+		},
+		{ // Pool 17
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  17,
+		},
+		{ // Pool 18
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  18,
+		},
+		{ // Pool 19
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  19,
+		},
+		{ // Pool 20
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  20,
+		},
+		{ // Pool 21
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(0, 2),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  21,
+		},
+		{ // Pool 22
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(18986995439401)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(191801648570)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  22,
+		},
+		{ // Pool 23
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0", sdk.NewInt(72765460013038)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(596032233122)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(535, 5),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  23,
+		},
+		{ // Pool 24
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0", sdk.NewInt(165624820984787)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(13901565323)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  24,
+		},
+		{ // Pool 25
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(165624820984787)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(139015653231902)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  25,
+		},
+		{ // Pool 26
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(13305396712237)),
+					Weight: sdk.NewInt(50),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(171274446980)),
+					Weight: sdk.NewInt(50),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  26,
+		},
+		{ // Pool 27
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(15766179414665)),
+					Weight: sdk.NewInt(50),
+				},
+				{
+					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(13466662920841)),
+					Weight: sdk.NewInt(50),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  27,
+		},
+		{ // Pool 28
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE", pool28Amount1),
+					Weight: sdk.NewInt(25),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4", sdk.NewInt(6073813312)),
+					Weight: sdk.NewInt(25),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(403568175601)),
+					Weight: sdk.NewInt(25),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(6120465766)),
+					Weight: sdk.NewInt(25),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(4, 4),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  28,
+		},
+		{ // Pool 29
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("uosmo", sdk.NewInt(1000000000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("usdc", sdk.NewInt(2000000000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  29,
+		},
+		{ // Pool 30
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("uosmo", sdk.NewInt(1000000000)),
+					Weight: sdk.NewInt(1),
+				},
+				{
+					Token:  sdk.NewCoin("busd", sdk.NewInt(1000000000)),
+					Weight: sdk.NewInt(1),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(2, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  30,
+		},
+		{ // Pool 31
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE", pool28Amount1), // Amount didn't change on mainnet
+					Weight: sdk.NewInt(25),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4", sdk.NewInt(6073813312)),
+					Weight: sdk.NewInt(25),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(403523315860)),
+					Weight: sdk.NewInt(25),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(6121181710)),
+					Weight: sdk.NewInt(25),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(4, 4),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  31,
+		},
+		{ // Pool 32
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293", sdk.NewInt(23583984695)),
+					Weight: sdk.NewInt(70),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(381295003769)),
+					Weight: sdk.NewInt(30),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(3, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  32,
+		},
+		{ // Pool 33
+			PoolAssets: []balancertypes.PoolAsset{
+				{
+					Token:  sdk.NewCoin("ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293", sdk.NewInt(41552173575)),
+					Weight: sdk.NewInt(70),
+				},
+				{
+					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(10285796639)),
+					Weight: sdk.NewInt(30),
+				},
+			},
+			SwapFee: sdk.NewDecWithPrec(3, 3),
+			ExitFee: sdk.NewDecWithPrec(0, 2),
+			PoolId:  33,
+		},
+	}
+
+	for _, pool := range suite.pools {
+		suite.createGAMMPool(pool.PoolAssets, pool.SwapFee, pool.ExitFee)
+	}
+
+	suite.stableSwapPools = []StableSwapPool{
+		{ // Pool 34
+			initialLiquidity: sdk.NewCoins(
+				sdk.NewCoin("usdc", sdk.NewInt(1000000000000000)),
+				sdk.NewCoin("usdt", sdk.NewInt(1000000000000000)),
+				sdk.NewCoin("busd", sdk.NewInt(1000000000000000)),
+			),
+			poolParams: stableswap.PoolParams{
+				SwapFee: sdk.NewDecWithPrec(1, 4),
+				ExitFee: sdk.NewDecWithPrec(0, 2),
+			},
+			scalingFactors: []uint64{1, 1, 1},
+		}}
+
+	for _, pool := range suite.stableSwapPools {
+		suite.createStableswapPool(pool.initialLiquidity, pool.poolParams, pool.scalingFactors)
+	}
+
+	// Set all of the pool info into the stores
+	suite.App.AppKeepers.ProtoRevKeeper.EpochHooks().AfterEpochEnd(suite.Ctx, "week", 1)
+}
+
+// createStableswapPool creates a stableswap pool with the given pool assets and params
+func (suite *KeeperTestSuite) createStableswapPool(initialLiquidity sdk.Coins, poolParams stableswap.PoolParams, scalingFactors []uint64) {
+	_, err := suite.App.GAMMKeeper.CreatePool(
+		suite.Ctx,
+		stableswap.NewMsgCreateStableswapPool(suite.TestAccs[1], poolParams, initialLiquidity, scalingFactors, ""))
+	suite.Require().NoError(err)
+}
+
+// createGAMMPool creates a balancer pool with the given pool assets and params
+func (suite *KeeperTestSuite) createGAMMPool(poolAssets []balancertypes.PoolAsset, swapFee, exitFee sdk.Dec) uint64 {
+	poolParams := balancertypes.PoolParams{
+		SwapFee: swapFee,
+		ExitFee: exitFee,
+	}
+
+	return suite.prepareCustomBalancerPool(poolAssets, poolParams)
+}
+
+// prepareCustomBalancerPool creates a custom balancer pool with the given pool assets and params
+func (suite *KeeperTestSuite) prepareCustomBalancerPool(
+	poolAssets []balancertypes.PoolAsset,
+	poolParams balancer.PoolParams,
+) uint64 {
+	poolID, err := suite.App.GAMMKeeper.CreatePool(
+		suite.Ctx,
+		balancer.NewMsgCreateBalancerPool(suite.TestAccs[1], poolParams, poolAssets, ""),
+	)
+	suite.Require().NoError(err)
+
+	return poolID
+}
+
+// fundAllAccountsWith funds all the test accounts with the same amount of tokens
+func (suite *KeeperTestSuite) fundAllAccountsWith() {
+	for _, acc := range suite.TestAccs {
+		suite.FundAcc(acc, suite.balances)
+	}
+}
+
+// setUpTokenPairRoutes sets up the searcher routes for testing
+func (suite *KeeperTestSuite) setUpTokenPairRoutes() {
+	atomAkash := types.NewTrade(0, types.AtomDenomination, "akash")
+	akashBitcoin := types.NewTrade(14, "akash", "bitcoin")
+	atomBitcoin := types.NewTrade(4, "bitcoin", types.AtomDenomination)
+
+	suite.tokenPairArbRoutes = []*types.TokenPairArbRoutes{
+		{
+			TokenIn:  "akash",
+			TokenOut: types.AtomDenomination,
+			ArbRoutes: []*types.Route{
+				{
+					Trades: []*types.Trade{&atomAkash, &akashBitcoin, &atomBitcoin},
+				},
+			},
+		},
+	}
+
+	for _, tokenPair := range suite.tokenPairArbRoutes {
+		suite.App.AppKeepers.ProtoRevKeeper.SetTokenPairArbRoutes(suite.Ctx, tokenPair.TokenIn, tokenPair.TokenOut, tokenPair)
+	}
+}

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -93,12 +93,15 @@ func (k Keeper) SetOsmoPool(ctx sdk.Context, denom string, poolId uint64) {
 	store.Set(key, sdk.Uint64ToBigEndian(poolId))
 }
 
-// DeleteOsmoPool deletes the pool id of the Osmo pool for the given denom paired with Osmo
-func (k Keeper) DeleteOsmoPool(ctx sdk.Context, denom string) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixOsmoPools)
-	key := types.GetKeyPrefixOsmoPool(denom)
+// DeleteAllOsmoPools deletes all the Osmo pools
+func (k Keeper) DeleteAllOsmoPools(ctx sdk.Context) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixOsmoPools)
 
-	store.Delete(key)
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		store.Delete(iterator.Key())
+	}
 }
 
 // GetAtomPool returns the pool id of the Atom pool for the given denom paired with Atom
@@ -123,10 +126,13 @@ func (k Keeper) SetAtomPool(ctx sdk.Context, denom string, poolId uint64) {
 	store.Set(key, sdk.Uint64ToBigEndian(poolId))
 }
 
-// DeleteAtomPool deletes the pool id of the Atom pool for the given denom paired with Atom
-func (k Keeper) DeleteAtomPool(ctx sdk.Context, denom string) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixAtomPools)
-	key := types.GetKeyPrefixAtomPool(denom)
+// DeleteAllAtomPools deletes all the Atom pools
+func (k Keeper) DeleteAllAtomPools(ctx sdk.Context) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixAtomPools)
 
-	store.Delete(key)
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		store.Delete(iterator.Key())
+	}
 }

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -99,7 +99,7 @@ func (k Keeper) SetOsmoPool(ctx sdk.Context, denom string, poolId uint64) {
 	store.Set(key, sdk.Uint64ToBigEndian(poolId))
 }
 
-// DeleteAllOsmoPools deletes all the Osmo pools
+// DeleteAllOsmoPools deletes all the Osmo pools from modules store
 func (k Keeper) DeleteAllOsmoPools(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixOsmoPools)
@@ -132,7 +132,7 @@ func (k Keeper) SetAtomPool(ctx sdk.Context, denom string, poolId uint64) {
 	store.Set(key, sdk.Uint64ToBigEndian(poolId))
 }
 
-// DeleteAllAtomPools deletes all the Atom pools
+// DeleteAllAtomPools deletes all the Atom pools from modules store
 func (k Keeper) DeleteAllAtomPools(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixAtomPools)

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -68,13 +68,7 @@ func (k Keeper) SetTokenPairArbRoutes(ctx sdk.Context, tokenA, tokenB string, to
 
 // DeleteAllTokenPairArbRoutes deletes all the token pair arb routes
 func (k Keeper) DeleteAllTokenPairArbRoutes(ctx sdk.Context) {
-	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixTokenPairRoutes)
-
-	defer iterator.Close()
-	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
-	}
+	k.DeleteAllEntriesForKeyPrefix(ctx, types.KeyPrefixTokenPairRoutes)
 }
 
 // GetOsmoPool returns the pool id of the Osmo pool for the given denom paired with Osmo
@@ -101,13 +95,7 @@ func (k Keeper) SetOsmoPool(ctx sdk.Context, denom string, poolId uint64) {
 
 // DeleteAllOsmoPools deletes all the Osmo pools from modules store
 func (k Keeper) DeleteAllOsmoPools(ctx sdk.Context) {
-	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixOsmoPools)
-
-	defer iterator.Close()
-	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
-	}
+	k.DeleteAllEntriesForKeyPrefix(ctx, types.KeyPrefixOsmoPools)
 }
 
 // GetAtomPool returns the pool id of the Atom pool for the given denom paired with Atom
@@ -134,8 +122,13 @@ func (k Keeper) SetAtomPool(ctx sdk.Context, denom string, poolId uint64) {
 
 // DeleteAllAtomPools deletes all the Atom pools from modules store
 func (k Keeper) DeleteAllAtomPools(ctx sdk.Context) {
+	k.DeleteAllEntriesForKeyPrefix(ctx, types.KeyPrefixAtomPools)
+}
+
+// DeleteAllEntriesForKeyPrefix deletes all the entries from the store for the given key prefix
+func (k Keeper) DeleteAllEntriesForKeyPrefix(ctx sdk.Context, keyPrefix []byte) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixAtomPools)
+	iterator := sdk.KVStorePrefixIterator(store, keyPrefix)
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -1,0 +1,132 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ---------------------- Trading Stores  ---------------------- //
+
+// GetTokenPairArbRoutes returns the token pair arb routes given two denoms
+func (k Keeper) GetTokenPairArbRoutes(ctx sdk.Context, tokenA, tokenB string) (*types.TokenPairArbRoutes, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixTokenPairRoutes)
+	key := types.GetKeyPrefixRouteForTokenPair(tokenA, tokenB)
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		return nil, fmt.Errorf("no routes found for token pair %s-%s", tokenA, tokenB)
+	}
+
+	tokenPairArbRoutes := &types.TokenPairArbRoutes{}
+	tokenPairArbRoutes.Unmarshal(bz)
+
+	return tokenPairArbRoutes, nil
+}
+
+// GetAllTokenPairArbRoutes returns all the token pair arb routes
+func (k Keeper) GetAllTokenPairArbRoutes(ctx sdk.Context) (tokenPairs []*types.TokenPairArbRoutes) {
+	routes := make([]*types.TokenPairArbRoutes, 0)
+
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixTokenPairRoutes)
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		tokenPairArbRoutes := &types.TokenPairArbRoutes{}
+		tokenPairArbRoutes.Unmarshal(iterator.Value())
+
+		routes = append(routes, tokenPairArbRoutes)
+	}
+
+	return routes
+}
+
+// SetTokenPairArbRoutes sets the token pair arb routes given two denoms
+func (k Keeper) SetTokenPairArbRoutes(ctx sdk.Context, tokenA, tokenB string, tokenPair *types.TokenPairArbRoutes) (*types.TokenPairArbRoutes, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixTokenPairRoutes)
+	key := types.GetKeyPrefixRouteForTokenPair(tokenA, tokenB)
+
+	bz, err := tokenPair.Marshal()
+	if err != nil {
+		return tokenPair, err
+	}
+
+	store.Set(key, bz)
+
+	return tokenPair, nil
+}
+
+// DeleteAllTokenPairArbRoutes deletes all the token pair arb routes
+func (k Keeper) DeleteAllTokenPairArbRoutes(ctx sdk.Context) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixTokenPairRoutes)
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		store.Delete(iterator.Key())
+	}
+}
+
+// GetOsmoPool returns the pool id of the Osmo pool for the given denom paired with Osmo
+func (k Keeper) GetOsmoPool(ctx sdk.Context, denom string) (uint64, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixOsmoPools)
+	key := types.GetKeyPrefixOsmoPool(denom)
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		return 0, fmt.Errorf("no osmo pool for denom %s", denom)
+	}
+
+	poolId := sdk.BigEndianToUint64(bz)
+	return poolId, nil
+}
+
+// SetOsmoPool sets the pool id of the Osmo pool for the given denom paired with Osmo
+func (k Keeper) SetOsmoPool(ctx sdk.Context, denom string, poolId uint64) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixOsmoPools)
+	key := types.GetKeyPrefixOsmoPool(denom)
+
+	store.Set(key, sdk.Uint64ToBigEndian(poolId))
+}
+
+// DeleteOsmoPool deletes the pool id of the Osmo pool for the given denom paired with Osmo
+func (k Keeper) DeleteOsmoPool(ctx sdk.Context, denom string) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixOsmoPools)
+	key := types.GetKeyPrefixOsmoPool(denom)
+
+	store.Delete(key)
+}
+
+// GetAtomPool returns the pool id of the Atom pool for the given denom paired with Atom
+func (k Keeper) GetAtomPool(ctx sdk.Context, denom string) (uint64, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixAtomPools)
+	key := types.GetKeyPrefixAtomPool(denom)
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		return 0, fmt.Errorf("no atom pool for denom %s", denom)
+	}
+
+	poolId := sdk.BigEndianToUint64(bz)
+	return poolId, nil
+}
+
+// SetAtomPool sets the pool id of the Atom pool for the given denom paired with Atom
+func (k Keeper) SetAtomPool(ctx sdk.Context, denom string, poolId uint64) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixAtomPools)
+	key := types.GetKeyPrefixAtomPool(denom)
+
+	store.Set(key, sdk.Uint64ToBigEndian(poolId))
+}
+
+// DeleteAtomPool deletes the pool id of the Atom pool for the given denom paired with Atom
+func (k Keeper) DeleteAtomPool(ctx sdk.Context, denom string) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixAtomPools)
+	key := types.GetKeyPrefixAtomPool(denom)
+
+	store.Delete(key)
+}

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -22,13 +22,16 @@ func (k Keeper) GetTokenPairArbRoutes(ctx sdk.Context, tokenA, tokenB string) (*
 	}
 
 	tokenPairArbRoutes := &types.TokenPairArbRoutes{}
-	tokenPairArbRoutes.Unmarshal(bz)
+	err := tokenPairArbRoutes.Unmarshal(bz)
+	if err != nil {
+		return nil, err
+	}
 
 	return tokenPairArbRoutes, nil
 }
 
 // GetAllTokenPairArbRoutes returns all the token pair arb routes
-func (k Keeper) GetAllTokenPairArbRoutes(ctx sdk.Context) (tokenPairs []*types.TokenPairArbRoutes) {
+func (k Keeper) GetAllTokenPairArbRoutes(ctx sdk.Context) ([]*types.TokenPairArbRoutes, error) {
 	routes := make([]*types.TokenPairArbRoutes, 0)
 
 	store := ctx.KVStore(k.storeKey)
@@ -37,12 +40,15 @@ func (k Keeper) GetAllTokenPairArbRoutes(ctx sdk.Context) (tokenPairs []*types.T
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		tokenPairArbRoutes := &types.TokenPairArbRoutes{}
-		tokenPairArbRoutes.Unmarshal(iterator.Value())
+		err := tokenPairArbRoutes.Unmarshal(iterator.Value())
+		if err != nil {
+			return nil, err
+		}
 
 		routes = append(routes, tokenPairArbRoutes)
 	}
 
-	return routes
+	return routes, nil
 }
 
 // SetTokenPairArbRoutes sets the token pair arb routes given two denoms

--- a/x/protorev/keeper/protorev_test.go
+++ b/x/protorev/keeper/protorev_test.go
@@ -1,0 +1,160 @@
+package keeper_test
+
+import "github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+
+func (suite *KeeperTestSuite) TestGetAtomPool() {
+	cases := []struct {
+		description  string
+		denom        string
+		expectedPool uint64
+		exists       bool
+	}{
+		{
+			description:  "Atom pool exists for denom Akash",
+			denom:        "akash",
+			expectedPool: 1,
+			exists:       true,
+		},
+		{
+			description:  "Atom pool exists for denom juno",
+			denom:        "juno",
+			expectedPool: 2,
+			exists:       true,
+		},
+		{
+			description:  "Atom pool exists for denom juno with different casing",
+			denom:        "JuNo",
+			expectedPool: 2,
+			exists:       false,
+		},
+		{
+			description:  "Atom pool exists for denom Ethereum",
+			denom:        "ethereum",
+			expectedPool: 3,
+			exists:       true,
+		},
+		{
+			description:  "Atom pool does not exist for denom doge",
+			denom:        "doge",
+			expectedPool: 0,
+			exists:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.description, func() {
+			pool, err := suite.App.ProtoRevKeeper.GetAtomPool(suite.Ctx, tc.denom)
+
+			if tc.exists {
+				suite.Require().NoError(err)
+				suite.Require().Equal(tc.expectedPool, pool)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestDeleteAllAtomPools() {
+	suite.App.AppKeepers.ProtoRevKeeper.DeleteAllAtomPools(suite.Ctx)
+
+	// Iterate through all of the pools and check if any paired with Atom exist
+	for _, pool := range suite.pools {
+		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.AtomDenomination); match {
+			_, err := suite.App.AppKeepers.ProtoRevKeeper.GetAtomPool(suite.Ctx, otherDenom)
+			suite.Require().Error(err)
+		}
+	}
+}
+
+func (suite *KeeperTestSuite) TestGetOsmoPool() {
+	cases := []struct {
+		description  string
+		denom        string
+		expectedPool uint64
+		exists       bool
+	}{
+		{
+			description:  "Osmo pool exists for denom Akash",
+			denom:        "akash",
+			expectedPool: 7,
+			exists:       true,
+		},
+		{
+			description:  "Osmo pool exists for denom juno",
+			denom:        "juno",
+			expectedPool: 8,
+			exists:       true,
+		},
+		{
+			description:  "Empty string returns error",
+			denom:        "",
+			expectedPool: 0,
+			exists:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.description, func() {
+			pool, err := suite.App.ProtoRevKeeper.GetOsmoPool(suite.Ctx, tc.denom)
+
+			if tc.exists {
+				suite.Require().NoError(err)
+				suite.Require().Equal(tc.expectedPool, pool)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+
+}
+
+func (suite *KeeperTestSuite) TestDeleteAllOsmoPools() {
+	suite.App.AppKeepers.ProtoRevKeeper.DeleteAllOsmoPools(suite.Ctx)
+
+	// Iterate through all of the pools and check if any paired with Osmo exist
+	for _, pool := range suite.pools {
+		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.OsmosisDenomination); match {
+			_, err := suite.App.AppKeepers.ProtoRevKeeper.GetOsmoPool(suite.Ctx, otherDenom)
+			suite.Require().Error(err)
+		}
+	}
+}
+
+func (suite *KeeperTestSuite) TestGetTokenPairArbRoutes() {
+	// Tests that we can properly retrieve all of the routes that were set up
+	for _, tokenPair := range suite.tokenPairArbRoutes {
+		tokenPairArbRoutes, err := suite.App.ProtoRevKeeper.GetTokenPairArbRoutes(suite.Ctx, tokenPair.TokenIn, tokenPair.TokenOut)
+
+		suite.Require().NoError(err)
+		suite.Require().Equal(tokenPair, *tokenPairArbRoutes)
+	}
+
+	// Testing to see if we will not find a route that does not exist
+	_, err := suite.App.ProtoRevKeeper.GetTokenPairArbRoutes(suite.Ctx, "osmo", "abc")
+	suite.Require().Error(err)
+}
+
+func (suite *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
+	// Tests that we can properly retrieve all of the routes that were set up
+	tokenPairArbRoutes := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+
+	suite.Require().Equal(len(suite.tokenPairArbRoutes), len(tokenPairArbRoutes))
+	suite.Require().Equal(suite.tokenPairArbRoutes, tokenPairArbRoutes)
+}
+
+func (suite *KeeperTestSuite) TestDeleteAllTokenPairArbRoutes() {
+	// Tests that we can properly retrieve all of the routes that were set up
+	tokenPairArbRoutes := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+
+	suite.Require().Equal(len(suite.tokenPairArbRoutes), len(tokenPairArbRoutes))
+	suite.Require().Equal(suite.tokenPairArbRoutes, tokenPairArbRoutes)
+
+	// Delete all routes
+	suite.App.ProtoRevKeeper.DeleteAllTokenPairArbRoutes(suite.Ctx)
+
+	// Test after deletion
+	tokenPairArbRoutes = suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+
+	suite.Require().Equal(0, len(tokenPairArbRoutes))
+}

--- a/x/protorev/keeper/protorev_test.go
+++ b/x/protorev/keeper/protorev_test.go
@@ -137,7 +137,9 @@ func (suite *KeeperTestSuite) TestGetTokenPairArbRoutes() {
 
 func (suite *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
 	// Tests that we can properly retrieve all of the routes that were set up
-	tokenPairArbRoutes := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+	tokenPairArbRoutes, err := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+
+	suite.Require().NoError(err)
 
 	suite.Require().Equal(len(suite.tokenPairArbRoutes), len(tokenPairArbRoutes))
 	suite.Require().Equal(suite.tokenPairArbRoutes, tokenPairArbRoutes)
@@ -145,8 +147,9 @@ func (suite *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
 
 func (suite *KeeperTestSuite) TestDeleteAllTokenPairArbRoutes() {
 	// Tests that we can properly retrieve all of the routes that were set up
-	tokenPairArbRoutes := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+	tokenPairArbRoutes, err := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
 
+	suite.Require().NoError(err)
 	suite.Require().Equal(len(suite.tokenPairArbRoutes), len(tokenPairArbRoutes))
 	suite.Require().Equal(suite.tokenPairArbRoutes, tokenPairArbRoutes)
 
@@ -154,7 +157,8 @@ func (suite *KeeperTestSuite) TestDeleteAllTokenPairArbRoutes() {
 	suite.App.ProtoRevKeeper.DeleteAllTokenPairArbRoutes(suite.Ctx)
 
 	// Test after deletion
-	tokenPairArbRoutes = suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
+	tokenPairArbRoutes, err = suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
 
+	suite.Require().NoError(err)
 	suite.Require().Equal(0, len(tokenPairArbRoutes))
 }

--- a/x/protorev/keeper/protorev_test.go
+++ b/x/protorev/keeper/protorev_test.go
@@ -127,7 +127,7 @@ func (suite *KeeperTestSuite) TestGetTokenPairArbRoutes() {
 		tokenPairArbRoutes, err := suite.App.ProtoRevKeeper.GetTokenPairArbRoutes(suite.Ctx, tokenPair.TokenIn, tokenPair.TokenOut)
 
 		suite.Require().NoError(err)
-		suite.Require().Equal(tokenPair, *tokenPairArbRoutes)
+		suite.Require().Equal(tokenPair, tokenPairArbRoutes)
 	}
 
 	// Testing to see if we will not find a route that does not exist

--- a/x/protorev/keeper/protorev_test.go
+++ b/x/protorev/keeper/protorev_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import "github.com/osmosis-labs/osmosis/v13/x/protorev/types"
 
+// TestGetAtomPool tests the GetAtomPool function.
 func (suite *KeeperTestSuite) TestGetAtomPool() {
 	cases := []struct {
 		description  string
@@ -55,6 +56,7 @@ func (suite *KeeperTestSuite) TestGetAtomPool() {
 	}
 }
 
+// TestDeleteAllAtomPools tests the DeleteAllAtomPools function.
 func (suite *KeeperTestSuite) TestDeleteAllAtomPools() {
 	suite.App.AppKeepers.ProtoRevKeeper.DeleteAllAtomPools(suite.Ctx)
 
@@ -67,6 +69,7 @@ func (suite *KeeperTestSuite) TestDeleteAllAtomPools() {
 	}
 }
 
+// TestGetOsmoPool tests the GetOsmoPool function.
 func (suite *KeeperTestSuite) TestGetOsmoPool() {
 	cases := []struct {
 		description  string
@@ -109,6 +112,7 @@ func (suite *KeeperTestSuite) TestGetOsmoPool() {
 
 }
 
+// TestDeleteAllOsmoPools tests the DeleteAllOsmoPools function.
 func (suite *KeeperTestSuite) TestDeleteAllOsmoPools() {
 	suite.App.AppKeepers.ProtoRevKeeper.DeleteAllOsmoPools(suite.Ctx)
 
@@ -121,6 +125,7 @@ func (suite *KeeperTestSuite) TestDeleteAllOsmoPools() {
 	}
 }
 
+// TestGetTokenPairArbRoutes tests the GetTokenPairArbRoutes function.
 func (suite *KeeperTestSuite) TestGetTokenPairArbRoutes() {
 	// Tests that we can properly retrieve all of the routes that were set up
 	for _, tokenPair := range suite.tokenPairArbRoutes {
@@ -135,6 +140,7 @@ func (suite *KeeperTestSuite) TestGetTokenPairArbRoutes() {
 	suite.Require().Error(err)
 }
 
+// TestGetAllTokenPairArbRoutes tests the GetAllTokenPairArbRoutes function.
 func (suite *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
 	// Tests that we can properly retrieve all of the routes that were set up
 	tokenPairArbRoutes, err := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)
@@ -145,6 +151,7 @@ func (suite *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
 	suite.Require().Equal(suite.tokenPairArbRoutes, tokenPairArbRoutes)
 }
 
+// TestDeleteAllTokenPairArbRoutes tests the DeleteAllTokenPairArbRoutes function.
 func (suite *KeeperTestSuite) TestDeleteAllTokenPairArbRoutes() {
 	// Tests that we can properly retrieve all of the routes that were set up
 	tokenPairArbRoutes, err := suite.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(suite.Ctx)

--- a/x/protorev/keeper/protorev_test.go
+++ b/x/protorev/keeper/protorev_test.go
@@ -62,7 +62,7 @@ func (suite *KeeperTestSuite) TestDeleteAllAtomPools() {
 
 	// Iterate through all of the pools and check if any paired with Atom exist
 	for _, pool := range suite.pools {
-		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.AtomDenomination); match {
+		if otherDenom, match := types.CheckOsmoAtomDenomMatch(pool.Asset1, pool.Asset2, types.AtomDenomination); match {
 			_, err := suite.App.AppKeepers.ProtoRevKeeper.GetAtomPool(suite.Ctx, otherDenom)
 			suite.Require().Error(err)
 		}
@@ -118,7 +118,7 @@ func (suite *KeeperTestSuite) TestDeleteAllOsmoPools() {
 
 	// Iterate through all of the pools and check if any paired with Osmo exist
 	for _, pool := range suite.pools {
-		if otherDenom, match := types.CheckMatchAndReturnOther(pool.Asset1, pool.Asset2, types.OsmosisDenomination); match {
+		if otherDenom, match := types.CheckOsmoAtomDenomMatch(pool.Asset1, pool.Asset2, types.OsmosisDenomination); match {
 			_, err := suite.App.AppKeepers.ProtoRevKeeper.GetOsmoPool(suite.Ctx, otherDenom)
 			suite.Require().Error(err)
 		}

--- a/x/protorev/types/keys.go
+++ b/x/protorev/types/keys.go
@@ -10,3 +10,36 @@ const (
 	// RouterKey defines the module's message routing key
 	RouterKey = ModuleName
 )
+
+const (
+	prefixTokenPairRoutes = iota + 1
+	prefixOsmoPools
+	prefixAtomPools
+)
+
+var (
+	// -------------- Keys for trading stores -------------- //
+	// KeyPrefixTokenPairRoutes is the prefix for the TokenPairArbRoutes store
+	KeyPrefixTokenPairRoutes = []byte{prefixTokenPairRoutes}
+
+	// KeyPrefixOsmoPools is the prefix for the osmo pool store
+	KeyPrefixOsmoPools = []byte{prefixOsmoPools}
+
+	// KeyPrefixAtomPools is the prefix for the atom pool store
+	KeyPrefixAtomPools = []byte{prefixAtomPools}
+)
+
+// Returns the key needed to fetch the osmo pool for a given denom
+func GetKeyPrefixOsmoPool(denom string) []byte {
+	return append(KeyPrefixOsmoPools, []byte(denom)...)
+}
+
+// Returns the key needed to fetch the atom pool for a given denom
+func GetKeyPrefixAtomPool(denom string) []byte {
+	return append(KeyPrefixAtomPools, []byte(denom)...)
+}
+
+// Returns the key needed to fetch the tokenPair routes for a given pair of tokens
+func GetKeyPrefixRouteForTokenPair(tokenA, tokenB string) []byte {
+	return append(KeyPrefixTokenPairRoutes, []byte(tokenA+tokenB)...)
+}

--- a/x/protorev/types/keys.go
+++ b/x/protorev/types/keys.go
@@ -41,5 +41,5 @@ func GetKeyPrefixAtomPool(denom string) []byte {
 
 // Returns the key needed to fetch the tokenPair routes for a given pair of tokens
 func GetKeyPrefixRouteForTokenPair(tokenA, tokenB string) []byte {
-	return append(KeyPrefixTokenPairRoutes, []byte(tokenA+tokenB)...)
+	return append(KeyPrefixTokenPairRoutes, []byte(tokenA+"|"+tokenB)...)
 }

--- a/x/protorev/types/utils.go
+++ b/x/protorev/types/utils.go
@@ -1,7 +1,7 @@
 package types
 
 // Checks if the matching variable matches one of the tokens and if so returns the other and true
-func CheckMatchAndReturnOther(tokenA, tokenB, match string) (string, bool) {
+func CheckOsmoAtomDenomMatch(tokenA, tokenB, match string) (string, bool) {
 	if tokenA == match {
 		return tokenB, true
 	} else if tokenB == match {


### PR DESCRIPTION
## What is the purpose of the change

This PR includes all of the store keys + setters/getters needed to build cyclic arbitrage routes as well as the epoch hook which helps construct the stores. 

## Brief Changelog
- *Keys for keeper*
- *Setters and getters for TokenPairArbRoutes*
- *Setters and getters for Osmo Pools*
- *Setters and getters for Atom Pools*
- *Epoch hook runs after every week to update the highest liquidity pool pairings*

## Testing and Verifying
This PR will also include our testing environment that is configured through `keeper_test.go`. This test suite initializes user accounts for trading, creates over 30 pools, sets up token pair routes, and allows us to test all of the setters and getters for stateful information.

This change added tests and can be verified as follows:

- *Added unit tests for OsmoPools*
- *Added unit tests for AtomPools*
- *Added unit tests for TokenPairArbRoutes*
- *Added unit tests for the Epoch Hook*

## Documentation and Release Note
#### Keeper Updates
| State Object | Description | Key | Values | Store |
| --- | --- | --- | --- | --- |
| TokenPairArbRoutes | TokenPairRoutes tracks cyclic arb routes that can be used to create a MultiHopSwap given two denoms | []byte{1} + []byte{inputDenom} +[]byte{outputDenom} | []byte{TokenPairArbRoutes} | KV |
| OsmoPools | List of highest liquidity pools for every token pair with Osmo | []byte{2} + []byte{tokenDenom} | []byte{poolID} | KV |
| AtomPools | List of highest liquidity pools for every token pair with Atom | []byte{3} + []byte{tokenDenom} | []byte{poolID} | KV |

**TokenPairArbRoutes**
Each hot route configured through the admin account must be stored in the keeper. Each Route will be indexed by an input and output denomination. The value will correspond to a TokenPairArbRoutes object which contains a list of lists which correspond to routes that may be taken.

**OsmoPools**
This tracks the highest liquidity pools for every single asset that Osmo is paired with on-chain. This is updated through the epoch hook and on genesis.

**AtomPools**
This tracks the highest liquidity pools for every single asset that Atom is paired with on-chain. This is updated through the epoch hook and on genesis.

**Epoch Hook**
The Epoch hook allows the module to update the highest liquidity pools and distribute developer profits (implemented in a later PR) after every week while incrementally tracking profits through the day epoch identifier. 

### Highest Liquidity Pools
One method of determining cyclic arbitrage opportunities is to use the highest liquidity pools paired with Atom and Osmo. While this calculation is done on genesis, the pools may restructure over time and new tokens may end up being traded heavily with Osmo or Atom. As such, it is necessary to update this over time so that the module’s logic in determining cyclic arbitrage opportunities is most optimal. Using the `AfterEpochEnd` hook in combination with the `week` epoch identifier, we are able to successfully update the pool information every week. At runtime, `UpdatePools` will be executed and all of the pools updated.