### PR TITLE
refactor(osmoutils): UpdateAccumulator does not overwrite; tests

### DIFF
--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -63,10 +63,12 @@ func setAccumulator(accum AccumulatorObject, amt sdk.DecCoins) {
 	osmoutils.MustSet(accum.store, formatAccumPrefixKey(accum.name), &newAccum)
 }
 
-// TODO: consider making this increment the accumulator's value instead of overwriting it
-// Note: accum receiver is not mutated, only the store representation is.
-func (accum AccumulatorObject) UpdateAccumulator(amt sdk.DecCoins) {
-	setAccumulator(accum, amt)
+// UpdateAccumulator updates the accumulator's value by amt.
+// It does so by incresing the value of the accumulator by
+// the given amount. Persists to store. Mutates the receiver.
+func (accum *AccumulatorObject) UpdateAccumulator(amt sdk.DecCoins) {
+	accum.value = accum.value.Add(amt...)
+	setAccumulator(*accum, accum.value)
 }
 
 // NewPosition creates a new position for the given address, with the given number of share units
@@ -162,6 +164,11 @@ func (accum AccumulatorObject) GetPositionSize(addr sdk.AccAddress) (sdk.Dec, er
 	}
 
 	return position.NumShares, nil
+}
+
+// GetValue returns the current value of the accumulator.
+func (accum AccumulatorObject) GetValue() sdk.DecCoins {
+	return accum.value
 }
 
 // ClaimRewards claims the rewards for the given address, and returns the amount of rewards claimed.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR is extracted from https://github.com/osmosis-labs/osmosis/pull/3893

We should be updating the accumulator instead of overwriting its value. The accumulator is likely to always grow. As a result, this is a UX feature.

In the unlikely case when it is needed to reset the accumulator value, the user can still do so by providing negative input.

Additionally, added a `GetValue()` API on the accumulator.

Tests added.