### PR TITLE
fix(CL): flaky TestChargeFee

### DIFF
--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -318,32 +318,37 @@ func (suite *KeeperTestSuite) TestChargeFee() {
 	err = clKeeper.CreateFeeAccumulator(ctx, 2)
 	suite.Require().NoError(err)
 
-	tests := map[string]struct {
+	tests := []struct {
+		name      string
 		poolId    uint64
 		feeUpdate sdk.DecCoin
 
 		expectedGlobalGrowth sdk.DecCoins
 		expectError          error
 	}{
-		"pool id 1 - one eth": {
+		{
+			name:      "pool id 1 - one eth",
 			poolId:    1,
 			feeUpdate: oneEth,
 
 			expectedGlobalGrowth: sdk.NewDecCoins(oneEth),
 		},
-		"pool id 1 - 2 usdc": {
+		{
+			name:      "pool id 1 - 2 usdc",
 			poolId:    1,
 			feeUpdate: sdk.NewDecCoin(USDC, sdk.NewInt(2)),
 
 			expectedGlobalGrowth: sdk.NewDecCoins(oneEth).Add(sdk.NewDecCoin(USDC, sdk.NewInt(2))),
 		},
-		"pool id 2 - 1 usdc": {
+		{
+			name:      "pool id 2 - 1 usdc",
 			poolId:    2,
 			feeUpdate: oneEth,
 
 			expectedGlobalGrowth: sdk.NewDecCoins(oneEth),
 		},
-		"accumulator does not exist": {
+		{
+			name:      "accumulator does not exist",
 			poolId:    3,
 			feeUpdate: oneEth,
 
@@ -351,9 +356,9 @@ func (suite *KeeperTestSuite) TestChargeFee() {
 		},
 	}
 
-	for name, tc := range tests {
+	for _, tc := range tests {
 		tc := tc
-		suite.Run(name, func() {
+		suite.Run(tc.name, func() {
 			// System under test.
 			err := clKeeper.ChargeFee(ctx, tc.poolId, tc.feeUpdate)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The problem stems from the test relying on test case order while using maps. Map iterations are non-deterministic.

Fixed by switching to slice instead.