### PR TITLE
fix(ci): incorrect e2e images pushed to Docker hub

### DIFF
--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -79,4 +79,15 @@ jobs:
           GIT_COMMIT=${{ github.sha }}
         tags: |
           ${{ env.OSMOSIS_DEV_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
-          ${{ env.OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
+    - 
+      name: Build and Push E2E Init Docker Images
+        uses: docker/build-push-action@v3
+        with:
+          file: tests/e2e/initialization/init.Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            E2E_SCRIPT_NAME=chain
+          tags: |
+            ${{ env.OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -136,42 +136,9 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine
-  e2e-init-chain-images:
-    if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
-    runs-on: ubuntu-latest
-    steps:
       - 
-        name: Check out the repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - 
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - 
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - 
-        name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Parse tag
-        id: tag
-        run: |
-          VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
-          MAJOR_VERSION=$(echo $VERSION | cut -d '.' -f 1)
-          MINOR_VERSION=$(echo $VERSION | cut -d '.' -f 2)
-          PATCH_VERSION=$(echo $VERSION | cut -d '.' -f 3)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "MAJOR_VERSION=$MAJOR_VERSION" >> $GITHUB_ENV
-          echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
-          echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
-      - 
-        name: Build and push 
-        id: build_push_e2e_init_image
+        if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
+        name: Build and push (e2e-chain-init)
         uses: docker/build-push-action@v3
         with:
           file: tests/e2e/initialization/init.Dockerfile


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

In #4317, it was found that we push incorrect e2e init image to Docker hub. Instead of pushing the desired image, we end up pushing regular `osmosis` image.

This PR fixes this in `.github/workflows/push-dev-docker-images.yml` that uses a separate step "Build and Push E2E Init Docker Images" that uses the right Dockerfile, pushing to the right Docker Hub repository.


The change in `.github/workflows/push-docker-images.yml` is passthrough. It simply converts a Github Actions job to a step since all the setup boilerplate is the same between the jobs

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable