### PR TITLE
[CL][SwapRouter]: Move Inactive pool check to Swaprouter module

### DIFF
--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -30,9 +30,6 @@ func (k Keeper) SwapExactAmountIn(
 	if tokenIn.Denom == tokenOutDenom {
 		return sdk.Int{}, errors.New("cannot trade same denomination in and out")
 	}
-	if !pool.IsActive(ctx) {
-		return sdk.Int{}, fmt.Errorf("pool %d is not active", pool.GetId())
-	}
 	poolSwapFee := pool.GetSwapFee(ctx)
 	if swapFee.LT(poolSwapFee.QuoInt64(2)) {
 		return sdk.Int{}, fmt.Errorf("given swap fee (%s) must be greater than or equal to half of the pool's swap fee (%s)", swapFee, poolSwapFee)
@@ -92,9 +89,6 @@ func (k Keeper) SwapExactAmountOut(
 ) (tokenInAmount sdk.Int, err error) {
 	if tokenInDenom == tokenOut.Denom {
 		return sdk.Int{}, errors.New("cannot trade same denomination in and out")
-	}
-	if !pool.IsActive(ctx) {
-		return sdk.Int{}, fmt.Errorf("pool %d is not active", pool.GetId())
 	}
 	defer func() {
 		if r := recover(); r != nil {

--- a/x/gamm/keeper/swap_test.go
+++ b/x/gamm/keeper/swap_test.go
@@ -505,8 +505,32 @@ func (suite *KeeperTestSuite) TestInactivePoolFreezeSwaps() {
 	for _, test := range testCases {
 		suite.Run(test.name, func() {
 			// Check swaps
-			_, swapInErr := gammKeeper.SwapExactAmountIn(suite.Ctx, suite.TestAccs[0], test.pool, testCoin, "bar", sdk.ZeroInt(), sdk.ZeroDec())
-			_, swapOutErr := gammKeeper.SwapExactAmountOut(suite.Ctx, suite.TestAccs[0], test.pool, "bar", sdk.NewInt(1000000000000000000), testCoin, sdk.ZeroDec())
+			_, swapInErr := suite.App.SwapRouterKeeper.RouteExactAmountIn(
+				suite.Ctx,
+				suite.TestAccs[0],
+				[]swaproutertypes.SwapAmountInRoute{
+					{
+						PoolId:        test.pool.GetId(),
+						TokenOutDenom: "bar",
+					},
+				},
+				testCoin,
+				sdk.ZeroInt(),
+			)
+
+			_, swapOutErr := suite.App.SwapRouterKeeper.RouteExactAmountOut(
+				suite.Ctx,
+				suite.TestAccs[0],
+				[]swaproutertypes.SwapAmountOutRoute{
+					{
+						PoolId:       test.pool.GetId(),
+						TokenInDenom: "bar",
+					},
+				},
+				sdk.NewInt(1000000000000000000),
+				testCoin,
+			)
+
 			if test.expectPass {
 				suite.Require().NoError(swapInErr)
 				suite.Require().NoError(swapOutErr)

--- a/x/swaprouter/router.go
+++ b/x/swaprouter/router.go
@@ -2,6 +2,7 @@ package swaprouter
 
 import (
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -67,6 +68,11 @@ func (k Keeper) RouteExactAmountIn(
 			return sdk.Int{}, poolErr
 		}
 
+		// check if pool is active, if not error
+		if !pool.IsActive(ctx) {
+			return sdk.Int{}, fmt.Errorf("pool %d is not active", pool.GetId())
+		}
+
 		swapFee := pool.GetSwapFee(ctx)
 
 		// If we determined the route is an osmo multi-hop and both routes are incentivized,
@@ -107,6 +113,11 @@ func (k Keeper) SwapExactAmountIn(
 	pool, poolErr := swapModule.GetPool(ctx, poolId)
 	if poolErr != nil {
 		return sdk.Int{}, poolErr
+	}
+
+	// check if pool is active, if not error
+	if !pool.IsActive(ctx) {
+		return sdk.Int{}, fmt.Errorf("pool %d is not active", pool.GetId())
 	}
 
 	swapFee := pool.GetSwapFee(ctx)
@@ -250,6 +261,11 @@ func (k Keeper) RouteExactAmountOut(ctx sdk.Context,
 		pool, poolErr := swapModule.GetPool(ctx, route.PoolId)
 		if poolErr != nil {
 			return sdk.Int{}, poolErr
+		}
+
+		// check if pool is active, if not error
+		if !pool.IsActive(ctx) {
+			return sdk.Int{}, fmt.Errorf("pool %d is not active", pool.GetId())
 		}
 
 		swapFee := pool.GetSwapFee(ctx)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3798

## What is the purpose of the change
This PR adds inactive pool check to the swap router module, more specifically does a check before each swap if the pool is inactive or not. If not, errors out.

## Testing and Verifying

This PR changed existing test for inactive pool from using gamm module -> swaprouter module.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)