### PR TITLE
Adjust MaxNumInboundPeers and MaxNumOutboundPeers

### DIFF
--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -98,8 +98,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				"7c66126b64cd66bafd9ccfc721f068df451d31a3@osmosis-seed.sunshinevalidation.io:9393",         // Sunshine Validation
 			}
 			config.P2P.Seeds = strings.Join(seeds, ",")
-			config.P2P.MaxNumInboundPeers = 320
-			config.P2P.MaxNumOutboundPeers = 40
+			config.P2P.MaxNumInboundPeers = 80
+			config.P2P.MaxNumOutboundPeers = 60
 			config.Mempool.Size = 10000
 			config.StateSync.TrustPeriod = 112 * time.Hour
 			config.FastSync.Version = "v0"


### PR DESCRIPTION
## What is the purpose of the change

> Adjust MaxNumInboundPeers and MaxNumOutboundPeers

## Brief Changelog
 
  - The current MaxNumInboundPeers is 320. This is excessive and unnecessary. Recommend to change to 80 in the PR. 
  - The current MaxNumOutboundPeers is 40. This is not too bad, but we at Polkachu use 60 consistently. Recommend to change to 60 in this PR. 

## Testing and Verifying
This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable   /   specification (not documented)