### PR TITLE
Return lock id from BeginForceUnlock

### DIFF
--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -172,18 +172,29 @@ func (k Keeper) BeginUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) err
 		return fmt.Errorf("cannot BeginUnlocking a lock with synthetic lockup")
 	}
 
-	return k.beginUnlock(ctx, *lock, coins)
+	_, err = k.beginUnlock(ctx, *lock, coins)
+	if err != nil {
+		return err
+	}
+	
+	return nil
 }
 
 // BeginForceUnlock begins force unlock of the given lock.
 // This method should be called by the superfluid module ONLY, as it does not check whether
 // the lock has a synthetic lock or not before unlocking.
-func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) error {
+func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) (uint64, error) {
 	lock, err := k.GetLockByID(ctx, lockID)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	return k.beginUnlock(ctx, *lock, coins)
+	
+	lockID, err = k.beginUnlock(ctx, *lock, coins)
+	if err != nil {
+		return 0, err
+	}
+
+	return lockID, nil
 }
 
 // beginUnlock unlocks specified tokens from the given lock. Existing lock refs
@@ -191,14 +202,14 @@ func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins
 // EndTime of the lock is set within this method.
 // Coins provided as the parameter does not require to have all the tokens in the lock,
 // as we allow partial unlockings of a lock.
-func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coins) error {
+func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coins) (uint64, error) {
 	// sanity check
 	if !coins.IsAllLTE(lock.Coins) {
-		return fmt.Errorf("requested amount to unlock exceeds locked tokens")
+		return 0, fmt.Errorf("requested amount to unlock exceeds locked tokens")
 	}
 
 	if lock.IsUnlocking() {
-		return fmt.Errorf("trying to unlock a lock that is already unlocking")
+		return 0, fmt.Errorf("trying to unlock a lock that is already unlocking")
 	}
 
 	// If the amount were unlocking is empty, or the entire coins amount, unlock the entire lock.
@@ -207,7 +218,7 @@ func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Co
 	if len(coins) != 0 && !coins.IsEqual(lock.Coins) {
 		splitLock, err := k.splitLock(ctx, lock, coins, false)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		lock = splitLock
 	}
@@ -215,20 +226,20 @@ func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Co
 	// remove existing lock refs from not unlocking queue
 	err := k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// store lock with the end time set to current block time + duration
 	lock.EndTime = ctx.BlockTime().Add(lock.Duration)
 	err = k.setLock(ctx, lock)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// add lock refs into unlocking queue
 	err = k.addLockRefs(ctx, lock)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if k.hooks != nil {
@@ -239,7 +250,7 @@ func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Co
 		createBeginUnlockEvent(&lock),
 	})
 
-	return nil
+	return lock.ID, nil
 }
 
 func (k Keeper) clearKeysByPrefix(ctx sdk.Context, prefix []byte) {

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -173,22 +173,19 @@ func (k Keeper) BeginUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) err
 	}
 
 	_, err = k.beginUnlock(ctx, *lock, coins)
-	if err != nil {
-		return err
-	}
-	
-	return nil
+	return err
 }
 
 // BeginForceUnlock begins force unlock of the given lock.
 // This method should be called by the superfluid module ONLY, as it does not check whether
 // the lock has a synthetic lock or not before unlocking.
+// Returns lock id, new lock id if the lock was split, else same lock id.
 func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) (uint64, error) {
 	lock, err := k.GetLockByID(ctx, lockID)
 	if err != nil {
 		return 0, err
 	}
-	
+
 	lockID, err = k.beginUnlock(ctx, *lock, coins)
 	if err != nil {
 		return 0, err
@@ -202,6 +199,7 @@ func (k Keeper) BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins
 // EndTime of the lock is set within this method.
 // Coins provided as the parameter does not require to have all the tokens in the lock,
 // as we allow partial unlockings of a lock.
+// Returns lock id, new lock id if the lock was split, else same lock id.
 func (k Keeper) beginUnlock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coins) (uint64, error) {
 	// sanity check
 	if !coins.IsAllLTE(lock.Coins) {

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -285,11 +285,7 @@ func (k Keeper) SuperfluidUnbondLock(ctx sdk.Context, underlyingLockId uint64, s
 		return types.ErrBondingLockupNotSupported
 	}
 	_, err = k.lk.BeginForceUnlock(ctx, underlyingLockId, sdk.Coins{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // alreadySuperfluidStaking returns true if underlying lock used in superfluid staking.

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -284,7 +284,12 @@ func (k Keeper) SuperfluidUnbondLock(ctx sdk.Context, underlyingLockId uint64, s
 	if !synthLocks[0].IsUnlocking() {
 		return types.ErrBondingLockupNotSupported
 	}
-	return k.lk.BeginForceUnlock(ctx, underlyingLockId, sdk.Coins{})
+	_, err = k.lk.BeginForceUnlock(ctx, underlyingLockId, sdk.Coins{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // alreadySuperfluidStaking returns true if underlying lock used in superfluid staking.

--- a/x/superfluid/keeper/unpool.go
+++ b/x/superfluid/keeper/unpool.go
@@ -77,7 +77,7 @@ func (k Keeper) UnpoolAllowedPools(ctx sdk.Context, sender sdk.AccAddress, poolI
 
 	// 8) Begin unlocking every new lock
 	for _, newLock := range newLocks {
-		err = k.lk.BeginForceUnlock(ctx, newLock.ID, newLock.Coins)
+		_, err = k.lk.BeginForceUnlock(ctx, newLock.ID, newLock.Coins)
 		if err != nil {
 			return []uint64{}, err
 		}

--- a/x/superfluid/types/expected_keepers.go
+++ b/x/superfluid/types/expected_keepers.go
@@ -24,7 +24,7 @@ type LockupKeeper interface {
 	GetLockByID(ctx sdk.Context, lockID uint64) (*lockuptypes.PeriodLock, error)
 	// Despite the name, BeginForceUnlock is really BeginUnlock
 	// TODO: Fix this in future code update
-	BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) error
+	BeginForceUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) (uint64, error)
 	ForceUnlock(ctx sdk.Context, lock lockuptypes.PeriodLock) error
 
 	CreateLock(ctx sdk.Context, owner sdk.AccAddress, coins sdk.Coins, duration time.Duration) (lockuptypes.PeriodLock, error)


### PR DESCRIPTION
## What is the purpose of the change

Return lock id from `BeginForceUnlock`. This PR is 1st part of implementing partial withdraw from super fluid

https://github.com/osmosis-labs/osmosis/issues/3830

Algorithm for SF partial withdraw is the following

```
1. SuperfluidUndelegate
2. Unbond lock for partial amount of the lock and return the new underlying lock that was split
3. Re-delegate remainder
4. Create synthetic unlocking lock for the new lock from step 2
```

This PR makes step 2 possible.


## Brief Changelog
 
  - *Return lock id from `BeginForceUnlock`*

## Testing and Verifying

*(Please pick one of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)