### PR TITLE
test(e2e): upgrade e2e init image for Stride migration

### DIFF
--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -27,7 +27,7 @@ const (
 	previousVersionOsmoTag        = "v14.x-4d4583fa-1676370337"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "debug"
+	previousVersionInitTag        = "v14.x-19e3b252-1677104825-manual"
 	// Hermes repo/version for relayer
 	relayerRepository = "informalsystems/hermes"
 	relayerTag        = "1.2.0"

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -27,7 +27,7 @@ const (
 	previousVersionOsmoTag        = "v14.x-4d4583fa-1676370337"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "v14.x-937d601e-1676550460-manual"
+	previousVersionInitTag        = "debug"
 	// Hermes repo/version for relayer
 	relayerRepository = "informalsystems/hermes"
 	relayerTag        = "1.2.0"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1121,10 +1121,6 @@ func (s *IntegrationTestSuite) TestGeometricTWAP() {
 // This test is to be re-enabled for upgrade once the upgrade handler logic is added and
 // the balancer pool genesis is backported to v14.
 func (s *IntegrationTestSuite) TestStridePoolMigration() {
-	if !s.skipUpgrade {
-		s.T().Skip("skipping, to enable when upgrade handler is updates with migration")
-	}
-
 	const (
 		// Configurations for tests/e2e/scripts/pool1A.json
 		// This pool gets initialized pre-upgrade.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Updating previous (V14) e2e chain init Docker image to apply genesis changes from #4393 needed for #4384
