### PR TITLE
Make osmoutils store + module account tests not import osmosis

### DIFF
--- a/osmoutils/module_account_test.go
+++ b/osmoutils/module_account_test.go
@@ -1,66 +1,66 @@
 package osmoutils_test
 
-// import (
-// 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-// 	sdk "github.com/cosmos/cosmos-sdk/types"
-// 	"github.com/cosmos/cosmos-sdk/types/address"
-// 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-// 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
-// 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
-// )
+	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
+	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+)
 
-// func (s *TestSuite) TestCreateModuleAccount() {
-// 	baseWithAddr := func(addr sdk.AccAddress) authtypes.AccountI {
-// 		acc := authtypes.ProtoBaseAccount()
-// 		acc.SetAddress(addr)
-// 		return acc
-// 	}
-// 	userAccViaSeqnum := func(addr sdk.AccAddress) authtypes.AccountI {
-// 		base := baseWithAddr(addr)
-// 		base.SetSequence(2)
-// 		return base
-// 	}
-// 	userAccViaPubkey := func(addr sdk.AccAddress) authtypes.AccountI {
-// 		base := baseWithAddr(addr)
-// 		base.SetPubKey(secp256k1.GenPrivKey().PubKey())
-// 		return base
-// 	}
-// 	defaultModuleAccAddr := address.Module("dummy module", []byte{1})
-// 	testcases := map[string]struct {
-// 		priorAccounts []authtypes.AccountI
-// 		moduleAccAddr sdk.AccAddress
-// 		expErr        bool
-// 	}{
-// 		"no prior acc": {
-// 			priorAccounts: []authtypes.AccountI{},
-// 			moduleAccAddr: defaultModuleAccAddr,
-// 			expErr:        false,
-// 		},
-// 		"prior empty acc at addr": {
-// 			priorAccounts: []authtypes.AccountI{baseWithAddr(defaultModuleAccAddr)},
-// 			moduleAccAddr: defaultModuleAccAddr,
-// 			expErr:        false,
-// 		},
-// 		"prior user acc at addr (sequence)": {
-// 			priorAccounts: []authtypes.AccountI{userAccViaSeqnum(defaultModuleAccAddr)},
-// 			moduleAccAddr: defaultModuleAccAddr,
-// 			expErr:        true,
-// 		},
-// 		"prior user acc at addr (pubkey)": {
-// 			priorAccounts: []authtypes.AccountI{userAccViaPubkey(defaultModuleAccAddr)},
-// 			moduleAccAddr: defaultModuleAccAddr,
-// 			expErr:        true,
-// 		},
-// 	}
-// 	for name, tc := range testcases {
-// 		s.Run(name, func() {
-// 			s.SetupTest()
-// 			for _, priorAcc := range tc.priorAccounts {
-// 				s.accountKeeper.SetAccount(s.ctx, priorAcc)
-// 			}
-// 			err := osmoutils.CreateModuleAccount(s.ctx, s.accountKeeper, tc.moduleAccAddr)
-// 			osmoassert.ConditionalError(s.T(), tc.expErr, err)
-// 		})
-// 	}
-// }
+func (s *TestSuite) TestCreateModuleAccount() {
+	baseWithAddr := func(addr sdk.AccAddress) authtypes.AccountI {
+		acc := authtypes.ProtoBaseAccount()
+		acc.SetAddress(addr)
+		return acc
+	}
+	userAccViaSeqnum := func(addr sdk.AccAddress) authtypes.AccountI {
+		base := baseWithAddr(addr)
+		base.SetSequence(2)
+		return base
+	}
+	userAccViaPubkey := func(addr sdk.AccAddress) authtypes.AccountI {
+		base := baseWithAddr(addr)
+		base.SetPubKey(secp256k1.GenPrivKey().PubKey())
+		return base
+	}
+	defaultModuleAccAddr := address.Module("dummy module", []byte{1})
+	testcases := map[string]struct {
+		priorAccounts []authtypes.AccountI
+		moduleAccAddr sdk.AccAddress
+		expErr        bool
+	}{
+		"no prior acc": {
+			priorAccounts: []authtypes.AccountI{},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        false,
+		},
+		"prior empty acc at addr": {
+			priorAccounts: []authtypes.AccountI{baseWithAddr(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        false,
+		},
+		"prior user acc at addr (sequence)": {
+			priorAccounts: []authtypes.AccountI{userAccViaSeqnum(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        true,
+		},
+		"prior user acc at addr (pubkey)": {
+			priorAccounts: []authtypes.AccountI{userAccViaPubkey(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        true,
+		},
+	}
+	for name, tc := range testcases {
+		s.Run(name, func() {
+			s.SetupTest()
+			for _, priorAcc := range tc.priorAccounts {
+				s.accountKeeper.SetAccount(s.ctx, priorAcc)
+			}
+			err := osmoutils.CreateModuleAccount(s.ctx, s.accountKeeper, tc.moduleAccAddr)
+			osmoassert.ConditionalError(s.T(), tc.expErr, err)
+		})
+	}
+}

--- a/osmoutils/module_account_test.go
+++ b/osmoutils/module_account_test.go
@@ -1,67 +1,66 @@
 package osmoutils_test
 
-import (
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/address"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+// import (
+// 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+// 	sdk "github.com/cosmos/cosmos-sdk/types"
+// 	"github.com/cosmos/cosmos-sdk/types/address"
+// 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
-	"github.com/osmosis-labs/osmosis/v13/osmoutils"
-)
+// 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
+// 	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+// )
 
-func (s *TestSuite) TestCreateModuleAccount() {
-	baseWithAddr := func(addr sdk.AccAddress) authtypes.AccountI {
-		acc := authtypes.ProtoBaseAccount()
-		acc.SetAddress(addr)
-		return acc
-	}
-	userAccViaSeqnum := func(addr sdk.AccAddress) authtypes.AccountI {
-		base := baseWithAddr(addr)
-		base.SetSequence(2)
-		return base
-	}
-	userAccViaPubkey := func(addr sdk.AccAddress) authtypes.AccountI {
-		base := baseWithAddr(addr)
-		base.SetPubKey(secp256k1.GenPrivKey().PubKey())
-		return base
-	}
-	defaultModuleAccAddr := address.Module("dummy module", []byte{1})
-	testcases := map[string]struct {
-		priorAccounts []authtypes.AccountI
-		moduleAccAddr sdk.AccAddress
-		expErr        bool
-	}{
-		"no prior acc": {
-			priorAccounts: []authtypes.AccountI{},
-			moduleAccAddr: defaultModuleAccAddr,
-			expErr:        false,
-		},
-		"prior empty acc at addr": {
-			priorAccounts: []authtypes.AccountI{baseWithAddr(defaultModuleAccAddr)},
-			moduleAccAddr: defaultModuleAccAddr,
-			expErr:        false,
-		},
-		"prior user acc at addr (sequence)": {
-			priorAccounts: []authtypes.AccountI{userAccViaSeqnum(defaultModuleAccAddr)},
-			moduleAccAddr: defaultModuleAccAddr,
-			expErr:        true,
-		},
-		"prior user acc at addr (pubkey)": {
-			priorAccounts: []authtypes.AccountI{userAccViaPubkey(defaultModuleAccAddr)},
-			moduleAccAddr: defaultModuleAccAddr,
-			expErr:        true,
-		},
-	}
-	for name, tc := range testcases {
-		s.Run(name, func() {
-			s.SetupTest()
-			for _, priorAcc := range tc.priorAccounts {
-				s.App.AccountKeeper.SetAccount(s.Ctx, priorAcc)
-			}
-			err := osmoutils.CreateModuleAccount(s.Ctx, s.App.AccountKeeper, tc.moduleAccAddr)
-			osmoassert.ConditionalError(s.T(), tc.expErr, err)
-		})
-	}
-
-}
+// func (s *TestSuite) TestCreateModuleAccount() {
+// 	baseWithAddr := func(addr sdk.AccAddress) authtypes.AccountI {
+// 		acc := authtypes.ProtoBaseAccount()
+// 		acc.SetAddress(addr)
+// 		return acc
+// 	}
+// 	userAccViaSeqnum := func(addr sdk.AccAddress) authtypes.AccountI {
+// 		base := baseWithAddr(addr)
+// 		base.SetSequence(2)
+// 		return base
+// 	}
+// 	userAccViaPubkey := func(addr sdk.AccAddress) authtypes.AccountI {
+// 		base := baseWithAddr(addr)
+// 		base.SetPubKey(secp256k1.GenPrivKey().PubKey())
+// 		return base
+// 	}
+// 	defaultModuleAccAddr := address.Module("dummy module", []byte{1})
+// 	testcases := map[string]struct {
+// 		priorAccounts []authtypes.AccountI
+// 		moduleAccAddr sdk.AccAddress
+// 		expErr        bool
+// 	}{
+// 		"no prior acc": {
+// 			priorAccounts: []authtypes.AccountI{},
+// 			moduleAccAddr: defaultModuleAccAddr,
+// 			expErr:        false,
+// 		},
+// 		"prior empty acc at addr": {
+// 			priorAccounts: []authtypes.AccountI{baseWithAddr(defaultModuleAccAddr)},
+// 			moduleAccAddr: defaultModuleAccAddr,
+// 			expErr:        false,
+// 		},
+// 		"prior user acc at addr (sequence)": {
+// 			priorAccounts: []authtypes.AccountI{userAccViaSeqnum(defaultModuleAccAddr)},
+// 			moduleAccAddr: defaultModuleAccAddr,
+// 			expErr:        true,
+// 		},
+// 		"prior user acc at addr (pubkey)": {
+// 			priorAccounts: []authtypes.AccountI{userAccViaPubkey(defaultModuleAccAddr)},
+// 			moduleAccAddr: defaultModuleAccAddr,
+// 			expErr:        true,
+// 		},
+// 	}
+// 	for name, tc := range testcases {
+// 		s.Run(name, func() {
+// 			s.SetupTest()
+// 			for _, priorAcc := range tc.priorAccounts {
+// 				s.accountKeeper.SetAccount(s.ctx, priorAcc)
+// 			}
+// 			err := osmoutils.CreateModuleAccount(s.ctx, s.accountKeeper, tc.moduleAccAddr)
+// 			osmoassert.ConditionalError(s.T(), tc.expErr, err)
+// 		})
+// 	}
+// }

--- a/osmoutils/noapptest/cdc.go
+++ b/osmoutils/noapptest/cdc.go
@@ -1,0 +1,45 @@
+package noapptest
+
+// NOTE: This file is pulled from the SDK:
+// https://github.com/cosmos/cosmos-sdk/blob/2eb51447494163bc9beef1b2cc8aa91c3691b2a7/types/module/testutil/codec.go#L23
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/std"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+)
+
+// TestEncodingConfig defines an encoding configuration that is used for testing
+// purposes. Note, MakeTestEncodingConfig takes a series of AppModuleBasic types
+// which should only contain the relevant module being tested and any potential
+// dependencies.
+type TestEncodingConfig struct {
+	InterfaceRegistry types.InterfaceRegistry
+	Codec             codec.Codec
+	TxConfig          client.TxConfig
+	Amino             *codec.LegacyAmino
+}
+
+func MakeTestEncodingConfig(modules ...module.AppModuleBasic) TestEncodingConfig {
+	cdc := codec.NewLegacyAmino()
+	interfaceRegistry := types.NewInterfaceRegistry()
+	codec := codec.NewProtoCodec(interfaceRegistry)
+
+	encCfg := TestEncodingConfig{
+		InterfaceRegistry: interfaceRegistry,
+		Codec:             codec,
+		TxConfig:          tx.NewTxConfig(codec, tx.DefaultSignModes),
+		Amino:             cdc,
+	}
+
+	mb := module.NewBasicManager(modules...)
+
+	std.RegisterLegacyAminoCodec(encCfg.Amino)
+	std.RegisterInterfaces(encCfg.InterfaceRegistry)
+	mb.RegisterLegacyAminoCodec(encCfg.Amino)
+	mb.RegisterInterfaces(encCfg.InterfaceRegistry)
+
+	return encCfg
+}

--- a/osmoutils/noapptest/ctx.go
+++ b/osmoutils/noapptest/ctx.go
@@ -1,4 +1,4 @@
-package osmoutils
+package noapptest
 
 import (
 	"time"
@@ -11,7 +11,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-func NoAppCtxWithStore(keys []sdk.StoreKey, header tmproto.Header, isCheckTx bool) sdk.Context {
+func CtxWithStoreKeys(keys []sdk.StoreKey, header tmproto.Header, isCheckTx bool) sdk.Context {
 	db := dbm.NewMemDB()
 	logger := log.NewNopLogger()
 	cms := store.NewCommitMultiStore(db, logger)
@@ -25,8 +25,8 @@ func NoAppCtxWithStore(keys []sdk.StoreKey, header tmproto.Header, isCheckTx boo
 	return sdk.NewContext(cms, header, isCheckTx, logger)
 }
 
-func DefaultNoAppCtxWithStore(storeKeys []sdk.StoreKey) sdk.Context {
+func DefaultCtxWithStoreKeys(storeKeys []sdk.StoreKey) sdk.Context {
 	header := tmproto.Header{Height: 1, ChainID: "osmoutils-test-1", Time: time.Now().UTC()}
 	deliverTx := false
-	return NoAppCtxWithStore(storeKeys, header, deliverTx)
+	return CtxWithStoreKeys(storeKeys, header, deliverTx)
 }

--- a/osmoutils/test_ctx.go
+++ b/osmoutils/test_ctx.go
@@ -1,0 +1,32 @@
+package osmoutils
+
+import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	dbm "github.com/tendermint/tm-db"
+)
+
+func NoAppCtxWithStore(keys []sdk.StoreKey, header tmproto.Header, isCheckTx bool) sdk.Context {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	cms := store.NewCommitMultiStore(db, logger)
+	for _, key := range keys {
+		cms.MountStoreWithDB(key, sdk.StoreTypeIAVL, nil)
+	}
+	err := cms.LoadLatestVersion()
+	if err != nil {
+		panic(err)
+	}
+	return sdk.NewContext(cms, header, isCheckTx, logger)
+}
+
+func DefaultNoAppCtxWithStore(storeKeys []sdk.StoreKey) sdk.Context {
+	header := tmproto.Header{Height: 1, ChainID: "osmoutils-test-1", Time: time.Now().UTC()}
+	deliverTx := false
+	return NoAppCtxWithStore(storeKeys, header, deliverTx)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --

## What is the purpose of the change

As part of getting osmoutils into its own go.mod, makes its store tests and module accounts test no longer depend on integrated osmosis testing. Instead we directly setup a custom store for store tests, and directly wire an auth keeper for module account testing.

What remains to get osmoutils into its own go.mod is:

- [ ] Move osmoassert from app/apptesting/osmoassert into osmoutils/osmoassert
- [ ] Make store_test no longer use twaptypes, as "place holder proto message thats not sdk.ProtoDec"

I plan to do those two in separate PRs.

These helpers in `noapptest` made here should suffice for also enabling us to put `x/downtime-detector` and `x/epochs` into their own go.mod.

## Brief Changelog

No public facing change, just alters tests.

## Testing and Verifying

The same tests still pass, just without importing osmosis repo.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? N/A