### PR TITLE
refactor/test(osmomath): change package of decimal_test.go to osmomath_test

### DIFF
--- a/osmomath/decimal.go
+++ b/osmomath/decimal.go
@@ -52,7 +52,7 @@ var (
 	tickLogOf2 = MustNewDecFromStr("0.000144262291094554178391070900057480")
 	// initialized in init() since requires
 	// precision to be defined.
-	twoBigDec BigDec
+	twoBigDec BigDec = MustNewDecFromStr("2")
 )
 
 // Decimal errors
@@ -68,8 +68,6 @@ func init() {
 	for i := 0; i <= Precision; i++ {
 		precisionMultipliers[i] = calcPrecisionMultiplier(int64(i))
 	}
-
-	twoBigDec = NewBigDec(2)
 }
 
 func precisionInt() *big.Int {

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -475,6 +475,26 @@ func (s *decimalTestSuite) TestDecCeil() {
 	}
 }
 
+func (s *decimalTestSuite) TestPower() {
+	testCases := []struct {
+		input    osmomath.BigDec
+		power    uint64
+		expected osmomath.BigDec
+	}{
+		{osmomath.OneDec(), 10, osmomath.OneDec()},                                                                            // 1.0 ^ (10) => 1.0
+		{osmomath.NewDecWithPrec(5, 1), 2, osmomath.NewDecWithPrec(25, 2)},                                                    // 0.5 ^ 2 => 0.25
+		{osmomath.NewDecWithPrec(2, 1), 2, osmomath.NewDecWithPrec(4, 2)},                                                     // 0.2 ^ 2 => 0.04
+		{osmomath.NewDecFromInt(osmomath.NewInt(3)), 3, osmomath.NewDecFromInt(osmomath.NewInt(27))},                          // 3 ^ 3 => 27
+		{osmomath.NewDecFromInt(osmomath.NewInt(-3)), 4, osmomath.NewDecFromInt(osmomath.NewInt(81))},                         // -3 ^ 4 = 81
+		{osmomath.MustNewDecFromStr("1.414213562373095048801688724209698079"), 2, osmomath.NewDecFromInt(osmomath.NewInt(2))}, // 1.414213562373095048801688724209698079 ^ 2 = 2
+	}
+
+	for i, tc := range testCases {
+		res := tc.input.Power(tc.power)
+		s.Require().True(tc.expected.Sub(res).Abs().LTE(osmomath.SmallestDec()), "unexpected result for test case %d, input: %v", i, tc.input)
+	}
+}
+
 func (s *decimalTestSuite) TestApproxRoot() {
 	testCases := []struct {
 		input    osmomath.BigDec

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -1,4 +1,4 @@
-package osmomath
+package osmomath_test
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
+	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
@@ -27,7 +28,7 @@ func TestDecimalTestSuite(t *testing.T) {
 // assertMutResult given expected value after applying a math operation, a start value,
 // mutative and non mutative results with start values, asserts that mutation are only applied
 // to the mutative versions. Also, asserts that both results match the expected value.
-func (s *decimalTestSuite) assertMutResult(expectedResult, startValue, mutativeResult, nonMutativeResult, mutativeStartValue, nonMutativeStartValue BigDec) {
+func (s *decimalTestSuite) assertMutResult(expectedResult, startValue, mutativeResult, nonMutativeResult, mutativeStartValue, nonMutativeStartValue osmomath.BigDec) {
 	// assert both results are as expected.
 	s.Require().Equal(expectedResult, mutativeResult)
 	s.Require().Equal(expectedResult, nonMutativeResult)
@@ -40,30 +41,30 @@ func (s *decimalTestSuite) assertMutResult(expectedResult, startValue, mutativeR
 
 func TestDecApproxEq(t *testing.T) {
 	// d1 = 0.55, d2 = 0.6, tol = 0.1
-	d1 := NewDecWithPrec(55, 2)
-	d2 := NewDecWithPrec(6, 1)
-	tol := NewDecWithPrec(1, 1)
+	d1 := osmomath.NewDecWithPrec(55, 2)
+	d2 := osmomath.NewDecWithPrec(6, 1)
+	tol := osmomath.NewDecWithPrec(1, 1)
 
-	require.True(DecApproxEq(t, d1, d2, tol))
+	require.True(osmomath.DecApproxEq(t, d1, d2, tol))
 
 	// d1 = 0.55, d2 = 0.6, tol = 1E-5
-	d1 = NewDecWithPrec(55, 2)
-	d2 = NewDecWithPrec(6, 1)
-	tol = NewDecWithPrec(1, 5)
+	d1 = osmomath.NewDecWithPrec(55, 2)
+	d2 = osmomath.NewDecWithPrec(6, 1)
+	tol = osmomath.NewDecWithPrec(1, 5)
 
-	require.False(DecApproxEq(t, d1, d2, tol))
+	require.False(osmomath.DecApproxEq(t, d1, d2, tol))
 
 	// d1 = 0.6, d2 = 0.61, tol = 0.01
-	d1 = NewDecWithPrec(6, 1)
-	d2 = NewDecWithPrec(61, 2)
-	tol = NewDecWithPrec(1, 2)
+	d1 = osmomath.NewDecWithPrec(6, 1)
+	d2 = osmomath.NewDecWithPrec(61, 2)
+	tol = osmomath.NewDecWithPrec(1, 2)
 
-	require.True(DecApproxEq(t, d1, d2, tol))
+	require.True(osmomath.DecApproxEq(t, d1, d2, tol))
 }
 
 // create a decimal from a decimal string (ex. "1234.5678")
-func (s *decimalTestSuite) mustNewDecFromStr(str string) (d BigDec) {
-	d, err := NewDecFromStr(str)
+func (s *decimalTestSuite) MustNewDecFromStr(str string) (d osmomath.BigDec) {
+	d, err := osmomath.NewDecFromStr(str)
 	s.Require().NoError(err)
 
 	return d
@@ -76,36 +77,36 @@ func (s *decimalTestSuite) TestNewDecFromStr() {
 	tests := []struct {
 		decimalStr string
 		expErr     bool
-		exp        BigDec
+		exp        osmomath.BigDec
 	}{
-		{"", true, BigDec{}},
-		{"0.-75", true, BigDec{}},
-		{"0", false, NewBigDec(0)},
-		{"1", false, NewBigDec(1)},
-		{"1.1", false, NewDecWithPrec(11, 1)},
-		{"0.75", false, NewDecWithPrec(75, 2)},
-		{"0.8", false, NewDecWithPrec(8, 1)},
-		{"0.11111", false, NewDecWithPrec(11111, 5)},
-		{"314460551102969.31442782343433718353144278234343371835", true, NewBigDec(3141203149163817869)},
+		{"", true, osmomath.BigDec{}},
+		{"0.-75", true, osmomath.BigDec{}},
+		{"0", false, osmomath.NewBigDec(0)},
+		{"1", false, osmomath.NewBigDec(1)},
+		{"1.1", false, osmomath.NewDecWithPrec(11, 1)},
+		{"0.75", false, osmomath.NewDecWithPrec(75, 2)},
+		{"0.8", false, osmomath.NewDecWithPrec(8, 1)},
+		{"0.11111", false, osmomath.NewDecWithPrec(11111, 5)},
+		{"314460551102969.31442782343433718353144278234343371835", true, osmomath.NewBigDec(3141203149163817869)},
 		{
 			"314460551102969314427823434337.18357180924882313501835718092488231350",
-			true, NewDecFromBigIntWithPrec(largeBigInt, 4),
+			true, osmomath.NewDecFromBigIntWithPrec(largeBigInt, 4),
 		},
 		{
 			"314460551102969314427823434337.1835",
-			false, NewDecFromBigIntWithPrec(largeBigInt, 4),
+			false, osmomath.NewDecFromBigIntWithPrec(largeBigInt, 4),
 		},
-		{".", true, BigDec{}},
-		{".0", true, NewBigDec(0)},
-		{"1.", true, NewBigDec(1)},
-		{"foobar", true, BigDec{}},
-		{"0.foobar", true, BigDec{}},
-		{"0.foobar.", true, BigDec{}},
-		{"179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216", true, BigDec{}},
+		{".", true, osmomath.BigDec{}},
+		{".0", true, osmomath.NewBigDec(0)},
+		{"1.", true, osmomath.NewBigDec(1)},
+		{"foobar", true, osmomath.BigDec{}},
+		{"0.foobar", true, osmomath.BigDec{}},
+		{"0.foobar.", true, osmomath.BigDec{}},
+		{"179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216", true, osmomath.BigDec{}},
 	}
 
 	for tcIndex, tc := range tests {
-		res, err := NewDecFromStr(tc.decimalStr)
+		res, err := osmomath.NewDecFromStr(tc.decimalStr)
 		if tc.expErr {
 			s.Require().NotNil(err, "error expected, decimalStr %v, tc %v", tc.decimalStr, tcIndex)
 		} else {
@@ -114,12 +115,12 @@ func (s *decimalTestSuite) TestNewDecFromStr() {
 		}
 
 		// negative tc
-		res, err = NewDecFromStr("-" + tc.decimalStr)
+		res, err = osmomath.NewDecFromStr("-" + tc.decimalStr)
 		if tc.expErr {
 			s.Require().NotNil(err, "error expected, decimalStr %v, tc %v", tc.decimalStr, tcIndex)
 		} else {
 			s.Require().Nil(err, "unexpected error, decimalStr %v, tc %v", tc.decimalStr, tcIndex)
-			exp := tc.exp.Mul(NewBigDec(-1))
+			exp := tc.exp.Mul(osmomath.NewBigDec(-1))
 			s.Require().True(res.Equal(exp), "equality was incorrect, res %v, exp %v, tc %v", res, exp, tcIndex)
 		}
 	}
@@ -127,18 +128,18 @@ func (s *decimalTestSuite) TestNewDecFromStr() {
 
 func (s *decimalTestSuite) TestDecString() {
 	tests := []struct {
-		d    BigDec
+		d    osmomath.BigDec
 		want string
 	}{
-		{NewBigDec(0), "0.000000000000000000000000000000000000"},
-		{NewBigDec(1), "1.000000000000000000000000000000000000"},
-		{NewBigDec(10), "10.000000000000000000000000000000000000"},
-		{NewBigDec(12340), "12340.000000000000000000000000000000000000"},
-		{NewDecWithPrec(12340, 4), "1.234000000000000000000000000000000000"},
-		{NewDecWithPrec(12340, 5), "0.123400000000000000000000000000000000"},
-		{NewDecWithPrec(12340, 8), "0.000123400000000000000000000000000000"},
-		{NewDecWithPrec(1009009009009009009, 17), "10.090090090090090090000000000000000000"},
-		{MustNewDecFromStr("10.090090090090090090090090090090090090"), "10.090090090090090090090090090090090090"},
+		{osmomath.NewBigDec(0), "0.000000000000000000000000000000000000"},
+		{osmomath.NewBigDec(1), "1.000000000000000000000000000000000000"},
+		{osmomath.NewBigDec(10), "10.000000000000000000000000000000000000"},
+		{osmomath.NewBigDec(12340), "12340.000000000000000000000000000000000000"},
+		{osmomath.NewDecWithPrec(12340, 4), "1.234000000000000000000000000000000000"},
+		{osmomath.NewDecWithPrec(12340, 5), "0.123400000000000000000000000000000000"},
+		{osmomath.NewDecWithPrec(12340, 8), "0.000123400000000000000000000000000000"},
+		{osmomath.NewDecWithPrec(1009009009009009009, 17), "10.090090090090090090000000000000000000"},
+		{osmomath.MustNewDecFromStr("10.090090090090090090090090090090090090"), "10.090090090090090090090090090090090090"},
 	}
 	for tcIndex, tc := range tests {
 		s.Require().Equal(tc.want, tc.d.String(), "bad String(), index: %v", tcIndex)
@@ -147,17 +148,17 @@ func (s *decimalTestSuite) TestDecString() {
 
 func (s *decimalTestSuite) TestDecFloat64() {
 	tests := []struct {
-		d    BigDec
+		d    osmomath.BigDec
 		want float64
 	}{
-		{NewBigDec(0), 0.000000000000000000},
-		{NewBigDec(1), 1.000000000000000000},
-		{NewBigDec(10), 10.000000000000000000},
-		{NewBigDec(12340), 12340.000000000000000000},
-		{NewDecWithPrec(12340, 4), 1.234000000000000000},
-		{NewDecWithPrec(12340, 5), 0.123400000000000000},
-		{NewDecWithPrec(12340, 8), 0.000123400000000000},
-		{NewDecWithPrec(1009009009009009009, 17), 10.090090090090090090},
+		{osmomath.NewBigDec(0), 0.000000000000000000},
+		{osmomath.NewBigDec(1), 1.000000000000000000},
+		{osmomath.NewBigDec(10), 10.000000000000000000},
+		{osmomath.NewBigDec(12340), 12340.000000000000000000},
+		{osmomath.NewDecWithPrec(12340, 4), 1.234000000000000000},
+		{osmomath.NewDecWithPrec(12340, 5), 0.123400000000000000},
+		{osmomath.NewDecWithPrec(12340, 8), 0.000123400000000000},
+		{osmomath.NewDecWithPrec(1009009009009009009, 17), 10.090090090090090090},
 	}
 	for tcIndex, tc := range tests {
 		value, err := tc.d.Float64()
@@ -169,18 +170,18 @@ func (s *decimalTestSuite) TestDecFloat64() {
 
 func (s *decimalTestSuite) TestSdkDec() {
 	tests := []struct {
-		d        BigDec
+		d        osmomath.BigDec
 		want     sdk.Dec
 		expPanic bool
 	}{
-		{NewBigDec(0), sdk.MustNewDecFromStr("0.000000000000000000"), false},
-		{NewBigDec(1), sdk.MustNewDecFromStr("1.000000000000000000"), false},
-		{NewBigDec(10), sdk.MustNewDecFromStr("10.000000000000000000"), false},
-		{NewBigDec(12340), sdk.MustNewDecFromStr("12340.000000000000000000"), false},
-		{NewDecWithPrec(12340, 4), sdk.MustNewDecFromStr("1.234000000000000000"), false},
-		{NewDecWithPrec(12340, 5), sdk.MustNewDecFromStr("0.123400000000000000"), false},
-		{NewDecWithPrec(12340, 8), sdk.MustNewDecFromStr("0.000123400000000000"), false},
-		{NewDecWithPrec(1009009009009009009, 17), sdk.MustNewDecFromStr("10.090090090090090090"), false},
+		{osmomath.NewBigDec(0), sdk.MustNewDecFromStr("0.000000000000000000"), false},
+		{osmomath.NewBigDec(1), sdk.MustNewDecFromStr("1.000000000000000000"), false},
+		{osmomath.NewBigDec(10), sdk.MustNewDecFromStr("10.000000000000000000"), false},
+		{osmomath.NewBigDec(12340), sdk.MustNewDecFromStr("12340.000000000000000000"), false},
+		{osmomath.NewDecWithPrec(12340, 4), sdk.MustNewDecFromStr("1.234000000000000000"), false},
+		{osmomath.NewDecWithPrec(12340, 5), sdk.MustNewDecFromStr("0.123400000000000000"), false},
+		{osmomath.NewDecWithPrec(12340, 8), sdk.MustNewDecFromStr("0.000123400000000000"), false},
+		{osmomath.NewDecWithPrec(1009009009009009009, 17), sdk.MustNewDecFromStr("10.090090090090090090"), false},
 	}
 	for tcIndex, tc := range tests {
 		if tc.expPanic {
@@ -195,24 +196,24 @@ func (s *decimalTestSuite) TestSdkDec() {
 func (s *decimalTestSuite) TestBigDecFromSdkDec() {
 	tests := []struct {
 		d        sdk.Dec
-		want     BigDec
+		want     osmomath.BigDec
 		expPanic bool
 	}{
-		{sdk.MustNewDecFromStr("0.000000000000000000"), NewBigDec(0), false},
-		{sdk.MustNewDecFromStr("1.000000000000000000"), NewBigDec(1), false},
-		{sdk.MustNewDecFromStr("10.000000000000000000"), NewBigDec(10), false},
-		{sdk.MustNewDecFromStr("12340.000000000000000000"), NewBigDec(12340), false},
-		{sdk.MustNewDecFromStr("1.234000000000000000"), NewDecWithPrec(12340, 4), false},
-		{sdk.MustNewDecFromStr("0.123400000000000000"), NewDecWithPrec(12340, 5), false},
-		{sdk.MustNewDecFromStr("0.000123400000000000"), NewDecWithPrec(12340, 8), false},
-		{sdk.MustNewDecFromStr("10.090090090090090090"), NewDecWithPrec(1009009009009009009, 17), false},
+		{sdk.MustNewDecFromStr("0.000000000000000000"), osmomath.NewBigDec(0), false},
+		{sdk.MustNewDecFromStr("1.000000000000000000"), osmomath.NewBigDec(1), false},
+		{sdk.MustNewDecFromStr("10.000000000000000000"), osmomath.NewBigDec(10), false},
+		{sdk.MustNewDecFromStr("12340.000000000000000000"), osmomath.NewBigDec(12340), false},
+		{sdk.MustNewDecFromStr("1.234000000000000000"), osmomath.NewDecWithPrec(12340, 4), false},
+		{sdk.MustNewDecFromStr("0.123400000000000000"), osmomath.NewDecWithPrec(12340, 5), false},
+		{sdk.MustNewDecFromStr("0.000123400000000000"), osmomath.NewDecWithPrec(12340, 8), false},
+		{sdk.MustNewDecFromStr("10.090090090090090090"), osmomath.NewDecWithPrec(1009009009009009009, 17), false},
 	}
 	for tcIndex, tc := range tests {
 		if tc.expPanic {
-			s.Require().Panics(func() { BigDecFromSDKDec(tc.d) })
+			s.Require().Panics(func() { osmomath.BigDecFromSDKDec(tc.d) })
 		} else {
-			value := BigDecFromSDKDec(tc.d)
-			s.Require().Equal(tc.want, value, "bad BigDecFromSdkDec(), index: %v", tcIndex)
+			value := osmomath.BigDecFromSDKDec(tc.d)
+			s.Require().Equal(tc.want, value, "bad osmomath.BigDecFromSdkDec(), index: %v", tcIndex)
 		}
 	}
 }
@@ -220,56 +221,56 @@ func (s *decimalTestSuite) TestBigDecFromSdkDec() {
 func (s *decimalTestSuite) TestBigDecFromSdkDecSlice() {
 	tests := []struct {
 		d        []sdk.Dec
-		want     []BigDec
+		want     []osmomath.BigDec
 		expPanic bool
 	}{
-		{[]sdk.Dec{sdk.MustNewDecFromStr("0.000000000000000000")}, []BigDec{NewBigDec(0)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("0.000000000000000000"), sdk.MustNewDecFromStr("1.000000000000000000")}, []BigDec{NewBigDec(0), NewBigDec(1)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("1.000000000000000000"), sdk.MustNewDecFromStr("0.000000000000000000"), sdk.MustNewDecFromStr("0.000123400000000000")}, []BigDec{NewBigDec(1), NewBigDec(0), NewDecWithPrec(12340, 8)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("10.000000000000000000")}, []BigDec{NewBigDec(10)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("12340.000000000000000000")}, []BigDec{NewBigDec(12340)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("1.234000000000000000"), sdk.MustNewDecFromStr("12340.000000000000000000")}, []BigDec{NewDecWithPrec(12340, 4), NewBigDec(12340)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("0.123400000000000000"), sdk.MustNewDecFromStr("12340.000000000000000000")}, []BigDec{NewDecWithPrec(12340, 5), NewBigDec(12340)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("0.000123400000000000"), sdk.MustNewDecFromStr("10.090090090090090090")}, []BigDec{NewDecWithPrec(12340, 8), NewDecWithPrec(1009009009009009009, 17)}, false},
-		{[]sdk.Dec{sdk.MustNewDecFromStr("10.090090090090090090"), sdk.MustNewDecFromStr("10.090090090090090090")}, []BigDec{NewDecWithPrec(1009009009009009009, 17), NewDecWithPrec(1009009009009009009, 17)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("0.000000000000000000")}, []osmomath.BigDec{osmomath.NewBigDec(0)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("0.000000000000000000"), sdk.MustNewDecFromStr("1.000000000000000000")}, []osmomath.BigDec{osmomath.NewBigDec(0), osmomath.NewBigDec(1)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("1.000000000000000000"), sdk.MustNewDecFromStr("0.000000000000000000"), sdk.MustNewDecFromStr("0.000123400000000000")}, []osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(0), osmomath.NewDecWithPrec(12340, 8)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("10.000000000000000000")}, []osmomath.BigDec{osmomath.NewBigDec(10)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("12340.000000000000000000")}, []osmomath.BigDec{osmomath.NewBigDec(12340)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("1.234000000000000000"), sdk.MustNewDecFromStr("12340.000000000000000000")}, []osmomath.BigDec{osmomath.NewDecWithPrec(12340, 4), osmomath.NewBigDec(12340)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("0.123400000000000000"), sdk.MustNewDecFromStr("12340.000000000000000000")}, []osmomath.BigDec{osmomath.NewDecWithPrec(12340, 5), osmomath.NewBigDec(12340)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("0.000123400000000000"), sdk.MustNewDecFromStr("10.090090090090090090")}, []osmomath.BigDec{osmomath.NewDecWithPrec(12340, 8), osmomath.NewDecWithPrec(1009009009009009009, 17)}, false},
+		{[]sdk.Dec{sdk.MustNewDecFromStr("10.090090090090090090"), sdk.MustNewDecFromStr("10.090090090090090090")}, []osmomath.BigDec{osmomath.NewDecWithPrec(1009009009009009009, 17), osmomath.NewDecWithPrec(1009009009009009009, 17)}, false},
 	}
 	for tcIndex, tc := range tests {
 		if tc.expPanic {
-			s.Require().Panics(func() { BigDecFromSDKDecSlice(tc.d) })
+			s.Require().Panics(func() { osmomath.BigDecFromSDKDecSlice(tc.d) })
 		} else {
-			value := BigDecFromSDKDecSlice(tc.d)
-			s.Require().Equal(tc.want, value, "bad BigDecFromSdkDec(), index: %v", tcIndex)
+			value := osmomath.BigDecFromSDKDecSlice(tc.d)
+			s.Require().Equal(tc.want, value, "bad osmomath.BigDecFromSdkDec(), index: %v", tcIndex)
 		}
 	}
 }
 
 func (s *decimalTestSuite) TestEqualities() {
 	tests := []struct {
-		d1, d2     BigDec
+		d1, d2     osmomath.BigDec
 		gt, lt, eq bool
 	}{
-		{NewBigDec(0), NewBigDec(0), false, false, true},
-		{NewDecWithPrec(0, 2), NewDecWithPrec(0, 4), false, false, true},
-		{NewDecWithPrec(100, 0), NewDecWithPrec(100, 0), false, false, true},
-		{NewDecWithPrec(-100, 0), NewDecWithPrec(-100, 0), false, false, true},
-		{NewDecWithPrec(-1, 1), NewDecWithPrec(-1, 1), false, false, true},
-		{NewDecWithPrec(3333, 3), NewDecWithPrec(3333, 3), false, false, true},
+		{osmomath.NewBigDec(0), osmomath.NewBigDec(0), false, false, true},
+		{osmomath.NewDecWithPrec(0, 2), osmomath.NewDecWithPrec(0, 4), false, false, true},
+		{osmomath.NewDecWithPrec(100, 0), osmomath.NewDecWithPrec(100, 0), false, false, true},
+		{osmomath.NewDecWithPrec(-100, 0), osmomath.NewDecWithPrec(-100, 0), false, false, true},
+		{osmomath.NewDecWithPrec(-1, 1), osmomath.NewDecWithPrec(-1, 1), false, false, true},
+		{osmomath.NewDecWithPrec(3333, 3), osmomath.NewDecWithPrec(3333, 3), false, false, true},
 
-		{NewDecWithPrec(0, 0), NewDecWithPrec(3333, 3), false, true, false},
-		{NewDecWithPrec(0, 0), NewDecWithPrec(100, 0), false, true, false},
-		{NewDecWithPrec(-1, 0), NewDecWithPrec(3333, 3), false, true, false},
-		{NewDecWithPrec(-1, 0), NewDecWithPrec(100, 0), false, true, false},
-		{NewDecWithPrec(1111, 3), NewDecWithPrec(100, 0), false, true, false},
-		{NewDecWithPrec(1111, 3), NewDecWithPrec(3333, 3), false, true, false},
-		{NewDecWithPrec(-3333, 3), NewDecWithPrec(-1111, 3), false, true, false},
+		{osmomath.NewDecWithPrec(0, 0), osmomath.NewDecWithPrec(3333, 3), false, true, false},
+		{osmomath.NewDecWithPrec(0, 0), osmomath.NewDecWithPrec(100, 0), false, true, false},
+		{osmomath.NewDecWithPrec(-1, 0), osmomath.NewDecWithPrec(3333, 3), false, true, false},
+		{osmomath.NewDecWithPrec(-1, 0), osmomath.NewDecWithPrec(100, 0), false, true, false},
+		{osmomath.NewDecWithPrec(1111, 3), osmomath.NewDecWithPrec(100, 0), false, true, false},
+		{osmomath.NewDecWithPrec(1111, 3), osmomath.NewDecWithPrec(3333, 3), false, true, false},
+		{osmomath.NewDecWithPrec(-3333, 3), osmomath.NewDecWithPrec(-1111, 3), false, true, false},
 
-		{NewDecWithPrec(3333, 3), NewDecWithPrec(0, 0), true, false, false},
-		{NewDecWithPrec(100, 0), NewDecWithPrec(0, 0), true, false, false},
-		{NewDecWithPrec(3333, 3), NewDecWithPrec(-1, 0), true, false, false},
-		{NewDecWithPrec(100, 0), NewDecWithPrec(-1, 0), true, false, false},
-		{NewDecWithPrec(100, 0), NewDecWithPrec(1111, 3), true, false, false},
-		{NewDecWithPrec(3333, 3), NewDecWithPrec(1111, 3), true, false, false},
-		{NewDecWithPrec(-1111, 3), NewDecWithPrec(-3333, 3), true, false, false},
+		{osmomath.NewDecWithPrec(3333, 3), osmomath.NewDecWithPrec(0, 0), true, false, false},
+		{osmomath.NewDecWithPrec(100, 0), osmomath.NewDecWithPrec(0, 0), true, false, false},
+		{osmomath.NewDecWithPrec(3333, 3), osmomath.NewDecWithPrec(-1, 0), true, false, false},
+		{osmomath.NewDecWithPrec(100, 0), osmomath.NewDecWithPrec(-1, 0), true, false, false},
+		{osmomath.NewDecWithPrec(100, 0), osmomath.NewDecWithPrec(1111, 3), true, false, false},
+		{osmomath.NewDecWithPrec(3333, 3), osmomath.NewDecWithPrec(1111, 3), true, false, false},
+		{osmomath.NewDecWithPrec(-1111, 3), osmomath.NewDecWithPrec(-3333, 3), true, false, false},
 	}
 
 	for tcIndex, tc := range tests {
@@ -281,65 +282,65 @@ func (s *decimalTestSuite) TestEqualities() {
 
 func (s *decimalTestSuite) TestDecsEqual() {
 	tests := []struct {
-		d1s, d2s []BigDec
+		d1s, d2s []osmomath.BigDec
 		eq       bool
 	}{
-		{[]BigDec{NewBigDec(0)}, []BigDec{NewBigDec(0)}, true},
-		{[]BigDec{NewBigDec(0)}, []BigDec{NewBigDec(1)}, false},
-		{[]BigDec{NewBigDec(0)}, []BigDec{}, false},
-		{[]BigDec{NewBigDec(0), NewBigDec(1)}, []BigDec{NewBigDec(0), NewBigDec(1)}, true},
-		{[]BigDec{NewBigDec(1), NewBigDec(0)}, []BigDec{NewBigDec(1), NewBigDec(0)}, true},
-		{[]BigDec{NewBigDec(1), NewBigDec(0)}, []BigDec{NewBigDec(0), NewBigDec(1)}, false},
-		{[]BigDec{NewBigDec(1), NewBigDec(0)}, []BigDec{NewBigDec(1)}, false},
-		{[]BigDec{NewBigDec(1), NewBigDec(2)}, []BigDec{NewBigDec(2), NewBigDec(4)}, false},
-		{[]BigDec{NewBigDec(3), NewBigDec(18)}, []BigDec{NewBigDec(1), NewBigDec(6)}, false},
+		{[]osmomath.BigDec{osmomath.NewBigDec(0)}, []osmomath.BigDec{osmomath.NewBigDec(0)}, true},
+		{[]osmomath.BigDec{osmomath.NewBigDec(0)}, []osmomath.BigDec{osmomath.NewBigDec(1)}, false},
+		{[]osmomath.BigDec{osmomath.NewBigDec(0)}, []osmomath.BigDec{}, false},
+		{[]osmomath.BigDec{osmomath.NewBigDec(0), osmomath.NewBigDec(1)}, []osmomath.BigDec{osmomath.NewBigDec(0), osmomath.NewBigDec(1)}, true},
+		{[]osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(0)}, []osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(0)}, true},
+		{[]osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(0)}, []osmomath.BigDec{osmomath.NewBigDec(0), osmomath.NewBigDec(1)}, false},
+		{[]osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(0)}, []osmomath.BigDec{osmomath.NewBigDec(1)}, false},
+		{[]osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(2)}, []osmomath.BigDec{osmomath.NewBigDec(2), osmomath.NewBigDec(4)}, false},
+		{[]osmomath.BigDec{osmomath.NewBigDec(3), osmomath.NewBigDec(18)}, []osmomath.BigDec{osmomath.NewBigDec(1), osmomath.NewBigDec(6)}, false},
 	}
 
 	for tcIndex, tc := range tests {
-		s.Require().Equal(tc.eq, DecsEqual(tc.d1s, tc.d2s), "equality of decional arrays is incorrect, tc %d", tcIndex)
-		s.Require().Equal(tc.eq, DecsEqual(tc.d2s, tc.d1s), "equality of decional arrays is incorrect (converse), tc %d", tcIndex)
+		s.Require().Equal(tc.eq, osmomath.DecsEqual(tc.d1s, tc.d2s), "equality of decional arrays is incorrect, tc %d", tcIndex)
+		s.Require().Equal(tc.eq, osmomath.DecsEqual(tc.d2s, tc.d1s), "equality of decional arrays is incorrect (converse), tc %d", tcIndex)
 	}
 }
 
 func (s *decimalTestSuite) TestArithmetic() {
 	tests := []struct {
-		d1, d2                                BigDec
-		expMul, expMulTruncate                BigDec
-		expQuo, expQuoRoundUp, expQuoTruncate BigDec
-		expAdd, expSub                        BigDec
+		d1, d2                                osmomath.BigDec
+		expMul, expMulTruncate                osmomath.BigDec
+		expQuo, expQuoRoundUp, expQuoTruncate osmomath.BigDec
+		expAdd, expSub                        osmomath.BigDec
 	}{
 		//  d1         d2         MUL    MulTruncate    QUO    QUORoundUp QUOTrunctate  ADD         SUB
-		{NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0)},
-		{NewBigDec(1), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(1), NewBigDec(1)},
-		{NewBigDec(0), NewBigDec(1), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(1), NewBigDec(-1)},
-		{NewBigDec(0), NewBigDec(-1), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(-1), NewBigDec(1)},
-		{NewBigDec(-1), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(0), NewBigDec(-1), NewBigDec(-1)},
+		{osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0)},
+		{osmomath.NewBigDec(1), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(1), osmomath.NewBigDec(1)},
+		{osmomath.NewBigDec(0), osmomath.NewBigDec(1), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(1), osmomath.NewBigDec(-1)},
+		{osmomath.NewBigDec(0), osmomath.NewBigDec(-1), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(-1), osmomath.NewBigDec(1)},
+		{osmomath.NewBigDec(-1), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(0), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1)},
 
-		{NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(2), NewBigDec(0)},
-		{NewBigDec(-1), NewBigDec(-1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(-2), NewBigDec(0)},
-		{NewBigDec(1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(0), NewBigDec(2)},
-		{NewBigDec(-1), NewBigDec(1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(-1), NewBigDec(0), NewBigDec(-2)},
+		{osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(2), osmomath.NewBigDec(0)},
+		{osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(-2), osmomath.NewBigDec(0)},
+		{osmomath.NewBigDec(1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(0), osmomath.NewBigDec(2)},
+		{osmomath.NewBigDec(-1), osmomath.NewBigDec(1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(-1), osmomath.NewBigDec(0), osmomath.NewBigDec(-2)},
 
 		{
-			NewBigDec(3), NewBigDec(7), NewBigDec(21), NewBigDec(21),
-			MustNewDecFromStr("0.428571428571428571428571428571428571"), MustNewDecFromStr("0.428571428571428571428571428571428572"), MustNewDecFromStr("0.428571428571428571428571428571428571"),
-			NewBigDec(10), NewBigDec(-4),
+			osmomath.NewBigDec(3), osmomath.NewBigDec(7), osmomath.NewBigDec(21), osmomath.NewBigDec(21),
+			osmomath.MustNewDecFromStr("0.428571428571428571428571428571428571"), osmomath.MustNewDecFromStr("0.428571428571428571428571428571428572"), osmomath.MustNewDecFromStr("0.428571428571428571428571428571428571"),
+			osmomath.NewBigDec(10), osmomath.NewBigDec(-4),
 		},
 		{
-			NewBigDec(2), NewBigDec(4), NewBigDec(8), NewBigDec(8), NewDecWithPrec(5, 1), NewDecWithPrec(5, 1), NewDecWithPrec(5, 1),
-			NewBigDec(6), NewBigDec(-2),
+			osmomath.NewBigDec(2), osmomath.NewBigDec(4), osmomath.NewBigDec(8), osmomath.NewBigDec(8), osmomath.NewDecWithPrec(5, 1), osmomath.NewDecWithPrec(5, 1), osmomath.NewDecWithPrec(5, 1),
+			osmomath.NewBigDec(6), osmomath.NewBigDec(-2),
 		},
 
-		{NewBigDec(100), NewBigDec(100), NewBigDec(10000), NewBigDec(10000), NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(200), NewBigDec(0)},
+		{osmomath.NewBigDec(100), osmomath.NewBigDec(100), osmomath.NewBigDec(10000), osmomath.NewBigDec(10000), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(200), osmomath.NewBigDec(0)},
 
 		{
-			NewDecWithPrec(15, 1), NewDecWithPrec(15, 1), NewDecWithPrec(225, 2), NewDecWithPrec(225, 2),
-			NewBigDec(1), NewBigDec(1), NewBigDec(1), NewBigDec(3), NewBigDec(0),
+			osmomath.NewDecWithPrec(15, 1), osmomath.NewDecWithPrec(15, 1), osmomath.NewDecWithPrec(225, 2), osmomath.NewDecWithPrec(225, 2),
+			osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(1), osmomath.NewBigDec(3), osmomath.NewBigDec(0),
 		},
 		{
-			NewDecWithPrec(3333, 4), NewDecWithPrec(333, 4), NewDecWithPrec(1109889, 8), NewDecWithPrec(1109889, 8),
-			MustNewDecFromStr("10.009009009009009009009009009009009009"), MustNewDecFromStr("10.009009009009009009009009009009009010"), MustNewDecFromStr("10.009009009009009009009009009009009009"),
-			NewDecWithPrec(3666, 4), NewDecWithPrec(3, 1),
+			osmomath.NewDecWithPrec(3333, 4), osmomath.NewDecWithPrec(333, 4), osmomath.NewDecWithPrec(1109889, 8), osmomath.NewDecWithPrec(1109889, 8),
+			osmomath.MustNewDecFromStr("10.009009009009009009009009009009009009"), osmomath.MustNewDecFromStr("10.009009009009009009009009009009009010"), osmomath.MustNewDecFromStr("10.009009009009009009009009009009009009"),
+			osmomath.NewDecWithPrec(3666, 4), osmomath.NewDecWithPrec(3, 1),
 		},
 	}
 
@@ -373,19 +374,19 @@ func (s *decimalTestSuite) TestArithmetic() {
 
 func (s *decimalTestSuite) TestBankerRoundChop() {
 	tests := []struct {
-		d1  BigDec
+		d1  osmomath.BigDec
 		exp int64
 	}{
-		{s.mustNewDecFromStr("0.25"), 0},
-		{s.mustNewDecFromStr("0"), 0},
-		{s.mustNewDecFromStr("1"), 1},
-		{s.mustNewDecFromStr("0.75"), 1},
-		{s.mustNewDecFromStr("0.5"), 0},
-		{s.mustNewDecFromStr("7.5"), 8},
-		{s.mustNewDecFromStr("1.5"), 2},
-		{s.mustNewDecFromStr("2.5"), 2},
-		{s.mustNewDecFromStr("0.545"), 1}, // 0.545-> 1 even though 5 is first decimal and 1 not even
-		{s.mustNewDecFromStr("1.545"), 2},
+		{s.MustNewDecFromStr("0.25"), 0},
+		{s.MustNewDecFromStr("0"), 0},
+		{s.MustNewDecFromStr("1"), 1},
+		{s.MustNewDecFromStr("0.75"), 1},
+		{s.MustNewDecFromStr("0.5"), 0},
+		{s.MustNewDecFromStr("7.5"), 8},
+		{s.MustNewDecFromStr("1.5"), 2},
+		{s.MustNewDecFromStr("2.5"), 2},
+		{s.MustNewDecFromStr("0.545"), 1}, // 0.545-> 1 even though 5 is first decimal and 1 not even
+		{s.MustNewDecFromStr("1.545"), 2},
 	}
 
 	for tcIndex, tc := range tests {
@@ -399,19 +400,19 @@ func (s *decimalTestSuite) TestBankerRoundChop() {
 
 func (s *decimalTestSuite) TestTruncate() {
 	tests := []struct {
-		d1  BigDec
+		d1  osmomath.BigDec
 		exp int64
 	}{
-		{s.mustNewDecFromStr("0"), 0},
-		{s.mustNewDecFromStr("0.25"), 0},
-		{s.mustNewDecFromStr("0.75"), 0},
-		{s.mustNewDecFromStr("1"), 1},
-		{s.mustNewDecFromStr("1.5"), 1},
-		{s.mustNewDecFromStr("7.5"), 7},
-		{s.mustNewDecFromStr("7.6"), 7},
-		{s.mustNewDecFromStr("7.4"), 7},
-		{s.mustNewDecFromStr("100.1"), 100},
-		{s.mustNewDecFromStr("1000.1"), 1000},
+		{s.MustNewDecFromStr("0"), 0},
+		{s.MustNewDecFromStr("0.25"), 0},
+		{s.MustNewDecFromStr("0.75"), 0},
+		{s.MustNewDecFromStr("1"), 1},
+		{s.MustNewDecFromStr("1.5"), 1},
+		{s.MustNewDecFromStr("7.5"), 7},
+		{s.MustNewDecFromStr("7.6"), 7},
+		{s.MustNewDecFromStr("7.4"), 7},
+		{s.MustNewDecFromStr("100.1"), 100},
+		{s.MustNewDecFromStr("1000.1"), 1000},
 	}
 
 	for tcIndex, tc := range tests {
@@ -425,9 +426,9 @@ func (s *decimalTestSuite) TestTruncate() {
 
 func (s *decimalTestSuite) TestStringOverflow() {
 	// two random 64 bit primes
-	dec1, err := NewDecFromStr("51643150036226787134389711697696177267")
+	dec1, err := osmomath.NewDecFromStr("51643150036226787134389711697696177267")
 	s.Require().NoError(err)
-	dec2, err := NewDecFromStr("-31798496660535729618459429845579852627")
+	dec2, err := osmomath.NewDecFromStr("-31798496660535729618459429845579852627")
 	s.Require().NoError(err)
 	dec3 := dec1.Add(dec2)
 	s.Require().Equal(
@@ -438,14 +439,14 @@ func (s *decimalTestSuite) TestStringOverflow() {
 
 func (s *decimalTestSuite) TestDecMulInt() {
 	tests := []struct {
-		sdkDec BigDec
-		sdkInt BigInt
-		want   BigDec
+		sdkDec osmomath.BigDec
+		sdkInt osmomath.BigInt
+		want   osmomath.BigDec
 	}{
-		{NewBigDec(10), NewInt(2), NewBigDec(20)},
-		{NewBigDec(1000000), NewInt(100), NewBigDec(100000000)},
-		{NewDecWithPrec(1, 1), NewInt(10), NewBigDec(1)},
-		{NewDecWithPrec(1, 5), NewInt(20), NewDecWithPrec(2, 4)},
+		{osmomath.NewBigDec(10), osmomath.NewInt(2), osmomath.NewBigDec(20)},
+		{osmomath.NewBigDec(1000000), osmomath.NewInt(100), osmomath.NewBigDec(100000000)},
+		{osmomath.NewDecWithPrec(1, 1), osmomath.NewInt(10), osmomath.NewBigDec(1)},
+		{osmomath.NewDecWithPrec(1, 5), osmomath.NewInt(20), osmomath.NewDecWithPrec(2, 4)},
 	}
 	for i, tc := range tests {
 		got := tc.sdkDec.MulInt(tc.sdkInt)
@@ -455,17 +456,17 @@ func (s *decimalTestSuite) TestDecMulInt() {
 
 func (s *decimalTestSuite) TestDecCeil() {
 	testCases := []struct {
-		input    BigDec
-		expected BigDec
+		input    osmomath.BigDec
+		expected osmomath.BigDec
 	}{
-		{MustNewDecFromStr("0.001"), NewBigDec(1)},   // 0.001 => 1.0
-		{MustNewDecFromStr("-0.001"), ZeroDec()},     // -0.001 => 0.0
-		{ZeroDec(), ZeroDec()},                       // 0.0 => 0.0
-		{MustNewDecFromStr("0.9"), NewBigDec(1)},     // 0.9 => 1.0
-		{MustNewDecFromStr("4.001"), NewBigDec(5)},   // 4.001 => 5.0
-		{MustNewDecFromStr("-4.001"), NewBigDec(-4)}, // -4.001 => -4.0
-		{MustNewDecFromStr("4.7"), NewBigDec(5)},     // 4.7 => 5.0
-		{MustNewDecFromStr("-4.7"), NewBigDec(-4)},   // -4.7 => -4.0
+		{osmomath.MustNewDecFromStr("0.001"), osmomath.NewBigDec(1)},   // 0.001 => 1.0
+		{osmomath.MustNewDecFromStr("-0.001"), osmomath.ZeroDec()},     // -0.001 => 0.0
+		{osmomath.ZeroDec(), osmomath.ZeroDec()},                       // 0.0 => 0.0
+		{osmomath.MustNewDecFromStr("0.9"), osmomath.NewBigDec(1)},     // 0.9 => 1.0
+		{osmomath.MustNewDecFromStr("4.001"), osmomath.NewBigDec(5)},   // 4.001 => 5.0
+		{osmomath.MustNewDecFromStr("-4.001"), osmomath.NewBigDec(-4)}, // -4.001 => -4.0
+		{osmomath.MustNewDecFromStr("4.7"), osmomath.NewBigDec(5)},     // 4.7 => 5.0
+		{osmomath.MustNewDecFromStr("-4.7"), osmomath.NewBigDec(-4)},   // -4.7 => -4.0
 	}
 
 	for i, tc := range testCases {
@@ -474,42 +475,22 @@ func (s *decimalTestSuite) TestDecCeil() {
 	}
 }
 
-func (s *decimalTestSuite) TestPower() {
-	testCases := []struct {
-		input    BigDec
-		power    uint64
-		expected BigDec
-	}{
-		{OneDec(), 10, OneDec()},                                                                   // 1.0 ^ (10) => 1.0
-		{NewDecWithPrec(5, 1), 2, NewDecWithPrec(25, 2)},                                           // 0.5 ^ 2 => 0.25
-		{NewDecWithPrec(2, 1), 2, NewDecWithPrec(4, 2)},                                            // 0.2 ^ 2 => 0.04
-		{NewDecFromInt(NewInt(3)), 3, NewDecFromInt(NewInt(27))},                                   // 3 ^ 3 => 27
-		{NewDecFromInt(NewInt(-3)), 4, NewDecFromInt(NewInt(81))},                                  // -3 ^ 4 = 81
-		{MustNewDecFromStr("1.414213562373095048801688724209698079"), 2, NewDecFromInt(NewInt(2))}, // 1.414213562373095048801688724209698079 ^ 2 = 2
-	}
-
-	for i, tc := range testCases {
-		res := tc.input.Power(tc.power)
-		s.Require().True(tc.expected.Sub(res).Abs().LTE(SmallestDec()), "unexpected result for test case %d, input: %v", i, tc.input)
-	}
-}
-
 func (s *decimalTestSuite) TestApproxRoot() {
 	testCases := []struct {
-		input    BigDec
+		input    osmomath.BigDec
 		root     uint64
-		expected BigDec
+		expected osmomath.BigDec
 	}{
-		{OneDec(), 10, OneDec()},                                                                         // 1.0 ^ (0.1) => 1.0
-		{NewDecWithPrec(25, 2), 2, NewDecWithPrec(5, 1)},                                                 // 0.25 ^ (0.5) => 0.5
-		{NewDecWithPrec(4, 2), 2, NewDecWithPrec(2, 1)},                                                  // 0.04 ^ (0.5) => 0.2
-		{NewDecFromInt(NewInt(27)), 3, NewDecFromInt(NewInt(3))},                                         // 27 ^ (1/3) => 3
-		{NewDecFromInt(NewInt(-81)), 4, NewDecFromInt(NewInt(-3))},                                       // -81 ^ (0.25) => -3
-		{NewDecFromInt(NewInt(2)), 2, MustNewDecFromStr("1.414213562373095048801688724209698079")},       // 2 ^ (0.5) => 1.414213562373095048801688724209698079
-		{NewDecWithPrec(1005, 3), 31536000, MustNewDecFromStr("1.000000000158153903837946258002096839")}, // 1.005 ^ (1/31536000) ≈ 1.000000000158153903837946258002096839
-		{SmallestDec(), 2, NewDecWithPrec(1, 18)},                                                        // 1e-36 ^ (0.5) => 1e-18
-		{SmallestDec(), 3, MustNewDecFromStr("0.000000000001000000000000000002431786")},                  // 1e-36 ^ (1/3) => 1e-12
-		{NewDecWithPrec(1, 8), 3, MustNewDecFromStr("0.002154434690031883721759293566519280")},           // 1e-8 ^ (1/3) ≈ 0.002154434690031883721759293566519
+		{osmomath.OneDec(), 10, osmomath.OneDec()},                                                                            // 1.0 ^ (0.1) => 1.0
+		{osmomath.NewDecWithPrec(25, 2), 2, osmomath.NewDecWithPrec(5, 1)},                                                    // 0.25 ^ (0.5) => 0.5
+		{osmomath.NewDecWithPrec(4, 2), 2, osmomath.NewDecWithPrec(2, 1)},                                                     // 0.04 ^ (0.5) => 0.2
+		{osmomath.NewDecFromInt(osmomath.NewInt(27)), 3, osmomath.NewDecFromInt(osmomath.NewInt(3))},                          // 27 ^ (1/3) => 3
+		{osmomath.NewDecFromInt(osmomath.NewInt(-81)), 4, osmomath.NewDecFromInt(osmomath.NewInt(-3))},                        // -81 ^ (0.25) => -3
+		{osmomath.NewDecFromInt(osmomath.NewInt(2)), 2, osmomath.MustNewDecFromStr("1.414213562373095048801688724209698079")}, // 2 ^ (0.5) => 1.414213562373095048801688724209698079
+		{osmomath.NewDecWithPrec(1005, 3), 31536000, osmomath.MustNewDecFromStr("1.000000000158153903837946258002096839")},    // 1.005 ^ (1/31536000) ≈ 1.000000000158153903837946258002096839
+		{osmomath.SmallestDec(), 2, osmomath.NewDecWithPrec(1, 18)},                                                           // 1e-36 ^ (0.5) => 1e-18
+		{osmomath.SmallestDec(), 3, osmomath.MustNewDecFromStr("0.000000000001000000000000000002431786")},                     // 1e-36 ^ (1/3) => 1e-12
+		{osmomath.NewDecWithPrec(1, 8), 3, osmomath.MustNewDecFromStr("0.002154434690031883721759293566519280")},              // 1e-8 ^ (1/3) ≈ 0.002154434690031883721759293566519
 	}
 
 	// In the case of 1e-8 ^ (1/3), the result repeats every 5 iterations starting from iteration 24
@@ -519,21 +500,21 @@ func (s *decimalTestSuite) TestApproxRoot() {
 	for i, tc := range testCases {
 		res, err := tc.input.ApproxRoot(tc.root)
 		s.Require().NoError(err)
-		s.Require().True(tc.expected.Sub(res).Abs().LTE(SmallestDec()), "unexpected result for test case %d, input: %v", i, tc.input)
+		s.Require().True(tc.expected.Sub(res).Abs().LTE(osmomath.SmallestDec()), "unexpected result for test case %d, input: %v", i, tc.input)
 	}
 }
 
 func (s *decimalTestSuite) TestApproxSqrt() {
 	testCases := []struct {
-		input    BigDec
-		expected BigDec
+		input    osmomath.BigDec
+		expected osmomath.BigDec
 	}{
-		{OneDec(), OneDec()},                                                                    // 1.0 => 1.0
-		{NewDecWithPrec(25, 2), NewDecWithPrec(5, 1)},                                           // 0.25 => 0.5
-		{NewDecWithPrec(4, 2), NewDecWithPrec(2, 1)},                                            // 0.09 => 0.3
-		{NewDecFromInt(NewInt(9)), NewDecFromInt(NewInt(3))},                                    // 9 => 3
-		{NewDecFromInt(NewInt(-9)), NewDecFromInt(NewInt(-3))},                                  // -9 => -3
-		{NewDecFromInt(NewInt(2)), MustNewDecFromStr("1.414213562373095048801688724209698079")}, // 2 => 1.414213562373095048801688724209698079
+		{osmomath.OneDec(), osmomath.OneDec()},                                                                             // 1.0 => 1.0
+		{osmomath.NewDecWithPrec(25, 2), osmomath.NewDecWithPrec(5, 1)},                                                    // 0.25 => 0.5
+		{osmomath.NewDecWithPrec(4, 2), osmomath.NewDecWithPrec(2, 1)},                                                     // 0.09 => 0.3
+		{osmomath.NewDecFromInt(osmomath.NewInt(9)), osmomath.NewDecFromInt(osmomath.NewInt(3))},                           // 9 => 3
+		{osmomath.NewDecFromInt(osmomath.NewInt(-9)), osmomath.NewDecFromInt(osmomath.NewInt(-3))},                         // -9 => -3
+		{osmomath.NewDecFromInt(osmomath.NewInt(2)), osmomath.MustNewDecFromStr("1.414213562373095048801688724209698079")}, // 2 => 1.414213562373095048801688724209698079
 	}
 
 	for i, tc := range testCases {
@@ -545,61 +526,63 @@ func (s *decimalTestSuite) TestApproxSqrt() {
 
 func (s *decimalTestSuite) TestDecSortableBytes() {
 	tests := []struct {
-		d    BigDec
+		d    osmomath.BigDec
 		want []byte
 	}{
-		{NewBigDec(0), []byte("000000000000000000000000000000000000.000000000000000000000000000000000000")},
-		{NewBigDec(1), []byte("000000000000000000000000000000000001.000000000000000000000000000000000000")},
-		{NewBigDec(10), []byte("000000000000000000000000000000000010.000000000000000000000000000000000000")},
-		{NewBigDec(12340), []byte("000000000000000000000000000000012340.000000000000000000000000000000000000")},
-		{NewDecWithPrec(12340, 4), []byte("000000000000000000000000000000000001.234000000000000000000000000000000000")},
-		{NewDecWithPrec(12340, 5), []byte("000000000000000000000000000000000000.123400000000000000000000000000000000")},
-		{NewDecWithPrec(12340, 8), []byte("000000000000000000000000000000000000.000123400000000000000000000000000000")},
-		{NewDecWithPrec(1009009009009009009, 17), []byte("000000000000000000000000000000000010.090090090090090090000000000000000000")},
-		{NewDecWithPrec(-1009009009009009009, 17), []byte("-000000000000000000000000000000000010.090090090090090090000000000000000000")},
-		{MustNewDecFromStr("1000000000000000000000000000000000000"), []byte("max")},
-		{MustNewDecFromStr("-1000000000000000000000000000000000000"), []byte("--")},
+		{osmomath.NewBigDec(0), []byte("000000000000000000000000000000000000.000000000000000000000000000000000000")},
+		{osmomath.NewBigDec(1), []byte("000000000000000000000000000000000001.000000000000000000000000000000000000")},
+		{osmomath.NewBigDec(10), []byte("000000000000000000000000000000000010.000000000000000000000000000000000000")},
+		{osmomath.NewBigDec(12340), []byte("000000000000000000000000000000012340.000000000000000000000000000000000000")},
+		{osmomath.NewDecWithPrec(12340, 4), []byte("000000000000000000000000000000000001.234000000000000000000000000000000000")},
+		{osmomath.NewDecWithPrec(12340, 5), []byte("000000000000000000000000000000000000.123400000000000000000000000000000000")},
+		{osmomath.NewDecWithPrec(12340, 8), []byte("000000000000000000000000000000000000.000123400000000000000000000000000000")},
+		{osmomath.NewDecWithPrec(1009009009009009009, 17), []byte("000000000000000000000000000000000010.090090090090090090000000000000000000")},
+		{osmomath.NewDecWithPrec(-1009009009009009009, 17), []byte("-000000000000000000000000000000000010.090090090090090090000000000000000000")},
+		{osmomath.MustNewDecFromStr("1000000000000000000000000000000000000"), []byte("max")},
+		{osmomath.MustNewDecFromStr("-1000000000000000000000000000000000000"), []byte("--")},
 	}
 	for tcIndex, tc := range tests {
-		s.Require().Equal(tc.want, SortableDecBytes(tc.d), "bad String(), index: %v", tcIndex)
+		s.Require().Equal(tc.want, osmomath.SortableDecBytes(tc.d), "bad String(), index: %v", tcIndex)
 	}
 
-	s.Require().Panics(func() { SortableDecBytes(MustNewDecFromStr("1000000000000000000000000000000000001")) })
-	s.Require().Panics(func() { SortableDecBytes(MustNewDecFromStr("-1000000000000000000000000000000000001")) })
+	s.Require().Panics(func() { osmomath.SortableDecBytes(osmomath.MustNewDecFromStr("1000000000000000000000000000000000001")) })
+	s.Require().Panics(func() {
+		osmomath.SortableDecBytes(osmomath.MustNewDecFromStr("-1000000000000000000000000000000000001"))
+	})
 }
 
 func (s *decimalTestSuite) TestDecEncoding() {
 	testCases := []struct {
-		input   BigDec
+		input   osmomath.BigDec
 		rawBz   string
 		jsonStr string
 		yamlStr string
 	}{
 		{
-			NewBigDec(0), "30",
+			osmomath.NewBigDec(0), "30",
 			"\"0.000000000000000000000000000000000000\"",
 			"\"0.000000000000000000000000000000000000\"\n",
 		},
 		{
-			NewDecWithPrec(4, 2),
+			osmomath.NewDecWithPrec(4, 2),
 			"3430303030303030303030303030303030303030303030303030303030303030303030",
 			"\"0.040000000000000000000000000000000000\"",
 			"\"0.040000000000000000000000000000000000\"\n",
 		},
 		{
-			NewDecWithPrec(-4, 2),
+			osmomath.NewDecWithPrec(-4, 2),
 			"2D3430303030303030303030303030303030303030303030303030303030303030303030",
 			"\"-0.040000000000000000000000000000000000\"",
 			"\"-0.040000000000000000000000000000000000\"\n",
 		},
 		{
-			MustNewDecFromStr("1.414213562373095048801688724209698079"),
+			osmomath.MustNewDecFromStr("1.414213562373095048801688724209698079"),
 			"31343134323133353632333733303935303438383031363838373234323039363938303739",
 			"\"1.414213562373095048801688724209698079\"",
 			"\"1.414213562373095048801688724209698079\"\n",
 		},
 		{
-			MustNewDecFromStr("-1.414213562373095048801688724209698079"),
+			osmomath.MustNewDecFromStr("-1.414213562373095048801688724209698079"),
 			"2D31343134323133353632333733303935303438383031363838373234323039363938303739",
 			"\"-1.414213562373095048801688724209698079\"",
 			"\"-1.414213562373095048801688724209698079\"\n",
@@ -611,7 +594,7 @@ func (s *decimalTestSuite) TestDecEncoding() {
 		s.Require().NoError(err)
 		s.Require().Equal(tc.rawBz, fmt.Sprintf("%X", bz))
 
-		var other BigDec
+		var other osmomath.BigDec
 		s.Require().NoError((&other).Unmarshal(bz))
 		s.Require().True(tc.input.Equal(other))
 
@@ -629,26 +612,26 @@ func (s *decimalTestSuite) TestDecEncoding() {
 
 // Showcase that different orders of operations causes different results.
 func (s *decimalTestSuite) TestOperationOrders() {
-	n1 := NewBigDec(10)
-	n2 := NewBigDec(1000000010)
-	s.Require().Equal(n1.Mul(n2).Quo(n2), NewBigDec(10))
+	n1 := osmomath.NewBigDec(10)
+	n2 := osmomath.NewBigDec(1000000010)
+	s.Require().Equal(n1.Mul(n2).Quo(n2), osmomath.NewBigDec(10))
 	s.Require().NotEqual(n1.Mul(n2).Quo(n2), n1.Quo(n2).Mul(n2))
 }
 
 func BenchmarkMarshalTo(b *testing.B) {
 	b.ReportAllocs()
 	bis := []struct {
-		in   BigDec
+		in   osmomath.BigDec
 		want []byte
 	}{
 		{
-			NewBigDec(1e8), []byte{
+			osmomath.NewBigDec(1e8), []byte{
 				0x31, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
 				0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
 				0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
 			},
 		},
-		{NewBigDec(0), []byte{0x30}},
+		{osmomath.NewBigDec(0), []byte{0x30}},
 	}
 	data := make([]byte, 100)
 
@@ -669,83 +652,83 @@ func BenchmarkMarshalTo(b *testing.B) {
 }
 
 func (s *decimalTestSuite) TestLog2() {
-	var expectedErrTolerance = MustNewDecFromStr("0.000000000000000000000000000000000100")
+	var expectedErrTolerance = osmomath.MustNewDecFromStr("0.000000000000000000000000000000000100")
 
 	tests := map[string]struct {
-		initialValue BigDec
-		expected     BigDec
+		initialValue osmomath.BigDec
+		expected     osmomath.BigDec
 
 		expectedPanic bool
 	}{
 		"log_2{-1}; invalid; panic": {
-			initialValue:  OneDec().Neg(),
+			initialValue:  osmomath.OneDec().Neg(),
 			expectedPanic: true,
 		},
 		"log_2{0}; invalid; panic": {
-			initialValue:  ZeroDec(),
+			initialValue:  osmomath.ZeroDec(),
 			expectedPanic: true,
 		},
 		"log_2{0.001} = -9.965784284662087043610958288468170528": {
-			initialValue: MustNewDecFromStr("0.001"),
+			initialValue: osmomath.MustNewDecFromStr("0.001"),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+0.999912345+with+33+digits
-			expected: MustNewDecFromStr("-9.965784284662087043610958288468170528"),
+			expected: osmomath.MustNewDecFromStr("-9.965784284662087043610958288468170528"),
 		},
 		"log_2{0.56171821941421412902170941} = -0.832081497183140708984033250637831402": {
-			initialValue: MustNewDecFromStr("0.56171821941421412902170941"),
+			initialValue: osmomath.MustNewDecFromStr("0.56171821941421412902170941"),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+0.56171821941421412902170941+with+36+digits
-			expected: MustNewDecFromStr("-0.832081497183140708984033250637831402"),
+			expected: osmomath.MustNewDecFromStr("-0.832081497183140708984033250637831402"),
 		},
 		"log_2{0.999912345} = -0.000126464976533858080645902722235833": {
-			initialValue: MustNewDecFromStr("0.999912345"),
+			initialValue: osmomath.MustNewDecFromStr("0.999912345"),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+0.999912345+with+37+digits
-			expected: MustNewDecFromStr("-0.000126464976533858080645902722235833"),
+			expected: osmomath.MustNewDecFromStr("-0.000126464976533858080645902722235833"),
 		},
 		"log_2{1} = 0": {
-			initialValue: NewBigDec(1),
-			expected:     NewBigDec(0),
+			initialValue: osmomath.NewBigDec(1),
+			expected:     osmomath.NewBigDec(0),
 		},
 		"log_2{2} = 1": {
-			initialValue: NewBigDec(2),
-			expected:     NewBigDec(1),
+			initialValue: osmomath.NewBigDec(2),
+			expected:     osmomath.NewBigDec(1),
 		},
 		"log_2{7} = 2.807354922057604107441969317231830809": {
-			initialValue: NewBigDec(7),
+			initialValue: osmomath.NewBigDec(7),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+7+37+digits
-			expected: MustNewDecFromStr("2.807354922057604107441969317231830809"),
+			expected: osmomath.MustNewDecFromStr("2.807354922057604107441969317231830809"),
 		},
 		"log_2{512} = 9": {
-			initialValue: NewBigDec(512),
-			expected:     NewBigDec(9),
+			initialValue: osmomath.NewBigDec(512),
+			expected:     osmomath.NewBigDec(9),
 		},
 		"log_2{580} = 9.179909090014934468590092754117374938": {
-			initialValue: NewBigDec(580),
+			initialValue: osmomath.NewBigDec(580),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+600+37+digits
-			expected: MustNewDecFromStr("9.179909090014934468590092754117374938"),
+			expected: osmomath.MustNewDecFromStr("9.179909090014934468590092754117374938"),
 		},
 		"log_2{1024} = 10": {
-			initialValue: NewBigDec(1024),
-			expected:     NewBigDec(10),
+			initialValue: osmomath.NewBigDec(1024),
+			expected:     osmomath.NewBigDec(10),
 		},
 		"log_2{1024.987654321} = 10.001390817654141324352719749259888355": {
-			initialValue: NewDecWithPrec(1024987654321, 9),
+			initialValue: osmomath.NewDecWithPrec(1024987654321, 9),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+1024.987654321+38+digits
-			expected: MustNewDecFromStr("10.001390817654141324352719749259888355"),
+			expected: osmomath.MustNewDecFromStr("10.001390817654141324352719749259888355"),
 		},
 		"log_2{912648174127941279170121098210.92821920190204131121} = 99.525973560175362367047484597337715868": {
-			initialValue: MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
+			initialValue: osmomath.MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+912648174127941279170121098210.92821920190204131121+38+digits
-			expected: MustNewDecFromStr("99.525973560175362367047484597337715868"),
+			expected: osmomath.MustNewDecFromStr("99.525973560175362367047484597337715868"),
 		},
 		"log_2{Max Spot Price} = 128": {
-			initialValue: BigDecFromSDKDec(gammtypes.MaxSpotPrice), // 2^128 - 1
+			initialValue: osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice), // 2^128 - 1
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+%28%282%5E128%29+-+1%29+38+digits
-			expected: MustNewDecFromStr("128"),
+			expected: osmomath.MustNewDecFromStr("128"),
 		},
 		// The value tested below is: gammtypes.MaxSpotPrice * 0.99 = (2^128 - 1) * 0.99
 		"log_2{336879543251729078828740861357450529340.45} = 127.98550043030488492336620207564264562": {
-			initialValue: MustNewDecFromStr("336879543251729078828740861357450529340.45"),
+			initialValue: osmomath.MustNewDecFromStr("336879543251729078828740861357450529340.45"),
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+%28%28%282%5E128%29+-+1%29*0.99%29++38+digits
-			expected: MustNewDecFromStr("127.98550043030488492336620207564264562"),
+			expected: osmomath.MustNewDecFromStr("127.98550043030488492336620207564264562"),
 		},
 	}
 
@@ -754,12 +737,11 @@ func (s *decimalTestSuite) TestLog2() {
 			osmoassert.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that LogbBase2() is non-mutative.
-				initialCopy := ZeroDec()
-				initialCopy.i.Set(tc.initialValue.i)
+				initialCopy := tc.initialValue.Clone()
 
 				// system under test.
 				res := tc.initialValue.LogBase2()
-				require.True(DecApproxEq(s.T(), tc.expected, res, expectedErrTolerance))
+				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
 			})
 		})
@@ -767,70 +749,70 @@ func (s *decimalTestSuite) TestLog2() {
 }
 
 func (s *decimalTestSuite) TestLn() {
-	var expectedErrTolerance = MustNewDecFromStr("0.000000000000000000000000000000000100")
+	var expectedErrTolerance = osmomath.MustNewDecFromStr("0.000000000000000000000000000000000100")
 
 	tests := map[string]struct {
-		initialValue BigDec
-		expected     BigDec
+		initialValue osmomath.BigDec
+		expected     osmomath.BigDec
 
 		expectedPanic bool
 	}{
 		"log_e{-1}; invalid; panic": {
-			initialValue:  OneDec().Neg(),
+			initialValue:  osmomath.OneDec().Neg(),
 			expectedPanic: true,
 		},
 		"log_e{0}; invalid; panic": {
-			initialValue:  ZeroDec(),
+			initialValue:  osmomath.ZeroDec(),
 			expectedPanic: true,
 		},
 		"log_e{0.001} = -6.90775527898213705205397436405309262": {
-			initialValue: MustNewDecFromStr("0.001"),
+			initialValue: osmomath.MustNewDecFromStr("0.001"),
 			// From: https://www.wolframalpha.com/input?i=log0.001+to+36+digits+with+36+decimals
-			expected: MustNewDecFromStr("-6.90775527898213705205397436405309262"),
+			expected: osmomath.MustNewDecFromStr("-6.90775527898213705205397436405309262"),
 		},
 		"log_e{0.56171821941421412902170941} = -0.576754943768592057376050794884207180": {
-			initialValue: MustNewDecFromStr("0.56171821941421412902170941"),
+			initialValue: osmomath.MustNewDecFromStr("0.56171821941421412902170941"),
 			// From: https://www.wolframalpha.com/input?i=log0.56171821941421412902170941+to+36+digits
-			expected: MustNewDecFromStr("-0.576754943768592057376050794884207180"),
+			expected: osmomath.MustNewDecFromStr("-0.576754943768592057376050794884207180"),
 		},
 		"log_e{0.999912345} = -0.000087658841924023373535614212850888": {
-			initialValue: MustNewDecFromStr("0.999912345"),
+			initialValue: osmomath.MustNewDecFromStr("0.999912345"),
 			// From: https://www.wolframalpha.com/input?i=log0.999912345+to+32+digits
-			expected: MustNewDecFromStr("-0.000087658841924023373535614212850888"),
+			expected: osmomath.MustNewDecFromStr("-0.000087658841924023373535614212850888"),
 		},
 		"log_e{1} = 0": {
-			initialValue: NewBigDec(1),
-			expected:     NewBigDec(0),
+			initialValue: osmomath.NewBigDec(1),
+			expected:     osmomath.NewBigDec(0),
 		},
 		"log_e{e} = 1": {
-			initialValue: MustNewDecFromStr("2.718281828459045235360287471352662498"),
+			initialValue: osmomath.MustNewDecFromStr("2.718281828459045235360287471352662498"),
 			// From: https://www.wolframalpha.com/input?i=e+with+36+decimals
-			expected: NewBigDec(1),
+			expected: osmomath.NewBigDec(1),
 		},
 		"log_e{7} = 1.945910149055313305105352743443179730": {
-			initialValue: NewBigDec(7),
+			initialValue: osmomath.NewBigDec(7),
 			// From: https://www.wolframalpha.com/input?i=log7+up+to+36+decimals
-			expected: MustNewDecFromStr("1.945910149055313305105352743443179730"),
+			expected: osmomath.MustNewDecFromStr("1.945910149055313305105352743443179730"),
 		},
 		"log_e{512} = 6.238324625039507784755089093123589113": {
-			initialValue: NewBigDec(512),
+			initialValue: osmomath.NewBigDec(512),
 			// From: https://www.wolframalpha.com/input?i=log512+up+to+36+decimals
-			expected: MustNewDecFromStr("6.238324625039507784755089093123589113"),
+			expected: osmomath.MustNewDecFromStr("6.238324625039507784755089093123589113"),
 		},
 		"log_e{580} = 6.36302810354046502061849560850445238": {
-			initialValue: NewBigDec(580),
+			initialValue: osmomath.NewBigDec(580),
 			// From: https://www.wolframalpha.com/input?i=log580+up+to+36+decimals
-			expected: MustNewDecFromStr("6.36302810354046502061849560850445238"),
+			expected: osmomath.MustNewDecFromStr("6.36302810354046502061849560850445238"),
 		},
 		"log_e{1024.987654321} = 6.93243584693509415029056534690631614": {
-			initialValue: NewDecWithPrec(1024987654321, 9),
+			initialValue: osmomath.NewDecWithPrec(1024987654321, 9),
 			// From: https://www.wolframalpha.com/input?i=log1024.987654321+to+36+digits
-			expected: MustNewDecFromStr("6.93243584693509415029056534690631614"),
+			expected: osmomath.MustNewDecFromStr("6.93243584693509415029056534690631614"),
 		},
 		"log_e{912648174127941279170121098210.92821920190204131121} = 68.986147965719214790400745338243805015": {
-			initialValue: MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
+			initialValue: osmomath.MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
 			// From: https://www.wolframalpha.com/input?i=log912648174127941279170121098210.92821920190204131121+to+38+digits
-			expected: MustNewDecFromStr("68.986147965719214790400745338243805015"),
+			expected: osmomath.MustNewDecFromStr("68.986147965719214790400745338243805015"),
 		},
 	}
 
@@ -839,12 +821,11 @@ func (s *decimalTestSuite) TestLn() {
 			osmoassert.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that Ln() is non-mutative.
-				initialCopy := ZeroDec()
-				initialCopy.i.Set(tc.initialValue.i)
+				initialCopy := tc.initialValue.Clone()
 
 				// system under test.
 				res := tc.initialValue.Ln()
-				require.True(DecApproxEq(s.T(), tc.expected, res, expectedErrTolerance))
+				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
 			})
 		})
@@ -853,61 +834,61 @@ func (s *decimalTestSuite) TestLn() {
 
 func (s *decimalTestSuite) TestTickLog() {
 	tests := map[string]struct {
-		initialValue BigDec
-		expected     BigDec
+		initialValue osmomath.BigDec
+		expected     osmomath.BigDec
 
-		expectedErrTolerance BigDec
+		expectedErrTolerance osmomath.BigDec
 		expectedPanic        bool
 	}{
 		"log_1.0001{-1}; invalid; panic": {
-			initialValue:  OneDec().Neg(),
+			initialValue:  osmomath.OneDec().Neg(),
 			expectedPanic: true,
 		},
 		"log_1.0001{0}; invalid; panic": {
-			initialValue:  ZeroDec(),
+			initialValue:  osmomath.ZeroDec(),
 			expectedPanic: true,
 		},
 		"log_1.0001{0.001} = -69081.006609899112313305835611219486392199": {
-			initialValue: MustNewDecFromStr("0.001"),
+			initialValue: osmomath.MustNewDecFromStr("0.001"),
 			// From: https://www.wolframalpha.com/input?i=log_1.0001%280.001%29+to+41+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000143031879"),
-			expected:             MustNewDecFromStr("-69081.006609899112313305835611219486392199"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000143031879"),
+			expected:             osmomath.MustNewDecFromStr("-69081.006609899112313305835611219486392199"),
 		},
 		"log_1.0001{0.999912345} = -0.876632247930741919880461740717176538": {
-			initialValue: MustNewDecFromStr("0.999912345"),
+			initialValue: osmomath.MustNewDecFromStr("0.999912345"),
 			// From: https://www.wolframalpha.com/input?i=log_1.0001%280.999912345%29+to+36+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000138702"),
-			expected:             MustNewDecFromStr("-0.876632247930741919880461740717176538"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000138702"),
+			expected:             osmomath.MustNewDecFromStr("-0.876632247930741919880461740717176538"),
 		},
 		"log_1.0001{1} = 0": {
-			initialValue: NewBigDec(1),
+			initialValue: osmomath.NewBigDec(1),
 
-			expectedErrTolerance: ZeroDec(),
-			expected:             NewBigDec(0),
+			expectedErrTolerance: osmomath.ZeroDec(),
+			expected:             osmomath.NewBigDec(0),
 		},
 		"log_1.0001{1.0001} = 1": {
-			initialValue: MustNewDecFromStr("1.0001"),
+			initialValue: osmomath.MustNewDecFromStr("1.0001"),
 
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000152500"),
-			expected:             OneDec(),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000152500"),
+			expected:             osmomath.OneDec(),
 		},
 		"log_1.0001{512} = 62386.365360724158196763710649998441051753": {
-			initialValue: NewBigDec(512),
+			initialValue: osmomath.NewBigDec(512),
 			// From: https://www.wolframalpha.com/input?i=log_1.0001%28512%29+to+41+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000129292137"),
-			expected:             MustNewDecFromStr("62386.365360724158196763710649998441051753"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000129292137"),
+			expected:             osmomath.MustNewDecFromStr("62386.365360724158196763710649998441051753"),
 		},
 		"log_1.0001{1024.987654321} = 69327.824629506998657531621822514042777198": {
-			initialValue: NewDecWithPrec(1024987654321, 9),
+			initialValue: osmomath.NewDecWithPrec(1024987654321, 9),
 			// From: https://www.wolframalpha.com/input?i=log_1.0001%281024.987654321%29+to+41+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000143836264"),
-			expected:             MustNewDecFromStr("69327.824629506998657531621822514042777198"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000143836264"),
+			expected:             osmomath.MustNewDecFromStr("69327.824629506998657531621822514042777198"),
 		},
 		"log_1.0001{912648174127941279170121098210.92821920190204131121} = 689895.972156319183538389792485913311778672": {
-			initialValue: MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
+			initialValue: osmomath.MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
 			// From: https://www.wolframalpha.com/input?i=log_1.0001%28912648174127941279170121098210.92821920190204131121%29+to+42+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000001429936067"),
-			expected:             MustNewDecFromStr("689895.972156319183538389792485913311778672"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000001429936067"),
+			expected:             osmomath.MustNewDecFromStr("689895.972156319183538389792485913311778672"),
 		},
 	}
 
@@ -916,13 +897,12 @@ func (s *decimalTestSuite) TestTickLog() {
 			osmoassert.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that Ln() is non-mutative.
-				initialCopy := ZeroDec()
-				initialCopy.i.Set(tc.initialValue.i)
+				initialCopy := tc.initialValue.Clone()
 
 				// system under test.
 				res := tc.initialValue.TickLog()
 				fmt.Println(name, res.Sub(tc.expected).Abs())
-				require.True(DecApproxEq(s.T(), tc.expected, res, tc.expectedErrTolerance))
+				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, tc.expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
 			})
 		})
@@ -931,101 +911,101 @@ func (s *decimalTestSuite) TestTickLog() {
 
 func (s *decimalTestSuite) TestCustomBaseLog() {
 	tests := map[string]struct {
-		initialValue BigDec
-		base         BigDec
+		initialValue osmomath.BigDec
+		base         osmomath.BigDec
 
-		expected             BigDec
-		expectedErrTolerance BigDec
+		expected             osmomath.BigDec
+		expectedErrTolerance osmomath.BigDec
 
 		expectedPanic bool
 	}{
 		"log_2{-1}: normal base, invalid argument - panics": {
-			initialValue:  NewBigDec(-1),
-			base:          NewBigDec(2),
+			initialValue:  osmomath.NewBigDec(-1),
+			base:          osmomath.NewBigDec(2),
 			expectedPanic: true,
 		},
 		"log_2{0}: normal base, invalid argument - panics": {
-			initialValue:  NewBigDec(0),
-			base:          NewBigDec(2),
+			initialValue:  osmomath.NewBigDec(0),
+			base:          osmomath.NewBigDec(2),
 			expectedPanic: true,
 		},
 		"log_(-1)(2): invalid base, normal argument - panics": {
-			initialValue:  NewBigDec(2),
-			base:          NewBigDec(-1),
+			initialValue:  osmomath.NewBigDec(2),
+			base:          osmomath.NewBigDec(-1),
 			expectedPanic: true,
 		},
 		"log_1(2): base cannot equal to 1 - panics": {
-			initialValue:  NewBigDec(2),
-			base:          NewBigDec(1),
+			initialValue:  osmomath.NewBigDec(2),
+			base:          osmomath.NewBigDec(1),
 			expectedPanic: true,
 		},
 		"log_30(100) = 1.353984985057691049642502891262784015": {
-			initialValue: NewBigDec(100),
-			base:         NewBigDec(30),
+			initialValue: osmomath.NewBigDec(100),
+			base:         osmomath.NewBigDec(30),
 			// From: https://www.wolframalpha.com/input?i=log_30%28100%29+to+37+digits
-			expectedErrTolerance: ZeroDec(),
-			expected:             MustNewDecFromStr("1.353984985057691049642502891262784015"),
+			expectedErrTolerance: osmomath.ZeroDec(),
+			expected:             osmomath.MustNewDecFromStr("1.353984985057691049642502891262784015"),
 		},
 		"log_0.2(0.99) = 0.006244624769837438271878639001855450": {
-			initialValue: MustNewDecFromStr("0.99"),
-			base:         MustNewDecFromStr("0.2"),
+			initialValue: osmomath.MustNewDecFromStr("0.99"),
+			base:         osmomath.MustNewDecFromStr("0.2"),
 			// From: https://www.wolframalpha.com/input?i=log_0.2%280.99%29+to+34+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000000013"),
-			expected:             MustNewDecFromStr("0.006244624769837438271878639001855450"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000000013"),
+			expected:             osmomath.MustNewDecFromStr("0.006244624769837438271878639001855450"),
 		},
 
 		"log_0.0001(500000) = -1.424742501084004701196565276318876743": {
-			initialValue: NewBigDec(500000),
-			base:         NewDecWithPrec(1, 4),
+			initialValue: osmomath.NewBigDec(500000),
+			base:         osmomath.NewDecWithPrec(1, 4),
 			// From: https://www.wolframalpha.com/input?i=log_0.0001%28500000%29+to+37+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000000003"),
-			expected:             MustNewDecFromStr("-1.424742501084004701196565276318876743"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000000003"),
+			expected:             osmomath.MustNewDecFromStr("-1.424742501084004701196565276318876743"),
 		},
 
 		"log_500000(0.0001) = -0.701881216598197542030218906945601429": {
-			initialValue: NewDecWithPrec(1, 4),
-			base:         NewBigDec(500000),
+			initialValue: osmomath.NewDecWithPrec(1, 4),
+			base:         osmomath.NewBigDec(500000),
 			// From: https://www.wolframalpha.com/input?i=log_500000%280.0001%29+to+36+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000000001"),
-			expected:             MustNewDecFromStr("-0.701881216598197542030218906945601429"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000000001"),
+			expected:             osmomath.MustNewDecFromStr("-0.701881216598197542030218906945601429"),
 		},
 
 		"log_10000(5000000) = 1.674742501084004701196565276318876743": {
-			initialValue: NewBigDec(5000000),
-			base:         NewBigDec(10000),
+			initialValue: osmomath.NewBigDec(5000000),
+			base:         osmomath.NewBigDec(10000),
 			// From: https://www.wolframalpha.com/input?i=log_10000%285000000%29+to+37+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000000002"),
-			expected:             MustNewDecFromStr("1.674742501084004701196565276318876743"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000000002"),
+			expected:             osmomath.MustNewDecFromStr("1.674742501084004701196565276318876743"),
 		},
 		"log_0.123456789(1) = 0": {
-			initialValue: OneDec(),
-			base:         MustNewDecFromStr("0.123456789"),
+			initialValue: osmomath.OneDec(),
+			base:         osmomath.MustNewDecFromStr("0.123456789"),
 
-			expectedErrTolerance: ZeroDec(),
-			expected:             ZeroDec(),
+			expectedErrTolerance: osmomath.ZeroDec(),
+			expected:             osmomath.ZeroDec(),
 		},
 		"log_1111(1111) = 1": {
-			initialValue: NewBigDec(1111),
-			base:         NewBigDec(1111),
+			initialValue: osmomath.NewBigDec(1111),
+			base:         osmomath.NewBigDec(1111),
 
-			expectedErrTolerance: ZeroDec(),
-			expected:             OneDec(),
+			expectedErrTolerance: osmomath.ZeroDec(),
+			expected:             osmomath.OneDec(),
 		},
 
 		"log_1.123{1024.987654321} = 59.760484327223888489694630378785099461": {
-			initialValue: NewDecWithPrec(1024987654321, 9),
-			base:         NewDecWithPrec(1123, 3),
+			initialValue: osmomath.NewDecWithPrec(1024987654321, 9),
+			base:         osmomath.NewDecWithPrec(1123, 3),
 			// From: https://www.wolframalpha.com/input?i=log_1.123%281024.987654321%29+to+38+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000007686"),
-			expected:             MustNewDecFromStr("59.760484327223888489694630378785099461"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000007686"),
+			expected:             osmomath.MustNewDecFromStr("59.760484327223888489694630378785099461"),
 		},
 
 		"log_1.123{912648174127941279170121098210.92821920190204131121} = 594.689327867863079177915648832621538986": {
-			initialValue: MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
-			base:         NewDecWithPrec(1123, 3),
+			initialValue: osmomath.MustNewDecFromStr("912648174127941279170121098210.92821920190204131121"),
+			base:         osmomath.NewDecWithPrec(1123, 3),
 			// From: https://www.wolframalpha.com/input?i=log_1.123%28912648174127941279170121098210.92821920190204131121%29+to+39+digits
-			expectedErrTolerance: MustNewDecFromStr("0.000000000000000000000000000000077705"),
-			expected:             MustNewDecFromStr("594.689327867863079177915648832621538986"),
+			expectedErrTolerance: osmomath.MustNewDecFromStr("0.000000000000000000000000000000077705"),
+			expected:             osmomath.MustNewDecFromStr("594.689327867863079177915648832621538986"),
 		},
 	}
 	for name, tc := range tests {
@@ -1033,12 +1013,10 @@ func (s *decimalTestSuite) TestCustomBaseLog() {
 			osmoassert.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that Ln() is non-mutative.
-				initialCopy := ZeroDec()
-				initialCopy.i.Set(tc.initialValue.i)
-
+				initialCopy := tc.initialValue.Clone()
 				// system under test.
 				res := tc.initialValue.CustomBaseLog(tc.base)
-				require.True(DecApproxEq(s.T(), tc.expected, res, tc.expectedErrTolerance))
+				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, tc.expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
 			})
 		})
@@ -1046,119 +1024,119 @@ func (s *decimalTestSuite) TestCustomBaseLog() {
 }
 
 func (s *decimalTestSuite) TestPowerInteger() {
-	var expectedErrTolerance = MustNewDecFromStr("0.000000000000000000000000000000100000")
+	var expectedErrTolerance = osmomath.MustNewDecFromStr("0.000000000000000000000000000000100000")
 
 	tests := map[string]struct {
-		base           BigDec
+		base           osmomath.BigDec
 		exponent       uint64
-		expectedResult BigDec
+		expectedResult osmomath.BigDec
 
-		expectedToleranceOverwrite BigDec
+		expectedToleranceOverwrite osmomath.BigDec
 	}{
 		"0^2": {
-			base:     ZeroDec(),
+			base:     osmomath.ZeroDec(),
 			exponent: 2,
 
-			expectedResult: ZeroDec(),
+			expectedResult: osmomath.ZeroDec(),
 		},
 		"1^2": {
-			base:     OneDec(),
+			base:     osmomath.OneDec(),
 			exponent: 2,
 
-			expectedResult: OneDec(),
+			expectedResult: osmomath.OneDec(),
 		},
 		"4^4": {
-			base:     MustNewDecFromStr("4"),
+			base:     osmomath.MustNewDecFromStr("4"),
 			exponent: 4,
 
-			expectedResult: MustNewDecFromStr("256"),
+			expectedResult: osmomath.MustNewDecFromStr("256"),
 		},
 		"5^3": {
-			base:     MustNewDecFromStr("5"),
+			base:     osmomath.MustNewDecFromStr("5"),
 			exponent: 4,
 
-			expectedResult: MustNewDecFromStr("625"),
+			expectedResult: osmomath.MustNewDecFromStr("625"),
 		},
 		"e^10": {
-			base:     eulersNumber,
+			base:     osmomath.EulersNumber,
 			exponent: 10,
 
 			// https://www.wolframalpha.com/input?i=e%5E10+41+digits
-			expectedResult: MustNewDecFromStr("22026.465794806716516957900645284244366354"),
+			expectedResult: osmomath.MustNewDecFromStr("22026.465794806716516957900645284244366354"),
 		},
 		"geom twap overflow: 2^log_2{max spot price + 1}": {
-			base: twoBigDec,
+			base: osmomath.TwoBigDec,
 			// add 1 for simplicity of calculation to isolate overflow.
-			exponent: uint64(BigDecFromSDKDec(gammtypes.MaxSpotPrice).Add(OneDec()).LogBase2().TruncateInt().Uint64()),
+			exponent: uint64(osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice).Add(osmomath.OneDec()).LogBase2().TruncateInt().Uint64()),
 
 			// https://www.wolframalpha.com/input?i=2%5E%28floor%28+log+base+2+%282%5E128%29%29%29+++39+digits
-			expectedResult: MustNewDecFromStr("340282366920938463463374607431768211456"),
+			expectedResult: osmomath.MustNewDecFromStr("340282366920938463463374607431768211456"),
 		},
 		"geom twap overflow: 2^log_2{max spot price}": {
-			base:     twoBigDec,
-			exponent: uint64(BigDecFromSDKDec(gammtypes.MaxSpotPrice).LogBase2().TruncateInt().Uint64()),
+			base:     osmomath.TwoBigDec,
+			exponent: uint64(osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice).LogBase2().TruncateInt().Uint64()),
 
 			// https://www.wolframalpha.com/input?i=2%5E%28floor%28+log+base+2+%282%5E128+-+1%29%29%29+++39+digits
-			expectedResult: MustNewDecFromStr("170141183460469231731687303715884105728"),
+			expectedResult: osmomath.MustNewDecFromStr("170141183460469231731687303715884105728"),
 		},
 		"geom twap overflow: 2^log_2{max spot price / 2 - 2017}": { // 2017 is prime.
-			base:     twoBigDec,
-			exponent: uint64(BigDecFromSDKDec(gammtypes.MaxSpotPrice.Quo(sdk.NewDec(2)).Sub(sdk.NewDec(2017))).LogBase2().TruncateInt().Uint64()),
+			base:     osmomath.TwoBigDec,
+			exponent: uint64(osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice.Quo(sdk.NewDec(2)).Sub(sdk.NewDec(2017))).LogBase2().TruncateInt().Uint64()),
 
 			// https://www.wolframalpha.com/input?i=e%5E10+41+digits
-			expectedResult: MustNewDecFromStr("85070591730234615865843651857942052864"),
+			expectedResult: osmomath.MustNewDecFromStr("85070591730234615865843651857942052864"),
 		},
 
 		// sdk.Dec test vectors copied from osmosis-labs/cosmos-sdk:
 
 		"1.0 ^ (10) => 1.0": {
-			base:     OneDec(),
+			base:     osmomath.OneDec(),
 			exponent: 10,
 
-			expectedResult: OneDec(),
+			expectedResult: osmomath.OneDec(),
 		},
 		"0.5 ^ 2 => 0.25": {
-			base:     NewDecWithPrec(5, 1),
+			base:     osmomath.NewDecWithPrec(5, 1),
 			exponent: 2,
 
-			expectedResult: NewDecWithPrec(25, 2),
+			expectedResult: osmomath.NewDecWithPrec(25, 2),
 		},
 		"0.2 ^ 2 => 0.04": {
-			base:     NewDecWithPrec(2, 1),
+			base:     osmomath.NewDecWithPrec(2, 1),
 			exponent: 2,
 
-			expectedResult: NewDecWithPrec(4, 2),
+			expectedResult: osmomath.NewDecWithPrec(4, 2),
 		},
 		"3 ^ 3 => 27": {
-			base:     NewBigDec(3),
+			base:     osmomath.NewBigDec(3),
 			exponent: 3,
 
-			expectedResult: NewBigDec(27),
+			expectedResult: osmomath.NewBigDec(27),
 		},
 		"-3 ^ 4 = 81": {
-			base:     NewBigDec(-3),
+			base:     osmomath.NewBigDec(-3),
 			exponent: 4,
 
-			expectedResult: NewBigDec(81),
+			expectedResult: osmomath.NewBigDec(81),
 		},
 		"-3 ^ 50 = 717897987691852588770249": {
-			base:     NewBigDec(-3),
+			base:     osmomath.NewBigDec(-3),
 			exponent: 50,
 
-			expectedResult: MustNewDecFromStr("717897987691852588770249"),
+			expectedResult: osmomath.MustNewDecFromStr("717897987691852588770249"),
 		},
 		"-3 ^ 51 = -2153693963075557766310747": {
-			base:     NewBigDec(-3),
+			base:     osmomath.NewBigDec(-3),
 			exponent: 51,
 
-			expectedResult: MustNewDecFromStr("-2153693963075557766310747"),
+			expectedResult: osmomath.MustNewDecFromStr("-2153693963075557766310747"),
 		},
 		"1.414213562373095049 ^ 2 = 2": {
-			base:     NewDecWithPrec(1414213562373095049, 18),
+			base:     osmomath.NewDecWithPrec(1414213562373095049, 18),
 			exponent: 2,
 
-			expectedResult:             NewBigDec(2),
-			expectedToleranceOverwrite: MustNewDecFromStr("0.0000000000000000006"),
+			expectedResult:             osmomath.NewBigDec(2),
+			expectedToleranceOverwrite: osmomath.MustNewDecFromStr("0.0000000000000000006"),
 		},
 	}
 
@@ -1172,30 +1150,24 @@ func (s *decimalTestSuite) TestPowerInteger() {
 			}
 
 			actualResult := tc.base.PowerInteger(tc.exponent)
-			require.True(DecApproxEq(s.T(), tc.expectedResult, actualResult, tolerance))
+			require.True(osmomath.DecApproxEq(s.T(), tc.expectedResult, actualResult, tolerance))
 
 		})
 	}
 }
 
 func (s *decimalTestSuite) TestClone() {
-
-	// The value to change the underlying copy's
-	// internal value to assert on the original BigDec
-	// remaining unchanged.
-	changeValue := big.NewInt(10)
-
 	tests := map[string]struct {
-		startValue BigDec
+		startValue osmomath.BigDec
 	}{
 		"1.1": {
-			startValue: MustNewDecFromStr("1.1"),
+			startValue: osmomath.MustNewDecFromStr("1.1"),
 		},
 		"-3": {
-			startValue: MustNewDecFromStr("-3"),
+			startValue: osmomath.MustNewDecFromStr("-3"),
 		},
 		"0": {
-			startValue: MustNewDecFromStr("-3"),
+			startValue: osmomath.MustNewDecFromStr("-3"),
 		},
 	}
 
@@ -1207,7 +1179,7 @@ func (s *decimalTestSuite) TestClone() {
 
 			s.Require().Equal(tc.startValue, copy)
 
-			copy.i.Set(changeValue)
+			copy.MulMut(osmomath.NewBigDec(2))
 			// copy and startValue do not share internals.
 			s.Require().NotEqual(tc.startValue, copy)
 		})
@@ -1218,23 +1190,23 @@ func (s *decimalTestSuite) TestClone() {
 // while Mut is not.
 func (s *decimalTestSuite) TestMul_Mutation() {
 
-	mulBy := MustNewDecFromStr("2")
+	mulBy := osmomath.MustNewDecFromStr("2")
 
 	tests := map[string]struct {
-		startValue        BigDec
-		expectedMulResult BigDec
+		startValue        osmomath.BigDec
+		expectedMulResult osmomath.BigDec
 	}{
 		"1.1": {
-			startValue:        MustNewDecFromStr("1.1"),
-			expectedMulResult: MustNewDecFromStr("2.2"),
+			startValue:        osmomath.MustNewDecFromStr("1.1"),
+			expectedMulResult: osmomath.MustNewDecFromStr("2.2"),
 		},
 		"-3": {
-			startValue:        MustNewDecFromStr("-3"),
-			expectedMulResult: MustNewDecFromStr("-6"),
+			startValue:        osmomath.MustNewDecFromStr("-3"),
+			expectedMulResult: osmomath.MustNewDecFromStr("-6"),
 		},
 		"0": {
-			startValue:        ZeroDec(),
-			expectedMulResult: ZeroDec(),
+			startValue:        osmomath.ZeroDec(),
+			expectedMulResult: osmomath.ZeroDec(),
 		},
 	}
 
@@ -1260,24 +1232,24 @@ func (s *decimalTestSuite) TestPowerInteger_Mutation() {
 	exponent := uint64(2)
 
 	tests := map[string]struct {
-		startValue     BigDec
-		expectedResult BigDec
+		startValue     osmomath.BigDec
+		expectedResult osmomath.BigDec
 	}{
 		"1": {
-			startValue:     OneDec(),
-			expectedResult: OneDec(),
+			startValue:     osmomath.OneDec(),
+			expectedResult: osmomath.OneDec(),
 		},
 		"-3": {
-			startValue:     MustNewDecFromStr("-3"),
-			expectedResult: MustNewDecFromStr("9"),
+			startValue:     osmomath.MustNewDecFromStr("-3"),
+			expectedResult: osmomath.MustNewDecFromStr("9"),
 		},
 		"0": {
-			startValue:     ZeroDec(),
-			expectedResult: ZeroDec(),
+			startValue:     osmomath.ZeroDec(),
+			expectedResult: osmomath.ZeroDec(),
 		},
 		"4": {
-			startValue:     MustNewDecFromStr("4.5"),
-			expectedResult: MustNewDecFromStr("20.25"),
+			startValue:     osmomath.MustNewDecFromStr("4.5"),
+			expectedResult: osmomath.MustNewDecFromStr("20.25"),
 		},
 	}
 

--- a/osmomath/export_test.go
+++ b/osmomath/export_test.go
@@ -1,0 +1,6 @@
+package osmomath
+
+var (
+	EulersNumber = eulersNumber
+	TwoBigDec    = twoBigDec
+)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: #3540

## What is the purpose of the change

As per title, this is needed to prevent import cycles in tests.

The import cycle I encountered is with `osmoutils` to import `ErrTolerance`.