### PR TITLE
Bump CI go versions to 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             Makefile
       - uses: actions/setup-go@v2.1.4
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
         env:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -20,7 +20,7 @@ jobs:
       - 
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - 
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.4
         with:
-          go-version: 1.18
+          go-version: 1.19
       -
         name: Get git diff
         uses: technote-space/get-diff-action@v6.0.1

--- a/.github/workflows/test-e2e-makefile.yml
+++ b/.github/workflows/test-e2e-makefile.yml
@@ -13,7 +13,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2.2.0
         with:
-          go-version: 1.18
+          go-version: 1.19
       -
         name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         name: Setup Golang
         uses: actions/setup-go@v2.1.4
         with:
-          go-version: 1.18
+          go-version: 1.19
       -
         name: Display go version
         run: go version
@@ -55,7 +55,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2.2.0
         with:
-          go-version: 1.18
+          go-version: 1.19
       -
         name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
In https://github.com/osmosis-labs/osmosis/pull/3947, we introduced a bump of our go version from v1.18 to v1.19. 
This PR changes the existing CI tests so that we also bump CI go versions from 1.18 to 1.19

## Brief Changelog
Bump go versions in CI

## Testing and Verifying
Existing CI passes
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)