### PR TITLE
Making osmoutils compile on chains that don't use our SDK fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#3693](https://github.com/osmosis-labs/osmosis/pull/3693) Add `EstimateSwapExactAmountOut` query to stargate whitelist
 * [#3731](https://github.com/osmosis-labs/osmosis/pull/3731) BigDec Power functions with decimal exponent.
 * [#3847](https://github.com/osmosis-labs/osmosis/pull/3847) GeometricTwap and GeometricTwapToNow queries added to Stargate whitelist.
-
+* [#3899](https://github.com/osmosis-labs/osmosis/pull/3899) Fixed osmoutils so its importable by chains that don't use the osmosis CosmosSDK fork 
+  
 ### API breaks
 
 * [#3763](https://github.com/osmosis-labs/osmosis/pull/3763) Move binary search and error tolerance code from `osmoutils` into `osmomath`

--- a/app/app.go
+++ b/app/app.go
@@ -2,10 +2,13 @@ package app
 
 import (
 	"fmt"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
@@ -144,6 +147,16 @@ func init() {
 	DefaultNodeHome = filepath.Join(userHomeDir, ".osmosisd")
 }
 
+// initReusablePackageInjections injects data available within osmosis into the reusable packages.
+// This is done to ensure they can be built without depending on at compilation time and thus imported by other chains
+// This should always be called before any other function to avoid inconsistent data
+func initReusablePackageInjections() {
+	// Inject ClawbackVestingAccount account type into osmoutils
+	osmoutils.OsmoUtilsExtraAccountTypes = map[reflect.Type]struct{}{
+		reflect.TypeOf(&vestingtypes.ClawbackVestingAccount{}): {},
+	}
+}
+
 // NewOsmosisApp returns a reference to an initialized Osmosis.
 func NewOsmosisApp(
 	logger log.Logger,
@@ -158,6 +171,7 @@ func NewOsmosisApp(
 	wasmOpts []wasm.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *OsmosisApp {
+	initReusablePackageInjections() // This should run before anything else to make sure the variables are properly initialized
 	encodingConfig := GetEncodingConfig()
 	appCodec := encodingConfig.Marshaler
 	cdc := encodingConfig.Amino

--- a/app/app.go
+++ b/app/app.go
@@ -2,14 +2,15 @@ package app
 
 import (
 	"fmt"
-	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/osmosis-labs/osmosis/osmoutils"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	"github.com/gorilla/mux"

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3
 	github.com/osmosis-labs/osmosis/osmomath v0.0.2
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.2
-	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf
+	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101095308-fa4e70e17dbf
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3
 	github.com/osmosis-labs/osmosis/osmomath v0.0.2
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.2
-	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.4
+	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -857,8 +857,8 @@ github.com/osmosis-labs/osmosis/osmomath v0.0.2 h1:8vTobkYfoRTCJCie+jE7gzXvqUUfo
 github.com/osmosis-labs/osmosis/osmomath v0.0.2/go.mod h1:IpoXO7lvmfsBFfQzaqovs541hpqtrnM+GJSZDi/TZtc=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.2 h1:oFsKFhmVOQHzqRfezFAkg/BlsUEwPhQK5n13a3uC6xc=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.2/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.4 h1:Ny0GQ40agzVesBpZ/AG8Bi7Hn3ZN+qGEJOX272Bck+Q=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.4/go.mod h1:JleJ+kfjhlUpYnk7VfNrpHd+P7A5Lq5VhuAxGV7FbJM=
+github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb h1:ezbVFN4dkt3jt6kbmQQvV8yhIOoUEchqZrpb/NQxecA=
+github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb/go.mod h1:JleJ+kfjhlUpYnk7VfNrpHd+P7A5Lq5VhuAxGV7FbJM=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30 h1:6uMi7HhPSwvKKU7j5NqljseFTEz4I7qHr+IPnnn42Ck=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30/go.mod h1:5fDYJyMXBq6u2iuHqqOTYiZ5NitIOeIW5k7qEXqbwJE=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/go.sum
+++ b/go.sum
@@ -855,10 +855,10 @@ github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:Ylmch
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.2 h1:8vTobkYfoRTCJCie+jE7gzXvqUUfoPI4NSvTskoci50=
 github.com/osmosis-labs/osmosis/osmomath v0.0.2/go.mod h1:IpoXO7lvmfsBFfQzaqovs541hpqtrnM+GJSZDi/TZtc=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.2 h1:oFsKFhmVOQHzqRfezFAkg/BlsUEwPhQK5n13a3uC6xc=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.2/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb h1:ezbVFN4dkt3jt6kbmQQvV8yhIOoUEchqZrpb/NQxecA=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb/go.mod h1:JleJ+kfjhlUpYnk7VfNrpHd+P7A5Lq5VhuAxGV7FbJM=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf h1:FZOlrTSaf/YWokt3+tSSZpcu6zu3dXLhsvhJWkHeBxU=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
+github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101095308-fa4e70e17dbf h1:qcDUVsM6BNuGJ3dfGs3onOPzR0donLgXznqv60HRk+8=
+github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101095308-fa4e70e17dbf/go.mod h1:5zNisZDypMTW32EABSuWI/EacHC48590PpSO9QwFzCg=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30 h1:6uMi7HhPSwvKKU7j5NqljseFTEz4I7qHr+IPnnn42Ck=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30/go.mod h1:5fDYJyMXBq6u2iuHqqOTYiZ5NitIOeIW5k7qEXqbwJE=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/go.work.sum
+++ b/go.work.sum
@@ -259,7 +259,9 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb/go.mod h1:JleJ+kfjhlUpYnk7VfNrpHd+P7A5Lq5VhuAxGV7FbJM=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.2-flexible/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
+github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101095308-fa4e70e17dbf/go.mod h1:5zNisZDypMTW32EABSuWI/EacHC48590PpSO9QwFzCg=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.3/go.mod h1:bASDMbNQ0vD+2YRsEqlKXg8NiEsJpQ8B8p3nR8kB+hA=
 github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
 github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=

--- a/go.work.sum
+++ b/go.work.sum
@@ -259,9 +259,8 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.2/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
+github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230101091201-931acfca2ffb/go.mod h1:JleJ+kfjhlUpYnk7VfNrpHd+P7A5Lq5VhuAxGV7FbJM=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.3/go.mod h1:bASDMbNQ0vD+2YRsEqlKXg8NiEsJpQ8B8p3nR8kB+hA=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.4/go.mod h1:JleJ+kfjhlUpYnk7VfNrpHd+P7A5Lq5VhuAxGV7FbJM=
 github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
 github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
 github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=

--- a/osmoutils/module_account.go
+++ b/osmoutils/module_account.go
@@ -10,6 +10,11 @@ import (
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
+// OsmoUtilsExtraAccountTypes is a map of extra account types that can be overridden.
+// This is defined as a global variable so it can be modified in the chain's app.go and used here without
+// having to import the chain. Specifically, this is used for compatibility with Osmosis' Cosmos SDK fork
+var OsmoUtilsExtraAccountTypes map[reflect.Type]struct{}
+
 type AccountKeeper interface {
 	NewAccount(sdk.Context, authtypes.AccountI) authtypes.AccountI
 
@@ -48,8 +53,11 @@ func CanCreateModuleAccountAtAddr(ctx sdk.Context, ak AccountKeeper, addr sdk.Ac
 		reflect.TypeOf(&vestingtypes.BaseVestingAccount{}):       {},
 		reflect.TypeOf(&vestingtypes.PeriodicVestingAccount{}):   {},
 		reflect.TypeOf(&vestingtypes.PermanentLockedAccount{}):   {},
-		reflect.TypeOf(&vestingtypes.ClawbackVestingAccount{}):   {},
 	}
+	for extraAccountType := range OsmoUtilsExtraAccountTypes {
+		overrideAccountTypes[extraAccountType] = struct{}{}
+	}
+
 	if _, clear := overrideAccountTypes[reflect.TypeOf(existingAcct)]; clear {
 		return nil
 	}

--- a/x/ibc-hooks/go.mod
+++ b/x/ibc-hooks/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cosmos/ibc-go/v4 v4.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101091201-931acfca2ffb
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf
 	github.com/spf13/cobra v1.6.1
 	github.com/tendermint/tendermint v0.34.24
 )

--- a/x/ibc-hooks/go.mod
+++ b/x/ibc-hooks/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cosmos/ibc-go/v4 v4.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.2
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101091201-931acfca2ffb
 	github.com/spf13/cobra v1.6.1
 	github.com/tendermint/tendermint v0.34.24
 )

--- a/x/ibc-hooks/go.sum
+++ b/x/ibc-hooks/go.sum
@@ -620,8 +620,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221118211718-545aed73e94e h1:A3byMZpvq21iI7yWJUNdHw0nf8jVAbVUsWY9twnXSXE=
 github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221118211718-545aed73e94e/go.mod h1:rud0OaBIuq3+qOqtwT4SR7Q7iSzRp7w41fjninTjfnQ=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20221223175211-9d2007cbaad6 h1:/Ea4oM6/hQLusuQfex0slJg+Gc8UYq7XVOchBNQg9g4=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20221223175211-9d2007cbaad6/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101091201-931acfca2ffb h1:9APFNAUU4QKJ/6u2wL+vtMM0MjHT6X3uaxNFym6FnAM=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101091201-931acfca2ffb/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30 h1:6uMi7HhPSwvKKU7j5NqljseFTEz4I7qHr+IPnnn42Ck=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30/go.mod h1:5fDYJyMXBq6u2iuHqqOTYiZ5NitIOeIW5k7qEXqbwJE=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=

--- a/x/ibc-hooks/go.sum
+++ b/x/ibc-hooks/go.sum
@@ -620,8 +620,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221118211718-545aed73e94e h1:A3byMZpvq21iI7yWJUNdHw0nf8jVAbVUsWY9twnXSXE=
 github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20221118211718-545aed73e94e/go.mod h1:rud0OaBIuq3+qOqtwT4SR7Q7iSzRp7w41fjninTjfnQ=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101091201-931acfca2ffb h1:9APFNAUU4QKJ/6u2wL+vtMM0MjHT6X3uaxNFym6FnAM=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101091201-931acfca2ffb/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf h1:FZOlrTSaf/YWokt3+tSSZpcu6zu3dXLhsvhJWkHeBxU=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230101095308-fa4e70e17dbf/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30 h1:6uMi7HhPSwvKKU7j5NqljseFTEz4I7qHr+IPnnn42Ck=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30/go.mod h1:5fDYJyMXBq6u2iuHqqOTYiZ5NitIOeIW5k7qEXqbwJE=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Osmoutils wouldn't compile on chains that didn't use osmosis' sdk fork because ClawbackVestingAccount is not available.

This ensures that that struct is not needed at compile time.

Doing this via a global variable might be a bit controversial, but I think it's the cleanest abstraction to avoid having to maintain several other packages and/or have implementors override this with replace/fork.

We could use this pattern in other reusable packages and it might even be usable for supporting different versions of the sdk or ibc. 

## Brief Changelog

*(for example:)*
 
  - ClawbackVestingAccount is no longer part of osmoutils and is now injected in app.go


## Testing and Verifying
all tests pass

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (/ no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (/ no)
  - How is the feature or change documented? (not applicable )