### PR TITLE
[x/TWAP] Refactor geometric & arithmetic TWAP for reusable API functions

### DIFF
--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -8,15 +8,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
-type twapStrategies twapStrategy
-
-// arithmeticTwapType is the type of twap that is calculated by taking the arithmetic weighted average of the spot prices.
-var arithmeticTwapStrategy twapStrategies = &arithmetic{}
-
-// geometricTwapType is the type of twap that is calculated by taking the geometric weighted average of the spot prices.
-// nolint: unused
-var geometricTwapStrategy twapStrategies = &geometric{}
-
 // GetArithmeticTwap returns an arithmetic time weighted average price.
 // The returned twap is the time weighted average price (TWAP) of:
 // * the base asset, in units of the quote asset (1 unit of base = x units of quote)
@@ -119,7 +110,7 @@ func (k Keeper) getTwap(
 		return sdk.Dec{}, err
 	}
 
-	return strategy.computeTwap(startRecord, endRecord, quoteAssetDenom), err
+	return computeTwap(startRecord, endRecord, quoteAssetDenom, strategy)
 }
 
 // getTwapToNow computes and returns twap from the start time until the current block time. The type
@@ -145,7 +136,7 @@ func (k Keeper) getTwapToNow(
 		return sdk.Dec{}, err
 	}
 
-	return strategy.computeTwap(startRecord, endRecord, quoteAssetDenom), err
+	return computeTwap(startRecord, endRecord, quoteAssetDenom, strategy)
 }
 
 // GetBeginBlockAccumulatorRecord returns a TwapRecord struct corresponding to the state of pool `poolId`

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -8,15 +8,16 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
-// type twapType bool
+// arithmeticTwapType is the type of twap that is calculated by taking the arithmetic weighted average of the spot prices.
+// var arithmeticTwapType = &TwapType{
+// 	arithmeticTwap: Keeper,
+// }
 
-// const (
-// 	// arithmeticTwapType is the type of twap that is calculated by taking the arithmetic weighted average of the spot prices.
-// 	arithmeticTwapType twapType = true
-// 	// geometricTwapType is the type of twap that is calculated by taking the geometric weighted average of the spot prices.
-// 	// nolint: unused
-// 	geometricTwapType twapType = false
-// )
+// geometricTwapType is the type of twap that is calculated by taking the geometric weighted average of the spot prices.
+// nolint: unused
+// var geometricTwapType = &TwapType{
+// 	geometricTwap: Keeper,
+// }
 
 // GetArithmeticTwap returns an arithmetic time weighted average price.
 // The returned twap is the time weighted average price (TWAP) of:

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -8,15 +8,15 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
-type twapType bool
+// type twapType bool
 
-const (
-	// arithmeticTwapType is the type of twap that is calculated by taking the arithmetic weighted average of the spot prices.
-	arithmeticTwapType twapType = true
-	// geometricTwapType is the type of twap that is calculated by taking the geometric weighted average of the spot prices.
-	// nolint: unused
-	geometricTwapType twapType = false
-)
+// const (
+// 	// arithmeticTwapType is the type of twap that is calculated by taking the arithmetic weighted average of the spot prices.
+// 	arithmeticTwapType twapType = true
+// 	// geometricTwapType is the type of twap that is calculated by taking the geometric weighted average of the spot prices.
+// 	// nolint: unused
+// 	geometricTwapType twapType = false
+// )
 
 // GetArithmeticTwap returns an arithmetic time weighted average price.
 // The returned twap is the time weighted average price (TWAP) of:
@@ -56,6 +56,18 @@ func (k Keeper) GetArithmeticTwap(
 	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, arithmeticStrategy)
 }
 
+func (k Keeper) GetGeometricTwap(
+	ctx sdk.Context,
+	poolId uint64,
+	baseAssetDenom string,
+	quoteAssetDenom string,
+	startTime time.Time,
+	endTime time.Time,
+) (sdk.Dec, error) {
+	geometricStrategy := &geometric{k}
+	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, geometricStrategy)
+}
+
 // GetArithmeticTwapToNow returns arithmetic twap from start time until the current block time for quote and base
 // assets in a given pool.
 func (k Keeper) GetArithmeticTwapToNow(
@@ -67,6 +79,17 @@ func (k Keeper) GetArithmeticTwapToNow(
 ) (sdk.Dec, error) {
 	arithmeticStrategy := &arithmetic{k}
 	return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, arithmeticStrategy)
+}
+
+func (k Keeper) GetGeometricTwapToNow(
+	ctx sdk.Context,
+	poolId uint64,
+	baseAssetDenom string,
+	quoteAssetDenom string,
+	startTime time.Time,
+) (sdk.Dec, error) {
+	geometricStrategy := &geometric{k}
+	return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, geometricStrategy)
 }
 
 // getTwap computes and returns twap from the start time until the end time. The type
@@ -97,7 +120,7 @@ func (k Keeper) getTwap(
 		return sdk.Dec{}, err
 	}
 
-	return strategy.computeTwap(startRecord, endRecord, quoteAssetDenom)
+	return strategy.computeTwap(startRecord, endRecord, quoteAssetDenom), err
 }
 
 // getTwapToNow computes and returns twap from the start time until the current block time. The type
@@ -123,7 +146,7 @@ func (k Keeper) getTwapToNow(
 		return sdk.Dec{}, err
 	}
 
-	return strategy.computeTwap(startRecord, endRecord, quoteAssetDenom)
+	return strategy.computeTwap(startRecord, endRecord, quoteAssetDenom), err
 }
 
 // GetBeginBlockAccumulatorRecord returns a TwapRecord struct corresponding to the state of pool `poolId`

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -8,16 +8,14 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
+type twapStrategies twapStrategy
+
 // arithmeticTwapType is the type of twap that is calculated by taking the arithmetic weighted average of the spot prices.
-// var arithmeticTwapType = &TwapType{
-// 	arithmeticTwap: Keeper,
-// }
+var arithmeticTwapStrategy twapStrategies = &arithmetic{}
 
 // geometricTwapType is the type of twap that is calculated by taking the geometric weighted average of the spot prices.
 // nolint: unused
-// var geometricTwapType = &TwapType{
-// 	geometricTwap: Keeper,
-// }
+var geometricTwapStrategy twapStrategies = &geometric{}
 
 // GetArithmeticTwap returns an arithmetic time weighted average price.
 // The returned twap is the time weighted average price (TWAP) of:

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -42,8 +42,7 @@ func (k Keeper) GetArithmeticTwap(
 	startTime time.Time,
 	endTime time.Time,
 ) (sdk.Dec, error) {
-	arithmeticStrategy := &arithmetic{k}
-	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, arithmeticStrategy)
+	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, k.GetArithmeticStrategy())
 }
 
 func (k Keeper) GetGeometricTwap(
@@ -54,8 +53,7 @@ func (k Keeper) GetGeometricTwap(
 	startTime time.Time,
 	endTime time.Time,
 ) (sdk.Dec, error) {
-	geometricStrategy := &geometric{k}
-	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, geometricStrategy)
+	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, k.GetGeometricStrategy())
 }
 
 // GetArithmeticTwapToNow returns arithmetic twap from start time until the current block time for quote and base
@@ -67,8 +65,7 @@ func (k Keeper) GetArithmeticTwapToNow(
 	quoteAssetDenom string,
 	startTime time.Time,
 ) (sdk.Dec, error) {
-	arithmeticStrategy := &arithmetic{k}
-	return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, arithmeticStrategy)
+	return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, k.GetArithmeticStrategy())
 }
 
 func (k Keeper) GetGeometricTwapToNow(
@@ -78,8 +75,7 @@ func (k Keeper) GetGeometricTwapToNow(
 	quoteAssetDenom string,
 	startTime time.Time,
 ) (sdk.Dec, error) {
-	geometricStrategy := &geometric{k}
-	return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, geometricStrategy)
+	return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, k.GetGeometricStrategy())
 }
 
 // getTwap computes and returns twap from the start time until the end time. The type

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -10,7 +10,7 @@ import (
 
 type (
 	TimeTooOldError        = timeTooOldError
-	TwapStrategies         = twapStrategies
+	TwapStrategy           = twapStrategy
 	ArithmeticTwapStrategy = arithmetic
 	GeometricTwapStrategy  = geometric
 )

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -9,12 +9,11 @@ import (
 )
 
 type (
-	TimeTooOldError = timeTooOldError
-	TwapStrategies  = twapStrategies
+	TimeTooOldError        = timeTooOldError
+	TwapStrategies         = twapStrategies
+	ArithmeticTwapStrategy = arithmetic
+	GeometricTwapStrategy  = geometric
 )
-
-var ArithmeticTwapStrategy = arithmeticTwapStrategy
-var GeometricTwapStrategy = geometricTwapStrategy
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
 	k.storeNewRecord(ctx, record)
@@ -68,8 +67,16 @@ func (k Keeper) GetInterpolatedRecord(ctx sdk.Context, poolId uint64, asset0Deno
 	return k.getInterpolatedRecord(ctx, poolId, t, asset0Denom, asset1Denom)
 }
 
-func ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, strategy twapStrategy) sdk.Dec {
-	return strategy.computeTwap(startRecord, endRecord, quoteAsset)
+func ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, strategy twapStrategy) (sdk.Dec, error) {
+	return computeTwap(startRecord, endRecord, quoteAsset, strategy)
+}
+
+func (as arithmetic) ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+	return as.computeTwap(startRecord, endRecord, quoteAsset)
+}
+
+func (gs geometric) ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+	return gs.computeTwap(startRecord, endRecord, quoteAsset)
 }
 
 func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.TwapRecord {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -15,6 +15,8 @@ type (
 	GeometricTwapStrategy  = geometric
 )
 
+var GeometricTwapMathBase = geometricTwapMathBase
+
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
 	k.storeNewRecord(ctx, record)
 }

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -12,7 +12,13 @@ type (
 	TimeTooOldError = timeTooOldError
 )
 
-var GeometricTwapMathBase = geometricTwapMathBase
+var TwapGeometricStrategy twapStrategy = &geometric{}
+var TwapArithmetrcStrategy twapStrategy = &arithmetic{}
+
+type TwapStrategies struct {
+	GeometricStrategy  geometric
+	ArithmeticStrategy arithmetic
+}
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
 	k.storeNewRecord(ctx, record)
@@ -116,4 +122,14 @@ func (k *Keeper) SetAmmInterface(ammInterface types.AmmInterface) {
 
 func (k *Keeper) AfterCreatePool(ctx sdk.Context, poolId uint64) error {
 	return k.afterCreatePool(ctx, poolId)
+}
+
+func (k Keeper) GetArithmeticStrategy() *arithmetic {
+	arithmeticStrategy := &arithmetic{k}
+	return arithmeticStrategy
+}
+
+func (k Keeper) GetGeometricStrategy() *geometric {
+	geometricStrategy := &geometric{k}
+	return geometricStrategy
 }

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -10,12 +10,6 @@ import (
 
 type (
 	TimeTooOldError = timeTooOldError
-	TwapType        = twapType
-)
-
-const (
-	ArithmeticTwapType = arithmeticTwapType
-	GeometricTwapType  = geometricTwapType
 )
 
 var GeometricTwapMathBase = geometricTwapMathBase
@@ -72,16 +66,18 @@ func (k Keeper) GetInterpolatedRecord(ctx sdk.Context, poolId uint64, asset0Deno
 	return k.getInterpolatedRecord(ctx, poolId, t, asset0Denom, asset1Denom)
 }
 
-func ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, twapType twapType) (sdk.Dec, error) {
-	return computeTwap(startRecord, endRecord, quoteAsset, twapType)
+func ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, strategy twapStrategy) sdk.Dec {
+	return strategy.computeTwap(startRecord, endRecord, quoteAsset)
 }
 
-func ComputeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-	return computeArithmeticTwap(startRecord, endRecord, quoteAsset)
+func (k Keeper) ComputeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+	arithmeticStrategy := &arithmetic{k}
+	return arithmeticStrategy.computeTwap(startRecord, endRecord, quoteAsset)
 }
 
-func ComputeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-	return computeGeometricTwap(startRecord, endRecord, quoteAsset)
+func (k Keeper) ComputeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+	geometricStrategy := &geometric{k}
+	return geometricStrategy.computeTwap(startRecord, endRecord, quoteAsset)
 }
 
 func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.TwapRecord {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -10,15 +10,11 @@ import (
 
 type (
 	TimeTooOldError = timeTooOldError
+	TwapStrategies  = twapStrategies
 )
 
-var TwapGeometricStrategy twapStrategy = &geometric{}
-var TwapArithmetrcStrategy twapStrategy = &arithmetic{}
-
-type TwapStrategies struct {
-	GeometricStrategy  geometric
-	ArithmeticStrategy arithmetic
-}
+var ArithmeticTwapStrategy = arithmeticTwapStrategy
+var GeometricTwapStrategy = geometricTwapStrategy
 
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
 	k.storeNewRecord(ctx, record)
@@ -76,16 +72,6 @@ func ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quote
 	return strategy.computeTwap(startRecord, endRecord, quoteAsset)
 }
 
-func (k Keeper) ComputeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-	arithmeticStrategy := &arithmetic{k}
-	return arithmeticStrategy.computeTwap(startRecord, endRecord, quoteAsset)
-}
-
-func (k Keeper) ComputeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-	geometricStrategy := &geometric{k}
-	return geometricStrategy.computeTwap(startRecord, endRecord, quoteAsset)
-}
-
 func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.TwapRecord {
 	return recordWithUpdatedAccumulators(record, t)
 }
@@ -122,14 +108,4 @@ func (k *Keeper) SetAmmInterface(ammInterface types.AmmInterface) {
 
 func (k *Keeper) AfterCreatePool(ctx sdk.Context, poolId uint64) error {
 	return k.afterCreatePool(ctx, poolId)
-}
-
-func (k Keeper) GetArithmeticStrategy() *arithmetic {
-	arithmeticStrategy := &arithmetic{k}
-	return arithmeticStrategy
-}
-
-func (k Keeper) GetGeometricStrategy() *geometric {
-	geometricStrategy := &geometric{k}
-	return geometricStrategy
 }

--- a/x/twap/keeper.go
+++ b/x/twap/keeper.go
@@ -83,3 +83,13 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		Twaps:  twapRecords,
 	}
 }
+
+// GetGeometricStrategy gets geometric TWAP keeper.
+func (k Keeper) GetGeometricStrategy() *geometric {
+	return &geometric{k}
+}
+
+// GetArithmeticStrategy gets arithmetic TWAP keeper.
+func (k Keeper) GetArithmeticStrategy() *arithmetic {
+	return &arithmetic{k}
+}

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -264,7 +264,7 @@ func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quote
 		return endRecord.P1LastSpotPrice, err
 	}
 
-	return strategy.computeTwap(startRecord, endRecord, quoteAsset), nil
+	return strategy.computeTwap(startRecord, endRecord, quoteAsset), err
 }
 
 // twapLog returns the logarithm of the given spot price, base 2.

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -265,46 +265,7 @@ func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quote
 	}
 
 	return strategy.computeTwap(startRecord, endRecord, quoteAsset), err
-
-	// if isArithmeticTwap {
-	// 	return computeArithmeticTwap(startRecord, endRecord, quoteAsset), err
-	// }
-	// return computeGeometricTwap(startRecord, endRecord, quoteAsset), err
 }
-
-// computeArithmeticTwap computes and returns an arithmetic TWAP between
-// two records given the quote asset.
-// func computeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-// 	var accumDiff sdk.Dec
-// 	if quoteAsset == startRecord.Asset0Denom {
-// 		accumDiff = endRecord.P0ArithmeticTwapAccumulator.Sub(startRecord.P0ArithmeticTwapAccumulator)
-// 	} else {
-// 		accumDiff = endRecord.P1ArithmeticTwapAccumulator.Sub(startRecord.P1ArithmeticTwapAccumulator)
-// 	}
-// 	timeDelta := endRecord.Time.Sub(startRecord.Time)
-// 	return types.AccumDiffDivDuration(accumDiff, timeDelta)
-// }
-
-// computeGeometricTwap computes and returns a geometric TWAP between
-// two records given the quote asset.
-// The computation works as follows:
-// - compute arithmetic mean of logarithms of spot prices.
-// - exponentiate the result to get the geometric mean.
-// - if quoted asset is asset 1, take reciprocal of the exponentiated result.
-// func computeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-// 	accumDiff := endRecord.GeometricTwapAccumulator.Sub(startRecord.GeometricTwapAccumulator)
-
-// 	timeDelta := endRecord.Time.Sub(startRecord.Time)
-// 	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
-
-// 	geometricMeanDenom0 := twapPow(arithmeticMeanOfLogPrices)
-// 	// N.B.: Geometric mean of recprocals is reciprocal of geometric mean.
-// 	// https://proofwiki.org/wiki/Geometric_Mean_of_Reciprocals_is_Reciprocal_of_Geometric_Mean
-// 	if quoteAsset == startRecord.Asset1Denom {
-// 		return sdk.OneDec().Quo(geometricMeanDenom0)
-// 	}
-// 	return geometricMeanDenom0
-// }
 
 // twapLog returns the logarithm of the given spot price, base 2.
 // TODO: basic test

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -264,7 +264,7 @@ func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quote
 		return endRecord.P1LastSpotPrice, err
 	}
 
-	return strategy.computeTwap(startRecord, endRecord, quoteAsset), err
+	return strategy.computeTwap(startRecord, endRecord, quoteAsset), nil
 }
 
 // twapLog returns the logarithm of the given spot price, base 2.

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -247,7 +247,7 @@ func (k Keeper) getMostRecentRecord(ctx sdk.Context, poolId uint64, assetA, asse
 // if (endRecord.Time == startRecord.Time) returns endRecord.LastSpotPrice
 // else returns
 // (endRecord.Accumulator - startRecord.Accumulator) / (endRecord.Time - startRecord.Time)
-func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, isArithmeticTwap twapType) (sdk.Dec, error) {
+func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, strategy twapStrategy) (sdk.Dec, error) {
 	// see if we need to return an error, due to spot price issues
 	var err error = nil
 	if endRecord.LastErrorTime.After(startRecord.Time) ||
@@ -264,24 +264,26 @@ func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quote
 		return endRecord.P1LastSpotPrice, err
 	}
 
-	if isArithmeticTwap {
-		return computeArithmeticTwap(startRecord, endRecord, quoteAsset), err
-	}
-	return computeGeometricTwap(startRecord, endRecord, quoteAsset), err
+	return strategy.computeTwap(startRecord, endRecord, quoteAsset), err
+
+	// if isArithmeticTwap {
+	// 	return computeArithmeticTwap(startRecord, endRecord, quoteAsset), err
+	// }
+	// return computeGeometricTwap(startRecord, endRecord, quoteAsset), err
 }
 
 // computeArithmeticTwap computes and returns an arithmetic TWAP between
 // two records given the quote asset.
-func computeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-	var accumDiff sdk.Dec
-	if quoteAsset == startRecord.Asset0Denom {
-		accumDiff = endRecord.P0ArithmeticTwapAccumulator.Sub(startRecord.P0ArithmeticTwapAccumulator)
-	} else {
-		accumDiff = endRecord.P1ArithmeticTwapAccumulator.Sub(startRecord.P1ArithmeticTwapAccumulator)
-	}
-	timeDelta := endRecord.Time.Sub(startRecord.Time)
-	return types.AccumDiffDivDuration(accumDiff, timeDelta)
-}
+// func computeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+// 	var accumDiff sdk.Dec
+// 	if quoteAsset == startRecord.Asset0Denom {
+// 		accumDiff = endRecord.P0ArithmeticTwapAccumulator.Sub(startRecord.P0ArithmeticTwapAccumulator)
+// 	} else {
+// 		accumDiff = endRecord.P1ArithmeticTwapAccumulator.Sub(startRecord.P1ArithmeticTwapAccumulator)
+// 	}
+// 	timeDelta := endRecord.Time.Sub(startRecord.Time)
+// 	return types.AccumDiffDivDuration(accumDiff, timeDelta)
+// }
 
 // computeGeometricTwap computes and returns a geometric TWAP between
 // two records given the quote asset.
@@ -289,20 +291,20 @@ func computeArithmeticTwap(startRecord types.TwapRecord, endRecord types.TwapRec
 // - compute arithmetic mean of logarithms of spot prices.
 // - exponentiate the result to get the geometric mean.
 // - if quoted asset is asset 1, take reciprocal of the exponentiated result.
-func computeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
-	accumDiff := endRecord.GeometricTwapAccumulator.Sub(startRecord.GeometricTwapAccumulator)
+// func computeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+// 	accumDiff := endRecord.GeometricTwapAccumulator.Sub(startRecord.GeometricTwapAccumulator)
 
-	timeDelta := endRecord.Time.Sub(startRecord.Time)
-	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
+// 	timeDelta := endRecord.Time.Sub(startRecord.Time)
+// 	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
 
-	geometricMeanDenom0 := twapPow(arithmeticMeanOfLogPrices)
-	// N.B.: Geometric mean of recprocals is reciprocal of geometric mean.
-	// https://proofwiki.org/wiki/Geometric_Mean_of_Reciprocals_is_Reciprocal_of_Geometric_Mean
-	if quoteAsset == startRecord.Asset1Denom {
-		return sdk.OneDec().Quo(geometricMeanDenom0)
-	}
-	return geometricMeanDenom0
-}
+// 	geometricMeanDenom0 := twapPow(arithmeticMeanOfLogPrices)
+// 	// N.B.: Geometric mean of recprocals is reciprocal of geometric mean.
+// 	// https://proofwiki.org/wiki/Geometric_Mean_of_Reciprocals_is_Reciprocal_of_Geometric_Mean
+// 	if quoteAsset == startRecord.Asset1Denom {
+// 		return sdk.OneDec().Quo(geometricMeanDenom0)
+// 	}
+// 	return geometricMeanDenom0
+// }
 
 // twapLog returns the logarithm of the given spot price, base 2.
 // TODO: basic test

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -3,7 +3,6 @@ package twap_test
 import (
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
-	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
 	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v13/x/twap"

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -557,7 +557,6 @@ type computeTwapTestCase struct {
 	expPanic       bool
 }
 
-
 // TestPruneRecords tests that twap records earlier than
 // current block time - RecordHistoryKeepPeriod are pruned from the store
 // while keeping the newest record before the above time threshold.
@@ -1332,6 +1331,20 @@ func (s *TestSuite) TestComputeTwap() {
 		"geometric only: accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
 			s, sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
 		"geometric only: accumulator = log(10)*OneSec, t=100s. 0 base accum (asset 1)": geometricTestCaseFromDeltas1(s, sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, sdk.OneDec().Quo(twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000)))),
+		"three asset same record: asset1, end spot price = 1": {
+			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true)[1],
+			endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true)[1],
+			quoteAsset:  denom2,
+			expTwap:     sdk.OneDec(),
+			twapStrategies: []twap.TwapStrategy{
+				&twap.ArithmeticTwapStrategy{
+					TwapKeeper: *s.App.TwapKeeper,
+				},
+				&twap.GeometricTwapStrategy{
+					TwapKeeper: *s.App.TwapKeeper,
+				},
+			},
+		},
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
@@ -1414,7 +1427,6 @@ func (s *TestSuite) TestTwapLog() {
 	result_by_customBaseLog := priceValue.CustomBaseLog(osmomath.BigDecFromSDKDec(twap.GeometricTwapMathBase))
 	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 	s.Require().True(result_by_customBaseLog.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
-
 }
 
 func (s *TestSuite) TestTwapPow() {
@@ -1429,7 +1441,6 @@ func (s *TestSuite) TestTwapPow() {
 	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 	s.Require().True(osmomath.MustNewDecFromStr(fmt.Sprint(result_by_mathPow)).Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 }
-
 
 func testCaseFromDeltas(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
 	return computeTwapTestCase{

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -539,16 +539,6 @@ func (s *TestSuite) TestGetInterpolatedRecord_ThreeAsset() {
 	}
 }
 
-type computeTwapTestCase struct {
-	startRecord types.TwapRecord
-	endRecord   types.TwapRecord
-	twapTypes   []twap.TwapType
-	quoteAsset  string
-	expTwap     sdk.Dec
-	expErr      bool
-	expPanic    bool
-}
-
 type computeThreeAssetArithmeticTwapTestCase struct {
 	startRecord []types.TwapRecord
 	endRecord   []types.TwapRecord
@@ -557,331 +547,16 @@ type computeThreeAssetArithmeticTwapTestCase struct {
 	expErr      bool
 }
 
-// TestComputeArithmeticTwap tests computeTwap on various inputs.
-// TODO: test both arithmetic and geometric twap.
-// The test vectors are structured by setting up different start and records,
-// based on time interval, and their accumulator values.
-// Then an expected TWAP is provided in each test case, to compare against computed.
-func TestComputeTwap(t *testing.T) {
-	tests := map[string]computeTwapTestCase{
-		"arithmetic only, basic: spot price = 1 for one second, 0 init accumulator": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
-			quoteAsset:  denom0,
-			twapTypes:   []twap.TwapType{twap.ArithmeticTwapType},
-			expTwap:     sdk.OneDec(),
-		},
-		// this test just shows what happens in case the records are reversed.
-		// It should return the correct result, even though this is incorrect internal API usage
-		"arithmetic only: invalid call: reversed records of above": {
-			startRecord: newOneSidedRecord(tPlusOne, OneSec, true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom0,
-			twapTypes:   []twap.TwapType{twap.ArithmeticTwapType},
-			expTwap:     sdk.OneDec(),
-		},
-		"same record: denom0, end spot price = 0": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom0,
-			twapTypes:   []twap.TwapType{twap.ArithmeticTwapType, twap.GeometricTwapType},
-			expTwap:     sdk.ZeroDec(),
-		},
-		"same record: denom1, end spot price = 1": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom1,
-			twapTypes:   []twap.TwapType{twap.ArithmeticTwapType, twap.GeometricTwapType},
-			expTwap:     sdk.OneDec(),
-		},
-		"arithmetic only: accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
-			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
-		"arithmetic only: accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-		"geometric only: accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
-			sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
-		"geometric only: accumulator = log(10)*OneSec, t=100s. 0 base accum (asset 1)": geometricTestCaseFromDeltas1(sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, sdk.OneDec().Quo(twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000)))),
-	}
-	for name, test := range tests {
-		for _, twapType := range test.twapTypes {
-			twapType := twapType
-			twapTypeStr := "arithmetic"
-			if twapType == twap.GeometricTwapType {
-				twapTypeStr = "geometric"
-			}
-
-			t.Run(fmt.Sprintf("%s - %s", twapTypeStr, name), func(t *testing.T) {
-				actualTwap, err := twap.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset, twapType)
-				require.NoError(t, err)
-				osmoassert.DecApproxEq(t, test.expTwap, actualTwap, osmomath.GetPowPrecision())
-			})
-		}
-	}
+type computeTwapTestCase struct {
+	startRecord    types.TwapRecord
+	endRecord      types.TwapRecord
+	twapStrategies []twap.TwapStrategy
+	quoteAsset     string
+	expTwap        sdk.Dec
+	expErr         bool
+	expPanic       bool
 }
 
-// TestComputeArithmeticTwap tests computeArithmeticTwap on various inputs.
-// Contrary to computeTwap that handles the cases with zero delta correctly,
-// this function should panic in case of zero delta.
-func TestComputeArithmeticTwap(t *testing.T) {
-	pointOneAccum := OneSec.QuoInt64(10)
-	tests := map[string]computeTwapTestCase{
-		"basic: spot price = 1 for one second, 0 init accumulator": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-		},
-		// this test just shows what happens in case the records are reversed.
-		// It should return the correct result, even though this is incorrect internal API usage
-		"invalid call: reversed records of above": {
-			startRecord: newOneSidedRecord(tPlusOne, OneSec, true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-		},
-		"same record (zero time delta), division by 0 - panic": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom0,
-			expPanic:    true,
-		},
-		"accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
-			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
-		"accumulator = 10*OneSec, t=3s. 0 base accum": testCaseFromDeltas(
-			sdk.ZeroDec(), tenSecAccum, 3*time.Second, ThreePlusOneThird),
-		"accumulator = 10*OneSec, t=100s. 0 base accum": testCaseFromDeltas(
-			sdk.ZeroDec(), tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-
-		// test that base accum has no impact
-		"accumulator = 10*OneSec, t=5s. 10 base accum": testCaseFromDeltas(
-			sdk.NewDec(10), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
-		"accumulator = 10*OneSec, t=3s. 10*second base accum": testCaseFromDeltas(
-			tenSecAccum, tenSecAccum, 3*time.Second, ThreePlusOneThird),
-		"accumulator = 10*OneSec, t=100s. .1*second base accum": testCaseFromDeltas(
-			pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-
-		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-
-			osmoassert.ConditionalPanic(t, test.expPanic, func() {
-				actualTwap := twap.ComputeArithmeticTwap(test.startRecord, test.endRecord, test.quoteAsset)
-				require.Equal(t, test.expTwap, actualTwap)
-			})
-		})
-	}
-}
-
-func TestComputeGeometricTwap(t *testing.T) {
-	tests := map[string]computeTwapTestCase{
-		// basic test for both denom with zero start accumulator
-		"basic denom0: spot price = 1 for one second, 0 init accumulator": {
-			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
-			endRecord:   newOneSidedGeometricRecord(tPlusOne, geometricTenSecAccum),
-			quoteAsset:  denom0,
-			expTwap:     sdk.NewDec(10),
-		},
-		"basic denom1: spot price = 1 for one second, 0 init accumulator": {
-			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
-			endRecord:   newOneSidedGeometricRecord(tPlusOne, geometricTenSecAccum),
-			quoteAsset:  denom1,
-			expTwap:     sdk.OneDec().Quo(sdk.NewDec(10)),
-		},
-
-		// basic test for both denom with non-zero start accumulator
-		"denom0: start accumulator of 10 * 1s, end accumulator 10 * 1s + 20 * 2s = 20": {
-			startRecord: newOneSidedGeometricRecord(baseTime, geometricTenSecAccum),
-			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Second*2), geometricTenSecAccum.Add(OneSec.MulInt64(2).Mul(twap.TwapLog(sdk.NewDec(20))))),
-			quoteAsset:  denom0,
-			expTwap:     sdk.NewDec(20),
-		},
-		"denom1 start accumulator of 10 * 1s, end accumulator 10 * 1s + 20 * 2s = 20": {
-			startRecord: newOneSidedGeometricRecord(baseTime, geometricTenSecAccum),
-			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Second*2), geometricTenSecAccum.Add(OneSec.MulInt64(2).Mul(twap.TwapLog(sdk.NewDec(20))))),
-			quoteAsset:  denom1,
-			expTwap:     sdk.OneDec().Quo(sdk.NewDec(20)),
-		},
-
-		// toggle time delta.
-		"accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
-			sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
-		"accumulator = log(10)*OneSec, t=3s. 0 base accum": geometricTestCaseFromDeltas0(
-			sdk.ZeroDec(), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
-		"accumulator = log(10)*OneSec, t=100s. 0 base accum": geometricTestCaseFromDeltas0(
-			sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
-
-		// test that base accum has no impact
-		"accumulator = log(10)*OneSec, t=5s. 10 base accum": geometricTestCaseFromDeltas0(
-			logTen, geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
-		"accumulator = log(10)*OneSec, t=3s. 10*second base accum": geometricTestCaseFromDeltas0(
-			OneSec.MulInt64(10).Mul(logTen), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
-		"accumulator = 10*OneSec, t=100s. .1*second base accum": geometricTestCaseFromDeltas0(
-			OneSec.MulInt64(10).Mul(logOneOverTen), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
-
-		// TODO: this is the highest price we currently support with the given precision bounds.
-		// Need to choose better base and potentially improve math functions to mitigate.
-		"price of 1_000_000 for an hour": {
-			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
-			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Hour), OneSec.MulInt64(60*60).Mul(twap.TwapLog(sdk.NewDec(1_000_000)))),
-			quoteAsset:  denom0,
-			expTwap:     sdk.NewDec(1_000_000),
-		},
-		// TODO: overflow tests
-		// - max spot price
-		// - large time delta
-		// - both
-
-		// TODO: hand calculated tests
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			osmoassert.ConditionalPanic(t, tc.expPanic, func() {
-				actualTwap := twap.ComputeGeometricTwap(tc.startRecord, tc.endRecord, tc.quoteAsset)
-				osmoassert.DecApproxEq(t, tc.expTwap, actualTwap, osmomath.GetPowPrecision())
-			})
-		})
-	}
-}
-
-func TestComputeArithmeticTwap_ThreeAsset_Arithmetic(t *testing.T) {
-	tenSecAccum := OneSec.MulInt64(10)
-	pointOneAccum := OneSec.QuoInt64(10)
-	tests := map[string]computeThreeAssetArithmeticTwapTestCase{
-		"three asset basic: spot price = 1 for one second, 0 init accumulator": {
-			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newThreeAssetOneSidedRecord(tPlusOne, OneSec, true),
-			quoteAsset:  []string{denom0, denom0, denom1},
-			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		},
-		"three asset same record: asset1, end spot price = 1": {
-			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  []string{denom1, denom2, denom2},
-			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		},
-		"three asset. accumulator = 10*OneSec, t=5s. 0 base accum": testThreeAssetCaseFromDeltas(
-			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
-
-		// test that base accum has no impact
-		"three asset. accumulator = 10*OneSec, t=5s. 10 base accum": testThreeAssetCaseFromDeltas(
-			sdk.NewDec(10), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
-		"three asset. accumulator = 10*OneSec, t=100s. .1*second base accum": testThreeAssetCaseFromDeltas(
-			pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			for i, startRec := range test.startRecord {
-				actualTwap, err := twap.ComputeTwap(startRec, test.endRecord[i], test.quoteAsset[i], twap.ArithmeticTwapType)
-				require.Equal(t, test.expTwap[i], actualTwap)
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestComputeArithmeticTwap_ThreeAsset_Geometric(t *testing.T) {
-	var (
-		five        = sdk.NewDec(5)
-		fiveFor3Sec = OneSec.MulInt64(3).Mul(twap.TwapLog(five))
-
-		ten          = five.MulInt64(2)
-		tenFor100Sec = OneSec.MulInt64(100).Mul(twap.TwapLog(ten))
-
-		errTolerance = sdk.MustNewDecFromStr("0.00000001")
-	)
-
-	tests := map[string]computeThreeAssetArithmeticTwapTestCase{
-		"three asset basic: spot price = 10 for one second, 0 init accumulator": {
-			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newThreeAssetOneSidedRecord(tPlusOne, geometricTenSecAccum, true),
-			quoteAsset:  []string{denom0, denom0, denom1},
-			expTwap:     []sdk.Dec{sdk.NewDec(10), sdk.NewDec(10), sdk.NewDec(10)},
-		},
-		"three asset same record: asset1, end spot price = 1": {
-			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  []string{denom1, denom2, denom2},
-			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		},
-		"three asset. accumulator = 5*3Sec, t=3s, no start accum": testThreeAssetCaseFromDeltas(
-			sdk.ZeroDec(), fiveFor3Sec, 3*time.Second, five),
-
-		// test that base accum has no impact
-		"three asset. accumulator = 5*3Sec, t=3s. 10 base accum": testThreeAssetCaseFromDeltas(
-			geometricTenSecAccum, fiveFor3Sec, 3*time.Second, five),
-		"three asset. accumulator = 100*100s, t=100s. .1*second base accum": testThreeAssetCaseFromDeltas(
-			twap.TwapLog(OneSec.Quo(ten)), tenFor100Sec, 100*time.Second, ten),
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			for i, startRec := range test.startRecord {
-				actualTwap, err := twap.ComputeTwap(startRec, test.endRecord[i], test.quoteAsset[i], twap.GeometricTwapType)
-
-				require.NoError(t, err)
-				osmoassert.DecApproxEq(t, test.expTwap[i], actualTwap, errTolerance)
-			}
-		})
-	}
-}
-
-// This tests the behavior of computeArithmeticTwap, around error returning
-// when there has been an intermediate spot price error.
-func TestComputeArithmeticTwapWithSpotPriceError(t *testing.T) {
-	newOneSidedRecordWErrorTime := func(time time.Time, accum sdk.Dec, useP0 bool, errTime time.Time) types.TwapRecord {
-		record := newOneSidedRecord(time, accum, useP0)
-		record.LastErrorTime = errTime
-		return record
-	}
-	tests := map[string]computeTwapTestCase{
-		// should error, since end time may have been used to interpolate this value
-		"errAtEndTime from end record": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, tPlusOne),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-			expErr:      true,
-		},
-		// should error, since start time may have been used to interpolate this value
-		"err at StartTime exactly from end record": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, baseTime),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-			expErr:      true,
-		},
-		// should error, since start record is erroneous
-		"err at StartTime exactly from start record": {
-			startRecord: newOneSidedRecordWErrorTime(baseTime, sdk.ZeroDec(), true, baseTime),
-			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-			expErr:      true,
-		},
-		"err before StartTime": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, tMinOne),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-			expErr:      false,
-		},
-		// Should not happen, but if it did would error
-		"err after EndTime": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec.MulInt64(2), true, baseTime.Add(20*time.Second)),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec().MulInt64(2),
-			expErr:      true,
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			actualTwap, err := twap.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset, twap.ArithmeticTwapType)
-			require.Equal(t, test.expTwap, actualTwap)
-			osmoassert.ConditionalError(t, test.expErr, err)
-		})
-	}
-}
 
 // TestPruneRecords tests that twap records earlier than
 // current block time - RecordHistoryKeepPeriod are pruned from the store
@@ -1755,12 +1430,65 @@ func (s *TestSuite) TestTwapPow() {
 	s.Require().True(osmomath.MustNewDecFromStr(fmt.Sprint(result_by_mathPow)).Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 }
 
-type computeTwapTestCase struct {
-	startRecord    types.TwapRecord
-	endRecord      types.TwapRecord
-	twapStrategies []twap.TwapStrategy
-	quoteAsset     string
-	expTwap        sdk.Dec
-	expErr         bool
-	expPanic       bool
+
+func testCaseFromDeltas(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return computeTwapTestCase{
+		newOneSidedRecord(baseTime, startAccum, true),
+		newOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), true),
+		[]twap.TwapStrategy{
+			&twap.ArithmeticTwapStrategy{
+				TwapKeeper: *s.App.TwapKeeper,
+			},
+		},
+		denom0,
+		expectedTwap,
+		false,
+		false,
+	}
+}
+
+func testCaseFromDeltasAsset1(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return computeTwapTestCase{
+		newOneSidedRecord(baseTime, startAccum, false),
+		newOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), false),
+		[]twap.TwapStrategy{
+			&twap.ArithmeticTwapStrategy{
+				TwapKeeper: *s.App.TwapKeeper,
+			},
+		},
+		denom1,
+		expectedTwap,
+		false,
+		false,
+	}
+}
+
+func geometricTestCaseFromDeltas0(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return computeTwapTestCase{
+		newOneSidedGeometricRecord(baseTime, startAccum),
+		newOneSidedGeometricRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff)),
+		[]twap.TwapStrategy{
+			&twap.GeometricTwapStrategy{
+				TwapKeeper: *s.App.TwapKeeper,
+			},
+		},
+		denom0,
+		expectedTwap,
+		false,
+		false,
+	}
+}
+
+func geometricTestCaseFromDeltas1(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return geometricTestCaseFromDeltas0(s, startAccum, accumDiff, timeDelta, sdk.OneDec().Quo(expectedTwap))
+}
+
+func testThreeAssetCaseFromDeltas(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeThreeAssetArithmeticTwapTestCase {
+	return computeThreeAssetArithmeticTwapTestCase{
+		newThreeAssetOneSidedRecord(baseTime, startAccum, true),
+		newThreeAssetOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), true),
+		[]string{denom0, denom0, denom1},
+		[]sdk.Dec{expectedTwap, expectedTwap, expectedTwap},
+		false,
+	}
 }

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -14,18 +14,12 @@ type twapStrategy interface {
 }
 
 type arithmetic struct {
-	keeper Keeper
+	ArithKeeper Keeper
 }
 
 type geometric struct {
-	keeper Keeper
+	GeomKeeper Keeper
 }
-
-type twapStrategies twapStrategy
-
-var _ twapStrategies = &arithmetic{}
-
-var _ twapStrategies = &geometric{}
 
 // computeTwap computes and returns an arithmetic TWAP between
 // two records given the quote asset.

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -21,9 +21,11 @@ type geometric struct {
 	keeper Keeper
 }
 
-var _ twapStrategy = &arithmetic{}
+type twapStrategies twapStrategy
 
-var _ twapStrategy = &geometric{}
+var _ twapStrategies = &arithmetic{}
+
+var _ twapStrategies = &geometric{}
 
 // computeTwap computes and returns an arithmetic TWAP between
 // two records given the quote asset.

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -14,11 +14,11 @@ type twapStrategy interface {
 }
 
 type arithmetic struct {
-	ArithKeeper Keeper
+	TwapKeeper Keeper
 }
 
 type geometric struct {
-	GeomKeeper Keeper
+	TwapKeeper Keeper
 }
 
 // computeTwap computes and returns an arithmetic TWAP between

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -25,6 +25,8 @@ var _ twapStrategy = &arithmetic{}
 
 var _ twapStrategy = &geometric{}
 
+// computeTwap computes and returns an arithmetic TWAP between
+// two records given the quote asset.
 func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
 	var accumDiff sdk.Dec
 	if quoteAsset == startRecord.Asset0Denom {
@@ -37,6 +39,8 @@ func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.T
 
 }
 
+// computeTwap computes and returns a geometric TWAP between
+// two records given the quote asset.
 func (s *geometric) computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
 	accumDiff := endRecord.GeometricTwapAccumulator.Sub(startRecord.GeometricTwapAccumulator)
 

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -10,15 +10,44 @@ import (
 // We expose a common TWAP API to reduce duplication and avoid complexity.
 type twapStrategy interface {
 	// computeTwap calculates the TWAP with specific startRecord and endRecord.
-	computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) (sdk.Dec, error)
+	computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec
 }
 
 type arithmetic struct {
 	keeper Keeper
 }
 
+type geometric struct {
+	keeper Keeper
+}
+
 var _ twapStrategy = &arithmetic{}
 
-func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) (sdk.Dec, error) {
-	return computeTwap(startRecord, endRecord, quoteAsset, arithmeticTwapType)
+var _ twapStrategy = &geometric{}
+
+func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+	var accumDiff sdk.Dec
+	if quoteAsset == startRecord.Asset0Denom {
+		accumDiff = endRecord.P0ArithmeticTwapAccumulator.Sub(startRecord.P0ArithmeticTwapAccumulator)
+	} else {
+		accumDiff = endRecord.P1ArithmeticTwapAccumulator.Sub(startRecord.P1ArithmeticTwapAccumulator)
+	}
+	timeDelta := endRecord.Time.Sub(startRecord.Time)
+	return types.AccumDiffDivDuration(accumDiff, timeDelta)
+
+}
+
+func (s *geometric) computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
+	accumDiff := endRecord.GeometricTwapAccumulator.Sub(startRecord.GeometricTwapAccumulator)
+
+	timeDelta := endRecord.Time.Sub(startRecord.Time)
+	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
+
+	geometricMeanDenom0 := twapPow(arithmeticMeanOfLogPrices)
+	// N.B.: Geometric mean of recprocals is reciprocal of geometric mean.
+	// https://proofwiki.org/wiki/Geometric_Mean_of_Reciprocals_is_Reciprocal_of_Geometric_Mean
+	if quoteAsset == startRecord.Asset1Denom {
+		return sdk.OneDec().Quo(geometricMeanDenom0)
+	}
+	return geometricMeanDenom0
 }

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -32,7 +32,6 @@ func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.T
 	}
 	timeDelta := endRecord.Time.Sub(startRecord.Time)
 	return types.AccumDiffDivDuration(accumDiff, timeDelta)
-
 }
 
 // computeTwap computes and returns a geometric TWAP between

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -269,8 +269,7 @@ func (suite *TwapStrategyTestSuite) TestComputeArithmeticTwap_ThreeAsset() {
 		suite.Run(name, func() {
 			for i, startRec := range test.startRecord {
 				arithmeticStrategy := &twap.ArithmeticTwapStrategy{ArithKeeper: *suite.App.TwapKeeper}
-				actualTwap, err := twap.ComputeTwap(startRec, test.endRecord[i], test.quoteAsset[i], arithmeticStrategy)
-				suite.Require().Error(err)
+				actualTwap := arithmeticStrategy.ComputeTwap(startRec, test.endRecord[i], test.quoteAsset[i])
 				suite.Require().Equal(test.expTwap[i], actualTwap)
 			}
 		})

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -1,112 +1,20 @@
 package twap_test
 
 import (
-	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/suite"
 
-	"github.com/osmosis-labs/osmosis/v13/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/x/twap"
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
-type TwapStrategyTestSuite struct {
-	apptesting.KeeperTestHelper
-}
-
-func TestTwapStrategyTestSuite(t *testing.T) {
-	suite.Run(t, new(TwapStrategyTestSuite))
-}
-
-func (suite *TwapStrategyTestSuite) SetupTest() {
-	suite.Setup()
-}
-
-// TestComputeArithmeticTwap tests computeTwap on various inputs.
-// TODO: test both arithmetic and geometric twap.
-// The test vectors are structured by setting up different start and records,
-// based on time interval, and their accumulator values.
-// Then an expected TWAP is provided in each test case, to compare against computed.
-func (suite *TwapStrategyTestSuite) TestComputeTwap() {
-	tests := map[string]computeTwapTestCase{
-		"arithmetic only, basic: spot price = 1 for one second, 0 init accumulator": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
-			quoteAsset:  denom0,
-			twapStrategies: []twap.TwapStrategy{
-				&twap.ArithmeticTwapStrategy{
-					ArithKeeper: *suite.App.TwapKeeper,
-				},
-			},
-			expTwap: sdk.OneDec(),
-		},
-		// this test just shows what happens in case the records are reversed.
-		// It should return the correct result, even though this is incorrect internal API usage
-		"arithmetic only: invalid call: reversed records of above": {
-			startRecord: newOneSidedRecord(tPlusOne, OneSec, true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom0,
-			twapStrategies: []twap.TwapStrategy{
-				&twap.ArithmeticTwapStrategy{
-					ArithKeeper: *suite.App.TwapKeeper,
-				},
-			},
-			expTwap: sdk.OneDec(),
-		},
-		"same record: denom0, end spot price = 0": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom0,
-			twapStrategies: []twap.TwapStrategy{
-				&twap.ArithmeticTwapStrategy{
-					ArithKeeper: *suite.App.TwapKeeper,
-				},
-				&twap.GeometricTwapStrategy{
-					GeomKeeper: *suite.App.TwapKeeper,
-				},
-			},
-			expTwap: sdk.ZeroDec(),
-		},
-		"same record: denom1, end spot price = 1": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			quoteAsset:  denom1,
-			twapStrategies: []twap.TwapStrategy{
-				&twap.ArithmeticTwapStrategy{
-					ArithKeeper: *suite.App.TwapKeeper,
-				},
-				&twap.GeometricTwapStrategy{
-					GeomKeeper: *suite.App.TwapKeeper,
-				},
-			},
-			expTwap: sdk.OneDec(),
-		},
-		"arithmetic only: accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
-			suite, sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
-		"arithmetic only: accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(suite, sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
-		"geometric only: accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
-			suite, sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
-		"geometric only: accumulator = log(10)*OneSec, t=100s. 0 base accum (asset 1)": geometricTestCaseFromDeltas1(suite, sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, sdk.OneDec().Quo(twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000)))),
-	}
-	for name, test := range tests {
-		suite.Run(name, func() {
-			for _, twapStrategy := range test.twapStrategies {
-				actualTwap, err := twap.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset, twapStrategy)
-				suite.Require().NoError(err)
-				osmoassert.DecApproxEq(suite.T(), test.expTwap, actualTwap, osmomath.GetPowPrecision())
-			}
-		})
-	}
-}
-
 // TestComputeArithmeticStrategyTwap tests computeArithmeticTwap on various inputs.
 // Contrary to computeTwap that handles the cases with zero delta correctly,
 // this function should panic in case of zero delta.
-func (suite *TwapStrategyTestSuite) TestComputeArithmeticStrategyTwap() {
+func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 	pointOneAccum := OneSec.QuoInt64(10)
 	tests := map[string]computeTwapTestCase{
 		"basic: spot price = 1 for one second, 0 init accumulator": {
@@ -130,34 +38,34 @@ func (suite *TwapStrategyTestSuite) TestComputeArithmeticStrategyTwap() {
 			expPanic:    true,
 		},
 		"accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
-			suite, sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+			s, sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
 		"accumulator = 10*OneSec, t=3s. 0 base accum": testCaseFromDeltas(
-			suite, sdk.ZeroDec(), tenSecAccum, 3*time.Second, ThreePlusOneThird),
+			s, sdk.ZeroDec(), tenSecAccum, 3*time.Second, ThreePlusOneThird),
 		"accumulator = 10*OneSec, t=100s. 0 base accum": testCaseFromDeltas(
-			suite, sdk.ZeroDec(), tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+			s, sdk.ZeroDec(), tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 
 		// test that base accum has no impact
 		"accumulator = 10*OneSec, t=5s. 10 base accum": testCaseFromDeltas(
-			suite, sdk.NewDec(10), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+			s, sdk.NewDec(10), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
 		"accumulator = 10*OneSec, t=3s. 10*second base accum": testCaseFromDeltas(
-			suite, tenSecAccum, tenSecAccum, 3*time.Second, ThreePlusOneThird),
+			s, tenSecAccum, tenSecAccum, 3*time.Second, ThreePlusOneThird),
 		"accumulator = 10*OneSec, t=100s. .1*second base accum": testCaseFromDeltas(
-			suite, pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+			s, pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 
-		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(suite, sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(s, sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 	}
 	for name, test := range tests {
-		suite.Run(name, func() {
-			osmoassert.ConditionalPanic(suite.T(), test.expPanic, func() {
-				arithmeticStrategy := &twap.ArithmeticTwapStrategy{ArithKeeper: *suite.App.TwapKeeper}
+		s.Run(name, func() {
+			osmoassert.ConditionalPanic(s.T(), test.expPanic, func() {
+				arithmeticStrategy := &twap.ArithmeticTwapStrategy{TwapKeeper: *s.App.TwapKeeper}
 				actualTwap := arithmeticStrategy.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset)
-				suite.Require().Equal(test.expTwap, actualTwap)
+				s.Require().Equal(test.expTwap, actualTwap)
 			})
 		})
 	}
 }
 
-func (suite *TwapStrategyTestSuite) TestComputeGeometricStrategyTwap() {
+func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 	tests := map[string]computeTwapTestCase{
 		// basic test for both denom with zero start accumulator
 		"basic denom0: spot price = 1 for one second, 0 init accumulator": {
@@ -189,19 +97,19 @@ func (suite *TwapStrategyTestSuite) TestComputeGeometricStrategyTwap() {
 
 		// toggle time delta.
 		"accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
-			suite, sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
+			s, sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
 		"accumulator = log(10)*OneSec, t=3s. 0 base accum": geometricTestCaseFromDeltas0(
-			suite, sdk.ZeroDec(), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
+			s, sdk.ZeroDec(), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
 		"accumulator = log(10)*OneSec, t=100s. 0 base accum": geometricTestCaseFromDeltas0(
-			suite, sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
+			s, sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
 
 		// test that base accum has no impact
 		"accumulator = log(10)*OneSec, t=5s. 10 base accum": geometricTestCaseFromDeltas0(
-			suite, logTen, geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
+			s, logTen, geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
 		"accumulator = log(10)*OneSec, t=3s. 10*second base accum": geometricTestCaseFromDeltas0(
-			suite, OneSec.MulInt64(10).Mul(logTen), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
+			s, OneSec.MulInt64(10).Mul(logTen), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
 		"accumulator = 10*OneSec, t=100s. .1*second base accum": geometricTestCaseFromDeltas0(
-			suite, OneSec.MulInt64(10).Mul(logOneOverTen), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
+			s, OneSec.MulInt64(10).Mul(logOneOverTen), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
 
 		// TODO: this is the highest price we currently support with the given precision bounds.
 		// Need to choose better base and potentially improve math functions to mitigate.
@@ -220,18 +128,18 @@ func (suite *TwapStrategyTestSuite) TestComputeGeometricStrategyTwap() {
 	}
 
 	for name, tc := range tests {
-		suite.Run(name, func() {
-			osmoassert.ConditionalPanic(suite.T(), tc.expPanic, func() {
-				geometricStrategy := &twap.GeometricTwapStrategy{GeomKeeper: *suite.App.TwapKeeper}
+		s.Run(name, func() {
+			osmoassert.ConditionalPanic(s.T(), tc.expPanic, func() {
+				geometricStrategy := &twap.GeometricTwapStrategy{TwapKeeper: *s.App.TwapKeeper}
 				actualTwap := geometricStrategy.ComputeTwap(tc.startRecord, tc.endRecord, tc.quoteAsset)
-				osmoassert.DecApproxEq(suite.T(), tc.expTwap, actualTwap, osmomath.GetPowPrecision())
+				osmoassert.DecApproxEq(s.T(), tc.expTwap, actualTwap, osmomath.GetPowPrecision())
 			})
 		})
 	}
 }
 
 // TODO: split up this test case to cover both arithmetic and geometric twap
-func (suite *TwapStrategyTestSuite) TestComputeArithmeticTwap_ThreeAsset() {
+func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset() {
 	testThreeAssetCaseFromDeltas := func(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeThreeAssetArithmeticTwapTestCase {
 		return computeThreeAssetArithmeticTwapTestCase{
 			newThreeAssetOneSidedRecord(baseTime, startAccum, true),
@@ -266,76 +174,14 @@ func (suite *TwapStrategyTestSuite) TestComputeArithmeticTwap_ThreeAsset() {
 			pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 	}
 	for name, test := range tests {
-		suite.Run(name, func() {
+		s.Run(name, func() {
 			for i, startRec := range test.startRecord {
-				arithmeticStrategy := &twap.ArithmeticTwapStrategy{ArithKeeper: *suite.App.TwapKeeper}
+				arithmeticStrategy := &twap.ArithmeticTwapStrategy{TwapKeeper: *s.App.TwapKeeper}
 				actualTwap := arithmeticStrategy.ComputeTwap(startRec, test.endRecord[i], test.quoteAsset[i])
-				suite.Require().Equal(test.expTwap[i], actualTwap)
+				s.Require().Equal(test.expTwap[i], actualTwap)
 			}
 		})
 	}
-}
-
-// This tests the behavior of computeArithmeticTwap, around error returning
-// when there has been an intermediate spot price error.
-func (suite *TwapStrategyTestSuite) TestComputeArithmeticTwapWithSpotPriceError() {
-	newOneSidedRecordWErrorTime := func(time time.Time, accum sdk.Dec, useP0 bool, errTime time.Time) types.TwapRecord {
-		record := newOneSidedRecord(time, accum, useP0)
-		record.LastErrorTime = errTime
-		return record
-	}
-	tests := map[string]computeTwapTestCase{
-		// should error, since end time may have been used to interpolate this value
-		"errAtEndTime from end record": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, tPlusOne),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-		},
-		// should error, since start time may have been used to interpolate this value
-		"err at StartTime exactly from end record": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, baseTime),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-		},
-		// should error, since start record is erroneous
-		"err at StartTime exactly from start record": {
-			startRecord: newOneSidedRecordWErrorTime(baseTime, sdk.ZeroDec(), true, baseTime),
-			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-		},
-		"err before StartTime": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, tMinOne),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec(),
-		},
-		// Should not happen, but if it did would error
-		"err after EndTime": {
-			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec.MulInt64(2), true, baseTime.Add(20*time.Second)),
-			quoteAsset:  denom0,
-			expTwap:     sdk.OneDec().MulInt64(2),
-		},
-	}
-	for name, test := range tests {
-		suite.Run(name, func() {
-			arithmeticStrategy := &twap.ArithmeticTwapStrategy{*suite.App.TwapKeeper}
-			actualTwap := arithmeticStrategy.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset)
-			suite.Require().Equal(test.expTwap, actualTwap)
-		})
-	}
-}
-
-type computeTwapTestCase struct {
-	startRecord    types.TwapRecord
-	endRecord      types.TwapRecord
-	twapStrategies []twap.TwapStrategy
-	quoteAsset     string
-	expTwap        sdk.Dec
-	expPanic       bool
 }
 
 type computeThreeAssetArithmeticTwapTestCase struct {
@@ -345,13 +191,13 @@ type computeThreeAssetArithmeticTwapTestCase struct {
 	expTwap     []sdk.Dec
 }
 
-func testCaseFromDeltas(suite *TwapStrategyTestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+func testCaseFromDeltas(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
 	return computeTwapTestCase{
 		newOneSidedRecord(baseTime, startAccum, true),
 		newOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), true),
 		[]twap.TwapStrategy{
 			&twap.ArithmeticTwapStrategy{
-				ArithKeeper: *suite.App.TwapKeeper,
+				TwapKeeper: *s.App.TwapKeeper,
 			},
 		},
 		denom0,
@@ -360,13 +206,13 @@ func testCaseFromDeltas(suite *TwapStrategyTestSuite, startAccum, accumDiff sdk.
 	}
 }
 
-func testCaseFromDeltasAsset1(suite *TwapStrategyTestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+func testCaseFromDeltasAsset1(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
 	return computeTwapTestCase{
 		newOneSidedRecord(baseTime, startAccum, false),
 		newOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), false),
 		[]twap.TwapStrategy{
 			&twap.ArithmeticTwapStrategy{
-				ArithKeeper: *suite.App.TwapKeeper,
+				TwapKeeper: *s.App.TwapKeeper,
 			},
 		},
 		denom1,
@@ -375,13 +221,13 @@ func testCaseFromDeltasAsset1(suite *TwapStrategyTestSuite, startAccum, accumDif
 	}
 }
 
-func geometricTestCaseFromDeltas0(suite *TwapStrategyTestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+func geometricTestCaseFromDeltas0(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
 	return computeTwapTestCase{
 		newOneSidedGeometricRecord(baseTime, startAccum),
 		newOneSidedGeometricRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff)),
 		[]twap.TwapStrategy{
 			&twap.GeometricTwapStrategy{
-				GeomKeeper: *suite.App.TwapKeeper,
+				TwapKeeper: *s.App.TwapKeeper,
 			},
 		},
 		denom0,
@@ -390,6 +236,6 @@ func geometricTestCaseFromDeltas0(suite *TwapStrategyTestSuite, startAccum, accu
 	}
 }
 
-func geometricTestCaseFromDeltas1(suite *TwapStrategyTestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
-	return geometricTestCaseFromDeltas0(suite, startAccum, accumDiff, timeDelta, sdk.OneDec().Quo(expectedTwap))
+func geometricTestCaseFromDeltas1(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return geometricTestCaseFromDeltas0(s, startAccum, accumDiff, timeDelta, sdk.OneDec().Quo(expectedTwap))
 }

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -203,6 +203,7 @@ func testCaseFromDeltas(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta t
 		denom0,
 		expectedTwap,
 		false,
+		false,
 	}
 }
 
@@ -218,6 +219,7 @@ func testCaseFromDeltasAsset1(s *TestSuite, startAccum, accumDiff sdk.Dec, timeD
 		denom1,
 		expectedTwap,
 		false,
+		false,
 	}
 }
 
@@ -232,6 +234,7 @@ func geometricTestCaseFromDeltas0(s *TestSuite, startAccum, accumDiff sdk.Dec, t
 		},
 		denom0,
 		expectedTwap,
+		false,
 		false,
 	}
 }

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -1,0 +1,365 @@
+package twap_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
+	"github.com/osmosis-labs/osmosis/v13/osmomath"
+	"github.com/osmosis-labs/osmosis/v13/x/twap"
+	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
+)
+
+// TestComputeArithmeticTwap tests computeTwap on various inputs.
+// TODO: test both arithmetic and geometric twap.
+// The test vectors are structured by setting up different start and records,
+// based on time interval, and their accumulator values.
+// Then an expected TWAP is provided in each test case, to compare against computed.
+func TestComputeTwap(t *testing.T) {
+	tests := map[string]computeTwapTestCase{
+		"arithmetic only, basic: spot price = 1 for one second, 0 init accumulator": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
+			quoteAsset:  denom0,
+			// twapTypes:   []twap.TwapType{twap.ArithmeticTwapType},
+			expTwap: sdk.OneDec(),
+		},
+		// this test just shows what happens in case the records are reversed.
+		// It should return the correct result, even though this is incorrect internal API usage
+		"arithmetic only: invalid call: reversed records of above": {
+			startRecord: newOneSidedRecord(tPlusOne, OneSec, true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom0,
+			// twapTypes:   []twap.TwapType{twap.ArithmeticTwapType},
+			expTwap: sdk.OneDec(),
+		},
+		"same record: denom0, end spot price = 0": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom0,
+			// twapTypes:   []twap.TwapType{twap.ArithmeticTwapType, twap.GeometricTwapType},
+			expTwap: sdk.ZeroDec(),
+		},
+		"same record: denom1, end spot price = 1": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom1,
+			// twapTypes:   []twap.TwapType{twap.ArithmeticTwapType, twap.GeometricTwapType},
+			expTwap: sdk.OneDec(),
+		},
+		"arithmetic only: accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
+			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+		"arithmetic only: accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+		"geometric only: accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
+			sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
+		"geometric only: accumulator = log(10)*OneSec, t=100s. 0 base accum (asset 1)": geometricTestCaseFromDeltas1(sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, sdk.OneDec().Quo(twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000)))),
+	}
+	for name, test := range tests {
+		for _, twapType := range test.twapTypes {
+			twapType := twapType
+			twapTypeStr := "arithmetic"
+			if twapType == twap.GeometricTwapType {
+				twapTypeStr = "geometric"
+			}
+
+			t.Run(fmt.Sprintf("%s - %s", twapTypeStr, name), func(t *testing.T) {
+				actualTwap, err := twap.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset, twapType)
+				require.NoError(t, err)
+				osmoassert.DecApproxEq(t, test.expTwap, actualTwap, osmomath.GetPowPrecision())
+			})
+		}
+	}
+}
+
+// TestComputeArithmeticTwap tests computeArithmeticTwap on various inputs.
+// Contrary to computeTwap that handles the cases with zero delta correctly,
+// this function should panic in case of zero delta.
+func TestComputeArithmeticTwap(t *testing.T) {
+	pointOneAccum := OneSec.QuoInt64(10)
+	tests := map[string]computeTwapTestCase{
+		"basic: spot price = 1 for one second, 0 init accumulator": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+		},
+		// this test just shows what happens in case the records are reversed.
+		// It should return the correct result, even though this is incorrect internal API usage
+		"invalid call: reversed records of above": {
+			startRecord: newOneSidedRecord(tPlusOne, OneSec, true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+		},
+		"same record (zero time delta), division by 0 - panic": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom0,
+			expPanic:    true,
+		},
+		"accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
+			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+		"accumulator = 10*OneSec, t=3s. 0 base accum": testCaseFromDeltas(
+			sdk.ZeroDec(), tenSecAccum, 3*time.Second, ThreePlusOneThird),
+		"accumulator = 10*OneSec, t=100s. 0 base accum": testCaseFromDeltas(
+			sdk.ZeroDec(), tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+
+		// test that base accum has no impact
+		"accumulator = 10*OneSec, t=5s. 10 base accum": testCaseFromDeltas(
+			sdk.NewDec(10), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+		"accumulator = 10*OneSec, t=3s. 10*second base accum": testCaseFromDeltas(
+			tenSecAccum, tenSecAccum, 3*time.Second, ThreePlusOneThird),
+		"accumulator = 10*OneSec, t=100s. .1*second base accum": testCaseFromDeltas(
+			pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+
+		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			osmoassert.ConditionalPanic(t, test.expPanic, func() {
+				actualTwap := twap.ComputeArithmeticTwap(test.startRecord, test.endRecord, test.quoteAsset)
+				require.Equal(t, test.expTwap, actualTwap)
+			})
+		})
+	}
+}
+
+func TestComputeGeometricTwap(t *testing.T) {
+	tests := map[string]computeTwapTestCase{
+		// basic test for both denom with zero start accumulator
+		"basic denom0: spot price = 1 for one second, 0 init accumulator": {
+			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(tPlusOne, geometricTenSecAccum),
+			quoteAsset:  denom0,
+			expTwap:     sdk.NewDec(10),
+		},
+		"basic denom1: spot price = 1 for one second, 0 init accumulator": {
+			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(tPlusOne, geometricTenSecAccum),
+			quoteAsset:  denom1,
+			expTwap:     sdk.OneDec().Quo(sdk.NewDec(10)),
+		},
+
+		// basic test for both denom with non-zero start accumulator
+		"denom0: start accumulator of 10 * 1s, end accumulator 10 * 1s + 20 * 2s = 20": {
+			startRecord: newOneSidedGeometricRecord(baseTime, geometricTenSecAccum),
+			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Second*2), geometricTenSecAccum.Add(OneSec.MulInt64(2).Mul(twap.TwapLog(sdk.NewDec(20))))),
+			quoteAsset:  denom0,
+			expTwap:     sdk.NewDec(20),
+		},
+		"denom1 start accumulator of 10 * 1s, end accumulator 10 * 1s + 20 * 2s = 20": {
+			startRecord: newOneSidedGeometricRecord(baseTime, geometricTenSecAccum),
+			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Second*2), geometricTenSecAccum.Add(OneSec.MulInt64(2).Mul(twap.TwapLog(sdk.NewDec(20))))),
+			quoteAsset:  denom1,
+			expTwap:     sdk.OneDec().Quo(sdk.NewDec(20)),
+		},
+
+		// toggle time delta.
+		"accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
+			sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
+		"accumulator = log(10)*OneSec, t=3s. 0 base accum": geometricTestCaseFromDeltas0(
+			sdk.ZeroDec(), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
+		"accumulator = log(10)*OneSec, t=100s. 0 base accum": geometricTestCaseFromDeltas0(
+			sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
+
+		// test that base accum has no impact
+		"accumulator = log(10)*OneSec, t=5s. 10 base accum": geometricTestCaseFromDeltas0(
+			logTen, geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
+		"accumulator = log(10)*OneSec, t=3s. 10*second base accum": geometricTestCaseFromDeltas0(
+			OneSec.MulInt64(10).Mul(logTen), geometricTenSecAccum, 3*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(3*1000))),
+		"accumulator = 10*OneSec, t=100s. .1*second base accum": geometricTestCaseFromDeltas0(
+			OneSec.MulInt64(10).Mul(logOneOverTen), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
+
+		// TODO: this is the highest price we currently support with the given precision bounds.
+		// Need to choose better base and potentially improve math functions to mitigate.
+		"price of 1_000_000 for an hour": {
+			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Hour), OneSec.MulInt64(60*60).Mul(twap.TwapLog(sdk.NewDec(1_000_000)))),
+			quoteAsset:  denom0,
+			expTwap:     sdk.NewDec(1_000_000),
+		},
+		// TODO: overflow tests
+		// - max spot price
+		// - large time delta
+		// - both
+
+		// TODO: hand calculated tests
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			osmoassert.ConditionalPanic(t, tc.expPanic, func() {
+				actualTwap := twap.ComputeGeometricTwap(tc.startRecord, tc.endRecord, tc.quoteAsset)
+				osmoassert.DecApproxEq(t, tc.expTwap, actualTwap, osmomath.GetPowPrecision())
+			})
+		})
+	}
+}
+
+// TODO: split up this test case to cover both arithmetic and geometric twap
+func TestComputeArithmeticTwap_ThreeAsset(t *testing.T) {
+	testThreeAssetCaseFromDeltas := func(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeThreeAssetArithmeticTwapTestCase {
+		return computeThreeAssetArithmeticTwapTestCase{
+			newThreeAssetOneSidedRecord(baseTime, startAccum, true),
+			newThreeAssetOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), true),
+			[]string{denom0, denom0, denom1},
+			[]sdk.Dec{expectedTwap, expectedTwap, expectedTwap},
+			false,
+		}
+	}
+
+	tenSecAccum := OneSec.MulInt64(10)
+	pointOneAccum := OneSec.QuoInt64(10)
+	tests := map[string]computeThreeAssetArithmeticTwapTestCase{
+		"three asset basic: spot price = 1 for one second, 0 init accumulator": {
+			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newThreeAssetOneSidedRecord(tPlusOne, OneSec, true),
+			quoteAsset:  []string{denom0, denom0, denom1},
+			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
+		},
+		"three asset same record: asset1, end spot price = 1": {
+			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  []string{denom1, denom2, denom2},
+			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
+		},
+		"three asset. accumulator = 10*OneSec, t=5s. 0 base accum": testThreeAssetCaseFromDeltas(
+			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+
+		// test that base accum has no impact
+		"three asset. accumulator = 10*OneSec, t=5s. 10 base accum": testThreeAssetCaseFromDeltas(
+			sdk.NewDec(10), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+		"three asset. accumulator = 10*OneSec, t=100s. .1*second base accum": testThreeAssetCaseFromDeltas(
+			pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for i, startRec := range test.startRecord {
+				actualTwap, err := twap.ComputeTwap(startRec, test.endRecord[i], test.quoteAsset[i], twap.ArithmeticTwapType)
+				require.Equal(t, test.expTwap[i], actualTwap)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// This tests the behavior of computeArithmeticTwap, around error returning
+// when there has been an intermediate spot price error.
+func TestComputeArithmeticTwapWithSpotPriceError(t *testing.T) {
+	newOneSidedRecordWErrorTime := func(time time.Time, accum sdk.Dec, useP0 bool, errTime time.Time) types.TwapRecord {
+		record := newOneSidedRecord(time, accum, useP0)
+		record.LastErrorTime = errTime
+		return record
+	}
+	tests := map[string]computeTwapTestCase{
+		// should error, since end time may have been used to interpolate this value
+		"errAtEndTime from end record": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, tPlusOne),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+			expErr:      true,
+		},
+		// should error, since start time may have been used to interpolate this value
+		"err at StartTime exactly from end record": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, baseTime),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+			expErr:      true,
+		},
+		// should error, since start record is erroneous
+		"err at StartTime exactly from start record": {
+			startRecord: newOneSidedRecordWErrorTime(baseTime, sdk.ZeroDec(), true, baseTime),
+			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+			expErr:      true,
+		},
+		"err before StartTime": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec, true, tMinOne),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+			expErr:      false,
+		},
+		// Should not happen, but if it did would error
+		"err after EndTime": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecordWErrorTime(tPlusOne, OneSec.MulInt64(2), true, baseTime.Add(20*time.Second)),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec().MulInt64(2),
+			expErr:      true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualTwap, err := twap.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset, twap.ArithmeticTwapType)
+			require.Equal(t, test.expTwap, actualTwap)
+			osmoassert.ConditionalError(t, test.expErr, err)
+		})
+	}
+}
+
+type computeTwapTestCase struct {
+	startRecord types.TwapRecord
+	endRecord   types.TwapRecord
+	//twapTypes   []twap.TwapType
+	quoteAsset string
+	expTwap    sdk.Dec
+	expErr     bool
+	expPanic   bool
+}
+
+type computeThreeAssetArithmeticTwapTestCase struct {
+	startRecord []types.TwapRecord
+	endRecord   []types.TwapRecord
+	quoteAsset  []string
+	expTwap     []sdk.Dec
+	expErr      bool
+}
+
+func testCaseFromDeltas(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return computeTwapTestCase{
+		newOneSidedRecord(baseTime, startAccum, true),
+		newOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), true),
+		// []twap.TwapType{twap.ArithmeticTwapType},
+		denom0,
+		expectedTwap,
+		false,
+		false,
+	}
+}
+
+func testCaseFromDeltasAsset1(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return computeTwapTestCase{
+		newOneSidedRecord(baseTime, startAccum, false),
+		newOneSidedRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff), false),
+		// []twap.TwapType{twap.ArithmeticTwapType},
+		denom1,
+		expectedTwap,
+		false,
+		false,
+	}
+}
+
+func geometricTestCaseFromDeltas0(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return computeTwapTestCase{
+		newOneSidedGeometricRecord(baseTime, startAccum),
+		newOneSidedGeometricRecord(baseTime.Add(timeDelta), startAccum.Add(accumDiff)),
+		// []twap.TwapType{twap.GeometricTwapType},
+		denom0,
+		expectedTwap,
+		false,
+		false,
+	}
+}
+
+func geometricTestCaseFromDeltas1(startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
+	return geometricTestCaseFromDeltas0(startAccum, accumDiff, timeDelta, sdk.OneDec().Quo(expectedTwap))
+}

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -147,12 +147,6 @@ func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Arithmetic() {
 			quoteAsset:  []string{denom0, denom0, denom1},
 			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
 		},
-		// "three asset same record: asset1, end spot price = 1": {
-		// 	startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	quoteAsset:  []string{denom1, denom2, denom2},
-		// 	expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		// },
 		"three asset. accumulator = 10*OneSec, t=5s. 0 base accum": testThreeAssetCaseFromDeltas(
 			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
 
@@ -191,12 +185,6 @@ func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Geometric() {
 			quoteAsset:  []string{denom0, denom0, denom1},
 			expTwap:     []sdk.Dec{sdk.NewDec(10), sdk.NewDec(10), sdk.NewDec(10)},
 		},
-		// "three asset same record: asset1, end spot price = 1": {
-		// 	startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	quoteAsset:  []string{denom1, denom2, denom2},
-		// 	expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		// },
 		"three asset. accumulator = 5*3Sec, t=3s, no start accum": testThreeAssetCaseFromDeltas(
 			sdk.ZeroDec(), fiveFor3Sec, 3*time.Second, five),
 

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -8,10 +8,103 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/x/twap"
+	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
-// TestComputeArithmeticStrategyTwap tests computeArithmeticTwap on various inputs.
-// Contrary to computeTwap that handles the cases with zero delta correctly,
+type computeTwapTestCase struct {
+	startRecord    types.TwapRecord
+	endRecord      types.TwapRecord
+	twapStrategies []twap.TwapStrategy
+	quoteAsset     string
+	expTwap        sdk.Dec
+	expErr         bool
+	expPanic       bool
+}
+
+// TestComputeArithmeticTwap tests computeTwap on various inputs.
+// The test vectors are structured by setting up different start and records,
+// based on time interval, and their accumulator values.
+// Then an expected TWAP is provided in each test case, to compare against computed.
+func (s *TestSuite) TestComputeTwap() {
+	arithStrategy := &twap.ArithmeticTwapStrategy{
+		TwapKeeper: *s.App.TwapKeeper,
+	}
+
+	geomStrategy := &twap.GeometricTwapStrategy{
+		TwapKeeper: *s.App.TwapKeeper,
+	}
+
+	tests := map[string]computeTwapTestCase{
+		"arithmetic only, basic: spot price = 1 for one second, 0 init accumulator": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
+			quoteAsset:  denom0,
+			twapStrategies: []twap.TwapStrategy{
+				arithStrategy,
+			},
+			expTwap: sdk.OneDec(),
+		},
+		// this test just shows what happens in case the records are reversed.
+		// It should return the correct result, even though this is incorrect internal API usage
+		"arithmetic only: invalid call: reversed records of above": {
+			startRecord: newOneSidedRecord(tPlusOne, OneSec, true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom0,
+			twapStrategies: []twap.TwapStrategy{
+				arithStrategy,
+			},
+			expTwap: sdk.OneDec(),
+		},
+		"same record: denom0, end spot price = 0": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom0,
+			twapStrategies: []twap.TwapStrategy{
+				arithStrategy,
+				geomStrategy,
+			},
+			expTwap: sdk.ZeroDec(),
+		},
+		"same record: denom1, end spot price = 1": {
+			startRecord: newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(baseTime, sdk.ZeroDec(), true),
+			quoteAsset:  denom1,
+			twapStrategies: []twap.TwapStrategy{
+				arithStrategy,
+				geomStrategy,
+			},
+			expTwap: sdk.OneDec(),
+		},
+		"arithmetic only: accumulator = 10*OneSec, t=5s. 0 base accum": testCaseFromDeltas(
+			s, sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
+		"arithmetic only: accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(s, sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+		"geometric only: accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
+			s, sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
+		"geometric only: accumulator = log(10)*OneSec, t=100s. 0 base accum (asset 1)": geometricTestCaseFromDeltas1(s, sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, sdk.OneDec().Quo(twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000)))),
+		"three asset same record: asset1, end spot price = 1": {
+			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true)[1],
+			endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true)[1],
+			quoteAsset:  denom2,
+			expTwap:     sdk.OneDec(),
+			twapStrategies: []twap.TwapStrategy{
+				arithStrategy,
+				geomStrategy,
+			},
+		},
+	}
+	for name, test := range tests {
+		s.Run(name, func() {
+			for _, twapStrategy := range test.twapStrategies {
+				actualTwap, err := twap.ComputeTwap(test.startRecord, test.endRecord, test.quoteAsset, twapStrategy)
+				s.Require().NoError(err)
+				osmoassert.DecApproxEq(s.T(), test.expTwap, actualTwap, osmomath.GetPowPrecision())
+			}
+		})
+	}
+}
+
+// TestComputeArithmeticStrategyTwap tests arithmetic strategy's computeTwap
+// Contrary to computeTwap function (logic.go) that handles the cases with zero delta correctly,
 // this function should panic in case of zero delta.
 func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 	pointOneAccum := OneSec.QuoInt64(10)
@@ -64,6 +157,9 @@ func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 	}
 }
 
+// TestComputeGeometricStrategyTwap tests geometric strategy's computeTwap
+// Contrary to computeTwap function (logic.go) that handles the cases with zero delta correctly,
+// this function should panic in case of zero delta.
 func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 	tests := map[string]computeTwapTestCase{
 		// basic test for both denom with zero start accumulator
@@ -137,7 +233,7 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 	}
 }
 
-func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Arithmetic() {
+func (s *TestSuite) TestComputeArithmeticStrategyTwap_ThreeAsset() {
 	tenSecAccum := OneSec.MulInt64(10)
 	pointOneAccum := OneSec.QuoInt64(10)
 	tests := map[string]computeThreeAssetArithmeticTwapTestCase{
@@ -167,7 +263,7 @@ func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Arithmetic() {
 	}
 }
 
-func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Geometric() {
+func (s *TestSuite) TestComputeGeometricStrategyTwap_ThreeAsset() {
 	var (
 		five        = sdk.NewDec(5)
 		fiveFor3Sec = OneSec.MulInt64(3).Mul(twap.TwapLog(five))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: Part of https://github.com/osmosis-labs/osmosis/issues/3514 [3-8]

## What is the purpose of the change

1. geometric implementation is added to strategy.go
2. Refactor computeTwap to take twapStrategy instead of twapType.
3. move logic from computeArithmeticTwap to its respective strategy's computeTwap.
4. getTwap function is introduced to api.go
5. getArithmeticTwap utilizes arithmetic strategy and calls getTwap
6. getTwapToNow function is introduced to api.go
7. run these tests for both arithmetic and Geometric strategies, minimizing code duplication in tests

## Brief Changelog
n/a

## Testing and Verifying
moved test from logic_test.go to strategy_test.go 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)