### PR TITLE
refactor(osmoutils): index position by string name instead of address

### DIFF
--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -72,7 +72,7 @@ func (accum *AccumulatorObject) UpdateAccumulator(amt sdk.DecCoins) {
 }
 
 // NewPosition creates a new position for the given name, with the given number of share units.
-// The name cam be an owner's address, or any other unique identifier for a position.
+// The name can be an owner's address, or any other unique identifier for a position.
 // It takes a snapshot of the current accumulator value, and sets the position's initial value to that.
 // The position is initialized with empty unclaimed rewards
 // If there is an existing position for the given address, it is overwritten.

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -69,19 +69,20 @@ func (accum AccumulatorObject) UpdateAccumulator(amt sdk.DecCoins) {
 	setAccumulator(accum, amt)
 }
 
-// NewPosition creates a new position for the given address, with the given number of share units
+// NewPosition creates a new position for the given name, with the given number of share units.
+// The name cam be an owner's address, or any other unique identifier for a position.
 // It takes a snapshot of the current accumulator value, and sets the position's initial value to that.
 // The position is initialized with empty unclaimed rewards
 // If there is an existing position for the given address, it is overwritten.
-func (accum AccumulatorObject) NewPosition(addr sdk.AccAddress, numShareUnits sdk.Dec, options *Options) error {
+func (accum AccumulatorObject) NewPosition(name string, numShareUnits sdk.Dec, options *Options) error {
 	if err := options.validate(); err != nil {
 		return err
 	}
-	createNewPosition(accum, addr, numShareUnits, sdk.NewDecCoins(), options)
+	createNewPosition(accum, name, numShareUnits, sdk.NewDecCoins(), options)
 	return nil
 }
 
-// AddToPosition adds newShares of shares to addr's position.
+// AddToPosition adds newShares of shares to an existing position with the given name.
 // This is functionally equivalent to claiming rewards, closing down the position, and
 // opening a fresh one with the new number of shares. We can represent this behavior by
 // claiming rewards and moving up the accumulator start value to its current value.
@@ -95,27 +96,27 @@ func (accum AccumulatorObject) NewPosition(addr sdk.AccAddress, numShareUnits sd
 // - newShares are negative or zero.
 // - there is no existing position at the given address
 // - other internal or database error occurs.
-func (accum AccumulatorObject) AddToPosition(addr sdk.AccAddress, newShares sdk.Dec) error {
+func (accum AccumulatorObject) AddToPosition(name string, newShares sdk.Dec) error {
 	if !newShares.IsPositive() {
 		return errors.New("Attempted to add a non-zero and non-negative number of shares to a position")
 	}
 
 	// Get addr's current position
-	position, err := getPosition(accum, addr)
+	position, err := getPosition(accum, name)
 	if err != nil {
 		return err
 	}
 
 	// Save current number of shares and unclaimed rewards
 	unclaimedRewards := getTotalRewards(accum, position)
-	oldNumShares, err := accum.GetPositionSize(addr)
+	oldNumShares, err := accum.GetPositionSize(name)
 	if err != nil {
 		return err
 	}
 
 	// Update user's position with new number of shares while moving its unaccrued rewards
 	// into UnclaimedRewards. Starting accumulator value is moved up to accum'scurrent value
-	createNewPosition(accum, addr, oldNumShares.Add(newShares), unclaimedRewards, position.Options)
+	createNewPosition(accum, name, oldNumShares.Add(newShares), unclaimedRewards, position.Options)
 
 	return nil
 }
@@ -124,14 +125,14 @@ func (accum AccumulatorObject) AddToPosition(addr sdk.AccAddress, newShares sdk.
 // the unclaimed and newly accrued rewards and returns them alongside the redeemed shares. Then, it
 // overwrites the position record with the updated number of shares. Since it accrues rewards, it
 // also moves up the position's accumulator value to the current accum val.
-func (accum AccumulatorObject) RemoveFromPosition(addr sdk.AccAddress, numSharesToRemove sdk.Dec) error {
+func (accum AccumulatorObject) RemoveFromPosition(name string, numSharesToRemove sdk.Dec) error {
 	// Cannot remove zero or negative shares
 	if numSharesToRemove.LTE(sdk.ZeroDec()) {
 		return fmt.Errorf("Attempted to remove no/negative shares (%s)", numSharesToRemove)
 	}
 
 	// Get addr's current position
-	position, err := getPosition(accum, addr)
+	position, err := getPosition(accum, name)
 	if err != nil {
 		return err
 	}
@@ -143,20 +144,20 @@ func (accum AccumulatorObject) RemoveFromPosition(addr sdk.AccAddress, numShares
 
 	// Save current number of shares and unclaimed rewards
 	unclaimedRewards := getTotalRewards(accum, position)
-	oldNumShares, err := accum.GetPositionSize(addr)
+	oldNumShares, err := accum.GetPositionSize(name)
 	if err != nil {
 		return err
 	}
 
-	createNewPosition(accum, addr, oldNumShares.Sub(numSharesToRemove), unclaimedRewards, position.Options)
+	createNewPosition(accum, name, oldNumShares.Sub(numSharesToRemove), unclaimedRewards, position.Options)
 
 	return nil
 }
 
-// GetPositionSize returns the number of shares the position corresponding to `addr`
-// in accumulator `accum` has, or an error if no position exists.
-func (accum AccumulatorObject) GetPositionSize(addr sdk.AccAddress) (sdk.Dec, error) {
-	position, err := getPosition(accum, addr)
+// GetPositionSize returns the number of shares the position corresponding to postion's name
+// or an error if no position exists.
+func (accum AccumulatorObject) GetPositionSize(name string) (sdk.Dec, error) {
+	position, err := getPosition(accum, name)
 	if err != nil {
 		return sdk.Dec{}, err
 	}
@@ -164,22 +165,22 @@ func (accum AccumulatorObject) GetPositionSize(addr sdk.AccAddress) (sdk.Dec, er
 	return position.NumShares, nil
 }
 
-// ClaimRewards claims the rewards for the given address, and returns the amount of rewards claimed.
+// ClaimRewards claims the rewards for the given position name, and returns the amount of rewards claimed.
 // Upon claiming the rewards, the position at the current address is reset to have no
 // unclaimed rewards. The position's accumulator is also set to the current accumulator value.
 // Returns error if no position exists for the given address. Returns error if any
 // database errors occur.
-func (accum AccumulatorObject) ClaimRewards(addr sdk.AccAddress) (sdk.DecCoins, error) {
-	position, err := getPosition(accum, addr)
+func (accum AccumulatorObject) ClaimRewards(positionName string) (sdk.DecCoins, error) {
+	position, err := getPosition(accum, positionName)
 	if err != nil {
-		return sdk.DecCoins{}, NoPositionError{addr}
+		return sdk.DecCoins{}, NoPositionError{positionName}
 	}
 
 	totalRewards := getTotalRewards(accum, position)
 
 	// Create a completely new position, with no rewards
 	// TODO: remove the position from state entirely if numShares = zero
-	createNewPosition(accum, addr, position.NumShares, sdk.NewDecCoins(), position.Options)
+	createNewPosition(accum, positionName, position.NumShares, sdk.NewDecCoins(), position.Options)
 
 	return totalRewards, nil
 }

--- a/osmoutils/accum/accum_helpers.go
+++ b/osmoutils/accum/accum_helpers.go
@@ -7,25 +7,25 @@ import (
 )
 
 // Creates a new position at accumulator's current value with a specific number of shares and unclaimed rewards
-func createNewPosition(name AccumulatorObject, index string, numShareUnits sdk.Dec, unclaimedRewards sdk.DecCoins, options *Options) {
+func createNewPosition(accum AccumulatorObject, index string, numShareUnits sdk.Dec, unclaimedRewards sdk.DecCoins, options *Options) {
 	position := Record{
 		NumShares:        numShareUnits,
-		InitAccumValue:   name.value,
+		InitAccumValue:   accum.value,
 		UnclaimedRewards: unclaimedRewards,
 		Options:          options,
 	}
-	osmoutils.MustSet(name.store, formatPositionPrefixKey(name.name, index), &position)
+	osmoutils.MustSet(accum.store, formatPositionPrefixKey(accum.name, index), &position)
 }
 
 // Gets addr's current position from store
-func getPosition(accum AccumulatorObject, addr string) (Record, error) {
+func getPosition(accum AccumulatorObject, name string) (Record, error) {
 	position := Record{}
-	found, err := osmoutils.Get(accum.store, formatPositionPrefixKey(accum.name, addr), &position)
+	found, err := osmoutils.Get(accum.store, formatPositionPrefixKey(accum.name, name), &position)
 	if err != nil {
 		return Record{}, err
 	}
 	if !found {
-		return Record{}, NoPositionError{addr}
+		return Record{}, NoPositionError{name}
 	}
 
 	return position, nil

--- a/osmoutils/accum/accum_helpers.go
+++ b/osmoutils/accum/accum_helpers.go
@@ -7,20 +7,20 @@ import (
 )
 
 // Creates a new position at accumulator's current value with a specific number of shares and unclaimed rewards
-func createNewPosition(accum AccumulatorObject, addr sdk.AccAddress, numShareUnits sdk.Dec, unclaimedRewards sdk.DecCoins, options *Options) {
+func createNewPosition(name AccumulatorObject, index string, numShareUnits sdk.Dec, unclaimedRewards sdk.DecCoins, options *Options) {
 	position := Record{
 		NumShares:        numShareUnits,
-		InitAccumValue:   accum.value,
+		InitAccumValue:   name.value,
 		UnclaimedRewards: unclaimedRewards,
 		Options:          options,
 	}
-	osmoutils.MustSet(accum.store, formatPositionPrefixKey(accum.name, addr.String()), &position)
+	osmoutils.MustSet(name.store, formatPositionPrefixKey(name.name, index), &position)
 }
 
 // Gets addr's current position from store
-func getPosition(accum AccumulatorObject, addr sdk.AccAddress) (Record, error) {
+func getPosition(accum AccumulatorObject, addr string) (Record, error) {
 	position := Record{}
-	found, err := osmoutils.Get(accum.store, formatPositionPrefixKey(accum.name, addr.String()), &position)
+	found, err := osmoutils.Get(accum.store, formatPositionPrefixKey(accum.name, addr), &position)
 	if err != nil {
 		return Record{}, err
 	}

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -266,7 +266,7 @@ func (suite *AccumTestSuite) TestClaimRewards() {
 		"claim at testAddressTwo with no rewards - error - no position": {
 			accObject:   accumNoRewards,
 			name:        testAddressThree,
-			expectError: accumPackage.NoPositionError{Address: testAddressThree},
+			expectError: accumPackage.NoPositionError{Name: testAddressThree},
 		},
 		"claim at testAddressThree with single reward token - success": {
 			accObject: accumOneReward,

--- a/osmoutils/accum/errors.go
+++ b/osmoutils/accum/errors.go
@@ -5,9 +5,9 @@ import (
 )
 
 type NoPositionError struct {
-	Address string
+	Name string
 }
 
 func (e NoPositionError) Error() string {
-	return fmt.Sprintf("no position found for address (%s)", e.Address)
+	return fmt.Sprintf("no position found for address (%s)", e.Name)
 }

--- a/osmoutils/accum/errors.go
+++ b/osmoutils/accum/errors.go
@@ -2,12 +2,10 @@ package accum
 
 import (
 	"fmt"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type NoPositionError struct {
-	Address sdk.AccAddress
+	Address string
 }
 
 func (e NoPositionError) Error() string {

--- a/osmoutils/accum/export_test.go
+++ b/osmoutils/accum/export_test.go
@@ -15,9 +15,9 @@ import (
 // This function is currently used for testing purposes only.
 // If there is a need to use this function in production, it
 // can be moved to a non-test file.
-func (accum AccumulatorObject) GetPosition(addr sdk.AccAddress) Record {
+func (accum AccumulatorObject) GetPosition(name string) Record {
 	position := Record{}
-	osmoutils.MustGet(accum.store, formatPositionPrefixKey(accum.name, addr.String()), &position)
+	osmoutils.MustGet(accum.store, formatPositionPrefixKey(accum.name, name), &position)
 	return position
 }
 
@@ -39,12 +39,12 @@ func CreateRawAccumObject(store store.KVStore, name string, value sdk.DecCoins) 
 	}
 }
 
-func CreateRawPosition(accum AccumulatorObject, addr sdk.AccAddress, numShareUnits sdk.Dec, unclaimedRewards sdk.DecCoins, options *Options) {
-	createNewPosition(accum, addr, numShareUnits, unclaimedRewards, options)
+func CreateRawPosition(accum AccumulatorObject, name string, numShareUnits sdk.Dec, unclaimedRewards sdk.DecCoins, options *Options) {
+	createNewPosition(accum, name, numShareUnits, unclaimedRewards, options)
 }
 
-func GetPosition(accum AccumulatorObject, addr sdk.AccAddress) (Record, error) {
-	return getPosition(accum, addr)
+func GetPosition(accum AccumulatorObject, name string) (Record, error) {
+	return getPosition(accum, name)
 }
 
 // Gets store from accumulator for testing purposes
@@ -66,9 +66,9 @@ func parseRecordFromBz(bz []byte) (record Record, err error) {
 	return record, nil
 }
 
-// WithPosition is a decorator test function to append a position at given address to the given accumulator.
-func WithPosition(accum AccumulatorObject, addr sdk.Address, position Record) AccumulatorObject {
-	osmoutils.MustSet(accum.store, formatPositionPrefixKey(accum.name, addr.String()), &position)
+// WithPosition is a decorator test function to append a position with the given name to the given accumulator.
+func WithPosition(accum AccumulatorObject, name string, position Record) AccumulatorObject {
+	osmoutils.MustSet(accum.store, formatPositionPrefixKey(accum.name, name), &position)
 	return accum
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Index position by string name instead of the address. This is required for some use cases such as concentrated liquidity (CL).

In CL, we need to index positions by the owner, pool id, and ticks.

The flexibility to index by address is still provided since address can easily be converted to string.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
