### PR TITLE
osmocli: migrate to osmocli tests in tokenfactory cli

### DIFF
--- a/x/tokenfactory/client/cli/cli_test.go
+++ b/x/tokenfactory/client/cli/cli_test.go
@@ -20,3 +20,16 @@ func TestGetCmdDenomAuthorityMetadata(t *testing.T) {
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }
+
+func TestGetCmdDenomsFromCreator(t *testing.T) {
+	desc, _ := cli.GetCmdDenomsFromCreator()
+	tcs := map[string]osmocli.QueryCliTestCase[*types.QueryDenomsFromCreatorRequest]{
+		"basic test": {
+			Cmd: "osmo1test",
+			ExpectedQuery: &types.QueryDenomsFromCreatorRequest{
+				Creator: "osmo1test",
+			},
+		},
+	}
+	osmocli.RunQueryTestCases(t, desc, tcs)
+}

--- a/x/tokenfactory/client/cli/cli_test.go
+++ b/x/tokenfactory/client/cli/cli_test.go
@@ -1,0 +1,22 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/osmosis-labs/osmosis/v13/osmoutils/osmocli"
+	"github.com/osmosis-labs/osmosis/v13/x/tokenfactory/client/cli"
+	"github.com/osmosis-labs/osmosis/v13/x/tokenfactory/types"
+)
+
+func TestGetCmdDenomAuthorityMetadata(t *testing.T) {
+	desc, _ := cli.GetCmdDenomAuthorityMetadata()
+	tcs := map[string]osmocli.QueryCliTestCase[*types.QueryDenomAuthorityMetadataRequest]{
+		"basic test": {
+			Cmd: "uatom",
+			ExpectedQuery: &types.QueryDenomAuthorityMetadataRequest{
+				Denom: "uatom",
+			},
+		},
+	}
+	osmocli.RunQueryTestCases(t, desc, tcs)
+}

--- a/x/tokenfactory/client/cli/query.go
+++ b/x/tokenfactory/client/cli/query.go
@@ -17,28 +17,31 @@ import (
 func GetQueryCmd() *cobra.Command {
 	cmd := osmocli.QueryIndexCmd(types.ModuleName)
 
+	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdDenomAuthorityMetadata)
+	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdDenomAuthorityMetadata)
+
 	cmd.AddCommand(
 		osmocli.GetParams[*types.QueryParamsRequest](
 			types.ModuleName, types.NewQueryClient),
-		GetCmdDenomAuthorityMetadata(),
-		GetCmdDenomsFromCreator(),
 	)
 
 	return cmd
 }
 
-func GetCmdDenomAuthorityMetadata() *cobra.Command {
-	return osmocli.SimpleQueryCmd[*types.QueryDenomAuthorityMetadataRequest](
-		"denom-authority-metadata [denom] [flags]",
-		"Get the authority metadata for a specific denom", "",
-		types.ModuleName, types.NewQueryClient,
-	)
+func GetCmdDenomAuthorityMetadata() (*osmocli.QueryDescriptor, *types.QueryDenomAuthorityMetadataRequest) {
+	return &osmocli.QueryDescriptor{
+		Use:   "denom-authority-metadata [denom] [flags]",
+		Short: "Get the authority metadata for a specific denom",
+		Long: `{{.Short}}{{.ExampleHeader}}
+		{{.CommandPrefix}} uatom`,
+	}, &types.QueryDenomAuthorityMetadataRequest{}
 }
 
-func GetCmdDenomsFromCreator() *cobra.Command {
-	return osmocli.SimpleQueryCmd[*types.QueryDenomsFromCreatorRequest](
-		"denoms-from-creator [creator address] [flags]",
-		"Returns a list of all tokens created by a specific creator address", "",
-		types.ModuleName, types.NewQueryClient,
-	)
+func GetCmdDenomsFromCreator() (*osmocli.QueryDescriptor, *types.QueryDenomsFromCreatorRequest) {
+	return &osmocli.QueryDescriptor{
+		Use:   "denoms-from-creator [creator address] [flags]",
+		Short: "Returns a list of all tokens created by a specific creator address",
+		Long: `{{.Short}}{{.ExampleHeader}}
+		{{.CommandPrefix}} <address>`,
+	}, &types.QueryDenomsFromCreatorRequest{}
 }


### PR DESCRIPTION
- refactor query.go
- add test case for GetCmdDenomAuthorityMetadata
- test case for GetCmdDenomsFromCreator
- add field to QueryCliTestCase to check for wrong responses (does not return error)
- refactor RunQueryTestCase to check ExpectedNotEqual
- missed return
- add wrong test cases


## What is the purpose of the change
Migrate to use osmocli tests in tokenfactory module. Also adds a field to `QueryCliTestCase` to check the return value of a query, to be able to check for wrong response (might be not really important to add this, will wait for review)

## Documentation and Release Note
not documented





