### PR TITLE
chore: re-lower noise in e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
         if: env.GIT_DIFF
       -
         name: Test e2e and Upgrade
-        run: make test-e2e-debug
+        run: make test-e2e-ci
         if: env.GIT_DIFF
       - 
         name: Dump docker logs on failure


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The e2e makefile step was switched to debug, leading to increased noise in CI logs.

Switching back to the correct makefile step with excessive logs disabled
