### PR TITLE
[TokenFactory] Add `ForceTranfer`, `BurnFrom` and `MintTo`

### DIFF
--- a/proto/osmosis/tokenfactory/v1beta1/tx.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/tx.proto
@@ -17,9 +17,7 @@ service Msg {
       returns (MsgSetDenomMetadataResponse);
   rpc SetBeforeSendHook(MsgSetBeforeSendHook)
       returns (MsgSetBeforeSendHookResponse);
-  // ForceTransfer is deactivated for now because we need to think through edge
-  // cases rpc ForceTransfer(MsgForceTransfer) returns
-  // (MsgForceTransferResponse);
+  rpc ForceTransfer(MsgForceTransfer) returns (MsgForceTransferResponse);
 }
 
 // MsgCreateDenom defines the message structure for the CreateDenom gRPC service
@@ -52,6 +50,8 @@ message MsgMint {
     (gogoproto.moretags) = "yaml:\"amount\"",
     (gogoproto.nullable) = false
   ];
+  string mintToAddress = 3
+      [ (gogoproto.moretags) = "yaml:\"mint_to_address\"" ];
 }
 
 message MsgMintResponse {}
@@ -64,6 +64,8 @@ message MsgBurn {
     (gogoproto.moretags) = "yaml:\"amount\"",
     (gogoproto.nullable) = false
   ];
+  string burnFromAddress = 3
+      [ (gogoproto.moretags) = "yaml:\"burn_from_address\"" ];
 }
 
 message MsgBurnResponse {}
@@ -106,3 +108,17 @@ message MsgSetDenomMetadata {
 // MsgSetDenomMetadataResponse defines the response structure for an executed
 // MsgSetDenomMetadata message.
 message MsgSetDenomMetadataResponse {}
+
+message MsgForceTransfer {
+  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  cosmos.base.v1beta1.Coin amount = 2 [
+    (gogoproto.moretags) = "yaml:\"amount\"",
+    (gogoproto.nullable) = false
+  ];
+  string transferFromAddress = 3
+      [ (gogoproto.moretags) = "yaml:\"transfer_from_address\"" ];
+  string transferToAddress = 4
+      [ (gogoproto.moretags) = "yaml:\"transfer_to_address\"" ];
+}
+
+message MsgForceTransferResponse {}

--- a/x/tokenfactory/keeper/admins_test.go
+++ b/x/tokenfactory/keeper/admins_test.go
@@ -29,11 +29,19 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 	suite.Require().NoError(err)
 	suite.Require().True(bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64() == addr0bal, bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom))
 
-	// // Test force transferring
-	// _, err = suite.msgServer.ForceTransfer(sdk.WrapSDKContext(suite.Ctx), types.NewMsgForceTransfer(suite.TestAccs[0].String(), sdk.NewInt64Coin(denom, 5), suite.TestAccs[1].String(), suite.TestAccs[0].String()))
-	// suite.Require().NoError(err)
-	// suite.Require().True(bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], denom).IsEqual(sdk.NewInt64Coin(denom, 15)))
-	// suite.Require().True(bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[1], denom).IsEqual(sdk.NewInt64Coin(denom, 5)))
+	// Test minting to a different account
+	_, err = suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMintTo(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 10), suite.TestAccs[1].String()))
+	addr1bal += 10
+	suite.Require().NoError(err)
+	suite.Require().True(suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[1], suite.defaultDenom).Amount.Int64() == addr1bal, suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[1], suite.defaultDenom))
+
+	// Test force transferring
+	_, err = suite.msgServer.ForceTransfer(sdk.WrapSDKContext(suite.Ctx), types.NewMsgForceTransfer(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 5), suite.TestAccs[1].String(), suite.TestAccs[0].String()))
+	addr1bal -= 5
+	addr0bal += 5
+	suite.Require().NoError(err)
+	suite.Require().True(suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64() == addr0bal, suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom))
+	suite.Require().True(suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[1], suite.defaultDenom).Amount.Int64() == addr1bal, suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[1], suite.defaultDenom))
 
 	// Test burning from own account
 	_, err = suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 5)))
@@ -74,113 +82,224 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 // * Only the admin of a denom can mint tokens for it
 // * The admin of a denom can mint tokens for it
 func (suite *KeeperTestSuite) TestMintDenom() {
-	var addr0bal int64
+	balances := make(map[string]int64)
+	for _, acc := range suite.TestAccs {
+		balances[acc.String()] = 0
+	}
 
 	// Create a denom
 	suite.CreateDefaultDenom()
 
 	for _, tc := range []struct {
-		desc      string
-		amount    int64
-		mintDenom string
-		admin     string
-		valid     bool
+		desc       string
+		mintMsg    types.MsgMint
+		expectPass bool
 	}{
 		{
-			desc:      "denom does not exist",
-			amount:    10,
-			mintDenom: "factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/evmos",
-			admin:     suite.TestAccs[0].String(),
-			valid:     false,
+			desc: "denom does not exist",
+			mintMsg: *types.NewMsgMint(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin("factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/evmos", 10),
+			),
+			expectPass: false,
 		},
 		{
-			desc:      "mint is not by the admin",
-			amount:    10,
-			mintDenom: suite.defaultDenom,
-			admin:     suite.TestAccs[1].String(),
-			valid:     false,
+			desc: "mint is not by the admin",
+			mintMsg: *types.NewMsgMintTo(
+				suite.TestAccs[1].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+				suite.TestAccs[0].String(),
+			),
+			expectPass: false,
 		},
 		{
-			desc:      "success case",
-			amount:    10,
-			mintDenom: suite.defaultDenom,
-			admin:     suite.TestAccs[0].String(),
-			valid:     true,
+			desc: "success case - mint to self",
+			mintMsg: *types.NewMsgMint(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+			),
+			expectPass: true,
+		},
+		{
+			desc: "success case - mint to another address",
+			mintMsg: *types.NewMsgMintTo(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+				suite.TestAccs[1].String(),
+			),
+			expectPass: true,
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
-			// Test minting to admins own account
-			bankKeeper := suite.App.BankKeeper
-			_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(tc.admin, sdk.NewInt64Coin(tc.mintDenom, 10)))
-			if tc.valid {
-				addr0bal += 10
+			_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), &tc.mintMsg)
+			if tc.expectPass {
 				suite.Require().NoError(err)
-				suite.Require().Equal(bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64(), addr0bal, bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom))
+				balances[tc.mintMsg.MintToAddress] += tc.mintMsg.Amount.Amount.Int64()
 			} else {
 				suite.Require().Error(err)
 			}
+
+			mintToAddr, _ := sdk.AccAddressFromBech32(tc.mintMsg.MintToAddress)
+			bal := suite.App.BankKeeper.GetBalance(suite.Ctx, mintToAddr, suite.defaultDenom).Amount
+			suite.Require().Equal(bal.Int64(), balances[tc.mintMsg.MintToAddress])
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestBurnDenom() {
-	var addr0bal int64
-
 	// Create a denom.
 	suite.CreateDefaultDenom()
 
-	// mint 10 default token for testAcc[0]
-	suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 10)))
-	addr0bal += 10
+	// mint 1000 default token for all testAccs
+	balances := make(map[string]int64)
+	for _, acc := range suite.TestAccs {
+		_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMintTo(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 1000), acc.String()))
+		suite.Require().NoError(err)
+		balances[acc.String()] = 1000
+	}
 
 	for _, tc := range []struct {
-		desc      string
-		amount    int64
-		burnDenom string
-		admin     string
-		valid     bool
+		desc       string
+		burnMsg    types.MsgBurn
+		expectPass bool
 	}{
 		{
-			desc:      "denom does not exist",
-			amount:    10,
-			burnDenom: "factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/evmos",
-			admin:     suite.TestAccs[0].String(),
-			valid:     false,
+			desc: "denom does not exist",
+			burnMsg: *types.NewMsgBurn(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin("factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/evmos", 10),
+			),
+			expectPass: false,
 		},
 		{
-			desc:      "burn is not by the admin",
-			amount:    10,
-			burnDenom: suite.defaultDenom,
-			admin:     suite.TestAccs[1].String(),
-			valid:     false,
+			desc: "burn is not by the admin",
+			burnMsg: *types.NewMsgBurnFrom(
+				suite.TestAccs[1].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+				suite.TestAccs[0].String(),
+			),
+			expectPass: false,
 		},
 		{
-			desc:      "burn amount is bigger than minted amount",
-			amount:    1000,
-			burnDenom: suite.defaultDenom,
-			admin:     suite.TestAccs[1].String(),
-			valid:     false,
+			desc: "burn more than balance",
+			burnMsg: *types.NewMsgBurn(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10000),
+			),
+			expectPass: false,
 		},
 		{
-			desc:      "success case",
-			amount:    10,
-			burnDenom: suite.defaultDenom,
-			admin:     suite.TestAccs[0].String(),
-			valid:     true,
+			desc: "success case - burn from self",
+			burnMsg: *types.NewMsgBurn(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+			),
+			expectPass: true,
+		},
+		{
+			desc: "success case - burn from another address",
+			burnMsg: *types.NewMsgBurnFrom(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+				suite.TestAccs[1].String(),
+			),
+			expectPass: true,
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
-			// Test minting to admins own account
-			bankKeeper := suite.App.BankKeeper
-			_, err := suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(tc.admin, sdk.NewInt64Coin(tc.burnDenom, 10)))
-			if tc.valid {
-				addr0bal -= 10
+			_, err := suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), &tc.burnMsg)
+			if tc.expectPass {
 				suite.Require().NoError(err)
-				suite.Require().True(bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64() == addr0bal, bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom))
+				balances[tc.burnMsg.BurnFromAddress] -= tc.burnMsg.Amount.Amount.Int64()
 			} else {
 				suite.Require().Error(err)
-				suite.Require().True(bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64() == addr0bal, bankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom))
 			}
+
+			burnFromAddr, _ := sdk.AccAddressFromBech32(tc.burnMsg.BurnFromAddress)
+			bal := suite.App.BankKeeper.GetBalance(suite.Ctx, burnFromAddr, suite.defaultDenom).Amount
+			suite.Require().Equal(bal.Int64(), balances[tc.burnMsg.BurnFromAddress])
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestForceTransferDenom() {
+	// Create a denom.
+	suite.CreateDefaultDenom()
+
+	// mint 1000 default token for all testAccs
+	balances := make(map[string]int64)
+	for _, acc := range suite.TestAccs {
+		_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMintTo(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 1000), acc.String()))
+		suite.Require().NoError(err)
+		balances[acc.String()] = 1000
+	}
+
+	for _, tc := range []struct {
+		desc             string
+		forceTransferMsg types.MsgForceTransfer
+		expectPass       bool
+	}{
+		{
+			desc: "valid force transfer",
+			forceTransferMsg: *types.NewMsgForceTransfer(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+				suite.TestAccs[1].String(),
+				suite.TestAccs[2].String(),
+			),
+			expectPass: true,
+		},
+		{
+			desc: "denom does not exist",
+			forceTransferMsg: *types.NewMsgForceTransfer(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin("factory/osmo1t7egva48prqmzl59x5ngv4zx0dtrwewc9m7z44/evmos", 10),
+				suite.TestAccs[1].String(),
+				suite.TestAccs[2].String(),
+			),
+			expectPass: false,
+		},
+		{
+			desc: "forceTransfer is not by the admin",
+			forceTransferMsg: *types.NewMsgForceTransfer(
+				suite.TestAccs[1].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10),
+				suite.TestAccs[1].String(),
+				suite.TestAccs[2].String(),
+			),
+			expectPass: false,
+		},
+		{
+			desc: "forceTransfer is greater than the balance of",
+			forceTransferMsg: *types.NewMsgForceTransfer(
+				suite.TestAccs[0].String(),
+				sdk.NewInt64Coin(suite.defaultDenom, 10000),
+				suite.TestAccs[1].String(),
+				suite.TestAccs[2].String(),
+			),
+			expectPass: false,
+		},
+	} {
+		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			_, err := suite.msgServer.ForceTransfer(sdk.WrapSDKContext(suite.Ctx), &tc.forceTransferMsg)
+			if tc.expectPass {
+				suite.Require().NoError(err)
+
+				balances[tc.forceTransferMsg.TransferFromAddress] -= tc.forceTransferMsg.Amount.Amount.Int64()
+				balances[tc.forceTransferMsg.TransferToAddress] += tc.forceTransferMsg.Amount.Amount.Int64()
+			} else {
+				suite.Require().Error(err)
+			}
+
+			fromAddr, err := sdk.AccAddressFromBech32(tc.forceTransferMsg.TransferFromAddress)
+			suite.Require().NoError(err)
+			fromBal := suite.App.BankKeeper.GetBalance(suite.Ctx, fromAddr, suite.defaultDenom).Amount
+			suite.Require().True(fromBal.Int64() == balances[tc.forceTransferMsg.TransferFromAddress])
+
+			toAddr, err := sdk.AccAddressFromBech32(tc.forceTransferMsg.TransferToAddress)
+			suite.Require().NoError(err)
+			toBal := suite.App.BankKeeper.GetBalance(suite.Ctx, toAddr, suite.defaultDenom).Amount
+			suite.Require().True(toBal.Int64() == balances[tc.forceTransferMsg.TransferToAddress])
 		})
 	}
 }

--- a/x/tokenfactory/keeper/bankactions.go
+++ b/x/tokenfactory/keeper/bankactions.go
@@ -51,7 +51,6 @@ func (k Keeper) burnFrom(ctx sdk.Context, amount sdk.Coin, burnFrom string) erro
 	return k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
 }
 
-// nolint: unused
 func (k Keeper) forceTransfer(ctx sdk.Context, amount sdk.Coin, fromAddr string, toAddr string) error {
 	// verify that denom is an x/tokenfactory denom
 	_, _, err := types.DeconstructDenom(amount.Denom)

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -59,7 +59,11 @@ func (server msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.
 		return nil, types.ErrUnauthorized
 	}
 
-	err = server.Keeper.mintTo(ctx, msg.Amount, msg.Sender)
+	if msg.MintToAddress == "" {
+		msg.MintToAddress = msg.Sender
+	}
+
+	err = server.Keeper.mintTo(ctx, msg.Amount, msg.MintToAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +91,11 @@ func (server msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.
 		return nil, types.ErrUnauthorized
 	}
 
-	err = server.Keeper.burnFrom(ctx, msg.Amount, msg.Sender)
+	if msg.BurnFromAddress == "" {
+		msg.BurnFromAddress = msg.Sender
+	}
+
+	err = server.Keeper.burnFrom(ctx, msg.Amount, msg.BurnFromAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -103,34 +111,34 @@ func (server msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.
 	return &types.MsgBurnResponse{}, nil
 }
 
-// func (server msgServer) ForceTransfer(goCtx context.Context, msg *types.MsgForceTransfer) (*types.MsgForceTransferResponse, error) {
-// 	ctx := sdk.UnwrapSDKContext(goCtx)
+func (server msgServer) ForceTransfer(goCtx context.Context, msg *types.MsgForceTransfer) (*types.MsgForceTransferResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
 
-// 	authorityMetadata, err := server.Keeper.GetAuthorityMetadata(ctx, msg.Amount.GetDenom())
-// 	if err != nil {
-// 		return nil, err
-// 	}
+	authorityMetadata, err := server.Keeper.GetAuthorityMetadata(ctx, msg.Amount.GetDenom())
+	if err != nil {
+		return nil, err
+	}
 
-// 	if msg.Sender != authorityMetadata.GetAdmin() {
-// 		return nil, types.ErrUnauthorized
-// 	}
+	if msg.Sender != authorityMetadata.GetAdmin() {
+		return nil, types.ErrUnauthorized
+	}
 
-// 	err = server.Keeper.forceTransfer(ctx, msg.Amount, msg.TransferFromAddress, msg.TransferToAddress)
-// 	if err != nil {
-// 		return nil, err
-// 	}
+	err = server.Keeper.forceTransfer(ctx, msg.Amount, msg.TransferFromAddress, msg.TransferToAddress)
+	if err != nil {
+		return nil, err
+	}
 
-// 	ctx.EventManager().EmitEvents(sdk.Events{
-// 		sdk.NewEvent(
-// 			types.TypeMsgForceTransfer,
-// 			sdk.NewAttribute(types.AttributeTransferFromAddress, msg.TransferFromAddress),
-// 			sdk.NewAttribute(types.AttributeTransferToAddress, msg.TransferToAddress),
-// 			sdk.NewAttribute(types.AttributeAmount, msg.Amount.String()),
-// 		),
-// 	})
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.TypeMsgForceTransfer,
+			sdk.NewAttribute(types.AttributeTransferFromAddress, msg.TransferFromAddress),
+			sdk.NewAttribute(types.AttributeTransferToAddress, msg.TransferToAddress),
+			sdk.NewAttribute(types.AttributeAmount, msg.Amount.String()),
+		),
+	})
 
-// 	return &types.MsgForceTransferResponse{}, nil
-// }
+	return &types.MsgForceTransferResponse{}, nil
+}
 
 func (server msgServer) ChangeAdmin(goCtx context.Context, msg *types.MsgChangeAdmin) (*types.MsgChangeAdminResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/tokenfactory/types/codec.go
+++ b/x/tokenfactory/types/codec.go
@@ -14,7 +14,7 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgCreateDenom{}, "osmosis/tokenfactory/create-denom", nil)
 	cdc.RegisterConcrete(&MsgMint{}, "osmosis/tokenfactory/mint", nil)
 	cdc.RegisterConcrete(&MsgBurn{}, "osmosis/tokenfactory/burn", nil)
-	// cdc.RegisterConcrete(&MsgForceTransfer{}, "osmosis/tokenfactory/force-transfer", nil)
+	cdc.RegisterConcrete(&MsgForceTransfer{}, "osmosis/tokenfactory/force-transfer", nil)
 	cdc.RegisterConcrete(&MsgChangeAdmin{}, "osmosis/tokenfactory/change-admin", nil)
 	cdc.RegisterConcrete(&MsgSetBeforeSendHook{}, "osmosis/tokenfactory/set-beforesend-hook", nil)
 }

--- a/x/tokenfactory/types/msgs.go
+++ b/x/tokenfactory/types/msgs.go
@@ -62,6 +62,14 @@ func NewMsgMint(sender string, amount sdk.Coin) *MsgMint {
 	}
 }
 
+func NewMsgMintTo(sender string, amount sdk.Coin, mintToAddress string) *MsgMint {
+	return &MsgMint{
+		Sender:        sender,
+		Amount:        amount,
+		MintToAddress: mintToAddress,
+	}
+}
+
 func (m MsgMint) Route() string { return RouterKey }
 func (m MsgMint) Type() string  { return TypeMsgMint }
 func (m MsgMint) ValidateBasic() error {
@@ -96,6 +104,15 @@ func NewMsgBurn(sender string, amount sdk.Coin) *MsgBurn {
 	}
 }
 
+// NewMsgBurn creates a message to burn tokens
+func NewMsgBurnFrom(sender string, amount sdk.Coin, burnFromAddress string) *MsgBurn {
+	return &MsgBurn{
+		Sender:          sender,
+		Amount:          amount,
+		BurnFromAddress: burnFromAddress,
+	}
+}
+
 func (m MsgBurn) Route() string { return RouterKey }
 func (m MsgBurn) Type() string  { return TypeMsgBurn }
 func (m MsgBurn) ValidateBasic() error {
@@ -120,50 +137,50 @@ func (m MsgBurn) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{sender}
 }
 
-// var _ sdk.Msg = &MsgForceTransfer{}
+var _ sdk.Msg = &MsgForceTransfer{}
 
-// // NewMsgForceTransfer creates a transfer funds from one account to another
-// func NewMsgForceTransfer(sender string, amount sdk.Coin, fromAddr, toAddr string) *MsgForceTransfer {
-// 	return &MsgForceTransfer{
-// 		Sender:              sender,
-// 		Amount:              amount,
-// 		TransferFromAddress: fromAddr,
-// 		TransferToAddress:   toAddr,
-// 	}
-// }
+// NewMsgForceTransfer creates a transfer funds from one account to another
+func NewMsgForceTransfer(sender string, amount sdk.Coin, fromAddr, toAddr string) *MsgForceTransfer {
+	return &MsgForceTransfer{
+		Sender:              sender,
+		Amount:              amount,
+		TransferFromAddress: fromAddr,
+		TransferToAddress:   toAddr,
+	}
+}
 
-// func (m MsgForceTransfer) Route() string { return RouterKey }
-// func (m MsgForceTransfer) Type() string  { return TypeMsgForceTransfer }
-// func (m MsgForceTransfer) ValidateBasic() error {
-// 	_, err := sdk.AccAddressFromBech32(m.Sender)
-// 	if err != nil {
-// 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
-// 	}
+func (m MsgForceTransfer) Route() string { return RouterKey }
+func (m MsgForceTransfer) Type() string  { return TypeMsgForceTransfer }
+func (m MsgForceTransfer) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(m.Sender)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
+	}
 
-// 	_, err = sdk.AccAddressFromBech32(m.TransferFromAddress)
-// 	if err != nil {
-// 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid address (%s)", err)
-// 	}
-// 	_, err = sdk.AccAddressFromBech32(m.TransferToAddress)
-// 	if err != nil {
-// 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid address (%s)", err)
-// 	}
+	_, err = sdk.AccAddressFromBech32(m.TransferFromAddress)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid address (%s)", err)
+	}
+	_, err = sdk.AccAddressFromBech32(m.TransferToAddress)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid address (%s)", err)
+	}
 
-// 	if !m.Amount.IsValid() {
-// 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, m.Amount.String())
-// 	}
+	if !m.Amount.IsValid() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, m.Amount.String())
+	}
 
-// 	return nil
-// }
+	return nil
+}
 
-// func (m MsgForceTransfer) GetSignBytes() []byte {
-// 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&m))
-// }
+func (m MsgForceTransfer) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&m))
+}
 
-// func (m MsgForceTransfer) GetSigners() []sdk.AccAddress {
-// 	sender, _ := sdk.AccAddressFromBech32(m.Sender)
-// 	return []sdk.AccAddress{sender}
-// }
+func (m MsgForceTransfer) GetSigners() []sdk.AccAddress {
+	sender, _ := sdk.AccAddressFromBech32(m.Sender)
+	return []sdk.AccAddress{sender}
+}
 
 var _ sdk.Msg = &MsgChangeAdmin{}
 

--- a/x/tokenfactory/types/tx.pb.go
+++ b/x/tokenfactory/types/tx.pb.go
@@ -141,8 +141,9 @@ func (m *MsgCreateDenomResponse) GetNewTokenDenom() string {
 // MsgMint is the sdk.Msg type for allowing an admin account to mint
 // more of a token.  For now, we only support minting to the sender account
 type MsgMint struct {
-	Sender string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
-	Amount types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`
+	Sender        string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
+	Amount        types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`
+	MintToAddress string     `protobuf:"bytes,3,opt,name=mintToAddress,proto3" json:"mintToAddress,omitempty" yaml:"mint_to_address"`
 }
 
 func (m *MsgMint) Reset()         { *m = MsgMint{} }
@@ -192,6 +193,13 @@ func (m *MsgMint) GetAmount() types.Coin {
 	return types.Coin{}
 }
 
+func (m *MsgMint) GetMintToAddress() string {
+	if m != nil {
+		return m.MintToAddress
+	}
+	return ""
+}
+
 type MsgMintResponse struct {
 }
 
@@ -231,8 +239,9 @@ var xxx_messageInfo_MsgMintResponse proto.InternalMessageInfo
 // MsgBurn is the sdk.Msg type for allowing an admin account to burn
 // a token.  For now, we only support burning from the sender account.
 type MsgBurn struct {
-	Sender string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
-	Amount types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`
+	Sender          string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
+	Amount          types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`
+	BurnFromAddress string     `protobuf:"bytes,3,opt,name=burnFromAddress,proto3" json:"burnFromAddress,omitempty" yaml:"burn_from_address"`
 }
 
 func (m *MsgBurn) Reset()         { *m = MsgBurn{} }
@@ -280,6 +289,13 @@ func (m *MsgBurn) GetAmount() types.Coin {
 		return m.Amount
 	}
 	return types.Coin{}
+}
+
+func (m *MsgBurn) GetBurnFromAddress() string {
+	if m != nil {
+		return m.BurnFromAddress
+	}
+	return ""
 }
 
 type MsgBurnResponse struct {
@@ -610,6 +626,110 @@ func (m *MsgSetDenomMetadataResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgSetDenomMetadataResponse proto.InternalMessageInfo
 
+type MsgForceTransfer struct {
+	Sender              string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
+	Amount              types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`
+	TransferFromAddress string     `protobuf:"bytes,3,opt,name=transferFromAddress,proto3" json:"transferFromAddress,omitempty" yaml:"transfer_from_address"`
+	TransferToAddress   string     `protobuf:"bytes,4,opt,name=transferToAddress,proto3" json:"transferToAddress,omitempty" yaml:"transfer_to_address"`
+}
+
+func (m *MsgForceTransfer) Reset()         { *m = MsgForceTransfer{} }
+func (m *MsgForceTransfer) String() string { return proto.CompactTextString(m) }
+func (*MsgForceTransfer) ProtoMessage()    {}
+func (*MsgForceTransfer) Descriptor() ([]byte, []int) {
+	return fileDescriptor_283b6c9a90a846b4, []int{12}
+}
+func (m *MsgForceTransfer) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgForceTransfer) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgForceTransfer.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgForceTransfer) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgForceTransfer.Merge(m, src)
+}
+func (m *MsgForceTransfer) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgForceTransfer) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgForceTransfer.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgForceTransfer proto.InternalMessageInfo
+
+func (m *MsgForceTransfer) GetSender() string {
+	if m != nil {
+		return m.Sender
+	}
+	return ""
+}
+
+func (m *MsgForceTransfer) GetAmount() types.Coin {
+	if m != nil {
+		return m.Amount
+	}
+	return types.Coin{}
+}
+
+func (m *MsgForceTransfer) GetTransferFromAddress() string {
+	if m != nil {
+		return m.TransferFromAddress
+	}
+	return ""
+}
+
+func (m *MsgForceTransfer) GetTransferToAddress() string {
+	if m != nil {
+		return m.TransferToAddress
+	}
+	return ""
+}
+
+type MsgForceTransferResponse struct {
+}
+
+func (m *MsgForceTransferResponse) Reset()         { *m = MsgForceTransferResponse{} }
+func (m *MsgForceTransferResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgForceTransferResponse) ProtoMessage()    {}
+func (*MsgForceTransferResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_283b6c9a90a846b4, []int{13}
+}
+func (m *MsgForceTransferResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgForceTransferResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgForceTransferResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgForceTransferResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgForceTransferResponse.Merge(m, src)
+}
+func (m *MsgForceTransferResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgForceTransferResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgForceTransferResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgForceTransferResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgCreateDenom)(nil), "osmosis.tokenfactory.v1beta1.MsgCreateDenom")
 	proto.RegisterType((*MsgCreateDenomResponse)(nil), "osmosis.tokenfactory.v1beta1.MsgCreateDenomResponse")
@@ -623,6 +743,8 @@ func init() {
 	proto.RegisterType((*MsgSetBeforeSendHookResponse)(nil), "osmosis.tokenfactory.v1beta1.MsgSetBeforeSendHookResponse")
 	proto.RegisterType((*MsgSetDenomMetadata)(nil), "osmosis.tokenfactory.v1beta1.MsgSetDenomMetadata")
 	proto.RegisterType((*MsgSetDenomMetadataResponse)(nil), "osmosis.tokenfactory.v1beta1.MsgSetDenomMetadataResponse")
+	proto.RegisterType((*MsgForceTransfer)(nil), "osmosis.tokenfactory.v1beta1.MsgForceTransfer")
+	proto.RegisterType((*MsgForceTransferResponse)(nil), "osmosis.tokenfactory.v1beta1.MsgForceTransferResponse")
 }
 
 func init() {
@@ -630,49 +752,58 @@ func init() {
 }
 
 var fileDescriptor_283b6c9a90a846b4 = []byte{
-	// 670 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x55, 0xcf, 0x4e, 0x13, 0x41,
-	0x1c, 0xee, 0x8a, 0x20, 0x0c, 0x62, 0xcb, 0x82, 0x50, 0x17, 0xd8, 0x35, 0x93, 0x60, 0x34, 0x91,
-	0xdd, 0x14, 0x35, 0x51, 0x6e, 0x2c, 0xc6, 0x70, 0xe9, 0x65, 0xf1, 0x64, 0x48, 0xc8, 0xb4, 0x3b,
-	0x2c, 0x4d, 0xd9, 0x19, 0xdc, 0x99, 0x52, 0xb8, 0x18, 0x13, 0x5f, 0xc0, 0x83, 0xf1, 0x39, 0xf4,
-	0x2d, 0x38, 0x72, 0xf4, 0xb4, 0x31, 0xf0, 0x06, 0x7d, 0x02, 0xb3, 0x33, 0xb3, 0xdb, 0x2d, 0x25,
-	0xb6, 0x7b, 0x30, 0xde, 0xda, 0xf9, 0x7d, 0xdf, 0x37, 0xdf, 0xef, 0xdf, 0x2c, 0x58, 0xa7, 0x2c,
-	0xa4, 0xac, 0xc5, 0x1c, 0x4e, 0xdb, 0x98, 0x1c, 0xa2, 0x26, 0xa7, 0xd1, 0xb9, 0x73, 0x5a, 0x6b,
-	0x60, 0x8e, 0x6a, 0x0e, 0x3f, 0xb3, 0x4f, 0x22, 0xca, 0xa9, 0xbe, 0xaa, 0x60, 0x76, 0x1e, 0x66,
-	0x2b, 0x98, 0xb1, 0x18, 0xd0, 0x80, 0x0a, 0xa0, 0x93, 0xfc, 0x92, 0x1c, 0xc3, 0x6c, 0x0a, 0x92,
-	0xd3, 0x40, 0x0c, 0x67, 0x8a, 0x4d, 0xda, 0x22, 0x43, 0x71, 0xd2, 0xce, 0xe2, 0xc9, 0x1f, 0x19,
-	0x87, 0xc7, 0xe0, 0x41, 0x9d, 0x05, 0x3b, 0x11, 0x46, 0x1c, 0xbf, 0xc5, 0x84, 0x86, 0xfa, 0x33,
-	0x30, 0xc5, 0x30, 0xf1, 0x71, 0x54, 0xd5, 0x1e, 0x6b, 0x4f, 0x67, 0xdc, 0xf9, 0x5e, 0x6c, 0xcd,
-	0x9d, 0xa3, 0xf0, 0x78, 0x0b, 0xca, 0x73, 0xe8, 0x29, 0x80, 0xee, 0x80, 0x69, 0xd6, 0x69, 0xf8,
-	0x09, 0xad, 0x7a, 0x47, 0x80, 0x17, 0x7a, 0xb1, 0x55, 0x56, 0x60, 0x15, 0x81, 0x5e, 0x06, 0x82,
-	0xfb, 0x60, 0x69, 0xf0, 0x36, 0x0f, 0xb3, 0x13, 0x4a, 0x18, 0xd6, 0x5d, 0x50, 0x26, 0xb8, 0x7b,
-	0x20, 0x32, 0x3f, 0x90, 0x8a, 0xf2, 0x7a, 0xa3, 0x17, 0x5b, 0x4b, 0x52, 0xf1, 0x06, 0x00, 0x7a,
-	0x73, 0x04, 0x77, 0xdf, 0x27, 0x07, 0x42, 0x0b, 0x7e, 0x02, 0xf7, 0xea, 0x2c, 0xa8, 0xb7, 0x08,
-	0x2f, 0x92, 0xc4, 0x2e, 0x98, 0x42, 0x21, 0xed, 0x10, 0x2e, 0x52, 0x98, 0xdd, 0x7c, 0x64, 0xcb,
-	0x92, 0xd9, 0x49, 0x49, 0xd3, 0xea, 0xdb, 0x3b, 0xb4, 0x45, 0xdc, 0x87, 0x17, 0xb1, 0x55, 0xea,
-	0x2b, 0x49, 0x1a, 0xf4, 0x14, 0x1f, 0xce, 0x83, 0xb2, 0xba, 0x3f, 0x4d, 0x4b, 0x59, 0x72, 0x3b,
-	0x11, 0xf9, 0x9f, 0x96, 0x92, 0xfb, 0x33, 0x4b, 0xdf, 0x35, 0xd9, 0xf2, 0x23, 0x44, 0x02, 0xbc,
-	0xed, 0x87, 0xad, 0x42, 0xd6, 0x9e, 0x80, 0xc9, 0x7c, 0xbf, 0x2b, 0xbd, 0xd8, 0xba, 0x2f, 0x91,
-	0xaa, 0x27, 0x32, 0xac, 0xd7, 0xc0, 0x4c, 0xd2, 0x2e, 0x94, 0xe8, 0x57, 0x27, 0x04, 0x76, 0xb1,
-	0x17, 0x5b, 0x95, 0x7e, 0x27, 0x45, 0x08, 0x7a, 0xd3, 0x04, 0x77, 0x85, 0x0b, 0x58, 0x95, 0xc3,
-	0xd1, 0xf7, 0x95, 0x59, 0xfe, 0xa9, 0x81, 0xc5, 0x3a, 0x0b, 0xf6, 0x30, 0x77, 0xf1, 0x21, 0x8d,
-	0xf0, 0x1e, 0x26, 0xfe, 0x2e, 0xa5, 0xed, 0x7f, 0x61, 0xfc, 0x1d, 0xa8, 0x24, 0xc5, 0xee, 0x22,
-	0x16, 0x1e, 0x20, 0xdf, 0x8f, 0x30, 0x63, 0xca, 0xff, 0x4a, 0x2f, 0xb6, 0x96, 0x25, 0xe5, 0x26,
-	0x02, 0x7a, 0xe5, 0xf4, 0x68, 0x5b, 0x9d, 0x98, 0x60, 0xf5, 0x36, 0xcb, 0x59, 0x4e, 0xdf, 0x34,
-	0xb0, 0x20, 0x01, 0x62, 0x78, 0xeb, 0x98, 0x23, 0x1f, 0x71, 0x54, 0x24, 0x25, 0x0f, 0x4c, 0x87,
-	0x8a, 0xa6, 0x06, 0x65, 0xad, 0x3f, 0x28, 0xa4, 0x9d, 0x0d, 0x4a, 0xaa, 0xed, 0x2e, 0xab, 0x61,
-	0x51, 0x1b, 0x9a, 0x92, 0xa1, 0x97, 0xe9, 0xc0, 0x35, 0xb0, 0x72, 0x8b, 0xab, 0xd4, 0xf5, 0xe6,
-	0x8f, 0x49, 0x30, 0x51, 0x67, 0x81, 0xfe, 0x11, 0xcc, 0xe6, 0xdf, 0x8c, 0xe7, 0xf6, 0xdf, 0x9e,
-	0x2e, 0x7b, 0x70, 0xe7, 0x8d, 0x97, 0x45, 0xd0, 0xd9, 0x0b, 0xb1, 0x0f, 0xee, 0x8a, 0xd5, 0x5e,
-	0x1f, 0xc9, 0x4e, 0x60, 0xc6, 0xc6, 0x58, 0xb0, 0xbc, 0xba, 0xd8, 0xd2, 0xd1, 0xea, 0x09, 0x6c,
-	0x0c, 0xf5, 0xfc, 0xce, 0x89, 0x72, 0xe5, 0xf6, 0x6d, 0x8c, 0x72, 0xf5, 0xd1, 0xe3, 0x94, 0x6b,
-	0x78, 0x67, 0xf4, 0xcf, 0x1a, 0xa8, 0x0c, 0x0d, 0x57, 0x6d, 0xa4, 0xd4, 0x4d, 0x8a, 0xf1, 0xa6,
-	0x30, 0x25, 0xb3, 0xf0, 0x45, 0x03, 0xf3, 0xc3, 0x3b, 0xbb, 0x39, 0x8e, 0xe0, 0x20, 0xc7, 0xd8,
-	0x2a, 0xce, 0x49, 0x5d, 0xb8, 0xde, 0xc5, 0x95, 0xa9, 0x5d, 0x5e, 0x99, 0xda, 0xef, 0x2b, 0x53,
-	0xfb, 0x7a, 0x6d, 0x96, 0x2e, 0xaf, 0xcd, 0xd2, 0xaf, 0x6b, 0xb3, 0xf4, 0xe1, 0x75, 0xd0, 0xe2,
-	0x47, 0x9d, 0x86, 0xdd, 0xa4, 0xa1, 0xa3, 0xf4, 0x37, 0x8e, 0x51, 0x83, 0xa5, 0x7f, 0x9c, 0xd3,
-	0xda, 0x2b, 0xe7, 0x6c, 0xf0, 0xa3, 0xcd, 0xcf, 0x4f, 0x30, 0x6b, 0x4c, 0x89, 0x8f, 0xe7, 0x8b,
-	0x3f, 0x01, 0x00, 0x00, 0xff, 0xff, 0xfb, 0xad, 0xbd, 0x11, 0xd9, 0x07, 0x00, 0x00,
+	// 815 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x56, 0x41, 0x4f, 0xdb, 0x48,
+	0x14, 0x8e, 0x81, 0xcd, 0xc2, 0xb0, 0xd9, 0x24, 0x86, 0x85, 0xac, 0x09, 0x36, 0x1a, 0x89, 0xd5,
+	0xae, 0xb4, 0xd8, 0x0a, 0xbb, 0xad, 0x5a, 0x4e, 0x25, 0x54, 0x11, 0x87, 0xe6, 0x62, 0x38, 0x55,
+	0x48, 0x91, 0x93, 0x4c, 0x4c, 0x14, 0x3c, 0x43, 0x3d, 0x13, 0x02, 0xb7, 0x4a, 0xfd, 0x03, 0x3d,
+	0x54, 0xfd, 0x0f, 0x1c, 0xfb, 0x0f, 0x7a, 0xaa, 0x38, 0x72, 0xec, 0xc9, 0xaa, 0xe0, 0x1f, 0xf8,
+	0x17, 0x54, 0xf6, 0x8c, 0x9d, 0xd8, 0x41, 0x4d, 0x72, 0xa8, 0xb8, 0xc5, 0xf3, 0xbe, 0xef, 0x9b,
+	0xf7, 0xbd, 0xbc, 0xf7, 0x6c, 0xb0, 0x4d, 0xa8, 0x43, 0x68, 0x97, 0x1a, 0x8c, 0xf4, 0x10, 0xee,
+	0x58, 0x2d, 0x46, 0xdc, 0x2b, 0xe3, 0xa2, 0xd2, 0x44, 0xcc, 0xaa, 0x18, 0xec, 0x52, 0x3f, 0x77,
+	0x09, 0x23, 0x72, 0x59, 0xc0, 0xf4, 0x51, 0x98, 0x2e, 0x60, 0xca, 0xaa, 0x4d, 0x6c, 0x12, 0x02,
+	0x8d, 0xe0, 0x17, 0xe7, 0x28, 0x6a, 0x2b, 0x24, 0x19, 0x4d, 0x8b, 0xa2, 0x58, 0xb1, 0x45, 0xba,
+	0x78, 0x2c, 0x8e, 0x7b, 0x71, 0x3c, 0x78, 0xe0, 0x71, 0x78, 0x06, 0x7e, 0xaf, 0x53, 0xfb, 0xc0,
+	0x45, 0x16, 0x43, 0x2f, 0x11, 0x26, 0x8e, 0xfc, 0x0f, 0xc8, 0x52, 0x84, 0xdb, 0xc8, 0x2d, 0x49,
+	0x5b, 0xd2, 0xdf, 0x4b, 0xd5, 0xa2, 0xef, 0x69, 0xb9, 0x2b, 0xcb, 0x39, 0xdb, 0x83, 0xfc, 0x1c,
+	0x9a, 0x02, 0x20, 0x1b, 0x60, 0x91, 0xf6, 0x9b, 0xed, 0x80, 0x56, 0x9a, 0x0b, 0xc1, 0x2b, 0xbe,
+	0xa7, 0xe5, 0x05, 0x58, 0x44, 0xa0, 0x19, 0x83, 0xe0, 0x09, 0x58, 0x4b, 0xde, 0x66, 0x22, 0x7a,
+	0x4e, 0x30, 0x45, 0x72, 0x15, 0xe4, 0x31, 0x1a, 0x34, 0x42, 0xe7, 0x0d, 0xae, 0xc8, 0xaf, 0x57,
+	0x7c, 0x4f, 0x5b, 0xe3, 0x8a, 0x29, 0x00, 0x34, 0x73, 0x18, 0x0d, 0x8e, 0x83, 0x83, 0x50, 0x0b,
+	0x7e, 0x96, 0xc0, 0xaf, 0x75, 0x6a, 0xd7, 0xbb, 0x98, 0xcd, 0xe2, 0xe2, 0x10, 0x64, 0x2d, 0x87,
+	0xf4, 0x31, 0x0b, 0x3d, 0x2c, 0xef, 0xfe, 0xa9, 0xf3, 0x9a, 0xe9, 0x41, 0x4d, 0xa3, 0xf2, 0xeb,
+	0x07, 0xa4, 0x8b, 0xab, 0x7f, 0xdc, 0x78, 0x5a, 0x66, 0xa8, 0xc4, 0x69, 0xd0, 0x14, 0x7c, 0xf9,
+	0x05, 0xc8, 0x39, 0x5d, 0xcc, 0x8e, 0xc9, 0x7e, 0xbb, 0xed, 0x22, 0x4a, 0x4b, 0xf3, 0x69, 0x0b,
+	0x41, 0xb8, 0xc1, 0x48, 0xc3, 0xe2, 0x00, 0x68, 0x26, 0x09, 0xb0, 0x08, 0xf2, 0xc2, 0x41, 0x54,
+	0x19, 0xf8, 0x85, 0xbb, 0xaa, 0xf6, 0x5d, 0xfc, 0x38, 0xae, 0x6a, 0x20, 0xdf, 0xec, 0xbb, 0xb8,
+	0xe6, 0x12, 0x27, 0xe9, 0xab, 0xec, 0x7b, 0x5a, 0x89, 0x73, 0x02, 0x40, 0xa3, 0xe3, 0x12, 0x67,
+	0xe8, 0x2c, 0x4d, 0x12, 0xde, 0x02, 0x1f, 0xb1, 0xb7, 0x8f, 0x12, 0x6f, 0xbf, 0x53, 0x0b, 0xdb,
+	0x68, 0xbf, 0xed, 0x74, 0x67, 0xb2, 0xf8, 0x17, 0xf8, 0x65, 0xb4, 0xf7, 0x0a, 0xbe, 0xa7, 0xfd,
+	0xc6, 0x91, 0xa2, 0x3f, 0x78, 0x58, 0xae, 0x80, 0xa5, 0xa0, 0x75, 0xac, 0x40, 0x5f, 0xa4, 0xbe,
+	0xea, 0x7b, 0x5a, 0x61, 0xd8, 0x55, 0x61, 0x08, 0x9a, 0x8b, 0x18, 0x0d, 0xc2, 0x2c, 0x60, 0x89,
+	0x37, 0xea, 0x30, 0xaf, 0x38, 0xe5, 0x4f, 0x12, 0x58, 0xad, 0x53, 0xfb, 0x08, 0xb1, 0x2a, 0xea,
+	0x10, 0x17, 0x1d, 0x21, 0xdc, 0x3e, 0x24, 0xa4, 0xf7, 0x33, 0x12, 0xaf, 0x81, 0x42, 0xf0, 0xa7,
+	0x0d, 0x2c, 0x1a, 0xd7, 0x55, 0xe4, 0xbf, 0xe1, 0x7b, 0xda, 0x3a, 0xa7, 0xa4, 0x11, 0xd0, 0xcc,
+	0x47, 0x47, 0x51, 0xe5, 0x55, 0x50, 0x7e, 0x28, 0xe5, 0xd8, 0xd3, 0x07, 0x09, 0xac, 0x70, 0x40,
+	0x38, 0x48, 0x75, 0xc4, 0xac, 0xb6, 0xc5, 0xac, 0x59, 0x2c, 0x99, 0x60, 0xd1, 0x11, 0x34, 0xd1,
+	0x70, 0x9b, 0xc3, 0x86, 0xc3, 0xbd, 0xb8, 0xe1, 0x22, 0xed, 0xea, 0xba, 0x68, 0x3a, 0xb1, 0x2d,
+	0x22, 0x32, 0x34, 0x63, 0x1d, 0xb8, 0x09, 0x36, 0x1e, 0xc8, 0x2a, 0xce, 0xfa, 0x7a, 0x0e, 0x14,
+	0xea, 0xd4, 0xae, 0x11, 0xb7, 0x85, 0x8e, 0x5d, 0x0b, 0xd3, 0x0e, 0x72, 0x1f, 0x67, 0x42, 0x4c,
+	0xb0, 0xc2, 0x44, 0x02, 0xe3, 0x53, 0xb2, 0xe5, 0x7b, 0x5a, 0x99, 0xf3, 0x22, 0x50, 0x6a, 0x52,
+	0x1e, 0x22, 0xcb, 0xaf, 0x40, 0x31, 0x3a, 0x1e, 0xee, 0x93, 0x85, 0x50, 0x51, 0xf5, 0x3d, 0x4d,
+	0x49, 0x29, 0x8e, 0xee, 0x94, 0x71, 0x22, 0x54, 0x40, 0x29, 0x5d, 0xaa, 0xa8, 0x8e, 0xbb, 0xd7,
+	0x59, 0x30, 0x5f, 0xa7, 0xb6, 0xfc, 0x06, 0x2c, 0x8f, 0xbe, 0x07, 0xfe, 0xd5, 0x7f, 0xf4, 0x3a,
+	0xd2, 0x93, 0x7b, 0x5c, 0xf9, 0x7f, 0x16, 0x74, 0xbc, 0xf5, 0x4f, 0xc0, 0x42, 0xb8, 0xad, 0xb7,
+	0x27, 0xb2, 0x03, 0x98, 0xb2, 0x33, 0x15, 0x6c, 0x54, 0x3d, 0xdc, 0x9a, 0x93, 0xd5, 0x03, 0xd8,
+	0x14, 0xea, 0xa3, 0xbb, 0x2b, 0x2c, 0xd7, 0xc8, 0xde, 0x9a, 0xa2, 0x5c, 0x43, 0xf4, 0x34, 0xe5,
+	0x1a, 0xdf, 0x3d, 0xf2, 0x5b, 0x09, 0x14, 0xc6, 0x86, 0xb4, 0x32, 0x51, 0x2a, 0x4d, 0x51, 0x9e,
+	0xcf, 0x4c, 0x89, 0x53, 0x78, 0x27, 0x81, 0xe2, 0xf8, 0xee, 0xdb, 0x9d, 0x46, 0x30, 0xc9, 0x51,
+	0xf6, 0x66, 0xe7, 0xc4, 0x59, 0x0c, 0x40, 0x2e, 0x39, 0xf6, 0xfa, 0x44, 0xb1, 0x04, 0x5e, 0x79,
+	0x3a, 0x1b, 0x3e, 0xba, 0xb8, 0x6a, 0xde, 0xdc, 0xa9, 0xd2, 0xed, 0x9d, 0x2a, 0x7d, 0xbb, 0x53,
+	0xa5, 0xf7, 0xf7, 0x6a, 0xe6, 0xf6, 0x5e, 0xcd, 0x7c, 0xbd, 0x57, 0x33, 0xaf, 0x9f, 0xd9, 0x5d,
+	0x76, 0xda, 0x6f, 0xea, 0x2d, 0xe2, 0x18, 0x42, 0x7b, 0xe7, 0xcc, 0x6a, 0xd2, 0xe8, 0xc1, 0xb8,
+	0xa8, 0x3c, 0x31, 0x2e, 0x93, 0x5f, 0x80, 0xec, 0xea, 0x1c, 0xd1, 0x66, 0x36, 0xfc, 0x12, 0xfb,
+	0xef, 0x7b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x0b, 0x98, 0x33, 0x66, 0x26, 0x0a, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -693,6 +824,7 @@ type MsgClient interface {
 	ChangeAdmin(ctx context.Context, in *MsgChangeAdmin, opts ...grpc.CallOption) (*MsgChangeAdminResponse, error)
 	SetDenomMetadata(ctx context.Context, in *MsgSetDenomMetadata, opts ...grpc.CallOption) (*MsgSetDenomMetadataResponse, error)
 	SetBeforeSendHook(ctx context.Context, in *MsgSetBeforeSendHook, opts ...grpc.CallOption) (*MsgSetBeforeSendHookResponse, error)
+	ForceTransfer(ctx context.Context, in *MsgForceTransfer, opts ...grpc.CallOption) (*MsgForceTransferResponse, error)
 }
 
 type msgClient struct {
@@ -757,6 +889,15 @@ func (c *msgClient) SetBeforeSendHook(ctx context.Context, in *MsgSetBeforeSendH
 	return out, nil
 }
 
+func (c *msgClient) ForceTransfer(ctx context.Context, in *MsgForceTransfer, opts ...grpc.CallOption) (*MsgForceTransferResponse, error) {
+	out := new(MsgForceTransferResponse)
+	err := c.cc.Invoke(ctx, "/osmosis.tokenfactory.v1beta1.Msg/ForceTransfer", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	CreateDenom(context.Context, *MsgCreateDenom) (*MsgCreateDenomResponse, error)
@@ -765,6 +906,7 @@ type MsgServer interface {
 	ChangeAdmin(context.Context, *MsgChangeAdmin) (*MsgChangeAdminResponse, error)
 	SetDenomMetadata(context.Context, *MsgSetDenomMetadata) (*MsgSetDenomMetadataResponse, error)
 	SetBeforeSendHook(context.Context, *MsgSetBeforeSendHook) (*MsgSetBeforeSendHookResponse, error)
+	ForceTransfer(context.Context, *MsgForceTransfer) (*MsgForceTransferResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -788,6 +930,9 @@ func (*UnimplementedMsgServer) SetDenomMetadata(ctx context.Context, req *MsgSet
 }
 func (*UnimplementedMsgServer) SetBeforeSendHook(ctx context.Context, req *MsgSetBeforeSendHook) (*MsgSetBeforeSendHookResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetBeforeSendHook not implemented")
+}
+func (*UnimplementedMsgServer) ForceTransfer(ctx context.Context, req *MsgForceTransfer) (*MsgForceTransferResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ForceTransfer not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -902,6 +1047,24 @@ func _Msg_SetBeforeSendHook_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_ForceTransfer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgForceTransfer)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).ForceTransfer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/osmosis.tokenfactory.v1beta1.Msg/ForceTransfer",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).ForceTransfer(ctx, req.(*MsgForceTransfer))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "osmosis.tokenfactory.v1beta1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -929,6 +1092,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetBeforeSendHook",
 			Handler:    _Msg_SetBeforeSendHook_Handler,
+		},
+		{
+			MethodName: "ForceTransfer",
+			Handler:    _Msg_ForceTransfer_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -1022,6 +1189,13 @@ func (m *MsgMint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.MintToAddress) > 0 {
+		i -= len(m.MintToAddress)
+		copy(dAtA[i:], m.MintToAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.MintToAddress)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	{
 		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -1085,6 +1259,13 @@ func (m *MsgBurn) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.BurnFromAddress) > 0 {
+		i -= len(m.BurnFromAddress)
+		copy(dAtA[i:], m.BurnFromAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.BurnFromAddress)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	{
 		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -1325,6 +1506,83 @@ func (m *MsgSetDenomMetadataResponse) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgForceTransfer) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgForceTransfer) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgForceTransfer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.TransferToAddress) > 0 {
+		i -= len(m.TransferToAddress)
+		copy(dAtA[i:], m.TransferToAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.TransferToAddress)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.TransferFromAddress) > 0 {
+		i -= len(m.TransferFromAddress)
+		copy(dAtA[i:], m.TransferFromAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.TransferFromAddress)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	{
+		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if len(m.Sender) > 0 {
+		i -= len(m.Sender)
+		copy(dAtA[i:], m.Sender)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Sender)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgForceTransferResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgForceTransferResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgForceTransferResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -1378,6 +1636,10 @@ func (m *MsgMint) Size() (n int) {
 	}
 	l = m.Amount.Size()
 	n += 1 + l + sovTx(uint64(l))
+	l = len(m.MintToAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
 	return n
 }
 
@@ -1402,6 +1664,10 @@ func (m *MsgBurn) Size() (n int) {
 	}
 	l = m.Amount.Size()
 	n += 1 + l + sovTx(uint64(l))
+	l = len(m.BurnFromAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
 	return n
 }
 
@@ -1490,6 +1756,38 @@ func (m *MsgSetDenomMetadata) Size() (n int) {
 }
 
 func (m *MsgSetDenomMetadataResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgForceTransfer) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Sender)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.Amount.Size()
+	n += 1 + l + sovTx(uint64(l))
+	l = len(m.TransferFromAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.TransferToAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgForceTransferResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1794,6 +2092,38 @@ func (m *MsgMint) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MintToAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MintToAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTx(dAtA[iNdEx:])
@@ -1958,6 +2288,38 @@ func (m *MsgBurn) Unmarshal(dAtA []byte) error {
 			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BurnFromAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BurnFromAddress = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2564,6 +2926,235 @@ func (m *MsgSetDenomMetadataResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgSetDenomMetadataResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgForceTransfer) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgForceTransfer: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgForceTransfer: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sender", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sender = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TransferFromAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TransferFromAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TransferToAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TransferToAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgForceTransferResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgForceTransferResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgForceTransferResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
This PR adds the functionality of Force Transfer, in which allows the admin of the token factory denom to transfer the token factory denom from one account to the other.

Another change included in this PR is adding `mintTo` and `burnFrom` address, which adds functionality to designate a minting address or a burning address from the existing Mint and Burn messages in the token factory module.

## Brief Changelog
- Add `ForceTransfer`, `BurnFrom` and `MintTo` fields in Burn and Mint messages


## Testing and Verifying
Adds tests to existing tests, verified CI and tests are not failing.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)