### PR TITLE
test(x/twap): geometric twap edge case tests

### DIFF
--- a/osmomath/binary_search.go
+++ b/osmomath/binary_search.go
@@ -107,7 +107,7 @@ func (e ErrTolerance) CompareBigDec(expected BigDec, actual BigDec) int {
 	comparisonSign := 0
 	if expected.GT(actual) {
 		comparisonSign = 1
-	} else {
+	} else if expected.LT(actual) {
 		comparisonSign = -1
 	}
 

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -34,6 +34,9 @@ var (
 	// Other tests depend on being equal to MaxSpotPrice,
 	// but don't directly import it due to import issues.
 	MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
+	// MinSpotPrice is the minimum supported spot price. Anything less than this will error.
+	// It is limited by sdk.Dec's precision.
+	MinSpotPrice = sdk.NewDecWithPrec(1, 18)
 
 	// MultihopSwapFeeMultiplierForOsmoPools if a swap fees multiplier for trades consists of just two OSMO pools during a single transaction.
 	MultihopSwapFeeMultiplierForOsmoPools = sdk.NewDecWithPrec(5, 1) // 0.5

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -36,7 +36,7 @@ var (
 	MaxSpotPrice = sdk.NewDec(2).Power(128).Sub(sdk.OneDec())
 	// MinSpotPrice is the minimum supported spot price. Anything less than this will error.
 	// It is limited by sdk.Dec's precision.
-	MinSpotPrice = sdk.NewDecWithPrec(1, 18)
+	MinSpotPrice = sdk.SmallestDec()
 
 	// MultihopSwapFeeMultiplierForOsmoPools if a swap fees multiplier for trades consists of just two OSMO pools during a single transaction.
 	MultihopSwapFeeMultiplierForOsmoPools = sdk.NewDecWithPrec(5, 1) // 0.5

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -43,6 +43,10 @@ func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.T
 func (s *geometric) computeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string) sdk.Dec {
 	accumDiff := endRecord.GeometricTwapAccumulator.Sub(startRecord.GeometricTwapAccumulator)
 
+	if accumDiff.IsZero() {
+		return sdk.ZeroDec()
+	}
+
 	timeDelta := endRecord.Time.Sub(startRecord.Time)
 	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
 

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -249,15 +249,12 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 			expTwap:     gammtypes.MaxSpotPrice,
 		},
 
-		"expected precision loss test: - at spot price denom1 quote - panic": {
+		"expected precision loss test: - at spot price denom1 quote - return zero": {
 			startRecord: withSp0(baseRecord, gammtypes.MaxSpotPrice),
 			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), overflowTestCaseAccumDiff),
 			quoteAsset:  denom1,
 
-			// TODO: analyze if panic is acceptable.
-			// Should be acceptable since underlying logic is
-			// only called from the query path.
-			expPanic: true,
+			expTwap: sdk.ZeroDec(),
 		},
 
 		"no underflow test: spot price is smallestpossible denom0 quote": {
@@ -274,15 +271,12 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 			expTwap:     sdk.OneDec().Quo(gammtypes.MinSpotPrice),
 		},
 
-		"zero accum difference ": {
+		"zero accum difference - return zero": {
 			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
 			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(time.Millisecond), sdk.ZeroDec()),
 			quoteAsset:  denom1,
 
-			// TODO: analyze if panic is acceptable.
-			// Should be acceptable since underlying logic is
-			// only called from the query path.
-			expPanic: true,
+			expTwap: sdk.ZeroDec(),
 		},
 	}
 
@@ -297,7 +291,7 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 				// Sig fig round the expected value.
 				tc.expTwap = osmomath.SigFigRound(tc.expTwap, gammtypes.SpotPriceSigFigs)
 
-				s.Require().Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(tc.expTwap), osmomath.BigDecFromSDKDec(actualTwap)))
+				s.Require().Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(tc.expTwap), osmomath.BigDecFromSDKDec(actualTwap)), "expected %s, got %s", tc.expTwap, actualTwap)
 			})
 		})
 	}

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -257,7 +257,7 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 			expTwap: sdk.ZeroDec(),
 		},
 
-		"no underflow test: spot price is smallestpossible denom0 quote": {
+		"no underflow test: spot price is smallest possible denom0 quote": {
 			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
 			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), underflowTestCaseAccumDiff),
 			quoteAsset:  denom0,

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -22,10 +22,6 @@ type computeTwapTestCase struct {
 	expPanic       bool
 }
 
-var (
-	oneHundredYears = OneSec.MulInt64(60 * 60 * 24 * 365 * 100)
-)
-
 // TestComputeArithmeticTwap tests computeTwap on various inputs.
 // The test vectors are structured by setting up different start and records,
 // based on time interval, and their accumulator values.
@@ -166,6 +162,35 @@ func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 // Contrary to computeTwap function (logic.go) that handles the cases with zero delta correctly,
 // this function should panic in case of zero delta.
 func (s *TestSuite) TestComputeGeometricStrategyTwap() {
+	var (
+		errTolerance = osmomath.ErrTolerance{
+			MultiplicativeTolerance: sdk.SmallestDec(),
+			RoundingDir:             osmomath.RoundDown,
+		}
+		smallestDec = sdk.SmallestDec()
+
+		// Compute accumulator difference for the underflow test case by
+		// taking log base 2 of the max spot price
+		smallestDecLog = twap.TwapLog(smallestDec)
+
+		// Compute accumulator difference for the overflow test case by
+		// taking log base 2 of the max spot price
+		maxSpotPriceLogBase2 = twap.TwapLog(gammtypes.MaxSpotPrice)
+
+		oneHundredYearsInHours        int64 = 100 * 365 * 24
+		oneHundredYears                     = OneSec.MulInt64(60 * 60 * oneHundredYearsInHours)
+		oneHundredYearsMin1MsDuration       = time.Duration(oneHundredYearsInHours)*time.Hour - time.Millisecond
+
+		// Subtract 1ms from 100 years to assume that we interpolate.
+		oneHundredYearsMin1Ms = oneHundredYears.Sub(oneDec)
+
+		// Calculate the geometric accumulator difference for overflow test case.
+		overflowTestCaseAccumDiff = oneHundredYearsMin1Ms.Mul(maxSpotPriceLogBase2)
+
+		// Calculate the geometric accumulator difference for underflow test case.
+		underflowTestCaseAccumDiff = oneHundredYearsMin1Ms.Mul(smallestDecLog)
+	)
+
 	tests := map[string]computeTwapTestCase{
 		// basic test for both denom with zero start accumulator
 		"basic denom0: spot price = 1 for one second, 0 init accumulator": {
@@ -211,28 +236,69 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 		"accumulator = 10*OneSec, t=100s. .1*second base accum": geometricTestCaseFromDeltas0(
 			s, OneSec.MulInt64(10).Mul(logOneOverTen), geometricTenSecAccum, 100*time.Second, twap.TwapPow(geometricTenSecAccum.QuoInt64(100*1000))),
 
-		// TODO: this is the highest price we currently support with the given precision bounds.
-		// Need to choose better base and potentially improve math functions to mitigate.
 		"price of 1_000_000 for an hour": {
 			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
 			endRecord:   newOneSidedGeometricRecord(baseTime.Add(time.Hour), OneSec.MulInt64(60*60).Mul(twap.TwapLog(sdk.NewDec(1_000_000)))),
 			quoteAsset:  denom0,
 			expTwap:     sdk.NewDec(1_000_000),
 		},
-		// TODO: overflow tests
-		// - max spot price
-		// - large time delta
-		// - both
 
-		// TODO: hand calculated tests
+		"no overflow test: at max spot price denom0 quote - get max spot price": {
+			startRecord: withSp0(baseRecord, gammtypes.MaxSpotPrice),
+			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), overflowTestCaseAccumDiff),
+			quoteAsset:  denom0,
+			expTwap:     gammtypes.MaxSpotPrice,
+		},
+
+		"expected precision loss test: - at spot price denom1 quote - panic": {
+			startRecord: withSp0(baseRecord, gammtypes.MaxSpotPrice),
+			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), overflowTestCaseAccumDiff),
+			quoteAsset:  denom1,
+
+			// TODO: analyze if panic is acceptable.
+			// Should be acceptable since underlying logic is
+			// only called from the query path.
+			expPanic: true,
+		},
+
+		"no underflow test: spot price is smallest dec possible denom0 quote": {
+			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), underflowTestCaseAccumDiff),
+			quoteAsset:  denom0,
+			expTwap:     smallestDec,
+		},
+
+		"no underflow test: spot price is smallest dec possible denom1 quote": {
+			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), underflowTestCaseAccumDiff),
+			quoteAsset:  denom1,
+			expTwap:     sdk.OneDec().Quo(smallestDec),
+		},
+
+		"zero accum difference ": {
+			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(time.Millisecond), sdk.ZeroDec()),
+			quoteAsset:  denom1,
+
+			// TODO: analyze if panic is acceptable.
+			// Should be acceptable since underlying logic is
+			// only called from the query path.
+			expPanic: true,
+		},
 	}
 
 	for name, tc := range tests {
+		tc := tc
 		s.Run(name, func() {
 			osmoassert.ConditionalPanic(s.T(), tc.expPanic, func() {
+
 				geometricStrategy := &twap.GeometricTwapStrategy{TwapKeeper: *s.App.TwapKeeper}
 				actualTwap := geometricStrategy.ComputeTwap(tc.startRecord, tc.endRecord, tc.quoteAsset)
-				osmoassert.DecApproxEq(s.T(), tc.expTwap, actualTwap, osmomath.GetPowPrecision())
+
+				// Sig fig round the expected value.
+				tc.expTwap = osmomath.SigFigRound(tc.expTwap, gammtypes.SpotPriceSigFigs)
+
+				s.Require().Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(tc.expTwap), osmomath.BigDecFromSDKDec(actualTwap)))
 			})
 		})
 	}
@@ -304,20 +370,4 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap_ThreeAsset() {
 			}
 		})
 	}
-}
-
-// TestTwapPow_MaxSpotPrice_NoOverflow tests that no overflow occurs at log_2{max spot price values}.
-// and that the epsilon is within the tolerated multiplicative error.
-func (s *TestSuite) TestTwapLogPow_MaxSpotPrice_NoOverflow() {
-	errTolerance := osmomath.ErrTolerance{
-		MultiplicativeTolerance: sdk.OneDec().Quo(sdk.NewDec(10).Power(18)),
-		RoundingDir:             osmomath.RoundDown,
-	}
-
-	oneHundredYearsTimesMaxSpotPrice := oneHundredYears.Mul(gammtypes.MaxSpotPrice)
-
-	exponentValue := twap.TwapLog(oneHundredYearsTimesMaxSpotPrice)
-	finalValue := twap.TwapPow(exponentValue)
-
-	s.Require().Equal(0, errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(oneHundredYearsTimesMaxSpotPrice), osmomath.BigDecFromSDKDec(finalValue)))
 }

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -163,11 +163,12 @@ func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 // this function should panic in case of zero delta.
 func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 	var (
+		smallestDec = sdk.SmallestDec()
+
 		errTolerance = osmomath.ErrTolerance{
-			MultiplicativeTolerance: sdk.SmallestDec(),
+			MultiplicativeTolerance: smallestDec,
 			RoundingDir:             osmomath.RoundDown,
 		}
-		smallestDec = sdk.SmallestDec()
 
 		// Compute accumulator difference for the underflow test case by
 		// taking log base 2 of the max spot price

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -163,16 +163,14 @@ func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 // this function should panic in case of zero delta.
 func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 	var (
-		smallestDec = sdk.SmallestDec()
-
 		errTolerance = osmomath.ErrTolerance{
-			MultiplicativeTolerance: smallestDec,
+			MultiplicativeTolerance: sdk.SmallestDec(),
 			RoundingDir:             osmomath.RoundDown,
 		}
 
 		// Compute accumulator difference for the underflow test case by
-		// taking log base 2 of the max spot price
-		smallestDecLog = twap.TwapLog(smallestDec)
+		// taking log base 2 of the min spot price
+		smallestDecLog = twap.TwapLog(gammtypes.MinSpotPrice)
 
 		// Compute accumulator difference for the overflow test case by
 		// taking log base 2 of the max spot price
@@ -262,18 +260,18 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 			expPanic: true,
 		},
 
-		"no underflow test: spot price is smallest dec possible denom0 quote": {
+		"no underflow test: spot price is smallestpossible denom0 quote": {
 			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
 			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), underflowTestCaseAccumDiff),
 			quoteAsset:  denom0,
-			expTwap:     smallestDec,
+			expTwap:     gammtypes.MinSpotPrice,
 		},
 
-		"no underflow test: spot price is smallest dec possible denom1 quote": {
+		"no underflow test: spot price is smallest possible denom1 quote": {
 			startRecord: newOneSidedGeometricRecord(baseTime, sdk.ZeroDec()),
 			endRecord:   newOneSidedGeometricRecord(baseRecord.Time.Add(oneHundredYearsMin1MsDuration), underflowTestCaseAccumDiff),
 			quoteAsset:  denom1,
-			expTwap:     sdk.OneDec().Quo(smallestDec),
+			expTwap:     sdk.OneDec().Quo(gammtypes.MinSpotPrice),
 		},
 
 		"zero accum difference ": {

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -170,7 +170,7 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 
 		// Compute accumulator difference for the underflow test case by
 		// taking log base 2 of the min spot price
-		smallestDecLog = twap.TwapLog(gammtypes.MinSpotPrice)
+		minSpotPriceLogBase2 = twap.TwapLog(gammtypes.MinSpotPrice)
 
 		// Compute accumulator difference for the overflow test case by
 		// taking log base 2 of the max spot price
@@ -187,7 +187,7 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 		overflowTestCaseAccumDiff = oneHundredYearsMin1Ms.Mul(maxSpotPriceLogBase2)
 
 		// Calculate the geometric accumulator difference for underflow test case.
-		underflowTestCaseAccumDiff = oneHundredYearsMin1Ms.Mul(smallestDecLog)
+		underflowTestCaseAccumDiff = oneHundredYearsMin1Ms.Mul(minSpotPriceLogBase2)
 	)
 
 	tests := map[string]computeTwapTestCase{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Adds geometric twap edge case tests. Defines min spot price as `sdk.SmallestDec()`

## Brief Changelog

### Overflow test

The old test case setup was incorrect as it was taking the logarithm of the accumulator instead of just the price. To mimic the real environment, this test case is now incorporated into `TestComputeGeometricStrategyTwap` table-driven test with quote assets in both denomes.

With one of the denoms, there is a panic due to precision loss. This happens because we end up taking 1 / < extremely large value >, resulting in a value smaller than the smallest Dec possible.

### Underflow Test

This test case assumes that the spot price is the smallest dec possible. By taking a logarithm of the smallest value (0, 1) and multiplying it by 100 years, we confirm that our math functions do not accidentally cause an underflow.

The test is run in both denoms as quote assets.

### Zero Accumulator Differences

This unlikely case might happen if all spot prices in history had returned a spot price error, resulting in geometric accumulators for start and end records as well as their difference always being 0.

While this is unlikely, this test helps to ensure that we have accounted for all kinds of risky outcomes.