### PR TITLE
Replace `docker-build-debug-alpine` to `docker-build-debug` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,10 +304,6 @@ build-e2e-script:
 	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
 docker-build-debug:
-	@DOCKER_BUILDKIT=1 docker build -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug -f Dockerfile .
-	@DOCKER_BUILDKIT=1 docker tag osmosis:${COMMIT} osmosis:debug
-
-docker-build-debug-alpine:
 	@DOCKER_BUILDKIT=1 docker build -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug --build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_ALPINE) -f Dockerfile .
 	@DOCKER_BUILDKIT=1 docker tag osmosis:${COMMIT} osmosis:debug
 


### PR DESCRIPTION
Closes: #2853 

## What is the purpose of the change

> Deprecate docker-build-debug-alpine in Makefile
> Always use the alpine image in debug

## Brief Changelog
Following @p0mvn 's suggestion:

  - Remove docker-build-debug in Makefile
  - Rename docker-build-debug-alpine Makefile step to docker-build-debug