### PR TITLE
chore: add swaprouter change to localosmosis

### DIFF
--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -55,8 +55,8 @@ edit_genesis () {
     dasel put string -f $GENESIS '.app_state.mint.params.mint_denom' "uosmo"
     dasel put string -f $GENESIS '.app_state.mint.params.epoch_identifier' "day"
 
-    # Update gamm module
-    dasel put string -f $GENESIS '.app_state.gamm.params.pool_creation_fee.[0].denom' "uosmo"
+    # Update swaprouter module
+    dasel put string -f $GENESIS '.app_state.swaprouter.params.pool_creation_fee.[0].denom' "uosmo"
 
     # Update txfee basedenom
     dasel put string -f $GENESIS '.app_state.txfees.basedenom' "uosmo"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3725 

## What is the purpose of the change

While we initialize the swaprouter already with uosmo as the default denom, it is good practice to ensure this gets overridden when making a new localnet in the case this unexpectedly changes.

This PR simply removes the commented out code that changed the default pool creation fee denom from the gamm module to where it now exists (the swaprouter module)