### PR TITLE
upgrade-handler code gen: investigating why e2e does not pass

### DIFF
--- a/app/upgrades/v14/constants.go
+++ b/app/upgrades/v14/constants.go
@@ -6,11 +6,7 @@ import (
 	ibchookstypes "github.com/osmosis-labs/osmosis/x/ibc-hooks/types"
 
 	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
-	cltypes "github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/types"
 	downtimetypes "github.com/osmosis-labs/osmosis/v14/x/downtime-detector/types"
-	poolmanagertypes "github.com/osmosis-labs/osmosis/v14/x/poolmanager/types"
-	protorevtypes "github.com/osmosis-labs/osmosis/v14/x/protorev/types"
-	valsetpreftypes "github.com/osmosis-labs/osmosis/v14/x/valset-pref/types"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v14 upgrade.
@@ -20,7 +16,7 @@ var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
-		Added:   []string{valsetpreftypes.StoreKey, protorevtypes.StoreKey, poolmanagertypes.StoreKey, downtimetypes.StoreKey, ibchookstypes.StoreKey, cltypes.StoreKey},
+		Added:   []string{downtimetypes.StoreKey, ibchookstypes.StoreKey},
 		Deleted: []string{},
 	},
 }

--- a/app/upgrades/v14/upgrades.go
+++ b/app/upgrades/v14/upgrades.go
@@ -7,9 +7,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v14/app/keepers"
 	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
-	gammkeeper "github.com/osmosis-labs/osmosis/v14/x/gamm/keeper"
-	"github.com/osmosis-labs/osmosis/v14/x/poolmanager"
-	poolmanagertypes "github.com/osmosis-labs/osmosis/v14/x/poolmanager/types"
 )
 
 func CreateUpgradeHandler(
@@ -19,36 +16,6 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		poolmanagerParams := poolmanagertypes.NewParams(keepers.GAMMKeeper.GetParams(ctx).PoolCreationFee)
-
-		keepers.PoolManagerKeeper.SetParams(ctx, poolmanagerParams)
-
-		// N.B: pool id in gamm is to be deprecated in the future
-		// Instead,it is moved to poolmanager.
-		migrateNextPoolId(ctx, keepers.GAMMKeeper, keepers.PoolManagerKeeper)
-
-		//  N.B.: this is done to avoid initializing genesis for poolmanager module.
-		// Otherwise, it would overwrite migrations with InitGenesis().
-		// See RunMigrations() for details.
-		fromVM[poolmanagertypes.ModuleName] = 0
-
 		return mm.RunMigrations(ctx, configurator, fromVM)
-	}
-}
-
-func migrateNextPoolId(ctx sdk.Context, gammKeeper *gammkeeper.Keeper, poolmanagerKeeper *poolmanager.Keeper) {
-	// N.B: pool id in gamm is to be deprecated in the future
-	// Instead,it is moved to poolmanager.
-	// nolint: staticcheck
-	nextPoolId := gammKeeper.GetNextPoolId(ctx)
-	poolmanagerKeeper.SetNextPoolId(ctx, nextPoolId)
-
-	for poolId := uint64(1); poolId < nextPoolId; poolId++ {
-		poolType, err := gammKeeper.GetPoolType(ctx, poolId)
-		if err != nil {
-			panic(err)
-		}
-
-		poolmanagerKeeper.SetPoolRoute(ctx, poolId, poolType)
 	}
 }

--- a/app/upgrades/v15/constants.go
+++ b/app/upgrades/v15/constants.go
@@ -1,9 +1,13 @@
 package v15
 
 import (
-	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
-
 	store "github.com/cosmos/cosmos-sdk/store/types"
+
+	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
+	cltypes "github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/types"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v14/x/poolmanager/types"
+	protorevtypes "github.com/osmosis-labs/osmosis/v14/x/protorev/types"
+	valsetpreftypes "github.com/osmosis-labs/osmosis/v14/x/valset-pref/types"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v15 upgrade.
@@ -12,8 +16,8 @@ const UpgradeName = "v15"
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
-	StoreUpgrades:        store.StoreUpgrades{
-		Added:   []string{},
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{poolmanagertypes.StoreKey, cltypes.StoreKey, valsetpreftypes.StoreKey, protorevtypes.StoreKey},
 		Deleted: []string{},
-    },
+	},
 }

--- a/app/upgrades/v15/export_test.go
+++ b/app/upgrades/v15/export_test.go
@@ -1,4 +1,4 @@
-package v14
+package v15
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/app/upgrades/v15/upgrade_test.go
+++ b/app/upgrades/v15/upgrade_test.go
@@ -1,4 +1,4 @@
-package v14_test
+package v15_test
 
 import (
 	"reflect"
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/osmosis-labs/osmosis/v14/app/apptesting"
-	v14 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v14"
+	v15 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v15"
 )
 
 type UpgradeTestSuite struct {
@@ -43,7 +43,7 @@ func (suite *UpgradeTestSuite) TestMigrateNextPoolIdAndCreatePool() {
 	suite.Require().Equal(expectedNextPoolId, nextPoolId)
 
 	// system under test.
-	v14.MigrateNextPoolId(ctx, gammKeeper, poolmanagerKeeper)
+	v15.MigrateNextPoolId(ctx, gammKeeper, poolmanagerKeeper)
 
 	// validate poolmanager's next pool id.
 	actualNextPoolId := poolmanagerKeeper.GetNextPoolId(ctx)

--- a/app/upgrades/v15/upgrades.go
+++ b/app/upgrades/v15/upgrades.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v14/app/keepers"
 	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
+	"github.com/osmosis-labs/osmosis/v14/x/poolmanager"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v14/x/poolmanager/types"
+
+	gammkeeper "github.com/osmosis-labs/osmosis/v14/x/gamm/keeper"
 )
 
 func CreateUpgradeHandler(
@@ -16,6 +20,36 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		poolmanagerParams := poolmanagertypes.NewParams(keepers.GAMMKeeper.GetParams(ctx).PoolCreationFee)
+
+		keepers.PoolManagerKeeper.SetParams(ctx, poolmanagerParams)
+
+		// N.B: pool id in gamm is to be deprecated in the future
+		// Instead,it is moved to poolmanager.
+		migrateNextPoolId(ctx, keepers.GAMMKeeper, keepers.PoolManagerKeeper)
+
+		//  N.B.: this is done to avoid initializing genesis for poolmanager module.
+		// Otherwise, it would overwrite migrations with InitGenesis().
+		// See RunMigrations() for details.
+		fromVM[poolmanagertypes.ModuleName] = 0
+		
 		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
+func migrateNextPoolId(ctx sdk.Context, gammKeeper *gammkeeper.Keeper, poolmanagerKeeper *poolmanager.Keeper) {
+	// N.B: pool id in gamm is to be deprecated in the future
+	// Instead,it is moved to poolmanager.
+	// nolint: staticcheck
+	nextPoolId := gammKeeper.GetNextPoolId(ctx)
+	poolmanagerKeeper.SetNextPoolId(ctx, nextPoolId)
+
+	for poolId := uint64(1); poolId < nextPoolId; poolId++ {
+		poolType, err := gammKeeper.GetPoolType(ctx, poolId)
+		if err != nil {
+			panic(err)
+		}
+
+		poolmanagerKeeper.SetPoolRoute(ctx, poolId, poolType)
 	}
 }

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,10 +24,10 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis-dev"
-	previousVersionOsmoTag        = "v14.0.0"
+	previousVersionOsmoTag        = "v14.x-f6813bcb-1674140667"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "14.0.0"
+	previousVersionInitTag        = "v14.x-f6813bcb-1674140667-manual"
 	// Hermes repo/version for relayer
 	relayerRepository = "osmolabs/hermes"
 	relayerTag        = "0.13.0"


### PR DESCRIPTION
in this pr I am trying to understand why e2e does not pass on https://github.com/osmosis-labs/osmosis/pull/4052

## Problems

First of all, upgrade-handler's branch had wrong tags specified, but even after a fix, I got an error: 

```
recovered: UnmarshalJSON cannot decode empty bytes\nstack:\ngoroutine 277
```
when e2e test tried to execute:

```
"[osmosisd tx gamm create-pool --pool-file=./osmosis/pool1A.json --from=val --chain-id=osmo-test-a -b=block --yes --keyring-backend=test --log_format=json]", success condition is "code: 0"
```