### PR TITLE
(CL Fees): update tick `feeGrowthOutside` in `initOrUpdateTick`

### DIFF
--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -17,6 +17,13 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, tickIndex int64
 		return types.PoolNotFoundError{PoolId: poolId}
 	}
 
+	pool, err := k.getPoolById(ctx, poolId)
+	if err != nil {
+		return err
+	}
+
+	currentTick := pool.GetCurrentTick().Int64()
+
 	tickInfo, err := k.getTickInfo(ctx, poolId, tickIndex)
 	if err != nil {
 		return err
@@ -36,6 +43,16 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, tickIndex int64
 		tickInfo.LiquidityNet = tickInfo.LiquidityNet.Sub(liquidityIn)
 	} else {
 		tickInfo.LiquidityNet = tickInfo.LiquidityNet.Add(liquidityIn)
+	}
+
+	// if given tickIndex is LTE to current tick, tick's fee growth outside is set as fee accumulator's value
+	if tickIndex <= currentTick {
+		accum, err := k.getFeeAccumulator(ctx, poolId)
+		if err != nil {
+			return err
+		}
+
+		tickInfo.FeeGrowthOutside = accum.GetValue()
 	}
 
 	k.SetTickInfo(ctx, poolId, tickIndex, tickInfo)

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -13,10 +13,6 @@ import (
 // if we are initializing or updating an upper tick, we subtract the liquidityIn from the LiquidityNet
 // if we are initializing or updating an lower tick, we add the liquidityIn from the LiquidityNet
 func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, tickIndex int64, liquidityIn sdk.Dec, upper bool) (err error) {
-	if !k.poolExists(ctx, poolId) {
-		return types.PoolNotFoundError{PoolId: poolId}
-	}
-
 	pool, err := k.getPoolById(ctx, poolId)
 	if err != nil {
 		return err

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -230,6 +230,13 @@ func (s *KeeperTestSuite) TestInitOrUpdateTick() {
 
 			// Create a default CL pool
 			s.PrepareConcentratedPool()
+			_, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, 1)
+			feeAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, 1)
+			s.Require().NoError(err)
+
+			// manually update accumulator for testing
+			defaultAccumCoins := sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(50)))
+			feeAccum.UpdateAccumulator(defaultAccumCoins)
 
 			// If tickExists set, initialize the specified tick with defaultLiquidityAmt
 			preexistingLiquidity := sdk.ZeroDec()
@@ -260,6 +267,12 @@ func (s *KeeperTestSuite) TestInitOrUpdateTick() {
 			// Check that the initialized or updated tick matches our expectation
 			s.Require().Equal(test.expectedLiquidityNet, tickInfo.LiquidityNet)
 			s.Require().Equal(test.expectedLiquidityGross, tickInfo.LiquidityGross)
+
+			if test.param.tickIndex <= 0 {
+				s.Require().Equal(defaultAccumCoins, tickInfo.FeeGrowthOutside)
+			} else {
+				s.Require().Equal(sdk.DecCoins(nil), tickInfo.FeeGrowthOutside)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
This PR adds updating ticks for `feeGrowthOutside` in `initOrUpdateTick`



## Testing and Verifying
Tests has been added to check tick's fee growth outside to existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)