### PR TITLE
feat(CL Fees): initialize fee growth outside for ticks

### DIFF
--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -50,7 +50,7 @@ func GetAccumulator(accumStore store.KVStore, accumName string) (AccumulatorObje
 		return AccumulatorObject{}, err
 	}
 	if !found {
-		return AccumulatorObject{}, errors.New(fmt.Sprintf("Accumulator name %s does not exist in store", accumName))
+		return AccumulatorObject{}, AccumDoesNotExistError{AccumName: accumName}
 	}
 
 	accum := AccumulatorObject{accumStore, accumName, accumContent.AccumValue}

--- a/osmoutils/accum/errors.go
+++ b/osmoutils/accum/errors.go
@@ -34,3 +34,11 @@ type NegativeAccDifferenceError struct {
 func (e NegativeAccDifferenceError) Error() string {
 	return fmt.Sprintf("difference (%s) between the old and the new accumulator value is negative", e.AccumulatorDifference)
 }
+
+type AccumDoesNotExistError struct {
+	AccumName string
+}
+
+func (e AccumDoesNotExistError) Error() string {
+	return fmt.Sprintf("Accumulator name %s does not exist in store", e.AccumName)
+}

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -10,6 +10,10 @@ import (
 	swaproutertypes "github.com/osmosis-labs/osmosis/v13/x/swaprouter/types"
 )
 
+var (
+	EmptyCoins = emptyCoins
+)
+
 // OrderInitialPoolDenoms sets the pool denoms of a cl pool
 func OrderInitialPoolDenoms(denom0, denom1 string) (string, string, error) {
 	return cltypes.OrderInitialPoolDenoms(denom0, denom1)
@@ -110,4 +114,16 @@ func (k Keeper) GetFeeGrowthOutside(ctx sdk.Context, poolId uint64, lowerTick, u
 
 func CalculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, currentTick int64, feesGrowthGlobal sdk.DecCoins, isUpperTick bool) sdk.DecCoins {
 	return calculateFeeGrowth(targetTick, feeGrowthOutside, currentTick, feesGrowthGlobal, isUpperTick)
+}
+
+func (k Keeper) GetInitialFeeGrowthOtsideForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
+	return k.getInitialFeeGrowthOtsideForTick(ctx, poolId, tick)
+}
+
+func GetFeeAccumulatorName(poolId uint64) string {
+	return getFeeAccumulatorName(poolId)
+}
+
+func (k Keeper) ChargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
+	return k.chargeFee(ctx, poolId, feeUpdate)
 }

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -116,8 +116,8 @@ func CalculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, current
 	return calculateFeeGrowth(targetTick, feeGrowthOutside, currentTick, feesGrowthGlobal, isUpperTick)
 }
 
-func (k Keeper) GetInitialFeeGrowthOtsideForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
-	return k.getInitialFeeGrowthOtsideForTick(ctx, poolId, tick)
+func (k Keeper) GetInitialFeeGrowthOutsideForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
+	return k.getInitialFeeGrowthOutsideForTick(ctx, poolId, tick)
 }
 
 func GetFeeAccumulatorName(poolId uint64) string {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -151,7 +151,7 @@ func (k Keeper) getFeeGrowthOutside(ctx sdk.Context, poolId uint64, lowerTick, u
 //
 // The value is chosen as if all of the fees earned to date had occurrd below the tick.
 // Returns error if the pool with the given id does exist or if fails to get the fee accumulator.
-func (k Keeper) getInitialFeeGrowthOtsideForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
+func (k Keeper) getInitialFeeGrowthOutsideForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
 	pool, err := k.getPoolById(ctx, poolId)
 	if err != nil {
 		return sdk.DecCoins{}, err

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -44,6 +44,7 @@ func (k Keeper) getFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.Accumul
 // chargeFee charges the given fee on the pool with the given id by updating
 // the internal per-pool accumulator that tracks fee growth per one unit of
 // liquidity. Returns error if fails to get accumulator.
+// nolint: unused
 func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
 	feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
 	if err != nil {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -41,6 +41,9 @@ func (k Keeper) getFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.Accumul
 	return acc, nil
 }
 
+// chargeFee charges the given fee on the pool with the given id by updating
+// the internal per-pool accumulator that tracks fee growth per one unit of
+// liquidity. Returns error if fails to get accumulator.
 func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
 	feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
 	if err != nil {
@@ -146,6 +149,7 @@ func (k Keeper) getFeeGrowthOutside(ctx sdk.Context, poolId uint64, lowerTick, u
 //                    { 0               current tick <  tick }
 //
 // The value is chosen as if all of the fees earned to date had occurrd below the tick.
+// Returns error if the pool with the given id does exist or if fails to get the fee accumulator.
 func (k Keeper) getInitialFeeGrowthOtsideForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
 	pool, err := k.getPoolById(ctx, poolId)
 	if err != nil {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -143,7 +143,7 @@ func (k Keeper) getFeeGrowthOutside(ctx sdk.Context, poolId uint64, lowerTick, u
 	return feeGrowthAboveUpperTick.Add(feeGrowthBelowLowerTick...), nil
 }
 
-// getInitialFeeGrowthOtsideForTick returns the initial value of fee growth outside for a given tick.
+// getInitialFeeGrowthOutsideForTick returns the initial value of fee growth outside for a given tick.
 // This value depends on the tick's location relative to the current tick.
 //
 // feeGrowthOutside = { feeGrowthGlobal current tick >= tick }

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -243,7 +243,7 @@ func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOutsideForTick() {
 
 			expectedInitialFeeGrowthOutside: sdk.NewDecCoins(oneEth),
 		},
-		"current tick < tick -> fee growth global": {
+		"current tick < tick -> empty coins": {
 			poolId:                 validPoolId,
 			tick:                   initialPoolTick + 1,
 			initialGlobalFeeGrowth: oneEth,

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -211,7 +211,7 @@ func (s *KeeperTestSuite) TestCalculateFeeGrowth() {
 
 }
 
-func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOtsideForTick() {
+func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOutsideForTick() {
 	const (
 		validPoolId = 1
 	)
@@ -292,7 +292,7 @@ func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOtsideForTick() {
 			}
 
 			// System under test.
-			initialFeeGrowthOutside, err := clKeeper.GetInitialFeeGrowthOtsideForTick(ctx, tc.poolId, tc.tick)
+			initialFeeGrowthOutside, err := clKeeper.GetInitialFeeGrowthOutsideForTick(ctx, tc.poolId, tc.tick)
 
 			if tc.expectError != nil {
 				suite.Require().Error(err)

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -65,7 +65,7 @@ func (k Keeper) getTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (ti
 	// return 0 values if key has not been initialized
 	if !found {
 		// If tick has not yet been initialized, we create a new one and initialize
-		// the fee growth outside,
+		// the fee growth outside.
 		initialFeeGrowthOutside, err := k.getInitialFeeGrowthOtsideForTick(ctx, poolId, tickIndex)
 		if err != nil {
 			return tickStruct, err

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -64,7 +64,14 @@ func (k Keeper) getTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (ti
 	found, err := osmoutils.Get(store, key, &tickStruct)
 	// return 0 values if key has not been initialized
 	if !found {
-		return model.TickInfo{LiquidityGross: sdk.ZeroDec(), LiquidityNet: sdk.ZeroDec()}, err
+		// If tick has not yet been initialized, we create a new one and initialize
+		// the fee growth outside,
+		initialFeeGrowthOutside, err := k.getInitialFeeGrowthOtsideForTick(ctx, poolId, tickIndex)
+		if err != nil {
+			return tickStruct, err
+		}
+
+		return model.TickInfo{LiquidityGross: sdk.ZeroDec(), LiquidityNet: sdk.ZeroDec(), FeeGrowthOutside: initialFeeGrowthOutside}, nil
 	}
 	if err != nil {
 		return tickStruct, err

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -66,7 +66,7 @@ func (k Keeper) getTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (ti
 	if !found {
 		// If tick has not yet been initialized, we create a new one and initialize
 		// the fee growth outside.
-		initialFeeGrowthOutside, err := k.getInitialFeeGrowthOtsideForTick(ctx, poolId, tickIndex)
+		initialFeeGrowthOutside, err := k.getInitialFeeGrowthOutsideForTick(ctx, poolId, tickIndex)
 		if err != nil {
 			return tickStruct, err
 		}

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -291,7 +291,7 @@ func (s *KeeperTestSuite) TestGetTickInfo() {
 			expectedTickInfo: model.TickInfo{LiquidityGross: sdk.ZeroDec(), LiquidityNet: sdk.ZeroDec()},
 		},
 		{
-			name:      "Get tick info on existing pool with no existing tick (cur pool tick == tick)",
+			name:      "Get tick info on existing pool with no existing tick (cur pool tick == tick), initialized fee growth outside",
 			poolToGet: validPoolId,
 			tickToGet: DefaultCurrTick.Int64(),
 			// Note that FeeGrowthOutside is initialized.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3956

## What is the purpose of the change

Implementing the initialization for the fee growth outside tee accumulator.

This is extracted from the original fee POC: https://github.com/osmosis-labs/osmosis/pull/3893

## Changelog
- Implement and test `getInitialFeeGrowthOtsideForTick`
- Implement and test  `chargeFee`
- Refactor and test `getTickinfo`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable