### PR TITLE
fix: init genesis rate-limited-params not running

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -18,6 +18,8 @@ import (
 
 	downtimemodule "github.com/osmosis-labs/osmosis/v14/x/downtime-detector/module"
 	downtimetypes "github.com/osmosis-labs/osmosis/v14/x/downtime-detector/types"
+	"github.com/osmosis-labs/osmosis/v14/x/ibc-rate-limit/ibcratelimitmodule"
+	ibcratelimittypes "github.com/osmosis-labs/osmosis/v14/x/ibc-rate-limit/types"
 	ibc_hooks "github.com/osmosis-labs/osmosis/x/ibc-hooks"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -152,6 +154,7 @@ func appModules(
 		),
 		tokenfactory.NewAppModule(*app.TokenFactoryKeeper, app.AccountKeeper, app.BankKeeper),
 		ibc_hooks.NewAppModule(app.AccountKeeper),
+		ibcratelimitmodule.NewAppModule(*app.RateLimitingICS4Wrapper),
 	}
 }
 
@@ -231,6 +234,7 @@ func OrderInitGenesis(allModuleNames []string) []string {
 		wasm.ModuleName,
 		// ibc_hooks after auth keeper
 		ibchookstypes.ModuleName,
+		ibcratelimittypes.ModuleName,
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Rate limited params init genesis is failing to run because the module is not correctly wired. As a result, the state export isn't functioning properly. This PR adds the wiring.

Discovered with @czarcas7ic 