### PR TITLE
fix small markdown mistake

### DIFF
--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -36,7 +36,7 @@ us safe when it comes to the malicious creation of unneeded pools.
 
 #### Joining Pool
 
-When joining a pool without swapping - with `JoinPool`, a user can provide the maximum amount of tokens `TokenInMaxs'
+When joining a pool without swapping - with `JoinPool`, a user can provide the maximum amount of tokens `TokenInMaxs`
 they're willing to deposit. This argument must contain all the denominations from the pool or no tokens at all, 
 otherwise, the tx will be aborted.
 If `TokenInMaxs` contains no tokens, the calculations are done based on the user's balance as the only constraint.


### PR DESCRIPTION
There was a small markdown mistake that made the markdown render kinda funny. Lmk if it's necessary for me to go through song and dance of the full contribution process described in `CONTRIBUTING.md`.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #-

## What is the purpose of the change

Fix small markdown mistake.

## Brief Changelog

- Fix small markdown mistake.


## Testing and Verifying

Rendered it, looks much better now. Should not impact prod unless you have references to your docs.

## Documentation and Release Note

  - Tiny markdown fix!