### PR TITLE
x/gamm module minor code improvements

### DIFF
--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -225,14 +225,18 @@ func (k Keeper) JoinPoolNoSwap(
 	}
 
 	// check that needed lp liquidity does not exceed the given `tokenInMaxs` parameter. Return error if so.
-	// if tokenInMaxs == 0, don't do this check.
+	//if tokenInMaxs == 0, don't do this check.
 	if tokenInMaxs.Len() != 0 {
-		if !(neededLpLiquidity.DenomsSubsetOf(tokenInMaxs) && tokenInMaxs.IsAllGTE(neededLpLiquidity)) {
-			return nil, sdk.ZeroInt(), sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs is less than the needed LP liquidity to this JoinPoolNoSwap,"+
+		if !(neededLpLiquidity.DenomsSubsetOf(tokenInMaxs)) {
+			return nil, sdk.ZeroInt(), sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs does not include all the tokens that are part of the target pool,"+
 				" upperbound: %v, needed %v", tokenInMaxs, neededLpLiquidity)
 		} else if !(tokenInMaxs.DenomsSubsetOf(neededLpLiquidity)) {
 			return nil, sdk.ZeroInt(), sdkerrors.Wrapf(types.ErrDenomNotFoundInPool, "TokenInMaxs includes tokens that are not part of the target pool,"+
 				" input tokens: %v, pool tokens %v", tokenInMaxs, neededLpLiquidity)
+		}
+		if !(tokenInMaxs.IsAllGTE(neededLpLiquidity)) {
+			return nil, sdk.ZeroInt(), sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs is less than the needed LP liquidity to this JoinPoolNoSwap,"+
+				" upperbound: %v, needed %v", tokenInMaxs, neededLpLiquidity)
 		}
 	}
 

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -440,6 +440,15 @@ func (suite *KeeperTestSuite) TestJoinPoolNoSwap() {
 			},
 			expectPass: false,
 		},
+		{
+			name:            "join no swap with TokenInMaxs not containing every token in pool",
+			txSender:        suite.TestAccs[1],
+			sharesRequested: types.OneShare.MulRaw(50),
+			tokenInMaxs: sdk.Coins{
+				fiveKFooAndBar[0],
+			},
+			expectPass: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/x/gamm/pool-models/balancer/msgs.go
+++ b/x/gamm/pool-models/balancer/msgs.go
@@ -89,7 +89,7 @@ func (msg MsgCreateBalancerPool) InitialLiquidity() sdk.Coins {
 		coins = append(coins, asset.Token)
 	}
 	if coins == nil {
-		panic("Shouldn't happen")
+		panic("InitialLiquidity coins is equal to nil - this shouldn't happen")
 	}
 	coins = coins.Sort()
 	return coins


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change
This PR is created during the Informal Systems audit, after analysis of the existing specification and code inspection
Auditing is performed on commit hash: https://github.com/osmosis-labs/osmosis/commit/42d73f1cc1c52e85561518be1014b730ef6b7a12
Fixing  misleading error messages due to `tokenInMaxs` amount checks.


## Brief Changelog

- `JoinPoolNoSwap` changed to return specific error for not containing  all the tokens in pool, added one UT 
- `InitialLiquidity` panic message better explained (since I was here, but shouldn't happen anyhow)


## Testing and Verifying

*(Please pick one of the following options)*

This change is already covered by existing tests, such as `TestJoinPoolNoSwap` tests and

  - *Added unit test that validates failure of `JoinPoolNoSwap` when not providing all denoms from a pool in `tokenInMaxs`*


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? NO
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? NO
  - How is the feature or change documented?  was already documented in specification `x/GAMM/breaking_changes_notes.md`