### PR TITLE
test(x/twap): move three asset same record test to TestComputeTwap

### DIFF
--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -557,7 +557,6 @@ type computeTwapTestCase struct {
 	expPanic       bool
 }
 
-
 // TestPruneRecords tests that twap records earlier than
 // current block time - RecordHistoryKeepPeriod are pruned from the store
 // while keeping the newest record before the above time threshold.
@@ -1332,6 +1331,21 @@ func (s *TestSuite) TestComputeTwap() {
 		"geometric only: accumulator = log(10)*OneSec, t=5s. 0 base accum": geometricTestCaseFromDeltas0(
 			s, sdk.ZeroDec(), geometricTenSecAccum, 5*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(5*1000))),
 		"geometric only: accumulator = log(10)*OneSec, t=100s. 0 base accum (asset 1)": geometricTestCaseFromDeltas1(s, sdk.ZeroDec(), geometricTenSecAccum, 100*time.Second, sdk.OneDec().Quo(twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000)))),
+
+		"three asset same record: asset1, end spot price = 1": {
+			startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true)[1],
+			endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true)[1],
+			quoteAsset:  denom2,
+			expTwap:     sdk.OneDec(),
+			twapStrategies: []twap.TwapStrategy{
+				&twap.ArithmeticTwapStrategy{
+					TwapKeeper: *s.App.TwapKeeper,
+				},
+				&twap.GeometricTwapStrategy{
+					TwapKeeper: *s.App.TwapKeeper,
+				},
+			},
+		},
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
@@ -1429,7 +1443,6 @@ func (s *TestSuite) TestTwapPow() {
 	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 	s.Require().True(osmomath.MustNewDecFromStr(fmt.Sprint(result_by_mathPow)).Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 }
-
 
 func testCaseFromDeltas(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {
 	return computeTwapTestCase{

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -32,7 +32,6 @@ func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.T
 	}
 	timeDelta := endRecord.Time.Sub(startRecord.Time)
 	return types.AccumDiffDivDuration(accumDiff, timeDelta)
-
 }
 
 // computeTwap computes and returns a geometric TWAP between

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -52,6 +52,9 @@ func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 			s, pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 
 		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(s, sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+
+		// TODO: add a test where time difference between start and end records is zero,
+		// making it a panic.
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
@@ -147,12 +150,6 @@ func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Arithmetic() {
 			quoteAsset:  []string{denom0, denom0, denom1},
 			expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
 		},
-		// "three asset same record: asset1, end spot price = 1": {
-		// 	startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	quoteAsset:  []string{denom1, denom2, denom2},
-		// 	expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		// },
 		"three asset. accumulator = 10*OneSec, t=5s. 0 base accum": testThreeAssetCaseFromDeltas(
 			sdk.ZeroDec(), tenSecAccum, 5*time.Second, sdk.NewDec(2)),
 
@@ -191,12 +188,6 @@ func (s *TestSuite) TestComputeArithmeticTwap_ThreeAsset_Geometric() {
 			quoteAsset:  []string{denom0, denom0, denom1},
 			expTwap:     []sdk.Dec{sdk.NewDec(10), sdk.NewDec(10), sdk.NewDec(10)},
 		},
-		// "three asset same record: asset1, end spot price = 1": {
-		// 	startRecord: newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	endRecord:   newThreeAssetOneSidedRecord(baseTime, sdk.ZeroDec(), true),
-		// 	quoteAsset:  []string{denom1, denom2, denom2},
-		// 	expTwap:     []sdk.Dec{sdk.OneDec(), sdk.OneDec(), sdk.OneDec()},
-		// },
 		"three asset. accumulator = 5*3Sec, t=3s, no start accum": testThreeAssetCaseFromDeltas(
 			sdk.ZeroDec(), fiveFor3Sec, 3*time.Second, five),
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The old three asset twap equal record test assumes additional validation from `computeTwap` function. Therefore, we should move the test case from being made against strategies to be against `computeTwap` function.

Additionally, we should add a test case against the arithmetic twap strategy where we end up having a time delta of zero, making it panic (Currently marked as TODO)
