### PR TITLE
[CL]Misc: Add Denom Check upon pool creation

### DIFF
--- a/x/concentrated-liquidity/model/msgs.go
+++ b/x/concentrated-liquidity/model/msgs.go
@@ -85,6 +85,7 @@ func (msg MsgCreateConcentratedPool) PoolCreator() sdk.AccAddress {
 }
 
 func (msg MsgCreateConcentratedPool) Validate(ctx sdk.Context) error {
+
 	// TODO: Add check that denom exists on chain
 	// https://github.com/osmosis-labs/osmosis/issues/3723
 	return msg.ValidateBasic()

--- a/x/concentrated-liquidity/model/msgs.go
+++ b/x/concentrated-liquidity/model/msgs.go
@@ -85,9 +85,6 @@ func (msg MsgCreateConcentratedPool) PoolCreator() sdk.AccAddress {
 }
 
 func (msg MsgCreateConcentratedPool) Validate(ctx sdk.Context) error {
-
-	// TODO: Add check that denom exists on chain
-	// https://github.com/osmosis-labs/osmosis/issues/3723
 	return msg.ValidateBasic()
 }
 

--- a/x/concentrated-liquidity/msg_server.go
+++ b/x/concentrated-liquidity/msg_server.go
@@ -2,6 +2,7 @@ package concentrated_liquidity
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -36,6 +37,16 @@ var (
 // It will create a dedicated module account for the pool and sends the initial liquidity to the created module account.
 func (server msgServer) CreateConcentratedPool(goCtx context.Context, msg *clmodel.MsgCreateConcentratedPool) (*clmodel.MsgCreateConcentratedPoolResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	_, denomExists := server.keeper.bankKeeper.GetDenomMetaData(ctx, msg.Denom0)
+	if !denomExists {
+		return nil, fmt.Errorf("received denom0 with invalid metadata: %s", msg.Denom0)
+	}
+
+	_, denomExists = server.keeper.bankKeeper.GetDenomMetaData(ctx, msg.Denom1)
+	if !denomExists {
+		return nil, fmt.Errorf("received denom1 with invalid metadata: %s", msg.Denom1)
+	}
 
 	poolId, err := server.keeper.swaprouterKeeper.CreatePool(ctx, msg)
 	if err != nil {

--- a/x/concentrated-liquidity/types/expected_keepers.go
+++ b/x/concentrated-liquidity/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
@@ -9,6 +10,7 @@ import (
 // BankKeeper defines the banking contract that must be fulfilled when
 // creating a x/concentrated-liquidity keeper.
 type BankKeeper interface {
+	GetDenomMetaData(ctx sdk.Context, denom string) (banktypes.Metadata, bool)
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3723 

## What is the purpose of the change
Adds denom check upon pool creation via msg server. 
The original design discussed in the issue was doing the validation using msg validation method, but this is found impossible, as we need to use bank keeper for the verification.

The denom check done here is namely the `GetDenomMetaData` check using Bank keeper, reviewers please confirm if this is the correct check we want to do here.

