### PR TITLE
ProtoRev: Route building

### DIFF
--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -65,9 +65,9 @@ func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, 
 // BuildTradeInfoHotRoute constructs a cyclic arbitrage route given a hot route from the store and information about the swap that should be placed
 // in the hot route.
 func (k Keeper) BuildTradeInfoHotRoute(ctx sdk.Context, route *types.Route, tokenIn, tokenOut string, poolId uint64) (Route, error) {
-	newRoute := Route{}
+	newRoute := Route{Trades: make([]TradeInfo, len(route.Trades))}
 
-	for _, trade := range route.Trades {
+	for index, trade := range route.Trades {
 		var newTrade TradeInfo
 		// 0 is a placeholder for swaps that should be entered into the hot route
 		if trade.Pool == 0 {
@@ -96,7 +96,7 @@ func (k Keeper) BuildTradeInfoHotRoute(ctx sdk.Context, route *types.Route, toke
 			}
 		}
 
-		newRoute.Trades = append(newRoute.Trades, newTrade)
+		newRoute.Trades[index] = newTrade
 	}
 
 	if err := k.CheckValidHotRoute(newRoute); err != nil {

--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -16,11 +16,15 @@ type TradeInfo struct {
 	Pool        gammtypes.CFMMPoolI
 }
 
-// BuildRoutes builds all of the possible arbitrage routes given the given tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) [][]TradeInfo {
-	routes := make([][]TradeInfo, 0)
+type Route struct {
+	Trades []TradeInfo
+}
 
-	// Check hot routes if enabled
+// BuildRoutes builds all of the possible arbitrage routes given the tokenIn, tokenOut and poolId that were used in the swap
+func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) []Route {
+	routes := make([]Route, 0)
+
+	// Append hot routes if they exist
 	if tokenPairRoutes, err := k.BuildTokenPairRoutes(ctx, tokenIn, tokenOut, poolId); err == nil {
 		routes = append(routes, tokenPairRoutes...)
 	}
@@ -39,55 +43,18 @@ func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId ui
 }
 
 // BuildTokenPairRoutes builds all of the possible arbitrage routes from the hot routes given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([][]TradeInfo, error) {
+func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]Route, error) {
 	// Get all of the routes from the store that match the given tokenIn and tokenOut
 	tokenPairArbRoutes, err := k.GetTokenPairArbRoutes(ctx, tokenIn, tokenOut)
 	if err != nil {
-		return [][]TradeInfo{}, err
+		return []Route{}, err
 	}
 
 	// Iterate through all of the routes and build hot routes
-	routes := make([][]TradeInfo, 0)
+	routes := make([]Route, 0)
 	for _, route := range tokenPairArbRoutes.ArbRoutes {
-		newRoute := make([]TradeInfo, 0)
-
-		var newTrade TradeInfo
-		for _, trade := range route.Trades {
-			// 0 is a placeholder for swaps that should be entered into the hot route
-			if trade.Pool == 0 {
-				pool, err := k.GetAndCheckPool(ctx, poolId)
-				if err != nil {
-					return [][]TradeInfo{}, err
-				}
-
-				newTrade = TradeInfo{
-					InputDenom:  tokenOut,
-					OutputDenom: tokenIn,
-					SwapFee:     pool.GetSwapFee(ctx),
-					Pool:        pool,
-				}
-			} else {
-				pool, err := k.GetAndCheckPool(ctx, trade.Pool)
-				if err != nil {
-					return [][]TradeInfo{}, err
-				}
-
-				newTrade = TradeInfo{
-					InputDenom:  trade.TokenIn,
-					OutputDenom: trade.TokenOut,
-					SwapFee:     pool.GetSwapFee(ctx),
-					Pool:        pool,
-				}
-			}
-
-			newRoute = append(newRoute, newTrade)
-		}
-
-		// Only append if the arbitrage denom is valid
-		// In denom and out denom must be the same
-		// In denom must be uosmo or atom
-		// There must be exactly three hops in the route
-		if len(newRoute) == 3 && (newRoute[0].InputDenom == types.AtomDenomination || newRoute[0].InputDenom == types.OsmosisDenomination) && (newRoute[0].InputDenom == newRoute[2].OutputDenom) {
+		newRoute, err := k.BuildTradeInfoHotRoute(ctx, route, tokenIn, tokenOut, poolId)
+		if err == nil {
 			routes = append(routes, newRoute)
 		}
 	}
@@ -95,68 +62,91 @@ func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, 
 	return routes, nil
 }
 
+// BuildTradeInfoHotRoute constructs a cyclic arbitrage route given a hot route from the store and information about the swap that should be placed
+// in the hot route.
+func (k Keeper) BuildTradeInfoHotRoute(ctx sdk.Context, route *types.Route, tokenIn, tokenOut string, poolId uint64) (Route, error) {
+	newRoute := Route{}
+
+	for _, trade := range route.Trades {
+		var newTrade TradeInfo
+		// 0 is a placeholder for swaps that should be entered into the hot route
+		if trade.Pool == 0 {
+			pool, err := k.GetAndCheckPool(ctx, poolId)
+			if err != nil {
+				return Route{}, err
+			}
+
+			newTrade = TradeInfo{
+				InputDenom:  tokenOut,
+				OutputDenom: tokenIn,
+				SwapFee:     pool.GetSwapFee(ctx),
+				Pool:        pool,
+			}
+		} else {
+			pool, err := k.GetAndCheckPool(ctx, trade.Pool)
+			if err != nil {
+				return Route{}, err
+			}
+
+			newTrade = TradeInfo{
+				InputDenom:  trade.TokenIn,
+				OutputDenom: trade.TokenOut,
+				SwapFee:     pool.GetSwapFee(ctx),
+				Pool:        pool,
+			}
+		}
+
+		newRoute.Trades = append(newRoute.Trades, newTrade)
+	}
+
+	if err := k.CheckValidHotRoute(newRoute); err != nil {
+		return Route{}, err
+	}
+	return newRoute, nil
+}
+
+// CheckValidHotRoute checks if the cyclic arbitrage route that was built using the hot routes method is correct. The criteria for a valid hot route is that
+// the in denom and out denom must be the same, in denom must be uosmo or atom, and there must be exactly three hops in the route
+func (k Keeper) CheckValidHotRoute(route Route) error {
+	if len(route.Trades) != 3 {
+		return fmt.Errorf("invalid hot route length")
+	}
+
+	if route.Trades[0].InputDenom != route.Trades[2].OutputDenom {
+		return fmt.Errorf("invalid hot route in and out denoms. in: %s, out: %s", route.Trades[0].InputDenom, route.Trades[2].OutputDenom)
+	}
+
+	if route.Trades[0].InputDenom != types.OsmosisDenomination && route.Trades[0].InputDenom != types.AtomDenomination {
+		return fmt.Errorf("invalid hot route in denom")
+	}
+
+	return nil
+}
+
 // BuildOsmoRoute builds a cyclic arbitrage route that starts and ends with osmo given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]TradeInfo, error) {
-	// Creating the first trade in the arb
-	entryPoolId, err := k.GetOsmoPool(ctx, tokenOut)
-	if err != nil {
-		return []TradeInfo{}, err
-	}
-	entryPool, err := k.GetAndCheckPool(ctx, entryPoolId)
-	if err != nil {
-		return []TradeInfo{}, err
-	}
-	entryTrade := TradeInfo{
-		InputDenom:  types.OsmosisDenomination,
-		OutputDenom: tokenOut,
-		SwapFee:     entryPool.GetSwapFee(ctx),
-		Pool:        entryPool,
-	}
-
-	// Creating the second trade in the arb
-	middlePool, err := k.GetAndCheckPool(ctx, poolId)
-	if err != nil {
-		return []TradeInfo{}, err
-	}
-	middleTrade := TradeInfo{
-		InputDenom:  tokenOut,
-		OutputDenom: tokenIn,
-		SwapFee:     middlePool.GetSwapFee(ctx),
-		Pool:        middlePool,
-	}
-
-	// Creating the third trade in the arb
-	exitPoolId, err := k.GetOsmoPool(ctx, tokenIn)
-	if err != nil {
-		return []TradeInfo{}, err
-	}
-	exitPool, err := k.GetAndCheckPool(ctx, exitPoolId)
-	if err != nil {
-		return []TradeInfo{}, err
-	}
-	exitTrade := TradeInfo{
-		InputDenom:  tokenIn,
-		OutputDenom: types.OsmosisDenomination,
-		SwapFee:     exitPool.GetSwapFee(ctx),
-		Pool:        exitPool,
-	}
-
-	return []TradeInfo{entryTrade, middleTrade, exitTrade}, nil
+func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) (Route, error) {
+	return k.BuildTradeInfoRoute(ctx, types.OsmosisDenomination, tokenIn, tokenOut, poolId, k.GetOsmoPool)
 }
 
 // BuildAtomRoute builds a cyclic arbitrage route that starts and ends with atom given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]TradeInfo, error) {
+func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) (Route, error) {
+	return k.BuildTradeInfoRoute(ctx, types.AtomDenomination, tokenIn, tokenOut, poolId, k.GetAtomPool)
+}
+
+// BuildTradeInfoRoute constructs a cyclic arbitrage route that is starts/ends with swapDenom (atom or osmo) given the swap (tokenIn, tokenOut, poolId), and
+// a function that can get the poolId from the store given a (token, swapDenom) pair.
+func (k Keeper) BuildTradeInfoRoute(ctx sdk.Context, swapDenom, tokenIn, tokenOut string, poolId uint64, getPoolIDFromStore func(sdk.Context, string) (uint64, error)) (Route, error) {
 	// Creating the first trade in the arb
-	entryPoolId, err := k.GetAtomPool(ctx, tokenOut)
+	entryPoolId, err := getPoolIDFromStore(ctx, tokenOut)
 	if err != nil {
-		return []TradeInfo{}, err
+		return Route{}, err
 	}
 	entryPool, err := k.GetAndCheckPool(ctx, entryPoolId)
 	if err != nil {
-		return []TradeInfo{}, err
+		return Route{}, err
 	}
 	entryTrade := TradeInfo{
-		InputDenom:  types.AtomDenomination,
+		InputDenom:  swapDenom,
 		OutputDenom: tokenOut,
 		SwapFee:     entryPool.GetSwapFee(ctx),
 		Pool:        entryPool,
@@ -165,7 +155,7 @@ func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId
 	// Creating the second trade in the arb
 	middlePool, err := k.GetAndCheckPool(ctx, poolId)
 	if err != nil {
-		return []TradeInfo{}, err
+		return Route{}, err
 	}
 	middleTrade := TradeInfo{
 		InputDenom:  tokenOut,
@@ -175,22 +165,22 @@ func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId
 	}
 
 	// Creating the third trade in the arb
-	exitPoolId, err := k.GetAtomPool(ctx, tokenIn)
+	exitPoolId, err := getPoolIDFromStore(ctx, tokenIn)
 	if err != nil {
-		return []TradeInfo{}, err
+		return Route{}, err
 	}
 	exitPool, err := k.GetAndCheckPool(ctx, exitPoolId)
 	if err != nil {
-		return []TradeInfo{}, err
+		return Route{}, err
 	}
 	exitTrade := TradeInfo{
 		InputDenom:  tokenIn,
-		OutputDenom: types.AtomDenomination,
+		OutputDenom: swapDenom,
 		SwapFee:     exitPool.GetSwapFee(ctx),
 		Pool:        exitPool,
 	}
 
-	return []TradeInfo{entryTrade, middleTrade, exitTrade}, nil
+	return Route{Trades: []TradeInfo{entryTrade, middleTrade, exitTrade}}, nil
 }
 
 // GetAndCheckPool retrieves the pool from the x/gamm module given a poolId and ensures that the pool can be traded on

--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -1,0 +1,208 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+type TradeInfo struct {
+	InputDenom  string
+	OutputDenom string
+	SwapFee     sdk.Dec
+	Pool        gammtypes.CFMMPoolI
+}
+
+// BuildRoutes builds all of the possible routes given the given tokenIn, tokenOut and poolId
+func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) [][]TradeInfo {
+	routes := make([][]TradeInfo, 0)
+
+	// Check hot routes if enabled
+	if tokenPairRoutes, err := k.BuildTokenPairRoutes(ctx, tokenIn, tokenOut, poolId); err == nil {
+		routes = append(routes, tokenPairRoutes...)
+	}
+
+	// Append an osmo route if one exists
+	if osmoRoute, err := k.BuildOsmoRoute(ctx, tokenIn, tokenOut, poolId); err == nil {
+		routes = append(routes, osmoRoute)
+	}
+
+	// Append an atom route if one exists
+	if atomRoute, err := k.BuildAtomRoute(ctx, tokenIn, tokenOut, poolId); err == nil {
+		routes = append(routes, atomRoute)
+	}
+
+	return routes
+}
+
+// BuildTokenPairRoutes builds all of the possible routes given the given tokenIn and tokenOut from the
+// TokenPairRoutes store
+func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([][]TradeInfo, error) {
+	// Get all of the routes from the store that match the given tokenIn and tokenOut
+	tokenPairArbRoutes, err := k.GetTokenPairArbRoutes(ctx, tokenIn, tokenOut)
+	if err != nil {
+		return [][]TradeInfo{}, err
+	}
+
+	// Iterate through all of the routes and build hot routes
+	routes := make([][]TradeInfo, 0)
+	for _, route := range tokenPairArbRoutes.ArbRoutes {
+		newRoute := make([]TradeInfo, 0)
+
+		var newTrade TradeInfo
+		for _, trade := range route.Trades {
+
+			// 0 is a placeholder for swaps that should be entered into the hot route
+			if trade.Pool == 0 {
+				pool, err := k.GetAndCheckPool(ctx, poolId)
+				if err != nil {
+					return [][]TradeInfo{}, err
+				}
+
+				newTrade = TradeInfo{
+					InputDenom:  tokenOut,
+					OutputDenom: tokenIn,
+					SwapFee:     pool.GetSwapFee(ctx),
+					Pool:        pool,
+				}
+			} else {
+				pool, err := k.GetAndCheckPool(ctx, trade.Pool)
+				if err != nil {
+					return [][]TradeInfo{}, err
+				}
+
+				newTrade = TradeInfo{
+					InputDenom:  trade.TokenIn,
+					OutputDenom: trade.TokenOut,
+					SwapFee:     pool.GetSwapFee(ctx),
+					Pool:        pool,
+				}
+			}
+
+			newRoute = append(newRoute, newTrade)
+		}
+
+		// Only append if the arbitrage denom is valid
+		// In denom and out denom must be the same
+		// In denom must be uosmo or atom
+		// There must be exactly three hops in the route
+		if len(newRoute) == 3 && (newRoute[0].InputDenom == types.AtomDenomination || newRoute[0].InputDenom == types.OsmosisDenomination) && (newRoute[0].InputDenom == newRoute[2].OutputDenom) {
+			routes = append(routes, newRoute)
+		}
+	}
+
+	return routes, nil
+}
+
+// BuildOsmoRoute builds a route from the given tokenIn to the given tokenOut, using the given poolId as the middle hop
+func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]TradeInfo, error) {
+	// Creating the first trade in the arb
+	entryPoolId, err := k.GetOsmoPool(ctx, tokenOut)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	entryPool, err := k.GetAndCheckPool(ctx, entryPoolId)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	entryTrade := TradeInfo{
+		InputDenom:  types.OsmosisDenomination,
+		OutputDenom: tokenOut,
+		SwapFee:     entryPool.GetSwapFee(ctx),
+		Pool:        entryPool,
+	}
+
+	// Creating the second trade in the arb
+	middlePool, err := k.GetAndCheckPool(ctx, poolId)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	middleTrade := TradeInfo{
+		InputDenom:  tokenOut,
+		OutputDenom: tokenIn,
+		SwapFee:     middlePool.GetSwapFee(ctx),
+		Pool:        middlePool,
+	}
+
+	// Creating the third trade in the arb
+	exitPoolId, err := k.GetOsmoPool(ctx, tokenIn)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	exitPool, err := k.GetAndCheckPool(ctx, exitPoolId)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	exitTrade := TradeInfo{
+		InputDenom:  tokenIn,
+		OutputDenom: types.OsmosisDenomination,
+		SwapFee:     exitPool.GetSwapFee(ctx),
+		Pool:        exitPool,
+	}
+
+	return []TradeInfo{entryTrade, middleTrade, exitTrade}, nil
+}
+
+// BuildAtomRoute builds a route from the given tokenIn to the given tokenOut, using the given poolId as the middle hop
+func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]TradeInfo, error) {
+	// Creating the first trade in the arb
+	entryPoolId, err := k.GetAtomPool(ctx, tokenOut)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	entryPool, err := k.GetAndCheckPool(ctx, entryPoolId)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	entryTrade := TradeInfo{
+		InputDenom:  types.AtomDenomination,
+		OutputDenom: tokenOut,
+		SwapFee:     entryPool.GetSwapFee(ctx),
+		Pool:        entryPool,
+	}
+
+	// Creating the second trade in the arb
+	middlePool, err := k.GetAndCheckPool(ctx, poolId)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	middleTrade := TradeInfo{
+		InputDenom:  tokenOut,
+		OutputDenom: tokenIn,
+		SwapFee:     middlePool.GetSwapFee(ctx),
+		Pool:        middlePool,
+	}
+
+	// Creating the third trade in the arb
+	exitPoolId, err := k.GetAtomPool(ctx, tokenIn)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	exitPool, err := k.GetAndCheckPool(ctx, exitPoolId)
+	if err != nil {
+		return []TradeInfo{}, err
+	}
+	exitTrade := TradeInfo{
+		InputDenom:  tokenIn,
+		OutputDenom: types.AtomDenomination,
+		SwapFee:     exitPool.GetSwapFee(ctx),
+		Pool:        exitPool,
+	}
+
+	return []TradeInfo{entryTrade, middleTrade, exitTrade}, nil
+}
+
+// GetAndCheckPool retrieves the pool from the x/gamm module given a poolId and ensures that the pool can be traded on
+func (k Keeper) GetAndCheckPool(ctx sdk.Context, poolId uint64) (gammtypes.CFMMPoolI, error) {
+	pool, err := k.gammKeeper.GetPoolAndPoke(ctx, poolId)
+	if err != nil {
+		return pool, err
+	}
+	if !pool.IsActive(ctx) {
+		return pool, fmt.Errorf("pool %d is not active", poolId)
+	}
+	return pool, nil
+}

--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -16,7 +16,7 @@ type TradeInfo struct {
 	Pool        gammtypes.CFMMPoolI
 }
 
-// BuildRoutes builds all of the possible routes given the given tokenIn, tokenOut and poolId
+// BuildRoutes builds all of the possible arbitrage routes given the given tokenIn, tokenOut and poolId that were used in the swap
 func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) [][]TradeInfo {
 	routes := make([][]TradeInfo, 0)
 
@@ -38,8 +38,7 @@ func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId ui
 	return routes
 }
 
-// BuildTokenPairRoutes builds all of the possible routes given the given tokenIn and tokenOut from the
-// TokenPairRoutes store
+// BuildTokenPairRoutes builds all of the possible arbitrage routes from the hot routes given the tokenIn, tokenOut and poolId that were used in the swap
 func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([][]TradeInfo, error) {
 	// Get all of the routes from the store that match the given tokenIn and tokenOut
 	tokenPairArbRoutes, err := k.GetTokenPairArbRoutes(ctx, tokenIn, tokenOut)
@@ -54,7 +53,6 @@ func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, 
 
 		var newTrade TradeInfo
 		for _, trade := range route.Trades {
-
 			// 0 is a placeholder for swaps that should be entered into the hot route
 			if trade.Pool == 0 {
 				pool, err := k.GetAndCheckPool(ctx, poolId)
@@ -97,7 +95,7 @@ func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, 
 	return routes, nil
 }
 
-// BuildOsmoRoute builds a route from the given tokenIn to the given tokenOut, using the given poolId as the middle hop
+// BuildOsmoRoute builds a cyclic arbitrage route that starts and ends with osmo given the tokenIn, tokenOut and poolId that were used in the swap
 func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]TradeInfo, error) {
 	// Creating the first trade in the arb
 	entryPoolId, err := k.GetOsmoPool(ctx, tokenOut)
@@ -146,7 +144,7 @@ func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId
 	return []TradeInfo{entryTrade, middleTrade, exitTrade}, nil
 }
 
-// BuildAtomRoute builds a route from the given tokenIn to the given tokenOut, using the given poolId as the middle hop
+// BuildAtomRoute builds a cyclic arbitrage route that starts and ends with atom given the tokenIn, tokenOut and poolId that were used in the swap
 func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]TradeInfo, error) {
 	// Creating the first trade in the arb
 	entryPoolId, err := k.GetAtomPool(ctx, tokenOut)

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -1,0 +1,249 @@
+package keeper_test
+
+import (
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+type TestRoute struct {
+	PoolId      uint64
+	InputDenom  string
+	OutputDenom string
+}
+
+func (suite *KeeperTestSuite) TestBuildRoutes() {
+	cases := []struct {
+		description string
+		inputDenom  string
+		outputDenom string
+		poolID      uint64
+		expected    [][]TestRoute
+	}{
+		{
+			description: "Route exists for swap in Akash and swap out Atom",
+			inputDenom:  "akash",
+			outputDenom: types.AtomDenomination,
+			poolID:      1,
+			expected: [][]TestRoute{
+				{
+					{PoolId: 1, InputDenom: types.AtomDenomination, OutputDenom: "akash"},
+					{PoolId: 14, InputDenom: "akash", OutputDenom: "bitcoin"},
+					{PoolId: 4, InputDenom: "bitcoin", OutputDenom: types.AtomDenomination},
+				},
+				{
+					{PoolId: 25, InputDenom: types.OsmosisDenomination, OutputDenom: types.AtomDenomination},
+					{PoolId: 1, InputDenom: types.AtomDenomination, OutputDenom: "akash"},
+					{PoolId: 7, InputDenom: "akash", OutputDenom: types.OsmosisDenomination},
+				},
+			},
+		},
+		{
+			description: "Route exists for swap in Bitcoin and swap out Atom",
+			inputDenom:  "bitcoin",
+			outputDenom: types.AtomDenomination,
+			poolID:      4,
+			expected: [][]TestRoute{
+				{
+					{PoolId: 25, InputDenom: types.OsmosisDenomination, OutputDenom: types.AtomDenomination},
+					{PoolId: 4, InputDenom: types.AtomDenomination, OutputDenom: "bitcoin"},
+					{PoolId: 10, InputDenom: "bitcoin", OutputDenom: types.OsmosisDenomination},
+				},
+			},
+		},
+		{
+			description: "Route exists for swap in Bitcoin and swap out ethereum",
+			inputDenom:  "bitcoin",
+			outputDenom: "ethereum",
+			poolID:      19,
+			expected: [][]TestRoute{
+				{
+					{PoolId: 9, InputDenom: types.OsmosisDenomination, OutputDenom: "ethereum"},
+					{PoolId: 19, InputDenom: "ethereum", OutputDenom: "bitcoin"},
+					{PoolId: 10, InputDenom: "bitcoin", OutputDenom: types.OsmosisDenomination},
+				},
+				{
+					{PoolId: 3, InputDenom: types.AtomDenomination, OutputDenom: "ethereum"},
+					{PoolId: 19, InputDenom: "ethereum", OutputDenom: "bitcoin"},
+					{PoolId: 4, InputDenom: "bitcoin", OutputDenom: types.AtomDenomination},
+				},
+			},
+		},
+		{
+			description: "No route exists for swap in osmo and swap out Atom",
+			inputDenom:  types.OsmosisDenomination,
+			outputDenom: types.AtomDenomination,
+			poolID:      25,
+			expected:    [][]TestRoute{},
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.description, func() {
+			routes := suite.App.ProtoRevKeeper.BuildRoutes(suite.Ctx, tc.inputDenom, tc.outputDenom, tc.poolID)
+
+			suite.Require().Equal(len(tc.expected), len(routes))
+
+			for routeIndex, route := range routes {
+				for tradeIndex, trade := range route {
+					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].PoolId, trade.Pool.GetId())
+					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].InputDenom, trade.InputDenom)
+					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].OutputDenom, trade.OutputDenom)
+				}
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestBuildAtomRoute() {
+	cases := []struct {
+		description   string
+		swapIn        string
+		swapOut       string
+		poolId        uint64
+		expectedRoute []TestRoute
+		hasRoute      bool
+	}{
+		{
+			description:   "Route exists for swap in Osmo and swap out Akash",
+			swapIn:        types.OsmosisDenomination,
+			swapOut:       "akash",
+			poolId:        7,
+			expectedRoute: []TestRoute{{1, types.AtomDenomination, "akash"}, {7, "akash", types.OsmosisDenomination}, {25, types.OsmosisDenomination, types.AtomDenomination}},
+			hasRoute:      true,
+		},
+		{
+			description:   "Route exists for swap in Akash and swap out Osmo",
+			swapIn:        "akash",
+			swapOut:       types.OsmosisDenomination,
+			poolId:        7,
+			expectedRoute: []TestRoute{{25, types.AtomDenomination, types.OsmosisDenomination}, {7, types.OsmosisDenomination, "akash"}, {1, "akash", types.AtomDenomination}},
+			hasRoute:      true,
+		},
+		{
+			description:   "Route exists for swap in Terra and swap out Osmo (no mapping pool)",
+			swapIn:        "terra",
+			swapOut:       types.OsmosisDenomination,
+			poolId:        7,
+			expectedRoute: []TestRoute{},
+			hasRoute:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.description, func() {
+			route, err := suite.App.ProtoRevKeeper.BuildAtomRoute(suite.Ctx, tc.swapIn, tc.swapOut, tc.poolId)
+
+			if tc.hasRoute {
+				suite.Require().NoError(err)
+				suite.Require().Equal(len(tc.expectedRoute), len(route))
+
+				for index, trade := range tc.expectedRoute {
+					suite.Require().Equal(trade.PoolId, route[index].Pool.GetId())
+					suite.Require().Equal(trade.InputDenom, route[index].InputDenom)
+					suite.Require().Equal(trade.OutputDenom, route[index].OutputDenom)
+				}
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestBuildOsmoRoute() {
+	cases := []struct {
+		description   string
+		swapIn        string
+		swapOut       string
+		poolId        uint64
+		expectedRoute []TestRoute
+		hasRoute      bool
+	}{
+		{
+			description:   "Route exists for swap in Atom and swap out Akash",
+			swapIn:        types.AtomDenomination,
+			swapOut:       "akash",
+			poolId:        1,
+			expectedRoute: []TestRoute{{7, types.OsmosisDenomination, "akash"}, {1, "akash", types.AtomDenomination}, {25, types.AtomDenomination, types.OsmosisDenomination}},
+			hasRoute:      true,
+		},
+		{
+			description:   "Route exists for swap in Akash and swap out Atom",
+			swapIn:        "akash",
+			swapOut:       types.AtomDenomination,
+			poolId:        1,
+			expectedRoute: []TestRoute{{25, types.OsmosisDenomination, types.AtomDenomination}, {1, types.AtomDenomination, "akash"}, {7, "akash", types.OsmosisDenomination}},
+			hasRoute:      true,
+		},
+		{
+			description:   "Route exists for swap in Terra and swap out Atom (no mapping pool)",
+			swapIn:        "terra",
+			swapOut:       types.AtomDenomination,
+			poolId:        7,
+			expectedRoute: []TestRoute{},
+			hasRoute:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.description, func() {
+			route, err := suite.App.ProtoRevKeeper.BuildOsmoRoute(suite.Ctx, tc.swapIn, tc.swapOut, tc.poolId)
+
+			if tc.hasRoute {
+				suite.Require().NoError(err)
+				suite.Require().Equal(len(tc.expectedRoute), len(route))
+
+				for index, trade := range tc.expectedRoute {
+					suite.Require().Equal(trade.PoolId, route[index].Pool.GetId())
+					suite.Require().Equal(trade.InputDenom, route[index].InputDenom)
+					suite.Require().Equal(trade.OutputDenom, route[index].OutputDenom)
+				}
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestBuildTokenPairRoutes() {
+	cases := []struct {
+		description    string
+		swapIn         string
+		swapOut        string
+		poolId         uint64
+		expectedRoutes [][]TestRoute
+		hasRoutes      bool
+	}{
+		{
+			description:    "Route exists for swap in Atom and swap out Akash",
+			swapIn:         "akash",
+			swapOut:        types.AtomDenomination,
+			poolId:         1,
+			expectedRoutes: [][]TestRoute{{{1, types.AtomDenomination, "akash"}, {14, "akash", "bitcoin"}, {4, "bitcoin", types.AtomDenomination}}},
+			hasRoutes:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.description, func() {
+			routes, err := suite.App.ProtoRevKeeper.BuildTokenPairRoutes(suite.Ctx, tc.swapIn, tc.swapOut, tc.poolId)
+
+			if tc.hasRoutes {
+				suite.Require().NoError(err)
+				suite.Require().Equal(len(tc.expectedRoutes), len(routes))
+
+				for index, route := range routes {
+
+					suite.Require().Equal(len(tc.expectedRoutes[index]), len(route))
+
+					for index, trade := range tc.expectedRoutes[index] {
+						suite.Require().Equal(trade.PoolId, route[index].Pool.GetId())
+						suite.Require().Equal(trade.InputDenom, route[index].InputDenom)
+						suite.Require().Equal(trade.OutputDenom, route[index].OutputDenom)
+					}
+				}
+
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -83,7 +83,7 @@ func (suite *KeeperTestSuite) TestBuildRoutes() {
 			suite.Require().Equal(len(tc.expected), len(routes))
 
 			for routeIndex, route := range routes {
-				for tradeIndex, trade := range route {
+				for tradeIndex, trade := range route.Trades {
 					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].PoolId, trade.Pool.GetId())
 					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].InputDenom, trade.InputDenom)
 					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].OutputDenom, trade.OutputDenom)
@@ -119,7 +119,7 @@ func (suite *KeeperTestSuite) TestBuildAtomRoute() {
 			hasRoute:      true,
 		},
 		{
-			description:   "Route exists for swap in Terra and swap out Osmo (no mapping pool)",
+			description:   "Route does not exist for swap in Terra and swap out Osmo because the pool does not exist",
 			swapIn:        "terra",
 			swapOut:       types.OsmosisDenomination,
 			poolId:        7,
@@ -134,12 +134,12 @@ func (suite *KeeperTestSuite) TestBuildAtomRoute() {
 
 			if tc.hasRoute {
 				suite.Require().NoError(err)
-				suite.Require().Equal(len(tc.expectedRoute), len(route))
+				suite.Require().Equal(len(tc.expectedRoute), len(route.Trades))
 
 				for index, trade := range tc.expectedRoute {
-					suite.Require().Equal(trade.PoolId, route[index].Pool.GetId())
-					suite.Require().Equal(trade.InputDenom, route[index].InputDenom)
-					suite.Require().Equal(trade.OutputDenom, route[index].OutputDenom)
+					suite.Require().Equal(trade.PoolId, route.Trades[index].Pool.GetId())
+					suite.Require().Equal(trade.InputDenom, route.Trades[index].InputDenom)
+					suite.Require().Equal(trade.OutputDenom, route.Trades[index].OutputDenom)
 				}
 			} else {
 				suite.Require().Error(err)
@@ -174,7 +174,7 @@ func (suite *KeeperTestSuite) TestBuildOsmoRoute() {
 			hasRoute:      true,
 		},
 		{
-			description:   "Route exists for swap in Terra and swap out Atom (no mapping pool)",
+			description:   "Route does not exist for swap in Terra and swap out Atom because the pool does not exist",
 			swapIn:        "terra",
 			swapOut:       types.AtomDenomination,
 			poolId:        7,
@@ -189,12 +189,12 @@ func (suite *KeeperTestSuite) TestBuildOsmoRoute() {
 
 			if tc.hasRoute {
 				suite.Require().NoError(err)
-				suite.Require().Equal(len(tc.expectedRoute), len(route))
+				suite.Require().Equal(len(tc.expectedRoute), len(route.Trades))
 
 				for index, trade := range tc.expectedRoute {
-					suite.Require().Equal(trade.PoolId, route[index].Pool.GetId())
-					suite.Require().Equal(trade.InputDenom, route[index].InputDenom)
-					suite.Require().Equal(trade.OutputDenom, route[index].OutputDenom)
+					suite.Require().Equal(trade.PoolId, route.Trades[index].Pool.GetId())
+					suite.Require().Equal(trade.InputDenom, route.Trades[index].InputDenom)
+					suite.Require().Equal(trade.OutputDenom, route.Trades[index].OutputDenom)
 				}
 			} else {
 				suite.Require().Error(err)
@@ -232,12 +232,12 @@ func (suite *KeeperTestSuite) TestBuildTokenPairRoutes() {
 
 				for index, route := range routes {
 
-					suite.Require().Equal(len(tc.expectedRoutes[index]), len(route))
+					suite.Require().Equal(len(tc.expectedRoutes[index]), len(route.Trades))
 
 					for index, trade := range tc.expectedRoutes[index] {
-						suite.Require().Equal(trade.PoolId, route[index].Pool.GetId())
-						suite.Require().Equal(trade.InputDenom, route[index].InputDenom)
-						suite.Require().Equal(trade.OutputDenom, route[index].OutputDenom)
+						suite.Require().Equal(trade.PoolId, route.Trades[index].Pool.GetId())
+						suite.Require().Equal(trade.InputDenom, route.Trades[index].InputDenom)
+						suite.Require().Equal(trade.OutputDenom, route.Trades[index].OutputDenom)
 					}
 				}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR implements the logic of building cyclic arbitrage routes given a swap. There are two primary methods for route generation: Highest Liquidity Pools and Hot Routes.


## Brief Changelog

- *Build routes that start and end with osmo (Highest Liquidity Pools)*
- *Build routes that start and end with atom (Highest Liquidity Pools)*
- *Build routes that start and end with osmo or atom from the set of hot routes (Hot Routes)*


## Testing and Verifying

This change added tests and can be verified as follows:

- *Added unit tests for atom routes*
- *Added unit tests for osmo routes*
- *Added unit tests for routes built with tokenPairArbRoutes*
- *Added unit tests for BuildRoutes (which is a wrapper to the above three)*

## Documentation and Release Note

### Highest Liquidity Pools

There are two types of trades that must be considered:

1. **The assets in the trade are neither Atom nor Osmo**
    - In this case, `x/protorev` will sandwich the pool with either Osmo or Atom on the other end. For example, say that a swap occurs on the **Akash** ↔ **Juno** pool. There are four possible routes that can be taken (in order of trades made starting on the left and ending on the right).
        - (Osmo → Akash), (Akash → Juno), (Juno → Osmo)
        - (Osmo → Juno), (Juno → Akash), (Akash → Osmo)
        - (Atom → Akash), (Akash → Juno), Juno → Atom)
        - (Atom → Juno), (Juno → Akash), (Akash → Atom)
    - Capturing cyclic arbitrage opportunities happen in the opposite direction of the trade. Using the example above, we can cut down the routes to only two routes if we know that the user traded Akash → Juno. The routes in that case would be
        - (Osmo → Juno), (Juno → Akash), (Akash → Osmo)
        - (Atom → Juno), (Juno → Akash), (Akash → Atom)
2. **The assets in the trade include either Atom or Osmo or both**
- If the **************Osmo ↔ Atom**************  pool is swapped against, then the highest liquidity pool route building method does not produce any routes. Otherwise, if only one of OSMO or ATOM was swapped against in a single pool, then `x/protorev` will look for the opposite asset pools from what was traded in the pool. For example, say a swap has been executed on the  ************Osmo ↔ TokenXYZ************ pool, tendering OSMO and receiving TokenXYZ, the route generated would be:
    - (Atom → TokenXYZ), (TokenXYZ → Osmo), (Osmo → Atom)

In both cases, the route that is built will always sandwich the swap that was made. However, we allow for more flexibility in route generation as the highest liquidity method may not be optimal via Hot Routes.

### Hot Routes
Populated through the admin account (which will be implemented in a later PR), the module’s keeper holds a KV store that associates token pairs (for example, osmo/juno) to the routes that result in a high percentage of arbitrage profit on Osmosis (as determined by external analysis).

The purpose of storing Hot Routes is a recognition that the Highest Liquidity Pool method may not present the best arbitrage routes. As such, hot routes can be configured through governance to store additional routes that may be more effective at capturing arbitrage opportunities. Each hot route will store a placeholder (the value 0) for where the current swapped pool will fit into the trade. TokenPairArbRoutes are always going to be sorted in the direction of the trade i.e. if we see a swap of ***Atom -> Osmo*** we can immediately find a route that goes in the opposite direction by replacing the placeholder (0) with this pool id.
