### PR TITLE
chore[CL]: pre-compute min and max ticks

### DIFF
--- a/x/concentrated-liquidity/internal/math/tick.go
+++ b/x/concentrated-liquidity/internal/math/tick.go
@@ -147,13 +147,45 @@ func powTenBigDec(exponent sdk.Int) osmomath.BigDec {
 	return osmomath.OneDec().Quo(osmomath.NewBigDec(10).Power(osmomath.NewBigDec(exponent.Abs().Int64())))
 }
 
-// getMinAndMaxTicksFromExponentAtPriceOne determines min and max ticks allowed for a given exponentAtPriceOne value
+// ComputeMinAndMaxTicksFromExponentAtPriceOneInternal determines min and max ticks allowed for a given exponentAtPriceOne value
 // This allows for a min spot price of 0.000000000000000001 and a max spot price of 100000000000000000000000000000000000000 for every exponentAtPriceOne value
-func GetMinAndMaxTicksFromExponentAtPriceOneInternal(exponentAtPriceOne sdk.Int) (minTick, maxTick int64) {
+func ComputeMinAndMaxTicksFromExponentAtPriceOneInternal(exponentAtPriceOne sdk.Int) (minTick, maxTick int64) {
 	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(exponentAtPriceOne.Neg()))
 	minTick = sdkEighteenDec.Mul(geometricExponentIncrementDistanceInTicks).Neg().RoundInt64()
 	maxTick = sdkThirtyEightDec.Mul(geometricExponentIncrementDistanceInTicks).TruncateInt64()
 	return minTick, maxTick
+}
+
+// GetMinAndMaxTicksFromExponentAtPriceOneInternal retrieves min and max ticks allowed for a given exponentAtPriceOne value
+func GetMinAndMaxTicksFromExponentAtPriceOneInternal(exponentAtPriceOne sdk.Int) (minTick, maxTick int64) {
+	switch exponentAtPriceOne {
+	default:
+		return ComputeMinAndMaxTicksFromExponentAtPriceOneInternal(exponentAtPriceOne)
+	case sdk.NewInt(-12):
+		return types.MinTickNegTwelve, types.MaxTickNegTwelve
+	case sdk.NewInt(-11):
+		return types.MinTickNegEleven, types.MaxTickNegEleven
+	case sdk.NewInt(-10):
+		return types.MinTickNegTen, types.MaxTickNegTen
+	case sdk.NewInt(-9):
+		return types.MinTickNegNine, types.MaxTickNegNine
+	case sdk.NewInt(-8):
+		return types.MinTickNegEight, types.MaxTickNegEight
+	case sdk.NewInt(-7):
+		return types.MinTickNegSeven, types.MaxTickNegSeven
+	case sdk.NewInt(-6):
+		return types.MinTickNegSix, types.MaxTickNegSix
+	case sdk.NewInt(-5):
+		return types.MinTickNegFive, types.MaxTickNegFive
+	case sdk.NewInt(-4):
+		return types.MinTickNegFour, types.MaxTickNegFour
+	case sdk.NewInt(-3):
+		return types.MinTickNegThree, types.MaxTickNegThree
+	case sdk.NewInt(-2):
+		return types.MinTickNegTwo, types.MaxTickNegTwo
+	case sdk.NewInt(-1):
+		return types.MinTickNegOne, types.MaxTickNegOne
+	}
 }
 
 // calculatePriceAndTicksPassed takes in a price and an exponentAtPriceOne, and returns the currentPrice, ticksPassed, and currentAdditiveIncrementInTicks.

--- a/x/concentrated-liquidity/internal/math/tick_test.go
+++ b/x/concentrated-liquidity/internal/math/tick_test.go
@@ -354,3 +354,46 @@ func (suite *ConcentratedMathTestSuite) TestCalculatePriceAndTicksPassed() {
 		})
 	}
 }
+
+func (suite *ConcentratedMathTestSuite) TestGetMinAndMaxTicksFromExponentAtPriceOneInternal() {
+	testCases := map[string]struct {
+		price              sdk.Dec
+		exponentAtPriceOne sdk.Int
+		expectedMinTick    int64
+		expectedMaxTick    int64
+	}{
+		"exponentAtPriceOne = -1": {
+			exponentAtPriceOne: sdk.NewInt(-1),
+			expectedMinTick:    types.MinTickNegOne,
+			expectedMaxTick:    types.MaxTickNegOne,
+		},
+		"exponentAtPriceOne = -6": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			expectedMinTick:    types.MinTickNegSix,
+			expectedMaxTick:    types.MaxTickNegSix,
+		},
+		"exponentAtPriceOne = -12": {
+			exponentAtPriceOne: sdk.NewInt(-12),
+			expectedMinTick:    types.MinTickNegTwelve,
+			expectedMaxTick:    types.MaxTickNegTwelve,
+		},
+		"exponentAtPriceOne = -13 (non pre-computed value)": {
+			exponentAtPriceOne: sdk.NewInt(-13),
+			expectedMinTick: func() int64 {
+				minTick, _ := math.ComputeMinAndMaxTicksFromExponentAtPriceOneInternal(sdk.NewInt(-13))
+				return minTick
+			}(),
+			expectedMaxTick: func() int64 {
+				_, maxTick := math.ComputeMinAndMaxTicksFromExponentAtPriceOneInternal(sdk.NewInt(-13))
+				return maxTick
+			}(),
+		},
+	}
+	for name, tt := range testCases {
+		suite.Run(name, func() {
+			minTick, maxTick := math.GetMinAndMaxTicksFromExponentAtPriceOneInternal(tt.exponentAtPriceOne)
+			suite.Require().Equal(tt.expectedMinTick, minTick)
+			suite.Require().Equal(tt.expectedMaxTick, maxTick)
+		})
+	}
+}

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -6,6 +6,22 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const (
+	// Precomputed values for min and max ticks
+	MinTickNegTwelve, MaxTickNegTwelve int64 = -162000000000000, 342000000000000
+	MinTickNegEleven, MaxTickNegEleven int64 = -16200000000000, 34200000000000
+	MinTickNegTen, MaxTickNegTen       int64 = -1620000000000, 3420000000000
+	MinTickNegNine, MaxTickNegNine     int64 = -162000000000, 342000000000
+	MinTickNegEight, MaxTickNegEight   int64 = -16200000000, 34200000000
+	MinTickNegSeven, MaxTickNegSeven   int64 = -1620000000, 3420000000
+	MinTickNegSix, MaxTickNegSix       int64 = -162000000, 342000000
+	MinTickNegFive, MaxTickNegFive     int64 = -16200000, 34200000
+	MinTickNegFour, MaxTickNegFour     int64 = -1620000, 3420000
+	MinTickNegThree, MaxTickNegThree   int64 = -162000, 342000
+	MinTickNegTwo, MaxTickNegTwo       int64 = -16200, 34200
+	MinTickNegOne, MaxTickNegOne       int64 = -1620, 3420
+)
+
 var (
 	MaxSqrtRatio = sdk.MustNewDecFromStr("18446050711097703529.7763428")
 	// TODO: this is a temp value, figure out math for this.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3986 

## What is the purpose of the change

Right now, we utilize a GetMinAndMaxTicksFromExponentAtPriceOne function to determine the min and max ticks given an exponentAtPriceOne:

https://github.com/osmosis-labs/osmosis/blob/a3f2abbd9235b3b1f8b74c3409fa262c99c9c0a1/x/concentrated-liquidity/internal/math/tick.go#L180-L185

This PR pre-computes the min and max ticks for the allowed exponentAtPriceOne [-1,-12]. The get function fetches these precomputed values, and if the provided exponentAtPriceOne is not one of the authorized values, it calculates it on the fly like before.


## Brief Changelog

- Adds `ComputeMinAndMaxTicksFromExponentAtPriceOneInternal` which on the fly computes min and max ticks
- Modifies `GetMinAndMaxTicksFromExponentAtPriceOneInternal` to fetch pre-computed min and max ticks for authorized exponentsAtPriceOne.
  - For non expected/authorized exponentsAtPriceOne, it utilizes `ComputeMinAndMaxTicksFromExponentAtPriceOneInternal` to calculate it on the fly


## Testing and Verifying

- Adds `TestGetMinAndMaxTicksFromExponentAtPriceOneInternal` in `tick_test.go`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)