### PR TITLE
[CL: Positions] Add GetPositionsByUserAddress for CL user positions

### DIFF
--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -1,13 +1,9 @@
 package concentrated_liquidity
 
 import (
-	"errors"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/gogo/protobuf/proto"
-
-	"github.com/cosmos/cosmos-sdk/types/address"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v14/x/concentrated-liquidity/model"
@@ -96,18 +92,7 @@ func (k Keeper) GetPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress
 
 // GetUserPositions gets all the existing user positions across many pools.
 func (k Keeper) GetUserPositions(ctx sdk.Context, addr sdk.AccAddress) ([]model.Position, error) {
-	var key []byte
-	key = append(key, types.PositionPrefix...)
-	key = append(key, address.MustLengthPrefix(addr)...)
-	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), key, ParsePositionFromBz)
-}
-
-func ParsePositionFromBz(bz []byte) (position model.Position, err error) {
-	if len(bz) == 0 {
-		return model.Position{}, errors.New("position not found")
-	}
-	err = proto.Unmarshal(bz, &position)
-	return position, err
+	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), types.KeyUserPositions(addr), ParsePositionFromBz)
 }
 
 // ParsePositionFromBz parses bytes into a position struct. Returns a parsed position and nil on success.

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -110,6 +110,8 @@ func ParsePositionFromBz(bz []byte) (position model.Position, err error) {
 	return position, err
 }
 
+// ParsePositionFromBz parses bytes into a position struct. Returns a parsed position and nil on success.
+// Returns error if bytes length is zero or if fails to parse the given bytes into the position struct.
 func (k Keeper) setPosition(ctx sdk.Context,
 	poolId uint64,
 	owner sdk.AccAddress,

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -220,12 +220,13 @@ func (s *KeeperTestSuite) TestGetAllUserPositions() {
 	secondAddress := s.TestAccs[1]
 
 	type position struct {
-		poolId    uint64
-		acc       sdk.AccAddress
-		coin0     sdk.Coin
-		coin1     sdk.Coin
-		lowerTick int64
-		upperTick int64
+		poolId      uint64
+		acc         sdk.AccAddress
+		coin0       sdk.Coin
+		coin1       sdk.Coin
+		lowerTick   int64
+		upperTick   int64
+		frozenUntil time.Duration
 	}
 
 	tests := []struct {
@@ -238,25 +239,25 @@ func (s *KeeperTestSuite) TestGetAllUserPositions() {
 			name:   "Get current user one position",
 			sender: defaultAddress,
 			setupPositions: []position{
-				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick},
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick, DefaultFreezeDuration},
 			},
 		},
 		{
 			name:   "Get current users multiple position same pool",
 			sender: defaultAddress,
 			setupPositions: []position{
-				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick},
-				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 1, DefaultUpperTick + 1},
-				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 2, DefaultUpperTick + 2},
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick, DefaultFreezeDuration},
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 1, DefaultUpperTick + 1, DefaultFreezeDuration},
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 2, DefaultUpperTick + 2, DefaultFreezeDuration},
 			},
 		},
 		{
 			name:   "Get current users multiple position multiple pools",
 			sender: secondAddress,
 			setupPositions: []position{
-				{1, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick},
-				{2, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 1, DefaultUpperTick + 1},
-				{3, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 2, DefaultUpperTick + 2},
+				{1, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick, DefaultFreezeDuration},
+				{2, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 1, DefaultUpperTick + 1, DefaultFreezeDuration},
+				{3, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 2, DefaultUpperTick + 2, DefaultFreezeDuration},
 			},
 		},
 	}
@@ -272,7 +273,7 @@ func (s *KeeperTestSuite) TestGetAllUserPositions() {
 			expectedUserPositions := []model.Position{}
 			for _, pos := range test.setupPositions {
 				// if position does not exist this errors
-				position := s.SetupPosition(pos.poolId, pos.acc, pos.coin0, pos.coin1, pos.lowerTick, pos.upperTick)
+				position := s.SetupPosition(pos.poolId, pos.acc, pos.coin0, pos.coin1, pos.lowerTick, pos.upperTick, s.Ctx.BlockTime().Add(DefaultFreezeDuration))
 				if pos.acc.Equals(pos.acc) {
 					expectedUserPositions = append(expectedUserPositions, position)
 				}

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -215,6 +215,83 @@ func (s *KeeperTestSuite) TestGetPosition() {
 	}
 }
 
+func (s *KeeperTestSuite) TestGetAllUserPosition() {
+	defaultAddress := s.TestAccs[0]
+	secondAddress := s.TestAccs[1]
+
+	type position struct {
+		poolId    uint64
+		acc       sdk.AccAddress
+		coin0     sdk.Coin
+		coin1     sdk.Coin
+		lowerTick int64
+		upperTick int64
+	}
+
+	tests := []struct {
+		name           string
+		sender         sdk.AccAddress
+		setupPositions []position
+		expectedErr    error
+	}{
+		{
+			name:   "Get current user one position",
+			sender: defaultAddress,
+			setupPositions: []position{
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick},
+			},
+		},
+		{
+			name:   "Get current users multiple position same pool",
+			sender: defaultAddress,
+			setupPositions: []position{
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick},
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 1, DefaultUpperTick + 1},
+				{1, defaultAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 2, DefaultUpperTick + 2},
+			},
+		},
+		{
+			name:   "Get current users multiple position multiple pools",
+			sender: secondAddress,
+			setupPositions: []position{
+				{1, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick, DefaultUpperTick},
+				{2, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 1, DefaultUpperTick + 1},
+				{3, secondAddress, DefaultCoin0, DefaultCoin1, DefaultLowerTick + 2, DefaultUpperTick + 2},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// Init suite for each test.
+			s.Setup()
+
+			// Create a default CL pools
+			s.PrepareMultipleConcentratedPools(3)
+
+			expectedUserPositions := []model.Position{}
+			for _, pos := range test.setupPositions {
+				// if position doesnot exist this errors
+				position := s.SetupPosition(pos.poolId, pos.acc, pos.coin0, pos.coin1, pos.lowerTick, pos.upperTick)
+				if pos.acc.Equals(pos.acc) {
+					expectedUserPositions = append(expectedUserPositions, position)
+				}
+			}
+
+			// System under test
+			position, err := s.App.ConcentratedLiquidityKeeper.GetUserPositions(s.Ctx, test.sender)
+			if test.expectedErr != nil {
+				s.Require().Error(err)
+				s.Require().ErrorIs(err, test.expectedErr)
+				s.Require().Nil(position)
+			} else {
+				s.Require().NoError(err)
+				s.Require().Equal(expectedUserPositions, position)
+			}
+		})
+	}
+}
+
 func (s *KeeperTestSuite) TestDeletePosition() {
 	defaultFrozenUntil := s.Ctx.BlockTime().Add(DefaultFreezeDuration)
 	tests := []struct {

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -215,7 +215,7 @@ func (s *KeeperTestSuite) TestGetPosition() {
 	}
 }
 
-func (s *KeeperTestSuite) TestGetAllUserPosition() {
+func (s *KeeperTestSuite) TestGetAllUserPositions() {
 	defaultAddress := s.TestAccs[0]
 	secondAddress := s.TestAccs[1]
 
@@ -271,7 +271,7 @@ func (s *KeeperTestSuite) TestGetAllUserPosition() {
 
 			expectedUserPositions := []model.Position{}
 			for _, pos := range test.setupPositions {
-				// if position doesnot exist this errors
+				// if position does not exist this errors
 				position := s.SetupPosition(pos.poolId, pos.acc, pos.coin0, pos.coin1, pos.lowerTick, pos.upperTick)
 				if pos.acc.Equals(pos.acc) {
 					expectedUserPositions = append(expectedUserPositions, position)

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -79,6 +79,11 @@ func KeyPosition(poolId uint64, addr sdk.AccAddress, lowerTick, upperTick int64)
 	return []byte(fmt.Sprintf("%s%s%s%s%d%s%d%s%d", PositionPrefix, KeySeparator, addrKey, KeySeparator, poolId, KeySeparator, lowerTick, KeySeparator, upperTick))
 }
 
+func KeyUserPositions(addr sdk.AccAddress) []byte {
+	addrKey := address.MustLengthPrefix(addr.Bytes())
+	return []byte(fmt.Sprintf("%s%s%s", PositionPrefix, KeySeparator, addrKey))
+}
+
 func KeyPool(poolId uint64) []byte {
 	return []byte(fmt.Sprintf("%s%d", PoolPrefix, poolId))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#4115](https://github.com/osmosis-labs/osmosis/issues/4115)

## What is the purpose of the change

Currently in CL pools we Getpositions by poolid, userid, lowerTick, upperTick. We also would like to retrieve all current positions across many pools.

## Brief Changelog

- Added new keeper method that retrieves users position


## Testing and Verifying
added tests 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)