### PR TITLE
[ValSet-Pref] Make Redelegate to valset read all your current stake positions

### DIFF
--- a/x/valset-pref/README.md
+++ b/x/valset-pref/README.md
@@ -71,7 +71,7 @@ and preferences. The weights are in decimal format from 0 to 1 and must add up t
 
 Gets the existing validator-set of the delegator and delegates the given amount. The given amount 
 will be divided based on the weights distributed to the validators. The weights will be unchanged.
-If the user doesnot have an existing validator set use delegators' current staking position.
+If the user does not have an existing validator set use delegators' current staking position.
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
@@ -97,7 +97,7 @@ If the user doesnot have an existing validator set use delegators' current staki
 
 Gets the existing validator-set of the delegator and undelegate the given amount. The amount to undelegate will
 will be divided based on the weights distributed to the validators. The weights will be unchanged! 
-If the user doesnot have an existing validator set use delegators' current staking position.
+If the user does not have an existing validator set use delegators' current staking position.
 The given amount will be divided based on the weights distributed to the validators.
 
 ```go
@@ -125,7 +125,7 @@ The given amount will be divided based on the weights distributed to the validat
 ### MsgWithdrawDelegationRewards
 
 Allows the user to claim rewards based from the existing validator-set. The user can claim rewards from all the validators at once. 
-If the user doesnot have an existing validator set use delegators' current staking position.
+If the user does not have an existing validator set use delegators' current staking position.
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
@@ -134,7 +134,7 @@ If the user doesnot have an existing validator set use delegators' current staki
 ### MsgRedelegateValidatorSet
 
 The redelegation command allows delegators to instantly switch validators. Once the unbonding period has passed, 
-the redelegation is automatically completed in the EndBlocker. If the user doesnot have an existing validator set use delegators' current staking position.
+the redelegation is automatically completed in the EndBlocker. If the user does not have an existing validator set use delegators' current staking position.
 
 ```go
   // delegator is the user who is trying to create a validator-set.

--- a/x/valset-pref/README.md
+++ b/x/valset-pref/README.md
@@ -46,7 +46,7 @@ UnStaking Calculation
 
 ## Messages
 
-### CreateValidatorSetPreference
+### SetValidatorSetPreference
 
 Creates a validator-set of `{valAddr, Weight}` given the delegator address.
 and preferences. The weights are in decimal format from 0 to 1 and must add up to 1.
@@ -67,37 +67,21 @@ and preferences. The weights are in decimal format from 0 to 1 and must add up t
   - check if the validator-set add up to 1.
 - Add owner address to the `KVStore`, where a state of validator-set is stored. 
 
-### UpdateValidatorSetPreference
-
-Updates a validator-set of `{valAddr, Weight}` given the delegator address
-and existing preferences. The weights calculations follow the same rule as `CreateValidatorSetPreference`.
-If a user changes their preferences list, the unstaking logic will run from the old set and 
-restaking to a new set is going to happen behind the scenes.
-
-```go
-    string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
-    repeated ValidatorPreference preferences = 2 [
-      (gogoproto.moretags) = "yaml:\"preferences\"",
-      (gogoproto.nullable) = false
-    ];
-```
-
-**State Modifications:**
-
-- Follows the same rule as `CreateValidatorSetPreference` for weights checks.
-- Update the `KVStore` value for the specific owner address key.
-- Run the undelegate logic and restake the tokens with updated weights. 
-
-### DelegateToValidatorSet
+### MsgDelegateToValidatorSet
 
 Gets the existing validator-set of the delegator and delegates the given amount. The given amount 
-will be divided based on the weights distributed to the validators. The weights will be unchanged 
+will be divided based on the weights distributed to the validators. The weights will be unchanged.
+If the user doesnot have an existing validator set use delegators' current staking position.
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
-    repeated ValidatorPreference preferences = 2 [
-      (gogoproto.moretags) = "yaml:\"preferences\"",
-      (gogoproto.nullable) = false
+    // the amount of tokens the user is trying to delegate.
+    // For ex: delegate 10osmo with validator-set {ValA -> 0.5, ValB -> 0.3, ValC
+    // -> 0.2} our staking logic would attempt to delegate 5osmo to A , 3osmo to
+    // B, 2osmo to C.
+    cosmos.base.v1beta1.Coin coin = 2 [
+      (gogoproto.nullable) = false,
+      (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coin"
     ];
 ```
 
@@ -109,18 +93,23 @@ will be divided based on the weights distributed to the validators. The weights 
   - check overflow/underflow since `Delegate` method takes `sdk.Int` as tokenAmount.
 - use the [Delegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation. 
 
-### UnStakeFromValidatorSet
+### MsgUndelegateFromValidatorSet
 
 Gets the existing validator-set of the delegator and undelegate the given amount. The amount to undelegate will
 will be divided based on the weights distributed to the validators. The weights will be unchanged! 
-
+If the user doesnot have an existing validator set use delegators' current staking position.
 The given amount will be divided based on the weights distributed to the validators.
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
-    repeated ValidatorPreference preferences = 2 [
-      (gogoproto.moretags) = "yaml:\"preferences\"",
-      (gogoproto.nullable) = false
+    // the amount the user wants to undelegate
+    // For ex: Undelegate 10osmo with validator-set {ValA -> 0.5, ValB -> 0.3,
+    // ValC
+    // -> 0.2} our undelegate logic would attempt to undelegate 5osmo from A ,
+    // 3osmo from B, 2osmo from C
+    cosmos.base.v1beta1.Coin coin = 3 [
+      (gogoproto.nullable) = false,
+      (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coin"
     ];
 ```
 
@@ -133,26 +122,30 @@ The given amount will be divided based on the weights distributed to the validat
   - `UnDelegate` method takes `sdk.Dec` as tokenAmount, so check if overflow/underflow case is relevant.
 - use the [UnDelegate](https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/keeper/delegation.go#L614) method from the cosmos-sdk to handle delegation. 
 
-### WithdrawDelegationRewards
+### MsgWithdrawDelegationRewards
 
 Allows the user to claim rewards based from the existing validator-set. The user can claim rewards from all the validators at once. 
+If the user doesnot have an existing validator set use delegators' current staking position.
 
 ```go
     string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
 ```
 
-## Code Layout 
+### MsgRedelegateValidatorSet
 
-The Code Layout is very similar to TWAP module.
+The redelegation command allows delegators to instantly switch validators. Once the unbonding period has passed, 
+the redelegation is automatically completed in the EndBlocker. If the user doesnot have an existing validator set use delegators' current staking position.
 
-- client/* - Implementation of GRPC and CLI queries
-- types/* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
-- twapmodule/validatorsetpreference.go - SDK AppModule interface implementation.
-- api.go - Public API, that other users / modules can/should depend on
-- listeners.go - Defines hooks & calls to logic.go, for triggering actions on 
-- keeper.go - generic SDK boilerplate (defining a wrapper for store keys + params)
-- msg_server.go - handle messages request from client and process responses. 
-- store.go - Managing logic for getting and setting things to underlying stores (KVStore)
+```go
+  // delegator is the user who is trying to create a validator-set.
+  string delegator = 1 [ (gogoproto.moretags) = "yaml:\"delegator\"" ];
+
+  // list of {valAddr, weight} to delegate to
+  repeated ValidatorPreference preferences = 2 [
+    (gogoproto.moretags) = "yaml:\"preferences\"",
+    (gogoproto.nullable) = false
+  ];
+```
 
 ## Redelegate algorithm logic pseudocode
 
@@ -172,6 +165,11 @@ New ValSet        20osmos {ValD-> 0.2, ValE-> 0.2, ValF-> 0.6} [ValD-> 4osmo, Va
         source_validator = validator.address
         // FindMin returns the index and MinAmt of the minimum amount in diffValSet
         target_validator, idx = FindMin(diff_arr)   // gets the index of minValue and the minValue
+
+        // checks if there are any more redelegation possible
+        if target_validator.amount.Equal(0) {
+          break 
+        }
 
         // reDelegationAmt to is the amount to redelegate, which is the min of diffAmount and target_validator
         reDelegationAmt = FindMin(abs(target_validator.amount), validator.amount)
@@ -193,3 +191,16 @@ New ValSet        20osmos {ValD-> 0.2, ValE-> 0.2, ValF-> 0.6} [ValD-> 4osmo, Va
 3. Once you redelegate from ValA -> ValB, you will not be able to redelegate from ValB to another validator for the next 21 days.
   - the validator on the receiving end of redelegation will be on a 21-day redelegation lock
 4. Cannot redelegate to same validator 
+
+## Code Layout 
+
+The Code Layout is very similar to TWAP module.
+
+- client/* - Implementation of GRPC and CLI queries
+- types/* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
+- valpref-module/module.go - SDK AppModule interface implementation.
+- api.go - Public API, that other users / modules can/should depend on
+- listeners.go - Defines hooks & calls to logic.go, for triggering actions on 
+- keeper.go - generic SDK boilerplate (defining a wrapper for store keys + params)
+- msg_server.go - handle messages request from client and process responses. 
+- store.go - Managing logic for getting and setting things to underlying stores (KVStore)

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -68,7 +68,7 @@ func (server msgServer) RedelegateValidatorSet(goCtx context.Context, msg *types
 		return nil, err
 	}
 
-	// get existing delegation if there is not valset set, else get valset
+	// get existing delegation if there is no valset set, else get valset
 	existingSet, err := server.keeper.GetDelegationPreferences(ctx, msg.Delegator)
 	if err != nil {
 		return nil, fmt.Errorf("user has no delegation")

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -75,16 +75,15 @@ func (server msgServer) RedelegateValidatorSet(goCtx context.Context, msg *types
 	}
 
 	// Message 1: override the validator set preference set entry
-	_, err = server.SetValidatorSetPreference(goCtx, &types.MsgSetValidatorSetPreference{
-		Delegator:   msg.Delegator,
-		Preferences: msg.Preferences,
-	})
+	newPreferences, err := server.keeper.SetValidatorSetPreference(ctx, msg.Delegator, msg.Preferences)
 	if err != nil {
 		return nil, err
 	}
 
+	server.keeper.SetValidatorSetPreferences(ctx, msg.Delegator, newPreferences)
+
 	// Message 2: Perform the actual redelegation
-	err = server.keeper.PreformRedelegation(ctx, delegator, existingSet.Preferences, msg.Preferences)
+	err = server.keeper.PreformRedelegation(ctx, delegator, existingSet.Preferences, newPreferences.Preferences)
 	if err != nil {
 		return nil, err
 	}

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -411,85 +411,85 @@ func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 			newPreferences: []types.ValidatorPreference{
 				{
 					ValOperAddress: valAddrs[0],
-					Weight:         sdk.NewDecWithPrec(22, 2), // 0.22
+					Weight:         sdk.NewDecWithPrec(2, 1),
 				},
 				{
 					ValOperAddress: valAddrs[1],
-					Weight:         sdk.NewDecWithPrec(1345, 4), //0.1234
+					Weight:         sdk.NewDecWithPrec(2, 1),
 				},
 				{
 					ValOperAddress: valAddrs[2],
-					Weight:         sdk.NewDecWithPrec(6566, 4),
+					Weight:         sdk.NewDecWithPrec(6, 1),
 				},
 			},
-			amountToDelegate:            sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
+			amountToDelegate:            sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
 			expectedShares:              []sdk.Dec{sdk.NewDec(4_000_000), sdk.NewDec(4_000_000), sdk.NewDec(12_000_000)},
 			setExistingValSetDelegation: true,
 			expectPass:                  true, // addr1 successfully redelegates to (valAddr0, valAddr1, valAddr2)
 		},
-		// {
-		// 	name:      "redelegate to same set of validators",
-		// 	delegator: sdk.AccAddress([]byte("addr1---------------")),
-		// 	newPreferences: []types.ValidatorPreference{
-		// 		{
-		// 			ValOperAddress: valAddrs[0],
-		// 			Weight:         sdk.NewDecWithPrec(3, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[1],
-		// 			Weight:         sdk.NewDecWithPrec(2, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[2],
-		// 			Weight:         sdk.NewDecWithPrec(5, 1),
-		// 		},
-		// 	},
-		// 	amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-		// 	expectPass:       false, // first redelegation already in progress so must end that first
-		// },
-		// {
-		// 	name:      "redelegate to new set, but one validator from old set",
-		// 	delegator: sdk.AccAddress([]byte("addr1---------------")),
-		// 	newPreferences: []types.ValidatorPreference{
-		// 		{
-		// 			ValOperAddress: valAddrs[4],
-		// 			Weight:         sdk.NewDecWithPrec(5, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[1],
-		// 			Weight:         sdk.NewDecWithPrec(3, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[3],
-		// 			Weight:         sdk.NewDecWithPrec(2, 1),
-		// 		},
-		// 	},
-		// 	amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-		// 	expectedShares:   []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
-		// 	expectPass:       false, // this fails because valAddrs[1] is being redelegated to in first test
-		// },
-		// {
-		// 	name:      "Redelegate to new valset with one existing delegation validator",
-		// 	delegator: sdk.AccAddress([]byte("addr2---------------")),
-		// 	newPreferences: []types.ValidatorPreference{
-		// 		{
-		// 			ValOperAddress: valAddrs[0], // validator that has existing delegation
-		// 			Weight:         sdk.NewDecWithPrec(5, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[1],
-		// 			Weight:         sdk.NewDecWithPrec(3, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[2],
-		// 			Weight:         sdk.NewDecWithPrec(2, 1),
-		// 		},
-		// 	},
-		// 	amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
-		// 	expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
-		// 	setExistingDelegation: true,
-		// 	expectPass:            true,
-		// },
+		{
+			name:      "redelegate to same set of validators",
+			delegator: sdk.AccAddress([]byte("addr1---------------")),
+			newPreferences: []types.ValidatorPreference{
+				{
+					ValOperAddress: valAddrs[0],
+					Weight:         sdk.NewDecWithPrec(3, 1),
+				},
+				{
+					ValOperAddress: valAddrs[1],
+					Weight:         sdk.NewDecWithPrec(2, 1),
+				},
+				{
+					ValOperAddress: valAddrs[2],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+			},
+			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+			expectPass:       false, // first redelegation already in progress so must end that first
+		},
+		{
+			name:      "redelegate to new set, but one validator from old set",
+			delegator: sdk.AccAddress([]byte("addr1---------------")),
+			newPreferences: []types.ValidatorPreference{
+				{
+					ValOperAddress: valAddrs[4],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+				{
+					ValOperAddress: valAddrs[1],
+					Weight:         sdk.NewDecWithPrec(3, 1),
+				},
+				{
+					ValOperAddress: valAddrs[3],
+					Weight:         sdk.NewDecWithPrec(2, 1),
+				},
+			},
+			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+			expectedShares:   []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
+			expectPass:       false, // this fails because valAddrs[1] is being redelegated to in first test
+		},
+		{
+			name:      "Redelegate to new valset with one existing delegation validator",
+			delegator: sdk.AccAddress([]byte("addr2---------------")),
+			newPreferences: []types.ValidatorPreference{
+				{
+					ValOperAddress: valAddrs[0], // validator that has existing delegation
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+				{
+					ValOperAddress: valAddrs[1],
+					Weight:         sdk.NewDecWithPrec(3, 1),
+				},
+				{
+					ValOperAddress: valAddrs[2],
+					Weight:         sdk.NewDecWithPrec(2, 1),
+				},
+			},
+			amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
+			expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
+			setExistingDelegation: true,
+			expectPass:            true,
+		},
 	}
 
 	for _, test := range tests {

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	appParams "github.com/osmosis-labs/osmosis/v14/app/params"
@@ -387,20 +389,23 @@ func (suite *KeeperTestSuite) TestUnDelegateFromValidatorSet() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestRedelegateValidatorSet() {
+func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 	suite.SetupTest()
 
-	// setup 9 validators
-	valAddrs := suite.SetupMultipleValidators(9)
+	// prepare validators to delegate to
+	preferences := suite.PrepareDelegateToValidatorSet()
+
+	valAddrs := suite.SetupMultipleValidators(6)
 
 	tests := []struct {
-		name            string
-		delegator       sdk.AccAddress
-		newPreferences  []types.ValidatorPreference
-		coinToStake     sdk.Coin
-		expectedShares  []sdk.Dec // expected shares after redelegation
-		delegationExist bool
-		expectPass      bool
+		name                        string
+		delegator                   sdk.AccAddress
+		newPreferences              []types.ValidatorPreference
+		amountToDelegate            sdk.Coin  // amount to delegate
+		expectedShares              []sdk.Dec // expected shares after delegation
+		setExistingDelegation       bool      // ensures that there is existing delegations (non valset)
+		setExistingValSetDelegation bool      // ensures that there is existing valset delegation
+		expectPass                  bool
 	}{
 		{
 			name:      "redelegate to a new set of validators",
@@ -419,16 +424,37 @@ func (suite *KeeperTestSuite) TestRedelegateValidatorSet() {
 					Weight:         sdk.NewDecWithPrec(6, 1),
 				},
 			},
-			coinToStake:    sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-			expectedShares: []sdk.Dec{sdk.NewDec(4_000_000), sdk.NewDec(4_000_000), sdk.NewDec(12_000_000)},
-			expectPass:     true,
+			amountToDelegate:            sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+			expectedShares:              []sdk.Dec{sdk.NewDec(4_000_000), sdk.NewDec(4_000_000), sdk.NewDec(12_000_000)},
+			setExistingValSetDelegation: true,
+			expectPass:                  true, // addr1 successfully redelegates to (valAddr0, valAddr1, valAddr2)
 		},
+		// {
+		// 	name:      "redelegate to same set of validators",
+		// 	delegator: sdk.AccAddress([]byte("addr1---------------")),
+		// 	newPreferences: []types.ValidatorPreference{
+		// 		{
+		// 			ValOperAddress: valAddrs[0],
+		// 			Weight:         sdk.NewDecWithPrec(3, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[1],
+		// 			Weight:         sdk.NewDecWithPrec(2, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[2],
+		// 			Weight:         sdk.NewDecWithPrec(5, 1),
+		// 		},
+		// 	},
+		// 	amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+		// 	expectPass:       false, // first redelegation already in progress so must end that first
+		// },
 		{
-			name:      "redelegate to the same set of validators with different weights, same delegator",
+			name:      "redelegate to new set, but one validator from old set",
 			delegator: sdk.AccAddress([]byte("addr1---------------")),
 			newPreferences: []types.ValidatorPreference{
 				{
-					ValOperAddress: valAddrs[0],
+					ValOperAddress: valAddrs[4],
 					Weight:         sdk.NewDecWithPrec(5, 1),
 				},
 				{
@@ -436,109 +462,65 @@ func (suite *KeeperTestSuite) TestRedelegateValidatorSet() {
 					Weight:         sdk.NewDecWithPrec(3, 1),
 				},
 				{
-					ValOperAddress: valAddrs[2],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-			},
-			coinToStake:     sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-			expectedShares:  []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
-			expectPass:      false,
-			delegationExist: true,
-		},
-		{
-			name:      "redelegate to the different set of validators different weights, same delegator",
-			delegator: sdk.AccAddress([]byte("addr1---------------")),
-			newPreferences: []types.ValidatorPreference{
-				{
-					ValOperAddress: valAddrs[3],
-					Weight:         sdk.NewDecWithPrec(5, 1),
-				},
-				{
-					ValOperAddress: valAddrs[4],
-					Weight:         sdk.NewDecWithPrec(3, 1),
-				},
-				{
-					ValOperAddress: valAddrs[5],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-			},
-			coinToStake:    sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-			expectedShares: []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
-			expectPass:     true,
-		},
-		{
-			name:      "redelegate to new set, but one validator from old set with different delegator",
-			delegator: sdk.AccAddress([]byte("addr2---------------")),
-			newPreferences: []types.ValidatorPreference{
-				{
-					ValOperAddress: valAddrs[2],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-				{
 					ValOperAddress: valAddrs[3],
 					Weight:         sdk.NewDecWithPrec(2, 1),
 				},
-				{
-					ValOperAddress: valAddrs[4],
-					Weight:         sdk.NewDecWithPrec(6, 1),
-				},
 			},
-			coinToStake:    sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-			expectedShares: []sdk.Dec{sdk.NewDec(4_000_000), sdk.NewDec(4_000_000), sdk.NewDec(12_000_000)},
-			expectPass:     true,
+			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+			expectedShares:   []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
+			expectPass:       false, // this fails because valAddrs[1] is being redelegated to in first test
 		},
-		{
-			name:      "redelegate to new set of validators",
-			delegator: sdk.AccAddress([]byte("addr3---------------")),
-			newPreferences: []types.ValidatorPreference{
-				{
-					ValOperAddress: valAddrs[4],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-				{
-					ValOperAddress: valAddrs[5],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-				{
-					ValOperAddress: valAddrs[6],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-				{
-					ValOperAddress: valAddrs[7],
-					Weight:         sdk.NewDecWithPrec(1, 1),
-				},
-				{
-					ValOperAddress: valAddrs[8],
-					Weight:         sdk.NewDecWithPrec(3, 1),
-				},
-			},
-			coinToStake:    sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(50_000_000)),
-			expectedShares: []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(10_000_000), sdk.NewDec(10_000_000), sdk.NewDec(5_000_000), sdk.NewDec(15_000_000)},
-			expectPass:     true,
-		},
+		// {
+		// 	name:      "Redelegate to new valset with one existing delegation validator",
+		// 	delegator: sdk.AccAddress([]byte("addr2---------------")),
+		// 	newPreferences: []types.ValidatorPreference{
+		// 		{
+		// 			ValOperAddress: valAddrs[0], // validator that has existing delegation
+		// 			Weight:         sdk.NewDecWithPrec(5, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[1],
+		// 			Weight:         sdk.NewDecWithPrec(3, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[2],
+		// 			Weight:         sdk.NewDecWithPrec(2, 1),
+		// 		},
+		// 	},
+		// 	amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
+		// 	expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
+		// 	setExistingDelegation: true,
+		// 	expectPass:            true,
+		// },
 	}
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {
-
-			// fund the account that is trying to delegate
-			suite.FundAcc(test.delegator, sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 100_000_000)})
-
 			// setup message server
 			msgServer := valPref.NewMsgServerImpl(suite.App.ValidatorSetPreferenceKeeper)
 			c := sdk.WrapSDKContext(suite.Ctx)
 
-			if !test.delegationExist {
-				// creates a validator preference list to delegate to
-				preferences := suite.PrepareDelegateToValidatorSet()
+			// fund the account that is trying to delegate
+			suite.FundAcc(test.delegator, sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 100_000_000)})
 
+			if test.setExistingDelegation {
+				err := suite.PrepareExistingDelegations(suite.Ctx, []string{valAddrs[0]}, test.delegator, test.amountToDelegate.Amount)
+				suite.Require().NoError(err)
+			}
+
+			if test.setExistingValSetDelegation {
 				// SetValidatorSetPreference sets a new list of val-set
 				_, err := msgServer.SetValidatorSetPreference(c, types.NewMsgSetValidatorSetPreference(test.delegator, preferences))
 				suite.Require().NoError(err)
 
 				// DelegateToValidatorSet delegate to existing val-set
-				_, err = msgServer.DelegateToValidatorSet(c, types.NewMsgDelegateToValidatorSet(test.delegator, test.coinToStake))
+				_, err = msgServer.DelegateToValidatorSet(c, types.NewMsgDelegateToValidatorSet(test.delegator, test.amountToDelegate))
 				suite.Require().NoError(err)
+			}
+
+			existingSet, found := suite.App.ValidatorSetPreferenceKeeper.GetValidatorSetPreference(suite.Ctx, test.delegator.String())
+			if found {
+				fmt.Println("NO ERRORR: ", existingSet)
 			}
 
 			// RedelegateValidatorSet redelegates from an exisitng set to a new one
@@ -555,9 +537,16 @@ func (suite *KeeperTestSuite) TestRedelegateValidatorSet() {
 					del, _ := suite.App.StakingKeeper.GetDelegation(suite.Ctx, test.delegator, valAddr)
 					suite.Require().Equal(del.Shares, test.expectedShares[i])
 				}
-
 			} else {
 				suite.Require().Error(err)
+				// get delegators existing validators
+				// should be valAddrs[0], valAddrs[1], valAddrs[2]
+				// error if valAddrs[4], valAddrs[1], valAddrs[3]
+				fmt.Println(err)
+				existingSet2, found2 := suite.App.ValidatorSetPreferenceKeeper.GetValidatorSetPreference(suite.Ctx, test.delegator.String())
+				if found2 {
+					fmt.Println("ERRORR: ", existingSet2)
+				}
 			}
 
 		})

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -1,8 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	appParams "github.com/osmosis-labs/osmosis/v14/app/params"
@@ -429,26 +427,26 @@ func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 			setExistingValSetDelegation: true,
 			expectPass:                  true, // addr1 successfully redelegates to (valAddr0, valAddr1, valAddr2)
 		},
-		// {
-		// 	name:      "redelegate to same set of validators",
-		// 	delegator: sdk.AccAddress([]byte("addr1---------------")),
-		// 	newPreferences: []types.ValidatorPreference{
-		// 		{
-		// 			ValOperAddress: valAddrs[0],
-		// 			Weight:         sdk.NewDecWithPrec(3, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[1],
-		// 			Weight:         sdk.NewDecWithPrec(2, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[2],
-		// 			Weight:         sdk.NewDecWithPrec(5, 1),
-		// 		},
-		// 	},
-		// 	amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-		// 	expectPass:       false, // first redelegation already in progress so must end that first
-		// },
+		{
+			name:      "redelegate to same set of validators",
+			delegator: sdk.AccAddress([]byte("addr1---------------")),
+			newPreferences: []types.ValidatorPreference{
+				{
+					ValOperAddress: valAddrs[0],
+					Weight:         sdk.NewDecWithPrec(3, 1),
+				},
+				{
+					ValOperAddress: valAddrs[1],
+					Weight:         sdk.NewDecWithPrec(2, 1),
+				},
+				{
+					ValOperAddress: valAddrs[2],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+			},
+			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+			expectPass:       false, // first redelegation already in progress so must end that first
+		},
 		{
 			name:      "redelegate to new set, but one validator from old set",
 			delegator: sdk.AccAddress([]byte("addr1---------------")),
@@ -470,28 +468,28 @@ func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 			expectedShares:   []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
 			expectPass:       false, // this fails because valAddrs[1] is being redelegated to in first test
 		},
-		// {
-		// 	name:      "Redelegate to new valset with one existing delegation validator",
-		// 	delegator: sdk.AccAddress([]byte("addr2---------------")),
-		// 	newPreferences: []types.ValidatorPreference{
-		// 		{
-		// 			ValOperAddress: valAddrs[0], // validator that has existing delegation
-		// 			Weight:         sdk.NewDecWithPrec(5, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[1],
-		// 			Weight:         sdk.NewDecWithPrec(3, 1),
-		// 		},
-		// 		{
-		// 			ValOperAddress: valAddrs[2],
-		// 			Weight:         sdk.NewDecWithPrec(2, 1),
-		// 		},
-		// 	},
-		// 	amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
-		// 	expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
-		// 	setExistingDelegation: true,
-		// 	expectPass:            true,
-		// },
+		{
+			name:      "Redelegate to new valset with one existing delegation validator",
+			delegator: sdk.AccAddress([]byte("addr2---------------")),
+			newPreferences: []types.ValidatorPreference{
+				{
+					ValOperAddress: valAddrs[0], // validator that has existing delegation
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+				{
+					ValOperAddress: valAddrs[1],
+					Weight:         sdk.NewDecWithPrec(3, 1),
+				},
+				{
+					ValOperAddress: valAddrs[2],
+					Weight:         sdk.NewDecWithPrec(2, 1),
+				},
+			},
+			amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
+			expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
+			setExistingDelegation: true,
+			expectPass:            true,
+		},
 	}
 
 	for _, test := range tests {
@@ -518,11 +516,6 @@ func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 				suite.Require().NoError(err)
 			}
 
-			existingSet, found := suite.App.ValidatorSetPreferenceKeeper.GetValidatorSetPreference(suite.Ctx, test.delegator.String())
-			if found {
-				fmt.Println("NO ERRORR: ", existingSet)
-			}
-
 			// RedelegateValidatorSet redelegates from an exisitng set to a new one
 			_, err := msgServer.RedelegateValidatorSet(c, types.NewMsgRedelegateValidatorSet(test.delegator, test.newPreferences))
 			if test.expectPass {
@@ -539,16 +532,7 @@ func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 				}
 			} else {
 				suite.Require().Error(err)
-				// get delegators existing validators
-				// should be valAddrs[0], valAddrs[1], valAddrs[2]
-				// error if valAddrs[4], valAddrs[1], valAddrs[3]
-				fmt.Println(err)
-				existingSet2, found2 := suite.App.ValidatorSetPreferenceKeeper.GetValidatorSetPreference(suite.Ctx, test.delegator.String())
-				if found2 {
-					fmt.Println("ERRORR: ", existingSet2)
-				}
 			}
-
 		})
 	}
 }

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -411,85 +411,85 @@ func (suite *KeeperTestSuite) TestRedelegateToValidatorSet() {
 			newPreferences: []types.ValidatorPreference{
 				{
 					ValOperAddress: valAddrs[0],
-					Weight:         sdk.NewDecWithPrec(2, 1),
+					Weight:         sdk.NewDecWithPrec(22, 2), // 0.22
 				},
 				{
 					ValOperAddress: valAddrs[1],
-					Weight:         sdk.NewDecWithPrec(2, 1),
+					Weight:         sdk.NewDecWithPrec(1345, 4), //0.1234
 				},
 				{
 					ValOperAddress: valAddrs[2],
-					Weight:         sdk.NewDecWithPrec(6, 1),
+					Weight:         sdk.NewDecWithPrec(6566, 4),
 				},
 			},
-			amountToDelegate:            sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+			amountToDelegate:            sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
 			expectedShares:              []sdk.Dec{sdk.NewDec(4_000_000), sdk.NewDec(4_000_000), sdk.NewDec(12_000_000)},
 			setExistingValSetDelegation: true,
 			expectPass:                  true, // addr1 successfully redelegates to (valAddr0, valAddr1, valAddr2)
 		},
-		{
-			name:      "redelegate to same set of validators",
-			delegator: sdk.AccAddress([]byte("addr1---------------")),
-			newPreferences: []types.ValidatorPreference{
-				{
-					ValOperAddress: valAddrs[0],
-					Weight:         sdk.NewDecWithPrec(3, 1),
-				},
-				{
-					ValOperAddress: valAddrs[1],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-				{
-					ValOperAddress: valAddrs[2],
-					Weight:         sdk.NewDecWithPrec(5, 1),
-				},
-			},
-			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-			expectPass:       false, // first redelegation already in progress so must end that first
-		},
-		{
-			name:      "redelegate to new set, but one validator from old set",
-			delegator: sdk.AccAddress([]byte("addr1---------------")),
-			newPreferences: []types.ValidatorPreference{
-				{
-					ValOperAddress: valAddrs[4],
-					Weight:         sdk.NewDecWithPrec(5, 1),
-				},
-				{
-					ValOperAddress: valAddrs[1],
-					Weight:         sdk.NewDecWithPrec(3, 1),
-				},
-				{
-					ValOperAddress: valAddrs[3],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-			},
-			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
-			expectedShares:   []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
-			expectPass:       false, // this fails because valAddrs[1] is being redelegated to in first test
-		},
-		{
-			name:      "Redelegate to new valset with one existing delegation validator",
-			delegator: sdk.AccAddress([]byte("addr2---------------")),
-			newPreferences: []types.ValidatorPreference{
-				{
-					ValOperAddress: valAddrs[0], // validator that has existing delegation
-					Weight:         sdk.NewDecWithPrec(5, 1),
-				},
-				{
-					ValOperAddress: valAddrs[1],
-					Weight:         sdk.NewDecWithPrec(3, 1),
-				},
-				{
-					ValOperAddress: valAddrs[2],
-					Weight:         sdk.NewDecWithPrec(2, 1),
-				},
-			},
-			amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
-			expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
-			setExistingDelegation: true,
-			expectPass:            true,
-		},
+		// {
+		// 	name:      "redelegate to same set of validators",
+		// 	delegator: sdk.AccAddress([]byte("addr1---------------")),
+		// 	newPreferences: []types.ValidatorPreference{
+		// 		{
+		// 			ValOperAddress: valAddrs[0],
+		// 			Weight:         sdk.NewDecWithPrec(3, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[1],
+		// 			Weight:         sdk.NewDecWithPrec(2, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[2],
+		// 			Weight:         sdk.NewDecWithPrec(5, 1),
+		// 		},
+		// 	},
+		// 	amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+		// 	expectPass:       false, // first redelegation already in progress so must end that first
+		// },
+		// {
+		// 	name:      "redelegate to new set, but one validator from old set",
+		// 	delegator: sdk.AccAddress([]byte("addr1---------------")),
+		// 	newPreferences: []types.ValidatorPreference{
+		// 		{
+		// 			ValOperAddress: valAddrs[4],
+		// 			Weight:         sdk.NewDecWithPrec(5, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[1],
+		// 			Weight:         sdk.NewDecWithPrec(3, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[3],
+		// 			Weight:         sdk.NewDecWithPrec(2, 1),
+		// 		},
+		// 	},
+		// 	amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20_000_000)),
+		// 	expectedShares:   []sdk.Dec{sdk.NewDec(10_000_000), sdk.NewDec(6_000_000), sdk.NewDec(4_000_000)},
+		// 	expectPass:       false, // this fails because valAddrs[1] is being redelegated to in first test
+		// },
+		// {
+		// 	name:      "Redelegate to new valset with one existing delegation validator",
+		// 	delegator: sdk.AccAddress([]byte("addr2---------------")),
+		// 	newPreferences: []types.ValidatorPreference{
+		// 		{
+		// 			ValOperAddress: valAddrs[0], // validator that has existing delegation
+		// 			Weight:         sdk.NewDecWithPrec(5, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[1],
+		// 			Weight:         sdk.NewDecWithPrec(3, 1),
+		// 		},
+		// 		{
+		// 			ValOperAddress: valAddrs[2],
+		// 			Weight:         sdk.NewDecWithPrec(2, 1),
+		// 		},
+		// 	},
+		// 	amountToDelegate:      sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10_000_000)),
+		// 	expectedShares:        []sdk.Dec{sdk.NewDec(5_000_000), sdk.NewDec(3_000_000), sdk.NewDec(2_000_000)},
+		// 	setExistingDelegation: true,
+		// 	expectPass:            true,
+		// },
 	}
 
 	for _, test := range tests {

--- a/x/valset-pref/types/msgs.go
+++ b/x/valset-pref/types/msgs.go
@@ -272,6 +272,10 @@ func (m MsgDelegateBondedTokens) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
 	}
 
+	if m.LockID <= 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "lock id should be bigger than 1 (%s)", err)
+	}
+
 	return nil
 }
 

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -159,8 +159,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		existingValSet = append(existingValSet, existing_val)
 		newValSet = append(newValSet, existing_val_zero_amount)
 		totalTokenAmount = totalTokenAmount.Add(tokenFromShares)
-
-		//fmt.Println("Existing SET", existingVals.ValOperAddress, tokenFromShares)
 	}
 
 	for _, newVals := range newSet {
@@ -169,8 +167,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		new_val, new_val_zero_amount := k.GetValSetStruct(newVals, amountToDelegate)
 		newValSet = append(newValSet, new_val)
 		existingValSet = append(existingValSet, new_val_zero_amount)
-
-		//fmt.Println("New SET", newVals.ValOperAddress, amountToDelegate)
 	}
 
 	// calculate the difference between two sets
@@ -208,7 +204,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 
 			// reDelegationAmt to is the amount to redelegate, which is the min of diffAmount and target_validator
 			reDelegationAmt := sdk.MinDec(target_val.amount.Abs(), diff_val.amount).TruncateDec()
-			//fmt.Println("Redelegate: ", source_val, target_val.valAddr, reDelegationAmt)
 			_, err = k.stakingKeeper.BeginRedelegation(ctx, delegator, validator_source, validator_target, reDelegationAmt)
 			if err != nil {
 				return err

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -183,7 +183,7 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 
 	// Algorithm starts here
 	for _, diff_val := range diffValSet {
-		for diff_val.amount.GT(sdk.NewDec(0)) {
+		for diff_val.amount.TruncateDec().GT(sdk.NewDec(0)) {
 			source_val := diff_val.valAddr
 			target_val, idx := k.FindMin(diffValSet, source_val)
 

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -183,15 +183,15 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 			amount:  diffAmount,
 		}
 		diffValSet = append(diffValSet, &diff_val)
-		//fmt.Println("DIFF SET", diff_val.valAddr, diff_val.amount)
 	}
 
 	// Algorithm starts here
 	for _, diff_val := range diffValSet {
 		for diff_val.amount.GT(sdk.NewDec(0)) {
 			source_val := diff_val.valAddr
-			// FindMin returns the index and MinAmt of the minimum amount in diffValSet
 			target_val, idx := k.FindMin(diffValSet, source_val)
+
+			// checks if there are any more redelegation possible
 			if target_val.amount.Equal(sdk.NewDec(0)) {
 				break
 			}
@@ -388,7 +388,8 @@ func (k Keeper) GetValSetStruct(validator types.ValidatorPreference, amountFromS
 	return val_struct, val_struct_zero_amount
 }
 
-// FindMin takes in a valSet struct array and computes the minimum val set based on the amount delegated to a validator.
+// FindMin takes in a valSet struct array and computes the minimum val set that's not source validator
+//  based on the amount delegated to a validator.
 func (k Keeper) FindMin(valPrefs []*valSet, sourceVal string) (min valSet, idx int) {
 	min = *valPrefs[0]
 	idx = 0

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -159,7 +159,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		existingValSet = append(existingValSet, existing_val)
 		newValSet = append(newValSet, existing_val_zero_amount)
 		totalTokenAmount = totalTokenAmount.Add(tokenFromShares)
-		fmt.Println("EXISTING DELS: ", valAddr.String(), tokenFromShares)
 	}
 
 	for _, newVals := range newSet {
@@ -168,7 +167,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		new_val, new_val_zero_amount := k.GetValSetStruct(newVals, amountToDelegate)
 		newValSet = append(newValSet, new_val)
 		existingValSet = append(existingValSet, new_val_zero_amount)
-		fmt.Println("NEW DELS: ", newVals, amountToDelegate)
 	}
 
 	// calculate the difference between two sets
@@ -182,8 +180,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		}
 		diffValSet = append(diffValSet, &diff_val)
 	}
-
-	fmt.Println("DIFF AMOUNT: ", diffValSet)
 
 	// Algorithm starts here
 	for _, diff_val := range diffValSet {
@@ -208,7 +204,6 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 
 			// reDelegationAmt to is the amount to redelegate, which is the min of diffAmount and target_validator
 			reDelegationAmt := sdk.MinDec(target_val.amount.Abs(), diff_val.amount).TruncateDec()
-			fmt.Println("REDELEGATE: ", source_val, target_val.valAddr, reDelegationAmt)
 			_, err = k.stakingKeeper.BeginRedelegation(ctx, delegator, validator_source, validator_target, reDelegationAmt)
 			if err != nil {
 				return err
@@ -374,7 +369,7 @@ func (k Keeper) GetValidatorInfo(ctx sdk.Context, existingValAddr string) (sdk.V
 // GetValSetStruct initializes valSet struct with valAddr, weight and amount.
 // It also creates an extra struct with zero amount, that can be appended to newValSet that will be created.
 // We do this to make sure the struct array length is the same to calculate their difference.
-func (k Keeper) GetValSetStruct(validator types.ValidatorPreference, amountFromShares sdk.Dec) (existingValSet valSet, existingValsSetZeroFormatted valSet) {
+func (k Keeper) GetValSetStruct(validator types.ValidatorPreference, amountFromShares sdk.Dec) (existingValSet valSet, existingValsSetZeroFormat valSet) {
 	val_struct := valSet{
 		valAddr: validator.ValOperAddress,
 		amount:  amountFromShares,

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -188,7 +188,7 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 			target_val, idx := k.FindMin(diffValSet, source_val)
 
 			// checks if there are any more redelegation possible
-			if target_val.amount.Equal(sdk.NewDec(0)) {
+			if target_val.amount.TruncateDec().Equal(sdk.NewDec(0)) {
 				break
 			}
 

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -159,6 +159,7 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		existingValSet = append(existingValSet, existing_val)
 		newValSet = append(newValSet, existing_val_zero_amount)
 		totalTokenAmount = totalTokenAmount.Add(tokenFromShares)
+		fmt.Println("EXISTING DELS: ", valAddr.String(), tokenFromShares)
 	}
 
 	for _, newVals := range newSet {
@@ -167,6 +168,7 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		new_val, new_val_zero_amount := k.GetValSetStruct(newVals, amountToDelegate)
 		newValSet = append(newValSet, new_val)
 		existingValSet = append(existingValSet, new_val_zero_amount)
+		fmt.Println("NEW DELS: ", newVals, amountToDelegate)
 	}
 
 	// calculate the difference between two sets
@@ -180,6 +182,8 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 		}
 		diffValSet = append(diffValSet, &diff_val)
 	}
+
+	fmt.Println("DIFF AMOUNT: ", diffValSet)
 
 	// Algorithm starts here
 	for _, diff_val := range diffValSet {
@@ -204,6 +208,7 @@ func (k Keeper) PreformRedelegation(ctx sdk.Context, delegator sdk.AccAddress, e
 
 			// reDelegationAmt to is the amount to redelegate, which is the min of diffAmount and target_validator
 			reDelegationAmt := sdk.MinDec(target_val.amount.Abs(), diff_val.amount).TruncateDec()
+			fmt.Println("REDELEGATE: ", source_val, target_val.valAddr, reDelegationAmt)
 			_, err = k.stakingKeeper.BeginRedelegation(ctx, delegator, validator_source, validator_target, reDelegationAmt)
 			if err != nil {
 				return err
@@ -369,7 +374,7 @@ func (k Keeper) GetValidatorInfo(ctx sdk.Context, existingValAddr string) (sdk.V
 // GetValSetStruct initializes valSet struct with valAddr, weight and amount.
 // It also creates an extra struct with zero amount, that can be appended to newValSet that will be created.
 // We do this to make sure the struct array length is the same to calculate their difference.
-func (k Keeper) GetValSetStruct(validator types.ValidatorPreference, amountFromShares sdk.Dec) (valSet, valSet) {
+func (k Keeper) GetValSetStruct(validator types.ValidatorPreference, amountFromShares sdk.Dec) (existingValSet valSet, existingValsSetZeroFormatted valSet) {
 	val_struct := valSet{
 		valAddr: validator.ValOperAddress,
 		amount:  amountFromShares,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#3761](https://github.com/osmosis-labs/osmosis/issues/3761) 
Part of : https://github.com/osmosis-labs/osmosis/issues/2579

## What is the purpose of the change
In https://github.com/osmosis-labs/osmosis/pull/3599 the redelegate to (new valset pref list) message redelegates from your current valset.

Instead, we should change this to redelegate from all of your current staked positions. So that way the UX can be "Set new valset preference", "Redelegate everything to this new preference list", and it gracefully handles that you used to stake without a preference list.

## Brief Changelog
n/a

## Testing and Verifying
testing redelegation with existing non-valset delegation

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)