### PR TITLE
[osmoutils][accum] Make `getPosition` in accumulator package public

### DIFF
--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -151,7 +151,7 @@ func (accum AccumulatorObject) AddToPositionCustomAcc(name string, newShares sdk
 	}
 
 	// Get addr's current position
-	position, err := getPosition(accum, name)
+	position, err := GetPosition(accum, name)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (accum AccumulatorObject) RemoveFromPositionCustomAcc(name string, numShare
 	}
 
 	// Get addr's current position
-	position, err := getPosition(accum, name)
+	position, err := GetPosition(accum, name)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func (accum AccumulatorObject) UpdatePositionCustomAcc(name string, numShares sd
 // Returns nil on success, error otherwise.
 func (accum AccumulatorObject) SetPositionCustomAcc(name string, customAccumulatorValue sdk.DecCoins) error {
 	// Get addr's current position
-	position, err := getPosition(accum, name)
+	position, err := GetPosition(accum, name)
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (accum AccumulatorObject) deletePosition(name string) {
 // GetPositionSize returns the number of shares the position corresponding to `addr`
 // in accumulator `accum` has, or an error if no position exists.
 func (accum AccumulatorObject) GetPositionSize(name string) (sdk.Dec, error) {
-	position, err := getPosition(accum, name)
+	position, err := GetPosition(accum, name)
 	if err != nil {
 		return sdk.Dec{}, err
 	}
@@ -304,7 +304,7 @@ func (accum AccumulatorObject) GetPositionSize(name string) (sdk.Dec, error) {
 // HasPosition returns true if a position with the given name exists,
 // false otherwise. Returns error if internal database error occurs.
 func (accum AccumulatorObject) HasPosition(name string) (bool, error) {
-	_, err := getPosition(accum, name)
+	_, err := GetPosition(accum, name)
 
 	if err != nil {
 		isNoPositionError := errors.Is(err, NoPositionError{Name: name})
@@ -328,7 +328,7 @@ func (accum AccumulatorObject) GetValue() sdk.DecCoins {
 // Returns error if no position exists for the given address. Returns error if any
 // database errors occur.
 func (accum AccumulatorObject) ClaimRewards(positionName string) (sdk.Coins, error) {
-	position, err := getPosition(accum, positionName)
+	position, err := GetPosition(accum, positionName)
 	if err != nil {
 		return sdk.Coins{}, NoPositionError{positionName}
 	}

--- a/osmoutils/accum/accum_helpers.go
+++ b/osmoutils/accum/accum_helpers.go
@@ -23,7 +23,7 @@ func initOrUpdatePosition(accum AccumulatorObject, accumulatorValue sdk.DecCoins
 }
 
 // Gets addr's current position from store
-func getPosition(accum AccumulatorObject, name string) (Record, error) {
+func GetPosition(accum AccumulatorObject, name string) (Record, error) {
 	position := Record{}
 	found, err := osmoutils.Get(accum.store, formatPositionPrefixKey(accum.name, name), &position)
 	if err != nil {

--- a/osmoutils/accum/export_test.go
+++ b/osmoutils/accum/export_test.go
@@ -47,10 +47,6 @@ func CreateRawPosition(accum AccumulatorObject, name string, numShareUnits sdk.D
 	initOrUpdatePosition(accum, accum.value, name, numShareUnits, unclaimedRewards, options)
 }
 
-func GetPosition(accum AccumulatorObject, name string) (Record, error) {
-	return getPosition(accum, name)
-}
-
 // Gets store from accumulator for testing purposes
 func GetStore(accum AccumulatorObject) store.KVStore {
 	return accum.store


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR makes the `getPosition` function in the accum package public. This is so that position records need to be accessed to be properly tested in other modules (e.g. ensuring that new CL positions take on the correct initial accum value).

## Brief Changelog

- Made `getPosition` public

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)