### PR TITLE
e2e: setDenomMetadata

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -67,6 +67,9 @@ Conceptually, we can split the e2e setup into 2 parts:
     configurations is hapenning in the background. The appropriate logic is selected
     depending on what the values of the arguments to `configurer.New(...)` are.
 
+    `CurrentBranchConfigurer` configures chains from current Git branch.
+    `UpgradeConfigurer` takes older osmosis versions and configures chains from them. 
+
     The configurer constructor is using a factory design pattern
     to decide on what kind of configurer to return. Factory design
     pattern is used to decouple the client from the initialization

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -302,7 +302,7 @@ func initGenesis(chain *internalChain, votingPeriod, expeditedVotingPeriod time.
 func updateBankGenesis(bankGenState *banktypes.GenesisState) {
 	denomsToRegister := []string{StakeDenom, IonDenom, OsmoDenom, AtomDenom}
 	for _, denom := range denomsToRegister {
-		setDenomMetaData(bankGenState, denom)
+		setDenomMetadata(bankGenState, denom)
 	}
 }
 
@@ -422,7 +422,7 @@ func updateGenUtilGenesis(c *internalChain) func(*genutiltypes.GenesisState) {
 	}
 }
 
-func setDenomMetaData(genState *banktypes.GenesisState, denom string) {
+func setDenomMetadata(genState *banktypes.GenesisState, denom string) {
 	genState.DenomMetadata = append(genState.DenomMetadata, banktypes.Metadata{
 		Description: fmt.Sprintf("Registered denom %s for e2e testing", denom),
 		Display:     denom,

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -49,6 +49,7 @@ const (
 	OsmoDenom           = "uosmo"
 	IonDenom            = "uion"
 	StakeDenom          = "stake"
+	AtomDenom           = "uatom"
 	OsmoIBCDenom        = "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
 	StakeIBCDenom       = "ibc/C053D637CCA2A2BA030E2C5EE1B28A16F71CCB0E45E8BE52766DC1B241B7787"
 	MinGasPrice         = "0.000"
@@ -299,19 +300,10 @@ func initGenesis(chain *internalChain, votingPeriod, expeditedVotingPeriod time.
 }
 
 func updateBankGenesis(bankGenState *banktypes.GenesisState) {
-	bankGenState.DenomMetadata = append(bankGenState.DenomMetadata, banktypes.Metadata{
-		Description: "An example stable token",
-		Display:     OsmoDenom,
-		Base:        OsmoDenom,
-		Symbol:      OsmoDenom,
-		Name:        OsmoDenom,
-		DenomUnits: []*banktypes.DenomUnit{
-			{
-				Denom:    OsmoDenom,
-				Exponent: 0,
-			},
-		},
-	})
+	denomsToRegister := []string{StakeDenom, IonDenom, OsmoDenom, AtomDenom}
+	for _, denom := range denomsToRegister {
+		setDenomMetaData(bankGenState, denom)
+	}
 }
 
 func updateStakeGenesis(stakeGenState *staketypes.GenesisState) {
@@ -428,4 +420,20 @@ func updateGenUtilGenesis(c *internalChain) func(*genutiltypes.GenesisState) {
 		}
 		genUtilGenState.GenTxs = genTxs
 	}
+}
+
+func setDenomMetaData(genState *banktypes.GenesisState, denom string) {
+	genState.DenomMetadata = append(genState.DenomMetadata, banktypes.Metadata{
+		Description: fmt.Sprintf("Registered denom %s for e2e testing", denom),
+		Display:     denom,
+		Base:        denom,
+		Symbol:      denom,
+		Name:        denom,
+		DenomUnits: []*banktypes.DenomUnit{
+			{
+				Denom:    denom,
+				Exponent: 0,
+			},
+		},
+	})
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Brief Changelog

This PR adds a function to register denom metadata in genesis state of bank module in e2e tests.

## Problem that this PR solves 

https://github.com/osmosis-labs/osmosis/pull/4038 while working at this PR I have faced a problem that you cannot create a concentrated pool with any denom you want (what is weird, `gamm` does not have `DenomMetadata` check). Because of that, I was unable to add `CreateConcentratedPool` function to `e2e`, because tests would not pass (reason: using `UpgradeConfigurer` which does not register denoms other than `uosmo`). This PR is backport and introduces:

- A general function to add `DenomMetadata` to genesis state of bank module
- More denoms added to genesis state of bank module

