### PR TITLE
Fix merge conflicts in docker ci

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -7,17 +7,19 @@
 # osmolabs/osmosis:X        # is updated to X.Y.Z
 # osmolabs/osmosis:latest   # is updated to X.Y.Z
 #
-# On every new `vX.Y.0` tag the following images are pushed:
-#
-# osmolabs/osmosis-e2e-init-chain:X.Y.0    # is pushed
-# osmolabs/osmosis-e2e-init-chain:X.Y      # is updated to X.Y.0
-# osmolabs/osmosis-e2e-init-chain:X        # is updated to X.Y.0
-# The same osmosisd binary is copied in different base runner images:
+# # The same osmosisd binary is copied in different base runner images:
 #
 # - `osmolabs/osmosis:X.Y.Z`             uses `gcr.io/distroless/static-debian11`
 # - `osmolabs/osmosis:X.Y.Z-distroless`  uses `gcr.io/distroless/static-debian11`
 # - `osmolabs/osmosis:X.Y.Z-nonroot`     uses `gcr.io/distroless/static-debian11:nonroot`
 # - `osmolabs/osmosis:X.Y.Z-alpine`      uses `alpine:3.16` 
+#
+# On every new `vX.Y.0` tag the following images are also pushed:
+#
+# osmolabs/osmosis-e2e-init-chain:X.Y.0    # is pushed
+# osmolabs/osmosis-e2e-init-chain:X.Y      # is updated to X.Y.0
+# osmolabs/osmosis-e2e-init-chain:X        # is updated to X.Y.0
+#
 #
 # All the images above have support for linux/amd64 and linux/arm64.
 #
@@ -38,17 +40,14 @@ env:
   RUNNER_BASE_IMAGE_ALPINE: alpine:3.16
 
 jobs:
-<<<<<<< HEAD:.github/workflows/docker.yml
-  docker:
-    runs-on: ubuntu-latest
-=======
   osmosisd-images:
     runs-on: self-hosted
->>>>>>> a5f88e14 (feat(e2e/ci): auto-build and publish to docker hub e2e init images on release (#3249)):.github/workflows/push-docker-images.yml
     steps:
       - 
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - 
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -66,105 +65,80 @@ jobs:
         id: find_go_version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
-          echo "::set-output name=go_version::$(echo ${GO_VERSION})"
-
-      # Distroless Docker image (default)
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
       -
-        name: Docker meta (distroless)
-        id: meta_distroless
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_REPOSITORY }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=semver,pattern={{version}}-distroless
-            type=semver,pattern={{major}}.{{minor}}-distroless
-            type=semver,pattern={{major}}-distroless
+        name: Parse tag
+        id: tag
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
+          MAJOR_VERSION=$(echo $VERSION | cut -d '.' -f 1)
+          MINOR_VERSION=$(echo $VERSION | cut -d '.' -f 2)
+          PATCH_VERSION=$(echo $VERSION | cut -d '.' -f 3)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "MAJOR_VERSION=$MAJOR_VERSION" >> $GITHUB_ENV
+          echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
+          echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
+      # Distroless Docker image (default)
       - 
         name: Build and push (distroless)
         id: build_push_distroless
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: Dockerfile
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
-            GO_VERSION=${{ steps.find_go_version.outputs.go_version }}
+            GO_VERSION=${{ env.GO_VERSION }}
             RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_DISTROLESS }}
-            GIT_VERSION=${GITHUB_REF_NAME#v}
+            GIT_VERSION=${{ env.VERSION }}
             GIT_COMMIT=${{ github.sha }}
-          tags: ${{ steps.meta_distroless.outputs.tags }}
-
-      # Distroless nonroot Docker image
-      -
-        name: Docker meta (nonroot)
-        id: meta_nonroot
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_REPOSITORY }}
-          flavor: |
-            latest=false
-            suffix=-nonroot
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-distroless
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-distroless
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-distroless
+      # Distroless nonroot Docker image
       - 
         name: Build and push (nonroot)
         id: build_push_nonroot
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: Dockerfile
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
-            GO_VERSION=${{ steps.find_go_version.outputs.go_version }}
+            GO_VERSION=${{ env.GO_VERSION }}
             RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_NONROOT }}
-            GIT_VERSION=${GITHUB_REF_NAME#v}
-            GIT_COMMIT=$GITHUB_SHA
-          tags: ${{ steps.meta_nonroot.outputs.tags }}
-      
-      # Alpine Docker image
-      -
-        name: Docker meta (alpine)
-        id: meta_alpine
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_REPOSITORY }}
-          flavor: |
-            latest=false
-            suffix=-alpine
+            GIT_VERSION=${{ env.VERSION }}
+            GIT_COMMIT=${{ github.sha }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-nonroot
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-nonroot
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-nonroot
+      # Alpine Docker image
       - 
         name: Build and push (alpine)
         id: build_push_alpine
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: Dockerfile
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
-            GO_VERSION=${{ steps.find_go_version.outputs.go_version }}
+            GO_VERSION=${{ env.GO_VERSION }}
             RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_ALPINE }}
-<<<<<<< HEAD:.github/workflows/docker.yml
-            GIT_VERSION=${GITHUB_REF_NAME#v}
-            GIT_COMMIT=$GITHUB_SHA
-          tags: ${{ steps.meta_alpine.outputs.tags }}
-=======
             GIT_VERSION=${{ env.VERSION }}
             GIT_COMMIT=${{ github.sha }}
           tags: |
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine
+  
   e2e-init-chain-images:
     if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
     runs-on: ubuntu-latest
@@ -213,4 +187,3 @@ jobs:
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
->>>>>>> a5f88e14 (feat(e2e/ci): auto-build and publish to docker hub e2e init images on release (#3249)):.github/workflows/push-docker-images.yml


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis/issues/3631

## What is the purpose of the change

In this backport https://github.com/osmosis-labs/osmosis/pull/3471 we merged conflicts on the docker ci. 


```yaml
jobs:
<<<<<<< HEAD:.github/workflows/docker.yml
  docker:
    runs-on: ubuntu-latest
=======
  osmosisd-images:
    runs-on: self-hosted
>>>>>>> a5f88e14 (feat(e2e/ci): auto-build and publish to docker hub e2e init images on release (#3249)):.github/workflows/push-docker-images.yml
```

which is likely the cause of https://github.com/osmosis-labs/osmosis/issues/3631

## Brief Changelog

- Fix merge conflict
- Rename `docker.yml` --> `push-docker-images.yml`

## Testing and Verifying

N.A.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? no