### PR TITLE
Add more file-awareness for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
           PATTERNS: |
             **/**.wasm
             **/**!(test).go
-            tests/**/**.go
             go.mod
             go.sum
             Makefile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,20 +26,33 @@ jobs:
     name: osmosis ${{ matrix.arch }} for ${{ matrix.targetos }}
     steps:
       - uses: actions/checkout@v2
+      - name: Get git diff
+        uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.wasm
+            **/**!(test).go
+            tests/**/**.go
+            go.mod
+            go.sum
+            Makefile
       - uses: actions/setup-go@v2.1.4
         with:
           go-version: '^1.18'
         env:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}
+        if: env.GIT_DIFF
 
       - name: Compile osmosis
         run: |
           go mod download
           cd cmd/osmosisd
           go build .
+        if: env.GIT_DIFF
 
       - uses: actions/upload-artifact@v2
         with:
           name: osmosisd ${{ matrix.targetos }} ${{ matrix.arch }}
           path: cmd/osmosisd/osmosisd
+        if: env.GIT_DIFF

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,16 +32,19 @@ jobs:
         uses: dtolnay/rust-toolchain@1.65.0
         with:
           target: wasm32-unknown-unknown
+        if: env.GIT_DIFF
 
       - name: Add the wasm target
         working-directory: ${{ matrix.contract.workdir }}
         run: >
           rustup target add wasm32-unknown-unknown;
+        if: env.GIT_DIFF
 
       - name: Test
         working-directory: ${{ matrix.contract.workdir }}
         run: >
           cargo test
+        if: env.GIT_DIFF
 
 #      - name: Set latest cw-optimizoor version
 #        run: >
@@ -70,6 +73,7 @@ jobs:
             --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
             --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
             cosmwasm/workspace-optimizer:0.12.10
+        if: env.GIT_DIFF
 
       - name: 'Upload optimized contract artifact'
         uses: actions/upload-artifact@v3
@@ -77,6 +81,7 @@ jobs:
           name: ${{ matrix.contract.name }}
           path: ${{ matrix.contract.workdir }}${{ matrix.contract.build }}
           retention-days: 1
+        if: env.GIT_DIFF
 
       - name: 'Upload Cargo.lock artifact'
         uses: actions/upload-artifact@v3
@@ -84,12 +89,14 @@ jobs:
           name: Cargo.lock
           path: ${{ matrix.contract.workdir }}Cargo.lock
           retention-days: 1
+        if: env.GIT_DIFF
 
       - name: Check Test Data
         working-directory: ${{ matrix.contract.workdir }}
         if: ${{ matrix.contract.output != null }}
         run: >
           diff ${{ matrix.contract.output }} ${{ matrix.contract.build }}
+        if: env.GIT_DIFF
   
 
   lints:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
             go.mod
             go.sum
             .github/**
+            Makefile
       - name: Get data from build cache
         uses: actions/cache@v2
         with:
@@ -61,6 +62,7 @@ jobs:
             **/**.md
             go.mod
             go.sum
+            Makefile
       - name: Run documentation linter
         run: make mdlint
         if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,7 @@ jobs:
           key: ${{ runner.os }}-go-linter-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-linter-${{ matrix.go-version }}-
+        if: env.GIT_DIFF
       - name: Run golangci-lint
         run: make lint
         if: env.GIT_DIFF
@@ -53,5 +54,12 @@ jobs:
           # Full git history is needed to get a proper list of changed files
           # within `super-linter`.
           fetch-depth: 0
+      - uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.md
+            go.mod
+            go.sum
       - name: Run documentation linter
         run: make mdlint
+        if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
+            .github/**
       - name: Get data from build cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -14,11 +14,23 @@ jobs:
       - uses: actions/setup-go@v2.1.4
         with:
           go-version: 1.18
-      - name: Display go version
-        run: go version
+      -
+        name: Get git diff
+        uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.wasm
+            **/**!(test).go
+            tests/**/**.go
+            go.mod
+            go.sum
+            Makefile
       - name: Run full application simulation
         run: |
           make test-sim-app
+        if: env.GIT_DIFF
+
       - name: Run simulation determinism check
         run: |
           make test-sim-determinism
+        if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,8 @@ jobs:
         with:
           PATTERNS: |
             **/**.wasm
-            **/**.go
+            **/**!(test).go
+            tests/**/**.go
             go.mod
             go.sum
       -
@@ -88,9 +89,11 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        if: env.GIT_DIFF
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        if: env.GIT_DIFF
       -
         name: Build e2e image
         uses: docker/build-push-action@v3
@@ -103,6 +106,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
+        if: env.GIT_DIFF
       -
         name: Test e2e and Upgrade
         run: make test-e2e-ci
+        if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
             tests/**/**.go
             go.mod
             go.sum
+            Makefile
       -
         name: Get data from build cache
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
+        if: env.GIT_DIFF
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
         uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
+            **/**.wasm
             **/**.go
             go.mod
             go.sum

--- a/app/app.go
+++ b/app/app.go
@@ -74,6 +74,7 @@ var (
 	// module accounts that are allowed to receive tokens.
 	allowedReceivingModAcc = map[string]bool{ibc_hooks.WasmHookModuleAccountAddr.String(): true}
 
+	// TODO: Refactor wasm items into a wasm.go file
 	// WasmProposalsEnabled enables all x/wasm proposals when it's value is "true"
 	// and EnableSpecificWasmProposals is empty. Otherwise, all x/wasm proposals
 	// are disabled.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR makes:
go linter CI only run if:
- go mod/sum edited
- go file edited
- CI configs edited
- Makefile edited

md linter CI only run if
- go mod;sum edited
- markdown file edited
- Makefile edited

E2E tests (and simulation) only run if
- go mod;sum edited
- non-test go file edited
- anything in tests/** edited
- .wasm binary edited
- Makefile edited

Compile CI only run if:
- go mod;sum edited
- non-test go file edited
- .wasm binary edited
- Makefile edited

## Brief Changelog

Should hopefully speedup our average case CI time more.