### PR TITLE
(CL Test): Add inverse relationship testing between `CreatePosition` and `WithdrawPosition`

### DIFF
--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -952,7 +952,7 @@ func (s *KeeperTestSuite) TestInverseRelation_CreatePosition_WithdrawPosition() 
 			s.Require().Nil(position)
 
 			// 4. Check that pool has come back to original state
-			poolAfter, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
+			poolAfter, err := clKeeper.GetPool(s.Ctx, poolID)
 			s.Require().NoError(err)
 			s.Require().Equal(poolBefore.GetTotalShares(), poolAfter.GetTotalShares())
 			s.Require().Equal(poolBefore.GetTotalPoolLiquidity(s.Ctx), poolAfter.GetTotalPoolLiquidity(s.Ctx))

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -906,7 +906,7 @@ func (s *KeeperTestSuite) TestInverseRelation_CreatePosition_WithdrawPosition() 
 			// Create a CL pool with custom tickSpacing
 			poolID, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(s.TestAccs[0], ETH, USDC, tc.tickSpacing, tc.precisionFactorAtPriceOne))
 			s.Require().NoError(err)
-			poolBefore, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
+			poolBefore, err := clKeeper.GetPool(s.Ctx, poolID)
 			s.Require().NoError(err)
 
 			// Pre-set fee growth accumulator

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -62,10 +62,8 @@ var (
 		// as a result, the upper tick is not updated.
 		expectedFeeGrowthOutsideUpper: cl.EmptyCoins,
 	}
-)
 
-func (s *KeeperTestSuite) TestCreatePosition() {
-	tests := map[string]lpTest{
+	positionCases = map[string]lpTest{
 		"base case": {},
 		"create a position with non default tick spacing (10) with ticks that fall into tick spacing requirements": {
 			tickSpacing: 10,
@@ -118,6 +116,11 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 			expectedFeeGrowthOutsideLower: oneEthCoins,
 			expectedFeeGrowthOutsideUpper: oneEthCoins,
 		},
+	}
+)
+
+func (s *KeeperTestSuite) TestCreatePosition() {
+	tests := map[string]lpTest{
 		"error: non-existent pool": {
 			poolId:        2,
 			expectedError: types.PoolNotFoundError{PoolId: 2},
@@ -172,6 +175,11 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 		// - custom hand-picked values
 		// - think of overflows
 		// - think of truncations
+	}
+
+	// add test cases for different positions
+	for name, test := range positionCases {
+		tests[name] = test
 	}
 
 	for name, tc := range tests {
@@ -868,6 +876,86 @@ func (s *KeeperTestSuite) TestinitializeInitialPositionForPool() {
 				s.Require().NoError(err)
 			}
 
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestInverseRelation_CreatePosition_WithdrawPosition() {
+	tests := map[string]lpTest{}
+
+	// add test cases for different positions
+	for name, test := range positionCases {
+		tests[name] = test
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		s.Run(name, func() {
+			s.SetupTest()
+
+			// Merge tc with baseCase and update tc to the merged result. This is done to reduce the amount of boilerplate in test cases.
+			baseConfigCopy := *baseCase
+			mergeConfigs(&baseConfigCopy, &tc)
+			tc = baseConfigCopy
+
+			clKeeper := s.App.ConcentratedLiquidityKeeper
+
+			// Fund account to pay for the pool creation fee.
+			s.FundAcc(s.TestAccs[0], PoolCreationFee)
+
+			// Create a CL pool with custom tickSpacing
+			poolID, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(s.TestAccs[0], ETH, USDC, tc.tickSpacing, tc.precisionFactorAtPriceOne))
+			s.Require().NoError(err)
+			poolBefore, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
+			s.Require().NoError(err)
+
+			// Pre-set fee growth accumulator
+			if !tc.preSetChargeFee.IsZero() {
+				err = clKeeper.ChargeFee(s.Ctx, 1, tc.preSetChargeFee)
+				s.Require().NoError(err)
+			}
+
+			// If we want to test a non-first position, we create a first position with a separate account
+			if tc.isNotFirstPosition {
+				s.SetupPosition(1, s.TestAccs[1], DefaultCoin0, DefaultCoin1, tc.lowerTick, tc.upperTick)
+			}
+
+			// Fund test account and create the desired position
+			s.FundAcc(s.TestAccs[0], sdk.NewCoins(DefaultCoin0, DefaultCoin1))
+
+			// Note user and pool account balances before create position is called
+			userBalancePrePositionCreation := s.App.BankKeeper.GetAllBalances(s.Ctx, s.TestAccs[0])
+			poolBalancePrePositionCreation := s.App.BankKeeper.GetAllBalances(s.Ctx, poolBefore.GetAddress())
+
+			// System under test.
+			amtDenom0CreatePosition, amtDenom1CreatePosition, liquidityCreated, err := clKeeper.CreatePosition(s.Ctx, tc.poolId, s.TestAccs[0], tc.amount0Desired, tc.amount1Desired, tc.amount0Minimum, tc.amount1Minimum, tc.lowerTick, tc.upperTick)
+			s.Require().NoError(err)
+			amtDenom0WithdrawPosition, amtDenom1WithdrawPosition, err := clKeeper.WithdrawPosition(s.Ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick, liquidityCreated)
+			s.Require().NoError(err)
+
+			// INVARIANTS
+
+			// 1. amount for denom0 and denom1 upon creating and withdraw position should be same
+			s.Require().Equal(amtDenom0CreatePosition, amtDenom0WithdrawPosition)
+			s.Require().Equal(amtDenom1CreatePosition, amtDenom1WithdrawPosition)
+
+			// 2. user balance and pool balance after creating / withdrawing position should be same
+			userBalancePostPositionCreation := s.App.BankKeeper.GetAllBalances(s.Ctx, s.TestAccs[0])
+			poolBalancePostPositionCreation := s.App.BankKeeper.GetAllBalances(s.Ctx, poolBefore.GetAddress())
+			s.Require().Equal(userBalancePrePositionCreation, userBalancePostPositionCreation)
+			s.Require().Equal(poolBalancePrePositionCreation, poolBalancePostPositionCreation)
+
+			// 3. Check that position was deleted
+			position, err := clKeeper.GetPosition(s.Ctx, tc.poolId, s.TestAccs[0], tc.lowerTick, tc.upperTick)
+			s.Require().Error(err)
+			s.Require().ErrorAs(err, &types.PositionNotFoundError{PoolId: tc.poolId, LowerTick: tc.lowerTick, UpperTick: tc.upperTick})
+			s.Require().Nil(position)
+
+			// 4. Check that pool has come back to original state
+			poolAfter, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
+			s.Require().NoError(err)
+			s.Require().Equal(poolBefore.GetTotalShares(), poolAfter.GetTotalShares())
+			s.Require().Equal(poolBefore.GetTotalPoolLiquidity(s.Ctx), poolAfter.GetTotalPoolLiquidity(s.Ctx))
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change
Part of adding different invariant testings to the cl module.

This test adds inverse relationship testing between `CreatePosition` and `WithdrawPosition`
We specifically test the following four invariants upon the two methods
1.  amount for denom0 and denom1 upon creating and withdraw position should be same
2. user balance and pool balance after creating / withdrawing position should be same
3. Position should be deleted
4. pool state should come back to original state


## Brief Changelog
Add inverse relationship testing between `CreatePosition` and `WithdrawPosition`

## Testing and Verifying
Changes existing test code structure to avoid code duplication upon test cases and adds new test cases

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)