### PR TITLE
fix(CL Swaps): remove incorrect price limit constants

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -64,9 +64,9 @@ func (k Keeper) SwapExactAmountIn(
 	// change priceLimit based on which direction we are swapping
 	var priceLimit sdk.Dec
 	if zeroForOne {
-		priceLimit = types.LowerPriceLimit
+		priceLimit = types.MinSpotPrice
 	} else {
-		priceLimit = types.UpperPriceLimit
+		priceLimit = types.MaxSpotPrice
 	}
 	tokenIn, tokenOut, newCurrentTick, newLiquidity, newSqrtPrice, err := k.SwapOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee, priceLimit, pool.GetId())
 	if err != nil {
@@ -117,9 +117,9 @@ func (k Keeper) SwapExactAmountOut(
 	// change priceLimit based on which direction we are swapping
 	var priceLimit sdk.Dec
 	if zeroForOne {
-		priceLimit = types.LowerPriceLimit
+		priceLimit = types.MinSpotPrice
 	} else {
-		priceLimit = types.UpperPriceLimit
+		priceLimit = types.MaxSpotPrice
 	}
 	tokenIn, tokenOut, newCurrentTick, newLiquidity, newSqrtPrice, err := k.SwapInAmtGivenOut(ctx, tokenOut, tokenInDenom, swapFee, priceLimit, pool.GetId())
 	if err != nil {
@@ -251,9 +251,9 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 
 	// if priceLimit not set, set to max/min value based on swap direction
 	if zeroForOne && priceLimit.Equal(sdk.ZeroDec()) {
-		priceLimit = types.LowerPriceLimit
+		priceLimit = types.MinSpotPrice
 	} else if !zeroForOne && priceLimit.Equal(sdk.ZeroDec()) {
-		priceLimit = types.UpperPriceLimit
+		priceLimit = types.MaxSpotPrice
 	}
 
 	// take provided price limit and turn this into a sqrt price limit since formulas use sqrtPrice
@@ -407,9 +407,9 @@ func (k Keeper) calcInAmtGivenOut(
 
 	// if priceLimit not set, set to max/min value based on swap direction
 	if zeroForOne && priceLimit.Equal(sdk.ZeroDec()) {
-		priceLimit = types.LowerPriceLimit
+		priceLimit = types.MinSpotPrice
 	} else if !zeroForOne && priceLimit.Equal(sdk.ZeroDec()) {
-		priceLimit = types.UpperPriceLimit
+		priceLimit = types.MaxSpotPrice
 	}
 
 	// take provided price limit and turn this into a sqrt price limit since formulas use sqrtPrice

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -1420,7 +1420,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 			param: param{
 				tokenIn:           sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 				tokenOutDenom:     ETH,
-				tokenOutMinAmount: types.LowerPriceLimit.RoundInt(),
+				tokenOutMinAmount: types.MinSpotPrice.RoundInt(),
 				expectedTokenOut:  sdk.NewInt(8396),
 			},
 		},
@@ -1435,7 +1435,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 			param: param{
 				tokenIn:           sdk.NewCoin(ETH, sdk.NewInt(13370)),
 				tokenOutDenom:     USDC,
-				tokenOutMinAmount: types.LowerPriceLimit.RoundInt(),
+				tokenOutMinAmount: types.MinSpotPrice.RoundInt(),
 				expectedTokenOut:  sdk.NewInt(66808388),
 			},
 		},
@@ -1453,7 +1453,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 			param: param{
 				tokenIn:           sdk.NewCoin(ETH, sdk.NewInt(13370)),
 				tokenOutDenom:     ETH,
-				tokenOutMinAmount: types.LowerPriceLimit.RoundInt(),
+				tokenOutMinAmount: types.MinSpotPrice.RoundInt(),
 			},
 			expectedErr: types.DenomDuplicatedError{TokenInDenom: ETH, TokenOutDenom: ETH},
 		},
@@ -1462,7 +1462,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 			param: param{
 				tokenIn:           sdk.NewCoin("etha", sdk.NewInt(13370)),
 				tokenOutDenom:     ETH,
-				tokenOutMinAmount: types.LowerPriceLimit.RoundInt(),
+				tokenOutMinAmount: types.MinSpotPrice.RoundInt(),
 			},
 			expectedErr: types.TokenInDenomNotInPoolError{TokenInDenom: "etha"},
 		},
@@ -1471,7 +1471,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 			param: param{
 				tokenIn:           sdk.NewCoin(ETH, sdk.NewInt(13370)),
 				tokenOutDenom:     "etha",
-				tokenOutMinAmount: types.LowerPriceLimit.RoundInt(),
+				tokenOutMinAmount: types.MinSpotPrice.RoundInt(),
 			},
 			expectedErr: types.TokenOutDenomNotInPoolError{TokenOutDenom: "etha"},
 		},
@@ -1568,7 +1568,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 			param: param{
 				tokenOut:         sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 				tokenInDenom:     ETH,
-				tokenInMaxAmount: types.UpperPriceLimit.RoundInt(),
+				tokenInMaxAmount: types.MaxSpotPrice.RoundInt(),
 				expectedTokenIn:  sdk.NewInt(8396),
 			},
 		},
@@ -1583,7 +1583,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 			param: param{
 				tokenOut:         sdk.NewCoin(ETH, sdk.NewInt(13370)),
 				tokenInDenom:     USDC,
-				tokenInMaxAmount: types.UpperPriceLimit.RoundInt(),
+				tokenInMaxAmount: types.MaxSpotPrice.RoundInt(),
 				expectedTokenIn:  sdk.NewInt(66808388),
 			},
 		},
@@ -1592,16 +1592,16 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 			param: param{
 				tokenOut:         sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 				tokenInDenom:     ETH,
-				tokenInMaxAmount: types.LowerPriceLimit.RoundInt(),
+				tokenInMaxAmount: types.MinSpotPrice.RoundInt(),
 			},
-			expectedErr: types.AmountGreaterThanMaxError{TokenAmount: sdk.NewInt(8396), TokenMax: types.LowerPriceLimit.RoundInt()},
+			expectedErr: types.AmountGreaterThanMaxError{TokenAmount: sdk.NewInt(8396), TokenMax: types.MinSpotPrice.RoundInt()},
 		},
 		{
 			name: "in and out denom are same",
 			param: param{
 				tokenOut:         sdk.NewCoin(ETH, sdk.NewInt(13370)),
 				tokenInDenom:     ETH,
-				tokenInMaxAmount: types.UpperPriceLimit.RoundInt(),
+				tokenInMaxAmount: types.MaxSpotPrice.RoundInt(),
 			},
 			expectedErr: types.DenomDuplicatedError{TokenInDenom: ETH, TokenOutDenom: ETH},
 		},
@@ -1610,7 +1610,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 			param: param{
 				tokenOut:         sdk.NewCoin("etha", sdk.NewInt(13370)),
 				tokenInDenom:     ETH,
-				tokenInMaxAmount: types.UpperPriceLimit.RoundInt(),
+				tokenInMaxAmount: types.MaxSpotPrice.RoundInt(),
 			},
 			expectedErr: types.TokenOutDenomNotInPoolError{TokenOutDenom: "etha"},
 		},
@@ -1619,7 +1619,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 			param: param{
 				tokenOut:         sdk.NewCoin(ETH, sdk.NewInt(13370)),
 				tokenInDenom:     "etha",
-				tokenInMaxAmount: types.UpperPriceLimit.RoundInt(),
+				tokenInMaxAmount: types.MaxSpotPrice.RoundInt(),
 			},
 			expectedErr: types.TokenInDenomNotInPoolError{TokenInDenom: "etha"},
 		},

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -12,8 +12,6 @@ var (
 	// we basically want getSqrtRatioAtTick(MIN_TICK)
 	MinSqrtRatio              = sdk.MustNewDecFromStr("0")
 	ConcentratedGasFeeForSwap = 10_000
-	UpperPriceLimit           = sdk.NewDec(999999999999)
-	LowerPriceLimit           = sdk.NewDec(1)
 	ExponentAtPriceOneMax     = sdk.NewInt(-1)
 	ExponentAtPriceOneMin     = sdk.NewInt(-12)
 	MaxSpotPrice              = sdk.MustNewDecFromStr("100000000000000000000000000000000000000")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

`UpperPriceLimit` and `LowerPriceLimit` are incorrect. These values were added while prototyping dynamic tick spacing.

The correct price limits of `MaxSpotPrice ` and `MinSpotPrice` were also added. However, some references to the old limits were left out, causing pre-mature exit of the swap in fee tests because of hitting the wrong limits.

This PR removes the old limits completely.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable