### PR TITLE
Set proper wasm bytecode size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Misc Improvements
   * [#4131](https://github.com/osmosis-labs/osmosis/pull/4141) Add GatherValuesFromStorePrefixWithKeyParser function to osmoutils.
+  * [#4388](https://github.com/osmosis-labs/osmosis/pull/4388) Increase the max allowed contract size for non-proposal contracts to 3MB
 
 ### API breaks
 

--- a/app/app.go
+++ b/app/app.go
@@ -164,7 +164,7 @@ func initReusablePackageInjections() {
 //   - allow for larger wasm files
 func overrideWasmVariables() {
 	// Override Wasm size limitation from WASMD.
-	wasmtypes.MaxWasmSize = 2 * 1024 * 1024
+	wasmtypes.MaxWasmSize = 3 * 1024 * 1024
 	wasmtypes.MaxProposalWasmSize = wasmtypes.MaxWasmSize
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

https://github.com/osmosis-labs/osmosis/pull/4174 changed the maximum bytecode size to 2MB. I didn't realize at the time that the max size for wasm upload via proposals was already set to 3MB, so that change actually "decreesed" the maximum allowed bytecode size for mainnet (since most contracts are uploaded via proposals) and only increased it for the testnet and allowed uploaders.

## What is the purpose of the change

This change sets the wasm bytecode size to 3MB for both proposals and allowed wallets. 


## Brief Changelog

All stored contract codes have a maximum of 3MB now

## Testing and Verifying
all tests pass

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes /)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes /)
  - How is the feature or change documented? (not applicable)