### PR TITLE
feat(osmomath): BigDec power function with integer exponent, overflow tests at max spot price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The v1beta1 queries actually have base asset and quote asset reversed, so you were always getting 1/correct spot price. People fixed this by reordering the arguments.
   - This PR adds v2 queries for doing the correct thing, and giving people time to migrate from v1beta1 queries to v2.
   - It also changes cosmwasm to only allow the v2 queries, as no contracts on Osmosis mainnet uses the v1beta1 queries.
+* [#3676](https://github.com/osmosis-labs/osmosis/pull/3676) implement `PowerInteger` function on `osmomath.BigDec` 
 
 
 ### Bug fixes

--- a/osmomath/decimal.go
+++ b/osmomath/decimal.go
@@ -972,3 +972,23 @@ func (x BigDec) CustomBaseLog(base BigDec) BigDec {
 
 	return y
 }
+
+// PowerInteger takes a given decimal to an integer power
+// and returns the result. Non-mutative. Uses square and multiply
+// algorithm for performing the calculation.
+func (d BigDec) PowerInteger(power uint64) BigDec {
+	if power == 0 {
+		return OneDec()
+	}
+	tmp := OneDec()
+
+	for i := power; i > 1; {
+		if i%2 != 0 {
+			tmp = tmp.Mul(d)
+		}
+		i /= 2
+		d = d.Mul(d)
+	}
+
+	return d.Mul(tmp)
+}

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -1116,6 +1116,18 @@ func (s *decimalTestSuite) TestPowerInteger() {
 
 			expectedResult: NewBigDec(81),
 		},
+		"-3 ^ 50 = 717897987691852588770249": {
+			base:     NewBigDec(-3),
+			exponent: 50,
+
+			expectedResult: MustNewDecFromStr("717897987691852588770249"),
+		},
+		"-3 ^ 51 = -2153693963075557766310747": {
+			base:     NewBigDec(-3),
+			exponent: 51,
+
+			expectedResult: MustNewDecFromStr("-2153693963075557766310747"),
+		},
 		"1.414213562373095049 ^ 2 = 2": {
 			base:     NewDecWithPrec(1414213562373095049, 18),
 			exponent: 2,

--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -18,6 +18,9 @@ var (
 	one_half sdk.Dec = sdk.MustNewDecFromStr("0.5")
 	one      sdk.Dec = sdk.OneDec()
 	two      sdk.Dec = sdk.MustNewDecFromStr("2")
+
+	// https://www.wolframalpha.com/input?i=2.718281828459045235360287471352662498&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
+	eulersNumber = MustNewDecFromStr("2.718281828459045235360287471352662498")
 )
 
 // Returns the internal "power precision".

--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -20,6 +20,7 @@ var (
 	two      sdk.Dec = sdk.MustNewDecFromStr("2")
 
 	// https://www.wolframalpha.com/input?i=2.718281828459045235360287471352662498&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
+	// nolint: unused
 	eulersNumber = MustNewDecFromStr("2.718281828459045235360287471352662498")
 )
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: https://github.com/osmosis-labs/osmosis/issues/3013

## What is the purpose of the change

This PR introduces a `PowerInteger` function defined on `BigDec` to compute the power with an integer exponent.
The implementation is copied over from [`sdk.Dec`](https://github.com/osmosis-labs/cosmos-sdk/blob/f6e51566a5d878c561bc73fa4f0852ad6e02aa3c/types/decimal.go#L466) and uses square and multiply algorithm.

All pre-existing tests are also copied from the SDK and pass. More tests around max spot price are added to ensure that there are no-overflows occurring in geometric twap.

This function will be used by the future `Power` function that takes a decimal exponent. In that function, we split integer and non-integer part of the exponent. The integer part will be computed using this `PowerInteger` function. The non-integer part will be computed using Chebyshev Rational Approximation with 13 parameters. The progress towards that can be seen in: https://github.com/osmosis-labs/osmosis/pull/3620