### PR TITLE
feat/test(CL Swaps): Swap fees for amount out given in

### DIFF
--- a/scripts/cl/README.md
+++ b/scripts/cl/README.md
@@ -1,0 +1,21 @@
+# Concentrated Liquidity Test Case Estimate Scripts
+
+## Context
+
+These scripts exist to estimate the results of the swap
+concentrated liqudity test cases.
+
+Each existing test case is estimated by calling the
+respective function in `scripts/cl/main.py` main function.
+
+The function defining a swap test case specifies which
+CL go test case it estimates. See the spec for details.
+
+## Running the scripts
+
+To run with sage installed:
+```bash
+sage -python scripts/cl/main.py
+```
+
+Note, these scripts can also be run by installing `sympy` without sage.

--- a/scripts/cl/common.py
+++ b/scripts/cl/common.py
@@ -8,7 +8,7 @@ precision = 30
 # When swapping token one for zero, sqrt_price_current <= sqrt_price_next.
 #
 # sqrt_price_next can be None. When it is None, that implies that the next sqrt
-# price must be calculated. In such a case, nex sqrt price depends on the
+# price must be calculated. In such a case, next sqrt price depends on the
 # remaining amount of token in to be swapped. This occurs for the last sqrt price
 # range in the collection of sqrt price ranges that represent a swap.
 #

--- a/scripts/cl/common.py
+++ b/scripts/cl/common.py
@@ -1,0 +1,39 @@
+import sympy as sp
+
+precision = 30
+
+# SqrtPriceRange represents a price range between the current and the next tick
+# as well as the liquidity in that price range.
+# When swapping token zero for one, sqrt_price_current >= sqrt_price_next.
+# When swapping token one for zero, sqrt_price_current <= sqrt_price_next.
+#
+# sqrt_price_next can be None. When it is None, that implies that the next sqrt
+# price must be calculated. In such a case, nex sqrt price depends on the
+# remaining amount of token in to be swapped. This occurs for the last sqrt price
+# range in the collection of sqrt price ranges that represent a swap.
+#
+# For example, I might have a swap of 100 ETH in from 5000 to 5001 with liquidity
+# X, from 5001 to 5002 with liquidity Y,
+# and from 5002 to UNKNOWN with liquidity Z. In this case, the UNKWNOWN
+# depends on how much ETH we have remaining after consuming liquidity X and Y.
+class SqrtPriceRange:
+  def __init__(self, sqrt_price_current: int, sqrt_price_next: int, liquidity: sp.Float):
+    self.sqrt_price_start = sp.sqrt(fixed_prec_dec(sqrt_price_current))
+    if sqrt_price_next is not None:
+        self.sqrt_price_next = sp.sqrt(fixed_prec_dec(sqrt_price_next))
+    else:
+       self.sqrt_price_next =  None
+    self.liquidity = liquidity
+
+def fixed_prec_dec(string: str) -> sp.Float:
+    """ Return an equivalent of a Python Decimal with fixed precision. 
+    """
+    return sp.Float(string, precision)
+
+def get_fee_amount_per_share(token_in: sp.Float, swap_fee: sp.Float, liquidity: sp.Float) -> sp.Float:
+    """ Returns the fee amount per share.
+    """
+    fee_charge_total = token_in * swap_fee
+    return fee_charge_total / liquidity
+
+zero = fixed_prec_dec("0")

--- a/scripts/cl/common.py
+++ b/scripts/cl/common.py
@@ -14,7 +14,7 @@ precision = 30
 #
 # For example, I might have a swap of 100 ETH in from 5000 to 5001 with liquidity
 # X, from 5001 to 5002 with liquidity Y,
-# and from 5002 to UNKNOWN with liquidity Z. In this case, the UNKWNOWN
+# and from 5002 to UNKNOWN with liquidity Z. In this case, the UNKNOWN
 # depends on how much ETH we have remaining after consuming liquidity X and Y.
 class SqrtPriceRange:
   def __init__(self, sqrt_price_current: int, sqrt_price_next: int, liquidity: sp.Float):

--- a/scripts/cl/main.py
+++ b/scripts/cl/main.py
@@ -1,0 +1,267 @@
+from typing import Tuple
+from common import *
+import zero_for_one as zfo
+import one_for_zero as ofz
+
+def estimate_test_case(tick_ranges: list[SqrtPriceRange], token_in_initial: sp.Float, swap_fee: sp.Float, is_zero_for_one: bool) -> Tuple[sp.Float, sp.Float]:
+    """ Estimates a calc concentrated liquidity test case.
+    
+    Given
+      - sqrt price range with the start sqrt price, next sqrt price and liquidity
+      - initial token in
+      - swap fee
+      - zero for one boolean flag
+    Estimates the final token out and the fee growth per share and prints it to stdout.
+    Also, estimates these and other values at each range and prints them to stdout.
+
+    Returns the total token out and the total fee growth per share.
+    """
+
+    token_in_consumed_total, token_out_total, fee_growth_per_share_total = zero, zero, zero
+
+    for i in range(len(tick_ranges)):
+        tick_range = tick_ranges[i]
+
+        # Normally, for the last swap range we swap until token in runs out
+        # As a result, the next sqrt price for that range calculated at runtime.
+        is_last_range = i == len(tick_ranges) - 1
+        # Except for the cases where we set price limit explicitly. Then, the
+        # last price range may have the upper sqrt price limit configured.
+        is_next_price_set = tick_range.sqrt_price_next != None 
+
+        is_with_next_sqrt_price = not is_last_range or is_next_price_set
+
+        if is_with_next_sqrt_price:
+            token_in_consumed, token_out, fee_growth_per_share = zero, zero, zero
+            if is_zero_for_one:
+                token_in_consumed, token_out, fee_growth_per_share = zfo.calc_test_case_with_next_sqrt_price(tick_range.liquidity, tick_range.sqrt_price_start, tick_range.sqrt_price_next, swap_fee)
+            else:
+                token_in_consumed, token_out, fee_growth_per_share = ofz.calc_test_case_with_next_sqrt_price(tick_range.liquidity, tick_range.sqrt_price_start, tick_range.sqrt_price_next, swap_fee)
+            
+            token_in_consumed_total += token_in_consumed
+            token_out_total += token_out
+            fee_growth_per_share_total += fee_growth_per_share
+
+        else:
+            token_in_remaining = token_in_initial - token_in_consumed_total
+
+            if token_in_remaining < zero:
+                raise Exception(F"token_in_remaining {token_in_remaining} is negative with token_in_initial {token_in_initial} and token_in_consumed_total {token_in_consumed_total}")
+
+            token_out, fee_growth_per_share = zero, zero
+            if is_zero_for_one:
+                _, token_out, fee_growth_per_share = zfo.calc_test_case(tick_range.liquidity, tick_range.sqrt_price_start, token_in_remaining, swap_fee)
+            else:
+                _, token_out, fee_growth_per_share = ofz.calc_test_case(tick_range.liquidity, tick_range.sqrt_price_start, token_in_remaining, swap_fee)
+
+            token_out_total += token_out
+            fee_growth_per_share_total += fee_growth_per_share
+        print("\n")
+        print(F"After processing range {i}")
+        print(F"current token_out_total: {token_out_total}")
+        print(F"current current fee_growth_per_share_total: {fee_growth_per_share_total}")
+        print("\n\n\n")
+
+    print("\n\n")
+    print("Final results:")
+    print("token_out_total: ", token_out_total)
+    print("fee_growth_per_share_total: ", fee_growth_per_share_total)
+
+    return token_out_total, fee_growth_per_share_total
+
+def validate_confirmed_results(token_out_total: sp.Float, fee_growth_per_share_total: sp.Float, expected_token_out_total: sp.Float, expected_fee_growth_per_share_total: sp.Float):
+    """Validates the results of a calc concentrated liquidity test case estimates.
+
+    This validation helper exists to make sure that subsequent changes to the script do not break test cases.
+    """
+
+    if sp.N(token_out_total, 18) != sp.N(expected_token_out_total, 18):
+        raise Exception(F"token_out_total {token_out_total} does not match expected_token_out_total {expected_token_out_total}")
+    
+    if sp.N(fee_growth_per_share_total, 18) != sp.N(expected_fee_growth_per_share_total, 18):
+        raise Exception(F"fee_growth_per_share_total {fee_growth_per_share_total} does not match expected_fee_growth_per_share_total {expected_fee_growth_per_share_total}")
+
+def estimate_single_position_within_one_tick_ofz():
+    """Estimates and prints the results of a calc concentrated liquidity test case with a single position within one tick
+    when swapping token one for token zero (ofz).
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_1 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = False
+    swap_fee = fixed_prec_dec("0.01")
+    token_in_initial = fixed_prec_dec("42000000")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, None, fixed_prec_dec("1517882343.751510418088349649")), # last one must be computed based on remaining token in, therefore it is None
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("8312.77961614650590788243077782")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.000276701288297452775064000000017")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def estimate_two_positions_within_one_tick_zfo():
+    """Estimates and prints the results of a calc concentrated liquidity test case with two positions within one tick
+    when swapping token zero for one (zfo).
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_2 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = True
+    swap_fee = fixed_prec_dec("0.03")
+    token_in_initial = fixed_prec_dec("13370")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, None, fixed_prec_dec("3035764687.503020836176699298")), # last one must be computed based on remaining token in, therefore it is None
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("64824917.7760329489344598324379")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.000000132124865162033700093060000008")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def estimate_two_consecutive_positions_zfo():
+    """Estimates and prints the results of a calc concentrated liquidity test case with two consecutive positions
+    when swapping token zero for one (zfo).
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_3 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = True
+    swap_fee = fixed_prec_dec("0.05")
+    token_in_initial = fixed_prec_dec("2000000")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, 4545, fixed_prec_dec("1517882343.751510418088349649")),
+        SqrtPriceRange(4545, None, fixed_prec_dec("1198735489.597250295669959398")), # last one must be computed based on remaining token in, therefore it is None
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("8702563350.03654978407909736170")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.0000720353033851801313478676884502")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def estimate_overlapping_price_range_ofz_test():
+    """Estimates and prints the results of a calc concentrated liquidity test case with overlapping price ranges
+    when swapping token one for token zero (ofz).
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_4 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = False
+    swap_fee = fixed_prec_dec("0.1")
+    token_in_initial = fixed_prec_dec("10000000000")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, 5001, fixed_prec_dec("1517882343.751510418088349649")),
+        SqrtPriceRange(5001, 5500, fixed_prec_dec("2188298432.35717914512760058700")),
+        SqrtPriceRange(5500, None, fixed_prec_dec("670416088.605668727039250938")), # last one must be computed based on remaining token in, therefore it is None
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("1708743.47809184831586199935191")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.598328101473707318285291820984")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def estimate_overlapping_price_range_zfo_test():
+    """Estimates and prints the results of a calc concentrated liquidity test case with overlapping price ranges
+    when swapping token zero for one (zfo) and not consuming full liquidity of the second position.
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_5 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = True
+    swap_fee = fixed_prec_dec("0.005")
+    token_in_initial = fixed_prec_dec("1800000")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, 4999, fixed_prec_dec("1517882343.751510418088349649")),
+        SqrtPriceRange(4999, 4545, fixed_prec_dec("1517882343.751510418088349649") + fixed_prec_dec("670416215.718827443660400594")), # first and second position's liquidity.
+        SqrtPriceRange(4545, None, fixed_prec_dec("670416215.718827443660400594")), # last one must be computed based on remaining token in, therefore it is None
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("8440821620.46523833169832895388")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.00000555275275702765744105956374059")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def estimate_consecutive_positions_gap_ofz_test():
+    """Estimates and prints the results of a calc concentrated liquidity test case with consecutive positions with a gap
+    when swapping token one for zero (ofz).
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_6 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = False
+    swap_fee = fixed_prec_dec("0.03")
+    token_in_initial = fixed_prec_dec("10000000000")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, 5500, fixed_prec_dec("1517882343.751510418088349649")),
+        SqrtPriceRange(5501, None, fixed_prec_dec("1199528406.187413669220037261")), # last one must be computed based on remaining token in, therefore it is None
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("1772029.65214390801589935811000")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.218688507910948644574193665912")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def estimate_slippage_protection_zfo_test():
+    """Estimates and prints the results of a calc concentrated liquidity test case with slippage protection
+    when swapping token zero for one (zfo).
+
+     go test -timeout 30s -v -run TestKeeperTestSuite/TestCalcAndSwapOutAmtGivenIn/fee_7 github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity
+    """
+
+    is_zero_for_one = True
+    swap_fee = fixed_prec_dec("0.01")
+    token_in_initial = fixed_prec_dec("13370")
+
+    tick_ranges = [
+        SqrtPriceRange(5000, 4994, fixed_prec_dec("1517882343.751510418088349649")),
+    ]
+
+    token_out_total, fee_growth_per_share_total = estimate_test_case(tick_ranges, token_in_initial, swap_fee, is_zero_for_one)
+
+    expected_token_out_total = fixed_prec_dec("64417624.9871649525380486017974")
+    expected_fee_growth_per_share_total = fixed_prec_dec("0.0000000849292577225588233432564611676")
+
+    validate_confirmed_results(token_out_total, fee_growth_per_share_total, expected_token_out_total, expected_fee_growth_per_share_total)
+
+def main():
+    # fee 1
+    estimate_single_position_within_one_tick_ofz()
+
+    # fee 2
+    estimate_two_positions_within_one_tick_zfo()
+
+    # fee 3
+    estimate_two_consecutive_positions_zfo()
+
+    # fee 4
+    estimate_overlapping_price_range_ofz_test()
+
+    # fee 5
+    estimate_overlapping_price_range_zfo_test()
+
+    # fee 6
+    estimate_consecutive_positions_gap_ofz_test()
+
+    # fee 7
+    estimate_slippage_protection_zfo_test()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cl/math.py
+++ b/scripts/cl/math.py
@@ -1,0 +1,11 @@
+import sympy as sp
+
+def calc_liquidity_0(amount_zero: sp.Float, sqrtPriceA: sp.Float, sqrtPriceB: sp.Float) -> sp.Float:
+    """Calculates and returns liquidity zero. 
+    """
+    return amount_zero * (sqrtPriceA * sqrtPriceB) / (sqrtPriceB - sqrtPriceA)
+
+def calc_liquidity_1(amount_one: sp.Float, sqrtPriceA: sp.Float, sqrtPriceB: sp.Float) -> sp.Float:
+    """Calculates and returns liquidity one. 
+    """
+    return amount_one * (sqrtPriceB - sqrtPriceA)

--- a/scripts/cl/one_for_zero.py
+++ b/scripts/cl/one_for_zero.py
@@ -1,0 +1,55 @@
+from typing import Tuple
+import sympy as sp
+from common import *
+
+def get_next_sqrt_price(liquidity: sp.Float, sqrt_price_current: sp.Float, token_in: sp.Float, swap_fee: sp.Float) -> sp.Float:
+    """ Return the next sqrt price when swapping token one for zero. 
+    """
+    return sqrt_price_current + (token_in * (1 - swap_fee) / liquidity)
+
+def get_token_out(liquidity: sp.Float, sqrt_price_current: sp.Float, sqrt_price_next: sp.Float) -> sp.Float:
+    """ Returns the token out when swapping token one for zero. 
+    """
+    return liquidity * (sqrt_price_next - sqrt_price_current) / (sqrt_price_next * sqrt_price_current)
+
+def get_expected_token_in(liquidity: sp.Float, sqrt_price_current: sp.Float, sqrt_price_next: sp.Float):
+    """ Returns the expected token in when swapping token one for zero. 
+    """
+    return liquidity * sp.Abs((sqrt_price_current - sqrt_price_next))
+
+def calc_test_case(liquidity: sp.Float, sqrt_price_current: sp.Float, token_in: sp.Float, swap_fee: sp.Float) -> Tuple[sp.Float, sp.Float, sp.Float]:
+    """ Computes and prints all one for zero test case parameters. Next sqrt price is computed from the given parameters.
+
+    Returns the next square root price, token out and fee amount per share.
+    """
+    sqrt_price_next = get_next_sqrt_price(liquidity, sqrt_price_current, token_in, swap_fee)
+    price_next = sp.Pow(sqrt_price_next, 2)
+    token_out = get_token_out(liquidity, sqrt_price_current, sqrt_price_next)
+    fee_amount_per_share = get_fee_amount_per_share(token_in, swap_fee, liquidity)
+
+    print(F"sqrt_price_next: {sqrt_price_next}")
+    print(F"price_next: {price_next}")
+    print(F"token_out: {token_out}")
+    print(F"fee_amount_per_share: {fee_amount_per_share}")
+
+    return sqrt_price_next, token_out, fee_amount_per_share
+
+def calc_test_case_with_next_sqrt_price(liquidity: sp.Float, sqrt_price_current: sp.Float, sqrt_price_next: sp.Float, swap_fee: sp.Float) -> Tuple[sp.Float, sp.Float, sp.Float]:
+    """ Computes and prints one for zero test case parameters when next square root price is known.
+
+    Returns the expected token in, token out and fee amount per share. 
+    """
+    price_next = sp.Pow(sqrt_price_next, 2)
+    expected_token_in_before_fee = get_expected_token_in(liquidity, sqrt_price_current, sqrt_price_next)
+    expected_token_in = expected_token_in_before_fee * (1 + swap_fee)
+
+    token_out = get_token_out(liquidity, sqrt_price_current, sqrt_price_next)
+    fee_amount_per_share = get_fee_amount_per_share(expected_token_in_before_fee, swap_fee, liquidity)
+
+    print(F"given sqrt_price_next: {sqrt_price_next}")
+    print(F"price_next: {price_next}")
+    print(F"expected_token_in: {expected_token_in}")
+    print(F"token_out: {token_out}")
+    print(F"fee_amount_per_share: {fee_amount_per_share}")
+
+    return expected_token_in, token_out, fee_amount_per_share

--- a/scripts/cl/zero_for_one.py
+++ b/scripts/cl/zero_for_one.py
@@ -1,0 +1,56 @@
+from typing import Tuple
+import sympy as sp
+from common import *
+
+def get_next_sqrt_price(liquidity: sp.Float, sqrt_price_current: sp.Float, token_in: sp.Float, swap_fee: sp.Float) -> sp.Float:
+    """ Return the next sqrt price when swapping token zero for one. 
+    """
+    return ((liquidity)) / (((liquidity) / (sqrt_price_current)) + (token_in * (1 - swap_fee)))
+
+def get_token_out(liquidity: sp.Float, sqrt_price_current: sp.Float, sqrt_price_next: sp.Float) -> sp.Float:
+    """ Returns the token out when swapping token zero for one. 
+    """
+    return liquidity * (sqrt_price_current - sqrt_price_next)
+
+def get_expected_token_in(liquidity: sp.Float, sqrt_price_current: sp.Float, sqrt_price_next: sp.Float):
+    """ Returns the expected token in when swapping token zero for one. 
+    """
+    return liquidity * (sqrt_price_current - sqrt_price_next) / (sqrt_price_current * sqrt_price_next)
+
+def calc_test_case(liquidity: sp.Float, sqrt_price_current: sp.Float, token_in: sp.Float, swap_fee: sp.Float) -> Tuple[sp.Float, sp.Float, sp.Float]:
+    """ Computes and prints all zero for one test case parameters. Next sqrt price is computed from the given parameters.
+
+    Returns the next square root price, token out and fee amount per share.
+    """
+    sqrt_price_next = get_next_sqrt_price(liquidity, sqrt_price_current, token_in, swap_fee)
+    token_out = get_token_out(liquidity, sqrt_price_current, sqrt_price_next)
+    fee_amount_per_share = get_fee_amount_per_share(token_in, swap_fee, liquidity)
+
+    print(F"current sqrt price: {sqrt_price_current}")
+    print(F"sqrt_price_next: {sqrt_price_next}")
+    print(F"liquidity: {liquidity}")
+    print(F"token_out: {token_out}")
+    print(F"fee_amount_per_share: {fee_amount_per_share}")
+
+    return sqrt_price_next, token_out, fee_amount_per_share
+
+def calc_test_case_with_next_sqrt_price(liquidity: sp.Float, sqrt_price_current: sp.Float, sqrt_price_next: sp.Float, swap_fee: sp.Float) -> Tuple[sp.Float, sp.Float, sp.Float]:
+    """ Computes and prints all zero for one test case parameters when next square root price is known.
+    
+    Returns the expected token in, token out and fee amount per share. 
+    """
+    expected_token_in_before_fee = get_expected_token_in(liquidity, sqrt_price_current, sqrt_price_next)
+    expected_token_in = expected_token_in_before_fee * (1 + swap_fee)
+
+    token_out = get_token_out(liquidity, sqrt_price_current, sqrt_price_next)
+    fee_amount_per_share = get_fee_amount_per_share(expected_token_in_before_fee, swap_fee, liquidity)
+
+    print(F"current sqrt price: {sqrt_price_current}")
+    print(F"given sqrt_price_next: {sqrt_price_next}")
+    print(F"liquidity: {liquidity}")
+    print(F"expected_token_in: {expected_token_in}")
+    print(F"token_out: {token_out}")
+    print(F"fee_amount_per_share: {fee_amount_per_share}")
+
+    return expected_token_in, token_out, fee_amount_per_share
+   

--- a/x/concentrated-liquidity/architecture.md
+++ b/x/concentrated-liquidity/architecture.md
@@ -787,8 +787,9 @@ of positions. As a result, there is a different accumulator-based mechanism for 
 of and storing the fees.
 
 First, note that the fees are collected in tokens themselves rather than in units of liquidity.
-Thus, we need two accumulators for each token. Temporally, these fee accumulators are accessed together
-from state most of the time. Therefore, we define a data structure for storing the fees of each token in the pool.
+Thus, we need two accumulators for each token.
+
+TODO: explain the `accum` package and how it is used in CL
 
 ```go
 // Note that this is proto-generated.
@@ -819,8 +820,7 @@ type Pool struct {
 ```
 
 Each pool is initialized with an immutable fee value `SwapFee` to be paid by
-the swappers. It is denominated in units of hundredths of a basis point `0.0001%`.
-// TODO: from uniswap whitepaper. What is the reason for this denomination?
+the swappers.
 
 `FeeGrowthGlobalOutside` represents the total amount of fees that have been earned
 per unit of virtual liquidity in each token `L` from the time of the creation of the pool.
@@ -1023,6 +1023,39 @@ Here, `tokenInAmtAfterFee` is delta x.
 
 Once we have the updated square root price, we can calculate the amount of `tokenOut` to be returned.
 The returned `tokenOut` is computed with fees accounted for given that we used `tokenInAmtAfterFee`.
+
+##### Swap Step Fees
+
+We have a notion of `swapState.amountSpecifiedRemaining` which  is the amount of token in
+remaining over all swap steps.
+
+After performing the current swap step, the following cases are possible:
+
+1. All amount remaining is consumed
+
+In that case, the fee is equal to the difference between the original amount remaining
+and the one actually consumed. The difference between them is the fee.
+
+```go
+feeChargeTotal = amountSpecifiedRemaining.Sub(amountIn) 
+```
+
+2. Did not consume amount remaining in-full.
+
+The fee is charged on the amount actually consumed during a swap step.
+
+```go
+feeChargeTotal = amountIn.Mul(swapFee) 
+```
+
+3. Price impact protection makes it exit before consuming all amount remaining.
+
+The fee is charged on the amount in actually consumed before price impact
+protection got trigerred.
+
+```go
+feeChargeTotal = amountIn.Mul(swapFee) 
+```
 
 #### Liquidity Rewards
 

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -255,3 +255,45 @@ func calculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, current
 func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick, upperTick int64) string {
 	return strings.Join([]string{strconv.FormatUint(poolId, uintBase), owner.String(), strconv.FormatInt(lowerTick, uintBase), strconv.FormatInt(upperTick, uintBase)}, keySeparator)
 }
+
+// computeFeeChargePerStep returns the total fee charge per swap step given the parameters.
+// - currentSqrtPrice the sqrt price at which the swap step begins.
+// - nextSqrtPrice the sqrt price at which the swap step should end.
+// - sqrtPriceLimit the sqrt price corresponding to the sqrt of the price representing price impact protection.
+// - amountIn the amount of token in to be consumed during the swap step
+// - amountSpecifiedRemaining is the total remaining amount of token in that needs to be consumed to complete the swap.
+// - swapFee the swap fee to be charged.
+//
+// If swap fee is negative, it panics.
+// If swap fee is 0, returns 0. Otherwise, computes and returns the fee charge per step.
+// TODO: test this function.
+func computeFeeChargePerStep(currentSqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
+	feeChargeTotal := sdk.ZeroDec()
+
+	if swapFee.IsNegative() {
+		// This should never happen but is added as a defense-in-depth measure.
+		panic(fmt.Errorf("swap fee must be non-negative, was (%s)", swapFee))
+	}
+
+	if swapFee.IsZero() {
+		return feeChargeTotal
+	}
+
+	// 1. The current tick does not have enough liqudity to fulfill the swap.
+	didReachNextSqrtPrice := nextSqrtPrice.Equal(currentSqrtPrice)
+	// 2. The next sqrt price was not reached due to price impact protection.
+	isPriceImpactProtection := currentSqrtPrice.Equal(sqrtPriceLimit)
+
+	// In both cases, charge fee on the full amount that the tick
+	// originally had.
+	if didReachNextSqrtPrice || isPriceImpactProtection {
+		feeChargeTotal = amountIn.Mul(swapFee)
+	} else {
+		// Otherwise, the current tick had enough liquidity to fulfill the swap
+		// In that case, the fee is the difference between
+		// the amount needed to fulfill and the actual amount we ended up charging.
+		feeChargeTotal = amountSpecifiedRemaining.Sub(amountIn)
+	}
+
+	return feeChargeTotal
+}

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -258,7 +258,7 @@ func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick
 
 // computeFeeChargePerSwapStep returns the total fee charge per swap step given the parameters.
 // - currentSqrtPrice the sqrt price at which the swap step begins.
-// - nextSqrtPrice the sqrt price at which the swap step should end.
+// - nextTickSqrtPrice the next tick's sqrt price.
 // - sqrtPriceLimit the sqrt price corresponding to the sqrt of the price representing price impact protection.
 // - amountIn the amount of token in to be consumed during the swap step
 // - amountSpecifiedRemaining is the total remaining amount of token in that needs to be consumed to complete the swap.
@@ -267,7 +267,7 @@ func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick
 // If swap fee is negative, it panics.
 // If swap fee is 0, returns 0. Otherwise, computes and returns the fee charge per step.
 // TODO: test this function.
-func computeFeeChargePerSwapStep(currentSqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
+func computeFeeChargePerSwapStep(currentSqrtPrice, nextTickSqrtPrice, sqrtPriceLimit, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
 	feeChargeTotal := sdk.ZeroDec()
 
 	if swapFee.IsNegative() {
@@ -280,9 +280,9 @@ func computeFeeChargePerSwapStep(currentSqrtPrice, nextSqrtPrice, sqrtPriceLimit
 	}
 
 	// 1. The current tick does not have enough liqudity to fulfill the swap.
-	didReachNextSqrtPrice := nextSqrtPrice.Equal(currentSqrtPrice)
+	didReachNextSqrtPrice := currentSqrtPrice.Equal(nextTickSqrtPrice)
 	// 2. The next sqrt price was not reached due to price impact protection.
-	isPriceImpactProtection := sqrtPriceLimit.Equal(currentSqrtPrice)
+	isPriceImpactProtection := currentSqrtPrice.Equal(sqrtPriceLimit)
 
 	// In both cases, charge fee on the full amount that the tick
 	// originally had.

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -256,7 +256,7 @@ func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick
 	return strings.Join([]string{strconv.FormatUint(poolId, uintBase), owner.String(), strconv.FormatInt(lowerTick, uintBase), strconv.FormatInt(upperTick, uintBase)}, keySeparator)
 }
 
-// computeFeeChargePerStep returns the total fee charge per swap step given the parameters.
+// computeFeeChargePerSwapStep returns the total fee charge per swap step given the parameters.
 // - currentSqrtPrice the sqrt price at which the swap step begins.
 // - nextSqrtPrice the sqrt price at which the swap step should end.
 // - sqrtPriceLimit the sqrt price corresponding to the sqrt of the price representing price impact protection.
@@ -267,7 +267,7 @@ func formatPositionAccumulatorKey(poolId uint64, owner sdk.AccAddress, lowerTick
 // If swap fee is negative, it panics.
 // If swap fee is 0, returns 0. Otherwise, computes and returns the fee charge per step.
 // TODO: test this function.
-func computeFeeChargePerStep(currentSqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
+func computeFeeChargePerSwapStep(currentSqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
 	feeChargeTotal := sdk.ZeroDec()
 
 	if swapFee.IsNegative() {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -282,7 +282,7 @@ func computeFeeChargePerSwapStep(currentSqrtPrice, nextSqrtPrice, sqrtPriceLimit
 	// 1. The current tick does not have enough liqudity to fulfill the swap.
 	didReachNextSqrtPrice := nextSqrtPrice.Equal(currentSqrtPrice)
 	// 2. The next sqrt price was not reached due to price impact protection.
-	isPriceImpactProtection := currentSqrtPrice.Equal(sqrtPriceLimit)
+	isPriceImpactProtection := sqrtPriceLimit.Equal(currentSqrtPrice)
 
 	// In both cases, charge fee on the full amount that the tick
 	// originally had.

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -10,7 +10,7 @@ import (
 	types "github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/types"
 )
 
-// createPosition creates a concentrated liquidity position in range between lowerTick and upperTick
+// CreatePosition creates a concentrated liquidity position in range between lowerTick and upperTick
 // in a given `PoolId with the desired amount of each token. Since LPs are only allowed to provide
 // liquidity proportional to the existing reserves, the actual amount of tokens used might differ from requested.
 // As a result, LPs may also provide the minimum amount of each token to be used so that the system fails
@@ -95,7 +95,7 @@ func (k Keeper) CreatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	return actualAmount0, actualAmount1, liquidityDelta, nil
 }
 
-// withdrawPosition attempts to withdraw liquidityAmount from a position with the given pool id in the given tick range.
+// WithdrawPosition attempts to withdraw liquidityAmount from a position with the given pool id in the given tick range.
 // On success, returns a positive amount of each token withdrawn.
 // Returns error if
 // - there is no position in the given tick ranges

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -319,7 +319,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 		}
 
 		// Charge fee
-		feeOnFullAmountRemainingIn := swapState.amountSpecifiedRemaining.Mul(swapFee)
+		feeOnAmountRemainingIn := swapState.amountSpecifiedRemaining.Mul(swapFee)
 
 		// utilizing the bucket's liquidity and knowing the price target, we calculate the how much tokenOut we get from the tokenIn
 		// we also calculate the swap state's new sqrtPrice after this swap
@@ -327,7 +327,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 			swapState.sqrtPrice,
 			nextSqrtPrice,
 			swapState.liquidity,
-			swapState.amountSpecifiedRemaining.Sub(feeOnFullAmountRemainingIn),
+			swapState.amountSpecifiedRemaining.Mul(feeOnAmountRemainingIn),
 		)
 
 		feeChargeTotal := computeFeeChargePerSwapStep(sqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, swapState.amountSpecifiedRemaining, swapFee)

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -34,8 +34,6 @@ type SwapState struct {
 func (ss *SwapState) updateFeeGrowthGlobal(feeChargeTotal sdk.Dec) {
 	if !ss.liquidity.IsZero() {
 		feeChargePerUnitOfLiquidity := feeChargeTotal.Quo(ss.liquidity)
-		// TODO: remove print.
-		fmt.Println("feeChargePerUnitOfLiquidity", feeChargePerUnitOfLiquidity)
 		ss.feeGrowthGlobal = ss.feeGrowthGlobal.Add(feeChargePerUnitOfLiquidity)
 	}
 }
@@ -323,9 +321,6 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 		// Charge fee
 		feeOnFullAmountRemainingIn := swapState.amountSpecifiedRemaining.Mul(swapFee)
 
-		// TODO: remove this print.
-		fmt.Println("sqrtPrice before swap step", swapState.sqrtPrice)
-
 		// utilizing the bucket's liquidity and knowing the price target, we calculate the how much tokenOut we get from the tokenIn
 		// we also calculate the swap state's new sqrtPrice after this swap
 		sqrtPrice, amountIn, amountOut := swapStrategy.ComputeSwapStep(
@@ -337,20 +332,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 
 		feeChargeTotal := computeFeeChargePerStep(sqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, swapState.amountSpecifiedRemaining, swapFee)
 
-		// TODO: remove prints.
-		fmt.Println("current sqrtPrice", swapState.sqrtPrice)
-		fmt.Println("next sqrtPrice", sqrtPrice)
-		fmt.Println("liquidity", swapState.liquidity)
-		fmt.Println("amountSpecifiedRemaining", swapState.amountSpecifiedRemaining)
-		fmt.Println("amountIn", amountIn)
-		fmt.Println("amountOut", amountOut)
-
-		fmt.Println("feeChargeTotal", feeChargeTotal)
-
 		swapState.updateFeeGrowthGlobal(feeChargeTotal)
-
-		// TODO: remove print.
-		fmt.Print("\n\n")
 
 		// if the computeSwapStep calculated a sqrtPrice that is equal to the nextSqrtPrice, this means all liquidity in the current
 		// tick has been consumed and we must move on to the next tick to complete the swap

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -327,7 +327,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 			swapState.sqrtPrice,
 			nextSqrtPrice,
 			swapState.liquidity,
-			swapState.amountSpecifiedRemaining.Mul(feeOnAmountRemainingIn),
+			swapState.amountSpecifiedRemaining.Sub(feeOnAmountRemainingIn),
 		)
 
 		feeChargeTotal := computeFeeChargePerSwapStep(sqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, swapState.amountSpecifiedRemaining, swapFee)

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -330,8 +330,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 			swapState.amountSpecifiedRemaining.Sub(feeOnFullAmountRemainingIn),
 		)
 
-		feeChargeTotal := computeFeeChargePerStep(sqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, swapState.amountSpecifiedRemaining, swapFee)
-
+		feeChargeTotal := computeFeeChargePerSwapStep(sqrtPrice, nextSqrtPrice, sqrtPriceLimit, amountIn, swapState.amountSpecifiedRemaining, swapFee)
 		swapState.updateFeeGrowthGlobal(feeChargeTotal)
 
 		// update the swapState with the new sqrtPrice from the above swap

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -179,8 +179,9 @@ var (
 			expectedTick:                      sdk.NewInt(309970),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000132124865162"),
 			// two positions with same liquidity entered
-			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1:             sdk.NewInt(5000000000).MulRaw(2),
+			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
+			poolLiqAmount1: sdk.NewInt(5000000000).MulRaw(2),
+			// tick's accum coins stay same since crossing tick does not occur in this case
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
 		},
@@ -257,7 +258,7 @@ var (
 			// Thus the tick's fee growth is DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
-			// 	//  second positions both have greater tick than the current tick, thus never initialized
+			//  second positions both have greater tick than the current tick, thus never initialized
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 300000, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 305450, expectedFeeGrowth: cl.EmptyCoins},
 			newLowerPrice:                    sdk.NewDec(4000),
@@ -293,7 +294,7 @@ var (
 			// Thus the tick's fee growth is DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
-			// 	//  second positions both have greater tick than the current tick, thus never initialized
+			//  second positions both have greater tick than the current tick, thus never initialized
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 300000, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 305450, expectedFeeGrowth: cl.EmptyCoins},
 			newLowerPrice:                    sdk.NewDec(4000),
@@ -537,7 +538,7 @@ var (
 			newLowerPrice:                     sdk.NewDec(5501),
 			newUpperPrice:                     sdk.NewDec(6250),
 		},
-		// // Slippage protection doesn't cause a failure but interrupts early.
+		// Slippage protection doesn't cause a failure but interrupts early.
 		"single position within one tick, trade completes but slippage protection interrupts trade early: eth -> usdc": {
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
 			tokenOutDenom: "usdc",

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -25,15 +25,17 @@ type SwapOutGivenInTest struct {
 	tokenIn                  sdk.Coin
 	tokenOutDenom            string
 	priceLimit               sdk.Dec
+	swapFee                  sdk.Dec
 	secondPositionLowerPrice sdk.Dec
 	secondPositionUpperPrice sdk.Dec
 
-	expectedTokenIn            sdk.Coin
-	expectedTokenOut           sdk.Coin
-	expectedTick               sdk.Int
-	expectedSqrtPrice          sdk.Dec
-	expectedLowerTickFeeGrowth sdk.DecCoins
-	expectedUpperTickFeeGrowth sdk.DecCoins
+	expectedTokenIn                   sdk.Coin
+	expectedTokenOut                  sdk.Coin
+	expectedTick                      sdk.Int
+	expectedSqrtPrice                 sdk.Dec
+	expectedLowerTickFeeGrowth        sdk.DecCoins
+	expectedUpperTickFeeGrowth        sdk.DecCoins
+	expectedFeeGrowthAccumulatorValue sdk.Dec
 	// since we use different values for the seondary position's tick, save (tick, expectedFeeGrowth) tuple
 	expectedSecondLowerTickFeeGrowth secondPosition
 	expectedSecondUpperTickFeeGrowth secondPosition
@@ -55,6 +57,7 @@ var (
 			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(5004),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity: 		 1517882343.751510418088349649
 			// sqrtPriceNext:    70.738348247484497717 which is 5003.9139127823931095409 https://www.wolframalpha.com/input?i=70.710678118654752440+%2B+42000000+%2F+1517882343.751510418088349649
@@ -68,10 +71,33 @@ var (
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
 		},
+		"fee 1 - single position within one tick: usdc -> eth (1% fee)": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			tokenOutDenom: "eth",
+			priceLimit:    sdk.NewDec(5004),
+			swapFee:       sdk.MustNewDecFromStr("0.01"),
+
+			// params
+			// liquidity:                         1517882343.751510418088349649
+			// sqrtPriceNext:                     70.738071546196200264 which is 5003.9139127814610432508
+			// expectedTokenIn:                   41999999.9999 rounded up
+			// expectedTokenOut:                  8312
+			// expectedFeeGrowthAccumulatorValue: 0.000276701288297452
+			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
+			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(8312)),
+			expectedTick:                      sdk.NewInt(310039),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000276701288297452"),
+			// tick's accum coins stay same since crossing tick does not occur in this case
+			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
+			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
+		},
 		"single position within one tick: eth -> usdc": {
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
 			tokenOutDenom: "usdc",
 			priceLimit:    sdk.NewDec(4993),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity: 		 1517882343.751510418088349649
 			// sqrtPriceNext:    70.6666639108571443311 which is 4993.7773882900395488 https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813370%29%29
@@ -93,6 +119,7 @@ var (
 			tokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			tokenOutDenom:            "eth",
 			priceLimit:               sdk.NewDec(5002),
+			swapFee:                  sdk.ZeroDec(),
 			secondPositionLowerPrice: DefaultLowerPrice,
 			secondPositionUpperPrice: DefaultUpperPrice,
 			// params
@@ -114,6 +141,7 @@ var (
 			tokenIn:                  sdk.NewCoin("eth", sdk.NewInt(13370)),
 			tokenOutDenom:            "usdc",
 			priceLimit:               sdk.NewDec(4996),
+			swapFee:                  sdk.ZeroDec(),
 			secondPositionLowerPrice: DefaultLowerPrice,
 			secondPositionUpperPrice: DefaultUpperPrice,
 			// params
@@ -131,6 +159,31 @@ var (
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
 		},
+		"fee 2 - two positions within one tick: eth -> usdc (3% fee) ": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:                  sdk.NewCoin("eth", sdk.NewInt(13370)),
+			tokenOutDenom:            "usdc",
+			priceLimit:               sdk.NewDec(4996),
+			swapFee:                  sdk.MustNewDecFromStr("0.03"),
+			secondPositionLowerPrice: DefaultLowerPrice,
+			secondPositionUpperPrice: DefaultUpperPrice,
+			// params
+			// liquidity:                         3035764687.503020836176699298
+			// sqrtPriceCurrent:                  70.710678118654752440 which is 5000
+			// given tokenIn:                     13370
+			// expectedTokenOut:                  64824917.7760329489344598324379
+			// expectedFeeGrowthAccumulatorValue: 0.000000132124865162033700093060000008
+			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13370)),
+			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64824917)),
+			expectedTick:                      sdk.NewInt(309970),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000132124865162"),
+			// two positions with same liquidity entered
+			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
+			poolLiqAmount1:             sdk.NewInt(5000000000).MulRaw(2),
+			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
+			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
+		},
 		//  Consecutive price ranges
 
 		//          5000
@@ -141,6 +194,7 @@ var (
 			tokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			tokenOutDenom:            "eth",
 			priceLimit:               sdk.NewDec(6106),
+			swapFee:                  sdk.ZeroDec(),
 			secondPositionLowerPrice: sdk.NewDec(5500),
 			secondPositionUpperPrice: sdk.NewDec(6250),
 			// params
@@ -178,6 +232,7 @@ var (
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			tokenOutDenom: "usdc",
 			priceLimit:    sdk.NewDec(4094),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    67.416615162732695594 which is 4545
@@ -208,8 +263,44 @@ var (
 			newLowerPrice:                    sdk.NewDec(4000),
 			newUpperPrice:                    sdk.NewDec(4545),
 		},
-		//  Partially overlapping price ranges
+		//  Consecutive price ranges
 		//
+		//                     5000
+		//             4545 -----|----- 5500
+		//  4000 ----------- 4545
+		//
+		// Ticks:
+		// position   1:    305450, 315000,
+		// posisition 2:    300000, 305450
+		// current tick: 310000
+		"fee 3 - two positions with consecutive price ranges: eth -> usdc (5% fee)": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:                  sdk.NewCoin("eth", sdk.NewInt(2000000)),
+			tokenOutDenom:            "usdc",
+			priceLimit:               sdk.NewDec(4094),
+			swapFee:                  sdk.MustNewDecFromStr("0.05"),
+			secondPositionLowerPrice: sdk.NewDec(4000),
+			secondPositionUpperPrice: sdk.NewDec(4545),
+			// expectedTokenIn:                   1101304.35717321706748347321599 + 898695.642826782932516526784010 = 2000000 eth
+			// expectedTokenOut:                  4999999999.99999999999999999970 + 3702563350.03654978405015422548 = 8702563350.03654978405015422518 round down = 8702.563350 usdc
+			// expectedFeeGrowthAccumulatorValue: 0.000034550151296760 + 0.0000374851520884196734228699332666 = 0.0000720353033851796734228699332666
+			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(2000000)),
+			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8702563350)),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000072035303385179"),
+			expectedTick:                      sdk.NewInt(301381),
+			// crossing tick happens single time for each upper tick and lower tick.
+			// Thus the tick's fee growth is DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins
+			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
+			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
+			// 	//  second positions both have greater tick than the current tick, thus never initialized
+			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 300000, expectedFeeGrowth: cl.EmptyCoins},
+			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 305450, expectedFeeGrowth: cl.EmptyCoins},
+			newLowerPrice:                    sdk.NewDec(4000),
+			newUpperPrice:                    sdk.NewDec(4545),
+		},
+		//  Partially overlapping price ranges
+
 		//          5000
 		//  4545 -----|----- 5500
 		//        5001 ----------- 6250
@@ -218,6 +309,7 @@ var (
 			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(6056),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    74.161984870956629487 which is 5500
@@ -243,11 +335,35 @@ var (
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
 		},
+		"fee 4 - two positions with partially overlapping price ranges: usdc -> eth (10% fee)": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
+			tokenOutDenom:            "eth",
+			priceLimit:               sdk.NewDec(6056),
+			swapFee:                  sdk.MustNewDecFromStr("0.1"),
+			secondPositionLowerPrice: sdk.NewDec(5001),
+			secondPositionUpperPrice: sdk.NewDec(6250),
+			// expectedTokenIn:  5762545340.40832543134898983723 + 4237454659.59167456865101016277 = 10000000000.0000 = 10000.00 usdc
+			// expectedTokenOut: 2146.28785880640879265591374059 + "1437108.91592757237716789250871 + 269488.274305469529889078712213 = 1708743.47809184831584962713466 eth
+			// expectedFeeGrowthAccumulatorValue: 0.000707071429382580300000000000073 + 0.344423603800805124400000000000 + 0.253197426243519613677553835191 = 0.598328101473707318377553835191
+			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
+			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1708743)),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.598328101473707318"),
+			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
+			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
+			expectedSecondLowerTickFeeGrowth:  secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
+			expectedSecondUpperTickFeeGrowth:  secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
+			expectedTick:                      sdk.NewInt(318432),
+			newLowerPrice:                     sdk.NewDec(5001),
+			newUpperPrice:                     sdk.NewDec(6250),
+		},
 		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc -> eth": {
 
 			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(8500000000)),
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(6056),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    74.161984870956629487 which is 5500
@@ -283,6 +399,7 @@ var (
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			tokenOutDenom: "usdc",
 			priceLimit:    sdk.NewDec(4128),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    67.416615162732695594 which is 4545
@@ -314,6 +431,7 @@ var (
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(1800000)),
 			tokenOutDenom: "usdc",
 			priceLimit:    sdk.NewDec(4128),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    67.416615162732695594 which is 4545
@@ -341,6 +459,28 @@ var (
 			newLowerPrice:                    sdk.NewDec(4000),
 			newUpperPrice:                    sdk.NewDec(4999),
 		},
+		"fee 5 - two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc (0.5% fee)": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:                           sdk.NewCoin("eth", sdk.NewInt(1800000)),
+			tokenOutDenom:                     "usdc",
+			priceLimit:                        sdk.NewDec(4128),
+			swapFee:                           sdk.MustNewDecFromStr("0.005"),
+			secondPositionLowerPrice:          sdk.NewDec(4000),
+			secondPositionUpperPrice:          sdk.NewDec(4999),
+			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(1800000)),
+			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8440821620)),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000005552752757027"),
+			expectedTick:                      sdk.NewInt(302996),
+			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
+			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
+			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
+			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
+			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 300000, expectedFeeGrowth: cl.EmptyCoins},
+			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 309990, expectedFeeGrowth: cl.EmptyCoins},
+			newLowerPrice:                    sdk.NewDec(4000),
+			newUpperPrice:                    sdk.NewDec(4999),
+		},
 		//  Sequential price ranges with a gap
 		//
 		//          5000
@@ -351,6 +491,7 @@ var (
 			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(6106),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    74.161984870956629487 which is 5500
@@ -376,11 +517,32 @@ var (
 			newLowerPrice:                    sdk.NewDec(5501),
 			newUpperPrice:                    sdk.NewDec(6250),
 		},
+		"fee 6 - two sequential positions with a gap (3% fee)": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:                           sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
+			tokenOutDenom:                     "eth",
+			priceLimit:                        sdk.NewDec(6106),
+			secondPositionLowerPrice:          sdk.NewDec(5501),
+			secondPositionUpperPrice:          sdk.NewDec(6250),
+			swapFee:                           sdk.MustNewDecFromStr("0.03"),
+			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
+			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1772029)),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.218688507910948644"),
+			expectedTick:                      sdk.NewInt(320672),
+			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
+			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
+			expectedSecondLowerTickFeeGrowth:  secondPosition{tickIndex: 315010, expectedFeeGrowth: cl.EmptyCoins},
+			expectedSecondUpperTickFeeGrowth:  secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
+			newLowerPrice:                     sdk.NewDec(5501),
+			newUpperPrice:                     sdk.NewDec(6250),
+		},
 		// // Slippage protection doesn't cause a failure but interrupts early.
 		"single position within one tick, trade completes but slippage protection interrupts trade early: eth -> usdc": {
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
 			tokenOutDenom: "usdc",
 			priceLimit:    sdk.NewDec(4994),
+			swapFee:       sdk.ZeroDec(),
 			// params
 			// liquidity: 		 1517882343.751510418088349649
 			// sqrtPriceNext:    70.668238976219012614 which is 4994 https://www.wolframalpha.com/input?i=70.710678118654752440+%2B+42000000+%2F+1517882343.751510418088349649
@@ -393,6 +555,24 @@ var (
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
 		},
+		"fee 7: single position within one tick, trade completes but slippage protection interrupts trade early: eth -> usdc (1% fee)": {
+			// parameters and results of this test case
+			// are estimated by utilizing scripts from scripts/cl/main.py
+			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(13370)),
+			tokenOutDenom: "usdc",
+			priceLimit:    sdk.NewDec(4994),
+			swapFee:       sdk.MustNewDecFromStr("0.01"),
+			// params
+			// liquidity: 		 1517882343.751510418088349649
+			// sqrtPriceNext:    70.668238976219012614 which is 4994
+			// sqrtPriceCurrent: 70.710678118654752440 which is 5000
+			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13020)),
+			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64417624)),
+			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000084929257722"),
+			expectedTick:                      sdk.NewInt(309941),
+			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
+			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
+		},
 	}
 
 	swapOutGivenInErrorCases = map[string]SwapOutGivenInTest{
@@ -400,12 +580,14 @@ var (
 			tokenIn:       sdk.NewCoin("usdc", sdk.NewInt(5300000000)),
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(6000),
+			swapFee:       sdk.ZeroDec(),
 			expectErr:     true,
 		},
 		"single position within one tick, trade does not complete due to lack of liquidity: eth -> usdc": {
 			tokenIn:       sdk.NewCoin("eth", sdk.NewInt(1100000)),
 			tokenOutDenom: "usdc",
 			priceLimit:    sdk.NewDec(4000),
+			swapFee:       sdk.ZeroDec(),
 			expectErr:     true,
 		},
 	}
@@ -423,13 +605,14 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 	}
 
 	for name, test := range tests {
+		test := test
 		s.Run(name, func() {
 			s.Setup()
 			s.FundAcc(s.TestAccs[0], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
 			s.FundAcc(s.TestAccs[1], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
 
 			// Create default CL pool
-			pool := s.PrepareConcentratedPool()
+			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultExponentAtPriceOne, sdk.ZeroDec())
 
 			// manually update fee accumulator for the pool
 			feeAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, 1)
@@ -463,10 +646,12 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 			_, tokenIn, tokenOut, updatedTick, updatedLiquidity, _, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenInInternal(
 				s.Ctx,
 				test.tokenIn, test.tokenOutDenom,
-				DefaultZeroSwapFee, test.priceLimit, pool.GetId())
+				test.swapFee, test.priceLimit, pool.GetId())
 			if test.expectErr {
 				s.Require().Error(err)
 			} else {
+				// writeCtx()
+
 				s.Require().NoError(err)
 
 				// check that tokenIn, tokenOut, tick, and sqrtPrice from CalcOut are all what we expected
@@ -514,7 +699,7 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 			tokenIn, tokenOut, updatedTick, updatedLiquidity, _, err = s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
 				s.Ctx,
 				test.tokenIn, test.tokenOutDenom,
-				DefaultZeroSwapFee, test.priceLimit, pool.GetId())
+				test.swapFee, test.priceLimit, pool.GetId())
 			if test.expectErr {
 				s.Require().Error(err)
 			} else {

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -78,7 +78,6 @@ var (
 			tokenOutDenom: "eth",
 			priceLimit:    sdk.NewDec(5004),
 			swapFee:       sdk.MustNewDecFromStr("0.01"),
-
 			// params
 			// liquidity:                         1517882343.751510418088349649
 			// sqrtPriceNext:                     70.738071546196200264 which is 5003.9139127814610432508
@@ -264,16 +263,6 @@ var (
 			newLowerPrice:                    sdk.NewDec(4000),
 			newUpperPrice:                    sdk.NewDec(4545),
 		},
-		//  Consecutive price ranges
-		//
-		//                     5000
-		//             4545 -----|----- 5500
-		//  4000 ----------- 4545
-		//
-		// Ticks:
-		// position   1:    305450, 315000,
-		// posisition 2:    300000, 305450
-		// current tick: 310000
 		"fee 3 - two positions with consecutive price ranges: eth -> usdc (5% fee)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
@@ -651,8 +640,6 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 			if test.expectErr {
 				s.Require().Error(err)
 			} else {
-				// writeCtx()
-
 				s.Require().NoError(err)
 
 				// check that tokenIn, tokenOut, tick, and sqrtPrice from CalcOut are all what we expected


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR introduces the implementation for swap fees when swapping for amount out given token in.

The test vectors are estimated using the Python `sympy` scripts. The documentation for running the scripts is added.

There are some internal methods that are untested:
- https://github.com/osmosis-labs/osmosis/issues/4087
- https://github.com/osmosis-labs/osmosis/issues/4086

It is best to test them after swap fees in the other direction are complete (ref: https://github.com/osmosis-labs/osmosis/issues/4088). The reason is that we might refactor and remove these methods so it doesn't make sense to spend time adding detailed tests right now. The test coverage via script estimates is sufficient at this stage.

Lastly, there are some prints left in the codebase for development convenience. Removing them is tracked here: https://github.com/osmosis-labs/osmosis/issues/4096

For context, the original implementation was prototyped here: https://github.com/osmosis-labs/osmosis/pull/3893

## Brief Changelog

- implement swap fee for amount out given in
- implement tests with swap fee for all existing edge case tests
   * implement Python scripts to estimate the right values for them
 - refactor with better abstractions

## Testing and Verifying

This change added tests 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable