### PR TITLE
feat(x/twap): use exp2 in twapPow; add overflow test

### DIFF
--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -15,8 +15,6 @@ type (
 	GeometricTwapStrategy  = geometric
 )
 
-var GeometricTwapMathBase = geometricTwapMathBase
-
 func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
 	k.storeNewRecord(ctx, record)
 }

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -11,15 +11,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
-// geometricTwapMathBase is the base used for geometric twap calculation
-// in logarithm and power math functions.
-// See twapLog and computeGeometricTwap functions for more details.
-var (
-	geometricTwapMathBase = sdk.NewDec(2)
-	// TODO: analyze choice.
-	geometricTwapPowPrecision = sdk.MustNewDecFromStr("0.00000001")
-)
-
 func newTwapRecord(k types.AmmInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
 	denom0, denom1, err := types.LexicographicalOrderDenoms(denom0, denom1)
 	if err != nil {
@@ -268,13 +259,11 @@ func computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quote
 }
 
 // twapLog returns the logarithm of the given spot price, base 2.
-// TODO: basic test
 func twapLog(price sdk.Dec) sdk.Dec {
 	return osmomath.BigDecFromSDKDec(price).LogBase2().SDKDec()
 }
 
 // twapPow exponentiates the geometricTwapMathBase to the given exponent.
-// TODO: basic test and benchmark.
 func twapPow(exponent sdk.Dec) sdk.Dec {
-	return osmomath.PowApprox(geometricTwapMathBase, exponent, geometricTwapPowPrecision)
+	return osmomath.Exp2(osmomath.BigDecFromSDKDec(exponent)).SDKDec()
 }

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -265,5 +265,9 @@ func twapLog(price sdk.Dec) sdk.Dec {
 
 // twapPow exponentiates the geometricTwapMathBase to the given exponent.
 func twapPow(exponent sdk.Dec) sdk.Dec {
+	exp2 := osmomath.Exp2(osmomath.BigDecFromSDKDec(exponent.Abs()))
+	if exponent.IsNegative() {
+		return osmomath.OneDec().Quo(exp2).SDKDec()
+	}
 	return osmomath.Exp2(osmomath.BigDecFromSDKDec(exponent)).SDKDec()
 }

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -263,7 +263,7 @@ func twapLog(price sdk.Dec) sdk.Dec {
 	return osmomath.BigDecFromSDKDec(price).LogBase2().SDKDec()
 }
 
-// twapPow exponentiates the geometricTwapMathBase to the given exponent.
+// twapPow exponentiates 2 to the given exponent.
 func twapPow(exponent sdk.Dec) sdk.Dec {
 	exp2 := osmomath.Exp2(osmomath.BigDecFromSDKDec(exponent.Abs()))
 	if exponent.IsNegative() {

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -269,5 +269,5 @@ func twapPow(exponent sdk.Dec) sdk.Dec {
 	if exponent.IsNegative() {
 		return osmomath.OneDec().Quo(exp2).SDKDec()
 	}
-	return osmomath.Exp2(osmomath.BigDecFromSDKDec(exponent)).SDKDec()
+	return exp2.SDKDec()
 }

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -3,7 +3,6 @@ package twap_test
 import (
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -1319,31 +1318,34 @@ func (s *TestSuite) TestComputeArithmeticTwapWithSpotPriceError() {
 	}
 }
 
-func (s *TestSuite) TestTwapLog() {
-	var expectedErrTolerance = osmomath.MustNewDecFromStr("0.000000000000000100")
-	// "Twaplog{912648174127941279170121098210.928219201902041311} = 99.525973560175362367"
-	// From: https://www.wolframalpha.com/input?i2d=true&i=log+base+2+of+912648174127941279170121098210.928219201902041311+with+20+digits
-	var priceValue = osmomath.MustNewDecFromStr("912648174127941279170121098210.928219201902041311")
-	var expectedValue = osmomath.MustNewDecFromStr("99.525973560175362367")
+// TestTwapLog_CorrectBase tests that the base of 2 is used for the twap log function.
+// log_2{16} = 4
+func (s *TestSuite) TestTwapLog_CorrectBase() {
+	logOf := sdk.NewDec(16)
+	expectedValue := sdk.NewDec(4)
 
-	result := twap.TwapLog(priceValue.SDKDec())
-	result_by_customBaseLog := priceValue.CustomBaseLog(geometricTwapMathBase)
-	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
-	s.Require().True(result_by_customBaseLog.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
+	result := twap.TwapLog(logOf)
+
+	s.Require().Equal(expectedValue, result)
 }
 
-// TestTwapPow_CorrectBase tests that the right base is used for the twap power function.
+// TestTwapPow_CorrectBase tests that the base of 2 is used for the twap power function.
+// 2^3 = 8
 func (s *TestSuite) TestTwapPow_CorrectBase() {
-	var expectedErrTolerance = osmomath.MustNewDecFromStr("0.00000100")
-	// "TwapPow(0.5) = 1.41421356"
-	// From: https://www.wolframalpha.com/input?i2d=true&i=power+base+2+exponent+0.5+with+9+digits
-	exponentValue := osmomath.MustNewDecFromStr("0.5")
-	expectedValue := osmomath.MustNewDecFromStr("1.41421356")
+	exponentValue := osmomath.NewBigDec(3)
+	expectedValue := sdk.NewDec(8)
 
 	result := twap.TwapPow(exponentValue.SDKDec())
-	result_by_mathPow := math.Pow(geometricTwapMathBase.MustFloat64(), exponentValue.SDKDec().MustFloat64())
-	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
-	s.Require().True(osmomath.MustNewDecFromStr(fmt.Sprint(result_by_mathPow)).Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
+
+	s.Require().Equal(expectedValue, result)
+}
+
+// TestTwapPow_NegativeExponent tests that twap pow can handle a negative exponent
+// 2^-1 = 0.5
+func (s *TestSuite) TestTwapPow_NegativeExponent() {
+	expectedResult := sdk.MustNewDecFromStr("0.5")
+	result := twap.TwapPow(oneDec.Neg())
+	s.Require().Equal(expectedResult, result)
 }
 
 func testCaseFromDeltas(s *TestSuite, startAccum, accumDiff sdk.Dec, timeDelta time.Duration, expectedTwap sdk.Dec) computeTwapTestCase {

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -1327,12 +1327,13 @@ func (s *TestSuite) TestTwapLog() {
 	var expectedValue = osmomath.MustNewDecFromStr("99.525973560175362367")
 
 	result := twap.TwapLog(priceValue.SDKDec())
-	result_by_customBaseLog := priceValue.CustomBaseLog(osmomath.BigDecFromSDKDec(twap.GeometricTwapMathBase))
+	result_by_customBaseLog := priceValue.CustomBaseLog(geometricTwapMathBase)
 	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 	s.Require().True(result_by_customBaseLog.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 }
 
-func (s *TestSuite) TestTwapPow() {
+// TestTwapPow_CorrectBase tests that the right base is used for the twap power function.
+func (s *TestSuite) TestTwapPow_CorrectBase() {
 	var expectedErrTolerance = osmomath.MustNewDecFromStr("0.00000100")
 	// "TwapPow(0.5) = 1.41421356"
 	// From: https://www.wolframalpha.com/input?i2d=true&i=power+base+2+exponent+0.5+with+9+digits
@@ -1340,7 +1341,7 @@ func (s *TestSuite) TestTwapPow() {
 	expectedValue := osmomath.MustNewDecFromStr("1.41421356")
 
 	result := twap.TwapPow(exponentValue.SDKDec())
-	result_by_mathPow := math.Pow(twap.GeometricTwapMathBase.MustFloat64(), exponentValue.SDKDec().MustFloat64())
+	result_by_mathPow := math.Pow(geometricTwapMathBase.MustFloat64(), exponentValue.SDKDec().MustFloat64())
 	s.Require().True(expectedValue.Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 	s.Require().True(osmomath.MustNewDecFromStr(fmt.Sprint(result_by_mathPow)).Sub(osmomath.BigDecFromSDKDec(result)).Abs().LTE(expectedErrTolerance))
 }

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -2,7 +2,11 @@ package twap
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v13/osmomath"
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 )
 
 // twapStrategy is an interface for computing TWAPs.
@@ -42,11 +46,14 @@ func (s *geometric) computeTwap(startRecord types.TwapRecord, endRecord types.Tw
 	timeDelta := endRecord.Time.Sub(startRecord.Time)
 	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
 
-	geometricMeanDenom0 := twapPow(arithmeticMeanOfLogPrices)
+	result := twapPow(arithmeticMeanOfLogPrices)
 	// N.B.: Geometric mean of recprocals is reciprocal of geometric mean.
 	// https://proofwiki.org/wiki/Geometric_Mean_of_Reciprocals_is_Reciprocal_of_Geometric_Mean
 	if quoteAsset == startRecord.Asset1Denom {
-		return sdk.OneDec().Quo(geometricMeanDenom0)
+		result = sdk.OneDec().Quo(result)
 	}
-	return geometricMeanDenom0
+
+	// N.B. we round because this is the max number of significant figures supported
+	// by the underlying spot price function.
+	return osmomath.SigFigRound(result, gammtypes.SpotPriceSigFigs)
 }

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -22,6 +22,10 @@ type computeTwapTestCase struct {
 	expPanic       bool
 }
 
+var (
+	oneHundredYears = OneSec.MulInt64(60 * 60 * 24 * 365 * 100)
+)
+
 // TestComputeArithmeticTwap tests computeTwap on various inputs.
 // The test vectors are structured by setting up different start and records,
 // based on time interval, and their accumulator values.
@@ -310,12 +314,10 @@ func (s *TestSuite) TestTwapLogPow_MaxSpotPrice_NoOverflow() {
 		RoundingDir:             osmomath.RoundDown,
 	}
 
-	oneYear := OneSec.MulInt64(60 * 60 * 24 * 365)
+	oneHundredYearsTimesMaxSpotPrice := oneHundredYears.Mul(gammtypes.MaxSpotPrice)
 
-	oneYearTimesMaxSpotPrice := oneYear.Mul(gammtypes.MaxSpotPrice)
-
-	exponentValue := twap.TwapLog(oneYearTimesMaxSpotPrice)
+	exponentValue := twap.TwapLog(oneHundredYearsTimesMaxSpotPrice)
 	finalValue := twap.TwapPow(exponentValue)
 
-	s.Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(oneYearTimesMaxSpotPrice), osmomath.BigDecFromSDKDec(finalValue)))
+	s.Require().Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(oneHundredYearsTimesMaxSpotPrice), osmomath.BigDecFromSDKDec(finalValue)))
 }

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -310,7 +310,7 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap_ThreeAsset() {
 }
 
 // TestTwapPow_MaxSpotPrice_NoOverflow tests that no overflow occurs at log_2{max spot price values}.
-// and that the epsilot is within the tolerated multiplicative error.
+// and that the epsilon is within the tolerated multiplicative error.
 func (s *TestSuite) TestTwapLogPow_MaxSpotPrice_NoOverflow() {
 	errTolerance := osmomath.ErrTolerance{
 		MultiplicativeTolerance: sdk.OneDec().Quo(sdk.NewDec(10).Power(18)),

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -22,13 +22,6 @@ type computeTwapTestCase struct {
 	expPanic       bool
 }
 
-// geometricTwapMathBase is the base used for geometric twap calculation
-// in logarithm and power math functions.
-// See twapLog and computeGeometricTwap functions for more details.
-var (
-	geometricTwapMathBase = osmomath.NewBigDec(2)
-)
-
 // TestComputeArithmeticTwap tests computeTwap on various inputs.
 // The test vectors are structured by setting up different start and records,
 // based on time interval, and their accumulator values.

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v13/app/apptesting/osmoassert"
 	"github.com/osmosis-labs/osmosis/v13/osmomath"
+	gammtypes "github.com/osmosis-labs/osmosis/v13/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v13/x/twap"
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
@@ -20,6 +21,13 @@ type computeTwapTestCase struct {
 	expErr         bool
 	expPanic       bool
 }
+
+// geometricTwapMathBase is the base used for geometric twap calculation
+// in logarithm and power math functions.
+// See twapLog and computeGeometricTwap functions for more details.
+var (
+	geometricTwapMathBase = osmomath.NewBigDec(2)
+)
 
 // TestComputeArithmeticTwap tests computeTwap on various inputs.
 // The test vectors are structured by setting up different start and records,
@@ -299,4 +307,22 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap_ThreeAsset() {
 			}
 		})
 	}
+}
+
+// TestTwapPow_MaxSpotPrice_NoOverflow tests that no overflow occurs at log_2{max spot price values}.
+// and that the epsilot is within the tolerated multiplicative error.
+func (s *TestSuite) TestTwapLogPow_MaxSpotPrice_NoOverflow() {
+	errTolerance := osmomath.ErrTolerance{
+		MultiplicativeTolerance: sdk.OneDec().Quo(sdk.NewDec(10).Power(18)),
+		RoundingDir:             osmomath.RoundDown,
+	}
+
+	oneYear := OneSec.MulInt64(60 * 60 * 24 * 365)
+
+	oneYearTimesMaxSpotPrice := oneYear.Mul(gammtypes.MaxSpotPrice)
+
+	exponentValue := twap.TwapLog(oneYearTimesMaxSpotPrice)
+	finalValue := twap.TwapPow(exponentValue)
+
+	s.Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(oneYearTimesMaxSpotPrice), osmomath.BigDecFromSDKDec(finalValue)))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3540 

## What is the purpose of the change

This PR switches to use the new `Exp2` function (#3708) in x/twap for computing geometric twap.

It also adds a test at max spot price, showing that there is no overflow.

## Testing and Verifying

This change added overflow test and refactored twap math function tests to be simpler.

Note that adding more hand-calculated tests is tracked in: https://github.com/osmosis-labs/osmosis/issues/3541

On top of this PR, I made a PR with query tests that currently pass: https://github.com/osmosis-labs/osmosis/pull/3802

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable