### PR TITLE
chore: disable valset pref sim

### DIFF
--- a/x/valset-pref/valpref-module/module.go
+++ b/x/valset-pref/valpref-module/module.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/osmosis-labs/osmosis/v14/simulation/simtypes"
-	simulation "github.com/osmosis-labs/osmosis/v14/x/valset-pref/simulation"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -16,14 +14,15 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	keeper "github.com/osmosis-labs/osmosis/v14/x/valset-pref"
 	validatorprefclient "github.com/osmosis-labs/osmosis/v14/x/valset-pref/client"
 	valsetprefcli "github.com/osmosis-labs/osmosis/v14/x/valset-pref/client/cli"
 	"github.com/osmosis-labs/osmosis/v14/x/valset-pref/client/grpc"
 	"github.com/osmosis-labs/osmosis/v14/x/valset-pref/client/queryproto"
 	"github.com/osmosis-labs/osmosis/v14/x/valset-pref/types"
-	"github.com/spf13/cobra"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 var (
@@ -166,17 +165,17 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // AppModuleSimulation functions
 
-// GenerateGenesisState creates a randomized GenState of the valset module.
-func (am AppModule) GenerateGenesisState(simState *module.SimulationState, s *simtypes.SimCtx) {
-}
+// // GenerateGenesisState creates a randomized GenState of the valset module.
+// func (am AppModule) GenerateGenesisState(simState *module.SimulationState, s *simtypes.SimCtx) {
+// }
 
-// WeightedOperations returns the all the valset module operations with their respective weights.
-func (am AppModule) Actions() []simtypes.Action {
-	return []simtypes.Action{
-		simtypes.NewMsgBasedAction("SetValidatorSetPreference", am.keeper, simulation.RandomMsgSetValSetPreference),
-		simtypes.NewMsgBasedAction("MsgDelegateToValidatorSet", am.keeper, simulation.RandomMsgDelegateToValSet),
-		simtypes.NewMsgBasedAction("MsgUndelegateFromValidatorSet", am.keeper, simulation.RandomMsgUnDelegateFromValSet),
-		simtypes.NewMsgBasedAction("MsgRedelegateValSet", am.keeper, simulation.RandomMsgReDelegateToValSet),
-		simtypes.NewMsgBasedAction("MsgWithdrawDelegationRewards", am.keeper, simulation.RandomMsgWithdrawRewardsFromValSet),
-	}
-}
+// // WeightedOperations returns the all the valset module operations with their respective weights.
+// func (am AppModule) Actions() []simtypes.Action {
+// 	return []simtypes.Action{
+// 		simtypes.NewMsgBasedAction("SetValidatorSetPreference", am.keeper, simulation.RandomMsgSetValSetPreference),
+// 		simtypes.NewMsgBasedAction("MsgDelegateToValidatorSet", am.keeper, simulation.RandomMsgDelegateToValSet),
+// 		simtypes.NewMsgBasedAction("MsgUndelegateFromValidatorSet", am.keeper, simulation.RandomMsgUnDelegateFromValSet),
+// 		simtypes.NewMsgBasedAction("MsgRedelegateValSet", am.keeper, simulation.RandomMsgReDelegateToValSet),
+// 		simtypes.NewMsgBasedAction("MsgWithdrawDelegationRewards", am.keeper, simulation.RandomMsgWithdrawRewardsFromValSet),
+// 	}
+// }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

One of the simulator messages for valset pref is failing. This is temporarily disabling the simulator messages for valset pref until @stackman27 has time to look further into it.


## Brief Changelog

* Disables valset pref sim messages in module.go
