### PR TITLE
[Cl:Math] Remove less precise formula

### DIFF
--- a/x/concentrated-liquidity/internal/math/math.go
+++ b/x/concentrated-liquidity/internal/math/math.go
@@ -96,22 +96,15 @@ func CalcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 
 // getNextSqrtPriceFromAmount0RoundingUp utilizes the current squareRootPrice, liquidity of denom0, and amount of denom0 that still needs
 // to be swapped in order to determine the next squareRootPrice
-// TODO: make an issue to determine if we can remove the less precise formula
+// Note: we are using only using the precise formula here.
 func GetNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext sdk.Dec) {
 	if amountRemaining.Equal(sdk.ZeroDec()) {
 		return sqrtPriceCurrent
 	}
 
 	product := amountRemaining.Mul(sqrtPriceCurrent)
-	// use precise formula if product doesn't overflow
-	if (product.Quo(amountRemaining)).Equal(sqrtPriceCurrent) {
-		denominator := liquidity.Add(product)
-		if denominator.GTE(liquidity) {
-			return liquidity.Mul(sqrtPriceCurrent).QuoRoundUp(denominator)
-		}
-	}
-	// if the product does overflow, use less precise formula
-	return liquidity.QuoRoundUp(liquidity.Quo(sqrtPriceCurrent).Add(amountRemaining))
+	denominator := liquidity.Add(product)
+	return liquidity.Mul(sqrtPriceCurrent).QuoRoundUp(denominator)
 }
 
 // getNextSqrtPriceFromAmount1RoundingDown utilizes the current squareRootPrice, liquidity of denom1, and amount of denom1 that still needs


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

[Closes: #3887](https://github.com/osmosis-labs/osmosis/issues/3887)

## What is the purpose of the change

Uni v3 claims these the first of these two formulas is more accurate and the later is used for overflows. We should investigate if this is needed for our implementation.

`sqrtPriceNext = (liquidity * sqrtPriceCurrent) / ((liquidity) + (amountRemaining * sqrtPriceCurrent))`
`sqrtPriceNext = ((liquidity)) / (((liquidity) / (sqrtPriceCurrent)) + (amountRemaining))`

We are only gonna use the top equation


## Brief Changelog
n/a

## Testing and Verifying
all tests run as expected

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)