### PR TITLE
test(x/twap): geometric twap overflow tests

### DIFF
--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -15,7 +15,7 @@ import (
 // in logarithm and power math functions.
 // See twapLog and computeGeometricTwap functions for more details.
 var (
-	geometricTwapMathBase = sdk.NewDec(2)
+	geometricTwapMathBase = osmomath.NewBigDec(2)
 	// TODO: analyze choice.
 	geometricTwapPowPrecision = sdk.MustNewDecFromStr("0.00000001")
 )
@@ -305,13 +305,11 @@ func computeGeometricTwap(startRecord types.TwapRecord, endRecord types.TwapReco
 }
 
 // twapLog returns the logarithm of the given spot price, base 2.
-// TODO: basic test
 func twapLog(price sdk.Dec) sdk.Dec {
 	return osmomath.BigDecFromSDKDec(price).LogBase2().SDKDec()
 }
 
 // twapPow exponentiates the geometricTwapMathBase to the given exponent.
-// TODO: basic test and benchmark.
 func twapPow(exponent sdk.Dec) sdk.Dec {
-	return osmomath.PowApprox(geometricTwapMathBase, exponent, geometricTwapPowPrecision)
+	return geometricTwapMathBase.Power(osmomath.BigDecFromSDKDec(exponent)).SDKDec()
 }

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -16,8 +16,6 @@ import (
 // See twapLog and computeGeometricTwap functions for more details.
 var (
 	geometricTwapMathBase = osmomath.NewBigDec(2)
-	// TODO: analyze choice.
-	geometricTwapPowPrecision = sdk.MustNewDecFromStr("0.00000001")
 )
 
 func newTwapRecord(k types.AmmInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3540

## What is the purpose of the change

Given the improved `Power` function that was introduced in #3731, the geometric twap overflow tests can be added now. All pass.