### PR TITLE
concentrated-liquidity: invert exponentAtPriceOne

### DIFF
--- a/x/concentrated-liquidity/model/msgs.go
+++ b/x/concentrated-liquidity/model/msgs.go
@@ -39,11 +39,14 @@ func NewMsgCreateConcentratedPool(
 
 func (msg MsgCreateConcentratedPool) Route() string { return cltypes.RouterKey }
 func (msg MsgCreateConcentratedPool) Type() string  { return TypeMsgCreateConcentratedPool }
-func (msg MsgCreateConcentratedPool) ValidateBasic() error {
+func (msg *MsgCreateConcentratedPool) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
 	}
+
+	// invert PrecisionFactorAtPriceOne (https://github.com/osmosis-labs/osmosis/issues/4041)
+	msg.PrecisionFactorAtPriceOne = msg.PrecisionFactorAtPriceOne.Sub(msg.PrecisionFactorAtPriceOne.Mul(sdk.NewInt(2)))
 
 	if msg.TickSpacing <= 0 {
 		return fmt.Errorf("tick spacing must be positive")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4041

## What is the purpose of the change

This PR allows users to pass positive value as an `exponentAtPriceOne` argument, which 
will then be made negative in MsgCreateConcentratedPool. 

Refer to #4041 to know the reason why you cannot simply pass negative value as an 
argument (in short, it is interpreted as a flag)

## Brief Changelog

`MsgCreateConcentratedPool.ValidateBasic()` mutates the msg struct with inverted value 
for `PrecisionFactorAtPriceOne`. 

## Testing and Verifying

Manually checked:

Running 
```
osmosisd tx concentratedliquidity create-concentrated-pool uosmo uion 1 1 --from val --keyring-backend test --chain-id localosmosis 
```
will result in `MsgCreateConcentratedPool` being passed into [GenerateOrBroadcastTxWithFactory()](https://github.com/osmosis-labs/osmosis/blob/main/osmoutils/osmocli/tx_cmd_wrap.go#L86) as:
```
sender:"osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj" denom0:"uosmo" denom1:"uion" tick_spacing:1 precision_factor_at_price_one:"-1" 
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? 
no
  - How is the feature or change documented? no
