### PR TITLE
refactor(app/apptesting): PrepareBalancerPool helpers (simplifying swaprouter merge PR)

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -151,6 +151,7 @@ func (s *KeeperTestHelper) PrepareCustomBalancerPool(assets []balancer.PoolAsset
 }
 
 // PrepareCustomBalancerPoolFromCoins sets up a Balancer pool with an array of coins and given parameters
+// The coins are converted to pool assets where each asset has a weight of 1.
 func (s *KeeperTestHelper) PrepareCustomBalancerPoolFromCoins(coins sdk.Coins, params balancer.PoolParams) uint64 {
 	var poolAssets []balancer.PoolAsset
 	for _, coin := range coins {

--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -145,7 +145,7 @@ func (s *KeeperTestHelper) PrepareCustomBalancerPool(assets []balancer.PoolAsset
 	s.FundAcc(s.TestAccs[0], fundCoins)
 
 	msg := balancer.NewMsgCreateBalancerPool(s.TestAccs[0], params, assets, "")
-	poolId, err := s.App.GAMMKeeper.CreatePool(s.Ctx, msg)
+	poolId, err := s.App.SwapRouterKeeper.CreatePool(s.Ctx, msg)
 	s.NoError(err)
 	return poolId
 }

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -782,7 +782,7 @@ func (suite *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 			}
 
 			poolAssets := []balancer.PoolAsset{defaultBaseAsset, defaultQuoteAsset}
-			poolId := suite.PrepareBalancerPoolWithPoolAsset(poolAssets)
+			poolId := suite.PrepareCustomBalancerPool(poolAssets, balancer.PoolParams{SwapFee: sdk.ZeroDec(), ExitFee: sdk.ZeroDec()})
 
 			pool, err := suite.App.GAMMKeeper.GetPoolAndPoke(suite.Ctx, poolId)
 			suite.Require().NoError(err, "test: %s", tc.name)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

https://github.com/osmosis-labs/osmosis/pull/3764 needs `PrepareBalancerPool` helper that takes coins and pool params.

This PR introduces these helpers and slightly cleans them up.

- Introduced `PrapareCustomBalancerPool` that takes pool assets and pool params
- Introduced `PrepareCustomBalancerPoolFromCoins` that takes coins and pool params. Each coin is converted to asset with a weight of 1
- Removed `PrepareBalancerPoolWithPoolAssets` that takes pool assets only. There was only one use case. Replaced with `PrepareCustomBalancerPool instead
- Reused all existing helpers where applicable to reduce code duplication

For example, `PrepareBalancerPoolWithPoolAssets` was