### PR TITLE
fix(poolmanager): register message server

### DIFF
--- a/x/poolmanager/module/module.go
+++ b/x/poolmanager/module/module.go
@@ -81,6 +81,7 @@ type AppModule struct {
 }
 
 func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterMsgServer(cfg.MsgServer(), poolmanager.NewMsgServerImpl(&am.k))
 }
 
 func NewAppModule(poolmanagerKeeper poolmanager.Keeper, gammKeeper types.SwapI) AppModule {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

@iboss-ptk reported having issue with executing pool manager swaps from smart contracts.

Upon more investigation, it was found that we never registered a message server.

After reproducing Boss's issue and adding this line, the problem was gone and swaps msgs continued to execute as expected from cosmwasm.

## Testing and Verifying

Tested manually.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 