### PR TITLE
ProtoRev: Trade Execution + Statistics

### DIFF
--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -581,7 +581,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 					Weight: sdk.NewInt(25),
 				},
 				{
-					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(6121181710)),
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(6121181710)),
 					Weight: sdk.NewInt(25),
 				},
 			},
@@ -611,7 +611,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 					Weight: sdk.NewInt(70),
 				},
 				{
-					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(10285796639)),
+					Token:  sdk.NewCoin(types.AtomDenomination, sdk.NewInt(10285796639)),
 					Weight: sdk.NewInt(30),
 				},
 			},

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -92,28 +92,24 @@ func (k Keeper) FindMaxProfitForRoute(ctx sdk.Context, route gammtypes.SwapAmoun
 	tokenIn := sdk.Coin{}
 	profit := sdk.ZeroInt()
 
-	// 10 ^ 6 is multiplied to the input amount to convert to the base unit
-	million := sdk.NewInt(1_000_000)
 	curLeft := sdk.OneInt()
-	curMid := sdk.OneInt()
 	curRight := types.MaxInputAmount
-
 	iteration := 0
 
 	for curLeft.LT(curRight) && iteration < types.MaxIterations {
 		iteration++
 
-		curMid = (curLeft.Add(curRight)).Quo(sdk.NewInt(2))
+		curMid := (curLeft.Add(curRight)).Quo(sdk.NewInt(2))
 		curMidPlusOne := curMid.Add(sdk.OneInt())
 
 		// Short circuit profit searching if there is an error in the GAMM module
-		_, profitMid, err := k.EstimateMultihopProfit(ctx, inputDenom, curMid.Mul(million), route)
+		_, profitMid, err := k.EstimateMultihopProfit(ctx, inputDenom, curMid.Mul(types.StepSize), route)
 		if err != nil {
 			return sdk.Coin{}, sdk.ZeroInt(), err
 		}
 
 		// Short circuit profit searching if there is an error in the GAMM module
-		tokenInMidPlusOne, profitMidPlusOne, err := k.EstimateMultihopProfit(ctx, inputDenom, curMidPlusOne.Mul(million), route)
+		tokenInMidPlusOne, profitMidPlusOne, err := k.EstimateMultihopProfit(ctx, inputDenom, curMidPlusOne.Mul(types.StepSize), route)
 		if err != nil {
 			return sdk.Coin{}, sdk.ZeroInt(), err
 		}

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -1,0 +1,162 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+// IterateRoutes checks the profitability of every single route that is passed in
+// and returns the optimal route if there is one
+func (k Keeper) IterateRoutes(ctx sdk.Context, routes []gammtypes.SwapAmountInRoutes) (sdk.Coin, sdk.Int, gammtypes.SwapAmountInRoutes) {
+	var optimalRoute gammtypes.SwapAmountInRoutes
+	maxProfitInputCoin := sdk.NewCoin(types.OsmosisDenomination, sdk.ZeroInt())
+	maxProfit := sdk.ZeroInt()
+
+	for _, route := range routes {
+		// Find the max profit for the route using the token out denom of the last pool in the route as the input token denom
+		inputCoin, profit, err := k.FindMaxProfitForRoute(ctx, route, route[2].TokenOutDenom)
+		if err != nil {
+			k.Logger(ctx).Error("Error finding max profit for route: ", err)
+			continue
+		}
+
+		// Filter out routes that don't have any profit
+		if profit.LTE(sdk.ZeroInt()) {
+			continue
+		}
+
+		// If arb doesn't start and end with uosmo, then we convert the profit to uosmo, and compare profits in terms of uosmo
+		if inputCoin.Denom != types.OsmosisDenomination {
+			uosmoProfit, err := k.ConvertProfits(ctx, inputCoin, profit)
+			if err != nil {
+				k.Logger(ctx).Error("Error converting profits: ", err)
+				continue
+			}
+			profit = uosmoProfit
+		}
+
+		// Select the optimal route King of the Hill style (route with the highest profit will be executed)
+		if profit.GT(maxProfit) {
+			optimalRoute = route
+			maxProfit = profit
+			maxProfitInputCoin = inputCoin
+		}
+	}
+
+	return maxProfitInputCoin, maxProfit, optimalRoute
+}
+
+// ConvertProfits converts the profit denom to uosmo to allow for a fair comparison of profits
+func (k Keeper) ConvertProfits(ctx sdk.Context, inputCoin sdk.Coin, profit sdk.Int) (sdk.Int, error) {
+	// Get highest liquidity pool ID for the input coin and uosmo
+	conversionPoolID, err := k.GetOsmoPool(ctx, inputCoin.Denom)
+	if err != nil {
+		return profit, err
+	}
+
+	// Get the pool
+	conversionPool, err := k.gammKeeper.GetPoolAndPoke(ctx, conversionPoolID)
+	if err != nil {
+		return profit, err
+	}
+
+	// Calculate the amount of uosmo that we can get if we swapped the
+	// profited amount of the orignal asset through the highest uosmo liquidity pool
+	conversionTokenOut, err := conversionPool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewCoin(inputCoin.Denom, profit)), types.OsmosisDenomination, conversionPool.GetSwapFee(ctx))
+	if err != nil {
+		return profit, err
+	}
+
+	// Set and return the profit denominated in uosmo
+	uosmoProfit := conversionTokenOut.Amount
+
+	return uosmoProfit, nil
+}
+
+// EstimateMultihopProfit estimates the profit for a given route
+// by estimating the amount out given the amount in for the first pool in the route
+// and then subtracting the amount in from the amount out to get the profit
+func (k Keeper) EstimateMultihopProfit(ctx sdk.Context, inputDenom string, amount sdk.Int, route gammtypes.SwapAmountInRoutes) (sdk.Coin, sdk.Int, error) {
+	tokenIn := sdk.NewCoin(inputDenom, amount)
+	amtOut, err := k.gammKeeper.MultihopEstimateOutGivenExactAmountIn(ctx, route, tokenIn)
+	if err != nil {
+		return sdk.NewCoin(types.OsmosisDenomination, sdk.ZeroInt()), sdk.ZeroInt(), err
+	}
+	profit := amtOut.Sub(tokenIn.Amount)
+	return tokenIn, profit, nil
+}
+
+// FindMaxProfitRoute runs a binary search to find the max profit for a given route
+func (k Keeper) FindMaxProfitForRoute(ctx sdk.Context, route gammtypes.SwapAmountInRoutes, inputDenom string) (sdk.Coin, sdk.Int, error) {
+	left := 0
+	right := len(types.InputAmountList) - 1
+	midPosition := 0
+	iteration := 0
+
+	for left < right {
+		midPosition = (left + right) / 2
+
+		// Short circuit profit searching if there is an error in the GAMM module
+		_, profitMidPosition, err := k.EstimateMultihopProfit(ctx, inputDenom, types.InputAmountList[midPosition], route)
+		if err != nil {
+			return sdk.Coin{Denom: types.OsmosisDenomination, Amount: sdk.ZeroInt()}, sdk.ZeroInt(), err
+		}
+
+		// Short circuit profit searching if there is an error in the GAMM module
+		_, profitMidPositionPlusOne, err := k.EstimateMultihopProfit(ctx, inputDenom, types.InputAmountList[midPosition+1], route)
+		if err != nil {
+			return sdk.Coin{Denom: types.OsmosisDenomination, Amount: sdk.ZeroInt()}, sdk.ZeroInt(), err
+		}
+
+		// Reduce subspace to search for max profit
+		if profitMidPosition.LTE(profitMidPositionPlusOne) {
+			left = midPosition + 1
+		} else if profitMidPosition.GT(profitMidPositionPlusOne) {
+			right = midPosition
+		}
+
+		// Circuit breaker to prevent unbounded runtime
+		iteration += 1
+		if iteration >= 20 {
+			break
+		}
+	}
+
+	tokenIn, profit, err := k.EstimateMultihopProfit(ctx, inputDenom, types.InputAmountList[left], route)
+	if err != nil {
+		return sdk.Coin{Denom: types.OsmosisDenomination, Amount: sdk.ZeroInt()}, sdk.ZeroInt(), err
+	}
+
+	return tokenIn, profit, nil
+}
+
+// ExecuteTrade inputs a route, amount in, and rebalances the pool
+func (k Keeper) ExecuteTrade(ctx sdk.Context, route gammtypes.SwapAmountInRoutes, inputCoin sdk.Coin, poolId uint64) error {
+	// Get the module address which will execute the trade
+	protorevModuleAddress := k.accountKeeper.GetModuleAddress(types.ModuleName)
+
+	// Mint the module account the input coin to trade
+	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(inputCoin)); err != nil {
+		return err
+	}
+
+	// Use the inputCoin.Amount as the min amount out to ensure profitability
+	tokenOutAmount, err := k.gammKeeper.MultihopSwapExactAmountIn(ctx, protorevModuleAddress, route, inputCoin, inputCoin.Amount)
+	if err != nil {
+		return err
+	}
+
+	// Burn the coins from the module account after the trade and leave all remaining coins in the module account
+	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(inputCoin)); err != nil {
+		return err
+	}
+
+	// Update the module statistics stores
+	if err = k.UpdateStatistics(ctx, route, inputCoin, tokenOutAmount); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -69,10 +69,8 @@ func (k Keeper) ConvertProfits(ctx sdk.Context, inputCoin sdk.Coin, profit sdk.I
 		return profit, err
 	}
 
-	// Set and return the profit denominated in uosmo
-	uosmoProfit := conversionTokenOut.Amount
-
-	return uosmoProfit, nil
+	// return the profit denominated in uosmo
+	return conversionTokenOut.Amount, nil
 }
 
 // EstimateMultihopProfit estimates the profit for a given route

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -1,0 +1,388 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+func (suite *KeeperTestSuite) TestFindMaxProfitRoute() {
+
+	type param struct {
+		route          gammtypes.SwapAmountInRoutes
+		expectedAmtIn  sdk.Int
+		expectedProfit sdk.Int
+	}
+
+	tests := []struct {
+		name       string
+		param      param
+		expectPass bool
+	}{
+		{name: "Mainnet Arb Route - 2 Asset, Same Weights (Block: 5905150)",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        22,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        23,
+						TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        24,
+						TokenOutDenom: "uosmo",
+					}},
+				expectedAmtIn:  sdk.NewInt(10100000),
+				expectedProfit: sdk.NewInt(24852)},
+			expectPass: true},
+		{name: "Mainnet Arb Route - Multi Asset, Same Weights (Block: 6906570)",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        26,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        28,
+						TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        27,
+						TokenOutDenom: "uosmo",
+					}},
+				expectedAmtIn:  sdk.NewInt(4800000),
+				expectedProfit: sdk.NewInt(4547)},
+			expectPass: true},
+		{name: "Arb Route - Multi Asset, Same Weights - Pool 22 instead of 26 (Block: 6906570)",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        22,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        28,
+						TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        27,
+						TokenOutDenom: "uosmo",
+					}},
+				expectedAmtIn:  sdk.NewInt(519700000),
+				expectedProfit: sdk.NewInt(67511701)},
+			expectPass: true},
+		{name: "Mainnet Arb Route - Multi Asset, Different Weights (Block: 6908256)",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        31,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        32,
+						TokenOutDenom: "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        33,
+						TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+					}},
+				expectedAmtIn:  sdk.NewInt(4100000),
+				expectedProfit: sdk.NewInt(5826)},
+			expectPass: true},
+		{name: "StableSwap Test Route",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        29,
+						TokenOutDenom: "usdc",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        34,
+						TokenOutDenom: "busd",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        30,
+						TokenOutDenom: "uosmo",
+					}},
+				expectedAmtIn:  sdk.NewInt(137600000),
+				expectedProfit: sdk.NewInt(56585438)},
+			expectPass: true},
+		{name: "No Arbitrage Opportunity",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        7,
+						TokenOutDenom: "akash",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        12,
+						TokenOutDenom: "juno",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        8,
+						TokenOutDenom: "uosmo",
+					}},
+				expectedAmtIn:  sdk.NewInt(0),
+				expectedProfit: sdk.NewInt(0)},
+			expectPass: false},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+
+			amtIn, profit, err := suite.App.ProtoRevKeeper.FindMaxProfitForRoute(
+				suite.Ctx,
+				test.param.route,
+				test.param.route[2].TokenOutDenom,
+			)
+
+			if test.expectPass {
+				suite.Require().NoError(err)
+				suite.Require().Equal(test.param.expectedAmtIn, amtIn.Amount)
+				suite.Require().Equal(test.param.expectedProfit, profit)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestExecuteTrade() {
+
+	type param struct {
+		route          gammtypes.SwapAmountInRoutes
+		inputCoin      sdk.Coin
+		expectedProfit sdk.Int
+	}
+
+	tests := []struct {
+		name       string
+		param      param
+		poolId     uint64
+		arbDenom   string
+		expectPass bool
+	}{
+		{
+			name: "Mainnet Arb Route",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        22,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        23,
+						TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        24,
+						TokenOutDenom: "uosmo",
+					},
+				},
+				inputCoin:      sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
+				expectedProfit: sdk.NewInt(24852),
+			},
+			poolId:     23,
+			arbDenom:   types.OsmosisDenomination,
+			expectPass: true,
+		},
+		{
+			name: "No arbitrage opportunity - expect error at multihopswap due to profitability invariant",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        7,
+						TokenOutDenom: "akash",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        12,
+						TokenOutDenom: "juno",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        8,
+						TokenOutDenom: "uosmo",
+					}},
+				inputCoin:      sdk.NewCoin("uosmo", sdk.NewInt(1000000)),
+				expectedProfit: sdk.NewInt(0),
+			},
+			poolId:     12,
+			arbDenom:   types.OsmosisDenomination,
+			expectPass: false,
+		},
+		{
+			name: "0 input amount - expect error at multihopswap due to amount needing to be positive",
+			param: param{
+				route: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        7,
+						TokenOutDenom: "akash",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        12,
+						TokenOutDenom: "juno",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        8,
+						TokenOutDenom: "uosmo",
+					}},
+				inputCoin:      sdk.NewCoin("uosmo", sdk.NewInt(0)),
+				expectedProfit: sdk.NewInt(0),
+			},
+			poolId:     12,
+			arbDenom:   types.OsmosisDenomination,
+			expectPass: false,
+		},
+	}
+
+	for _, test := range tests {
+
+		err := suite.App.ProtoRevKeeper.ExecuteTrade(
+			suite.Ctx,
+			test.param.route,
+			test.param.inputCoin,
+			test.poolId,
+		)
+
+		if test.expectPass {
+			suite.Require().NoError(err)
+
+			// Check the protorev statistics
+			numberOfTrades, err := suite.App.ProtoRevKeeper.GetTradesByRoute(suite.Ctx, test.param.route.PoolIds())
+			suite.Require().NoError(err)
+			suite.Require().Equal(sdk.OneInt(), numberOfTrades)
+
+			routeProfit, err := suite.App.ProtoRevKeeper.GetProfitsByRoute(suite.Ctx, test.param.route.PoolIds(), test.arbDenom)
+			suite.Require().NoError(err)
+			suite.Require().Equal(test.param.expectedProfit, routeProfit.Amount)
+
+			profit, err := suite.App.ProtoRevKeeper.GetProfitsByDenom(suite.Ctx, test.arbDenom)
+			suite.Require().NoError(err)
+			suite.Require().Equal(test.param.expectedProfit, profit.Amount)
+
+			totalNumberOfTrades, err := suite.App.ProtoRevKeeper.GetNumberOfTrades(suite.Ctx)
+			suite.Require().NoError(err)
+			suite.Require().Equal(sdk.OneInt(), totalNumberOfTrades)
+		} else {
+			suite.Require().Error(err)
+		}
+	}
+}
+
+func (suite *KeeperTestSuite) TestIterateRoutes() {
+	type paramm struct {
+		routes                     []gammtypes.SwapAmountInRoutes
+		expectedMaxProfitAmount    sdk.Int
+		expectedMaxProfitInputCoin sdk.Coin
+		expectedOptimalRoute       gammtypes.SwapAmountInRoutes
+
+		arbDenom string
+	}
+
+	tests := []struct {
+		name       string
+		params     paramm
+		expectPass bool
+	}{
+		{name: "Single Route Test",
+			params: paramm{
+				routes: []gammtypes.SwapAmountInRoutes{
+					{
+						gammtypes.SwapAmountInRoute{
+							PoolId:        22,
+							TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+						},
+						gammtypes.SwapAmountInRoute{
+							PoolId:        23,
+							TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+						},
+						gammtypes.SwapAmountInRoute{
+							PoolId:        24,
+							TokenOutDenom: "uosmo",
+						},
+					},
+				},
+				expectedMaxProfitAmount:    sdk.NewInt(24852),
+				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
+				expectedOptimalRoute: gammtypes.SwapAmountInRoutes{
+					gammtypes.SwapAmountInRoute{
+						PoolId:        22,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        23,
+						TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+					},
+					gammtypes.SwapAmountInRoute{
+						PoolId:        24,
+						TokenOutDenom: "uosmo",
+					}},
+				arbDenom: types.OsmosisDenomination,
+			},
+			expectPass: true,
+		},
+	}
+
+	for _, test := range tests {
+		maxProfitInputCoin, maxProfitAmount, optimalRoute := suite.App.ProtoRevKeeper.IterateRoutes(suite.Ctx, test.params.routes)
+
+		if test.expectPass {
+			suite.Require().Equal(test.params.expectedMaxProfitAmount, maxProfitAmount)
+			suite.Require().Equal(test.params.expectedMaxProfitInputCoin, maxProfitInputCoin)
+			suite.Require().Equal(test.params.expectedOptimalRoute, optimalRoute)
+		}
+	}
+}
+
+// Test logic that compares proftability of routes with different assets
+func (suite *KeeperTestSuite) TestConvertProfits() {
+	type param struct {
+		inputCoin           sdk.Coin
+		profit              sdk.Int
+		expectedUosmoProfit sdk.Int
+	}
+
+	tests := []struct {
+		name       string
+		param      param
+		expectPass bool
+	}{
+		{name: "Convert atom to uosmo",
+			param: param{
+				inputCoin:           sdk.NewCoin(types.AtomDenomination, sdk.NewInt(100)),
+				profit:              sdk.NewInt(10),
+				expectedUosmoProfit: sdk.NewInt(8),
+			},
+			expectPass: true,
+		},
+		{name: "Convert juno to uosmo (random denom)",
+			param: param{
+				inputCoin:           sdk.NewCoin("juno", sdk.NewInt(100)),
+				profit:              sdk.NewInt(10),
+				expectedUosmoProfit: sdk.NewInt(9),
+			},
+			expectPass: true,
+		},
+		{name: "Convert denom without pool to uosmo",
+			param: param{
+				inputCoin:           sdk.NewCoin("random", sdk.NewInt(100)),
+				profit:              sdk.NewInt(10),
+				expectedUosmoProfit: sdk.NewInt(10),
+			},
+			expectPass: false,
+		},
+	}
+
+	for _, test := range tests {
+		profit, err := suite.App.ProtoRevKeeper.ConvertProfits(suite.Ctx, test.param.inputCoin, test.param.profit)
+
+		if test.expectPass {
+			suite.Require().NoError(err)
+			suite.Require().Equal(test.param.expectedUosmoProfit, profit)
+		} else {
+			suite.Require().Error(err)
+		}
+	}
+}

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -7,6 +7,108 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
 )
 
+// Mainnet Arb Route - 2 Asset, Same Weights (Block: 5905150)
+// expectedAmtIn:  sdk.NewInt(10100000),
+// expectedProfit: sdk.NewInt(24852)
+var routeTwoAssetSameWeight = gammtypes.SwapAmountInRoutes{
+	gammtypes.SwapAmountInRoute{
+		PoolId:        22,
+		TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        23,
+		TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        24,
+		TokenOutDenom: "uosmo",
+	}}
+
+// Mainnet Arb Route - Multi Asset, Same Weights (Block: 6906570)
+// expectedAmtIn:  sdk.NewInt(4800000),
+// expectedProfit: sdk.NewInt(4547)
+var routeMultiAssetSameWeight = gammtypes.SwapAmountInRoutes{
+	gammtypes.SwapAmountInRoute{
+		PoolId:        26,
+		TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        28,
+		TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        27,
+		TokenOutDenom: "uosmo",
+	}}
+
+// Arb Route - Multi Asset, Same Weights - Pool 22 instead of 26 (Block: 6906570)
+// expectedAmtIn:  sdk.NewInt(519700000),
+// expectedProfit: sdk.NewInt(67511701)
+var routeMostProfitable = gammtypes.SwapAmountInRoutes{
+	gammtypes.SwapAmountInRoute{
+		PoolId:        22,
+		TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        28,
+		TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        27,
+		TokenOutDenom: "uosmo",
+	}}
+
+// Mainnet Arb Route - Multi Asset, Different Weights (Block: 6908256)
+// expectedAmtIn:  sdk.NewInt(4100000),
+// expectedProfit: sdk.NewInt(5826)
+var routeDiffDenom = gammtypes.SwapAmountInRoutes{
+	gammtypes.SwapAmountInRoute{
+		PoolId:        31,
+		TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        32,
+		TokenOutDenom: "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        33,
+		TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+	}}
+
+// No Arbitrage Opportunity
+// expectedAmtIn:  sdk.NewInt(0),
+// expectedProfit: sdk.NewInt(0)
+var routeNoArb = gammtypes.SwapAmountInRoutes{
+	gammtypes.SwapAmountInRoute{
+		PoolId:        7,
+		TokenOutDenom: "akash",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        12,
+		TokenOutDenom: "juno",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        8,
+		TokenOutDenom: "uosmo",
+	}}
+
+// StableSwap Test Route
+// expectedAmtIn:  sdk.NewInt(137600000),
+// expectedProfit: sdk.NewInt(56585438)
+var routeStableSwap = gammtypes.SwapAmountInRoutes{
+	gammtypes.SwapAmountInRoute{
+		PoolId:        29,
+		TokenOutDenom: "usdc",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        34,
+		TokenOutDenom: "busd",
+	},
+	gammtypes.SwapAmountInRoute{
+		PoolId:        30,
+		TokenOutDenom: "uosmo",
+	}}
+
 func (suite *KeeperTestSuite) TestFindMaxProfitRoute() {
 
 	type param struct {
@@ -22,109 +124,37 @@ func (suite *KeeperTestSuite) TestFindMaxProfitRoute() {
 	}{
 		{name: "Mainnet Arb Route - 2 Asset, Same Weights (Block: 5905150)",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        22,
-						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        23,
-						TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        24,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeTwoAssetSameWeight,
 				expectedAmtIn:  sdk.NewInt(10100000),
 				expectedProfit: sdk.NewInt(24852)},
 			expectPass: true},
 		{name: "Mainnet Arb Route - Multi Asset, Same Weights (Block: 6906570)",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        26,
-						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        28,
-						TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        27,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeMultiAssetSameWeight,
 				expectedAmtIn:  sdk.NewInt(4800000),
 				expectedProfit: sdk.NewInt(4547)},
 			expectPass: true},
 		{name: "Arb Route - Multi Asset, Same Weights - Pool 22 instead of 26 (Block: 6906570)",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        22,
-						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        28,
-						TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        27,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeMostProfitable,
 				expectedAmtIn:  sdk.NewInt(519700000),
 				expectedProfit: sdk.NewInt(67511701)},
 			expectPass: true},
 		{name: "Mainnet Arb Route - Multi Asset, Different Weights (Block: 6908256)",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        31,
-						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        32,
-						TokenOutDenom: "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        33,
-						TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-					}},
+				route:          routeDiffDenom,
 				expectedAmtIn:  sdk.NewInt(4100000),
 				expectedProfit: sdk.NewInt(5826)},
 			expectPass: true},
 		{name: "StableSwap Test Route",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        29,
-						TokenOutDenom: "usdc",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        34,
-						TokenOutDenom: "busd",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        30,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeStableSwap,
 				expectedAmtIn:  sdk.NewInt(137600000),
 				expectedProfit: sdk.NewInt(56585438)},
 			expectPass: true},
 		{name: "No Arbitrage Opportunity",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        7,
-						TokenOutDenom: "akash",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        12,
-						TokenOutDenom: "juno",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        8,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeNoArb,
 				expectedAmtIn:  sdk.NewInt(0),
 				expectedProfit: sdk.NewInt(0)},
 			expectPass: false},
@@ -168,20 +198,7 @@ func (suite *KeeperTestSuite) TestExecuteTrade() {
 		{
 			name: "Mainnet Arb Route",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        22,
-						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        23,
-						TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        24,
-						TokenOutDenom: "uosmo",
-					},
-				},
+				route:          routeTwoAssetSameWeight,
 				inputCoin:      sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
 				expectedProfit: sdk.NewInt(24852),
 			},
@@ -192,19 +209,7 @@ func (suite *KeeperTestSuite) TestExecuteTrade() {
 		{
 			name: "No arbitrage opportunity - expect error at multihopswap due to profitability invariant",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        7,
-						TokenOutDenom: "akash",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        12,
-						TokenOutDenom: "juno",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        8,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeNoArb,
 				inputCoin:      sdk.NewCoin("uosmo", sdk.NewInt(1000000)),
 				expectedProfit: sdk.NewInt(0),
 			},
@@ -215,19 +220,7 @@ func (suite *KeeperTestSuite) TestExecuteTrade() {
 		{
 			name: "0 input amount - expect error at multihopswap due to amount needing to be positive",
 			param: param{
-				route: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        7,
-						TokenOutDenom: "akash",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        12,
-						TokenOutDenom: "juno",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        8,
-						TokenOutDenom: "uosmo",
-					}},
+				route:          routeNoArb,
 				inputCoin:      sdk.NewCoin("uosmo", sdk.NewInt(0)),
 				expectedProfit: sdk.NewInt(0),
 			},
@@ -288,40 +281,41 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 	}{
 		{name: "Single Route Test",
 			params: paramm{
-				routes: []gammtypes.SwapAmountInRoutes{
-					{
-						gammtypes.SwapAmountInRoute{
-							PoolId:        22,
-							TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-						},
-						gammtypes.SwapAmountInRoute{
-							PoolId:        23,
-							TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-						},
-						gammtypes.SwapAmountInRoute{
-							PoolId:        24,
-							TokenOutDenom: "uosmo",
-						},
-					},
-				},
+				routes:                     []gammtypes.SwapAmountInRoutes{routeTwoAssetSameWeight},
 				expectedMaxProfitAmount:    sdk.NewInt(24852),
 				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
-				expectedOptimalRoute: gammtypes.SwapAmountInRoutes{
-					gammtypes.SwapAmountInRoute{
-						PoolId:        22,
-						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        23,
-						TokenOutDenom: "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-					},
-					gammtypes.SwapAmountInRoute{
-						PoolId:        24,
-						TokenOutDenom: "uosmo",
-					}},
-				arbDenom: types.OsmosisDenomination,
+				expectedOptimalRoute:       routeTwoAssetSameWeight,
+				arbDenom:                   types.OsmosisDenomination,
 			},
 			expectPass: true,
+		},
+		{name: "Two routes with same arb denom test - more profitable route second",
+			params: paramm{
+				routes:                     []gammtypes.SwapAmountInRoutes{routeMultiAssetSameWeight, routeTwoAssetSameWeight},
+				expectedMaxProfitAmount:    sdk.NewInt(24852),
+				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
+				expectedOptimalRoute:       routeTwoAssetSameWeight,
+				arbDenom:                   types.OsmosisDenomination,
+			},
+			expectPass: true,
+		},
+		{name: "Three routes with same arb denom test - most profitable route first",
+			params: paramm{
+				routes:                     []gammtypes.SwapAmountInRoutes{routeMostProfitable, routeMultiAssetSameWeight, routeTwoAssetSameWeight},
+				expectedMaxProfitAmount:    sdk.NewInt(67511701),
+				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(519700000)),
+				expectedOptimalRoute:       routeMostProfitable,
+				arbDenom:                   types.OsmosisDenomination,
+			},
+		},
+		{name: "Two routes, different arb denoms test - more profitable route second",
+			params: paramm{
+				routes:                     []gammtypes.SwapAmountInRoutes{routeNoArb, routeDiffDenom},
+				expectedMaxProfitAmount:    sdk.NewInt(5826),
+				expectedMaxProfitInputCoin: sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(4100000)),
+				expectedOptimalRoute:       routeDiffDenom,
+				arbDenom:                   "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+			},
 		},
 	}
 

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -72,7 +72,7 @@ var routeDiffDenom = gammtypes.SwapAmountInRoutes{
 	},
 	gammtypes.SwapAmountInRoute{
 		PoolId:        33,
-		TokenOutDenom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+		TokenOutDenom: types.AtomDenomination,
 	}}
 
 // No Arbitrage Opportunity
@@ -125,39 +125,39 @@ func (suite *KeeperTestSuite) TestFindMaxProfitRoute() {
 		{name: "Mainnet Arb Route - 2 Asset, Same Weights (Block: 5905150)",
 			param: param{
 				route:          routeTwoAssetSameWeight,
-				expectedAmtIn:  sdk.NewInt(10100000),
-				expectedProfit: sdk.NewInt(24852)},
+				expectedAmtIn:  sdk.NewInt(10000000),
+				expectedProfit: sdk.NewInt(24848)},
 			expectPass: true},
 		{name: "Mainnet Arb Route - Multi Asset, Same Weights (Block: 6906570)",
 			param: param{
 				route:          routeMultiAssetSameWeight,
-				expectedAmtIn:  sdk.NewInt(4800000),
-				expectedProfit: sdk.NewInt(4547)},
+				expectedAmtIn:  sdk.NewInt(5000000),
+				expectedProfit: sdk.NewInt(4538)},
 			expectPass: true},
 		{name: "Arb Route - Multi Asset, Same Weights - Pool 22 instead of 26 (Block: 6906570)",
 			param: param{
 				route:          routeMostProfitable,
-				expectedAmtIn:  sdk.NewInt(519700000),
-				expectedProfit: sdk.NewInt(67511701)},
+				expectedAmtIn:  sdk.NewInt(520000000),
+				expectedProfit: sdk.NewInt(67511675)},
 			expectPass: true},
 		{name: "Mainnet Arb Route - Multi Asset, Different Weights (Block: 6908256)",
 			param: param{
 				route:          routeDiffDenom,
-				expectedAmtIn:  sdk.NewInt(4100000),
+				expectedAmtIn:  sdk.NewInt(4000000),
 				expectedProfit: sdk.NewInt(5826)},
 			expectPass: true},
 		{name: "StableSwap Test Route",
 			param: param{
 				route:          routeStableSwap,
-				expectedAmtIn:  sdk.NewInt(137600000),
-				expectedProfit: sdk.NewInt(56585438)},
+				expectedAmtIn:  sdk.NewInt(138000000),
+				expectedProfit: sdk.NewInt(56585052)},
 			expectPass: true},
 		{name: "No Arbitrage Opportunity",
 			param: param{
 				route:          routeNoArb,
-				expectedAmtIn:  sdk.NewInt(0),
+				expectedAmtIn:  sdk.Int{},
 				expectedProfit: sdk.NewInt(0)},
-			expectPass: false},
+			expectPass: true},
 	}
 
 	for _, test := range tests {
@@ -282,8 +282,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 		{name: "Single Route Test",
 			params: paramm{
 				routes:                     []gammtypes.SwapAmountInRoutes{routeTwoAssetSameWeight},
-				expectedMaxProfitAmount:    sdk.NewInt(24852),
-				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
+				expectedMaxProfitAmount:    sdk.NewInt(24848),
+				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10000000)),
 				expectedOptimalRoute:       routeTwoAssetSameWeight,
 				arbDenom:                   types.OsmosisDenomination,
 			},
@@ -292,8 +292,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 		{name: "Two routes with same arb denom test - more profitable route second",
 			params: paramm{
 				routes:                     []gammtypes.SwapAmountInRoutes{routeMultiAssetSameWeight, routeTwoAssetSameWeight},
-				expectedMaxProfitAmount:    sdk.NewInt(24852),
-				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10100000)),
+				expectedMaxProfitAmount:    sdk.NewInt(24848),
+				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(10000000)),
 				expectedOptimalRoute:       routeTwoAssetSameWeight,
 				arbDenom:                   types.OsmosisDenomination,
 			},
@@ -302,20 +302,22 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 		{name: "Three routes with same arb denom test - most profitable route first",
 			params: paramm{
 				routes:                     []gammtypes.SwapAmountInRoutes{routeMostProfitable, routeMultiAssetSameWeight, routeTwoAssetSameWeight},
-				expectedMaxProfitAmount:    sdk.NewInt(67511701),
-				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(519700000)),
+				expectedMaxProfitAmount:    sdk.NewInt(67511675),
+				expectedMaxProfitInputCoin: sdk.NewCoin("uosmo", sdk.NewInt(520000000)),
 				expectedOptimalRoute:       routeMostProfitable,
 				arbDenom:                   types.OsmosisDenomination,
 			},
+			expectPass: true,
 		},
 		{name: "Two routes, different arb denoms test - more profitable route second",
 			params: paramm{
 				routes:                     []gammtypes.SwapAmountInRoutes{routeNoArb, routeDiffDenom},
-				expectedMaxProfitAmount:    sdk.NewInt(5826),
-				expectedMaxProfitInputCoin: sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(4100000)),
+				expectedMaxProfitAmount:    sdk.NewInt(4880),
+				expectedMaxProfitInputCoin: sdk.NewCoin("ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2", sdk.NewInt(4000000)),
 				expectedOptimalRoute:       routeDiffDenom,
-				arbDenom:                   "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+				arbDenom:                   types.AtomDenomination,
 			},
+			expectPass: true,
 		},
 	}
 

--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -9,20 +9,9 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
 )
 
-type TradeInfo struct {
-	InputDenom  string
-	OutputDenom string
-	SwapFee     sdk.Dec
-	Pool        gammtypes.CFMMPoolI
-}
-
-type Route struct {
-	Trades []TradeInfo
-}
-
 // BuildRoutes builds all of the possible arbitrage routes given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) []Route {
-	routes := make([]Route, 0)
+func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) []gammtypes.SwapAmountInRoutes {
+	routes := make([]gammtypes.SwapAmountInRoutes, 0)
 
 	// Append hot routes if they exist
 	if tokenPairRoutes, err := k.BuildTokenPairRoutes(ctx, tokenIn, tokenOut, poolId); err == nil {
@@ -43,17 +32,17 @@ func (k Keeper) BuildRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId ui
 }
 
 // BuildTokenPairRoutes builds all of the possible arbitrage routes from the hot routes given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]Route, error) {
+func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) ([]gammtypes.SwapAmountInRoutes, error) {
 	// Get all of the routes from the store that match the given tokenIn and tokenOut
 	tokenPairArbRoutes, err := k.GetTokenPairArbRoutes(ctx, tokenIn, tokenOut)
 	if err != nil {
-		return []Route{}, err
+		return []gammtypes.SwapAmountInRoutes{}, err
 	}
 
 	// Iterate through all of the routes and build hot routes
-	routes := make([]Route, 0)
+	routes := make([]gammtypes.SwapAmountInRoutes, 0)
 	for _, route := range tokenPairArbRoutes.ArbRoutes {
-		newRoute, err := k.BuildTradeInfoHotRoute(ctx, route, tokenIn, tokenOut, poolId)
+		newRoute, err := k.BuildHotRoute(ctx, route, tokenIn, tokenOut, poolId)
 		if err == nil {
 			routes = append(routes, newRoute)
 		}
@@ -62,125 +51,107 @@ func (k Keeper) BuildTokenPairRoutes(ctx sdk.Context, tokenIn, tokenOut string, 
 	return routes, nil
 }
 
-// BuildTradeInfoHotRoute constructs a cyclic arbitrage route given a hot route from the store and information about the swap that should be placed
+// BuildHotRoute constructs a cyclic arbitrage route given a hot route from the store and information about the swap that should be placed
 // in the hot route.
-func (k Keeper) BuildTradeInfoHotRoute(ctx sdk.Context, route *types.Route, tokenIn, tokenOut string, poolId uint64) (Route, error) {
-	newRoute := Route{Trades: make([]TradeInfo, len(route.Trades))}
+func (k Keeper) BuildHotRoute(ctx sdk.Context, route *types.Route, tokenIn, tokenOut string, poolId uint64) (gammtypes.SwapAmountInRoutes, error) {
+	newRoute := make(gammtypes.SwapAmountInRoutes, 0)
 
-	for index, trade := range route.Trades {
-		var newTrade TradeInfo
-		// 0 is a placeholder for swaps that should be entered into the hot route
+	for _, trade := range route.Trades {
+		// 0 is a placeholder for pools swapped on that should be entered into the hot route
 		if trade.Pool == 0 {
-			pool, err := k.GetAndCheckPool(ctx, poolId)
-			if err != nil {
-				return Route{}, err
-			}
-
-			newTrade = TradeInfo{
-				InputDenom:  tokenOut,
-				OutputDenom: tokenIn,
-				SwapFee:     pool.GetSwapFee(ctx),
-				Pool:        pool,
-			}
+			newRoute = append(newRoute, gammtypes.SwapAmountInRoute{
+				PoolId:        poolId,
+				TokenOutDenom: trade.TokenOut,
+			})
 		} else {
-			pool, err := k.GetAndCheckPool(ctx, trade.Pool)
-			if err != nil {
-				return Route{}, err
-			}
-
-			newTrade = TradeInfo{
-				InputDenom:  trade.TokenIn,
-				OutputDenom: trade.TokenOut,
-				SwapFee:     pool.GetSwapFee(ctx),
-				Pool:        pool,
-			}
+			newRoute = append(newRoute, gammtypes.SwapAmountInRoute{
+				PoolId:        trade.Pool,
+				TokenOutDenom: trade.TokenOut,
+			})
 		}
-
-		newRoute.Trades[index] = newTrade
 	}
 
-	if err := k.CheckValidHotRoute(newRoute); err != nil {
-		return Route{}, err
+	// Check that the hot route is valid
+	if err := k.CheckValidHotRoute(ctx, newRoute); err != nil {
+		return gammtypes.SwapAmountInRoutes{}, err
 	}
 	return newRoute, nil
 }
 
-// CheckValidHotRoute checks if the cyclic arbitrage route that was built using the hot routes method is correct. The criteria for a valid hot route is that
-// the in denom and out denom must be the same, in denom must be uosmo or atom, and there must be exactly three hops in the route
-func (k Keeper) CheckValidHotRoute(route Route) error {
-	if len(route.Trades) != 3 {
+// CheckValidHotRoute checks if the cyclic arbitrage route that was built using the hot routes method is correct. Much of the stateless
+// validation achieves the desired checks, however, we also check that the route is traversing pools that
+// are active.
+func (k Keeper) CheckValidHotRoute(ctx sdk.Context, route gammtypes.SwapAmountInRoutes) error {
+	if route.Length() != 3 {
 		return fmt.Errorf("invalid hot route length")
 	}
 
-	if route.Trades[0].InputDenom != route.Trades[2].OutputDenom {
-		return fmt.Errorf("invalid hot route in and out denoms. in: %s, out: %s", route.Trades[0].InputDenom, route.Trades[2].OutputDenom)
-	}
-
-	if route.Trades[0].InputDenom != types.OsmosisDenomination && route.Trades[0].InputDenom != types.AtomDenomination {
-		return fmt.Errorf("invalid hot route in denom")
+	// Ensure that all of the pools in the route exist and are active
+	for _, poolId := range route.PoolIds() {
+		_, err := k.GetAndCheckPool(ctx, poolId)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
 // BuildOsmoRoute builds a cyclic arbitrage route that starts and ends with osmo given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) (Route, error) {
-	return k.BuildTradeInfoRoute(ctx, types.OsmosisDenomination, tokenIn, tokenOut, poolId, k.GetOsmoPool)
+func (k Keeper) BuildOsmoRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) (gammtypes.SwapAmountInRoutes, error) {
+	return k.BuildRoute(ctx, types.OsmosisDenomination, tokenIn, tokenOut, poolId, k.GetOsmoPool)
 }
 
 // BuildAtomRoute builds a cyclic arbitrage route that starts and ends with atom given the tokenIn, tokenOut and poolId that were used in the swap
-func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) (Route, error) {
-	return k.BuildTradeInfoRoute(ctx, types.AtomDenomination, tokenIn, tokenOut, poolId, k.GetAtomPool)
+func (k Keeper) BuildAtomRoute(ctx sdk.Context, tokenIn, tokenOut string, poolId uint64) (gammtypes.SwapAmountInRoutes, error) {
+	return k.BuildRoute(ctx, types.AtomDenomination, tokenIn, tokenOut, poolId, k.GetAtomPool)
 }
 
-// BuildTradeInfoRoute constructs a cyclic arbitrage route that is starts/ends with swapDenom (atom or osmo) given the swap (tokenIn, tokenOut, poolId), and
+// BuildRoute constructs a cyclic arbitrage route that is starts/ends with swapDenom (atom or osmo) given the swap (tokenIn, tokenOut, poolId), and
 // a function that can get the poolId from the store given a (token, swapDenom) pair.
-func (k Keeper) BuildTradeInfoRoute(ctx sdk.Context, swapDenom, tokenIn, tokenOut string, poolId uint64, getPoolIDFromStore func(sdk.Context, string) (uint64, error)) (Route, error) {
+func (k Keeper) BuildRoute(ctx sdk.Context, swapDenom, tokenIn, tokenOut string, poolId uint64, getPoolIDFromStore func(sdk.Context, string) (uint64, error)) (gammtypes.SwapAmountInRoutes, error) {
 	// Creating the first trade in the arb
 	entryPoolId, err := getPoolIDFromStore(ctx, tokenOut)
 	if err != nil {
-		return Route{}, err
+		return gammtypes.SwapAmountInRoutes{}, err
 	}
-	entryPool, err := k.GetAndCheckPool(ctx, entryPoolId)
+
+	// Check that the pool exists and is active
+	_, err = k.GetAndCheckPool(ctx, entryPoolId)
 	if err != nil {
-		return Route{}, err
+		return gammtypes.SwapAmountInRoutes{}, err
 	}
-	entryTrade := TradeInfo{
-		InputDenom:  swapDenom,
-		OutputDenom: tokenOut,
-		SwapFee:     entryPool.GetSwapFee(ctx),
-		Pool:        entryPool,
+	// Create the first swap for the MultiHopSwap Route
+	entryRoute := gammtypes.SwapAmountInRoute{
+		PoolId:        entryPoolId,
+		TokenOutDenom: tokenOut,
 	}
 
 	// Creating the second trade in the arb
-	middlePool, err := k.GetAndCheckPool(ctx, poolId)
+	_, err = k.GetAndCheckPool(ctx, poolId)
 	if err != nil {
-		return Route{}, err
+		return gammtypes.SwapAmountInRoutes{}, err
 	}
-	middleTrade := TradeInfo{
-		InputDenom:  tokenOut,
-		OutputDenom: tokenIn,
-		SwapFee:     middlePool.GetSwapFee(ctx),
-		Pool:        middlePool,
+	middleRoute := gammtypes.SwapAmountInRoute{
+		PoolId:        poolId,
+		TokenOutDenom: tokenIn,
 	}
 
 	// Creating the third trade in the arb
 	exitPoolId, err := getPoolIDFromStore(ctx, tokenIn)
 	if err != nil {
-		return Route{}, err
+		return gammtypes.SwapAmountInRoutes{}, err
 	}
-	exitPool, err := k.GetAndCheckPool(ctx, exitPoolId)
+	_, err = k.GetAndCheckPool(ctx, exitPoolId)
 	if err != nil {
-		return Route{}, err
+		return gammtypes.SwapAmountInRoutes{}, err
 	}
-	exitTrade := TradeInfo{
-		InputDenom:  tokenIn,
-		OutputDenom: swapDenom,
-		SwapFee:     exitPool.GetSwapFee(ctx),
-		Pool:        exitPool,
+	exitRoute := gammtypes.SwapAmountInRoute{
+		PoolId:        exitPoolId,
+		TokenOutDenom: swapDenom,
 	}
 
-	return Route{Trades: []TradeInfo{entryTrade, middleTrade, exitTrade}}, nil
+	return gammtypes.SwapAmountInRoutes{entryRoute, middleRoute, exitRoute}, nil
 }
 
 // GetAndCheckPool retrieves the pool from the x/gamm module given a poolId and ensures that the pool can be traded on

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -83,10 +83,9 @@ func (suite *KeeperTestSuite) TestBuildRoutes() {
 			suite.Require().Equal(len(tc.expected), len(routes))
 
 			for routeIndex, route := range routes {
-				for tradeIndex, trade := range route.Trades {
-					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].PoolId, trade.Pool.GetId())
-					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].InputDenom, trade.InputDenom)
-					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].OutputDenom, trade.OutputDenom)
+				for tradeIndex, trade := range route {
+					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].PoolId, trade.PoolId)
+					suite.Require().Equal(tc.expected[routeIndex][tradeIndex].OutputDenom, trade.TokenOutDenom)
 				}
 			}
 		})
@@ -134,12 +133,11 @@ func (suite *KeeperTestSuite) TestBuildAtomRoute() {
 
 			if tc.hasRoute {
 				suite.Require().NoError(err)
-				suite.Require().Equal(len(tc.expectedRoute), len(route.Trades))
+				suite.Require().Equal(len(tc.expectedRoute), len(route.PoolIds()))
 
 				for index, trade := range tc.expectedRoute {
-					suite.Require().Equal(trade.PoolId, route.Trades[index].Pool.GetId())
-					suite.Require().Equal(trade.InputDenom, route.Trades[index].InputDenom)
-					suite.Require().Equal(trade.OutputDenom, route.Trades[index].OutputDenom)
+					suite.Require().Equal(trade.PoolId, route[index].PoolId)
+					suite.Require().Equal(trade.OutputDenom, route[index].TokenOutDenom)
 				}
 			} else {
 				suite.Require().Error(err)
@@ -189,12 +187,11 @@ func (suite *KeeperTestSuite) TestBuildOsmoRoute() {
 
 			if tc.hasRoute {
 				suite.Require().NoError(err)
-				suite.Require().Equal(len(tc.expectedRoute), len(route.Trades))
+				suite.Require().Equal(len(tc.expectedRoute), len(route.PoolIds()))
 
 				for index, trade := range tc.expectedRoute {
-					suite.Require().Equal(trade.PoolId, route.Trades[index].Pool.GetId())
-					suite.Require().Equal(trade.InputDenom, route.Trades[index].InputDenom)
-					suite.Require().Equal(trade.OutputDenom, route.Trades[index].OutputDenom)
+					suite.Require().Equal(trade.PoolId, route[index].PoolId)
+					suite.Require().Equal(trade.OutputDenom, route[index].TokenOutDenom)
 				}
 			} else {
 				suite.Require().Error(err)
@@ -232,12 +229,11 @@ func (suite *KeeperTestSuite) TestBuildTokenPairRoutes() {
 
 				for index, route := range routes {
 
-					suite.Require().Equal(len(tc.expectedRoutes[index]), len(route.Trades))
+					suite.Require().Equal(len(tc.expectedRoutes[index]), len(route.PoolIds()))
 
 					for index, trade := range tc.expectedRoutes[index] {
-						suite.Require().Equal(trade.PoolId, route.Trades[index].Pool.GetId())
-						suite.Require().Equal(trade.InputDenom, route.Trades[index].InputDenom)
-						suite.Require().Equal(trade.OutputDenom, route.Trades[index].OutputDenom)
+						suite.Require().Equal(trade.PoolId, route[index].PoolId)
+						suite.Require().Equal(trade.OutputDenom, route[index].TokenOutDenom)
 					}
 				}
 

--- a/x/protorev/keeper/statistics.go
+++ b/x/protorev/keeper/statistics.go
@@ -1,0 +1,220 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+// ----------------------- Statistics Stores  ----------------------- //
+
+// GetNumberOfTrades returns the number of trades executed by the ProtoRev module
+func (k Keeper) GetNumberOfTrades(ctx sdk.Context) (sdk.Int, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixNumberOfTrades)
+
+	bz := store.Get(types.KeyPrefixNumberOfTrades)
+	if len(bz) == 0 {
+		return sdk.ZeroInt(), fmt.Errorf("no trades have been executed by the protorev module")
+	}
+
+	trades := sdk.Int{}
+	trades.Unmarshal(bz)
+
+	return trades, nil
+}
+
+// IncrementNumberOfTrades increments the number of trades executed by the ProtoRev module
+func (k Keeper) IncrementNumberOfTrades(ctx sdk.Context) error {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixNumberOfTrades)
+
+	numberOfTrades, _ := k.GetNumberOfTrades(ctx)
+	numberOfTrades = numberOfTrades.Add(sdk.OneInt())
+
+	bz, err := numberOfTrades.Marshal()
+	if err != nil {
+		return err
+	}
+	store.Set(types.KeyPrefixNumberOfTrades, bz)
+	return nil
+}
+
+// GetProfitsByDenom returns the profits made by the ProtoRev module for the given denom
+func (k Keeper) GetProfitsByDenom(ctx sdk.Context, denom string) (sdk.Coin, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixProfitByDenom)
+	key := types.GetKeyPrefixProfitByDenom(denom)
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		return sdk.NewCoin(denom, sdk.ZeroInt()), fmt.Errorf("no profits for denom %s", denom)
+	}
+
+	profits := sdk.Coin{}
+	profits.Unmarshal(bz)
+
+	return profits, nil
+}
+
+// GetAllProfits returns all of the profits made by the ProtoRev module. This will only include
+// profits made in the Atom and Osmosis denominations because protorev only trades in those two.
+func (k Keeper) GetAllProfits(ctx sdk.Context) []*sdk.Coin {
+	profits := make([]*sdk.Coin, 0)
+
+	if profit, err := k.GetProfitsByDenom(ctx, types.AtomDenomination); err == nil {
+		profits = append(profits, &profit)
+	}
+
+	if profit, err := k.GetProfitsByDenom(ctx, types.OsmosisDenomination); err == nil {
+		profits = append(profits, &profit)
+	}
+
+	return profits
+}
+
+// UpdateProfitsByDenom updates the profits made by the ProtoRev module for the given denom
+func (k Keeper) UpdateProfitsByDenom(ctx sdk.Context, denom string, tradeProfit sdk.Int) error {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixProfitByDenom)
+	key := types.GetKeyPrefixProfitByDenom(denom)
+
+	profits, _ := k.GetProfitsByDenom(ctx, denom)
+	profits.Amount = profits.Amount.Add(tradeProfit)
+	bz, err := profits.Marshal()
+	if err != nil {
+		return err
+	}
+
+	store.Set(key, bz)
+	return nil
+}
+
+// GetAllRoutes returns all of the routes that the ProtoRev module has traded on
+func (k Keeper) GetAllRoutes(ctx sdk.Context) ([][]uint64, error) {
+	routes := make([][]uint64, 0)
+
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixTradesByRoute)
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		// ignore the portion of the key that is the prefix
+		key := iterator.Key()[len(types.KeyPrefixTradesByRoute)+1:]
+
+		// convert the key into a route
+		route, err := types.CreateRouteFromKey(key)
+		if err != nil {
+			return nil, err
+		}
+
+		routes = append(routes, route)
+	}
+
+	return routes, nil
+}
+
+// GetTradesByRoute returns the number of trades executed by the ProtoRev module for the given route
+func (k Keeper) GetTradesByRoute(ctx sdk.Context, route []uint64) (sdk.Int, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixTradesByRoute)
+	key := types.GetKeyPrefixTradesByRoute(route)
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		return sdk.ZeroInt(), fmt.Errorf("no trades for route %d", route)
+	}
+
+	trades := sdk.Int{}
+	trades.Unmarshal(bz)
+	return trades, nil
+}
+
+// IncrementTradesByRoute increments the number of trades executed by the ProtoRev module for the given route
+func (k Keeper) IncrementTradesByRoute(ctx sdk.Context, route []uint64) error {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixTradesByRoute)
+	key := types.GetKeyPrefixTradesByRoute(route)
+
+	trades, _ := k.GetTradesByRoute(ctx, route)
+	trades = trades.Add(sdk.OneInt())
+	bz, err := trades.Marshal()
+	if err != nil {
+		return err
+	}
+
+	store.Set(key, bz)
+	return nil
+}
+
+// GetProfitsByRoute returns the profits made by the ProtoRev module for the given route and denom
+func (k Keeper) GetProfitsByRoute(ctx sdk.Context, route []uint64, denom string) (sdk.Coin, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixProfitsByRoute)
+	key := types.GetKeyPrefixProfitsByRoute(route, denom)
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		return sdk.NewCoin(denom, sdk.ZeroInt()), fmt.Errorf("no profits for route %d", route)
+	}
+
+	profits := sdk.Coin{}
+	profits.Unmarshal(bz)
+
+	return profits, nil
+}
+
+// GetAllProfitsByRoute returns all of the profits made by the ProtoRev module for the given route. This will only include
+// profits made in the Atom and Osmosis denominations because protorev only trades in those two.
+func (k Keeper) GetAllProfitsByRoute(ctx sdk.Context, route []uint64) []*sdk.Coin {
+	profits := make([]*sdk.Coin, 0)
+	if profit, err := k.GetProfitsByRoute(ctx, route, types.AtomDenomination); err == nil {
+		profits = append(profits, &profit)
+	}
+
+	if profit, err := k.GetProfitsByRoute(ctx, route, types.OsmosisDenomination); err == nil {
+		profits = append(profits, &profit)
+	}
+
+	return profits
+}
+
+// UpdateProfitsByRoute updates the profits made by the ProtoRev module for the given route and denom
+func (k Keeper) UpdateProfitsByRoute(ctx sdk.Context, route []uint64, denom string, profit sdk.Int) error {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixProfitsByRoute)
+	key := types.GetKeyPrefixProfitsByRoute(route, denom)
+
+	profits, _ := k.GetProfitsByRoute(ctx, route, denom)
+	profits.Amount = profits.Amount.Add(profit)
+	bz, err := profits.Marshal()
+	if err != nil {
+		return err
+	}
+
+	store.Set(key, bz)
+	return nil
+}
+
+// UpdateStatistics updates the module statistics after each trade is executed
+func (k Keeper) UpdateStatistics(ctx sdk.Context, route gammtypes.SwapAmountInRoutes, inputCoin sdk.Coin, outputAmt sdk.Int) error {
+	// Increment the number of trades executed by the ProtoRev module
+	if err := k.IncrementNumberOfTrades(ctx); err != nil {
+		return err
+	}
+
+	// Update the profits made by the ProtoRev module for the denom
+	profit := outputAmt.Sub(inputCoin.Amount)
+	if err := k.UpdateProfitsByDenom(ctx, inputCoin.Denom, profit); err != nil {
+		return err
+	}
+
+	// Increment the number of times the module has executed a trade on a given route
+	if err := k.IncrementTradesByRoute(ctx, route.PoolIds()); err != nil {
+		return err
+	}
+
+	// Update the profits accumulated by the ProtoRev module for the given route and denom
+	if err := k.UpdateProfitsByRoute(ctx, route.PoolIds(), inputCoin.Denom, profit); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/protorev/keeper/statistics.go
+++ b/x/protorev/keeper/statistics.go
@@ -23,7 +23,9 @@ func (k Keeper) GetNumberOfTrades(ctx sdk.Context) (sdk.Int, error) {
 	}
 
 	trades := sdk.Int{}
-	trades.Unmarshal(bz)
+	if err := trades.Unmarshal(bz); err != nil {
+		return sdk.ZeroInt(), err
+	}
 
 	return trades, nil
 }
@@ -54,7 +56,9 @@ func (k Keeper) GetProfitsByDenom(ctx sdk.Context, denom string) (sdk.Coin, erro
 	}
 
 	profits := sdk.Coin{}
-	profits.Unmarshal(bz)
+	if err := profits.Unmarshal(bz); err != nil {
+		return sdk.NewCoin(denom, sdk.ZeroInt()), err
+	}
 
 	return profits, nil
 }
@@ -126,7 +130,9 @@ func (k Keeper) GetTradesByRoute(ctx sdk.Context, route []uint64) (sdk.Int, erro
 	}
 
 	trades := sdk.Int{}
-	trades.Unmarshal(bz)
+	if err := trades.Unmarshal(bz); err != nil {
+		return sdk.ZeroInt(), err
+	}
 	return trades, nil
 }
 
@@ -157,7 +163,9 @@ func (k Keeper) GetProfitsByRoute(ctx sdk.Context, route []uint64, denom string)
 	}
 
 	profits := sdk.Coin{}
-	profits.Unmarshal(bz)
+	if err := profits.Unmarshal(bz); err != nil {
+		return sdk.NewCoin(denom, sdk.ZeroInt()), err
+	}
 
 	return profits, nil
 }

--- a/x/protorev/keeper/statistics_test.go
+++ b/x/protorev/keeper/statistics_test.go
@@ -1,0 +1,182 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
+	"github.com/osmosis-labs/osmosis/v13/x/protorev/types"
+)
+
+// TestGetNumberOfTrades tests GetNumberOfTrades and IncrementNumberOfTrades
+func (suite *KeeperTestSuite) TestGetNumberOfTrades() {
+	// Should be zero by default
+	numberOfTrades, err := suite.App.AppKeepers.ProtoRevKeeper.GetNumberOfTrades(suite.Ctx)
+	suite.Require().Error(err)
+	suite.Require().Equal(sdk.NewInt(0), numberOfTrades)
+
+	// Pseudo execute a trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.IncrementNumberOfTrades(suite.Ctx)
+	suite.Require().NoError(err)
+
+	// Check the updated result
+	numberOfTrades, err = suite.App.AppKeepers.ProtoRevKeeper.GetNumberOfTrades(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(1), numberOfTrades)
+}
+
+// TestGetProfitsByDenom tests GetProfitsByDenom, UpdateProfitsByDenom, and GetAllProfits
+func (suite *KeeperTestSuite) TestGetProfitsByDenom() {
+	// Should be zero by default
+	profits, err := suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByDenom(suite.Ctx, types.OsmosisDenomination)
+	suite.Require().Error(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.ZeroInt()), profits)
+
+	// Pseudo execute a trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.UpdateProfitsByDenom(suite.Ctx, types.OsmosisDenomination, sdk.NewInt(9000))
+	suite.Require().NoError(err)
+
+	// Check the updated result
+	profits, err = suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByDenom(suite.Ctx, types.OsmosisDenomination)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(9000)), profits)
+
+	// Pseudo execute a second trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.UpdateProfitsByDenom(suite.Ctx, types.OsmosisDenomination, sdk.NewInt(5000))
+	suite.Require().NoError(err)
+
+	// Check the updated result after the second trade
+	profits, err = suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByDenom(suite.Ctx, types.OsmosisDenomination)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(14000)), profits)
+
+	// Check the result of GetAllProfits
+	allProfits := suite.App.AppKeepers.ProtoRevKeeper.GetAllProfits(suite.Ctx)
+	suite.Require().Equal([]*sdk.Coin{{Denom: types.OsmosisDenomination, Amount: sdk.NewInt(14000)}}, allProfits)
+
+	// Pseudo execute a third trade in a different denom
+	err = suite.App.AppKeepers.ProtoRevKeeper.UpdateProfitsByDenom(suite.Ctx, types.AtomDenomination, sdk.NewInt(1000))
+	suite.Require().NoError(err)
+
+	// Check the result of GetAllProfits
+	allProfits = suite.App.AppKeepers.ProtoRevKeeper.GetAllProfits(suite.Ctx)
+	suite.Require().Equal([]*sdk.Coin{{Denom: types.AtomDenomination, Amount: sdk.NewInt(1000)}, {Denom: types.OsmosisDenomination, Amount: sdk.NewInt(14000)}}, allProfits)
+}
+
+// TestGetTradesByRoute tests GetTradesByRoute, IncrementTradesByRoute, and GetAllRoutes
+func (suite *KeeperTestSuite) TestGetTradesByRoute() {
+	// There should be no routes that have been executed by default
+	routes, err := suite.App.AppKeepers.ProtoRevKeeper.GetAllRoutes(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, len(routes))
+
+	// Check the number of trades for a route that has not been executed
+	trades, err := suite.App.AppKeepers.ProtoRevKeeper.GetTradesByRoute(suite.Ctx, []uint64{1, 2, 3})
+	suite.Require().Error(err)
+	suite.Require().Equal(sdk.NewInt(0), trades)
+
+	// Pseudo execute a trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.IncrementTradesByRoute(suite.Ctx, []uint64{1, 2, 3})
+	suite.Require().NoError(err)
+
+	// Check the updated result
+	trades, err = suite.App.AppKeepers.ProtoRevKeeper.GetTradesByRoute(suite.Ctx, []uint64{1, 2, 3})
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(1), trades)
+
+	// Check the result of GetAllRoutes
+	routes, err = suite.App.AppKeepers.ProtoRevKeeper.GetAllRoutes(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, len(routes))
+	suite.Require().Equal([]uint64{1, 2, 3}, routes[0])
+
+	// Pseudo execute a second trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.IncrementTradesByRoute(suite.Ctx, []uint64{2, 3, 4})
+	suite.Require().NoError(err)
+
+	// Check the updated result after the second trade
+	trades, err = suite.App.AppKeepers.ProtoRevKeeper.GetTradesByRoute(suite.Ctx, []uint64{2, 3, 4})
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(1), trades)
+
+	// Check the result of GetAllRoutes
+	routes, err = suite.App.AppKeepers.ProtoRevKeeper.GetAllRoutes(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(2, len(routes))
+	suite.Require().Equal([]uint64{1, 2, 3}, routes[0])
+	suite.Require().Equal([]uint64{2, 3, 4}, routes[1])
+}
+
+// TestGetProfitsByRoute tests GetProfitsByRoute, UpdateProfitsByRoute, and GetAllProfitsByRoute
+func (suite *KeeperTestSuite) TestGetProfitsByRoute() {
+	// There should be no profits that have been executed by default
+	profits := suite.App.AppKeepers.ProtoRevKeeper.GetAllProfitsByRoute(suite.Ctx, []uint64{1, 2, 3})
+	suite.Require().Equal([]*sdk.Coin{}, profits)
+
+	// Check the profits for a route that has not been executed
+	profit, err := suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByRoute(suite.Ctx, []uint64{1, 2, 3}, types.OsmosisDenomination)
+	suite.Require().Error(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.ZeroInt()), profit)
+
+	// Pseudo execute a trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.UpdateProfitsByRoute(suite.Ctx, []uint64{1, 2, 3}, types.OsmosisDenomination, sdk.NewInt(1000))
+	suite.Require().NoError(err)
+
+	// Check the updated result
+	profit, err = suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByRoute(suite.Ctx, []uint64{1, 2, 3}, types.OsmosisDenomination)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)), profit)
+
+	// Check the result of GetAllProfitsByRoute
+	profits = suite.App.AppKeepers.ProtoRevKeeper.GetAllProfitsByRoute(suite.Ctx, []uint64{1, 2, 3})
+	suite.Require().Equal([]*sdk.Coin{{Denom: types.OsmosisDenomination, Amount: sdk.NewInt(1000)}}, profits)
+}
+
+// TestUpdateStatistics tests UpdateStatistics which is a wrapper for much of the statistics keeper
+// functionality.
+func (suite *KeeperTestSuite) TestUpdateStatistics() {
+	// Psuedo execute a trade
+	err := suite.App.AppKeepers.ProtoRevKeeper.UpdateStatistics(suite.Ctx,
+		gammtypes.SwapAmountInRoutes{{TokenOutDenom: "", PoolId: 1}, {TokenOutDenom: "", PoolId: 2}, {TokenOutDenom: "", PoolId: 3}},
+		sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(800)),
+		sdk.NewInt(1000),
+	)
+	suite.Require().NoError(err)
+
+	// Check the result of GetTradesByRoute
+	trades, err := suite.App.AppKeepers.ProtoRevKeeper.GetTradesByRoute(suite.Ctx, []uint64{1, 2, 3})
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(1), trades)
+
+	// Check the result of GetProfitsByRoute
+	profit, err := suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByRoute(suite.Ctx, []uint64{1, 2, 3}, types.OsmosisDenomination)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(200)), profit)
+
+	// Check the result of GetAllRoutes
+	routes, err := suite.App.AppKeepers.ProtoRevKeeper.GetAllRoutes(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, len(routes))
+
+	// Psuedo execute a second trade
+	err = suite.App.AppKeepers.ProtoRevKeeper.UpdateStatistics(suite.Ctx,
+		gammtypes.SwapAmountInRoutes{{TokenOutDenom: "", PoolId: 2}, {TokenOutDenom: "", PoolId: 3}, {TokenOutDenom: "", PoolId: 4}},
+		sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(850)),
+		sdk.NewInt(1100),
+	)
+	suite.Require().NoError(err)
+
+	// Check the result of GetTradesByRoute
+	trades, err = suite.App.AppKeepers.ProtoRevKeeper.GetTradesByRoute(suite.Ctx, []uint64{2, 3, 4})
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(1), trades)
+
+	// Check the result of GetProfitsByRoute
+	profit, err = suite.App.AppKeepers.ProtoRevKeeper.GetProfitsByRoute(suite.Ctx, []uint64{2, 3, 4}, types.OsmosisDenomination)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(250)), profit)
+
+	// Check the result of GetAllRoutes
+	routes, err = suite.App.AppKeepers.ProtoRevKeeper.GetAllRoutes(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(2, len(routes))
+}

--- a/x/protorev/types/expected_keepers.go
+++ b/x/protorev/types/expected_keepers.go
@@ -29,6 +29,7 @@ type GAMMKeeper interface {
 	GetPoolDenoms(ctx sdk.Context, poolId uint64) ([]string, error)
 	SwapExactAmountIn(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, tokenIn sdk.Coin, tokenOutDenom string, tokenOutMinAmount sdk.Int) (sdk.Int, error)
 	MultihopSwapExactAmountIn(ctx sdk.Context, sender sdk.AccAddress, routes []gammtypes.SwapAmountInRoute, tokenIn sdk.Coin, tokenOutMinAmount sdk.Int) (tokenOutAmount sdk.Int, err error)
+	MultihopEstimateOutGivenExactAmountIn(ctx sdk.Context, routes []gammtypes.SwapAmountInRoute, tokenIn sdk.Coin) (tokenOutAmount sdk.Int, err error)
 }
 
 // EpochKeeper defines the Epoch contract that must be fulfilled when

--- a/x/protorev/types/genesis.go
+++ b/x/protorev/types/genesis.go
@@ -12,7 +12,7 @@ var AtomDenomination string = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9C
 // OsmosisDenomination stores the native denom name for Osmosis on chain used for route building
 var OsmosisDenomination string = "uosmo"
 
-// MaxInputAmount is the upper bound for what will be used to find the optimal in amount when creating (2 ^ 14) = 16,384
+// MaxInputAmount is the upper bound index for finding the optimal in amount when determining route profitability (2 ^ 14) = 16,384
 var MaxInputAmount = sdk.NewInt(16_384)
 
 // StepSize is the amount we multiply each index in the binary search method

--- a/x/protorev/types/genesis.go
+++ b/x/protorev/types/genesis.go
@@ -6,15 +6,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// InputAmountList contains a list of input amounts to test when creating the optimal amount to swap in the
-// binary search method
-var InputAmountList []sdk.Int
-
 // AtomDenomination stores the native denom name for Atom on chain used for route building
 var AtomDenomination string = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
 
 // OsmosisDenomination stores the native denom name for Osmosis on chain used for route building
 var OsmosisDenomination string = "uosmo"
+
+// (2 ^ 14) = 16,384
+var MaxInputAmount = sdk.NewInt(16_384)
+
+// Max iterations for binary search (log2(16_384) = 14)
+const MaxIterations = 14
 
 type TokenPair struct {
 	TokenA string
@@ -40,11 +42,7 @@ func (gs GenesisState) Validate() error {
 }
 
 func init() {
-	// Init all of the input amounts
-	InputAmountList = make([]sdk.Int, 0)
-	for i := 0; i < 1000000000; i += 100000 {
-		InputAmountList = append(InputAmountList, sdk.NewInt(int64(i)))
-	}
+	// no-op
 }
 
 // Routes entered into the genesis state must start and end with the same denomination and

--- a/x/protorev/types/genesis.go
+++ b/x/protorev/types/genesis.go
@@ -12,8 +12,11 @@ var AtomDenomination string = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9C
 // OsmosisDenomination stores the native denom name for Osmosis on chain used for route building
 var OsmosisDenomination string = "uosmo"
 
-// (2 ^ 14) = 16,384
+// MaxInputAmount is the upper bound for what will be used to find the optimal in amount when creating (2 ^ 14) = 16,384
 var MaxInputAmount = sdk.NewInt(16_384)
+
+// StepSize is the amount we multiply each index in the binary search method
+var StepSize = sdk.NewInt(1_000_000)
 
 // Max iterations for binary search (log2(16_384) = 14)
 const MaxIterations = 14

--- a/x/protorev/types/keys.go
+++ b/x/protorev/types/keys.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 const (
 	// ModuleName defines the module name
 	ModuleName = "protorev"
@@ -15,6 +21,10 @@ const (
 	prefixTokenPairRoutes = iota + 1
 	prefixOsmoPools
 	prefixAtomPools
+	prefixNumberOfTrades
+	prefixProfitsByDenom
+	prefixTradesByRoute
+	prefixProfitsByRoute
 )
 
 var (
@@ -27,6 +37,19 @@ var (
 
 	// KeyPrefixAtomPools is the prefix for the atom pool store
 	KeyPrefixAtomPools = []byte{prefixAtomPools}
+
+	// -------------- Keys for statistics stores -------------- //
+	// KeyPrefixNumberOfTrades is the prefix for the store that keeps track of the number of trades executed
+	KeyPrefixNumberOfTrades = []byte{prefixNumberOfTrades}
+
+	// KeyPrefixProfitByDenom is the prefix for the store that keeps track of the profits
+	KeyPrefixProfitByDenom = []byte{prefixProfitsByDenom}
+
+	// KeyPrefixTradesByRoute is the prefix for the store that keeps track of the number of trades executed by route
+	KeyPrefixTradesByRoute = []byte{prefixTradesByRoute}
+
+	// KeyPrefixProfitsByRoute is the prefix for the store that keeps track of the profits made by route
+	KeyPrefixProfitsByRoute = []byte{prefixProfitsByRoute}
 )
 
 // Returns the key needed to fetch the osmo pool for a given denom
@@ -42,4 +65,40 @@ func GetKeyPrefixAtomPool(denom string) []byte {
 // Returns the key needed to fetch the tokenPair routes for a given pair of tokens
 func GetKeyPrefixRouteForTokenPair(tokenA, tokenB string) []byte {
 	return append(KeyPrefixTokenPairRoutes, []byte(tokenA+"|"+tokenB)...)
+}
+
+// Returns the key needed to fetch the profit by coin
+func GetKeyPrefixProfitByDenom(denom string) []byte {
+	return append(KeyPrefixProfitByDenom, []byte(denom)...)
+}
+
+// Returns the key needed to fetch the number of trades by route
+func GetKeyPrefixTradesByRoute(route []uint64) []byte {
+	return append(KeyPrefixTradesByRoute, CreateRouteKey(route)...)
+}
+
+// Returns the key needed to fetch the profits by route
+func GetKeyPrefixProfitsByRoute(route []uint64, denom string) []byte {
+	return append(append(KeyPrefixProfitsByRoute, CreateRouteKey(route)...), []byte(denom)...)
+}
+
+// createRouteKey creates a key for the given route. converts a slice of uint64 to a string separated by a pipe
+// {1,2,3,4} -> []byte("1|2|3|4")
+func CreateRouteKey(route []uint64) []byte {
+	return []byte(strings.Trim(strings.Join(strings.Fields(fmt.Sprint(route)), "|"), "[]"))
+}
+
+// createRouteFromKey creates a route from a key. converts a string separated by a pipe to a slice of uint64
+// []byte("1|2|3|4") -> {1,2,3,4}
+func CreateRouteFromKey(key []byte) ([]uint64, error) {
+	var route []uint64
+	for _, r := range strings.Split(string(key), "|") {
+		pool, err := strconv.ParseUint(r, 10, 64)
+		if err != nil {
+			return []uint64{}, err
+		}
+
+		route = append(route, pool)
+	}
+	return route, nil
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR implements all of the logic surrounding finding the most profitable arbitrage opportunities given a set of routes, executing the most profitable arbitrage route, and storing profits in the module account. Additionally, the module tracks various statistics about how many trades have been executed, what pools had the most amount of arbitrage opportunities and more. Lastly, this PR refactors routes.go to use SwapAmountInRoutes instead of the custom route struct as it plugs into the gamm interface in a cleaner way.

Linking main issue for reference : https://github.com/osmosis-labs/osmosis/issues/3594.

## Brief Changelog
- *Calculating whether a cyclic arbitrage route is profitable*
- *Determining the most profitable cyclic arbitrage route from a set of routes given a swap*
- *Executing the most profitable cyclic arbitrage opportunity (if one exists)*
- *New setters, getters, and keys for statistics tracking*


## Testing and Verifying

This change added tests and can be verified as follows:
- *Added unit tests for setters and getters for module statistics*
- *Added unit tests for FindMaxProfitRoute*
- *Added unit tests for CalculateRouteProfit*
- *Added unit tests for ExecuteTrade*
- *Added unit tests for ConvertProfits*

## Documentation and Release Note
| State Object | Description | Key | Values | Store |
| --- | --- | --- | --- | --- |
| NumberOfTrades | Tracks the number of trades protorev has executed | []byte{4} | []byte{numberOfTrades} | KV |
| ProfitsByDenom | Tracks the profits protorev has made | []byte{5} + []byte{tokenDenom} | []byte{sdk.Coin} | KV |
| TradesByRoute | Tracks the number of trades the module has executed on a given route | []byte{6} + []byte{route} | []byte{numberOfTrades} | KV |
| ProfitsByRoute | Tracks the profits the module has accumulated after trading on a given route | []byte{7} + []byte{route} | []byte{sdk.Coin} | KV |

**NumberOfTrades**
This will store the total number of arbitrage trades that `x/protorev` has executed since genesis. When finding a pool that has a cyclic arbitrage opportunity, the trade will be executed and this incremented.

**ProfitsByDenom**
`x/protorev` can execute cyclic arbitrage trades with either Osmosis or Atom. As such, this will store the profits that the module has earned from either denomination.

**TradesByRoute & ProfitsByRoute**
These metrics allows users and researchers to query the number of cyclic arbitrage trades that have been executed by `x/protorev` on an cyclic arbitrage route as well as all of the profits captured on that same route.

#### Trade Execution Logic
Now that we have a list of cyclic routes for each pool swapped by the user’s tx, we then determine if any of the routes are profitable. We determine this using a binary search algorithm that finds the amount of the asset to swap in that results in the most of that same asset out. We then calculate profits by taking the difference between the amount of asset out and amount of asset in. By iterating through the routes and storing the route, optimal input amount, and profit of the route with the highest profit > 0, we are left with the route and amount to execute the MultiHopSwap against.

The module mints the optimal input amount of the coin to swap in from the `bankkeeper` to the `x/protorev` module account, executes the MultiHopSwap by interacting with the `x/gamm` module, burns the optimal input amount of the coin minted to execute the MultiHopSwap, and sends subsequent profits to the module account.

- Note: `x/protorev` will exclusively execute MultiHopSwaps that originate and end in either OSMO or ATOM.
