### PR TITLE
Gamm balancer improvements

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -197,7 +197,7 @@ func (s *KeeperTestHelper) ModifySpotPrice(poolID uint64, targetSpotPrice sdk.De
 		_, err = gammMsgServer.SwapExactAmountIn(sdk.WrapSDKContext(s.Ctx), &msg)
 		s.Require().NoError(err)
 	} else {
-		swapOut := sdk.NewCoins(sdk.NewCoin(quoteDenom, sdk.NewInt(amountTrade.RoundInt64()).Abs()))
+		swapOut := sdk.NewCoin(quoteDenom, sdk.NewInt(amountTrade.RoundInt64()).Abs())
 		swapFee := pool.GetSwapFee(s.Ctx)
 		tokenIn, err := pool.CalcInAmtGivenOut(s.Ctx, swapOut, baseDenom, swapFee)
 		s.Require().NoError(err)
@@ -206,7 +206,7 @@ func (s *KeeperTestHelper) ModifySpotPrice(poolID uint64, targetSpotPrice sdk.De
 			Sender:           s.TestAccs[0].String(),
 			Routes:           []gammtypes.SwapAmountOutRoute{{PoolId: poolID, TokenInDenom: baseDenom}},
 			TokenInMaxAmount: sdk.NewInt(int64Max),
-			TokenOut:         swapOut[0],
+			TokenOut:         swapOut,
 		}
 
 		gammMsgServer := gammkeeper.NewMsgServerImpl(s.App.GAMMKeeper)

--- a/tests/mocks/cfmm_pool.go
+++ b/tests/mocks/cfmm_pool.go
@@ -51,7 +51,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcExitPoolCoinsFromShares(ctx, numShares,
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockCFMMPoolI) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coin, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -98,7 +98,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcJoinPoolShares(ctx, tokensIn, swapFee i
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -309,7 +309,7 @@ func (mr *MockCFMMPoolIMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockCFMMPoolI) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coin, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -324,7 +324,7 @@ func (mr *MockCFMMPoolIMockRecorder) SwapInAmtGivenOut(ctx, tokenOut, tokenInDen
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -377,7 +377,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcExitPoolCoinsFromShares(ct
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coin, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -424,7 +424,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolShares(ctx, tokens
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -692,7 +692,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockPoolAmountOutExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coin, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -707,7 +707,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) SwapInAmtGivenOut(ctx, tokenOu
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -760,7 +760,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcExitPoolCoinsFromShares(ctx
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockWeightedPoolExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coin, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -807,7 +807,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcJoinPoolShares(ctx, tokensI
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -1045,7 +1045,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockWeightedPoolExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coin, tokenInDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)
@@ -1060,7 +1060,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) SwapInAmtGivenOut(ctx, tokenOut
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, swapFee types.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, swapFee)
 	ret0, _ := ret[0].(types.Coin)

--- a/tests/mocks/cfmm_pool.go
+++ b/tests/mocks/cfmm_pool.go
@@ -623,21 +623,6 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPoolNoSwap(ctx, tokensIn, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinPoolNoSwap", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).JoinPoolNoSwap), ctx, tokensIn, swapFee)
 }
 
-// JoinPoolTokenInMaxShareAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPoolTokenInMaxShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount types.Int) (types.Int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JoinPoolTokenInMaxShareAmountOut", ctx, tokenInDenom, shareOutAmount)
-	ret0, _ := ret[0].(types.Int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// JoinPoolTokenInMaxShareAmountOut indicates an expected call of JoinPoolTokenInMaxShareAmountOut.
-func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPoolTokenInMaxShareAmountOut(ctx, tokenInDenom, shareOutAmount interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinPoolTokenInMaxShareAmountOut", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).JoinPoolTokenInMaxShareAmountOut), ctx, tokenInDenom, shareOutAmount)
-}
-
 // ProtoMessage mocks base method.
 func (m *MockPoolAmountOutExtension) ProtoMessage() {
 	m.ctrl.T.Helper()

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -37,7 +37,6 @@ func (k Keeper) SwapExactAmountIn(
 	if swapFee.LT(poolSwapFee.QuoInt64(2)) {
 		return sdk.Int{}, fmt.Errorf("given swap fee (%s) must be greater than or equal to half of the pool's swap fee (%s)", swapFee, poolSwapFee)
 	}
-	tokensIn := sdk.Coins{tokenIn}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -53,7 +52,7 @@ func (k Keeper) SwapExactAmountIn(
 
 	// Executes the swap in the pool and stores the output. Updates pool assets but
 	// does not actually transfer any tokens to or from the pool.
-	tokenOutCoin, err := cfmmPool.SwapOutAmtGivenIn(ctx, tokensIn, tokenOutDenom, swapFee)
+	tokenOutCoin, err := cfmmPool.SwapOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -114,7 +113,7 @@ func (k Keeper) SwapExactAmountOut(
 		return sdk.Int{}, err
 	}
 
-	tokenIn, err := cfmmPool.SwapInAmtGivenOut(ctx, sdk.Coins{tokenOut}, tokenInDenom, swapFee)
+	tokenIn, err := cfmmPool.SwapInAmtGivenOut(ctx, tokenOut, tokenInDenom, swapFee)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -148,7 +147,7 @@ func (k Keeper) CalcOutAmtGivenIn(
 	if err != nil {
 		return sdk.Coin{}, err
 	}
-	return cfmmPool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(tokenIn), tokenOutDenom, swapFee)
+	return cfmmPool.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee)
 }
 
 // CalcInAmtGivenOut calculates the amount of tokenIn given tokenOut and the pool's current state.
@@ -164,7 +163,7 @@ func (k Keeper) CalcInAmtGivenOut(
 	if err != nil {
 		return sdk.Coin{}, err
 	}
-	return cfmmPool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), tokenInDenom, swapFee)
+	return cfmmPool.CalcInAmtGivenOut(ctx, tokenOut, tokenInDenom, swapFee)
 }
 
 // updatePoolForSwap takes a pool, sender, and tokenIn, tokenOut amounts

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -894,39 +894,6 @@ func (p *Pool) CalcTokenInShareAmountOut(
 	return tokenInAmount, nil
 }
 
-func (p *Pool) JoinPoolTokenInMaxShareAmountOut(
-	ctx sdk.Context,
-	tokenInDenom string,
-	shareOutAmount sdk.Int,
-) (tokenInAmount sdk.Int, err error) {
-	_, poolAssetIn, err := p.getPoolAssetAndIndex(tokenInDenom)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-
-	normalizedWeight := poolAssetIn.Weight.ToDec().Quo(p.GetTotalWeight().ToDec())
-
-	tokenInAmount = calcSingleAssetInGivenPoolSharesOut(
-		poolAssetIn.Token.Amount.ToDec(),
-		normalizedWeight,
-		p.GetTotalShares().ToDec(),
-		shareOutAmount.ToDec(),
-		p.GetSwapFee(ctx),
-	).TruncateInt()
-
-	if !tokenInAmount.IsPositive() {
-		return sdk.Int{}, sdkerrors.Wrapf(types.ErrNotPositiveRequireAmount, nonPostiveTokenAmountErrFormat, tokenInAmount)
-	}
-
-	poolAssetIn.Token.Amount = poolAssetIn.Token.Amount.Add(tokenInAmount)
-	err = p.UpdatePoolAssetBalance(poolAssetIn.Token)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-
-	return tokenInAmount, nil
-}
-
 func (p *Pool) ExitSwapExactAmountOut(
 	ctx sdk.Context,
 	tokenOut sdk.Coin,

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -174,7 +174,7 @@ func SwapAllCoinsToSingleAsset(pool types.CFMMPoolI, ctx sdk.Context, inTokens s
 		if coin.Denom == swapToDenom {
 			continue
 		}
-		tokenOut, err := pool.SwapOutAmtGivenIn(ctx, sdk.NewCoins(coin), swapToDenom, swapFee)
+		tokenOut, err := pool.SwapOutAmtGivenIn(ctx, coin, swapToDenom, swapFee)
 		if err != nil {
 			return sdk.Int{}, err
 		}

--- a/x/gamm/pool-models/internal/test_helpers/test_helpers.go
+++ b/x/gamm/pool-models/internal/test_helpers/test_helpers.go
@@ -43,15 +43,14 @@ func TestCalculateAmountOutAndIn_InverseRelationship(
 	errTolerance osmomath.ErrTolerance,
 ) {
 	initialOut := sdk.NewInt64Coin(assetOutDenom, initialCalcOut)
-	initialOutCoins := sdk.NewCoins(initialOut)
 
-	actualTokenIn, err := pool.CalcInAmtGivenOut(ctx, initialOutCoins, assetInDenom, swapFee)
+	actualTokenIn, err := pool.CalcInAmtGivenOut(ctx, initialOut, assetInDenom, swapFee)
 	require.NoError(t, err)
 
 	// we expect that any output less than 1 will always be rounded up
 	require.True(t, actualTokenIn.Amount.GTE(sdk.OneInt()))
 
-	inverseTokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(actualTokenIn), assetOutDenom, swapFee)
+	inverseTokenOut, err := pool.CalcOutAmtGivenIn(ctx, actualTokenIn, assetOutDenom, swapFee)
 	require.NoError(t, err)
 
 	require.Equal(t, initialOut.Denom, inverseTokenOut.Denom)
@@ -94,7 +93,7 @@ func TestSlippageRelationOutGivenIn(
 	initLiquidity sdk.Coins,
 ) {
 	r := rand.New(rand.NewSource(100))
-	swapInAmt := sdkrand.RandCoin(r, initLiquidity[:1])
+	swapInAmt := sdkrand.RandCoin(r, initLiquidity[:1])[0]
 	swapOutDenom := initLiquidity[1].Denom
 
 	curPool := createPoolWithLiquidity(ctx, initLiquidity)
@@ -127,7 +126,7 @@ func TestSlippageRelationInGivenOut(
 	initLiquidity sdk.Coins,
 ) {
 	r := rand.New(rand.NewSource(100))
-	swapOutAmt := sdkrand.RandCoin(r, initLiquidity[:1])
+	swapOutAmt := sdkrand.RandCoin(r, initLiquidity[:1])[0]
 	swapInDenom := initLiquidity[1].Denom
 
 	curPool := createPoolWithLiquidity(ctx, initLiquidity)
@@ -164,7 +163,7 @@ func TestSlippageRelationInGivenOut(
 }
 
 // returns true if the pool can accommodate an InGivenOut swap with `tokenOut` amount out, false otherwise
-func isWithinBounds(ctx sdk.Context, pool types.CFMMPoolI, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (b bool) {
+func isWithinBounds(ctx sdk.Context, pool types.CFMMPoolI, tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec) (b bool) {
 	b = true
 	defer func() {
 		if r := recover(); r != nil {

--- a/x/gamm/pool-models/stableswap/pool_test.go
+++ b/x/gamm/pool-models/stableswap/pool_test.go
@@ -687,7 +687,7 @@ func TestSwapOutAmtGivenIn(t *testing.T) {
 	tests := map[string]struct {
 		poolAssets            sdk.Coins
 		scalingFactors        []uint64
-		tokenIn               sdk.Coins
+		tokenIn               sdk.Coin
 		expectedTokenOut      sdk.Coin
 		expectedPoolLiquidity sdk.Coins
 		swapFee               sdk.Dec
@@ -696,7 +696,7 @@ func TestSwapOutAmtGivenIn(t *testing.T) {
 		"even pool basic trade": {
 			poolAssets:            twoEvenStablePoolAssets,
 			scalingFactors:        defaultTwoAssetScalingFactors,
-			tokenIn:               sdk.NewCoins(sdk.NewInt64Coin("foo", 100)),
+			tokenIn:               sdk.NewInt64Coin("foo", 100),
 			expectedTokenOut:      sdk.NewInt64Coin("bar", 99),
 			expectedPoolLiquidity: twoEvenStablePoolAssets.Add(sdk.NewInt64Coin("foo", 100)).Sub(sdk.NewCoins(sdk.NewInt64Coin("bar", 99))),
 			swapFee:               sdk.ZeroDec(),
@@ -708,7 +708,7 @@ func TestSwapOutAmtGivenIn(t *testing.T) {
 				sdk.NewInt64Coin("foo", 10000000),
 			),
 			scalingFactors:   []uint64{100, 1},
-			tokenIn:          sdk.NewCoins(sdk.NewInt64Coin("foo", 100)),
+			tokenIn:          sdk.NewInt64Coin("foo", 100),
 			expectedTokenOut: sdk.NewInt64Coin("bar", 9999),
 			expectedPoolLiquidity: sdk.NewCoins(
 				sdk.NewInt64Coin("bar", 1000000000).SubAmount(sdk.NewIntFromUint64(9999)),
@@ -727,7 +727,7 @@ func TestSwapOutAmtGivenIn(t *testing.T) {
 				sdk.NewInt64Coin("bar", 9_999_999_998),
 			),
 			scalingFactors:   defaultTwoAssetScalingFactors,
-			tokenIn:          sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+			tokenIn:          sdk.NewInt64Coin("foo", 1),
 			expectedTokenOut: sdk.Coin{},
 			expectedPoolLiquidity: sdk.NewCoins(
 				sdk.NewInt64Coin("foo", 9_999_999_999),
@@ -742,7 +742,7 @@ func TestSwapOutAmtGivenIn(t *testing.T) {
 				sdk.NewInt64Coin("bar", 10_000_000_000),
 			),
 			scalingFactors:   defaultTwoAssetScalingFactors,
-			tokenIn:          sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+			tokenIn:          sdk.NewInt64Coin("foo", 1),
 			expectedTokenOut: sdk.Coin{},
 			expectedPoolLiquidity: sdk.NewCoins(
 				sdk.NewInt64Coin("foo", 10_000_000_000),
@@ -774,7 +774,7 @@ func TestSwapInAmtGivenOut(t *testing.T) {
 	tests := map[string]struct {
 		poolAssets            sdk.Coins
 		scalingFactors        []uint64
-		tokenOut              sdk.Coins
+		tokenOut              sdk.Coin
 		expectedTokenIn       sdk.Coin
 		expectedPoolLiquidity sdk.Coins
 		swapFee               sdk.Dec
@@ -783,7 +783,7 @@ func TestSwapInAmtGivenOut(t *testing.T) {
 		"even pool basic trade": {
 			poolAssets:            twoEvenStablePoolAssets,
 			scalingFactors:        defaultTwoAssetScalingFactors,
-			tokenOut:              sdk.NewCoins(sdk.NewInt64Coin("bar", 100)),
+			tokenOut:              sdk.NewInt64Coin("bar", 100),
 			expectedTokenIn:       sdk.NewInt64Coin("foo", 100),
 			expectedPoolLiquidity: twoEvenStablePoolAssets.Add(sdk.NewInt64Coin("foo", 100)).Sub(sdk.NewCoins(sdk.NewInt64Coin("bar", 100))),
 			swapFee:               sdk.ZeroDec(),
@@ -795,7 +795,7 @@ func TestSwapInAmtGivenOut(t *testing.T) {
 				sdk.NewInt64Coin("bar", 9_999_999_997*types.ScalingFactorMultiplier),
 			),
 			scalingFactors:  defaultTwoAssetScalingFactors,
-			tokenOut:        sdk.NewCoins(sdk.NewInt64Coin("bar", 1*types.ScalingFactorMultiplier)),
+			tokenOut:        sdk.NewInt64Coin("bar", 1*types.ScalingFactorMultiplier),
 			expectedTokenIn: sdk.NewInt64Coin("foo", 1*types.ScalingFactorMultiplier),
 			expectedPoolLiquidity: sdk.NewCoins(
 				sdk.NewInt64Coin("foo", 9_999_999_998*types.ScalingFactorMultiplier),
@@ -810,7 +810,7 @@ func TestSwapInAmtGivenOut(t *testing.T) {
 				sdk.NewInt64Coin("bar", 10_000_000_000*types.ScalingFactorMultiplier),
 			),
 			scalingFactors:  defaultTwoAssetScalingFactors,
-			tokenOut:        sdk.NewCoins(sdk.NewInt64Coin("bar", 1)),
+			tokenOut:        sdk.NewInt64Coin("bar", 1),
 			expectedTokenIn: sdk.Coin{},
 			expectedPoolLiquidity: sdk.NewCoins(
 				sdk.NewInt64Coin("foo", 10_000_000_000*types.ScalingFactorMultiplier),

--- a/x/gamm/simulation/sim_msgs.go
+++ b/x/gamm/simulation/sim_msgs.go
@@ -144,7 +144,7 @@ func RandomSwapExactAmountIn(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Cont
 	randomCoinSubset := sim.RandSubsetCoins(sdk.NewCoins(sdk.NewCoin(accCoinIn.Denom, accCoinIn.Amount)))
 
 	// calculate the minimum number of tokens received from input of tokenIn
-	tokenOutMin, err := pool.CalcOutAmtGivenIn(ctx, randomCoinSubset, coinOut.Denom, pool.GetSwapFee(ctx))
+	tokenOutMin, err := pool.CalcOutAmtGivenIn(ctx, randomCoinSubset[0], coinOut.Denom, pool.GetSwapFee(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -182,11 +182,11 @@ func RandomSwapExactAmountOut(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Con
 	randomCoinInSubset := osmoutils.MinCoins(sdk.NewCoins(coinIn), sdk.NewCoins(accCoin))
 
 	// utilize CalcOutAmtGivenIn to calculate tokenOut and use tokenOut to calculate tokenInMax
-	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, randomCoinInSubset, coinOut.Denom, pool.GetSwapFee(ctx))
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, randomCoinInSubset[0], coinOut.Denom, pool.GetSwapFee(ctx))
 	if err != nil {
 		return nil, err
 	}
-	tokenInMax, err := pool.CalcInAmtGivenOut(ctx, sdk.NewCoins(tokenOut), coinIn.Denom, pool.GetSwapFee(ctx))
+	tokenInMax, err := pool.CalcInAmtGivenOut(ctx, tokenOut, coinIn.Denom, pool.GetSwapFee(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func RandomExitSwapExternAmountOut(k keeper.Keeper, sim *simtypes.SimCtx, ctx sd
 
 	// get amount of coinIn from exitedCoins and calculate how much of tokenOut you should get from that
 	exitedCoinsIn := exitedCoins.AmountOf(coinIn.Denom)
-	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewCoin(coinIn.Denom, exitedCoinsIn)), coinOut.Denom, pool.GetSwapFee(ctx))
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoin(coinIn.Denom, exitedCoinsIn), coinOut.Denom, pool.GetSwapFee(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func RandomExitSwapShareAmountIn(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.
 
 	// get amount of coinIn from exitedCoins and calculate how much of tokenOut you should get from that
 	exitedCoinsIn := exitedCoins.AmountOf(coinIn.Denom)
-	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewCoin(coinIn.Denom, exitedCoinsIn)), coinOut.Denom, pool.GetSwapFee(ctx))
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoin(coinIn.Denom, exitedCoinsIn), coinOut.Denom, pool.GetSwapFee(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/x/gamm/types/pool.go
+++ b/x/gamm/types/pool.go
@@ -75,14 +75,6 @@ type PoolAmountOutExtension interface {
 		swapFee sdk.Dec,
 	) (tokenInAmount sdk.Int, err error)
 
-	// JoinPoolTokenInMaxShareAmountOut add liquidity to a specified pool with a maximum amount of tokens in (tokenInMaxAmount)
-	// and swaps to an exact number of shares (shareOutAmount).
-	JoinPoolTokenInMaxShareAmountOut(
-		ctx sdk.Context,
-		tokenInDenom string,
-		shareOutAmount sdk.Int,
-	) (tokenInAmount sdk.Int, err error)
-
 	// ExitSwapExactAmountOut removes liquidity from a specified pool with a maximum amount of LP shares (shareInMaxAmount)
 	// and swaps to an exact amount of one of the token pairs (tokenOut).
 	ExitSwapExactAmountOut(

--- a/x/gamm/types/pool.go
+++ b/x/gamm/types/pool.go
@@ -41,17 +41,17 @@ type CFMMPoolI interface {
 	CalcJoinPoolShares(ctx sdk.Context, tokensIn sdk.Coins, swapFee sdk.Dec) (numShares sdk.Int, newLiquidity sdk.Coins, err error)
 	// SwapOutAmtGivenIn swaps 'tokenIn' against the pool, for tokenOutDenom, with the provided swapFee charged.
 	// Balance transfers are done in the keeper, but this method updates the internal pool state.
-	SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
+	SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
 	// CalcOutAmtGivenIn returns how many coins SwapOutAmtGivenIn would return on these arguments.
 	// This does not mutate the pool, or state.
-	CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
+	CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom string, swapFee sdk.Dec) (tokenOut sdk.Coin, err error)
 
 	// SwapInAmtGivenOut swaps exactly enough tokensIn against the pool, to get the provided tokenOut amount out of the pool.
 	// Balance transfers are done in the keeper, but this method updates the internal pool state.
-	SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
+	SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
 	// CalcInAmtGivenOut returns how many coins SwapInAmtGivenOut would return on these arguments.
 	// This does not mutate the pool, or state.
-	CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
+	CalcInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coin, tokenInDenom string, swapFee sdk.Dec) (tokenIn sdk.Coin, err error)
 }
 
 // PoolAmountOutExtension is an extension of the PoolI

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -64,7 +64,7 @@ func (k Keeper) ConvertProfits(ctx sdk.Context, inputCoin sdk.Coin, profit sdk.I
 
 	// Calculate the amount of uosmo that we can get if we swapped the
 	// profited amount of the orignal asset through the highest uosmo liquidity pool
-	conversionTokenOut, err := conversionPool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewCoin(inputCoin.Denom, profit)),
+	conversionTokenOut, err := conversionPool.CalcOutAmtGivenIn(ctx, sdk.NewCoin(inputCoin.Denom, profit),
 		types.OsmosisDenomination, conversionPool.GetSwapFee(ctx))
 	if err != nil {
 		return profit, err

--- a/x/txfees/keeper/hooks_test.go
+++ b/x/txfees/keeper/hooks_test.go
@@ -77,7 +77,7 @@ func (suite *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 				suite.Require().True(ok)
 
 				expectedOutput, err := pool.CalcOutAmtGivenIn(suite.Ctx,
-					sdk.Coins{sdk.Coin{Denom: tc.denoms[i], Amount: coin.Amount}},
+					sdk.Coin{Denom: tc.denoms[i], Amount: coin.Amount},
 					tc.baseDenom,
 					tc.swapFee)
 				suite.NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR is created during the Informal Systems audit, after analysis of the existing specification and code inspection
Auditing is performed on commit hash: [42d73f1](https://github.com/osmosis-labs/osmosis/commit/42d73f1cc1c52e85561518be1014b730ef6b7a12)
Some functions expect `Coins` as arguments and check if these `Coins` contain only 1 element. Other functions, which call them, have only one `Coin` from which make a set.


## Brief Changelog

* `SwapOutAmtGivenIn`, `CalcOutAmtGivenIn`, `SwapInAmtGivenOut`, `CalcInAmtGivenOut` and several other functions are changed to work with exactly one Coin.
* The `JoinPoolTokenInMaxShareAmountOut` function is removed because it is not used


## Testing and Verifying

Existing tests are modified in accordance with the new changes

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable