### PR TITLE
feat(CL Fees): collect fees

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3
 	github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230105183030-bccf5202f260
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230111151925-129792310797
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230112084519-84d6450e1670
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -855,8 +855,8 @@ github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:Ylmch
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230105183030-bccf5202f260 h1:+EbINXzHQyDtHje2CND357A22H2zUpceTtwJClC9IAM=
 github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230105183030-bccf5202f260/go.mod h1:KrzYoNtnWUH75rj1XAsSR4nymlHFU7jeVOx7/1KMe0k=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230111151925-129792310797 h1:CnSeyZkQPq90GgirSTBUgEVeT+InCW1jsLDGiozcnR8=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230111151925-129792310797/go.mod h1:K4de+n3DtLdueen98dOzaRXZvqMd8JvigL8O1xW445o=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230112084519-84d6450e1670 h1:kaYzxnimKTDaIXuYewc3NVt/IXqBOqTEbPX+ttQwWho=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230112084519-84d6450e1670/go.mod h1:K4de+n3DtLdueen98dOzaRXZvqMd8JvigL8O1xW445o=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8 h1:iOJO+5jffUFlLVy51XaGnec22rNX5YAs71rxD+7M2Ac=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8/go.mod h1:ey8gfcDaTYJMkj5d0FZ4+p3CPcXP6tbPQ/WyOww17Gc=
 github.com/osmosis-labs/wasmd v0.29.2-0.20221222131554-7c8ea36a6e30 h1:6uMi7HhPSwvKKU7j5NqljseFTEz4I7qHr+IPnnn42Ck=

--- a/go.work.sum
+++ b/go.work.sum
@@ -262,8 +262,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/osmosis-labs/osmosis/osmomath v0.0.0-20230103093812-a17356c326b8/go.mod h1:IpoXO7lvmfsBFfQzaqovs541hpqtrnM+GJSZDi/TZtc=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230112084519-84d6450e1670/go.mod h1:K4de+n3DtLdueen98dOzaRXZvqMd8JvigL8O1xW445o=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.2-flexible/go.mod h1:T7CCZKYhKWASnv5mRE8u3m0gst3NZ/sU16Brjmv4UPw=
-github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8/go.mod h1:ey8gfcDaTYJMkj5d0FZ4+p3CPcXP6tbPQ/WyOww17Gc=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.3/go.mod h1:bASDMbNQ0vD+2YRsEqlKXg8NiEsJpQ8B8p3nR8kB+hA=
 github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
 github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -252,8 +252,8 @@ func (accum AccumulatorObject) SetPositionCustomAcc(name string, customAccumulat
 		return err
 	}
 
-	// Update user's position with new number of shares while moving its unaccrued rewards
-	// into UnclaimedRewards. Starting accumulator value is moved up to accum'scurrent value
+	// Update the user's position with the new accumulator value. The unclaimed rewards, options, and 
+	// the number of shares stays the same as in the original position.
 	createNewPosition(accum, customAccumulatorValue, name, position.NumShares, position.UnclaimedRewards, position.Options)
 
 	return nil

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -237,7 +237,7 @@ func (accum AccumulatorObject) UpdatePositionCustomAcc(name string, numShares sd
 	return accum.AddToPositionCustomAcc(name, numShares, customAccumulatorValue)
 }
 
-// SetPositionCustomAcc sets the position's accumulator the given value.
+// SetPositionCustomAcc sets the position's accumulator to the given value.
 // Does not update shares or attempt to claim rewards.
 // The new accumulator value must be greater than or equal to the old accumulator value.
 // Returns nil on success, error otherwise.

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1373,7 +1373,11 @@ func (suite *AccumTestSuite) TestSetPositionCustomAcc() {
 	suite.SetupTest()
 
 	// Setup.
-	accObject := accumPackage.CreateRawAccumObject(suite.store, testNameOne, initialCoinsDenomOne)
+	var (
+		accObject           = accumPackage.CreateRawAccumObject(suite.store, testNameOne, initialCoinsDenomOne)
+		validPositionName   = testAddressThree
+		invalidPositionName = testAddressTwo
+	)
 
 	tests := map[string]struct {
 		positionName           string
@@ -1381,18 +1385,22 @@ func (suite *AccumTestSuite) TestSetPositionCustomAcc() {
 		expectedError          error
 	}{
 		"valid update greater than initial value": {
-			positionName:           testAddressThree,
+			positionName:           validPositionName,
 			customAccumulatorValue: initialCoinsDenomOne.Add(initialCoinDenomOne),
 		},
 		"valid update equal to the initial value": {
-			positionName:           testAddressThree,
+			positionName:           validPositionName,
 			customAccumulatorValue: initialCoinsDenomOne,
 		},
 		"invalid update smaller than the initial value": {
-			positionName:           testAddressThree,
+			positionName:           validPositionName,
 			customAccumulatorValue: emptyCoins,
 
 			expectedError: accumPackage.NegativeAccDifferenceError{AccumulatorDifference: initialCoinsDenomOne},
+		},
+		"invalid position - different name": {
+			positionName:  invalidPositionName,
+			expectedError: accumPackage.NoPositionError{Name: invalidPositionName},
 		},
 	}
 
@@ -1400,7 +1408,7 @@ func (suite *AccumTestSuite) TestSetPositionCustomAcc() {
 		suite.Run(name, func() {
 
 			// Setup
-			err := accObject.NewPositionCustomAcc(tc.positionName, sdk.OneDec(), initialCoinsDenomOne, nil)
+			err := accObject.NewPositionCustomAcc(validPositionName, sdk.OneDec(), initialCoinsDenomOne, nil)
 			suite.Require().NoError(err)
 
 			// System under test.

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1398,6 +1398,12 @@ func (suite *AccumTestSuite) TestSetPositionCustomAcc() {
 
 			expectedError: accumPackage.NegativeAccDifferenceError{AccumulatorDifference: initialCoinsDenomOne},
 		},
+		"invalid update smaller than the initial value (non-empty custom value)": {
+			positionName:           validPositionName,
+			customAccumulatorValue: initialCoinsDenomOne.QuoDec(sdk.NewDec(2)),
+
+			expectedError: accumPackage.NegativeAccDifferenceError{AccumulatorDifference: initialCoinsDenomOne.QuoDec(sdk.NewDec(2))},
+		},
 		"invalid position - different name": {
 			positionName:  invalidPositionName,
 			expectedError: accumPackage.NoPositionError{Name: invalidPositionName},

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1407,7 +1407,6 @@ func (suite *AccumTestSuite) TestSetPositionCustomAcc() {
 			err = accObject.SetPositionCustomAcc(tc.positionName, tc.customAccumulatorValue)
 
 			// Assertions.
-
 			if tc.expectedError != nil {
 				suite.Require().Error(err)
 				suite.Require().Equal(tc.expectedError, err)

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1368,7 +1368,6 @@ func (suite *AccumTestSuite) TestHasPosition() {
 }
 
 func (suite *AccumTestSuite) TestSetPositionCustomAcc() {
-
 	// We setup store and accum
 	// once at beginning.
 	suite.SetupTest()

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -83,6 +83,10 @@ func (k Keeper) InitializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 	return k.initializeInitialPositionForPool(ctx, pool, amount0Desired, amount1Desired)
 }
 
+func (k Keeper) CollectFees(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64) (sdk.Coins, error) {
+	return k.collectFees(ctx, poolId, owner, lowerTick, upperTick)
+}
+
 func ConvertConcentratedToPoolInterface(concentratedPool types.ConcentratedPoolExtension) (poolmanagertypes.PoolI, error) {
 	return convertConcentratedToPoolInterface(concentratedPool)
 }

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -200,6 +200,12 @@ func (k Keeper) getInitialFeeGrowthOutsideForTick(ctx sdk.Context, poolId uint64
 	return emptyCoins, nil
 }
 
+// collectFees collects fees from the fee accumulator for the position given by pool id, owner, lower tick and upper tick.
+// Upon successful collection, it bank sends the fees from the pool address to the owner and returns the collected coins.
+// Returns error if:
+// - pool with the given id does not exist
+// - position given by pool id, owner, lower tick and upper tick does not exist
+// - other internal database or math errors.
 // nolint: unused
 func (k Keeper) collectFees(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64) (sdk.Coins, error) {
 	feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -479,7 +479,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 		// been updated when crossed.
 		// Since we track fees accrued below a tick, upper tick is updated
 		// while lower tick is zero.
-		"single swap left -> right: 2 ticks, one share - current price > upper tick": {
+		"single swap left -> right: 2 ticks, one share, current tick > upper tick": {
 			initialLiquidity: sdk.OneDec(),
 
 			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
@@ -495,7 +495,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 
 			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
 		},
-		"single swap left -> right: 3 ticks, two shares - current price > upper tick": {
+		"single swap left -> right: 3 ticks, two shares, current tick > upper tick": {
 			initialLiquidity: sdk.NewDec(2),
 
 			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
@@ -511,7 +511,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 
 			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(20))),
 		},
-		"single swap left -> right: 2 ticks, one share - current tick == upper tick": {
+		"single swap left -> right: 2 ticks, one share, current tick == upper tick": {
 			initialLiquidity: sdk.OneDec(),
 
 			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
@@ -533,7 +533,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 		// In this case, all fees must have been accrued inside the tick
 		// Since we track fees accrued below a tick, both upper and lower position
 		// ticks are zero
-		"single swap right -> left: 2 ticks, one share - current price == lower tick": {
+		"single swap right -> left: 2 ticks, one share, current tick == lower tick": {
 			initialLiquidity: sdk.OneDec(),
 
 			// lower tick accumulator is not updated yet.
@@ -550,7 +550,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 
 			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
 		},
-		"single swap right -> left: 2 ticks, one share - current price < lower tick": {
+		"single swap right -> left: 2 ticks, one share, current price < lower tick": {
 			initialLiquidity: sdk.OneDec(),
 
 			// lower tick accumulator updated when crossed.

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/internal/math"
 	clmodel "github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/types"
+	cltypes "github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/types"
 )
 
 var (
@@ -374,4 +375,209 @@ func (suite *KeeperTestSuite) TestChargeFee() {
 			suite.Require().Equal(tc.expectedGlobalGrowth, feeAcumulator.GetValue())
 		})
 	}
+}
+
+func (s *KeeperTestSuite) TestCollectFees() {
+	tests := map[string]struct {
+		// setup parameters.
+		initialLiquidity          sdk.Dec
+		lowerTickFeeGrowthOutside sdk.DecCoins
+		upperTickFeeGrowthOutside sdk.DecCoins
+		globalFeeGrowth           sdk.DecCoins
+		currentTick               int64
+		isInvalidPoolIdGiven      bool
+
+		// inputs parameters.
+		owner     sdk.AccAddress
+		lowerTick int64
+		upperTick int64
+
+		// expectations.
+		expectedFeesClaimed sdk.Coins
+		expectedError       error
+	}{
+		// imagine single swap over entire position
+		// crossing left > right and stopping above upper tick
+		// In this case, only the upper tick accumulator must have
+		// been updated when crossed.
+		// Since we track fees accrued below a tick, upper tick is updated
+		// while lower tick is zero.
+		"single swap left -> right: 2 ticks, one share - current price > upper tick": {
+			initialLiquidity: sdk.OneDec(),
+
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			owner:     s.TestAccs[0],
+			lowerTick: 0,
+			upperTick: 1,
+
+			currentTick: 2,
+
+			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
+		},
+		"single swap left -> right: 3 ticks, two shares - current price > upper tick": {
+			initialLiquidity: sdk.NewDec(2),
+
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			owner:     s.TestAccs[0],
+			lowerTick: 0,
+			upperTick: 2,
+
+			currentTick: 3,
+
+			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(20))),
+		},
+		"single swap left -> right: 2 ticks, one share - current price == upper tick": {
+			initialLiquidity: sdk.OneDec(),
+
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			owner:     s.TestAccs[0],
+			lowerTick: 0,
+			upperTick: 1,
+
+			currentTick: 1,
+
+			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
+		},
+
+		// imagine single swap over entire position
+		// crossing right > left and stopping at lower tick
+		// In this case, all fees must have been accrued inside the tick
+		// Since we track fees accrued below a tick, both upper and lower position
+		// ticks are zero
+		"single swap right -> left: 2 ticks, one share - current price == lower tick": {
+			initialLiquidity: sdk.OneDec(),
+
+			// lower tick accumulator is not updated yet.
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			owner:     s.TestAccs[0],
+			lowerTick: 0,
+			upperTick: 1,
+
+			currentTick: 0,
+
+			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
+		},
+		"single swap right -> left: 2 ticks, one share - current price < lower tick": {
+			initialLiquidity: sdk.OneDec(),
+
+			// lower tick accumulator updated when crossed.
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			owner:     s.TestAccs[0],
+			lowerTick: 0,
+			upperTick: 1,
+
+			currentTick: -1,
+
+			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
+		},
+
+		"invalid pool id given": {
+			initialLiquidity: sdk.OneDec(),
+
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			owner:     s.TestAccs[0],
+			lowerTick: 0,
+			upperTick: 1,
+
+			currentTick: 2,
+
+			isInvalidPoolIdGiven: true,
+			expectedError:        cltypes.PoolNotFoundError{PoolId: 2},
+
+			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(10))),
+		},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+			tc := tc
+			s.SetupTest()
+
+			validPool := s.PrepareConcentratedPool()
+			validPoolId := validPool.GetId()
+
+			s.FundAcc(validPool.GetAddress(), tc.expectedFeesClaimed)
+
+			clKeeper := s.App.ConcentratedLiquidityKeeper
+			ctx := s.Ctx
+
+			err := clKeeper.InitializeFeeAccumulatorPosition(ctx, validPoolId, tc.owner, tc.initialLiquidity)
+			s.Require().NoError(err)
+
+			s.initializeTick(ctx, tc.lowerTick, tc.initialLiquidity, tc.lowerTickFeeGrowthOutside, false)
+
+			s.initializeTick(ctx, tc.upperTick, tc.initialLiquidity, tc.upperTickFeeGrowthOutside, true)
+
+			validPool.SetCurrentTick(sdk.NewInt(tc.currentTick))
+			clKeeper.SetPool(ctx, validPool)
+
+			err = clKeeper.ChargeFee(ctx, validPoolId, tc.globalFeeGrowth[0])
+			s.Require().NoError(err)
+
+			poolBalanceBeforeCollect := s.App.BankKeeper.GetBalance(ctx, validPool.GetAddress(), ETH)
+			ownerBalancerBeforeCollect := s.App.BankKeeper.GetBalance(ctx, tc.owner, ETH)
+
+			sutPoolId := validPoolId
+			if tc.isInvalidPoolIdGiven {
+				sutPoolId = sutPoolId + 1
+			}
+
+			// System under test
+			actualFeesClaimed, err := clKeeper.CollectFees(ctx, sutPoolId, tc.owner, tc.lowerTick, tc.upperTick)
+
+			// Assertions.
+
+			if tc.expectedError != nil {
+				s.Require().Error(err)
+				s.Require().ErrorAs(err, &tc.expectedError)
+				return
+			}
+
+			s.Require().NoError(err)
+			s.Require().Equal(tc.expectedFeesClaimed, actualFeesClaimed)
+
+			poolBalanceAfterCollect := s.App.BankKeeper.GetBalance(ctx, validPool.GetAddress(), ETH)
+			ownerBalancerAfterCollect := s.App.BankKeeper.GetBalance(ctx, tc.owner, ETH)
+
+			expectedETHAmount := tc.expectedFeesClaimed.AmountOf(ETH)
+			s.Require().Equal(expectedETHAmount, poolBalanceBeforeCollect.Sub(poolBalanceAfterCollect).Amount)
+			s.Require().Equal(expectedETHAmount, ownerBalancerAfterCollect.Sub(ownerBalancerBeforeCollect).Amount)
+		})
+	}
+}
+
+func (s *KeeperTestSuite) initializeTick(ctx sdk.Context, tickIndex int64, initialLiquidity sdk.Dec, feeGrowthOutside sdk.DecCoins, isLower bool) {
+	err := s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(ctx, validPoolId, tickIndex, initialLiquidity, isLower)
+	s.Require().NoError(err)
+
+	tickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(ctx, validPoolId, tickIndex)
+	s.Require().NoError(err)
+
+	tickInfo.FeeGrowthOutside = feeGrowthOutside
+
+	s.App.ConcentratedLiquidityKeeper.SetTickInfo(ctx, validPoolId, tickIndex, tickInfo)
 }

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -644,18 +644,22 @@ func (s *KeeperTestSuite) TestCollectFees() {
 
 			// Assertions.
 
+			poolBalanceAfterCollect := s.App.BankKeeper.GetBalance(ctx, validPool.GetAddress(), ETH)
+			ownerBalancerAfterCollect := s.App.BankKeeper.GetBalance(ctx, tc.owner, ETH)
+
 			if tc.expectedError != nil {
 				s.Require().Error(err)
 				s.Require().ErrorAs(err, &tc.expectedError)
 				s.Require().Equal(sdk.Coins{}, actualFeesClaimed)
+
+				// balances are unchanged
+				s.Require().Equal(poolBalanceBeforeCollect, poolBalanceAfterCollect)
+				s.Require().Equal(ownerBalancerAfterCollect, ownerBalancerBeforeCollect)
 				return
 			}
 
 			s.Require().NoError(err)
 			s.Require().Equal(tc.expectedFeesClaimed, actualFeesClaimed)
-
-			poolBalanceAfterCollect := s.App.BankKeeper.GetBalance(ctx, validPool.GetAddress(), ETH)
-			ownerBalancerAfterCollect := s.App.BankKeeper.GetBalance(ctx, tc.owner, ETH)
 
 			expectedETHAmount := tc.expectedFeesClaimed.AmountOf(ETH)
 			s.Require().Equal(expectedETHAmount, poolBalanceBeforeCollect.Sub(poolBalanceAfterCollect).Amount)

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -529,7 +529,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 		},
 
 		// imagine single swap over entire position
-		// crossing right > left and stopping at lower tick
+		// crossing right -> left and stopping at lower tick
 		// In this case, all fees must have been accrued inside the tick
 		// Since we track fees accrued below a tick, both upper and lower position
 		// ticks are zero

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -663,15 +663,3 @@ func (s *KeeperTestSuite) TestCollectFees() {
 		})
 	}
 }
-
-func (s *KeeperTestSuite) initializeTick(ctx sdk.Context, tickIndex int64, initialLiquidity sdk.Dec, feeGrowthOutside sdk.DecCoins, isLower bool) {
-	err := s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(ctx, validPoolId, tickIndex, initialLiquidity, isLower)
-	s.Require().NoError(err)
-
-	tickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(ctx, validPoolId, tickIndex)
-	s.Require().NoError(err)
-
-	tickInfo.FeeGrowthOutside = feeGrowthOutside
-
-	s.App.ConcentratedLiquidityKeeper.SetTickInfo(ctx, validPoolId, tickIndex, tickInfo)
-}

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -511,7 +511,7 @@ func (s *KeeperTestSuite) TestCollectFees() {
 
 			expectedFeesClaimed: sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(20))),
 		},
-		"single swap left -> right: 2 ticks, one share - current price == upper tick": {
+		"single swap left -> right: 2 ticks, one share - current tick == upper tick": {
 			initialLiquidity: sdk.OneDec(),
 
 			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -73,3 +73,15 @@ func (s *KeeperTestSuite) validateTickUpdates(ctx sdk.Context, poolId uint64, ow
 	s.Require().Equal(expectedRemainingLiquidity.String(), upperTickInfo.LiquidityGross.String())
 	s.Require().Equal(expectedRemainingLiquidity.Neg().String(), upperTickInfo.LiquidityNet.String())
 }
+
+func (s *KeeperTestSuite) initializeTick(ctx sdk.Context, tickIndex int64, initialLiquidity sdk.Dec, feeGrowthOutside sdk.DecCoins, isLower bool) {
+	err := s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(ctx, validPoolId, tickIndex, initialLiquidity, isLower)
+	s.Require().NoError(err)
+
+	tickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(ctx, validPoolId, tickIndex)
+	s.Require().NoError(err)
+
+	tickInfo.FeeGrowthOutside = feeGrowthOutside
+
+	s.App.ConcentratedLiquidityKeeper.SetTickInfo(ctx, validPoolId, tickIndex, tickInfo)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR implements the `collectFees` method and tests it.

Additionally, it adds and tests`SetPositionCustomAcc` `accum` package method that is necessary for collecting fees.

Fee collection works by retrieving fee growth outside of the range given by the position we are trying to collect the fees from.

Next, we update that position's accumulator for the fee growth outside.

Once that's done, we claim rewards by substracting the updated position's fee growth outside of the fee growth global and multiplying by the number of shares. This is abstracted by the `accum` package's `ClaimRewards` function.

Finally, we send the fees from the pool to the position owner.

## Brief Changelog
- implement and test `SetPositionCustomAcc`
- implement and test `collectFees`

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable