### PR TITLE
(CL Bug): Re-run swap test cases

### DIFF
--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -413,7 +413,7 @@ var (
 
 func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 	tests := make(map[string]SwapOutGivenInTest)
-	for name, test := range tests {
+	for name, test := range swapOutGivenInCases {
 		tests[name] = test
 	}
 
@@ -431,8 +431,13 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 			// Create default CL pool
 			pool := s.PrepareConcentratedPool()
 
+			// manually update fee accumulator for the pool
+			feeAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, 1)
+			s.Require().NoError(err)
+			feeAccum.AddToAccumulator(DefaultFeeAccumCoins)
+
 			// add default position
-			_, _, _, err := s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[0], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), DefaultLowerTick, DefaultUpperTick)
+			_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[0], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), DefaultLowerTick, DefaultUpperTick)
 			s.Require().NoError(err)
 
 			// add second position depending on the test
@@ -445,11 +450,6 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 				_, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
 				s.Require().NoError(err)
 			}
-
-			// manually update fee accumulator for the pool
-			feeAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, 1)
-			s.Require().NoError(err)
-			feeAccum.AddToAccumulator(DefaultFeeAccumCoins)
 
 			poolBeforeCalc, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
 			s.Require().NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

A bug was introduced in https://github.com/osmosis-labs/osmosis/commit/a352af1be78a4ba5665f5b43b642d04fcd7cb944, where test cases were not properly running for `TestCalcAndSwapOutAmtGivenIn`. This was caused due to the combination of refactoring + merge conflicts. Thanks @p0mvn  for catching this

This PR re-enables the swap test cases properly
