### PR TITLE
refactor(CL Fees): prefix positions by pool id, owner and ticks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3
 	github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230105183030-bccf5202f260
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230105184425-1e6fcd979d99
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230111151925-129792310797
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -855,8 +855,8 @@ github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:Ylmch
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230105183030-bccf5202f260 h1:+EbINXzHQyDtHje2CND357A22H2zUpceTtwJClC9IAM=
 github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230105183030-bccf5202f260/go.mod h1:KrzYoNtnWUH75rj1XAsSR4nymlHFU7jeVOx7/1KMe0k=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230105184425-1e6fcd979d99 h1:8yYGNa5u8MmFdh+FpZQ7/4jlGABd5XSDfPcENJE9HXs=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230105184425-1e6fcd979d99/go.mod h1:K4de+n3DtLdueen98dOzaRXZvqMd8JvigL8O1xW445o=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230111151925-129792310797 h1:CnSeyZkQPq90GgirSTBUgEVeT+InCW1jsLDGiozcnR8=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230111151925-129792310797/go.mod h1:K4de+n3DtLdueen98dOzaRXZvqMd8JvigL8O1xW445o=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8 h1:iOJO+5jffUFlLVy51XaGnec22rNX5YAs71rxD+7M2Ac=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8/go.mod h1:ey8gfcDaTYJMkj5d0FZ4+p3CPcXP6tbPQ/WyOww17Gc=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30 h1:6uMi7HhPSwvKKU7j5NqljseFTEz4I7qHr+IPnnn42Ck=

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -254,6 +254,8 @@ func (accum AccumulatorObject) GetPositionSize(name string) (sdk.Dec, error) {
 	return position.NumShares, nil
 }
 
+// HasPosition returns true if a position with the given name exists,
+// false otherwise. Returns error if internal database error occurs.
 func (accum AccumulatorObject) HasPosition(name string) (bool, error) {
 	_, err := getPosition(accum, name)
 

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -254,6 +254,20 @@ func (accum AccumulatorObject) GetPositionSize(name string) (sdk.Dec, error) {
 	return position.NumShares, nil
 }
 
+func (accum AccumulatorObject) HasPosition(name string) (bool, error) {
+	_, err := getPosition(accum, name)
+
+	if err != nil {
+		isNoPositionError := errors.Is(err, NoPositionError{Name: name})
+		if isNoPositionError {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 // GetValue returns the current value of the accumulator.
 func (accum AccumulatorObject) GetValue() sdk.DecCoins {
 	return accum.value

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1326,3 +1326,43 @@ func (suite *AccumTestSuite) TestUpdatePositionCustomAcc() {
 		})
 	}
 }
+
+func (suite *AccumTestSuite) TestHasPosition() {
+	// We setup store and accum
+	// once at beginning.
+	suite.SetupTest()
+
+	const (
+		defaultPositionName = "posname"
+	)
+
+	// Setup.
+	accObject := accumPackage.CreateRawAccumObject(suite.store, testNameOne, initialCoinsDenomOne)
+
+	tests := map[string]struct {
+		preCreatePosition bool
+	}{
+		"position exists -> true": {
+			preCreatePosition: true,
+		},
+		"position does not exist -> false": {
+			preCreatePosition: false,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+			// Setup
+			if tc.preCreatePosition {
+				err := accObject.NewPosition(defaultPositionName, sdk.ZeroDec(), nil)
+				suite.Require().NoError(err)
+			}
+
+			hasPosition, err := accObject.HasPosition(defaultPositionName)
+			suite.NoError(err)
+
+			suite.Equal(tc.preCreatePosition, hasPosition)
+		})
+	}
+}

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -100,8 +100,8 @@ func (k Keeper) GetFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.Accumul
 	return k.getFeeAccumulator(ctx, poolId)
 }
 
-func (k Keeper) InitializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, liquidityDelta sdk.Dec) error {
-	return k.initializeFeeAccumulatorPosition(ctx, poolId, owner, liquidityDelta)
+func (k Keeper) InitializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityDelta sdk.Dec) error {
+	return k.initializeFeeAccumulatorPosition(ctx, poolId, owner, lowerTick, upperTick, liquidityDelta)
 }
 
 func (k Keeper) UpdateFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, liquidityDelta sdk.Dec, lowerTick int64, upperTick int64) error {
@@ -126,4 +126,8 @@ func GetFeeAccumulatorName(poolId uint64) string {
 
 func (k Keeper) ChargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
 	return k.chargeFee(ctx, poolId, feeUpdate)
+}
+
+func FormatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) string {
+	return formatPositionAccumulatorKey(poolId, owner, lowerTick, upperTick)
 }

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -218,6 +218,7 @@ func calculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, current
 
 // formatPositionAccumulatorKey formats the position accumulator key prefixed by pool id, owner, lower tick
 // and upper tick with a key separator in-between.
+// nolint: unused
 func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) string {
 	return strings.Join([]string{strconv.FormatUint(poolId, uintBase), owner.String(), strconv.FormatInt(lowerTick, uintBase), strconv.FormatInt(upperTick, uintBase)}, keySeparator)
 }

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -1,6 +1,7 @@
 package concentrated_liquidity
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -10,9 +11,9 @@ import (
 )
 
 const (
-	feeAccumPrefix        = "fee"
-	feeAccumNameSeparator = "/"
-	uintBase              = 10
+	feeAccumPrefix = "fee"
+	keySeparator   = "/"
+	uintBase       = 10
 )
 
 var (
@@ -57,16 +58,38 @@ func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin)
 }
 
 // initializeFeeAccumulatorPosition initializes the pool fee accumulator with given liquidity delta and zero value for the accumulator.
+// Returns nil on success. Returns error if:
+// - fails to get an accumulator for a given poold id
+// - attempts to re-initialize an existing non-zero liqudity position
+// - fails to create a position
 // nolint: unused
-func (k Keeper) initializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, liquidityDelta sdk.Dec) error {
+func (k Keeper) initializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64, liquidityDelta sdk.Dec) error {
 	// get fee accumulator for the pool
 	feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
 	if err != nil {
 		return err
 	}
 
+	positionKey := formatPositionAccumulatorKey(poolId, owner, lowerTick, upperTick)
+
+	hasPosition, err := feeAccumulator.HasPosition(positionKey)
+	if err != nil {
+		return err
+	}
+
+	if hasPosition {
+		positionSize, err := feeAccumulator.GetPositionSize(positionKey)
+		if err != nil {
+			return err
+		}
+
+		if !positionSize.IsZero() {
+			return fmt.Errorf("attempted to re-initialize fee accumulator position (%s) with non-zero liquidity", positionKey)
+		}
+	}
+
 	// initialize the owner's position with liquidity Delta and zero accumulator value
-	if err := feeAccumulator.NewPositionCustomAcc(owner.String(), liquidityDelta, sdk.NewDecCoins(), nil); err != nil {
+	if err := feeAccumulator.NewPosition(positionKey, liquidityDelta, nil); err != nil {
 		return err
 	}
 
@@ -75,6 +98,7 @@ func (k Keeper) initializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64,
 
 // updateFeeAccumulatorPosition updates the owner's position
 // nolint: unused
+// TODO: test
 func (k Keeper) updateFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, liquidityDelta sdk.Dec, lowerTick int64, upperTick int64) error {
 	feeGrowthOutside, err := k.getFeeGrowthOutside(ctx, poolId, lowerTick, upperTick)
 	if err != nil {
@@ -87,7 +111,11 @@ func (k Keeper) updateFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, own
 	}
 
 	// replace position's accumulator with the updated liquidity and the feeGrowthOutside
-	if err := feeAccumulator.UpdatePositionCustomAcc(owner.String(), liquidityDelta, feeGrowthOutside); err != nil {
+	err = feeAccumulator.UpdatePositionCustomAcc(
+		formatPositionAccumulatorKey(poolId, owner, lowerTick, upperTick),
+		liquidityDelta,
+		feeGrowthOutside)
+	if err != nil {
 		return err
 	}
 
@@ -102,7 +130,7 @@ func (k Keeper) initOrUpdateFeeAccumulatorPosition(ctx sdk.Context, poolId uint6
 	// first try updating fee accum position
 	err := k.updateFeeAccumulatorPosition(ctx, poolId, owner, liquidityDelta, lowerTick, upperTick)
 	if err != nil {
-		err = k.initializeFeeAccumulatorPosition(ctx, poolId, owner, liquidityDelta)
+		err = k.initializeFeeAccumulatorPosition(ctx, poolId, owner, lowerTick, upperTick, liquidityDelta)
 		if err != nil {
 			return err
 		}
@@ -146,8 +174,9 @@ func (k Keeper) getFeeGrowthOutside(ctx sdk.Context, poolId uint64, lowerTick, u
 // getInitialFeeGrowthOutsideForTick returns the initial value of fee growth outside for a given tick.
 // This value depends on the tick's location relative to the current tick.
 //
-// feeGrowthOutside = { feeGrowthGlobal current tick >= tick }
-//                    { 0               current tick <  tick }
+// feeGrowthOutside =
+// { feeGrowthGlobal current tick >= tick }
+// { 0               current tick <  tick }
 //
 // The value is chosen as if all of the fees earned to date had occurrd below the tick.
 // Returns error if the pool with the given id does exist or if fails to get the fee accumulator.
@@ -185,4 +214,10 @@ func calculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, current
 		return feesGrowthGlobal.Sub(feeGrowthOutside)
 	}
 	return feeGrowthOutside
+}
+
+// formatPositionAccumulatorKey formats the position accumulator key prefixed by pool id, owner, lower tick
+// and upper tick with a key separator in-between.
+func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) string {
+	return strings.Join([]string{strconv.FormatUint(poolId, uintBase), owner.String(), strconv.FormatInt(lowerTick, uintBase), strconv.FormatInt(upperTick, uintBase)}, keySeparator)
 }

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -77,7 +77,7 @@ func (k Keeper) initializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64,
 		return err
 	}
 
-        // assure that existing position has zero liquidity
+	// assure that existing position has zero liquidity
 	if hasPosition {
 		positionSize, err := feeAccumulator.GetPositionSize(positionKey)
 		if err != nil {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -77,6 +77,7 @@ func (k Keeper) initializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64,
 		return err
 	}
 
+        // assure that existing position has zero liquidity
 	if hasPosition {
 		positionSize, err := feeAccumulator.GetPositionSize(positionKey)
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently, our CL fees positions are prefixed by the owner. However, they should be prefixed by pool id, owner, lower and upper tick.

This PR changes the logic to apply the appropriate position prefixing.

Additionally, we should not allow re-initializing a position with non-zero liquidity to avoid accidentally overriding it. However, we do want to override a zero-liquidity position because a user might want to provide liquidity at the ticks where their old position used to be.

## Brief Changelog
- changed position prefixing
- added `HasPosition` accumulator method
- tested `HasPosition`
- refactored `initializeFeeAccumulatorPosition`
- refactor `initializeFeeAccumulatorPosition` test to account for the new prefix and behavior

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable