### PR TITLE
feat[CL]: delete position from state when completely removed

### DIFF
--- a/x/concentrated-liquidity/architecture.md
+++ b/x/concentrated-liquidity/architecture.md
@@ -289,7 +289,8 @@ This message should call the `createPosition` keeper method that is introduced i
 
 This message allows LPs to withdraw their position in a given pool and range (given by ticks), potentially in partial
 amount of liquidity. It should fail if there is no position in the given tick ranges, if tick ranges are invalid,
-or if attempting to withdraw an amount higher than originally provided.
+or if attempting to withdraw an amount higher than originally provided. If an LP withdraws all of their liquidity
+from a position, the collectFees method is called and then the position is deleted from state.
 
 ```go
 type MsgWithdrawPosition struct {
@@ -303,7 +304,7 @@ type MsgWithdrawPosition struct {
 
 - **Response**
 
-On succesful response, we receive the amounts of each token withdrawn
+On successful response, we receive the amounts of each token withdrawn
 for the provided share liquidity amount.
 
 ```go

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -39,6 +39,10 @@ func (k Keeper) HasPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress
 	return k.hasPosition(ctx, poolId, owner, lowerTick, upperTick)
 }
 
+func (k Keeper) DeletePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) error {
+	return k.deletePosition(ctx, poolId, owner, lowerTick, upperTick)
+}
+
 func (k Keeper) GetPoolById(ctx sdk.Context, poolId uint64) (types.ConcentratedPoolExtension, error) {
 	return k.getPoolById(ctx, poolId)
 }

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -141,7 +141,11 @@ func (k Keeper) withdrawPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAd
 	}
 
 	// If the requested liquidity amount to withdraw is equal to the available liquidity, delete the position from state.
+	// Ensure we collect any outstanding fees prior to deleting the position from state
 	if requestedLiquidityAmountToWithdraw.Equal(availableLiquidity) {
+		if _, err := k.collectFees(ctx, poolId, owner, lowerTick, upperTick); err != nil {
+			return sdk.Int{}, sdk.Int{}, err
+		}
 		if err := k.deletePosition(ctx, poolId, owner, lowerTick, upperTick); err != nil {
 			return sdk.Int{}, sdk.Int{}, err
 		}

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -395,13 +395,26 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			)
 
 			// If a setupConfig is provided, use it to create a pool and position.
-			if tc.setupConfig != nil {
-				s.PrepareConcentratedPool()
-				var err error
-				s.FundAcc(s.TestAccs[0], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
-				_, _, liquidityCreated, err = concentratedLiquidityKeeper.CreatePosition(ctx, config.poolId, owner, config.amount0Desired, config.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), config.lowerTick, config.upperTick)
-				s.Require().NoError(err)
-			}
+			pool := s.PrepareConcentratedPool()
+			s.FundAcc(owner, sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
+
+			// Create a position from the parameters in the test case.
+			_, _, liquidityCreated, err := concentratedLiquidityKeeper.CreatePosition(ctx, config.poolId, owner, config.amount0Desired, config.amount1Desired, sdk.ZeroInt(), sdk.ZeroInt(), config.lowerTick, config.upperTick)
+			s.Require().NoError(err)
+
+			// Set global fee growth to 1 ETH and charge the fee to the pool.
+			globalFeeGrowth := sdk.NewDecCoin(ETH, sdk.NewInt(1))
+			err = concentratedLiquidityKeeper.ChargeFee(ctx, pool.GetId(), globalFeeGrowth)
+			s.Require().NoError(err)
+
+			// Set the expected fees claimed to the amount of liquidity created since the global fee growth is 1.
+			// Fund the pool account with the expected fees claimed.
+			expectedFeesClaimed := sdk.NewCoins(sdk.NewCoin(ETH, liquidityCreated.TruncateInt()))
+			s.FundAcc(pool.GetAddress(), expectedFeesClaimed)
+
+			// Note the pool and owner balances before collecting fees.
+			poolBalanceBeforeCollect := s.App.BankKeeper.GetBalance(ctx, pool.GetAddress(), ETH)
+			ownerBalancerBeforeCollect := s.App.BankKeeper.GetBalance(ctx, owner, ETH)
 
 			// If specific configs are provided in the test case, overwrite the config with those values.
 			mergeConfigs(&config, &sutConfigOverwrite)
@@ -425,7 +438,15 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			expectedRemainingLiquidity := liquidityCreated.Sub(config.liquidityAmount)
 
 			if expectedRemainingLiquidity.IsZero() {
-				// If the remaining liquidity is zero, the position should be deleted.
+				// If the remaining liquidity is zero, all fees should be collected and the position should be deleted.
+				// Check if all fees were collected.
+				poolBalanceAfterCollect := s.App.BankKeeper.GetBalance(ctx, pool.GetAddress(), ETH)
+				ownerBalancerAfterCollect := s.App.BankKeeper.GetBalance(ctx, owner, ETH)
+				expectedETHAmount := expectedFeesClaimed.AmountOf(ETH)
+				s.Require().Equal(expectedETHAmount.String(), poolBalanceBeforeCollect.Sub(poolBalanceAfterCollect).Amount.String())
+				s.Require().Equal(expectedETHAmount.String(), ownerBalancerAfterCollect.Sub(ownerBalancerBeforeCollect).Amount.String())
+
+				// Check that the position was deleted.
 				position, err := concentratedLiquidityKeeper.GetPosition(ctx, config.poolId, owner, config.lowerTick, config.upperTick)
 				s.Require().Error(err)
 				s.Require().ErrorAs(err, &types.PositionNotFoundError{PoolId: config.poolId, LowerTick: config.lowerTick, UpperTick: config.upperTick})
@@ -435,8 +456,8 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				s.validatePositionUpdate(ctx, config.poolId, owner, config.lowerTick, config.upperTick, expectedRemainingLiquidity)
 			}
 
-			// check tick state
-			s.validateTickUpdates(ctx, config.poolId, owner, config.lowerTick, config.upperTick, expectedRemainingLiquidity, cl.EmptyCoins, cl.EmptyCoins)
+			// Check tick state.
+			s.validateTickUpdates(ctx, config.poolId, owner, config.lowerTick, config.upperTick, expectedRemainingLiquidity, config.expectedFeeGrowthOutsideLower, config.expectedFeeGrowthOutsideUpper)
 		})
 	}
 }

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -94,3 +94,19 @@ func (k Keeper) setPosition(ctx sdk.Context,
 	key := types.KeyPosition(poolId, owner, lowerTick, upperTick)
 	osmoutils.MustSet(store, key, position)
 }
+
+func (k Keeper) deletePosition(ctx sdk.Context,
+	poolId uint64,
+	owner sdk.AccAddress,
+	lowerTick, upperTick int64,
+) error {
+	store := ctx.KVStore(k.storeKey)
+	key := types.KeyPosition(poolId, owner, lowerTick, upperTick)
+
+	if !store.Has(key) {
+		return types.PositionNotFoundError{PoolId: poolId, LowerTick: lowerTick, UpperTick: upperTick}
+	}
+
+	store.Delete(key)
+	return nil
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: #3951 

## What is the purpose of the change

Currently, when a user makes a concentrated liquidity position and removes it in it's entirety, the position is still persisted in state. This PR removes any position from state when their is no more liquidity remaining.


## Brief Changelog

- Adds a check in `withdrawPosition` to `ClaimRewards` if the number of shares for a given position becomes zero
- Adds a check in `withdrawPosition` to clear the position from CL state if the number of shares becomes zero
- Updates `TestWithdrawPosition` to validate both of the above

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable