### PR TITLE
e2e: Write node Docker container logs to a file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,5 +112,21 @@ jobs:
         if: env.GIT_DIFF
       -
         name: Test e2e and Upgrade
-        run: make test-e2e-ci
+        run: make test-e2e-debug
         if: env.GIT_DIFF
+      - 
+        name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+      - 
+        name: Upload logs to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs.tgz
+          path: ./logs.tgz
+        if: failure()

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -258,4 +258,4 @@ This section contains information about debugging osmosis's `e2e` tests.
 
 3. Viewing docker container logs when run osmosis's `e2e` tests in CI
 
-    When a failure occurs in CI, we have persists these log files of all container running as artifacts ####logs.tgz.
+    When a failure occurs in CI, we have persists these log files of all container running as artifacts `logs.tgz.`

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -255,3 +255,7 @@ This section contains information about debugging osmosis's `e2e` tests.
     ```
 
     Example: `docker logs osmo-test-a-node-prune-nothing-snapshot` will print logs emitted by container `osmo-test-a-node-prune-nothing-snapshot` to your standard output.
+
+3. Viewing docker container logs when run osmosis's `e2e` tests in CI
+
+    When a failure occurs in CI, we have persists these log files of all container running as artifacts ####logs.tgz.


### PR DESCRIPTION
Closes: #4045 

## What is the purpose of the change

> Write node Docker container logs to a file, persist as artifacts in CI

## Brief Changelog

  - *Write the docker container logs to a temporary file on the host. Then, persists these log files as artifacts in CI.*
  - *Use `make test-e2e-debug` to skip cleanup container*

## Testing and Verifying
  - *I have tested in fork version [here](https://github.com/anhductn2001/osmosis/actions/runs/4022809583/jobs/6912940242)
