### PR TITLE
Gamm code improvements

### DIFF
--- a/osmoutils/conv_helper.go
+++ b/osmoutils/conv_helper.go
@@ -1,4 +1,4 @@
-package utils
+package osmoutils
 
 import (
 	"encoding/binary"

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -310,6 +310,10 @@ func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, fs *flag.FlagSet) (
 			return nil, err
 		}
 
+		if len(targetPoolAssetCoins) != len(poolAssetCoins) {
+			return txf, nil, errors.New("initial pool weights and target pool weights should have same length")
+		}
+
 		var targetPoolAssets []balancer.PoolAsset
 		for i := 0; i < len(targetPoolAssetCoins); i++ {
 			if targetPoolAssetCoins[i].Denom != poolAssetCoins[i].Denom {

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -311,7 +311,7 @@ func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, fs *flag.FlagSet) (
 		}
 
 		if len(targetPoolAssetCoins) != len(poolAssetCoins) {
-			return txf, nil, errors.New("initial pool weights and target pool weights should have same length")
+			return nil, errors.New("initial pool weights and target pool weights should have same length")
 		}
 
 		var targetPoolAssets []balancer.PoolAsset

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -360,7 +360,7 @@ func (k Keeper) JoinSwapShareAmountOut(
 	}
 
 	if tokenInAmount.GT(tokenInMaxAmount) {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, "%d resulted tokens is larger than the max amount of %d", tokenInAmount.Int64(), tokenInMaxAmount.Int64())
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, "%s resulted tokens is larger than the max amount of %s", tokenInAmount, tokenInMaxAmount)
 	}
 
 	tokenIn := sdk.NewCoins(sdk.NewCoin(tokenInDenom, tokenInAmount))

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -17,9 +17,9 @@ import (
 
 //nolint:deadcode
 const (
-	nonPostiveSharesAmountErrFormat = "shares amount must be positive, was %d"
-	nonPostiveTokenAmountErrFormat  = "token amount must be positive, was %d"
-	sharesLargerThanMaxErrFormat    = "%d resulted shares is larger than the max amount of %d"
+	nonPostiveSharesAmountErrFormat = "shares amount must be positive, was %s"
+	nonPostiveTokenAmountErrFormat  = "token amount must be positive, was %s"
+	sharesLargerThanMaxErrFormat    = "%s resulted shares is larger than the max amount of %s"
 	invalidInputDenomsErrFormat     = "input denoms must already exist in the pool (%s)"
 
 	failedInterimLiquidityUpdateErrFormat        = "failed to update interim liquidity - pool asset %s does not exist"
@@ -894,7 +894,7 @@ func (p *Pool) CalcTokenInShareAmountOut(
 	).Ceil().TruncateInt()
 
 	if !tokenInAmount.IsPositive() {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveTokenAmountErrFormat, tokenInAmount.Int64())
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveTokenAmountErrFormat, tokenInAmount)
 	}
 
 	return tokenInAmount, nil
@@ -921,7 +921,7 @@ func (p *Pool) JoinPoolTokenInMaxShareAmountOut(
 	).TruncateInt()
 
 	if !tokenInAmount.IsPositive() {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveTokenAmountErrFormat, tokenInAmount.Int64())
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveTokenAmountErrFormat, tokenInAmount)
 	}
 
 	poolAssetIn.Token.Amount = poolAssetIn.Token.Amount.Add(tokenInAmount)
@@ -953,11 +953,11 @@ func (p *Pool) ExitSwapExactAmountOut(
 	).TruncateInt()
 
 	if !sharesIn.IsPositive() {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveSharesAmountErrFormat, sharesIn.Int64())
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveSharesAmountErrFormat, sharesIn)
 	}
 
 	if sharesIn.GT(shareInMaxAmount) {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, sharesLargerThanMaxErrFormat, sharesIn.Int64(), shareInMaxAmount.Uint64())
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMaxAmount, sharesLargerThanMaxErrFormat, sharesIn, shareInMaxAmount)
 	}
 
 	if err := p.exitPool(ctx, sdk.NewCoins(tokenOut), sharesIn); err != nil {

--- a/x/gamm/pool-models/balancer/pool_asset.go
+++ b/x/gamm/pool-models/balancer/pool_asset.go
@@ -5,8 +5,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 	"gopkg.in/yaml.v2"
+
+	"github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -69,11 +70,11 @@ func sortPoolAssetsByDenom(assets []PoolAsset) {
 
 func validateUserSpecifiedPoolAssets(assets []PoolAsset) error {
 	// The pool must be swapping between at least two assets
-	if len(assets) < 2 {
+	if len(assets) < types.MinNumOfAssetsInPool {
 		return types.ErrTooFewPoolAssets
 	}
 
-	if len(assets) > 8 {
+	if len(assets) > types.MaxNumOfAssetsInPool {
 		return sdkerrors.Wrapf(types.ErrTooManyPoolAssets, "%d", len(assets))
 	}
 

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -14,6 +14,10 @@ const (
 	StableswapMinScaledAmtPerAsset = 1
 	// We keep this multiplier at 1, but can increase if needed in the unlikely scenario where default scaling factors of 1 cannot accommodate enough assets
 	ScalingFactorMultiplier = 1
+
+	// pools can be created with min and max number of assets defined with this constants
+	MinNumOfAssetsInPool = 2
+	MaxNumOfAssetsInPool = 8
 )
 
 var (

--- a/x/incentives/keeper/msg_server.go
+++ b/x/incentives/keeper/msg_server.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/utils"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/incentives/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -45,7 +45,7 @@ func (server msgServer) CreateGauge(goCtx context.Context, msg *types.MsgCreateG
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeEvtCreateGauge,
-			sdk.NewAttribute(types.AttributeGaugeID, utils.Uint64ToString(gaugeID)),
+			sdk.NewAttribute(types.AttributeGaugeID, osmoutils.Uint64ToString(gaugeID)),
 		),
 	})
 
@@ -72,7 +72,7 @@ func (server msgServer) AddToGauge(goCtx context.Context, msg *types.MsgAddToGau
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeEvtAddToGauge,
-			sdk.NewAttribute(types.AttributeGaugeID, utils.Uint64ToString(msg.GaugeId)),
+			sdk.NewAttribute(types.AttributeGaugeID, osmoutils.Uint64ToString(msg.GaugeId)),
 		),
 	})
 

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/utils"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/lockup/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -49,7 +49,7 @@ func (server msgServer) LockTokens(goCtx context.Context, msg *types.MsgLockToke
 		ctx.EventManager().EmitEvents(sdk.Events{
 			sdk.NewEvent(
 				types.TypeEvtAddTokensToLock,
-				sdk.NewAttribute(types.AttributePeriodLockID, utils.Uint64ToString(lockID)),
+				sdk.NewAttribute(types.AttributePeriodLockID, osmoutils.Uint64ToString(lockID)),
 				sdk.NewAttribute(types.AttributePeriodLockOwner, msg.Owner),
 				sdk.NewAttribute(types.AttributePeriodLockAmount, msg.Coins.String()),
 			),
@@ -66,7 +66,7 @@ func (server msgServer) LockTokens(goCtx context.Context, msg *types.MsgLockToke
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeEvtLockTokens,
-			sdk.NewAttribute(types.AttributePeriodLockID, utils.Uint64ToString(lock.ID)),
+			sdk.NewAttribute(types.AttributePeriodLockID, osmoutils.Uint64ToString(lock.ID)),
 			sdk.NewAttribute(types.AttributePeriodLockOwner, lock.Owner),
 			sdk.NewAttribute(types.AttributePeriodLockAmount, lock.Coins.String()),
 			sdk.NewAttribute(types.AttributePeriodLockDuration, lock.Duration.String()),
@@ -136,7 +136,7 @@ func (server msgServer) BeginUnlockingAll(goCtx context.Context, msg *types.MsgB
 func createBeginUnlockEvent(lock *types.PeriodLock) sdk.Event {
 	return sdk.NewEvent(
 		types.TypeEvtBeginUnlock,
-		sdk.NewAttribute(types.AttributePeriodLockID, utils.Uint64ToString(lock.ID)),
+		sdk.NewAttribute(types.AttributePeriodLockID, osmoutils.Uint64ToString(lock.ID)),
 		sdk.NewAttribute(types.AttributePeriodLockOwner, lock.Owner),
 		sdk.NewAttribute(types.AttributePeriodLockDuration, lock.Duration.String()),
 		sdk.NewAttribute(types.AttributePeriodLockUnlockTime, lock.EndTime.String()),
@@ -167,7 +167,7 @@ func (server msgServer) ExtendLockup(goCtx context.Context, msg *types.MsgExtend
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeEvtLockTokens,
-			sdk.NewAttribute(types.AttributePeriodLockID, utils.Uint64ToString(lock.ID)),
+			sdk.NewAttribute(types.AttributePeriodLockID, osmoutils.Uint64ToString(lock.ID)),
 			sdk.NewAttribute(types.AttributePeriodLockOwner, lock.Owner),
 			sdk.NewAttribute(types.AttributePeriodLockDuration, lock.Duration.String()),
 		),

--- a/x/superfluid/keeper/internal/events/emit.go
+++ b/x/superfluid/keeper/internal/events/emit.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/x/gamm/utils"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/superfluid/types"
 )
 
@@ -57,7 +57,7 @@ func EmitSuperfluidDelegateEvent(ctx sdk.Context, lockId uint64, valAddress stri
 func newSuperfluidDelegateEvent(lockId uint64, valAddress string) sdk.Event {
 	return sdk.NewEvent(
 		types.TypeEvtSuperfluidDelegate,
-		sdk.NewAttribute(types.AttributeLockId, utils.Uint64ToString(lockId)),
+		sdk.NewAttribute(types.AttributeLockId, osmoutils.Uint64ToString(lockId)),
 		sdk.NewAttribute(types.AttributeValidator, valAddress),
 	)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR is created during the Informal Systems audit, after analysis of the existing specification and code inspection
Auditing is performed on commit hash: https://github.com/osmosis-labs/osmosis/commit/42d73f1cc1c52e85561518be1014b730ef6b7a12
This PR contains minor GAMM module code improvements noticed during code inspection with the aim of finding issues.


## Brief Changelog

- gamm/utils/conv.go is moved to osmoutils package and renamed to conv_helper.go - because helper functions were used not only from the GAMM module but from other modules as well
- Some unsafe arithmetic operations were noticed -> sdk.Int values were cast to Int64 during error wrapping. This will not lead to aborting the tx because the possible issues are during returning of error (in already aborted tx), also string formatting was changed, due to sdk.Int numbers.
- gamm/types/constants.go updated - two new constants added, holding the number of min and max possible denominations in pools
- one issue on CLI fixed - possible index out of range in NewBuildCreateBalancerPoolMsg

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework/code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduces a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?  no
  - How is the feature or change documented? not applicable 