### PR TITLE
[ValSet-Pref] Add Redelegate, Withdraw cli commands and sim_msgs

### DIFF
--- a/x/valset-pref/client/cli/tx.go
+++ b/x/valset-pref/client/cli/tx.go
@@ -50,12 +50,60 @@ func NewUnDelValSetCmd() (*osmocli.TxCliDesc, *types.MsgUndelegateFromValidatorS
 	}, &types.MsgUndelegateFromValidatorSet{}
 }
 
+func NewReDelValSetCmd() (*osmocli.TxCliDesc, *types.MsgRedelegateValidatorSet) {
+	return &osmocli.TxCliDesc{
+		Use:              "redelegate-valset [delegator_addr] [validators] [weights]",
+		Short:            "Redelegate tokens from existing validators to new sets of validators",
+		Example:          "osmosisd tx valset-pref redelegate-valset  osmo1... osmovaloper1efg...,osmovaloper1hij...  0.56,0.44",
+		NumArgs:          3,
+		ParseAndBuildMsg: NewMsgReDelValidatorSetPreference,
+	}, &types.MsgRedelegateValidatorSet{}
+}
+
+func NewWithDelRewCmd() (*osmocli.TxCliDesc, *types.MsgWithdrawDelegationRewards) {
+	return &osmocli.TxCliDesc{
+		Use:     "withdraw-valset [delegator_addr]",
+		Short:   "Withdraw delegation reward form the new validator set.",
+		Example: "osmosisd tx valset-pref withdraw-valset  osmo1...",
+		NumArgs: 1,
+	}, &types.MsgWithdrawDelegationRewards{}
+}
+
 func NewMsgSetValidatorSetPreference(clientCtx client.Context, args []string, fs *pflag.FlagSet) (sdk.Msg, error) {
 	delAddr, err := sdk.AccAddressFromBech32(args[0])
 	if err != nil {
 		return nil, err
 	}
 
+	valset, err := ValidateValAddrAndWeight(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewMsgSetValidatorSetPreference(
+		delAddr,
+		valset,
+	), nil
+}
+
+func NewMsgReDelValidatorSetPreference(clientCtx client.Context, args []string, fs *pflag.FlagSet) (sdk.Msg, error) {
+	delAddr, err := sdk.AccAddressFromBech32(args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	valset, err := ValidateValAddrAndWeight(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewMsgRedelegateValidatorSet(
+		delAddr,
+		valset,
+	), nil
+}
+
+func ValidateValAddrAndWeight(args []string) ([]types.ValidatorPreference, error) {
 	var valAddrs []string
 	valAddrs = append(valAddrs, strings.Split(args[1], ",")...)
 
@@ -80,8 +128,5 @@ func NewMsgSetValidatorSetPreference(clientCtx client.Context, args []string, fs
 		})
 	}
 
-	return types.NewMsgSetValidatorSetPreference(
-		delAddr,
-		valset,
-	), nil
+	return valset, nil
 }

--- a/x/valset-pref/client/cli/tx.go
+++ b/x/valset-pref/client/cli/tx.go
@@ -19,6 +19,8 @@ func GetTxCmd() *cobra.Command {
 	osmocli.AddTxCmd(txCmd, NewSetValSetCmd)
 	osmocli.AddTxCmd(txCmd, NewDelValSetCmd)
 	osmocli.AddTxCmd(txCmd, NewUnDelValSetCmd)
+	osmocli.AddTxCmd(txCmd, NewReDelValSetCmd)
+	osmocli.AddTxCmd(txCmd, NewWithRewValSetCmd)
 	return txCmd
 }
 
@@ -60,7 +62,7 @@ func NewReDelValSetCmd() (*osmocli.TxCliDesc, *types.MsgRedelegateValidatorSet) 
 	}, &types.MsgRedelegateValidatorSet{}
 }
 
-func NewWithDelRewCmd() (*osmocli.TxCliDesc, *types.MsgWithdrawDelegationRewards) {
+func NewWithRewValSetCmd() (*osmocli.TxCliDesc, *types.MsgWithdrawDelegationRewards) {
 	return &osmocli.TxCliDesc{
 		Use:     "withdraw-reward-valset [delegator_addr]",
 		Short:   "Withdraw delegation reward form the new validator set.",

--- a/x/valset-pref/client/cli/tx.go
+++ b/x/valset-pref/client/cli/tx.go
@@ -36,7 +36,7 @@ func NewDelValSetCmd() (*osmocli.TxCliDesc, *types.MsgDelegateToValidatorSet) {
 	return &osmocli.TxCliDesc{
 		Use:     "delegate-valset [delegator_addr] [amount]",
 		Short:   "Delegate tokens to existing valset using delegatorAddress and tokenAmount.",
-		Example: "osmosisd tx valset-pref delegate-valset  osmo1... 100stake",
+		Example: "osmosisd tx valset-pref delegate-valset osmo1... 100stake",
 		NumArgs: 2,
 	}, &types.MsgDelegateToValidatorSet{}
 }
@@ -45,7 +45,7 @@ func NewUnDelValSetCmd() (*osmocli.TxCliDesc, *types.MsgUndelegateFromValidatorS
 	return &osmocli.TxCliDesc{
 		Use:     "undelegate-valset [delegator_addr] [amount]",
 		Short:   "UnDelegate tokens from existing valset using delegatorAddress and tokenAmount.",
-		Example: "osmosisd tx valset-pref undelegate-valset  osmo1... 100stake",
+		Example: "osmosisd tx valset-pref undelegate-valset osmo1... 100stake",
 		NumArgs: 2,
 	}, &types.MsgUndelegateFromValidatorSet{}
 }
@@ -62,9 +62,9 @@ func NewReDelValSetCmd() (*osmocli.TxCliDesc, *types.MsgRedelegateValidatorSet) 
 
 func NewWithDelRewCmd() (*osmocli.TxCliDesc, *types.MsgWithdrawDelegationRewards) {
 	return &osmocli.TxCliDesc{
-		Use:     "withdraw-valset [delegator_addr]",
+		Use:     "withdraw-reward-valset [delegator_addr]",
 		Short:   "Withdraw delegation reward form the new validator set.",
-		Example: "osmosisd tx valset-pref withdraw-valset  osmo1...",
+		Example: "osmosisd tx valset-pref withdraw-valset osmo1...",
 		NumArgs: 1,
 	}, &types.MsgWithdrawDelegationRewards{}
 }

--- a/x/valset-pref/valpref-module/module.go
+++ b/x/valset-pref/valpref-module/module.go
@@ -175,6 +175,7 @@ func (am AppModule) Actions() []simtypes.Action {
 	return []simtypes.Action{
 		simtypes.NewMsgBasedAction("SetValidatorSetPreference", am.keeper, simulation.RandomMsgSetValSetPreference),
 		simtypes.NewMsgBasedAction("MsgDelegateToValidatorSet", am.keeper, simulation.RandomMsgDelegateToValSet),
-		simtypes.NewMsgBasedAction("MsgUndelegateFromValidatorSet", am.keeper, simulation.RandomMsgUnDelegateToValSet),
+		simtypes.NewMsgBasedAction("MsgUndelegateFromValidatorSet", am.keeper, simulation.RandomMsgUnDelegateFromValSet),
+		//simtypes.NewMsgBasedAction("MsgWithdrawDelegationRewards", am.keeper, simulation.RandomMsgWithdrawRewardsFromValSet),
 	}
 }

--- a/x/valset-pref/valpref-module/module.go
+++ b/x/valset-pref/valpref-module/module.go
@@ -176,6 +176,7 @@ func (am AppModule) Actions() []simtypes.Action {
 		simtypes.NewMsgBasedAction("SetValidatorSetPreference", am.keeper, simulation.RandomMsgSetValSetPreference),
 		simtypes.NewMsgBasedAction("MsgDelegateToValidatorSet", am.keeper, simulation.RandomMsgDelegateToValSet),
 		simtypes.NewMsgBasedAction("MsgUndelegateFromValidatorSet", am.keeper, simulation.RandomMsgUnDelegateFromValSet),
-		//simtypes.NewMsgBasedAction("MsgWithdrawDelegationRewards", am.keeper, simulation.RandomMsgWithdrawRewardsFromValSet),
+		simtypes.NewMsgBasedAction("MsgRedelegateValSet", am.keeper, simulation.RandomMsgReDelegateToValSet),
+		simtypes.NewMsgBasedAction("MsgWithdrawDelegationRewards", am.keeper, simulation.RandomMsgWithdrawRewardsFromValSet),
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of : https://github.com/osmosis-labs/osmosis/issues/2579

## What is the purpose of the change
Adds simulator test support for RandomMsgReDelegateToValSet, RandomMsgWithdrawRewardsFromValSet and add cli tx commands. 

## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying
Cli tested all the commands. More Info: https://hackmd.io/6eb1WIyRQYiFmD1QjI-ivQ

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)