### PR TITLE
override QueryFnName

### DIFF
--- a/osmoutils/osmocli/query_cmd_wrap.go
+++ b/osmoutils/osmocli/query_cmd_wrap.go
@@ -48,7 +48,6 @@ func QueryIndexCmd(moduleName string) *cobra.Command {
 
 func AddQueryCmd[Q proto.Message, querier any](cmd *cobra.Command, newQueryClientFn func(grpc1.ClientConn) querier, f func() (*QueryDescriptor, Q)) {
 	desc, _ := f()
-	prepareDescriptor[Q](desc)
 	subCmd := BuildQueryCli[Q](desc, newQueryClientFn)
 	cmd.AddCommand(subCmd)
 }

--- a/x/gamm/client/cli/query.go
+++ b/x/gamm/client/cli/query.go
@@ -203,8 +203,9 @@ func GetCmdEstimateSwapExactAmountIn() (*osmocli.QueryDescriptor, *types.QuerySw
 		Short: "Query estimate-swap-exact-amount-in",
 		Long: `Query estimate-swap-exact-amount-in.{{.ExampleHeader}}
 {{.CommandPrefix}} estimate-swap-exact-amount-in 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3`,
-		ParseQuery: EstimateSwapExactAmountInParseArgs,
-		Flags:      osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		ParseQuery:  EstimateSwapExactAmountInParseArgs,
+		Flags:       osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		QueryFnName: "EstimateSwapExactAmountIn",
 	}, &types.QuerySwapExactAmountInRequest{}
 }
 
@@ -216,8 +217,9 @@ func GetCmdEstimateSwapExactAmountOut() (*osmocli.QueryDescriptor, *types.QueryS
 		Short: "Query estimate-swap-exact-amount-out",
 		Long: `Query estimate-swap-exact-amount-out.{{.ExampleHeader}}
 {{.CommandPrefix}} estimate-swap-exact-amount-out 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3`,
-		ParseQuery: EstimateSwapExactAmountOutParseArgs,
-		Flags:      osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		ParseQuery:  EstimateSwapExactAmountOutParseArgs,
+		Flags:       osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		QueryFnName: "EstimateSwapExactAmountIn",
 	}, &types.QuerySwapExactAmountOutRequest{}
 }
 

--- a/x/gamm/client/cli/query.go
+++ b/x/gamm/client/cli/query.go
@@ -41,6 +41,10 @@ func GetQueryCmd() *cobra.Command {
 	return cmd
 }
 
+var customRouterFlagOverride = map[string]string{
+	"router": FlagSwapRouteDenoms,
+}
+
 func GetCmdPool() (*osmocli.QueryDescriptor, *types.QueryPoolRequest) {
 	return &osmocli.QueryDescriptor{
 		Use:   "pool [poolID]",
@@ -203,9 +207,10 @@ func GetCmdEstimateSwapExactAmountIn() (*osmocli.QueryDescriptor, *types.QuerySw
 		Short: "Query estimate-swap-exact-amount-in",
 		Long: `Query estimate-swap-exact-amount-in.{{.ExampleHeader}}
 {{.CommandPrefix}} estimate-swap-exact-amount-in 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3`,
-		ParseQuery:  EstimateSwapExactAmountInParseArgs,
-		Flags:       osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
-		QueryFnName: "EstimateSwapExactAmountIn",
+		ParseQuery:          EstimateSwapExactAmountInParseArgs,
+		Flags:               osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		QueryFnName:         "EstimateSwapExactAmountIn",
+		CustomFlagOverrides: customRouterFlagOverride,
 	}, &types.QuerySwapExactAmountInRequest{}
 }
 
@@ -217,9 +222,10 @@ func GetCmdEstimateSwapExactAmountOut() (*osmocli.QueryDescriptor, *types.QueryS
 		Short: "Query estimate-swap-exact-amount-out",
 		Long: `Query estimate-swap-exact-amount-out.{{.ExampleHeader}}
 {{.CommandPrefix}} estimate-swap-exact-amount-out 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3`,
-		ParseQuery:  EstimateSwapExactAmountOutParseArgs,
-		Flags:       osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
-		QueryFnName: "EstimateSwapExactAmountIn",
+		ParseQuery:          EstimateSwapExactAmountOutParseArgs,
+		Flags:               osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		QueryFnName:         "EstimateSwapExactAmountOut",
+		CustomFlagOverrides: customRouterFlagOverride,
 	}, &types.QuerySwapExactAmountOutRequest{}
 }
 

--- a/x/poolmanager/client/cli/query.go
+++ b/x/poolmanager/client/cli/query.go
@@ -12,6 +12,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v14/x/poolmanager/types"
 )
 
+var customRouterFlagOverride = map[string]string{
+	"router": FlagSwapRouteDenoms,
+}
+
 // GetQueryCmd returns the cli query commands for this module.
 func GetQueryCmd() *cobra.Command {
 	cmd := osmocli.QueryIndexCmd(types.ModuleName)
@@ -30,8 +34,10 @@ func GetCmdEstimateSwapExactAmountIn() (*osmocli.QueryDescriptor, *queryproto.Es
 		Short: "Query estimate-swap-exact-amount-in",
 		Long: `Query estimate-swap-exact-amount-in.{{.ExampleHeader}}
 {{.CommandPrefix}} estimate-swap-exact-amount-in 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3`,
-		ParseQuery: EstimateSwapExactAmountInParseArgs,
-		Flags:      osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		ParseQuery:          EstimateSwapExactAmountInParseArgs,
+		Flags:               osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		QueryFnName:         "EstimateSwapExactAmountIn",
+		CustomFlagOverrides: customRouterFlagOverride,
 	}, &queryproto.EstimateSwapExactAmountInRequest{}
 }
 
@@ -42,8 +48,10 @@ func GetCmdEstimateSwapExactAmountOut() (*osmocli.QueryDescriptor, *queryproto.E
 		Short: "Query estimate-swap-exact-amount-out",
 		Long: `Query estimate-swap-exact-amount-out.{{.ExampleHeader}}
 {{.CommandPrefix}} estimate-swap-exact-amount-out 1 osm11vmx8jtggpd9u7qr0t8vxclycz85u925sazglr7 stake --swap-route-pool-ids=2 --swap-route-pool-ids=3`,
-		ParseQuery: EstimateSwapExactAmountOutParseArgs,
-		Flags:      osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		ParseQuery:          EstimateSwapExactAmountOutParseArgs,
+		Flags:               osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
+		QueryFnName:         "EstimateSwapExactAmountOut",
+		CustomFlagOverrides: customRouterFlagOverride,
 	}, &queryproto.EstimateSwapExactAmountOutRequest{}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4084

## What is the purpose of the change
- Add override QueryFnName for `EstimateSwapExactAmountIn`.`
- We need this override because when adding this query cmd,  function`ParseExpectedQueryFnName`  return SwapExactAmountIn instead of  EstimateSwapExactAmountIn. 
- Also, we have the same issue with  `EstimateSwapExactAmountOut query cmd.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no) no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented) no