### PR TITLE
refactor(x/twap): handle spot price error case in the context of geometric twap

### DIFF
--- a/osmomath/sigfig_round_test.go
+++ b/osmomath/sigfig_round_test.go
@@ -70,6 +70,13 @@ func TestSigFigRound(t *testing.T) {
 			tenToSigFig:    sdk.NewInt(100),
 			expectedResult: sdk.MustNewDecFromStr("0.087"),
 		},
+
+		{
+			name:           "minimum decimal is still kept",
+			decimal:        sdk.NewDecWithPrec(1, 18),
+			tenToSigFig:    sdk.NewInt(10),
+			expectedResult: sdk.NewDecWithPrec(1, 18),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -766,6 +766,22 @@ func (suite *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 			baseDenomWeight:     sdk.NewInt(100),
 			expectError:         true,
 		},
+		{
+			name:                "internal error due to spot price precision being too small, resulting in 0 spot price",
+			quoteDenomPoolInput: sdk.NewCoin(baseDenom, sdk.OneInt()),
+			quoteDenomWeight:    sdk.NewInt(100),
+			baseDenomPoolInput:  sdk.NewCoin(quoteDenom, sdk.NewDec(10).PowerMut(19).TruncateInt().Sub(sdk.NewInt(2))),
+			baseDenomWeight:     sdk.NewInt(100),
+			expectError:         true,
+		},
+		{
+			name:                "at min spot price",
+			quoteDenomPoolInput: sdk.NewCoin(baseDenom, sdk.OneInt()),
+			quoteDenomWeight:    sdk.NewInt(100),
+			baseDenomPoolInput:  sdk.NewCoin(quoteDenom, sdk.NewDec(10).PowerMut(18).TruncateInt()),
+			baseDenomWeight:     sdk.NewInt(100),
+			expectedOutput:      sdk.OneDec().Quo(sdk.NewDec(10).PowerMut(18)),
+		},
 	}
 
 	for _, tc := range tests {

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -1339,33 +1339,51 @@ func (s *TestSuite) TestTwapLog_CorrectBase() {
 	s.Require().Equal(expectedValue, result)
 }
 
-func (s *TestSuite) TestTwapLog_MaxSpotPrice() {
-	price := gammtypes.MaxSpotPrice
-	// log_2{2^128 - 1} = 128
-	expectedResult := sdk.MustNewDecFromStr("127.999999999999999999")
-	result := twap.TwapLog(price)
-
-	s.Require().Equal(expectedResult, result)
-}
-
-func (s *TestSuite) TestTwapLog_ZeroPanic() {
-	osmoassert.ConditionalPanic(s.T(), true, func() {
-		twap.TwapLog(sdk.ZeroDec())
-	})
-}
-
-func (s *TestSuite) TestTwapLog_SmallestDec() {
-	zero := sdk.SmallestDec()
-	// https://www.wolframalpha.com/input?i=log+base+2+of+%2810%5E-18%29+with+20+digits
-	expectedResult := sdk.MustNewDecFromStr("59.794705707972522262").Neg()
-	result := twap.TwapLog(zero)
-
-	osmomath.ErrTolerance{
+func (s *TestSuite) TestTwapLog() {
+	smallestAdditiveTolerance := osmomath.ErrTolerance{
 		AdditiveTolerance: sdk.SmallestDec(),
-	}.CompareBigDec(
-		osmomath.BigDecFromSDKDec(expectedResult),
-		osmomath.BigDecFromSDKDec(result),
-	)
+	}
+
+	testcases := []struct {
+		name        string
+		price       sdk.Dec
+		expected    sdk.Dec
+		expectPanic bool
+	}{
+		{
+			"max spot price",
+			gammtypes.MaxSpotPrice,
+			// log_2{2^128 - 1} = 128
+			sdk.MustNewDecFromStr("127.999999999999999999"),
+			false,
+		},
+		{
+			"zero price - panic",
+			sdk.ZeroDec(),
+			sdk.Dec{},
+			true,
+		},
+		{
+			"smallest dec",
+			sdk.SmallestDec(),
+			// https://www.wolframalpha.com/input?i=log+base+2+of+%2810%5E-18%29+with+20+digits
+			sdk.MustNewDecFromStr("59.794705707972522262").Neg(),
+			false,
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			osmoassert.ConditionalPanic(s.T(), tc.expectPanic, func() {
+				result := twap.TwapLog(tc.price)
+
+				smallestAdditiveTolerance.CompareBigDec(
+					osmomath.BigDecFromSDKDec(tc.expected),
+					osmomath.BigDecFromSDKDec(result),
+				)
+			})
+		})
+	}
 }
 
 // TestTwapPow_CorrectBase tests that the base of 2 is used for the twap power function.

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -270,10 +270,20 @@ func TestRecordWithUpdatedAccumulators(t *testing.T) {
 			newTime:   time.Unix(1, 0),
 			expRecord: newExpRecord(oneDec, twoDec, pointFiveDec),
 		},
-		"zero spot price - panic": {
-			record:      withPrice0Set(defaultRecord, sdk.ZeroDec()),
-			newTime:     defaultRecord.Time.Add(time.Second),
-			expectPanic: true,
+		"sp0 - zero spot price - accum0 unchanged, accum1 updated, geom accum unchanged, last err time set": {
+			record:    withPrice0Set(defaultRecord, sdk.ZeroDec()),
+			newTime:   defaultRecord.Time.Add(time.Second),
+			expRecord: withLastErrTime(newExpRecord(oneDec, twoDec.Add(sdk.NewDecWithPrec(1, 1).Mul(OneSec)), pointFiveDec), defaultRecord.Time.Add(time.Second)),
+		},
+		"sp1 - zero spot price - accum0 updated, accum1 unchanged, geom accum updated correctly": {
+			record:    withPrice1Set(defaultRecord, sdk.ZeroDec()),
+			newTime:   defaultRecord.Time.Add(time.Second),
+			expRecord: newExpRecord(tenSecAccum.Add(oneDec), twoDec, pointFiveDec.Add(geometricTenSecAccum)),
+		},
+		"both sp - zero spot price - accum0 unchange, accum1 unchanged, geom accum unchanged": {
+			record:    withPrice1Set(withPrice0Set(defaultRecord, sdk.ZeroDec()), sdk.ZeroDec()),
+			newTime:   defaultRecord.Time.Add(time.Second),
+			expRecord: withLastErrTime(newExpRecord(oneDec, twoDec, pointFiveDec), defaultRecord.Time.Add(time.Second)),
 		},
 		"spot price of one - geom accumulator 0": {
 			record:    withPrice1Set(withPrice0Set(defaultRecord, sdk.OneDec()), sdk.OneDec()),
@@ -1327,6 +1337,35 @@ func (s *TestSuite) TestTwapLog_CorrectBase() {
 	result := twap.TwapLog(logOf)
 
 	s.Require().Equal(expectedValue, result)
+}
+
+func (s *TestSuite) TestTwapLog_MaxSpotPrice() {
+	price := gammtypes.MaxSpotPrice
+	// log_2{2^128 - 1} = 128
+	expectedResult := sdk.MustNewDecFromStr("127.999999999999999999")
+	result := twap.TwapLog(price)
+
+	s.Require().Equal(expectedResult, result)
+}
+
+func (s *TestSuite) TestTwapLog_ZeroPanic() {
+	osmoassert.ConditionalPanic(s.T(), true, func() {
+		twap.TwapLog(sdk.ZeroDec())
+	})
+}
+
+func (s *TestSuite) TestTwapLog_SmallestDec() {
+	zero := sdk.SmallestDec()
+	// https://www.wolframalpha.com/input?i=log+base+2+of+%2810%5E-18%29+with+20+digits
+	expectedResult := sdk.MustNewDecFromStr("59.794705707972522262").Neg()
+	result := twap.TwapLog(zero)
+
+	osmomath.ErrTolerance{
+		AdditiveTolerance: sdk.SmallestDec(),
+	}.CompareBigDec(
+		osmomath.BigDecFromSDKDec(expectedResult),
+		osmomath.BigDecFromSDKDec(result),
+	)
 }
 
 // TestTwapPow_CorrectBase tests that the base of 2 is used for the twap power function.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR handles spot price errors in the context of geometric twap. When a spot price error occurs, twap module sets sp0 and sp1 to zero.

In geometric calculation logic, we take the log of sp0. Since logarithm of zero is undefined, we should be careful not to do it.

Therefore, we handle this edge case by not updating the geometric accumulator and setting last error time to the `newTime`

Additionally, it includes test cases for sig fig rounding and spot price that I use to facilitate my understanding of when errors are returned.

## Testing and Verifying

Added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable