### PR TITLE
refactor(osmoutils): accumulator ClaimRewards returns sdk.Coins

### DIFF
--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -178,12 +178,13 @@ func (accum AccumulatorObject) ClaimRewards(addr sdk.AccAddress) (sdk.Coins, err
 	totalRewards := getTotalRewards(accum, position)
 
 	// Return the integer coins to the user
-	// The remaining change is reinvested into the new position.
-	truncatedRewards, remainingChange := totalRewards.TruncateDecimal()
+	// The remaining change is thrown away.
+	// This is acceptable because we round in favour of the protocol.
+	truncatedRewards, _ := totalRewards.TruncateDecimal()
 
 	// Create a completely new position, with no rewards
 	// TODO: remove the position from state entirely if numShares = zero
-	createNewPosition(accum, addr, position.NumShares, remainingChange, position.Options)
+	createNewPosition(accum, addr, position.NumShares, sdk.NewDecCoins(), position.Options)
 
 	return truncatedRewards, nil
 }

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -218,7 +218,7 @@ func (suite *AccumTestSuite) TestClaimRewards() {
 		return coins
 	}
 
-	// single output convinience wrapper.
+	// single output convenience wrapper.
 	toChange := func(decCoins sdk.DecCoins) sdk.DecCoins {
 		_, change := decCoins.TruncateDecimal()
 		return change

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -218,12 +218,6 @@ func (suite *AccumTestSuite) TestClaimRewards() {
 		return coins
 	}
 
-	// single output convenience wrapper.
-	toChange := func(decCoins sdk.DecCoins) sdk.DecCoins {
-		_, change := decCoins.TruncateDecimal()
-		return change
-	}
-
 	// We setup store and accum
 	// once at beginning so we can test duplicate positions
 	suite.SetupTest()
@@ -263,50 +257,42 @@ func (suite *AccumTestSuite) TestClaimRewards() {
 		accObject      accumPackage.AccumulatorObject
 		addr           sdk.AccAddress
 		expectedResult sdk.Coins
-		// we reinvest this back into the newly created position.
-		expectedTruncatuionChangeReinvested sdk.DecCoins
-		expectError                         error
+		expectError    error
 	}{
 		"claim at testAddressOne with no rewards - success": {
-			accObject:                           accumNoRewards,
-			addr:                                testAddressOne,
-			expectedResult:                      toCoins(emptyCoins),
-			expectedTruncatuionChangeReinvested: emptyCoins,
+			accObject:      accumNoRewards,
+			addr:           testAddressOne,
+			expectedResult: toCoins(emptyCoins),
 		},
 		"claim at testAddressTwo with no rewards - success": {
-			accObject:                           accumNoRewards,
-			addr:                                testAddressTwo,
-			expectedResult:                      toCoins(emptyCoins),
-			expectedTruncatuionChangeReinvested: emptyCoins,
+			accObject:      accumNoRewards,
+			addr:           testAddressTwo,
+			expectedResult: toCoins(emptyCoins),
 		},
 		"claim at testAddressTwo with no rewards - error - no position": {
-			accObject:                           accumNoRewards,
-			addr:                                testAddressThree,
-			expectError:                         accumPackage.NoPositionError{Address: testAddressThree},
-			expectedTruncatuionChangeReinvested: emptyCoins,
+			accObject:   accumNoRewards,
+			addr:        testAddressThree,
+			expectError: accumPackage.NoPositionError{Address: testAddressThree},
 		},
 		"claim at testAddressThree with single reward token - success": {
 			accObject: accumOneReward,
 			addr:      testAddressThree,
 			// denomOne: (200.2 - 100.1) * 300 (accum diff * share count) = 30030
-			expectedResult:                      toCoins(initialCoinsDenomOne.MulDec(positionThree.NumShares)),
-			expectedTruncatuionChangeReinvested: emptyCoins,
+			expectedResult: toCoins(initialCoinsDenomOne.MulDec(positionThree.NumShares)),
 		},
 		"claim at testAddressOne with multiple reward tokens and unclaimed rewards - success": {
 			accObject: accumThreeRewards,
 			addr:      testAddressOne,
 			// denomOne: (300.3 - 0) * 100 (accum diff * share count) + 100.1 (unclaimed rewards) = 30130.1
 			// denomTwo: (3 - 0) * 100 (accum diff * share count) = 300
-			expectedResult:                      toCoins(tripleDenomOneAndTwo.MulDec(positionOne.NumShares).Add(initialCoinDenomOne)),
-			expectedTruncatuionChangeReinvested: toChange(tripleDenomOneAndTwo.MulDec(positionOne.NumShares).Add(initialCoinDenomOne)),
+			expectedResult: toCoins(tripleDenomOneAndTwo.MulDec(positionOne.NumShares).Add(initialCoinDenomOne)),
 		},
 		"claim at testAddressTwo with multiple reward tokens and no unclaimed rewards - success": {
 			accObject: accumThreeRewards,
 			addr:      testAddressTwo,
 			// denomOne: (300.3 - 0) * 200 (accum diff * share count) = 60060.6
 			// denomTwo: (3 - 0) * 200  (accum diff * share count) = 600
-			expectedResult:                      toCoins(sdk.NewDecCoins(initialCoinDenomOne, sdk.NewDecCoinFromDec(denomTwo, sdk.OneDec())).MulDec(positionTwo.NumShares).MulDec(sdk.NewDec(3))),
-			expectedTruncatuionChangeReinvested: toChange(sdk.NewDecCoins(initialCoinDenomOne, sdk.NewDecCoinFromDec(denomTwo, sdk.OneDec())).MulDec(positionTwo.NumShares).MulDec(sdk.NewDec(3))),
+			expectedResult: toCoins(sdk.NewDecCoins(initialCoinDenomOne, sdk.NewDecCoinFromDec(denomTwo, sdk.OneDec())).MulDec(positionTwo.NumShares).MulDec(sdk.NewDec(3))),
 		},
 	}
 
@@ -332,7 +318,7 @@ func (suite *AccumTestSuite) TestClaimRewards() {
 			suite.Require().NoError(err)
 
 			// Unclaimed rewards are reset.
-			suite.Require().Equal(tc.expectedTruncatuionChangeReinvested, finalPosition.UnclaimedRewards)
+			suite.Require().Equal(emptyCoins, finalPosition.UnclaimedRewards)
 		})
 	}
 }

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -212,7 +212,7 @@ func (suite *AccumTestSuite) TestClaimRewards() {
 			sdk.NewDecCoinFromDec(denomTwo, sdk.OneDec())).MulDec(sdk.NewDec(3))
 	)
 
-	// single output convinience wrapper.
+	// single output convenience wrapper.
 	toCoins := func(decCoins sdk.DecCoins) sdk.Coins {
 		coins, _ := decCoins.TruncateDecimal()
 		return coins


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When we `ClaimRewards` from the accumulator store, we are likely to utilize them for sdk operations such as "bank send". All such operations utilize `sdk.Coins` instead of `sdk.DecCoins`.

Therefore, in terms of UX, it is beneficial to return `sdk.Coins` right away.

It is also helpful for reinvesting the truncation change into the newly created position after claiming the rewards so that this change isn't lost.

## Testing and Verifying

This change is already covered by existing tests
