### PR TITLE
Remove osmomath's dependency on osmoassert & gammtypes

### DIFF
--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 type decimalTestSuite struct {
@@ -718,7 +719,7 @@ func (s *decimalTestSuite) TestLog2() {
 			expected: osmomath.MustNewDecFromStr("99.525973560175362367047484597337715868"),
 		},
 		"log_2{Max Spot Price} = 128": {
-			initialValue: osmomath.BigDecFromSDKDec(osmomath.MaxSpotPrice), // 2^128 - 1
+			initialValue: osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice), // 2^128 - 1
 			// From: https://www.wolframalpha.com/input?i=log+base+2+of+%28%282%5E128%29+-+1%29+38+digits
 			expected: osmomath.MustNewDecFromStr("128"),
 		},
@@ -732,7 +733,7 @@ func (s *decimalTestSuite) TestLog2() {
 
 	for name, tc := range tests {
 		s.Run(name, func() {
-			f := func() {
+			osmomath.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that LogbBase2() is non-mutative.
 				initialCopy := tc.initialValue.Clone()
@@ -740,12 +741,7 @@ func (s *decimalTestSuite) TestLog2() {
 				res := tc.initialValue.LogBase2()
 				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
-			}
-			if tc.expectedPanic {
-				require.Panics(s.T(), f)
-			} else {
-				f()
-			}
+			})
 		})
 	}
 }
@@ -820,7 +816,7 @@ func (s *decimalTestSuite) TestLn() {
 
 	for name, tc := range tests {
 		s.Run(name, func() {
-			f := func() {
+			osmomath.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that Ln() is non-mutative.
 				initialCopy := tc.initialValue.Clone()
@@ -828,12 +824,7 @@ func (s *decimalTestSuite) TestLn() {
 				res := tc.initialValue.Ln()
 				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
-			}
-			if tc.expectedPanic {
-				require.Panics(s.T(), f)
-			} else {
-				f()
-			}
+			})
 		})
 	}
 }
@@ -900,7 +891,7 @@ func (s *decimalTestSuite) TestTickLog() {
 
 	for name, tc := range tests {
 		s.Run(name, func() {
-			f := func() {
+			osmomath.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that Ln() is non-mutative.
 				initialCopy := tc.initialValue.Clone()
@@ -909,12 +900,7 @@ func (s *decimalTestSuite) TestTickLog() {
 				fmt.Println(name, res.Sub(tc.expected).Abs())
 				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, tc.expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
-			}
-			if tc.expectedPanic {
-				require.Panics(s.T(), f)
-			} else {
-				f()
-			}
+			})
 		})
 	}
 }
@@ -1020,19 +1006,14 @@ func (s *decimalTestSuite) TestCustomBaseLog() {
 	}
 	for name, tc := range tests {
 		s.Run(name, func() {
-			f := func() {
+			osmomath.ConditionalPanic(s.T(), tc.expectedPanic, func() {
 				// Create a copy to test that the original was not modified.
 				// That is, that Ln() is non-mutative.
 				initialCopy := tc.initialValue.Clone()
 				res := tc.initialValue.CustomBaseLog(tc.base)
 				require.True(osmomath.DecApproxEq(s.T(), tc.expected, res, tc.expectedErrTolerance))
 				require.Equal(s.T(), initialCopy, tc.initialValue)
-			}
-			if tc.expectedPanic {
-				s.Require().Panics(f)
-			} else {
-				f()
-			}
+			})
 		})
 	}
 }
@@ -1081,21 +1062,21 @@ func (s *decimalTestSuite) TestPowerInteger() {
 		"geom twap overflow: 2^log_2{max spot price + 1}": {
 			base: osmomath.TwoBigDec,
 			// add 1 for simplicity of calculation to isolate overflow.
-			exponent: uint64(osmomath.BigDecFromSDKDec(osmomath.MaxSpotPrice).Add(osmomath.OneDec()).LogBase2().TruncateInt().Uint64()),
+			exponent: uint64(osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice).Add(osmomath.OneDec()).LogBase2().TruncateInt().Uint64()),
 
 			// https://www.wolframalpha.com/input?i=2%5E%28floor%28+log+base+2+%282%5E128%29%29%29+++39+digits
 			expectedResult: osmomath.MustNewDecFromStr("340282366920938463463374607431768211456"),
 		},
 		"geom twap overflow: 2^log_2{max spot price}": {
 			base:     osmomath.TwoBigDec,
-			exponent: uint64(osmomath.BigDecFromSDKDec(osmomath.MaxSpotPrice).LogBase2().TruncateInt().Uint64()),
+			exponent: uint64(osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice).LogBase2().TruncateInt().Uint64()),
 
 			// https://www.wolframalpha.com/input?i=2%5E%28floor%28+log+base+2+%282%5E128+-+1%29%29%29+++39+digits
 			expectedResult: osmomath.MustNewDecFromStr("170141183460469231731687303715884105728"),
 		},
 		"geom twap overflow: 2^log_2{max spot price / 2 - 2017}": { // 2017 is prime.
 			base:     osmomath.TwoBigDec,
-			exponent: uint64(osmomath.BigDecFromSDKDec(osmomath.MaxSpotPrice.Quo(sdk.NewDec(2)).Sub(sdk.NewDec(2017))).LogBase2().TruncateInt().Uint64()),
+			exponent: uint64(osmomath.BigDecFromSDKDec(gammtypes.MaxSpotPrice.Quo(sdk.NewDec(2)).Sub(sdk.NewDec(2017))).LogBase2().TruncateInt().Uint64()),
 
 			// https://www.wolframalpha.com/input?i=e%5E10+41+digits
 			expectedResult: osmomath.MustNewDecFromStr("85070591730234615865843651857942052864"),
@@ -1227,7 +1208,6 @@ func (s *decimalTestSuite) TestMul_Mutation() {
 	for name, tc := range tests {
 		tc := tc
 		s.Run(name, func() {
-
 			startMut := tc.startValue.Clone()
 			startNonMut := tc.startValue.Clone()
 

--- a/osmomath/export_test.go
+++ b/osmomath/export_test.go
@@ -1,6 +1,11 @@
 package osmomath
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
 
 var (
 	EulersNumber = eulersNumber
@@ -12,3 +17,14 @@ var (
 // Hence we use the same var name, in hopes that if any change there happens,
 // this is caught via a CTRL+F
 var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
+
+// ConditionalPanic checks if expectPanic is true, asserts that sut (system under test)
+// panics. If expectPanic is false, asserts that sut does not panic.
+// returns true if sut panics and false it it does not
+func ConditionalPanic(t *testing.T, expectPanic bool, sut func()) {
+	if expectPanic {
+		require.Panics(t, sut)
+		return
+	}
+	require.NotPanics(t, sut)
+}

--- a/osmomath/export_test.go
+++ b/osmomath/export_test.go
@@ -1,6 +1,14 @@
 package osmomath
 
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
 var (
 	EulersNumber = eulersNumber
 	TwoBigDec    = twoBigDec
 )
+
+// 2^128 - 1, needs to be the same as gammtypes.MaxSpotPrice
+// but we can't directly import that due to import cycles.
+// Hence we use the same var name, in hopes that if any change there happens,
+// this is caught via a CTRL+F
+var MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())

--- a/osmomath/log2_bench_test.go
+++ b/osmomath/log2_bench_test.go
@@ -3,8 +3,6 @@ package osmomath
 import (
 	"math/rand"
 	"testing"
-
-	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 func BenchmarkLog2(b *testing.B) {
@@ -15,7 +13,7 @@ func BenchmarkLog2(b *testing.B) {
 		NewBigDec(2048 * 2048 * 2048 * 2048 * 2048),
 		MustNewDecFromStr("999999999999999999999999999999999999999999999999999999.9122181273612911"),
 		MustNewDecFromStr("0.563289239121902491248219047129047129"),
-		BigDecFromSDKDec(gammtypes.MaxSpotPrice),                        // 2^128 - 1
+		BigDecFromSDKDec(MaxSpotPrice),                                  // 2^128 - 1
 		MustNewDecFromStr("336879543251729078828740861357450529340.45"), // (2^128 - 1) * 0.99
 	}
 

--- a/osmomath/math_test.go
+++ b/osmomath/math_test.go
@@ -89,21 +89,16 @@ func TestPowApprox(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		expectPanic := tc.base.IsZero()
-		f := func() {
+		var actualResult sdk.Dec
+		ConditionalPanic(t, tc.base.Equal(sdk.ZeroDec()), func() {
 			fmt.Println(tc.base)
-			actualResult := PowApprox(tc.base, tc.exp, tc.powPrecision)
+			actualResult = PowApprox(tc.base, tc.exp, tc.powPrecision)
 			require.True(
 				t,
 				tc.expectedResult.Sub(actualResult).Abs().LTE(tc.powPrecision),
 				fmt.Sprintf("test %d failed: expected value & actual value's difference should be less than precision", i),
 			)
-		}
-		if expectPanic {
-			require.Panics(t, f, fmt.Sprintf("test %d failed: should panic", i))
-		} else {
-			f()
-		}
+		})
 	}
 }
 
@@ -158,19 +153,14 @@ func TestPow(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		f := func() {
-			actualResult := Pow(tc.base, tc.exp)
+		var actualResult sdk.Dec
+		ConditionalPanic(t, tc.base.Equal(sdk.ZeroDec()), func() {
+			actualResult = Pow(tc.base, tc.exp)
 			require.True(
 				t,
 				tc.expectedResult.Sub(actualResult).Abs().LTE(powPrecision),
 				fmt.Sprintf("test %d failed: expected value & actual value's difference should be less than precision", i),
 			)
-		}
-		expectPanic := tc.base.IsZero()
-		if expectPanic {
-			require.Panics(t, f)
-		} else {
-			f()
-		}
+		})
 	}
 }

--- a/osmomath/math_test.go
+++ b/osmomath/math_test.go
@@ -6,8 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,16 +89,21 @@ func TestPowApprox(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		var actualResult sdk.Dec
-		osmoassert.ConditionalPanic(t, tc.base.Equal(sdk.ZeroDec()), func() {
+		expectPanic := tc.base.IsZero()
+		f := func() {
 			fmt.Println(tc.base)
-			actualResult = PowApprox(tc.base, tc.exp, tc.powPrecision)
+			actualResult := PowApprox(tc.base, tc.exp, tc.powPrecision)
 			require.True(
 				t,
 				tc.expectedResult.Sub(actualResult).Abs().LTE(tc.powPrecision),
 				fmt.Sprintf("test %d failed: expected value & actual value's difference should be less than precision", i),
 			)
-		})
+		}
+		if expectPanic {
+			require.Panics(t, f, fmt.Sprintf("test %d failed: should panic", i))
+		} else {
+			f()
+		}
 	}
 }
 
@@ -155,14 +158,19 @@ func TestPow(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		var actualResult sdk.Dec
-		osmoassert.ConditionalPanic(t, tc.base.Equal(sdk.ZeroDec()), func() {
-			actualResult = Pow(tc.base, tc.exp)
+		f := func() {
+			actualResult := Pow(tc.base, tc.exp)
 			require.True(
 				t,
 				tc.expectedResult.Sub(actualResult).Abs().LTE(powPrecision),
 				fmt.Sprintf("test %d failed: expected value & actual value's difference should be less than precision", i),
 			)
-		})
+		}
+		expectPanic := tc.base.IsZero()
+		if expectPanic {
+			require.Panics(t, f)
+		} else {
+			f()
+		}
 	}
 }

--- a/osmomath/rounding_direction_test.go
+++ b/osmomath/rounding_direction_test.go
@@ -6,8 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-
-	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
 )
 
 func TestDivIntByU64ToBigDec(t *testing.T) {
@@ -45,7 +43,11 @@ func TestDivIntByU64ToBigDec(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := DivIntByU64ToBigDec(tt.i, tt.u, tt.round)
 			require.Equal(t, tt.want, got)
-			osmoassert.ConditionalError(t, tt.expErr, err)
+			if tt.expErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/osmomath/sigfig_round_test.go
+++ b/osmomath/sigfig_round_test.go
@@ -75,21 +75,16 @@ func TestSigFigRound(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			expPanic := tc.tenToSigFig.IsZero()
-			f := func() {
-				actualResult := SigFigRound(tc.decimal, tc.tenToSigFig)
+			var actualResult sdk.Dec
+			ConditionalPanic(t, tc.tenToSigFig.Equal(sdk.ZeroInt()), func() {
+				actualResult = SigFigRound(tc.decimal, tc.tenToSigFig)
 				require.Equal(
 					t,
 					tc.expectedResult,
 					actualResult,
 					fmt.Sprintf("test %d failed: expected value & actual value should be equal", i),
 				)
-			}
-			if expPanic {
-				require.Panics(t, f)
-			} else {
-				f()
-			}
+			})
 		})
 
 	}

--- a/osmomath/sigfig_round_test.go
+++ b/osmomath/sigfig_round_test.go
@@ -7,8 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
 )
 
 func TestSigFigRound(t *testing.T) {
@@ -77,16 +75,21 @@ func TestSigFigRound(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var actualResult sdk.Dec
-			osmoassert.ConditionalPanic(t, tc.tenToSigFig.Equal(sdk.ZeroInt()), func() {
-				actualResult = SigFigRound(tc.decimal, tc.tenToSigFig)
+			expPanic := tc.tenToSigFig.IsZero()
+			f := func() {
+				actualResult := SigFigRound(tc.decimal, tc.tenToSigFig)
 				require.Equal(
 					t,
 					tc.expectedResult,
 					actualResult,
 					fmt.Sprintf("test %d failed: expected value & actual value should be equal", i),
 				)
-			})
+			}
+			if expPanic {
+				require.Panics(t, f)
+			} else {
+				f()
+			}
 		})
 
 	}

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -30,6 +30,9 @@ var (
 	// SpotPriceSigFigs is the amount of significant figures used in return value of calculate SpotPrice
 	SpotPriceSigFigs = sdk.NewDec(10).Power(SigFigsExponent).TruncateInt()
 	// MaxSpotPrice is the maximum supported spot price. Anything greater than this will error.
+	// Internal note: Ctrl+F for MaxSpotPrice in code if ever changed.
+	// Other tests depend on being equal to MaxSpotPrice,
+	// but don't directly import it due to import issues.
 	MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
 
 	// MultihopSwapFeeMultiplierForOsmoPools if a swap fees multiplier for trades consists of just two OSMO pools during a single transaction.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Needed to split osmomath into its own go.mod

This basically involved making an exported var for `gammtypes.MaxSpotPrice`, and removing Conditional Panic cases. Only affects test files.