### PR TITLE
x/epochs: osmocli tests migrate

### DIFF
--- a/x/epochs/client/cli/cli_test.go
+++ b/x/epochs/client/cli/cli_test.go
@@ -1,113 +1,33 @@
 package cli_test
 
 import (
-	"github.com/gogo/protobuf/proto"
-	"github.com/stretchr/testify/suite"
+	"testing"
 
-	"github.com/osmosis-labs/osmosis/v13/app"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils/osmocli"
 	"github.com/osmosis-labs/osmosis/v13/x/epochs/client/cli"
 	"github.com/osmosis-labs/osmosis/v13/x/epochs/types"
-
-	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
-	"github.com/cosmos/cosmos-sdk/testutil/network"
 )
 
-type IntegrationTestSuite struct {
-	suite.Suite
-
-	cfg     network.Config
-	network *network.Network
-}
-
-func (s *IntegrationTestSuite) SetupSuite() {
-	s.T().Log("setting up integration test suite")
-
-	s.cfg = app.DefaultConfig()
-
-	s.network = network.New(s.T(), s.cfg)
-
-	_, err := s.network.WaitForHeight(1)
-	s.Require().NoError(err)
-}
-
-func (s *IntegrationTestSuite) TearDownSuite() {
-	s.T().Log("tearing down integration test suite")
-	s.network.Cleanup()
-}
-
-func (s *IntegrationTestSuite) TestGetCmdCurrentEpoch() {
-	val := s.network.Validators[0]
-
-	testCases := []struct {
-		name       string
-		identifier string
-		expectErr  bool
-		respType   proto.Message
-	}{
-		{
-			"query weekly epoch number",
-			"weekly",
-			false, &types.QueryCurrentEpochResponse{},
-		},
-		{
-			"query unavailable epoch number",
-			"unavailable",
-			false, &types.QueryCurrentEpochResponse{},
+func TestGetCmdCurrentEpoch(t *testing.T) {
+	desc, _ := cli.GetCmdCurrentEpoch()
+	tcs := map[string]osmocli.QueryCliTestCase[*types.QueryCurrentEpochRequest]{
+		"basic test": {
+			Cmd: "day",
+			ExpectedQuery: &types.QueryCurrentEpochRequest{
+				Identifier: "day",
+			},
 		},
 	}
-
-	for _, tc := range testCases {
-		tc := tc
-
-		s.Run(tc.name, func() {
-			cmd := cli.GetCmdCurrentEpoch()
-			clientCtx := val.ClientCtx
-
-			args := []string{
-				tc.identifier,
-			}
-
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
-			if tc.expectErr {
-				s.Require().Error(err)
-			} else {
-				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
-			}
-		})
-	}
+	osmocli.RunQueryTestCases(t, desc, tcs)
 }
 
-func (s *IntegrationTestSuite) TestGetCmdEpochsInfos() {
-	val := s.network.Validators[0]
-
-	testCases := []struct {
-		name      string
-		expectErr bool
-		respType  proto.Message
-	}{
-		{
-			"query epoch infos",
-			false, &types.QueryEpochsInfoResponse{},
+func TestGetCmdEpochsInfo(t *testing.T) {
+	desc, _ := cli.GetCmdEpochInfos()
+	tcs := map[string]osmocli.QueryCliTestCase[*types.QueryEpochsInfoRequest]{
+		"basic test": {
+			Cmd:           "",
+			ExpectedQuery: &types.QueryEpochsInfoRequest{},
 		},
 	}
-
-	for _, tc := range testCases {
-		tc := tc
-
-		s.Run(tc.name, func() {
-			cmd := cli.GetCmdCurrentEpoch()
-			clientCtx := val.ClientCtx
-
-			args := []string{}
-
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
-			if tc.expectErr {
-				s.Require().Error(err)
-			} else {
-				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
-			}
-		})
-	}
+	osmocli.RunQueryTestCases(t, desc, tcs)
 }

--- a/x/epochs/client/cli/query.go
+++ b/x/epochs/client/cli/query.go
@@ -20,12 +20,14 @@ func GetCmdEpochInfos() (*osmocli.QueryDescriptor, *types.QueryEpochsInfoRequest
 	return &osmocli.QueryDescriptor{
 		Use:   "epoch-infos",
 		Short: "Query running epoch infos.",
-		Long:  `{{.Short}}{{.ExampleHeader}}`}, &types.QueryEpochsInfoRequest{}
+		Long: `{{.Short}}{{.ExampleHeader}}
+		{{.CommandPrefix}}`}, &types.QueryEpochsInfoRequest{}
 }
 
 func GetCmdCurrentEpoch() (*osmocli.QueryDescriptor, *types.QueryCurrentEpochRequest) {
 	return &osmocli.QueryDescriptor{
 		Use:   "current-epoch",
 		Short: "Query current epoch by specified identifier.",
-		Long:  `{{.Short}}{{.ExampleHeader}}`}, &types.QueryCurrentEpochRequest{}
+		Long: `{{.Short}}{{.ExampleHeader}}
+		{{.CommandPrefix}} day`}, &types.QueryCurrentEpochRequest{}
 }

--- a/x/epochs/client/cli/query.go
+++ b/x/epochs/client/cli/query.go
@@ -10,33 +10,22 @@ import (
 // GetQueryCmd returns the cli query commands for this module.
 func GetQueryCmd() *cobra.Command {
 	cmd := osmocli.QueryIndexCmd(types.ModuleName)
-
-	cmd.AddCommand(
-		GetCmdEpochsInfos(),
-		GetCmdCurrentEpoch(),
-	)
+	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdEpochInfos)
+	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdCurrentEpoch)
 
 	return cmd
 }
 
-func GetCmdEpochsInfos() *cobra.Command {
-	return osmocli.SimpleQueryCmd[*types.QueryEpochsInfoRequest](
-		"epoch-infos",
-		"Query running epochInfos",
-		`{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} epoch-infos
-`,
-		types.ModuleName, types.NewQueryClient,
-	)
+func GetCmdEpochInfos() (*osmocli.QueryDescriptor, *types.QueryEpochsInfoRequest) {
+	return &osmocli.QueryDescriptor{
+		Use:   "epoch-infos",
+		Short: "Query running epoch infos.",
+		Long:  `{{.Short}}{{.ExampleHeader}}`}, &types.QueryEpochsInfoRequest{}
 }
 
-func GetCmdCurrentEpoch() *cobra.Command {
-	return osmocli.SimpleQueryCmd[*types.QueryCurrentEpochRequest](
-		"current-epoch [identifier]",
-		"Query current epoch by specified identifier",
-		`{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} current-epoch day
-`,
-		types.ModuleName, types.NewQueryClient,
-	)
+func GetCmdCurrentEpoch() (*osmocli.QueryDescriptor, *types.QueryCurrentEpochRequest) {
+	return &osmocli.QueryDescriptor{
+		Use:   "current-epoch",
+		Short: "Query current epoch by specified identifier.",
+		Long:  `{{.Short}}{{.ExampleHeader}}`}, &types.QueryCurrentEpochRequest{}
 }


### PR DESCRIPTION
`x/epochs` test `osmocli`