### PR TITLE
using GOWORK=off on go mod verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ go-mod-cache: go.sum
 
 go.sum: go.mod
 	@echo "--> Ensure dependencies have not been modified"
-	@go mod verify
+	@GOWORK=off go mod verify
 
 draw-deps:
 	@# requires brew install graphviz or apt-get install graphviz


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Building has sporadically been failing with:

```
❯ make build
--> Ensure dependencies have not been modified
github.com/osmosis-labs/osmosis/osmoutils : missing ziphash: open hash: no such file or directory
github.com/osmosis-labs/osmosis/x/ibc-hooks : missing ziphash: open hash: no such file or directory
github.com/osmosis-labs/osmosis/v15 : missing ziphash: open hash: no such file or directory
make: *** [go.sum] Error 1
```

This is because `go mod verify` is run without GOWORK=off and thus picks up the information from the local fs

This fixes that.

## Brief Changelog

Added GOWORK=off to the verify command


## Testing and Verifying

All tests pass
`make build` works as expected

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)