### PR TITLE
docs(e2e): fix outdated info

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -108,7 +108,7 @@ Conceptually, we can split the e2e setup into 2 parts:
         - An additional full node is created after a chain has started.
         - This node is meant to state sync with the rest of the system.
 
-    This is done in `configurer/setup_runner.go` via function decorator design pattern
+    This is done in `configurer/setup.go` via function decorator design pattern
     where we chain the desired setup components during configurer creation.
     [Example](https://github.com/osmosis-labs/osmosis/blob/c5d5c9f0c6b5c7fdf9688057eb78ec793f6dd580/tests/e2e/configurer/configurer.go#L166)
 
@@ -120,6 +120,8 @@ such as the `app.toml`. This package directly depends on the Osmosis
 codebase.
 
 ## `upgrade` Package
+
+***This package has been removed and it's logic has been moved to `initialization` package***
 
 The `upgrade` package starts chain initialization. In addition, there is
 a Dockerfile `init-e2e.Dockerfile`. When executed, its container
@@ -136,7 +138,7 @@ environment.
 Introduces an abstraction necessary for creating and managing
 Docker containers. Currently, validator containers are created
 with a name of the corresponding validator struct that is initialized
-in the `chain` package.
+in the `initialization/chain` package.
 
 ## Running From Current Branch
 
@@ -159,7 +161,7 @@ certain components of e2e testing.
 If OSMOSIS_E2E_SKIP_IBC is true, this must also be set to true because upgrade
 tests require IBC logic.
 
-- `OSMOSIS_E2E_SKIP_IBC` - when true, skips the IBC tests tests.
+- `OSMOSIS_E2E_SKIP_IBC` - when true, skips the IBC tests.
 
 - `OSMOSIS_E2E_SKIP_STATE_SYNC` - when true, skips the state sync tests.
 
@@ -172,7 +174,7 @@ of the height in which the network should fork. This should match the ForkHeight
 - `OSMOSIS_E2E_UPGRADE_VERSION` - string of what version will be upgraded to (for example, "v10")
 
 - `OSMOSIS_E2E_DEBUG_LOG` - when true, prints debug logs from executing CLI commands
-via Docker containers. Set to trus in CI by default.
+via Docker containers. Set to true in CI by default.
 
 #### VS Code Debug Configuration
 
@@ -180,28 +182,34 @@ This debug configuration helps to run e2e tests locally and skip the desired tes
 
 ```json
 {
-    "name": "E2E IntegrationTestSuite",
-    "type": "go",
-    "request": "launch",
-    "mode": "test",
-    "program": "${workspaceFolder}/tests/e2e",
-    "args": [
-        "-test.timeout",
-        "30m",
-        "-test.run",
-        "IntegrationTestSuite",
-        "-test.v"
-    ],
-    "buildFlags": "-tags e2e",
-    "env": {
-        "OSMOSIS_E2E_SKIP_IBC": "true",
-        "OSMOSIS_E2E_SKIP_UPGRADE": "true",
-        "OSMOSIS_E2E_SKIP_CLEANUP": "true",
-        "OSMOSIS_E2E_SKIP_STATE_SYNC": "true",
-        "OSMOSIS_E2E_UPGRADE_VERSION": "v10",
-        "OSMOSIS_E2E_DEBUG_LOG": "true",
-        "OSMOSIS_E2E_FORK_HEIGHT": "4713065" # this is v10 fork height.
-    }
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "E2E: (make test-e2e-short)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/tests/e2e",
+            "args": [
+                "-test.timeout",
+                "30m",
+                "-test.run",
+                "IntegrationTestSuite",
+                "-test.v"
+            ],
+            "buildFlags": "-tags e2e",
+            "env": {
+                "OSMOSIS_E2E": "True",
+                "OSMOSIS_E2E_SKIP_IBC": "true",
+                "OSMOSIS_E2E_SKIP_UPGRADE": "true",
+                "OSMOSIS_E2E_SKIP_CLEANUP": "true",
+                "OSMOSIS_E2E_SKIP_STATE_SYNC": "true",
+                "OSMOSIS_E2E_UPGRADE_VERSION": "v13",
+                "OSMOSIS_E2E_DEBUG_LOG": "true",
+            },
+            "preLaunchTask": "e2e-setup"
+        }
+    ]
 }
 ```
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -116,22 +116,13 @@ Conceptually, we can split the e2e setup into 2 parts:
 
 The `initialization` package introduces the logic necessary for initializing a
 chain by creating a genesis file and all required configuration files
-such as the `app.toml`. This package directly depends on the Osmosis
-codebase.
+such as the `app.toml`. In addition, it starts chain initialization.
+This package directly depends on the Osmosis codebase.
 
-## `upgrade` Package
-
-***This package has been removed and it's logic has been moved to `initialization` package***
-
-The `upgrade` package starts chain initialization. In addition, there is
-a Dockerfile `init-e2e.Dockerfile`. When executed, its container
-produces all files necessary for starting up a new chain. These
+In addition, there is a Dockerfile `init-e2e.Dockerfile`.
+When executed, its container produces all files necessary for starting up a new chain. These
 resulting files can be mounted on a volume and propagated to our
 production osmosis container to start the `osmosisd` service.
-
-The decoupling between chain initialization and start-up allows to
-minimize the differences between our test suite and the production
-environment.
 
 ## `containers` Package
 

--- a/tests/e2e/initialization/README.md
+++ b/tests/e2e/initialization/README.md
@@ -56,39 +56,39 @@ Additionally, it takes the following arguments:
 - `--config`
   - serialized node configurats (e.g. Pruning and Snapshot options).
     These correspond to the stuct `NodeConfig`, located in
-    `tests/e2e/chain/config.go` The number of initialized
+    `tests/e2e/initialization/config.go` The number of initialized
     validators on the new chain corresponds to the number of
     `NodeConfig`s provided by this parameter
 - `--voting-period`
   - The configurable voting period duration for the chain
 
 ```go
-    tmpDir, _ := os.MkdirTemp("", "osmosis-e2e-testnet-")
-
- initResource, _ = s.dkrPool.RunWithOptions(
-  &dockertest.RunOptions{
-   Name:       fmt.Sprintf("%s", chainId),
-   Repository: s.dockerImages.InitRepository,
-   Tag:        s.dockerImages.InitTag,
-   NetworkID:  s.dkrNet.Network.ID,
-   Cmd: []string{
-    fmt.Sprintf("--data-dir=%s", tmpDir),
-    fmt.Sprintf("--chain-id=%s", chainId),
-    fmt.Sprintf("--config=%s", nodeConfigBytes),
-    fmt.Sprintf("--voting-period=%v", votingPeriodDuration),
-   },
-   User: "root:root",
-   Mounts: []string{
-    fmt.Sprintf("%s:%s", tmpDir, tmpDir), 
-   },
-  },
-  noRestart,
- )
+initResource, err := m.pool.RunWithOptions(
+		&dockertest.RunOptions{
+			Name:       chainId,
+			Repository: m.ImageConfig.InitRepository,
+			Tag:        m.ImageConfig.InitTag,
+			NetworkID:  m.network.Network.ID,
+			Cmd: []string{
+				fmt.Sprintf("--data-dir=%s", mountDir),
+				fmt.Sprintf("--chain-id=%s", chainId),
+				fmt.Sprintf("--config=%s", validatorConfigBytes),
+				fmt.Sprintf("--voting-period=%v", votingPeriodDuration),
+				fmt.Sprintf("--expedited-voting-period=%v", expeditedVotingPeriodDuration),
+				fmt.Sprintf("--fork-height=%v", forkHeight),
+			},
+			User: "root:root",
+			Mounts: []string{
+				fmt.Sprintf("%s:%s", mountDir, mountDir),
+			},
+		},
+		noRestart,
+	)
 ```
 
 #### Container Output
 
-Assumming that a the container was correctly mounted on a volume,
+Assumming that the container was correctly mounted on a volume,
 it produces the following:
 
 - `osmo-test-< chain id >-encode` file
@@ -118,8 +118,8 @@ config  data  keyring-test  wasm
 `/tmp/osmosis-e2e-testnet-1167397304/osmo-test`as a volume
 - < chain id > = "a"
 - 4 `NodeConfig`s were provided via the `--config` flag
-- `osmo-test-a-encode` output file corresponds to the serialized `Chain` struct
-defined in `tests/e2e/chain/chain.go`
+- `osmo-test-a-encode` output file corresponds to the serialized `internalChain` struct
+defined in `tests/e2e/initialization/chain.go`
 
 ### Initializing a Node (`node`)
 


### PR DESCRIPTION
- upd e2e README
- upd e2e/initialization README

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Have been reading `e2e` docs. Noticed some stuff was outdated. This PR focuses on fixing minor outdated things in READMEs of e2e. Please, let me know if I made any mistakes in these changes
