### PR TITLE
Lower noise of e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ test-e2e: e2e-setup test-e2e-ci
 # does not do any validation about the state of the Docker environment
 # As a result, avoid using this locally.
 test-e2e-ci:
-	@VERSION=$(VERSION) OSMOSIS_E2E=True OSMOSIS_E2E_DEBUG_LOG=True OSMOSIS_E2E_UPGRADE_VERSION=$(E2E_UPGRADE_VERSION)  go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
+	@VERSION=$(VERSION) OSMOSIS_E2E=True OSMOSIS_E2E_DEBUG_LOG=False OSMOSIS_E2E_UPGRADE_VERSION=$(E2E_UPGRADE_VERSION)  go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 # test-e2e-debug runs a full e2e test suite but does
 # not attempt to delete Docker resources at the end.

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -22,7 +22,7 @@ const (
 	maxDebugLogsPerCommand = 3
 )
 
-var errRegex = regexp.MustCompile(`(E|e)rror`)
+var defaultErrRegex = regexp.MustCompile(`(E|e)rror`)
 
 // Manager is a wrapper around all Docker instances, and the Docker API.
 // It provides utilities to run and interact with all Docker containers used within e2e testing.
@@ -125,7 +125,7 @@ func (m *Manager) ExecCmd(t *testing.T, containerName string, command []string, 
 			// Note that this does not match all errors.
 			// This only works if CLI outpurs "Error" or "error"
 			// to stderr.
-			if (errRegex.MatchString(errBufString) || m.isDebugLogEnabled) && maxDebugLogTriesLeft > 0 {
+			if (defaultErrRegex.MatchString(errBufString) || m.isDebugLogEnabled) && maxDebugLogTriesLeft > 0 {
 				t.Log("\nstderr:")
 				t.Log(errBufString)
 
@@ -147,7 +147,8 @@ func (m *Manager) ExecCmd(t *testing.T, containerName string, command []string, 
 		},
 		time.Minute,
 		50*time.Millisecond,
-		"tx returned a non-zero code",
+		fmt.Sprintf("success condition (%s) was not met.\nstdout:\n %s\nstderr:\n %s\n",
+			success, outBuf.String(), errBuf.String()),
 	)
 
 	return outBuf, errBuf, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2653

## What is the purpose of the change

Debugging E2E via CI is pretty unusable. It emits over 13000 log lines right now.

This PR:
* Turns the debug flag off
* Sets it s.t. in event of a tx / general action failing in E2E, we output stdout & stderr as was previously done.

I claim that this will massively reduce log output, and maintain the same debuggability.

## Brief Changelog

- Reduce E2E noisiness in CI

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? N/A