### PR TITLE
fix: add negative to cli

### DIFF
--- a/osmoutils/osmocli/parsers.go
+++ b/osmoutils/osmocli/parsers.go
@@ -166,6 +166,14 @@ func parseFieldFromDirectlySetFlag(fVal reflect.Value, fType reflect.StructField
 }
 
 func ParseFieldFromArg(fVal reflect.Value, fType reflect.StructField, arg string) error {
+	// We cant pass in a negative number due to the way pflags works...
+	// This is an (extraordinarily ridiculous) workaround that checks if a negative int is encapsulated in square brackets,
+	// and if so, trims the square brackets
+	if strings.HasPrefix(arg, "[") && strings.HasSuffix(arg, "]") && arg[1] == '-' {
+		arg = strings.TrimPrefix(arg, "[")
+		arg = strings.TrimSuffix(arg, "]")
+	}
+
 	switch fType.Type.Kind() {
 	// SetUint allows anyof type u8, u16, u32, u64, and uint
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Osmocli does not allow negatives. This is a workaround. This needs to get merged since we utilize this as its own gomod package, so local changes do not overwrite like before.