### PR TITLE
refactor(osmomath): replace Power with PowerInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#3676](https://github.com/osmosis-labs/osmosis/pull/3676) implement `PowerInteger` function on `osmomath.BigDec` 
 * [#3678](https://github.com/osmosis-labs/osmosis/pull/3678) implement mutative `PowerIntegerMut` function on `osmomath.BigDec`.
 * [#3693](https://github.com/osmosis-labs/osmosis/pull/3693) Add `EstimateSwapExactAmountOut` query to stargate whitelist
-* [#3712](https://github.com/osmosis-labs/osmosis/pull/3712) replace `osmomath.BigDec` `Power` with `PowerInteger` 
 
 ### Bug fixes
 
@@ -60,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#3611](https://github.com/osmosis-labs/osmosis/pull/3611),[#3647](https://github.com/osmosis-labs/osmosis/pull/3647) Introduce osmocli, to automate thousands of lines of CLI boilerplate
 * [#3634](https://github.com/osmosis-labs/osmosis/pull/3634) (Makefile) Ensure correct golang version in make build and make install. (Thank you @jhernandezb )
+* [#3712](https://github.com/osmosis-labs/osmosis/pull/3712) replace `osmomath.BigDec` `Power` with `PowerInteger` 
 
 ## v13.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#3676](https://github.com/osmosis-labs/osmosis/pull/3676) implement `PowerInteger` function on `osmomath.BigDec` 
 * [#3678](https://github.com/osmosis-labs/osmosis/pull/3678) implement mutative `PowerIntegerMut` function on `osmomath.BigDec`.
 * [#3693](https://github.com/osmosis-labs/osmosis/pull/3693) Add `EstimateSwapExactAmountOut` query to stargate whitelist
+* [#3712](https://github.com/osmosis-labs/osmosis/pull/3712) replace `osmomath.BigDec` `Power` with `PowerInteger` 
 
 ### Bug fixes
 

--- a/osmomath/decimal.go
+++ b/osmomath/decimal.go
@@ -423,7 +423,7 @@ func (d BigDec) ApproxRoot(root uint64) (guess BigDec, err error) {
 	guess, delta := OneDec(), OneDec()
 
 	for iter := 0; delta.Abs().GT(SmallestDec()) && iter < maxApproxRootIterations; iter++ {
-		prev := guess.Power(root - 1)
+		prev := guess.PowerInteger(root - 1)
 		if prev.IsZero() {
 			prev = SmallestDec()
 		}
@@ -435,24 +435,6 @@ func (d BigDec) ApproxRoot(root uint64) (guess BigDec, err error) {
 	}
 
 	return guess, nil
-}
-
-// Power returns a the result of raising to a positive integer power
-func (d BigDec) Power(power uint64) BigDec {
-	if power == 0 {
-		return OneDec()
-	}
-	tmp := OneDec()
-
-	for i := power; i > 1; {
-		if i%2 != 0 {
-			tmp = tmp.Mul(d)
-		}
-		i /= 2
-		d = d.Mul(d)
-	}
-
-	return d.Mul(tmp)
 }
 
 // ApproxSqrt is a wrapper around ApproxRoot for the common special case

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -474,26 +474,6 @@ func (s *decimalTestSuite) TestDecCeil() {
 	}
 }
 
-func (s *decimalTestSuite) TestPower() {
-	testCases := []struct {
-		input    BigDec
-		power    uint64
-		expected BigDec
-	}{
-		{OneDec(), 10, OneDec()},                                                                   // 1.0 ^ (10) => 1.0
-		{NewDecWithPrec(5, 1), 2, NewDecWithPrec(25, 2)},                                           // 0.5 ^ 2 => 0.25
-		{NewDecWithPrec(2, 1), 2, NewDecWithPrec(4, 2)},                                            // 0.2 ^ 2 => 0.04
-		{NewDecFromInt(NewInt(3)), 3, NewDecFromInt(NewInt(27))},                                   // 3 ^ 3 => 27
-		{NewDecFromInt(NewInt(-3)), 4, NewDecFromInt(NewInt(81))},                                  // -3 ^ 4 = 81
-		{MustNewDecFromStr("1.414213562373095048801688724209698079"), 2, NewDecFromInt(NewInt(2))}, // 1.414213562373095048801688724209698079 ^ 2 = 2
-	}
-
-	for i, tc := range testCases {
-		res := tc.input.Power(tc.power)
-		s.Require().True(tc.expected.Sub(res).Abs().LTE(SmallestDec()), "unexpected result for test case %d, input: %v", i, tc.input)
-	}
-}
-
 func (s *decimalTestSuite) TestApproxRoot() {
 	testCases := []struct {
 		input    BigDec

--- a/osmoutils/binary_search_test.go
+++ b/osmoutils/binary_search_test.go
@@ -82,13 +82,13 @@ func lineF(a osmomath.BigDec) (osmomath.BigDec, error) {
 	return a, nil
 }
 func cubicF(a osmomath.BigDec) (osmomath.BigDec, error) {
-	return a.Power(3), nil
+	return a.PowerInteger(3), nil
 }
 
-var negCubicFConstant = osmomath.NewBigDec(1 << 62).Power(3).Neg()
+var negCubicFConstant = osmomath.NewBigDec(1 << 62).PowerInteger(3).Neg()
 
 func negCubicF(a osmomath.BigDec) (osmomath.BigDec, error) {
-	return a.Power(3).Add(negCubicFConstant), nil
+	return a.PowerInteger(3).Add(negCubicFConstant), nil
 }
 
 type searchFn func(osmomath.BigDec) (osmomath.BigDec, error)
@@ -232,7 +232,7 @@ func TestBinarySearchBigDec(t *testing.T) {
 
 	twoTo50 := osmomath.NewBigDec(1 << 50)
 	twoTo25PlusOne := osmomath.NewBigDec(1 + (1 << 25))
-	twoTo25PlusOneCubed := twoTo25PlusOne.Power(3)
+	twoTo25PlusOneCubed := twoTo25PlusOne.PowerInteger(3)
 
 	tests := map[string]binarySearchTestCase{
 		"cubic f, no err tolerance, converges":     {cubicF, zero, twoTo50, twoTo25PlusOneCubed, withinOne, 51, twoTo25PlusOne, false},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: #3540 

## What is the purpose of the change

I missed the existence of `Power` when adding `PowerInteger`. As a result, these functions are identical.

I propose removing the old `Power` and replace all calls with `PowerInteger` since I am adding a new `Power` function that takes a decimal exponent.

**Note:**
- The removed `Power` is identical with `PowerInteger`
- The existing `PowerInteger` tests include and cover all removed test cases.
