### PR TITLE
fix(twap/upgrades): geometric twap accumulator initialization; testnet bug reproduction

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -34,6 +34,10 @@ import (
 // in-response to a testnet incident when performing the geometric twap
 // upgrade. Upon adding the migrations logic, the tests began to pass.
 func (s *IntegrationTestSuite) TestGeometricTwapMigration() {
+	if s.skipUpgrade {
+		s.T().Skip("Skipping upgrade tests")
+	}
+
 	const (
 		// Configurations for tests/e2e/scripts/pool1A.json
 		// This pool gets initialized pre-upgrade.
@@ -60,10 +64,6 @@ func (s *IntegrationTestSuite) TestGeometricTwapMigration() {
 // TestIBCTokenTransfer tests that IBC token transfers work as expected.
 // Additionally, it attempst to create a pool with IBC denoms.
 func (s *IntegrationTestSuite) TestIBCTokenTransferAndCreatePool() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -87,10 +87,6 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferAndCreatePool() {
 // - voting no on the proposal from the delegator wallet
 // - ensuring that delegator's wallet overwrites the validator's vote
 func (s *IntegrationTestSuite) TestSuperfluidVoting() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
@@ -176,10 +172,6 @@ func copyFile(a, b string) error {
 }
 
 func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -276,10 +268,6 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
 }
 
 func (s *IntegrationTestSuite) TestIBCWasmHooks() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -353,10 +341,6 @@ func (s *IntegrationTestSuite) TestIBCWasmHooks() {
 
 // TestAddToExistingLockPostUpgrade ensures addToExistingLock works for locks created preupgrade.
 func (s *IntegrationTestSuite) TestAddToExistingLockPostUpgrade() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	if s.skipUpgrade {
 		s.T().Skip("Skipping AddToExistingLockPostUpgrade test")
 	}
@@ -372,10 +356,6 @@ func (s *IntegrationTestSuite) TestAddToExistingLockPostUpgrade() {
 
 // TestAddToExistingLock tests lockups to both regular and superfluid locks.
 func (s *IntegrationTestSuite) TestAddToExistingLock() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
@@ -400,10 +380,6 @@ func (s *IntegrationTestSuite) TestAddToExistingLock() {
 // because twap keep time = epoch time / 4 and we use a timer
 // to wait for at least the twap keep time.
 func (s *IntegrationTestSuite) TestArithmeticTWAP() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	const (
 		poolFile   = "nativeDenomThreeAssetPool.json"
 		walletName = "arithmetic-twap-wallet"
@@ -581,10 +557,6 @@ func (s *IntegrationTestSuite) TestArithmeticTWAP() {
 }
 
 func (s *IntegrationTestSuite) TestStateSync() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	if s.skipStateSync {
 		s.T().Skip()
 	}
@@ -678,10 +650,6 @@ func (s *IntegrationTestSuite) TestStateSync() {
 }
 
 func (s *IntegrationTestSuite) TestExpeditedProposals() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
@@ -721,10 +689,6 @@ func (s *IntegrationTestSuite) TestExpeditedProposals() {
 // Upon swapping 1_000_000 uosmo for stake, supply changes, making uosmo less expensive.
 // As a result of the swap, twap changes to 0.5.
 func (s *IntegrationTestSuite) TestGeometricTWAP() {
-
-	// TODO: remove
-	s.T().SkipNow()
-
 	const (
 		// This pool contains 1_000_000 uosmo and 2_000_000 stake.
 		// Equals weights.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3,13 +3,14 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	ibchookskeeper "github.com/osmosis-labs/osmosis/x/ibc-hooks/keeper"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	ibchookskeeper "github.com/osmosis-labs/osmosis/x/ibc-hooks/keeper"
 
 	paramsutils "github.com/cosmos/cosmos-sdk/x/params/client/utils"
 
@@ -24,9 +25,38 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/tests/e2e/initialization"
 )
 
+func (s *IntegrationTestSuite) TestTwapMigration() {
+	// Swap against pre-upgrade pool to trigger twap record update
+
+	const (
+		oldPoolId       = 1
+		minAmountOut    = "1"
+		otherDenom      = "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
+		migrationWallet = "migration"
+	)
+
+	chainA := s.configurer.GetChainConfig(0)
+	node, err := chainA.GetDefaultNode()
+	s.Require().NoError(err)
+
+	uosmoIn := fmt.Sprintf("1000000%s", "uosmo")
+
+	swapWalletAddr := node.CreateWallet(migrationWallet)
+
+	node.BankSend(uosmoIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
+
+	// Swap to create new twap records on pre-upgrade pool.
+	node.SwapExactAmountIn(uosmoIn, minAmountOut, fmt.Sprintf("%d", oldPoolId), otherDenom, swapWalletAddr)
+
+}
+
 // TestIBCTokenTransfer tests that IBC token transfers work as expected.
 // Additionally, it attempst to create a pool with IBC denoms.
 func (s *IntegrationTestSuite) TestIBCTokenTransferAndCreatePool() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -50,6 +80,10 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferAndCreatePool() {
 // - voting no on the proposal from the delegator wallet
 // - ensuring that delegator's wallet overwrites the validator's vote
 func (s *IntegrationTestSuite) TestSuperfluidVoting() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
@@ -135,6 +169,10 @@ func copyFile(a, b string) error {
 }
 
 func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -231,6 +269,10 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
 }
 
 func (s *IntegrationTestSuite) TestIBCWasmHooks() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	if s.skipIBC {
 		s.T().Skip("Skipping IBC tests")
 	}
@@ -304,6 +346,10 @@ func (s *IntegrationTestSuite) TestIBCWasmHooks() {
 
 // TestAddToExistingLockPostUpgrade ensures addToExistingLock works for locks created preupgrade.
 func (s *IntegrationTestSuite) TestAddToExistingLockPostUpgrade() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	if s.skipUpgrade {
 		s.T().Skip("Skipping AddToExistingLockPostUpgrade test")
 	}
@@ -319,6 +365,10 @@ func (s *IntegrationTestSuite) TestAddToExistingLockPostUpgrade() {
 
 // TestAddToExistingLock tests lockups to both regular and superfluid locks.
 func (s *IntegrationTestSuite) TestAddToExistingLock() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
@@ -343,6 +393,10 @@ func (s *IntegrationTestSuite) TestAddToExistingLock() {
 // because twap keep time = epoch time / 4 and we use a timer
 // to wait for at least the twap keep time.
 func (s *IntegrationTestSuite) TestArithmeticTWAP() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	const (
 		poolFile   = "nativeDenomThreeAssetPool.json"
 		walletName = "arithmetic-twap-wallet"
@@ -520,6 +574,10 @@ func (s *IntegrationTestSuite) TestArithmeticTWAP() {
 }
 
 func (s *IntegrationTestSuite) TestStateSync() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	if s.skipStateSync {
 		s.T().Skip()
 	}
@@ -613,6 +671,10 @@ func (s *IntegrationTestSuite) TestStateSync() {
 }
 
 func (s *IntegrationTestSuite) TestExpeditedProposals() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	chainA := s.configurer.GetChainConfig(0)
 	chainANode, err := chainA.GetDefaultNode()
 	s.NoError(err)
@@ -652,6 +714,10 @@ func (s *IntegrationTestSuite) TestExpeditedProposals() {
 // Upon swapping 1_000_000 uosmo for stake, supply changes, making uosmo less expensive.
 // As a result of the swap, twap changes to 0.5.
 func (s *IntegrationTestSuite) TestGeometricTWAP() {
+
+	// TODO: remove
+	s.T().SkipNow()
+
 	const (
 		// This pool contains 1_000_000 uosmo and 2_000_000 stake.
 		// Equals weights.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -25,10 +25,18 @@ import (
 	"github.com/osmosis-labs/osmosis/v13/tests/e2e/initialization"
 )
 
-func (s *IntegrationTestSuite) TestTwapMigration() {
-	// Swap against pre-upgrade pool to trigger twap record update
-
+// TestGeometricTwapMigration tests that the geometric twap record
+// migration runs succesfully. It does so by attempting to execute
+// the swap on the pool created pre-upgrade. When a pool is created
+// pre-upgrade, twap records are initialized for a pool. By runnning
+// a swap post-upgrade, we confirm that the geometric twap was initialized
+// correctly and does not cause a chain halt. This test was created
+// in-response to a testnet incident when performing the geometric twap
+// upgrade. Upon adding the migrations logic, the tests began to pass.
+func (s *IntegrationTestSuite) TestGeometricTwapMigration() {
 	const (
+		// Configurations for tests/e2e/scripts/pool1A.json
+		// This pool gets initialized pre-upgrade.
 		oldPoolId       = 1
 		minAmountOut    = "1"
 		otherDenom      = "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
@@ -45,9 +53,8 @@ func (s *IntegrationTestSuite) TestTwapMigration() {
 
 	node.BankSend(uosmoIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
 
-	// Swap to create new twap records on pre-upgrade pool.
+	// Swap to create new twap records on the pool that was created pre-upgrade.
 	node.SwapExactAmountIn(uosmoIn, minAmountOut, fmt.Sprintf("%d", oldPoolId), otherDenom, swapWalletAddr)
-
 }
 
 // TestIBCTokenTransfer tests that IBC token transfers work as expected.

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -124,6 +124,6 @@ func (k *Keeper) AfterCreatePool(ctx sdk.Context, poolId uint64) error {
 	return k.afterCreatePool(ctx, poolId)
 }
 
-func (k Keeper) InitializeGeometricTwap(ctx sdk.Context) error {
-	return k.initializeGeometricTwap(ctx)
+func (k Keeper) InitializeGeometricTwap(ctx sdk.Context, value sdk.Dec) error {
+	return k.initializeGeometricTwapAcc(ctx, value)
 }

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -123,3 +123,7 @@ func (k *Keeper) SetAmmInterface(ammInterface types.AmmInterface) {
 func (k *Keeper) AfterCreatePool(ctx sdk.Context, poolId uint64) error {
 	return k.afterCreatePool(ctx, poolId)
 }
+
+func (k Keeper) InitializeGeometricTwap(ctx sdk.Context) error {
+	return k.initializeGeometricTwap(ctx)
+}

--- a/x/twap/migrate.go
+++ b/x/twap/migrate.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/osmosis-labs/osmosis/osmoutils"
-	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
 type Migrator struct {
@@ -30,41 +27,6 @@ func (k Keeper) MigrateExistingPools(ctx sdk.Context, latestPoolId uint64) error
 			return err
 		}
 	}
-	return nil
-}
-
-func (k Keeper) MigrateTwapRecordsToGeometric(ctx sdk.Context) error {
-
-	// types
-
-	allMostRecetRecords, err := k.getAllMostRecentRecords(ctx)
-	if err != nil {
-		return err
-	}
-
-	store := ctx.KVStore(k.storeKey)
-
-	for _, record := range allMostRecetRecords {
-		record := record
-		record.GeometricTwapAccumulator = sdk.ZeroDec()
-		key := types.FormatMostRecentTWAPKey(record.PoolId, record.Asset0Denom, record.Asset1Denom)
-		osmoutils.MustSet(store, key, &record)
-	}
-
-	// make available for GC
-	allMostRecetRecords = nil
-
-	allHistoricalRecords, err := k.getAllHistoricalPoolIndexedTWAPs(ctx)
-
-	for _, record := range allHistoricalRecords {
-		record := record
-		record.GeometricTwapAccumulator = sdk.ZeroDec()
-		k.storeHistoricalTWAP(ctx, record)
-	}
-
-	// make available for GC
-	allHistoricalRecords = nil
-
 	return nil
 }
 

--- a/x/twap/migrate.go
+++ b/x/twap/migrate.go
@@ -1,11 +1,26 @@
 package twap
 
 import (
+	"errors"
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
+
+type Migrator struct {
+	keeper Keeper
+}
+
+func NewMigrator(keeper Keeper) Migrator {
+	return Migrator{keeper: keeper}
+}
+
+func (m Migrator) Migrate1To2(ctx sdk.Context) error {
+	return m.keeper.initializeGeometricTwap(ctx)
+}
 
 // MigrateExistingPools iterates through all pools and creates state entry for the twap module.
 func (k Keeper) MigrateExistingPools(ctx sdk.Context, latestPoolId uint64) error {
@@ -50,5 +65,35 @@ func (k Keeper) MigrateTwapRecordsToGeometric(ctx sdk.Context) error {
 	// make available for GC
 	allHistoricalRecords = nil
 
+	return nil
+}
+
+func (k Keeper) initializeGeometricTwap(ctx sdk.Context) error {
+	// In ascending order by time.
+	historicalTimeIndexed, err := k.getAllHistoricalTimeIndexedTWAPs(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(historicalTimeIndexed) == 0 {
+		return errors.New("error: no historical twap records found")
+	}
+
+	// Since we are iterate over time-indexed records in ascending order,
+	// most recent record should also be updated correctly.
+	for i, record := range historicalTimeIndexed {
+		// Sanity check order.
+		if i > 0 {
+			previousRecord := historicalTimeIndexed[i-1]
+
+			isCorrectOrder := previousRecord.Time.Before(record.Time)
+			if !isCorrectOrder {
+				return fmt.Errorf("error: historical twap records are not in ascending order, (%v), was after (%v)", previousRecord, record)
+			}
+		}
+
+		record.GeometricTwapAccumulator = sdk.ZeroDec()
+		k.storeNewRecord(ctx, record)
+	}
 	return nil
 }

--- a/x/twap/migrate.go
+++ b/x/twap/migrate.go
@@ -2,6 +2,9 @@ package twap
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/osmoutils"
+	"github.com/osmosis-labs/osmosis/v13/x/twap/types"
 )
 
 // MigrateExistingPools iterates through all pools and creates state entry for the twap module.
@@ -12,5 +15,40 @@ func (k Keeper) MigrateExistingPools(ctx sdk.Context, latestPoolId uint64) error
 			return err
 		}
 	}
+	return nil
+}
+
+func (k Keeper) MigrateTwapRecordsToGeometric(ctx sdk.Context) error {
+
+	// types
+
+	allMostRecetRecords, err := k.getAllMostRecentRecords(ctx)
+	if err != nil {
+		return err
+	}
+
+	store := ctx.KVStore(k.storeKey)
+
+	for _, record := range allMostRecetRecords {
+		record := record
+		record.GeometricTwapAccumulator = sdk.ZeroDec()
+		key := types.FormatMostRecentTWAPKey(record.PoolId, record.Asset0Denom, record.Asset1Denom)
+		osmoutils.MustSet(store, key, &record)
+	}
+
+	// make available for GC
+	allMostRecetRecords = nil
+
+	allHistoricalRecords, err := k.getAllHistoricalPoolIndexedTWAPs(ctx)
+
+	for _, record := range allHistoricalRecords {
+		record := record
+		record.GeometricTwapAccumulator = sdk.ZeroDec()
+		k.storeHistoricalTWAP(ctx, record)
+	}
+
+	// make available for GC
+	allHistoricalRecords = nil
+
 	return nil
 }

--- a/x/twap/migrate.go
+++ b/x/twap/migrate.go
@@ -87,9 +87,8 @@ func (k Keeper) initializeGeometricTwapAcc(ctx sdk.Context, value sdk.Dec) error
 		if i > 0 {
 			previousRecord := historicalTimeIndexed[i-1]
 
-			isSamePool := previousRecord.PoolId == record.PoolId
-			isCorrectOrder := previousRecord.Time.Before(record.Time)
-			if !isCorrectOrder && !isSamePool {
+			isInvalidOrder := previousRecord.Time.After(record.Time)
+			if isInvalidOrder {
 				return fmt.Errorf("error: historical twap records are not in ascending order, (%v), was after (%v)", previousRecord, record)
 			}
 		}

--- a/x/twap/migrate_test.go
+++ b/x/twap/migrate_test.go
@@ -96,6 +96,13 @@ func (suite *TestSuite) TestTwapRecord_GeometricTwap_MarshalUnmarshal() {
 
 func (suite *TestSuite) TestInitializeGeometricTwap() {
 
+	setGeometricAccumToOne := func(records []types.TwapRecord) []types.TwapRecord {
+		for i := range records {
+			records[i].GeometricTwapAccumulator = sdk.OneDec()
+		}
+		return records
+	}
+
 	tests := map[string]struct {
 		expectError bool
 
@@ -104,15 +111,22 @@ func (suite *TestSuite) TestInitializeGeometricTwap() {
 		// pool id -> most recent records
 		expectedMostRecent map[uint64][]types.TwapRecord
 	}{
-		"one record, one pool": {
-			preExistingRecords: []types.TwapRecord{
-				baseRecord,
-			},
+		// "one record, one pool": {
+		// 	preExistingRecords: []types.TwapRecord{
+		// 		baseRecord,
+		// 	},
+
+		// 	expectedMostRecent: map[uint64][]types.TwapRecord{
+		// 		1: {
+		// 			baseRecord,
+		// 		},
+		// 	},
+		// },
+		"three records, one pool": {
+			preExistingRecords: newThreeAssetRecord(basePoolId, baseTime, sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec()),
 
 			expectedMostRecent: map[uint64][]types.TwapRecord{
-				1: {
-					baseRecord,
-				},
+				1: setGeometricAccumToOne(newThreeAssetRecord(basePoolId, baseTime, sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec(), sdk.OneDec())),
 			},
 		},
 	}
@@ -125,8 +139,7 @@ func (suite *TestSuite) TestInitializeGeometricTwap() {
 			ctx := suite.Ctx
 
 			suite.preSetRecords(tc.preExistingRecords)
-
-			err := k.InitializeGeometricTwap(ctx)
+			err := k.InitializeGeometricTwap(ctx, sdk.OneDec())
 
 			if tc.expectError {
 				suite.Require().Error(err)

--- a/x/twap/migrate_test.go
+++ b/x/twap/migrate_test.go
@@ -241,7 +241,7 @@ func (suite *TestSuite) TestInitializeGeometricTwap() {
 			// Initialize the geometric accumulator to get the expected values.
 			expectedHistoricalPoolIndexed := updateGeometricAccum(oldHistoricalPoolIndexed)
 
-			// Repeate for historical time indexed records.
+			// Repeat for historical time indexed records.
 			oldHistoricalTimeIndexed, err := k.GetAllHistoricalTimeIndexedTWAPs(ctx)
 			suite.Require().NoError(err)
 			expectedHistoricalTimeIndexed := updateGeometricAccum(oldHistoricalTimeIndexed)

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -151,12 +151,6 @@ func (k Keeper) getAllMostRecentRecordsForPool(ctx sdk.Context, poolId uint64) (
 	return types.GetAllMostRecentTwapsForPool(store, poolId)
 }
 
-// getAllMostRecentRecords returns all most recent TWAPs.
-// nolint: unused
-func (k Keeper) getAllMostRecentRecords(ctx sdk.Context) ([]types.TwapRecord, error) {
-	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPPoolIndexPrefix), types.ParseTwapFromBz)
-}
-
 // getAllHistoricalTimeIndexedTWAPs returns all historical TWAPs indexed by time.
 func (k Keeper) getAllHistoricalTimeIndexedTWAPs(ctx sdk.Context) ([]types.TwapRecord, error) {
 	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPTimeIndexPrefix), types.ParseTwapFromBz)

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -151,6 +151,12 @@ func (k Keeper) getAllMostRecentRecordsForPool(ctx sdk.Context, poolId uint64) (
 	return types.GetAllMostRecentTwapsForPool(store, poolId)
 }
 
+// getAllMostRecentRecords returns all most recent TWAPs.
+// nolint: unused
+func (k Keeper) getAllMostRecentRecords(ctx sdk.Context) ([]types.TwapRecord, error) {
+	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPPoolIndexPrefix), types.ParseTwapFromBz)
+}
+
 // getAllHistoricalTimeIndexedTWAPs returns all historical TWAPs indexed by time.
 func (k Keeper) getAllHistoricalTimeIndexedTWAPs(ctx sdk.Context) ([]types.TwapRecord, error) {
 	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPTimeIndexPrefix), types.ParseTwapFromBz)

--- a/x/twap/twapmodule/module.go
+++ b/x/twap/twapmodule/module.go
@@ -81,7 +81,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	queryproto.RegisterQueryServer(cfg.QueryServer(), grpc.Querier{Q: twapclient.Querier{K: am.k}})
 
 	m := twap.NewMigrator(am.k)
-	err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1To2)
+	err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1To2GeometricTwapAcc)
 	if err != nil {
 		panic(err)
 	}

--- a/x/twap/twapmodule/module.go
+++ b/x/twap/twapmodule/module.go
@@ -81,7 +81,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	queryproto.RegisterQueryServer(cfg.QueryServer(), grpc.Querier{Q: twapclient.Querier{K: am.k}})
 
 	m := twap.NewMigrator(am.k)
-	err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate1To2)
+	err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1To2)
 	if err != nil {
 		panic(err)
 	}

--- a/x/twap/twapmodule/module.go
+++ b/x/twap/twapmodule/module.go
@@ -79,6 +79,12 @@ type AppModule struct {
 
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	queryproto.RegisterQueryServer(cfg.QueryServer(), grpc.Querier{Q: twapclient.Querier{K: am.k}})
+
+	m := twap.NewMigrator(am.k)
+	err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate1To2)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func NewAppModule(twapKeeper twap.Keeper) AppModule {
@@ -134,4 +140,4 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return 2 }

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -35,7 +35,7 @@ var (
 
 	// format is just pool id | denom1 | denom2
 	// made for getting most recent key
-	mostRecentTWAPsPrefix = mostRecentTWAPsNoSeparator + KeySeparator
+	MostRecentTWAPsPrefix = mostRecentTWAPsNoSeparator + KeySeparator
 	// format is time | pool id | denom1 | denom2
 	// made for efficiently deleting records by time in pruning
 	HistoricalTWAPTimeIndexPrefix = historicalTWAPTimeIndexNoSeparator + KeySeparator
@@ -48,7 +48,7 @@ var (
 
 func FormatMostRecentTWAPKey(poolId uint64, denom1, denom2 string) []byte {
 	poolIdS := osmoutils.FormatFixedLengthU64(poolId)
-	return []byte(fmt.Sprintf("%s%s%s%s%s%s", mostRecentTWAPsPrefix, poolIdS, KeySeparator, denom1, KeySeparator, denom2))
+	return []byte(fmt.Sprintf("%s%s%s%s%s%s", MostRecentTWAPsPrefix, poolIdS, KeySeparator, denom1, KeySeparator, denom2))
 }
 
 // TODO: Replace historical management with ORM, we currently accept 2x write amplification right now.
@@ -77,8 +77,8 @@ func FormatHistoricalPoolIndexTimeSuffix(poolId uint64, denom1, denom2 string, a
 func GetAllMostRecentTwapsForPool(store sdk.KVStore, poolId uint64) ([]TwapRecord, error) {
 	poolIdS := osmoutils.FormatFixedLengthU64(poolId)
 	poolIdPlusOneS := osmoutils.FormatFixedLengthU64(poolId + 1)
-	startPrefix := fmt.Sprintf("%s%s%s", mostRecentTWAPsPrefix, poolIdS, KeySeparator)
-	endPrefix := fmt.Sprintf("%s%s%s", mostRecentTWAPsPrefix, poolIdPlusOneS, KeySeparator)
+	startPrefix := fmt.Sprintf("%s%s%s", MostRecentTWAPsPrefix, poolIdS, KeySeparator)
+	endPrefix := fmt.Sprintf("%s%s%s", MostRecentTWAPsPrefix, poolIdPlusOneS, KeySeparator)
 	return osmoutils.GatherValuesFromStore(store, []byte(startPrefix), []byte(endPrefix), ParseTwapFromBz)
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

In https://github.com/osmosis-labs/osmosis/issues/3542, it was concluded that we do not need to perform the migrations to initialize the geometric twap accumulator.

However, the testnet halted due to the geometric twap accumulator ending up uninitialized.

The reason why our e2e test did not catch this problem was because we neve swapped against a pool that was created pre-upgrade after the upgrade itself.

This PR reproduced the testnet halt bug and fixed it by introducing twap record migrations that were originally spearheaded  in: https://github.com/osmosis-labs/osmosis/pull/3729

## Brief Changelog

- reproduce testnet halt
- introduce twap migrations from: https://github.com/osmosis-labs/osmosis/pull/3729
- test more thoroughly and document

## Testing and Verifying


This change added e2e and migrations tests.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 