### PR TITLE
fix(x/twap): incorrect time delta due to nanoseconds in time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#3715](https://github.com/osmosis-labs/osmosis/pull/3715) Fix x/gamm (golang API) CalculateSpotPrice, balancer.SpotPrice and Stableswap.SpotPrice base and quote asset.
 * [#3746](https://github.com/osmosis-labs/osmosis/pull/3746) Make ApplyFuncIfNoErr logic preserve panics for OutOfGas behavior.
 * [#4306](https://github.com/osmosis-labs/osmosis/pull/4306) Prevent adding more tokens to an already finished gauge
+* [#4359](https://github.com/osmosis-labs/osmosis/pull/4359) Fix incorrect time delta due to nanoseconds in time causing twap jitter.
+
 
 ## v14.0.1
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -980,8 +980,6 @@ func (s *IntegrationTestSuite) TestExpeditedProposals() {
 // Upon swapping 1_000_000 uosmo for stake, supply changes, making uosmo less expensive.
 // As a result of the swap, twap changes to 0.5.
 func (s *IntegrationTestSuite) TestGeometricTWAP() {
-	s.T().Skip("TODO: investigate further: https://github.com/osmosis-labs/osmosis/issues/4342")
-
 	const (
 		// This pool contains 1_000_000 uosmo and 2_000_000 stake.
 		// Equals weights.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -709,12 +709,22 @@ func (s *IntegrationTestSuite) TestArithmeticTWAP() {
 	// start time (timeBeforeSwap) is not equal to the block time.
 	chainA.WaitForNumHeights(2)
 
+	timeBeforeSwapEnd := chainANode.QueryLatestBlockTime()
+
+	// timeBeforeSwapStartTwo = right in betweeen timeBeforeSwap and timeBeforeSwapEnd
+	timeBeforeSwapStartTwo := timeBeforeSwap.Add(timeBeforeSwapEnd.Sub(timeBeforeSwap) / 2)
+
+	// Wait longer to make sure that in both series of queries, both do not land
+	// on the current block time with twap end time.
+	chainA.WaitForNumHeights(1)
+
 	s.T().Log("querying for the first TWAP to now before swap")
-	twapFromBeforeSwapToBeforeSwapOneAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap)
+	fmt.Println("timeBeforeSwapEnd ", timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapOneAB, err := chainANode.QueryArithmeticTwap(poolId, denomA, denomB, timeBeforeSwap, timeBeforeSwapEnd)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapOneBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomC, timeBeforeSwap)
+	twapFromBeforeSwapToBeforeSwapOneBC, err := chainANode.QueryArithmeticTwap(poolId, denomB, denomC, timeBeforeSwap, timeBeforeSwapEnd)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapOneCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap)
+	twapFromBeforeSwapToBeforeSwapOneCA, err := chainANode.QueryArithmeticTwap(poolId, denomC, denomA, timeBeforeSwap, timeBeforeSwapEnd)
 	s.Require().NoError(err)
 
 	chainANode.BankSend(coinAIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
@@ -722,11 +732,11 @@ func (s *IntegrationTestSuite) TestArithmeticTWAP() {
 	chainANode.BankSend(coinCIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
 
 	s.T().Log("querying for the second TWAP to now before swap, must equal to first")
-	twapFromBeforeSwapToBeforeSwapTwoAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap.Add(50*time.Millisecond))
+	twapFromBeforeSwapToBeforeSwapTwoAB, err := chainANode.QueryArithmeticTwap(poolId, denomA, denomB, timeBeforeSwapStartTwo, timeBeforeSwapEnd)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapTwoBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomC, timeBeforeSwap.Add(50*time.Millisecond))
+	twapFromBeforeSwapToBeforeSwapTwoBC, err := chainANode.QueryArithmeticTwap(poolId, denomB, denomC, timeBeforeSwapStartTwo, timeBeforeSwapEnd)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapTwoCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap.Add(50*time.Millisecond))
+	twapFromBeforeSwapToBeforeSwapTwoCA, err := chainANode.QueryArithmeticTwap(poolId, denomC, denomA, timeBeforeSwapStartTwo, timeBeforeSwapEnd)
 	s.Require().NoError(err)
 
 	// Since there were no swaps between the two queries, the TWAPs should be the same.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -709,22 +709,12 @@ func (s *IntegrationTestSuite) TestArithmeticTWAP() {
 	// start time (timeBeforeSwap) is not equal to the block time.
 	chainA.WaitForNumHeights(2)
 
-	timeBeforeSwapEnd := chainANode.QueryLatestBlockTime()
-
-	// timeBeforeSwapStartTwo = right in betweeen timeBeforeSwap and timeBeforeSwapEnd
-	timeBeforeSwapStartTwo := timeBeforeSwap.Add(timeBeforeSwapEnd.Sub(timeBeforeSwap) / 2)
-
-	// Wait longer to make sure that in both series of queries, both do not land
-	// on the current block time with twap end time.
-	chainA.WaitForNumHeights(1)
-
 	s.T().Log("querying for the first TWAP to now before swap")
-	fmt.Println("timeBeforeSwapEnd ", timeBeforeSwapEnd)
-	twapFromBeforeSwapToBeforeSwapOneAB, err := chainANode.QueryArithmeticTwap(poolId, denomA, denomB, timeBeforeSwap, timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapOneAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapOneBC, err := chainANode.QueryArithmeticTwap(poolId, denomB, denomC, timeBeforeSwap, timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapOneBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomC, timeBeforeSwap)
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapOneCA, err := chainANode.QueryArithmeticTwap(poolId, denomC, denomA, timeBeforeSwap, timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapOneCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap)
 	s.Require().NoError(err)
 
 	chainANode.BankSend(coinAIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
@@ -732,11 +722,11 @@ func (s *IntegrationTestSuite) TestArithmeticTWAP() {
 	chainANode.BankSend(coinCIn, chainA.NodeConfigs[0].PublicAddress, swapWalletAddr)
 
 	s.T().Log("querying for the second TWAP to now before swap, must equal to first")
-	twapFromBeforeSwapToBeforeSwapTwoAB, err := chainANode.QueryArithmeticTwap(poolId, denomA, denomB, timeBeforeSwapStartTwo, timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapTwoAB, err := chainANode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap.Add(50*time.Millisecond))
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapTwoBC, err := chainANode.QueryArithmeticTwap(poolId, denomB, denomC, timeBeforeSwapStartTwo, timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapTwoBC, err := chainANode.QueryArithmeticTwapToNow(poolId, denomB, denomC, timeBeforeSwap.Add(50*time.Millisecond))
 	s.Require().NoError(err)
-	twapFromBeforeSwapToBeforeSwapTwoCA, err := chainANode.QueryArithmeticTwap(poolId, denomC, denomA, timeBeforeSwapStartTwo, timeBeforeSwapEnd)
+	twapFromBeforeSwapToBeforeSwapTwoCA, err := chainANode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap.Add(50*time.Millisecond))
 	s.Require().NoError(err)
 
 	// Since there were no swaps between the two queries, the TWAPs should be the same.

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -1,7 +1,6 @@
 package twap
 
 import (
-	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -43,9 +42,7 @@ func (k Keeper) GetArithmeticTwap(
 	startTime time.Time,
 	endTime time.Time,
 ) (sdk.Dec, error) {
-	result, err := k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, k.GetArithmeticStrategy())
-	fmt.Print("\n\n\n")
-	return result, err
+	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, k.GetArithmeticStrategy())
 }
 
 func (k Keeper) GetGeometricTwap(
@@ -95,7 +92,6 @@ func (k Keeper) getTwap(
 	if startTime.After(endTime) {
 		return sdk.Dec{}, types.StartTimeAfterEndTimeError{StartTime: startTime, EndTime: endTime}
 	}
-	fmt.Printf("start time (%d), end time (%d), block time (%d)", startTime.UnixMilli(), endTime.UnixMilli(), ctx.BlockTime().UnixMilli())
 	if endTime.Equal(ctx.BlockTime()) {
 		return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, strategy)
 	} else if endTime.After(ctx.BlockTime()) {

--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -1,6 +1,7 @@
 package twap
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -42,7 +43,9 @@ func (k Keeper) GetArithmeticTwap(
 	startTime time.Time,
 	endTime time.Time,
 ) (sdk.Dec, error) {
-	return k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, k.GetArithmeticStrategy())
+	result, err := k.getTwap(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, endTime, k.GetArithmeticStrategy())
+	fmt.Print("\n\n\n")
+	return result, err
 }
 
 func (k Keeper) GetGeometricTwap(
@@ -92,6 +95,7 @@ func (k Keeper) getTwap(
 	if startTime.After(endTime) {
 		return sdk.Dec{}, types.StartTimeAfterEndTimeError{StartTime: startTime, EndTime: endTime}
 	}
+	fmt.Printf("start time (%d), end time (%d), block time (%d)", startTime.UnixMilli(), endTime.UnixMilli(), ctx.BlockTime().UnixMilli())
 	if endTime.Equal(ctx.BlockTime()) {
 		return k.getTwapToNow(ctx, poolId, baseAssetDenom, quoteAssetDenom, startTime, strategy)
 	} else if endTime.After(ctx.BlockTime()) {

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -26,6 +26,7 @@ var (
 	tMinOne                       = baseTime.Add(-time.Second)
 	tPlusOneMin                   = baseTime.Add(time.Minute)
 	basePoolId             uint64 = 1
+	oneHundredNanoseconds         = 100 * time.Nanosecond
 )
 
 type TestSuite struct {
@@ -476,6 +477,11 @@ func withPrice0Set(twapRecord types.TwapRecord, price0ToSet sdk.Dec) types.TwapR
 
 func withPrice1Set(twapRecord types.TwapRecord, price1ToSet sdk.Dec) types.TwapRecord {
 	twapRecord.P1LastSpotPrice = price1ToSet
+	return twapRecord
+}
+
+func withTime(twapRecord types.TwapRecord, time time.Time) types.TwapRecord {
+	twapRecord.Time = time
 	return twapRecord
 }
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -183,18 +183,15 @@ func recordWithUpdatedAccumulators(record types.TwapRecord, newTime time.Time) t
 	}
 	newRecord := record
 	timeDelta := types.CanonicalTimeMs(newTime) - types.CanonicalTimeMs(record.Time)
-	fmt.Println("timeDelta ", timeDelta)
 	newRecord.Time = newTime
 
 	// record.LastSpotPrice is the last spot price from the block the record was created in,
 	// thus it is treated as the effective spot price until the new time.
 	// (As there was no change until at or after this time)
 	p0NewAccum := types.SpotPriceMulDuration(record.P0LastSpotPrice, timeDelta)
-	fmt.Println("p0NewAccum ", p0NewAccum)
 	newRecord.P0ArithmeticTwapAccumulator = newRecord.P0ArithmeticTwapAccumulator.Add(p0NewAccum)
 
 	p1NewAccum := types.SpotPriceMulDuration(record.P1LastSpotPrice, timeDelta)
-	fmt.Println("p1NewAccum ", p1NewAccum)
 	newRecord.P1ArithmeticTwapAccumulator = newRecord.P1ArithmeticTwapAccumulator.Add(p1NewAccum)
 
 	// If the last spot price is zero, then the logarithm is undefined.
@@ -220,9 +217,6 @@ func recordWithUpdatedAccumulators(record types.TwapRecord, newTime time.Time) t
 // If for the record obtained, r.Time == r.LastErrorTime, this will also hold for the interpolated record.
 func (k Keeper) getInterpolatedRecord(ctx sdk.Context, poolId uint64, t time.Time, assetA, assetB string) (types.TwapRecord, error) {
 	record, err := k.getRecordAtOrBeforeTime(ctx, poolId, t, assetA, assetB)
-	fmt.Println("time ", t.UnixMilli())
-	fmt.Println("recordAtOrBeforeTime ", record)
-	fmt.Println("AtOrBeforeTime ", record.Time.UnixMilli())
 	if err != nil {
 		return types.TwapRecord{}, err
 	}
@@ -231,8 +225,6 @@ func (k Keeper) getInterpolatedRecord(ctx sdk.Context, poolId uint64, t time.Tim
 		record.LastErrorTime = t
 	}
 	record = recordWithUpdatedAccumulators(record, t)
-	fmt.Println("recordWithUpdatedAccumulators ", record)
-	fmt.Println("recordWithUpdatedAccumulators time ", record.Time.UnixMilli())
 	return record, nil
 }
 
@@ -241,12 +233,8 @@ func (k Keeper) getMostRecentRecord(ctx sdk.Context, poolId uint64, assetA, asse
 	if err != nil {
 		return types.TwapRecord{}, err
 	}
-	fmt.Println("mostRecentRecordStoreRepresentatione ", record)
-	fmt.Println("mostRecentRecordStoreRepresentatione time ", record.Time.UnixMilli())
 	record = recordWithUpdatedAccumulators(record, ctx.BlockTime())
 
-	fmt.Println("mostRecent recordWithUpdatedAccumulators ", record)
-	fmt.Println("mostRecent recordWithUpdatedAccumulators time ", record.Time.UnixMilli())
 	return record, nil
 }
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -234,7 +234,6 @@ func (k Keeper) getMostRecentRecord(ctx sdk.Context, poolId uint64, assetA, asse
 		return types.TwapRecord{}, err
 	}
 	record = recordWithUpdatedAccumulators(record, ctx.BlockTime())
-
 	return record, nil
 }
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -182,16 +182,19 @@ func recordWithUpdatedAccumulators(record types.TwapRecord, newTime time.Time) t
 		return record
 	}
 	newRecord := record
-	timeDelta := newTime.Sub(record.Time)
+	timeDelta := types.CanonicalTimeMs(newTime) - types.CanonicalTimeMs(record.Time)
+	fmt.Println("timeDelta ", timeDelta)
 	newRecord.Time = newTime
 
 	// record.LastSpotPrice is the last spot price from the block the record was created in,
 	// thus it is treated as the effective spot price until the new time.
 	// (As there was no change until at or after this time)
 	p0NewAccum := types.SpotPriceMulDuration(record.P0LastSpotPrice, timeDelta)
+	fmt.Println("p0NewAccum ", p0NewAccum)
 	newRecord.P0ArithmeticTwapAccumulator = newRecord.P0ArithmeticTwapAccumulator.Add(p0NewAccum)
 
 	p1NewAccum := types.SpotPriceMulDuration(record.P1LastSpotPrice, timeDelta)
+	fmt.Println("p1NewAccum ", p1NewAccum)
 	newRecord.P1ArithmeticTwapAccumulator = newRecord.P1ArithmeticTwapAccumulator.Add(p1NewAccum)
 
 	// If the last spot price is zero, then the logarithm is undefined.
@@ -217,6 +220,9 @@ func recordWithUpdatedAccumulators(record types.TwapRecord, newTime time.Time) t
 // If for the record obtained, r.Time == r.LastErrorTime, this will also hold for the interpolated record.
 func (k Keeper) getInterpolatedRecord(ctx sdk.Context, poolId uint64, t time.Time, assetA, assetB string) (types.TwapRecord, error) {
 	record, err := k.getRecordAtOrBeforeTime(ctx, poolId, t, assetA, assetB)
+	fmt.Println("time ", t.UnixMilli())
+	fmt.Println("recordAtOrBeforeTime ", record)
+	fmt.Println("AtOrBeforeTime ", record.Time.UnixMilli())
 	if err != nil {
 		return types.TwapRecord{}, err
 	}
@@ -225,6 +231,8 @@ func (k Keeper) getInterpolatedRecord(ctx sdk.Context, poolId uint64, t time.Tim
 		record.LastErrorTime = t
 	}
 	record = recordWithUpdatedAccumulators(record, t)
+	fmt.Println("recordWithUpdatedAccumulators ", record)
+	fmt.Println("recordWithUpdatedAccumulators time ", record.Time.UnixMilli())
 	return record, nil
 }
 
@@ -233,7 +241,12 @@ func (k Keeper) getMostRecentRecord(ctx sdk.Context, poolId uint64, assetA, asse
 	if err != nil {
 		return types.TwapRecord{}, err
 	}
+	fmt.Println("mostRecentRecordStoreRepresentatione ", record)
+	fmt.Println("mostRecentRecordStoreRepresentatione time ", record.Time.UnixMilli())
 	record = recordWithUpdatedAccumulators(record, ctx.BlockTime())
+
+	fmt.Println("mostRecent recordWithUpdatedAccumulators ", record)
+	fmt.Println("mostRecent recordWithUpdatedAccumulators time ", record.Time.UnixMilli())
 	return record, nil
 }
 

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -290,6 +290,12 @@ func TestRecordWithUpdatedAccumulators(t *testing.T) {
 			newTime:   defaultRecord.Time.Add(time.Second),
 			expRecord: newExpRecord(oneDec.Add(OneSec), twoDec.Add(OneSec), pointFiveDec),
 		},
+
+		"nanoseconds in time of the original record do not affect final result": {
+			record:    withTime(defaultRecord, defaultRecord.Time.Add(oneHundredNanoseconds)),
+			newTime:   time.Unix(2, 0),
+			expRecord: newExpRecord(oneDec.Add(OneSec.MulInt64(10)), twoDec.Add(OneSec.QuoInt64(10)), pointFiveDec.Add(geometricTenSecAccum)),
+		},
 	}
 
 	for name, test := range tests {

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -47,10 +47,6 @@ func (s *geometric) computeTwap(startRecord types.TwapRecord, endRecord types.Tw
 		return sdk.ZeroDec()
 	}
 
-	// timeDelta := endRecord.Time.Sub(startRecord.Time)
-	// deltaMS := timeDelta.Milliseconds()
-	// arithmeticMeanOfLogPrices := accumDiff.QuoInt64(deltaMS)
-
 	timeDelta := types.CanonicalTimeMs(endRecord.Time) - types.CanonicalTimeMs(startRecord.Time)
 	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
 

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -1,6 +1,8 @@
 package twap
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -34,8 +36,12 @@ func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.T
 	} else {
 		accumDiff = endRecord.P1ArithmeticTwapAccumulator.Sub(startRecord.P1ArithmeticTwapAccumulator)
 	}
-	timeDelta := endRecord.Time.Sub(startRecord.Time)
-	return types.AccumDiffDivDuration(accumDiff, timeDelta)
+	timeDelta := types.CanonicalTimeMs(endRecord.Time) - types.CanonicalTimeMs(startRecord.Time)
+	fmt.Println("accumDiff", accumDiff)
+	fmt.Println("timeDelta", timeDelta)
+	result := types.AccumDiffDivDuration(accumDiff, timeDelta)
+	fmt.Println("twap", result)
+	return result
 }
 
 // computeTwap computes and returns a geometric TWAP between
@@ -47,7 +53,11 @@ func (s *geometric) computeTwap(startRecord types.TwapRecord, endRecord types.Tw
 		return sdk.ZeroDec()
 	}
 
-	timeDelta := endRecord.Time.Sub(startRecord.Time)
+	// timeDelta := endRecord.Time.Sub(startRecord.Time)
+	// deltaMS := timeDelta.Milliseconds()
+	// arithmeticMeanOfLogPrices := accumDiff.QuoInt64(deltaMS)
+
+	timeDelta := types.CanonicalTimeMs(endRecord.Time) - types.CanonicalTimeMs(startRecord.Time)
 	arithmeticMeanOfLogPrices := types.AccumDiffDivDuration(accumDiff, timeDelta)
 
 	exponent := arithmeticMeanOfLogPrices

--- a/x/twap/strategy.go
+++ b/x/twap/strategy.go
@@ -1,8 +1,6 @@
 package twap
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -37,11 +35,7 @@ func (s *arithmetic) computeTwap(startRecord types.TwapRecord, endRecord types.T
 		accumDiff = endRecord.P1ArithmeticTwapAccumulator.Sub(startRecord.P1ArithmeticTwapAccumulator)
 	}
 	timeDelta := types.CanonicalTimeMs(endRecord.Time) - types.CanonicalTimeMs(startRecord.Time)
-	fmt.Println("accumDiff", accumDiff)
-	fmt.Println("timeDelta", timeDelta)
-	result := types.AccumDiffDivDuration(accumDiff, timeDelta)
-	fmt.Println("twap", result)
-	return result
+	return types.AccumDiffDivDuration(accumDiff, timeDelta)
 }
 
 // computeTwap computes and returns a geometric TWAP between

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -146,6 +146,13 @@ func (s *TestSuite) TestComputeArithmeticStrategyTwap() {
 			s, pointOneAccum, tenSecAccum, 100*time.Second, sdk.NewDecWithPrec(1, 1)),
 
 		"accumulator = 10*OneSec, t=100s. 0 base accum (asset 1)": testCaseFromDeltasAsset1(s, sdk.ZeroDec(), OneSec.MulInt64(10), 100*time.Second, sdk.NewDecWithPrec(1, 1)),
+
+		"start record time with nanoseconds does not change result": {
+			startRecord: newOneSidedRecord(baseTime.Add(oneHundredNanoseconds), sdk.ZeroDec(), true),
+			endRecord:   newOneSidedRecord(tPlusOne, OneSec, true),
+			quoteAsset:  denom0,
+			expTwap:     sdk.OneDec(),
+		},
 	}
 	for name, test := range tests {
 		s.Run(name, func() {
@@ -277,6 +284,13 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 			quoteAsset:  denom1,
 
 			expTwap: sdk.ZeroDec(),
+		},
+
+		"start record time with nanoseconds does not change result": {
+			startRecord: newOneSidedGeometricRecord(baseTime.Add(oneHundredNanoseconds), sdk.ZeroDec()),
+			endRecord:   newOneSidedGeometricRecord(tPlusOne, geometricTenSecAccum),
+			quoteAsset:  denom0,
+			expTwap:     sdk.NewDec(10),
 		},
 	}
 

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -62,6 +62,8 @@ func LexicographicalOrderDenoms(denom0, denom1 string) (string, string, error) {
 
 // CanonicalTimeMs returns the canonical time in milliseconds used for twap
 // math computations in UTC. Removes any monotonic clock reading prior to conversion to ms.
+// In twap, we assume all calculations are done in milliseconds. Therefore, this conversion
+// is necessary to make sure that there are no rounding errors.
 func CanonicalTimeMs(twapTime time.Time) int64 {
 	return twapTime.Round(0).UnixMilli()
 }

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -37,16 +37,19 @@ func GetAllUniqueDenomPairs(denoms []string) []DenomPair {
 // SpotPriceMulDuration returns the spot price multiplied by the time delta,
 // that is the spot price between the current and last TWAP record.
 // A single second accounts for 1_000_000_000 when converted to int64.
-func SpotPriceMulDuration(sp sdk.Dec, timeDelta time.Duration) sdk.Dec {
+func SpotPriceMulDuration(sp sdk.Dec, timeDeltaMs int64) sdk.Dec {
+	return sp.MulInt64(timeDeltaMs)
+}
+
+func SpotPriceMulDurationOld(sp sdk.Dec, timeDelta time.Duration) sdk.Dec {
 	deltaMS := timeDelta.Milliseconds()
 	return sp.MulInt64(deltaMS)
 }
 
 // AccumDiffDivDuration returns the accumulated difference divided by the the
 // time delta, that is the spot price between the current and last TWAP record.
-func AccumDiffDivDuration(accumDiff sdk.Dec, timeDelta time.Duration) sdk.Dec {
-	deltaMS := timeDelta.Milliseconds()
-	return accumDiff.QuoInt64(deltaMS)
+func AccumDiffDivDuration(accumDiff sdk.Dec, timeDeltaMs int64) sdk.Dec {
+	return accumDiff.QuoInt64(timeDeltaMs)
 }
 
 // LexicographicalOrderDenoms takes two denoms and returns them to be in lexicographically ascending order.
@@ -60,6 +63,12 @@ func LexicographicalOrderDenoms(denom0, denom1 string) (string, string, error) {
 		denom0, denom1 = denom1, denom0
 	}
 	return denom0, denom1, nil
+}
+
+// CanonicalTimeMs returns the canonical time in milleseconds used for twap
+// math computations in UTC. Removes any monotonic clock reading prior to conversion to ms.
+func CanonicalTimeMs(twapTime time.Time) int64 {
+	return twapTime.Round(0).UnixMilli()
 }
 
 // DenomPair contains pair of assetA and assetB denoms which belong to a pool.

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -41,11 +41,6 @@ func SpotPriceMulDuration(sp sdk.Dec, timeDeltaMs int64) sdk.Dec {
 	return sp.MulInt64(timeDeltaMs)
 }
 
-func SpotPriceMulDurationOld(sp sdk.Dec, timeDelta time.Duration) sdk.Dec {
-	deltaMS := timeDelta.Milliseconds()
-	return sp.MulInt64(deltaMS)
-}
-
 // AccumDiffDivDuration returns the accumulated difference divided by the the
 // time delta, that is the spot price between the current and last TWAP record.
 func AccumDiffDivDuration(accumDiff sdk.Dec, timeDeltaMs int64) sdk.Dec {

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -60,7 +60,7 @@ func LexicographicalOrderDenoms(denom0, denom1 string) (string, string, error) {
 	return denom0, denom1, nil
 }
 
-// CanonicalTimeMs returns the canonical time in milleseconds used for twap
+// CanonicalTimeMs returns the canonical time in milliseconds used for twap
 // math computations in UTC. Removes any monotonic clock reading prior to conversion to ms.
 func CanonicalTimeMs(twapTime time.Time) int64 {
 	return twapTime.Round(0).UnixMilli()

--- a/x/twap/types/utils_test.go
+++ b/x/twap/types/utils_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -65,4 +66,15 @@ func TestLexicographicalOrderDenoms(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCanonicalTimeMs(t *testing.T) {
+	const expectedMs int64 = 2
+
+	newYorkLocation, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	time := time.Unix(0, int64(time.Millisecond+999999+1)).In(newYorkLocation)
+
+	actualTime := CanonicalTimeMs(time)
+	require.Equal(t, expectedMs, actualTime)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4342

## What is the purpose of the change

This PR fixes twap jitter that is caused by nanoseconds being accounted for in the time delta calculations.

In twap, we assume the time delta in milliseconds. However, the block time is given in nanoseconds. As a result, there were some cases such as:
```go
timeDelta := endRecord.Time.Sub(startRecord.Time)
```
where if `startRecord.Time` contained just a few nanoseconds, it would cause the timeDelta to fall by 1 ms below the expected value, causing a larger denominator in arithmetic mean computations. This would lead the final twap being off in the 10^-4-10^-2 digit.

To fix this, a function `types.CanonicalTimeMs` is introduced that converts the time stored in state into unix milliseconds with monotonic clock stripped away. This is consistent with how [CometBFT handles time](https://github.com/osmosis-labs/tendermint/blob/167fa738a379147f333b86f539bc03f597b978e5/libs/time/time.go#L17).

## Brief Changelog

- observed random failures in e2e twap tests in #4244 
- debugged with various logs added and manual Python recomputation of every step
- observed problems related to nanoseconds when computing time delta
- reproduced in unit tests
- refactored to strip away nanoseconds with the use of  `types.CanonicalTimeMs` function


## Testing and Verifying

This change added tests and is covered by e2e

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable