### PR TITLE
test(x/twap): geometric twap accum initialized to zero by default

### DIFF
--- a/x/twap/migrate_test.go
+++ b/x/twap/migrate_test.go
@@ -3,6 +3,9 @@ package twap_test
 import (
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gogo/protobuf/proto"
+
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
@@ -63,4 +66,30 @@ func (s *TestSuite) TestMigrateExistingPoolsError() {
 	latestPoolIdPlusOne := s.App.GAMMKeeper.GetNextPoolId(s.Ctx)
 	err := s.twapkeeper.MigrateExistingPools(s.Ctx, latestPoolIdPlusOne)
 	s.Require().Error(err)
+}
+
+// TestTwapRecord_GeometricTwap_MarshalUnmarshal this test proves that migrations
+// to initialize geometric twap accumulators are not required.
+// This is because proto marshalling will initialize the field to the zero value.
+// Zero value is the expected initialization value for the geometric twap accumulator.
+func (suite *TestSuite) TestTwapRecord_GeometricTwap_MarshalUnmarshal() {
+	originalRecord := types.TwapRecord{
+		Asset0Denom: "uatom",
+		Asset1Denom: "uusd",
+	}
+
+	suite.Require().True(originalRecord.GeometricTwapAccumulator.IsNil())
+
+	bz, err := proto.Marshal(&originalRecord)
+	suite.Require().NoError(err)
+
+	var deserialized types.TwapRecord
+	err = proto.Unmarshal(bz, &deserialized)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(originalRecord, deserialized)
+	suite.Require().Equal(originalRecord.String(), deserialized.String())
+
+	suite.Require().False(originalRecord.GeometricTwapAccumulator.IsNil())
+	suite.Require().Equal(sdk.ZeroDec(), originalRecord.GeometricTwapAccumulator)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3542

## What is the purpose of the change

The original goal of twap record migrations was assumed to have the need to initialize the new geometric accumulator to 0.

Upon more testing, I realized that the new fields are getting initialized to zero by default during proto deserialization. As a result, the migrations aren't needed.


This PR adds a marshal/unmarshal test to prove this. 

Also, https://github.com/osmosis-labs/osmosis/issues/3728 will help confirm that this is valid