### PR TITLE
Remove search bar from swagger

### DIFF
--- a/client/docs/static/swagger/index.html
+++ b/client/docs/static/swagger/index.html
@@ -45,7 +45,7 @@
         deepLinking: true,
         presets: [
           SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
+          SwaggerUIStandalonePreset.slice(1) // here
         ],
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -93,6 +93,9 @@ edit_config () {
 
     # Expose the rpc
     dasel put string -f $CONFIG_FOLDER/config.toml '.rpc.laddr' "tcp://0.0.0.0:26657"
+
+    # Disable fast_sync
+    dasel put bool -f $CONFIG_FOLDER/app.toml '.api.swagger' 'true'
 }
 
 create_two_asset_pool () {

--- a/tests/localosmosis/state_export/scripts/start.sh
+++ b/tests/localosmosis/state_export/scripts/start.sh
@@ -31,6 +31,9 @@ edit_config () {
 
     # Expose the rpc
     dasel put string -f $CONFIG_FOLDER/config.toml '.rpc.laddr' "tcp://0.0.0.0:26657"
+
+    # Disable fast_sync
+    dasel put bool -f $CONFIG_FOLDER/app.toml '.api.swagger' 'true'
 }
 
 if [[ ! -d $CONFIG_FOLDER ]]


### PR DESCRIPTION
## What is the purpose of the change

According to https://github.com/swagger-api/swagger-ui/issues/3229 adding `SwaggerUIStandalonePreset.slice(1)` to:

```js
    const ui = SwaggerUIBundle({
      url: "/static/swagger.api.json",
      dom_id: `#${ DOM_ID }`,
      presets: [
        SwaggerUIBundle.presets.apis,
        SwaggerUIStandalonePreset.slice(1) // here
      ],
      plugins: [
        SwaggerUIBundle.plugins.DownloadUrl
      ],
      layout: "StandaloneLayout"
    })
```

Should remove the search bar on the `swagger-ui`:

![image](https://user-images.githubusercontent.com/6024049/208133838-0c8661e6-e01e-42b5-9fe4-946186010f86.png)

which is not very useful as it doesn't allow to search the endpoints.
I wasn't able to rebuild the docs. Could you help me @daniel-farina please?

## Brief Changelog

- Remove search bar from rest swagger

## Testing and Verifying

In Progress

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 