### PR TITLE
Add SuperfluidUndelegateAndUnbondLock to CLI

### DIFF
--- a/x/superfluid/client/cli/tx.go
+++ b/x/superfluid/client/cli/tx.go
@@ -26,6 +26,7 @@ func GetTxCmd() *cobra.Command {
 		NewSuperfluidDelegateCmd(),
 		NewSuperfluidUndelegateCmd(),
 		NewSuperfluidUnbondLockCmd(),
+		NewSuperfluidUndelegateAndUnbondLockCmd(),
 		// NewSuperfluidRedelegateCmd(),
 		NewCmdLockAndSuperfluidDelegate(),
 		NewCmdUnPoolWhitelistedPool(),
@@ -83,6 +84,13 @@ func NewSuperfluidUnbondLockCmd() *cobra.Command {
 	return osmocli.BuildTxCli[*types.MsgSuperfluidUnbondLock](&osmocli.TxCliDesc{
 		Use:   "unbond-lock [lock_id] [flags]",
 		Short: "unbond lock that has been superfluid staked",
+	})
+}
+
+func NewSuperfluidUndelegateAndUnbondLockCmd() *cobra.Command {
+	return osmocli.BuildTxCli[*types.MsgSuperfluidUndelegateAndUnbondLock](&osmocli.TxCliDesc{
+		Use:   "undelegate-and-unbond-lock [lock_id] [coin]",
+		Short: "superfluid undelegate and unbond lock for the given amount of coin",
 	})
 }
 


### PR DESCRIPTION
## What is the purpose of the change

Add CLI command for `SuperfluidUndelegateAndUnbondLock`

## Brief Changelog

  - *add CLI  command for `SuperfluidUndelegateAndUnbondLock`*


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)