### PR TITLE
chore: switch to sqrt price for tick functions

### DIFF
--- a/x/concentrated-liquidity/internal/math/tick.go
+++ b/x/concentrated-liquidity/internal/math/tick.go
@@ -16,7 +16,7 @@ var (
 	sdkThirtyEightDec = sdk.NewDec(38)
 )
 
-// TicksToPrice returns the price for the lower and upper ticks.
+// TicksToSqrtPrice returns the sqrtPrice for the lower and upper ticks.
 // Returns error if fails to calculate price.
 // TODO: spec and tests
 func TicksToSqrtPrice(lowerTick, upperTick int64, exponentAtPriceOne sdk.Int) (sdk.Dec, sdk.Dec, error) {
@@ -82,6 +82,8 @@ func TickToSqrtPrice(tickIndex, exponentAtPriceOne sdk.Int) (price sdk.Dec, err 
 	if price.GT(types.MaxSpotPrice) || price.LT(types.MinSpotPrice) {
 		return sdk.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPrice, MaxSpotPrice: types.MaxSpotPrice}
 	}
+
+	// Determine the sqrtPrice from the price
 	sqrtPrice, err := price.ApproxSqrt()
 	if err != nil {
 		return sdk.Dec{}, err

--- a/x/concentrated-liquidity/internal/math/tick.go
+++ b/x/concentrated-liquidity/internal/math/tick.go
@@ -19,24 +19,24 @@ var (
 // TicksToPrice returns the price for the lower and upper ticks.
 // Returns error if fails to calculate price.
 // TODO: spec and tests
-func TicksToPrice(lowerTick, upperTick int64, exponentAtPriceOne sdk.Int) (sdk.Dec, sdk.Dec, error) {
-	priceUpperTick, err := TickToPrice(sdk.NewInt(upperTick), exponentAtPriceOne)
+func TicksToSqrtPrice(lowerTick, upperTick int64, exponentAtPriceOne sdk.Int) (sdk.Dec, sdk.Dec, error) {
+	sqrtPriceUpperTick, err := TickToSqrtPrice(sdk.NewInt(upperTick), exponentAtPriceOne)
 	if err != nil {
 		return sdk.Dec{}, sdk.Dec{}, err
 	}
-	priceLowerTick, err := TickToPrice(sdk.NewInt(lowerTick), exponentAtPriceOne)
+	sqrtPriceLowerTick, err := TickToSqrtPrice(sdk.NewInt(lowerTick), exponentAtPriceOne)
 	if err != nil {
 		return sdk.Dec{}, sdk.Dec{}, err
 	}
-	return priceLowerTick, priceUpperTick, nil
+	return sqrtPriceLowerTick, sqrtPriceUpperTick, nil
 }
 
-// TickToPrice returns the price given the following two arguments:
+// TickToSqrtPrice returns the sqrtPrice given the following two arguments:
 //   - tickIndex: the tick index to calculate the price for
 //   - exponentAtPriceOne: the value of the exponent (and therefore the precision) at which the starting price of 1 is set
 //
 // If tickIndex is zero, the function returns sdk.OneDec().
-func TickToPrice(tickIndex, exponentAtPriceOne sdk.Int) (price sdk.Dec, err error) {
+func TickToSqrtPrice(tickIndex, exponentAtPriceOne sdk.Int) (price sdk.Dec, err error) {
 	if tickIndex.IsZero() {
 		return sdk.OneDec(), nil
 	}
@@ -82,8 +82,11 @@ func TickToPrice(tickIndex, exponentAtPriceOne sdk.Int) (price sdk.Dec, err erro
 	if price.GT(types.MaxSpotPrice) || price.LT(types.MinSpotPrice) {
 		return sdk.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPrice, MaxSpotPrice: types.MaxSpotPrice}
 	}
-
-	return price, nil
+	sqrtPrice, err := price.ApproxSqrt()
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	return sqrtPrice, nil
 }
 
 // PriceToTick takes a price and returns the corresponding tick index

--- a/x/concentrated-liquidity/internal/math/tick_test.go
+++ b/x/concentrated-liquidity/internal/math/tick_test.go
@@ -17,7 +17,7 @@ import (
 // numAdditiveTicks(tickIndex, exponentAtPriceOne) = tickIndex - (geometricExponentDelta(tickIndex, exponentAtPriceOne) * geometricExponentIncrementDistanceInTicks(exponentAtPriceOne)
 // price(tickIndex, exponentAtPriceOne) = pow(10, geometricExponentDelta(tickIndex, exponentAtPriceOne)) +
 // (numAdditiveTicks(tickIndex, exponentAtPriceOne) * currentAdditiveIncrementInTicks(tickIndex, exponentAtPriceOne))
-func (suite *ConcentratedMathTestSuite) TestTickToPrice() {
+func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 	testCases := map[string]struct {
 		tickIndex          sdk.Int
 		exponentAtPriceOne sdk.Int
@@ -145,14 +145,16 @@ func (suite *ConcentratedMathTestSuite) TestTickToPrice() {
 		tc := tc
 
 		suite.Run(name, func() {
-			sqrtPrice, err := math.TickToPrice(tc.tickIndex, tc.exponentAtPriceOne)
+			sqrtPrice, err := math.TickToSqrtPrice(tc.tickIndex, tc.exponentAtPriceOne)
 			if tc.expectedError != nil {
 				suite.Require().Error(err)
 				suite.Require().Equal(tc.expectedError.Error(), err.Error())
 				return
 			}
 			suite.Require().NoError(err)
-			suite.Require().Equal(tc.expectedPrice.String(), sqrtPrice.String())
+			expectedSqrtPrice, err := tc.expectedPrice.ApproxSqrt()
+			suite.Require().NoError(err)
+			suite.Require().Equal(expectedSqrtPrice.String(), sqrtPrice.String())
 
 		})
 	}

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -32,7 +32,7 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
 	}
 
-	// Transform the provided ticks into their corresponding prices.
+	// Transform the provided ticks into their corresponding sqrtPrices.
 	sqrtPriceLowerTick, sqrtPriceUpperTick, err := math.TicksToSqrtPrice(lowerTick, upperTick, pool.GetPrecisionFactorAtPriceOne())
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
@@ -170,7 +170,7 @@ func (k Keeper) updatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		return sdk.Int{}, sdk.Int{}, err
 	}
 
-	// Transform the provided ticks into their corresponding prices.
+	// Transform the provided ticks into their corresponding sqrtPrices.
 	sqrtPriceLowerTick, sqrtPriceUpperTick, err := math.TicksToSqrtPrice(lowerTick, upperTick, pool.GetPrecisionFactorAtPriceOne())
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, err

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -33,17 +33,7 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	}
 
 	// Transform the provided ticks into their corresponding prices.
-	priceLowerTick, priceUpperTick, err := math.TicksToPrice(lowerTick, upperTick, pool.GetPrecisionFactorAtPriceOne())
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
-	}
-
-	// Transform the provided prices into their corresponding square root prices.
-	sqrtPriceLowerTick, err := priceLowerTick.ApproxSqrt()
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
-	}
-	sqrtPriceUpperTick, err := priceUpperTick.ApproxSqrt()
+	sqrtPriceLowerTick, sqrtPriceUpperTick, err := math.TicksToSqrtPrice(lowerTick, upperTick, pool.GetPrecisionFactorAtPriceOne())
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
 	}
@@ -181,17 +171,7 @@ func (k Keeper) updatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	}
 
 	// Transform the provided ticks into their corresponding prices.
-	priceLowerTick, priceUpperTick, err := math.TicksToPrice(lowerTick, upperTick, pool.GetPrecisionFactorAtPriceOne())
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, err
-	}
-
-	// Transform the provided prices into their corresponding square root prices.
-	sqrtPriceLowerTick, err := priceLowerTick.ApproxSqrt()
-	if err != nil {
-		return sdk.Int{}, sdk.Int{}, err
-	}
-	sqrtPriceUpperTick, err := priceUpperTick.ApproxSqrt()
+	sqrtPriceLowerTick, sqrtPriceUpperTick, err := math.TicksToSqrtPrice(lowerTick, upperTick, pool.GetPrecisionFactorAtPriceOne())
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, err
 	}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -296,15 +296,9 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 		}
 
 		// utilizing the next initialized tick, we find the corresponding nextPrice (the target price)
-		nextPrice, err := math.TickToPrice(nextTick, p.GetPrecisionFactorAtPriceOne())
+		nextSqrtPrice, err := math.TickToSqrtPrice(nextTick, p.GetPrecisionFactorAtPriceOne())
 		if err != nil {
 			return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", nextTick)
-		}
-
-		// transform to sqrtPrice
-		nextSqrtPrice, err := nextPrice.ApproxSqrt()
-		if err != nil {
-			return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", nextSqrtPrice)
 		}
 
 		// utilizing the bucket's liquidity and knowing the price target, we calculate the how much tokenOut we get from the tokenIn
@@ -444,15 +438,9 @@ func (k Keeper) calcInAmtGivenOut(
 		}
 
 		// utilizing the next initialized tick, we find the corresponding nextPrice (the target price)
-		nextPrice, err := math.TickToPrice(nextTick, p.GetPrecisionFactorAtPriceOne())
+		nextSqrtPrice, err := math.TickToSqrtPrice(nextTick, p.GetPrecisionFactorAtPriceOne())
 		if err != nil {
 			return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", nextTick)
-		}
-
-		// transform to sqrtPrice
-		nextSqrtPrice, err := nextPrice.ApproxSqrt()
-		if err != nil {
-			return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("could not convert next tick (%v) to nextSqrtPrice", nextSqrtPrice)
 		}
 
 		// utilizing the bucket's liquidity and knowing the price target, we calculate the how much tokenOut we get from the tokenIn

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -531,13 +531,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
-				lowerPrice, err := math.TickToPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
+				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
-				lowerSqrtPrice, err := lowerPrice.ApproxSqrt()
-				s.Require().NoError(err)
-				upperPrice, err := math.TickToPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
-				s.Require().NoError(err)
-				upperSqrtPrice, err := upperPrice.ApproxSqrt()
+				upperSqrtPrice, err := math.TickToSqrtPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
 				if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
@@ -585,13 +581,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
-				lowerPrice, err := math.TickToPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
+				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
-				lowerSqrtPrice, err := lowerPrice.ApproxSqrt()
-				s.Require().NoError(err)
-				upperPrice, err := math.TickToPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
-				s.Require().NoError(err)
-				upperSqrtPrice, err := upperPrice.ApproxSqrt()
+				upperSqrtPrice, err := math.TickToSqrtPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
 				if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
@@ -997,13 +989,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
-				lowerPrice, err := math.TickToPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
+				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
-				lowerSqrtPrice, err := lowerPrice.ApproxSqrt()
-				s.Require().NoError(err)
-				upperPrice, err := math.TickToPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
-				s.Require().NoError(err)
-				upperSqrtPrice, err := upperPrice.ApproxSqrt()
+				upperSqrtPrice, err := math.TickToSqrtPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
 				if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
@@ -1057,13 +1045,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
-				lowerPrice, err := math.TickToPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
+				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
-				lowerSqrtPrice, err := lowerPrice.ApproxSqrt()
-				s.Require().NoError(err)
-				upperPrice, err := math.TickToPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
-				s.Require().NoError(err)
-				upperSqrtPrice, err := upperPrice.ApproxSqrt()
+				upperSqrtPrice, err := math.TickToSqrtPrice(newUpperTick, pool.GetPrecisionFactorAtPriceOne())
 				s.Require().NoError(err)
 
 				if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3988 

## What is the purpose of the change

See https://github.com/osmosis-labs/osmosis/issues/3988 for details

The only thing to note here is I chose to keep the test cases in expectedPrice, then within the test itself we transform the expected price into a sqrtPrice. IMO this makes more sense since its harder to conceptualize what is correct when having to look at sqrtPrices
