### PR TITLE
fix(x/twap): geometric twap genesis validation

### DIFF
--- a/x/twap/types/genesis.go
+++ b/x/twap/types/genesis.go
@@ -82,8 +82,8 @@ func (t TwapRecord) validate() error {
 		return fmt.Errorf("twap record p1 accumulator cannot be negative, was (%s)", t.P1ArithmeticTwapAccumulator)
 	}
 
-	if t.GeometricTwapAccumulator.IsNil() || t.GeometricTwapAccumulator.IsNegative() {
-		return fmt.Errorf("twap record geometric accumulator cannot be negative, was (%s)", t.GeometricTwapAccumulator)
+	if t.GeometricTwapAccumulator.IsNil() {
+		return fmt.Errorf("twap record geometric accumulator cannot be nil, was (%s)", t.GeometricTwapAccumulator)
 	}
 	return nil
 }

--- a/x/twap/types/genesis_test.go
+++ b/x/twap/types/genesis_test.go
@@ -73,6 +73,11 @@ func TestGenesisState_Validate(t *testing.T) {
 			})
 	)
 
+	withGeometricAcc := func(record TwapRecord, geometricAcc sdk.Dec) TwapRecord {
+		record.GeometricTwapAccumulator = geometricAcc
+		return record
+	}
+
 	testCases := map[string]struct {
 		twapGenesis *GenesisState
 
@@ -89,6 +94,13 @@ func TestGenesisState_Validate(t *testing.T) {
 		},
 		"valid empty records": {
 			twapGenesis: NewGenesisState(basicParams, []TwapRecord{}),
+		},
+		"valid geometric twap acc is negative": {
+			twapGenesis: NewGenesisState(basicParams, []TwapRecord{withGeometricAcc(baseRecord, sdk.NewDec(-1))}),
+		},
+		"invalid geometric twap acc is nil": {
+			twapGenesis: NewGenesisState(basicParams, []TwapRecord{withGeometricAcc(baseRecord, sdk.Dec{})}),
+			expectedErr: true,
 		},
 		"invalid genesis - pool ID doesn't exist": {
 			twapGenesis: NewGenesisState(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This broke state-exported testnet upgrade.

Geometric twap is allowed to be negative. This PR relaxes the validation and adds tests. 