### PR TITLE
fix(scripts): proto gen osmoutils path

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -25,7 +25,7 @@ cd ..
 #
 # Note: Proto files are suffixed with the current binary version.
 cp -r github.com/osmosis-labs/osmosis/v13/* ./
-cp -r github.com/osmosis-labs/osmosis/osmoutils ./osmoutils
+cp -r github.com/osmosis-labs/osmosis/osmoutils ./
 rm -rf github.com
 
 go mod tidy -compat=1.18


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Upon more testing, I discovered that I made a [wrong change](https://github.com/osmosis-labs/osmosis/pull/3854#discussion_r1056877782) in https://github.com/osmosis-labs/osmosis/pull/3854 last minute. We don't need `osmoutils` extenstion in the copy to path.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable