### PR TITLE
CL: check denoms match when creating migrate link

### DIFF
--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -143,19 +143,25 @@ func (k Keeper) validateRecords(ctx sdk.Context, records []types.BalancerToConce
 		}
 
 		// Ensure the balancer pools denoms are the same as the concentrated pool denoms
-		balancerPoolAssets := balancerPool.GetTotalPoolLiquidity(ctx)
+		// If clPoolID is 0, this signals a removal, so we skip this check.
+		if record.ClPoolId != 0 {
+			balancerPoolAssets := balancerPool.GetTotalPoolLiquidity(ctx)
 
-		// Type cast PoolI to ConcentratedPoolExtension
-		clPoolExt, ok := clPool.(cltypes.ConcentratedPoolExtension)
-		if !ok {
-			return fmt.Errorf("pool type (%T) cannot be cast to ConcentratedPoolExtension", clPool)
-		}
+			if len(balancerPoolAssets) != 2 {
+				return fmt.Errorf("Balancer pool ID #%d does not contain exactly 2 tokens", record.BalancerPoolId)
+			}
 
-		if balancerPoolAssets.AmountOf(clPoolExt.GetToken0()).IsZero() {
-			return fmt.Errorf("Balancer pool ID #%d does not contain token %s", record.BalancerPoolId, clPoolExt.GetToken0())
-		}
-		if balancerPoolAssets.AmountOf(clPoolExt.GetToken1()).IsZero() {
-			return fmt.Errorf("Balancer pool ID #%d does not contain token %s", record.BalancerPoolId, clPoolExt.GetToken1())
+			clPoolExt, ok := clPool.(cltypes.ConcentratedPoolExtension)
+			if !ok {
+				return fmt.Errorf("pool type (%T) cannot be cast to ConcentratedPoolExtension", clPool)
+			}
+
+			if balancerPoolAssets.AmountOf(clPoolExt.GetToken0()).IsZero() {
+				return fmt.Errorf("Balancer pool ID #%d does not contain token %s", record.BalancerPoolId, clPoolExt.GetToken0())
+			}
+			if balancerPoolAssets.AmountOf(clPoolExt.GetToken1()).IsZero() {
+				return fmt.Errorf("Balancer pool ID #%d does not contain token %s", record.BalancerPoolId, clPoolExt.GetToken1())
+			}
 		}
 
 		lastBalancerPoolID = record.BalancerPoolId

--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -82,6 +82,8 @@ func (k Keeper) SetMigrationInfo(ctx sdk.Context, migrationInfo types.MigrationR
 // validateRecords validates a list of BalancerToConcentratedPoolLink records to ensure that:
 // 1) there are no duplicates
 // 2) both the balancer and gamm pool IDs are valid
+// 3) the balancer pool has exactly two tokens
+// 4) the denoms of the tokens in the balancer pool match the denoms of the tokens in the gamm pool
 // It also reorders records from lowest to highest balancer pool ID if they are not provided in order already.
 func (k Keeper) validateRecords(ctx sdk.Context, records []types.BalancerToConcentratedPoolLink) error {
 	lastBalancerPoolID := uint64(0)

--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -126,7 +126,7 @@ func (k Keeper) validateRecords(ctx sdk.Context, records []types.BalancerToConce
 			return err
 		}
 		poolType := balancerPool.GetType()
-		if poolType.String() != "Balancer" {
+		if poolType != poolmanagertypes.Balancer {
 			return fmt.Errorf("Balancer pool ID #%d is not of type balancer", record.BalancerPoolId)
 		}
 
@@ -139,7 +139,7 @@ func (k Keeper) validateRecords(ctx sdk.Context, records []types.BalancerToConce
 				return err
 			}
 			poolType = clPool.GetType()
-			if poolType.String() != "Concentrated" {
+			if poolType != poolmanagertypes.Concentrated {
 				return fmt.Errorf("Concentrated pool ID #%d is not of type concentrated", record.ClPoolId)
 			}
 

--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -130,10 +130,10 @@ func (k Keeper) validateRecords(ctx sdk.Context, records []types.BalancerToConce
 			return fmt.Errorf("Balancer pool ID #%d is not of type balancer", record.BalancerPoolId)
 		}
 
-		// Ensure the provided ClPoolId exists and that it is of type concentrated.
 		// If clPoolID is 0, this signals a removal, so we skip this check.
 		var clPool poolmanagertypes.PoolI
 		if record.ClPoolId != 0 {
+			// Ensure the provided ClPoolId exists and that it is of type concentrated.
 			clPool, err = k.clKeeper.GetPool(ctx, record.ClPoolId)
 			if err != nil {
 				return err
@@ -142,11 +142,8 @@ func (k Keeper) validateRecords(ctx sdk.Context, records []types.BalancerToConce
 			if poolType.String() != "Concentrated" {
 				return fmt.Errorf("Concentrated pool ID #%d is not of type concentrated", record.ClPoolId)
 			}
-		}
 
-		// Ensure the balancer pools denoms are the same as the concentrated pool denoms
-		// If clPoolID is 0, this signals a removal, so we skip this check.
-		if record.ClPoolId != 0 {
+			// Ensure the balancer pools denoms are the same as the concentrated pool denoms
 			balancerPoolAssets := balancerPool.GetTotalPoolLiquidity(ctx)
 
 			if len(balancerPoolAssets) != 2 {

--- a/x/gamm/keeper/migrate_test.go
+++ b/x/gamm/keeper/migrate_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v14/x/gamm/types"
 )
 
-var (
-	defaultBalancerCoin0 = sdk.NewCoin(ETH, sdk.NewInt(1000000000))
-	defaultBalancerCoin1 = sdk.NewCoin(USDC, sdk.NewInt(1000000000))
-)
-
 func (suite *KeeperTestSuite) TestMigrate() {
 	defaultAccount := suite.TestAccs[0]
 	defaultGammShares := sdk.NewCoin("gamm/pool/1", sdk.MustNewDecFromStr("100000000000000000000").RoundInt())
@@ -357,6 +352,9 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 			suite.SetupTest()
 			keeper := suite.App.GAMMKeeper
 
+			defaultBalancerCoin0 := sdk.NewCoin(ETH, sdk.NewInt(1000000000))
+			defaultBalancerCoin1 := sdk.NewCoin(USDC, sdk.NewInt(1000000000))
+
 			if test.overwriteBalancerDenom0 != "" {
 				defaultBalancerCoin0.Denom = test.overwriteBalancerDenom0
 			}
@@ -611,6 +609,9 @@ func (suite *KeeperTestSuite) TestUpdateMigrationRecords() {
 		suite.Run(test.name, func() {
 			suite.SetupTest()
 			keeper := suite.App.GAMMKeeper
+
+			defaultBalancerCoin0 := sdk.NewCoin(ETH, sdk.NewInt(1000000000))
+			defaultBalancerCoin1 := sdk.NewCoin(USDC, sdk.NewInt(1000000000))
 
 			if test.overwriteBalancerDenom0 != "" {
 				defaultBalancerCoin0.Denom = test.overwriteBalancerDenom0

--- a/x/gamm/keeper/migrate_test.go
+++ b/x/gamm/keeper/migrate_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v14/x/gamm/types"
 )
 
+var (
+	defaultBalancerCoin0 = sdk.NewCoin(ETH, sdk.NewInt(1000000000))
+	defaultBalancerCoin1 = sdk.NewCoin(USDC, sdk.NewInt(1000000000))
+)
+
 func (suite *KeeperTestSuite) TestMigrate() {
 	defaultAccount := suite.TestAccs[0]
 	defaultGammShares := sdk.NewCoin("gamm/pool/1", sdk.MustNewDecFromStr("100000000000000000000").RoundInt())
@@ -352,21 +357,18 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 			suite.SetupTest()
 			keeper := suite.App.GAMMKeeper
 
-			balancerDenom0 := ETH
-			balancerDenom1 := USDC
-
 			if test.overwriteBalancerDenom0 != "" {
-				balancerDenom0 = test.overwriteBalancerDenom0
+				defaultBalancerCoin0.Denom = test.overwriteBalancerDenom0
 			}
 			if test.overwriteBalancerDenom1 != "" {
-				balancerDenom1 = test.overwriteBalancerDenom1
+				defaultBalancerCoin1.Denom = test.overwriteBalancerDenom1
 			}
 
 			// Our testing environment is as follows:
 			// Balancer pool IDs: 1, 2
 			// Concentrated pool IDs: 3, 4
 			for i := 0; i < 2; i++ {
-				poolCoins := sdk.NewCoins(sdk.NewCoin(balancerDenom0, sdk.NewInt(1000000000)), sdk.NewCoin(balancerDenom1, sdk.NewInt(5000000000)))
+				poolCoins := sdk.NewCoins(defaultBalancerCoin0, defaultBalancerCoin1)
 				suite.PrepareBalancerPoolWithCoins(poolCoins...)
 			}
 			for i := 0; i < 2; i++ {
@@ -610,21 +612,18 @@ func (suite *KeeperTestSuite) TestUpdateMigrationRecords() {
 			suite.SetupTest()
 			keeper := suite.App.GAMMKeeper
 
-			balancerDenom0 := ETH
-			balancerDenom1 := USDC
-
 			if test.overwriteBalancerDenom0 != "" {
-				balancerDenom0 = test.overwriteBalancerDenom0
+				defaultBalancerCoin0.Denom = test.overwriteBalancerDenom0
 			}
 			if test.overwriteBalancerDenom1 != "" {
-				balancerDenom1 = test.overwriteBalancerDenom1
+				defaultBalancerCoin1.Denom = test.overwriteBalancerDenom1
 			}
 
 			// Our testing environment is as follows:
 			// Balancer pool IDs: 1, 2, 3, 4
 			// Concentrated pool IDs: 5, 6, 7, 8
 			for i := 0; i < 4; i++ {
-				poolCoins := sdk.NewCoins(sdk.NewCoin(balancerDenom0, sdk.NewInt(1000000000)), sdk.NewCoin(balancerDenom1, sdk.NewInt(5000000000)))
+				poolCoins := sdk.NewCoins(defaultBalancerCoin0, defaultBalancerCoin1)
 				suite.PrepareBalancerPoolWithCoins(poolCoins...)
 			}
 			for i := 0; i < 4; i++ {

--- a/x/gamm/keeper/migrate_test.go
+++ b/x/gamm/keeper/migrate_test.go
@@ -222,11 +222,12 @@ func (suite *KeeperTestSuite) TestMigrate() {
 
 func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 	tests := []struct {
-		name                    string
-		testingMigrationRecords []types.BalancerToConcentratedPoolLink
-		overwriteBalancerDenom0 string
-		overwriteBalancerDenom1 string
-		expectErr               bool
+		name                        string
+		testingMigrationRecords     []types.BalancerToConcentratedPoolLink
+		overwriteBalancerDenom0     string
+		overwriteBalancerDenom1     string
+		createFourAssetBalancerPool bool
+		expectErr                   bool
 	}{
 		{
 			name: "Non existent balancer pool",
@@ -340,6 +341,17 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 			overwriteBalancerDenom1: "uosmo",
 			expectErr:               true,
 		},
+		{
+			name: "Balancer pool has more than two tokens",
+			testingMigrationRecords: []types.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: 5,
+					ClPoolId:       3,
+				},
+			},
+			createFourAssetBalancerPool: true,
+			expectErr:                   true,
+		},
 	}
 
 	for _, test := range tests {
@@ -368,6 +380,10 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 			for i := 0; i < 2; i++ {
 				suite.PrepareCustomConcentratedPool(suite.TestAccs[0], ETH, USDC, defaultTickSpacing, DefaultExponentAtPriceOne, sdk.ZeroDec())
 			}
+			// Four asset balancer pool ID if created: 5
+			if test.createFourAssetBalancerPool {
+				suite.PrepareBalancerPool()
+			}
 
 			err := keeper.ReplaceMigrationRecords(suite.Ctx, test.testingMigrationRecords)
 			if test.expectErr {
@@ -388,14 +404,15 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 
 func (suite *KeeperTestSuite) TestUpdateMigrationRecords() {
 	tests := []struct {
-		name                     string
-		testingMigrationRecords  []types.BalancerToConcentratedPoolLink
-		expectedResultingRecords []types.BalancerToConcentratedPoolLink
-		isPoolPrepared           bool
-		isPreexistingRecordsSet  bool
-		overwriteBalancerDenom0  string
-		overwriteBalancerDenom1  string
-		expectErr                bool
+		name                        string
+		testingMigrationRecords     []types.BalancerToConcentratedPoolLink
+		expectedResultingRecords    []types.BalancerToConcentratedPoolLink
+		isPoolPrepared              bool
+		isPreexistingRecordsSet     bool
+		overwriteBalancerDenom0     string
+		overwriteBalancerDenom1     string
+		createFourAssetBalancerPool bool
+		expectErr                   bool
 	}{
 		{
 			name: "Non existent balancer pool.",
@@ -565,20 +582,6 @@ func (suite *KeeperTestSuite) TestUpdateMigrationRecords() {
 					BalancerPoolId: 1,
 					ClPoolId:       6,
 				},
-				{
-					BalancerPoolId: 2,
-					ClPoolId:       8,
-				},
-			},
-			expectedResultingRecords: []types.BalancerToConcentratedPoolLink{
-				{
-					BalancerPoolId: 1,
-					ClPoolId:       6,
-				},
-				{
-					BalancerPoolId: 2,
-					ClPoolId:       8,
-				},
 			},
 			overwriteBalancerDenom0: "osmo",
 			isPreexistingRecordsSet: false,
@@ -591,24 +594,22 @@ func (suite *KeeperTestSuite) TestUpdateMigrationRecords() {
 					BalancerPoolId: 1,
 					ClPoolId:       6,
 				},
-				{
-					BalancerPoolId: 2,
-					ClPoolId:       8,
-				},
-			},
-			expectedResultingRecords: []types.BalancerToConcentratedPoolLink{
-				{
-					BalancerPoolId: 1,
-					ClPoolId:       6,
-				},
-				{
-					BalancerPoolId: 2,
-					ClPoolId:       8,
-				},
 			},
 			overwriteBalancerDenom1: "osmo",
 			isPreexistingRecordsSet: false,
 			expectErr:               true,
+		},
+		{
+			name: "Balancer pool has more than two tokens",
+			testingMigrationRecords: []types.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: 9,
+					ClPoolId:       6,
+				},
+			},
+			isPreexistingRecordsSet:     false,
+			createFourAssetBalancerPool: true,
+			expectErr:                   true,
 		},
 	}
 
@@ -636,6 +637,10 @@ func (suite *KeeperTestSuite) TestUpdateMigrationRecords() {
 			}
 			for i := 0; i < 4; i++ {
 				suite.PrepareCustomConcentratedPool(suite.TestAccs[0], ETH, USDC, defaultTickSpacing, DefaultExponentAtPriceOne, sdk.ZeroDec())
+			}
+			// Four asset balancer pool ID if created: 9
+			if test.createFourAssetBalancerPool {
+				suite.PrepareBalancerPool()
 			}
 
 			if test.isPreexistingRecordsSet {

--- a/x/gamm/keeper/migrate_test.go
+++ b/x/gamm/keeper/migrate_test.go
@@ -318,10 +318,6 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 					BalancerPoolId: 1,
 					ClPoolId:       3,
 				},
-				{
-					BalancerPoolId: 2,
-					ClPoolId:       4,
-				},
 			},
 			overwriteBalancerDenom0: "uosmo",
 			expectErr:               true,
@@ -332,10 +328,6 @@ func (suite *KeeperTestSuite) TestReplaceMigrationRecords() {
 				{
 					BalancerPoolId: 1,
 					ClPoolId:       3,
-				},
-				{
-					BalancerPoolId: 2,
-					ClPoolId:       4,
 				},
 			},
 			overwriteBalancerDenom1: "uosmo",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is a small patch to prevent migration links from being created between two pools that don't contain the same denoms. It also checks if the balancer pool in question has more than two assets. If it does, it throws an error.

Some tests had to be changed around, since the default balancer pool actually creates a four asset pool! 


## Brief Changelog

- Adds check for balancer pools with more than two assets
- Adds check for balancer pool assets to match cl pool assets
- Adds respective tests to ensure this logic is sound


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)