### PR TITLE
chore: CL merge to main build fixes (no state-breaks)

### DIFF
--- a/app/apptesting/concentrated_liquidity.go
+++ b/app/apptesting/concentrated_liquidity.go
@@ -1,0 +1,32 @@
+package apptesting
+
+import (
+	clmodel "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/model"
+	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
+)
+
+var (
+	ETH                = "eth"
+	USDC               = "usdc"
+	DefaultTickSpacing = uint64(1)
+)
+
+// PrepareConcentratedPool sets up an eth usdc concentrated liquidity pool with pool ID 1, tick spacing of 1, and no liquidity
+func (s *KeeperTestHelper) PrepareConcentratedPool() types.ConcentratedPoolExtension {
+	// Mint some assets to the account.
+	s.FundAcc(s.TestAccs[0], DefaultAcctFunds)
+
+	// Create a concentrated pool via the swaprouter
+	poolID, err := s.App.SwapRouterKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing))
+	s.Require().NoError(err)
+
+	// Retrieve the poolInterface via the poolID
+	poolI, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
+	s.Require().NoError(err)
+
+	// Type cast the PoolInterface to a ConcentratedPoolExtension
+	pool, ok := poolI.(types.ConcentratedPoolExtension)
+	s.Require().True(ok)
+
+	return pool
+}

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -60,6 +60,8 @@ import (
 
 	_ "github.com/osmosis-labs/osmosis/v13/client/docs/statik"
 	owasm "github.com/osmosis-labs/osmosis/v13/wasmbinding"
+	concentratedliquidity "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity"
+	concentratedliquiditytypes "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 	epochskeeper "github.com/osmosis-labs/osmosis/v13/x/epochs/keeper"
 	epochstypes "github.com/osmosis-labs/osmosis/v13/x/epochs/types"
 	gammkeeper "github.com/osmosis-labs/osmosis/v13/x/gamm/keeper"
@@ -131,6 +133,7 @@ type AppKeepers struct {
 	ContractKeeper               *wasmkeeper.PermissionedKeeper
 	TokenFactoryKeeper           *tokenfactorykeeper.Keeper
 	SwapRouterKeeper             *swaprouter.Keeper
+	ConcentratedLiquidityKeeper  *concentratedliquidity.Keeper
 	ValidatorSetPreferenceKeeper *valsetpref.Keeper
 
 	// IBC modules
@@ -275,16 +278,24 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.GetSubspace(twaptypes.ModuleName),
 		appKeepers.GAMMKeeper)
 
+	appKeepers.ConcentratedLiquidityKeeper = concentratedliquidity.NewKeeper(
+		appCodec,
+		appKeepers.keys[concentratedliquiditytypes.StoreKey],
+		appKeepers.BankKeeper,
+		appKeepers.GetSubspace(concentratedliquiditytypes.ModuleName),
+	)
+
 	appKeepers.SwapRouterKeeper = swaprouter.NewKeeper(
 		appKeepers.keys[swaproutertypes.StoreKey],
 		appKeepers.GetSubspace(swaproutertypes.ModuleName),
 		appKeepers.GAMMKeeper,
-		nil, // TODO: add concentrated liquidity keeper once it is merged
+		appKeepers.ConcentratedLiquidityKeeper,
 		appKeepers.BankKeeper,
 		appKeepers.AccountKeeper,
 		appKeepers.DistrKeeper,
 	)
 	appKeepers.GAMMKeeper.SetPoolManager(appKeepers.SwapRouterKeeper)
+	appKeepers.ConcentratedLiquidityKeeper.SetSwapRouterKeeper(appKeepers.SwapRouterKeeper)
 
 	appKeepers.LockupKeeper = lockupkeeper.NewKeeper(
 		appKeepers.keys[lockuptypes.StoreKey],
@@ -554,6 +565,7 @@ func (appKeepers *AppKeepers) initParamsKeeper(appCodec codec.BinaryCodec, legac
 	paramsKeeper.Subspace(tokenfactorytypes.ModuleName)
 	paramsKeeper.Subspace(twaptypes.ModuleName)
 	paramsKeeper.Subspace(ibcratelimittypes.ModuleName)
+	paramsKeeper.Subspace(concentratedliquiditytypes.ModuleName)
 
 	return paramsKeeper
 }
@@ -644,6 +656,7 @@ func KVStoreKeys() []string {
 		incentivestypes.StoreKey,
 		epochstypes.StoreKey,
 		poolincentivestypes.StoreKey,
+		concentratedliquiditytypes.StoreKey,
 		swaproutertypes.StoreKey,
 		authzkeeper.StoreKey,
 		txfeestypes.StoreKey,

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -60,8 +60,6 @@ import (
 
 	_ "github.com/osmosis-labs/osmosis/v13/client/docs/statik"
 	owasm "github.com/osmosis-labs/osmosis/v13/wasmbinding"
-	concentratedliquidity "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity"
-	concentratedliquiditytypes "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 	epochskeeper "github.com/osmosis-labs/osmosis/v13/x/epochs/keeper"
 	epochstypes "github.com/osmosis-labs/osmosis/v13/x/epochs/types"
 	gammkeeper "github.com/osmosis-labs/osmosis/v13/x/gamm/keeper"
@@ -133,7 +131,6 @@ type AppKeepers struct {
 	ContractKeeper               *wasmkeeper.PermissionedKeeper
 	TokenFactoryKeeper           *tokenfactorykeeper.Keeper
 	SwapRouterKeeper             *swaprouter.Keeper
-	ConcentratedLiquidityKeeper  *concentratedliquidity.Keeper
 	ValidatorSetPreferenceKeeper *valsetpref.Keeper
 
 	// IBC modules
@@ -278,24 +275,16 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.GetSubspace(twaptypes.ModuleName),
 		appKeepers.GAMMKeeper)
 
-	appKeepers.ConcentratedLiquidityKeeper = concentratedliquidity.NewKeeper(
-		appCodec,
-		appKeepers.keys[concentratedliquiditytypes.StoreKey],
-		appKeepers.BankKeeper,
-		appKeepers.GetSubspace(concentratedliquiditytypes.ModuleName),
-	)
-
 	appKeepers.SwapRouterKeeper = swaprouter.NewKeeper(
 		appKeepers.keys[swaproutertypes.StoreKey],
 		appKeepers.GetSubspace(swaproutertypes.ModuleName),
 		appKeepers.GAMMKeeper,
-		appKeepers.ConcentratedLiquidityKeeper,
+		nil, // TODO: add concentrated liquidity keeper once it is merged
 		appKeepers.BankKeeper,
 		appKeepers.AccountKeeper,
 		appKeepers.DistrKeeper,
 	)
 	appKeepers.GAMMKeeper.SetPoolManager(appKeepers.SwapRouterKeeper)
-	appKeepers.ConcentratedLiquidityKeeper.SetSwapRouterKeeper(appKeepers.SwapRouterKeeper)
 
 	appKeepers.LockupKeeper = lockupkeeper.NewKeeper(
 		appKeepers.keys[lockuptypes.StoreKey],
@@ -565,7 +554,6 @@ func (appKeepers *AppKeepers) initParamsKeeper(appCodec codec.BinaryCodec, legac
 	paramsKeeper.Subspace(tokenfactorytypes.ModuleName)
 	paramsKeeper.Subspace(twaptypes.ModuleName)
 	paramsKeeper.Subspace(ibcratelimittypes.ModuleName)
-	paramsKeeper.Subspace(concentratedliquiditytypes.ModuleName)
 
 	return paramsKeeper
 }
@@ -656,7 +644,6 @@ func KVStoreKeys() []string {
 		incentivestypes.StoreKey,
 		epochstypes.StoreKey,
 		poolincentivestypes.StoreKey,
-		concentratedliquiditytypes.StoreKey,
 		swaproutertypes.StoreKey,
 		authzkeeper.StoreKey,
 		txfeestypes.StoreKey,

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -60,6 +60,7 @@ import (
 
 	_ "github.com/osmosis-labs/osmosis/v13/client/docs/statik"
 	owasm "github.com/osmosis-labs/osmosis/v13/wasmbinding"
+	concentratedliquidity "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity"
 	epochskeeper "github.com/osmosis-labs/osmosis/v13/x/epochs/keeper"
 	epochstypes "github.com/osmosis-labs/osmosis/v13/x/epochs/types"
 	gammkeeper "github.com/osmosis-labs/osmosis/v13/x/gamm/keeper"
@@ -132,6 +133,10 @@ type AppKeepers struct {
 	TokenFactoryKeeper           *tokenfactorykeeper.Keeper
 	SwapRouterKeeper             *swaprouter.Keeper
 	ValidatorSetPreferenceKeeper *valsetpref.Keeper
+	// Note: this keeper is unwired. It is only present to avoid build
+	// issues in tests. However, It is not yet wired to be used
+	// in regular app code.
+	ConcentratedLiquidityKeeper *concentratedliquidity.Keeper
 
 	// IBC modules
 	// transfer module

--- a/x/concentrated-liquidity/client/cli/query.go
+++ b/x/concentrated-liquidity/client/cli/query.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/osmosis-labs/osmosis/v13/osmoutils/osmocli"
+	"github.com/osmosis-labs/osmosis/osmoutils/osmocli"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 )
 

--- a/x/concentrated-liquidity/client/cli/tx.go
+++ b/x/concentrated-liquidity/client/cli/tx.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/osmosis-labs/osmosis/v13/osmoutils/osmocli"
+	"github.com/osmosis-labs/osmosis/osmoutils/osmocli"
 	clmodel "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 )

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -22,6 +22,9 @@ var (
 // TestInitGenesis tests the InitGenesis function of the ConcentratedLiquidityKeeper.
 // It checks that the state is initialized correctly based on the provided genesis.
 func TestInitGenesis(t *testing.T) {
+
+	t.Skip("TODO: re-enable this when CL state-breakage PR is merged.")
+
 	// Set up the app and context
 	app := osmoapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
@@ -39,6 +42,9 @@ func TestInitGenesis(t *testing.T) {
 // TestExportGenesis tests the ExportGenesis function of the ConcentratedLiquidityKeeper.
 // It checks that the correct genesis state is returned.
 func TestExportGenesis(t *testing.T) {
+
+	t.Skip("TODO: re-enable this when CL state-breakage PR is merged.")
+
 	// Set up the app and context
 	app := osmoapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -62,6 +62,9 @@ func TestExportGenesis(t *testing.T) {
 // TestMarshalUnmarshalGenesis tests the MarshalUnmarshalGenesis functions of the ConcentratedLiquidityKeeper.
 // It checks that the exported genesis can be marshaled and unmarshaled without panicking.
 func TestMarshalUnmarshalGenesis(t *testing.T) {
+
+	t.Skip("TODO: re-enable this when CL state-breakage PR is merged.")
+
 	// Set up the app and context
 	app := osmoapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})

--- a/x/concentrated-liquidity/grpc_query.go
+++ b/x/concentrated-liquidity/grpc_query.go
@@ -11,7 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
-	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 )
@@ -68,7 +68,7 @@ func (q Querier) Pools(
 	pageRes, err := query.Paginate(poolStore, req.Pagination, func(key, _ []byte) error {
 		pool := model.Pool{}
 		// Get the next pool from the poolStore and pass it to the pool variable
-		_, err := osmoutils.GetIfFound(poolStore, key, &pool)
+		_, err := osmoutils.Get(poolStore, key, &pool)
 		if err != nil {
 			return err
 		}

--- a/x/concentrated-liquidity/internal/math/tick.go
+++ b/x/concentrated-liquidity/internal/math/tick.go
@@ -3,7 +3,7 @@ package math
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/osmomath"
+	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
 // TicksToSqrtPrice returns the sqrt price for the lower and upper ticks.

--- a/x/concentrated-liquidity/internal/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/swap_strategy_test.go
@@ -17,6 +17,9 @@ type StrategyTestSuite struct {
 }
 
 func TestStrategyTestSuite(t *testing.T) {
+
+	t.Skip("TODO: re-enable this when CL state-breakage PR is merged.")
+
 	suite.Run(t, new(StrategyTestSuite))
 }
 

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -35,6 +35,9 @@ type KeeperTestSuite struct {
 }
 
 func TestKeeperTestSuite(t *testing.T) {
+
+	t.Skip("TODO: re-enable this when CL state-breakage PR is merged.")
+
 	suite.Run(t, new(KeeperTestSuite))
 }
 

--- a/x/concentrated-liquidity/model/codec.go
+++ b/x/concentrated-liquidity/model/codec.go
@@ -5,7 +5,6 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -22,17 +21,19 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	msgservice.RegisterMsgServiceDesc(registry, &_MsgCreator_serviceDesc)
 }
 
-var (
-	amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(amino)
-)
+// TODO: re-enable this when CL state-breakage PR is merged.
+// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+// var (
+// 	amino     = codec.NewLegacyAmino()
+// 	ModuleCdc = codec.NewAminoCodec(amino)
+// )
 
-func init() {
-	RegisterCodec(amino)
-	sdk.RegisterLegacyAminoCodec(amino)
+// func init() {
+// 	RegisterCodec(amino)
+// 	sdk.RegisterLegacyAminoCodec(amino)
 
-	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
-	// used to properly serialize MsgGrant and MsgExec instances
-	RegisterCodec(authzcodec.Amino)
-	amino.Seal()
-}
+// 	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
+// 	// used to properly serialize MsgGrant and MsgExec instances
+// 	RegisterCodec(authzcodec.Amino)
+// 	amino.Seal()
+// }

--- a/x/concentrated-liquidity/model/msgs.go
+++ b/x/concentrated-liquidity/model/msgs.go
@@ -63,7 +63,8 @@ func (msg MsgCreateConcentratedPool) ValidateBasic() error {
 }
 
 func (msg MsgCreateConcentratedPool) GetSignBytes() []byte {
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return nil
+	// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgCreateConcentratedPool) GetSigners() []sdk.AccAddress {

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -6,7 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/model"
 	types "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
@@ -46,7 +46,7 @@ func (k Keeper) getPoolById(ctx sdk.Context, poolId uint64) (types.ConcentratedP
 	store := ctx.KVStore(k.storeKey)
 	pool := model.Pool{}
 	key := types.KeyPool(poolId)
-	found, err := osmoutils.GetIfFound(store, key, &pool)
+	found, err := osmoutils.Get(store, key, &pool)
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ func (k Keeper) poolExists(ctx sdk.Context, poolId uint64) bool {
 	store := ctx.KVStore(k.storeKey)
 	pool := model.Pool{}
 	key := types.KeyPool(poolId)
-	found, err := osmoutils.GetIfFound(store, key, &pool)
+	found, err := osmoutils.Get(store, key, &pool)
 	if err != nil {
 		panic(err)
 	}

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -3,7 +3,7 @@ package concentrated_liquidity
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/model"
 	types "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
 )
@@ -72,7 +72,7 @@ func (k Keeper) getPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress
 	positionStruct := &model.Position{}
 	key := types.KeyPosition(poolId, owner, lowerTick, upperTick)
 
-	found, err := osmoutils.GetIfFound(store, key, positionStruct)
+	found, err := osmoutils.Get(store, key, positionStruct)
 	if err != nil {
 		return nil, err
 	}

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -1170,7 +1170,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 				s.Require().Greater(gasConsumedForSwap, uint64(cltypes.ConcentratedGasFeeForSwap))
 
 				// Assert events
-				s.AssertEventEmitted(s.Ctx, swaproutertypes.TypeEvtTokenSwapped, 1)
+				s.AssertEventEmitted(s.Ctx, cltypes.TypeEvtTokenSwapped, 1)
 
 				// Retrieve pool again post swap
 				pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
@@ -1314,7 +1314,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 				s.Require().Greater(gasConsumedForSwap, uint64(cltypes.ConcentratedGasFeeForSwap))
 
 				// Assert events
-				s.AssertEventEmitted(s.Ctx, swaproutertypes.TypeEvtTokenSwapped, 1)
+				s.AssertEventEmitted(s.Ctx, cltypes.TypeEvtTokenSwapped, 1)
 
 				// Retrieve pool again post swap
 				pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -3,7 +3,7 @@ package concentrated_liquidity
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/v13/osmoutils"
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/internal/math"
 	"github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/model"
 	types "github.com/osmosis-labs/osmosis/v13/x/concentrated-liquidity/types"
@@ -61,7 +61,7 @@ func (k Keeper) getTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (ti
 		return model.TickInfo{}, types.PoolNotFoundError{PoolId: poolId}
 	}
 
-	found, err := osmoutils.GetIfFound(store, key, &tickStruct)
+	found, err := osmoutils.Get(store, key, &tickStruct)
 	// return 0 values if key has not been initialized
 	if !found {
 		return model.TickInfo{LiquidityGross: sdk.ZeroDec(), LiquidityNet: sdk.ZeroDec()}, err

--- a/x/concentrated-liquidity/types/codec.go
+++ b/x/concentrated-liquidity/types/codec.go
@@ -5,7 +5,7 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
+	// authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -29,17 +29,19 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
-var (
-	amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(amino)
-)
+// TODO: re-enable this when CL state-breakage PR is merged.
+// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+// var (
+// 	amino     = codec.NewLegacyAmino()
+// 	ModuleCdc = codec.NewAminoCodec(amino)
+// )
 
-func init() {
-	RegisterCodec(amino)
-	sdk.RegisterLegacyAminoCodec(amino)
+// func init() {
+// 	RegisterCodec(amino)
+// 	sdk.RegisterLegacyAminoCodec(amino)
 
-	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
-	// used to properly serialize MsgGrant and MsgExec instances
-	RegisterCodec(authzcodec.Amino)
-	amino.Seal()
-}
+// 	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
+// 	// used to properly serialize MsgGrant and MsgExec instances
+// 	RegisterCodec(authzcodec.Amino)
+// 	amino.Seal()
+// }

--- a/x/concentrated-liquidity/types/events.go
+++ b/x/concentrated-liquidity/types/events.go
@@ -17,4 +17,5 @@ const (
 	TypeEvtPoolJoined      = "pool_joined"
 	TypeEvtPoolExited      = "pool_exited"
 	TypeEvtPoolCreated     = "pool_created"
+	TypeEvtTokenSwapped    = "token_swapped"
 )

--- a/x/concentrated-liquidity/types/msgs.go
+++ b/x/concentrated-liquidity/types/msgs.go
@@ -54,7 +54,10 @@ func (msg MsgCreatePosition) ValidateBasic() error {
 }
 
 func (msg MsgCreatePosition) GetSignBytes() []byte {
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	// TODO: re-enable this when CL state-breakage PR is merged.
+	// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return nil
 }
 
 func (msg MsgCreatePosition) GetSigners() []sdk.AccAddress {
@@ -95,7 +98,9 @@ func (msg MsgWithdrawPosition) ValidateBasic() error {
 }
 
 func (msg MsgWithdrawPosition) GetSignBytes() []byte {
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	// TODO: re-enable this when CL state-breakage PR is merged.
+	// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return nil
 }
 
 func (msg MsgWithdrawPosition) GetSigners() []sdk.AccAddress {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR is a follow-up to: https://github.com/osmosis-labs/osmosis/pull/3868

It fixes all build issues in #3868 while continuing to preserve state compatibility with `main`.

The new keeper/module is not yet registered. The amino and codec are not registered either. Tests relying on these registrations are disabled until we merge state-breakage logic in a separate PR. 

The `ConcentratedLiquidityKeeper` is added to the app to avoid build issues in tests. However, it continues to be unwired.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable