### PR TITLE
feat(osmoutil/accum): Remove position Accumulator from state

### DIFF
--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	accumPackage "github.com/osmosis-labs/osmosis/osmoutils/accum"
-	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 )
 
 type AccumTestSuite struct {
@@ -1219,7 +1218,6 @@ func (suite *AccumTestSuite) TestUpdatePositionCustomAcc() {
 		customAcc        sdk.DecCoins
 		expectedPosition accumPackage.Record
 		expectedError    error
-		expectPanic      bool
 	}{
 		"custom acc value equals to acc; positive shares -> acts as AddToPosition": {
 			accObject:     accObject,
@@ -1233,18 +1231,12 @@ func (suite *AccumTestSuite) TestUpdatePositionCustomAcc() {
 				UnclaimedRewards: emptyCoins,
 			},
 		},
-		"custom acc value does not equal to acc; remove same amount -> acts as RemoveFromPosition, delete position accum": {
+		"custom acc value does not equal to acc; remove same amount -> acts as RemoveFromPosition": {
 			accObject:     accObject,
 			initialShares: positionTwo.NumShares,
 			name:          testAddressTwo,
 			numShareUnits: positionTwo.NumShares.Neg(), // note: negative shares
 			customAcc:     accObject.GetValue().MulDec(sdk.NewDec(2)),
-			// expectedPosition: accumPackage.Record{
-			// 	NumShares:        sdk.ZeroDec(), // results in zero shares
-			// 	InitAccumValue:   accObject.GetValue().MulDec(sdk.NewDec(2)),
-			// 	UnclaimedRewards: emptyCoins,
-			// },
-			expectPanic: true,
 		},
 		"custom acc value does not equal to acc; remove diff amount -> acts as RemoveFromPosition": {
 			accObject:     accObject,
@@ -1301,15 +1293,13 @@ func (suite *AccumTestSuite) TestUpdatePositionCustomAcc() {
 			tc.accObject, err = accumPackage.GetAccumulator(suite.store, testNameOne)
 			suite.Require().NoError(err)
 
-			osmoassert.ConditionalPanic(suite.T(), tc.expectPanic, func() {
-				position := tc.accObject.GetPosition(tc.name)
-				// Assertions.
+			position := tc.accObject.GetPosition(tc.name)
+			// Assertions.
 
-				suite.Require().Equal(tc.expectedPosition.NumShares, position.NumShares)
-				suite.Require().Equal(tc.expectedPosition.InitAccumValue, position.InitAccumValue)
-				suite.Require().Equal(tc.expectedPosition.UnclaimedRewards, position.UnclaimedRewards)
-				suite.Require().Nil(position.Options)
-			})
+			suite.Require().Equal(tc.expectedPosition.NumShares, position.NumShares)
+			suite.Require().Equal(tc.expectedPosition.InitAccumValue, position.InitAccumValue)
+			suite.Require().Equal(tc.expectedPosition.UnclaimedRewards, position.UnclaimedRewards)
+			suite.Require().Nil(position.Options)
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3950 

## What is the purpose of the change
Removes the position accumulator from state when the numShares for the position is equal to zero. 

This check / action happens when the update Position, specifically `RemoveFromPosition` is happening.


## Brief Changelog
- Remove position accumulator from state when numshares is zero


## Testing and Verifying
Added new tests for this / changed existing test cases

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)