### PR TITLE
fix(e2e): typo when skipping TestStridePoolMigration locally

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1097,7 +1097,7 @@ func (s *IntegrationTestSuite) TestGeometricTWAP() {
 // the balancer pool genesis is backported to v14.
 func (s *IntegrationTestSuite) TestStridePoolMigration() {
 	if s.skipUpgrade {
-		s.T().Log("Skipping migration test when upgrade is disable. This test depends on running v15 upgrade handler.")
+		s.T().Skip("Skipping migration test when upgrade is disable. This test depends on running v15 upgrade handler.")
 	}
 
 	const (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixing typo when skipping test
