### PR TITLE
feat/refactor: implement and test get next sqrt price helpers for out given in and in given out

### DIFF
--- a/x/concentrated-liquidity/internal/math/math.go
+++ b/x/concentrated-liquidity/internal/math/math.go
@@ -94,23 +94,52 @@ func CalcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	return liq.Mul(diff)
 }
 
-// getNextSqrtPriceFromAmount0RoundingUp utilizes the current squareRootPrice, liquidity of denom0, and amount of denom0 that still needs
-// to be swapped in order to determine the next squareRootPrice
-// Note: we are using only using the precise formula here.
-func GetNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext sdk.Dec) {
-	if amountRemaining.Equal(sdk.ZeroDec()) {
+// GetNextSqrtPriceFromAmount0InRoundingUp utilizes sqrtPriceCurrent, liquidity, and amount of denom0 that still needs
+// to be swapped in order to determine the sqrtPriceNext.
+// When we swap for token one out given token zero in, the price is decreasing, and we need to move the sqrt price (decrease it) less
+// to avoid overpaying the amount out of the pool. Therefore, we round up.
+// sqrt_next = liq * sqrt_cur / (liq + token_in * sqrt_cur)
+func GetNextSqrtPriceFromAmount0InRoundingUp(sqrtPriceCurrent, liquidity, amountZeroRemainingIn sdk.Dec) (sqrtPriceNext sdk.Dec) {
+	if amountZeroRemainingIn.Equal(sdk.ZeroDec()) {
 		return sqrtPriceCurrent
 	}
 
-	product := amountRemaining.Mul(sqrtPriceCurrent)
+	product := amountZeroRemainingIn.Mul(sqrtPriceCurrent)
 	denominator := liquidity.Add(product)
 	return liquidity.Mul(sqrtPriceCurrent).QuoRoundUp(denominator)
 }
 
-// getNextSqrtPriceFromAmount1RoundingDown utilizes the current squareRootPrice, liquidity of denom1, and amount of denom1 that still needs
-// to be swapped in order to determine the next squareRootPrice
-func GetNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext sdk.Dec) {
-	return sqrtPriceCurrent.Add(amountRemaining.QuoTruncate(liquidity))
+// GetNextSqrtPriceFromAmount0OutRoundingUp utilizes sqrtPriceCurrent, liquidity, and amount of denom0 that still needs
+// to be swapped out order to determine the sqrtPriceNext.
+// When we swap for token one in given token zero out, the price is increasing and we need to move the price up enough
+// so that we get the desired output amount out. Therefore, we round up.
+// sqrt_next = liq * sqrt_cur / (liq - token_out * sqrt_cur)
+func GetNextSqrtPriceFromAmount0OutRoundingUp(sqrtPriceCurrent, liquidity, amountZeroRemainingOut sdk.Dec) (sqrtPriceNext sdk.Dec) {
+	if amountZeroRemainingOut.Equal(sdk.ZeroDec()) {
+		return sqrtPriceCurrent
+	}
+
+	product := amountZeroRemainingOut.Mul(sqrtPriceCurrent)
+	denominator := liquidity.Sub(product)
+	return liquidity.Mul(sqrtPriceCurrent).QuoRoundUp(denominator)
+}
+
+// GetNextSqrtPriceFromAmount1InRoundingDown utilizes the current sqrtPriceCurrent, liquidity, and amount of denom1 that still needs
+// to be swapped in order to determine the sqrtPriceNext.
+// When we swap for token zero out given token one in, the price is increasing and we need to move the sqrt price (increase it) less to
+// avoid overpaying out of the pool. Therefore, we round down.
+// sqrt_next = sqrt_cur + token_in / liq
+func GetNextSqrtPriceFromAmount1InRoundingDown(sqrtPriceCurrent, liquidity, amountOneRemainingIn sdk.Dec) (sqrtPriceNext sdk.Dec) {
+	return sqrtPriceCurrent.Add(amountOneRemainingIn.QuoTruncate(liquidity))
+}
+
+// GetNextSqrtPriceFromAmount1OutRoundingDown utilizes the current sqrtPriceCurrent, liquidity, and amount of denom1 that still needs
+// to be swapped out order to determine the sqrtPriceNext.
+// When we swap for token zero in given token one out, the price is decrearing and we need to move the price down enough
+// so that we get the desired output amount out.
+// sqrt_next = sqrt_cur - token_out / liq
+func GetNextSqrtPriceFromAmount1OutRoundingDown(sqrtPriceCurrent, liquidity, amountOneRemainingOut sdk.Dec) (sqrtPriceNext sdk.Dec) {
+	return sqrtPriceCurrent.Sub(amountOneRemainingOut.QuoRoundUp(liquidity))
 }
 
 // getLiquidityFromAmounts takes the current sqrtPrice and the sqrtPrice for the upper and lower ticks as well as the amounts of asset0 and asset1

--- a/x/concentrated-liquidity/internal/math/math_test.go
+++ b/x/concentrated-liquidity/internal/math/math_test.go
@@ -113,7 +113,7 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount0RoundingU
 		tc := tc
 
 		suite.Run(name, func() {
-			sqrtPriceNext := math.GetNextSqrtPriceFromAmount0RoundingUp(tc.sqrtPCurrent, tc.liquidity, tc.amount0Remaining)
+			sqrtPriceNext := math.GetNextSqrtPriceFromAmount0InRoundingUp(tc.sqrtPCurrent, tc.liquidity, tc.amount0Remaining)
 			suite.Require().Equal(tc.sqrtPriceNextExpected, sqrtPriceNext.String())
 		})
 	}
@@ -143,7 +143,7 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1RoundingD
 		tc := tc
 
 		suite.Run(name, func() {
-			sqrtPriceNext := math.GetNextSqrtPriceFromAmount1RoundingDown(tc.sqrtPCurrent, tc.liquidity, tc.amount1Remaining)
+			sqrtPriceNext := math.GetNextSqrtPriceFromAmount1InRoundingDown(tc.sqrtPCurrent, tc.liquidity, tc.amount1Remaining)
 			suite.Require().Equal(tc.sqrtPriceNextExpected, sqrtPriceNext.String())
 		})
 	}
@@ -244,6 +244,154 @@ func (suite *ConcentratedMathTestSuite) TestGetLiquidityFromAmounts() {
 			liq := sdk.MinDec(liq0, liq1)
 			suite.Require().Equal(liq.String(), liquidity.String())
 
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount0InRoundingUp() {
+	tests := map[string]struct {
+		sqrtPriceCurrent     sdk.Dec
+		liquidity            sdk.Dec
+		amountZeroRemaininIn sdk.Dec
+
+		expectedSqrtPriceNext sdk.Dec
+	}{
+		"rounded up at precision end": {
+			sqrtPriceCurrent:     sdk.MustNewDecFromStr("70.710678118654752440"),
+			liquidity:            sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountZeroRemaininIn: sdk.MustNewDecFromStr("8398"),
+
+			// liq * sqrt_cur / (liq + token_in * sqrt_cur) = 70.69684905341696614869539245
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("70.696849053416966149"),
+		},
+		"no round up due zeroes at precision end": {
+			sqrtPriceCurrent:     sdk.MustNewDecFromStr("2"),
+			liquidity:            sdk.MustNewDecFromStr("10"),
+			amountZeroRemaininIn: sdk.MustNewDecFromStr("15"),
+
+			// liq * sqrt_cur / (liq + token_in * sqrt_cur) = 0.5
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("0.5"),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+
+			sqrtPriceNext := math.GetNextSqrtPriceFromAmount0InRoundingUp(tc.sqrtPriceCurrent, tc.liquidity, tc.amountZeroRemaininIn)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount0OutRoundingUp() {
+	tests := map[string]struct {
+		sqrtPriceCurrent       sdk.Dec
+		liquidity              sdk.Dec
+		amountZeroRemainingOut sdk.Dec
+
+		expectedSqrtPriceNext sdk.Dec
+	}{
+		"rounded up at precision end": {
+			sqrtPriceCurrent:       sdk.MustNewDecFromStr("70.710678118654752440"),
+			liquidity:              sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountZeroRemainingOut: sdk.MustNewDecFromStr("8398"),
+
+			// liq * sqrt_cur / (liq - token_out * sqrt_cur) = 70.72451259517930556540769876
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("70.724512595179305566"),
+		},
+		"no round up due zeroes at precision end": {
+			sqrtPriceCurrent:       sdk.MustNewDecFromStr("2"),
+			liquidity:              sdk.MustNewDecFromStr("10"),
+			amountZeroRemainingOut: sdk.MustNewDecFromStr("1"),
+
+			// liq * sqrt_cur / (liq + token_out * sqrt_cur) = 2.5
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("2.5"),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+
+			sqrtPriceNext := math.GetNextSqrtPriceFromAmount0OutRoundingUp(tc.sqrtPriceCurrent, tc.liquidity, tc.amountZeroRemainingOut)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1InRoundingDown() {
+	tests := map[string]struct {
+		sqrtPriceCurrent     sdk.Dec
+		liquidity            sdk.Dec
+		amountOneRemainingIn sdk.Dec
+
+		expectedSqrtPriceNext sdk.Dec
+	}{
+		"rounded down at precision end": {
+			sqrtPriceCurrent:     sdk.MustNewDecFromStr("70.710678118654752440"),
+			liquidity:            sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountOneRemainingIn: sdk.MustNewDecFromStr("8398"),
+
+			// sqrt_next = sqrt_cur + token_in / liq = 70.71068088500882282334333927
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("70.710680885008822823"),
+		},
+		"no round up due zeroes at precision end": {
+			sqrtPriceCurrent:     sdk.MustNewDecFromStr("2.5"),
+			liquidity:            sdk.MustNewDecFromStr("1"),
+			amountOneRemainingIn: sdk.MustNewDecFromStr("10"),
+
+			// sqrt_next = sqrt_cur + token_in / liq
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("12.5"),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+
+			sqrtPriceNext := math.GetNextSqrtPriceFromAmount1InRoundingDown(tc.sqrtPriceCurrent, tc.liquidity, tc.amountOneRemainingIn)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1OutRoundingDown() {
+	tests := map[string]struct {
+		sqrtPriceCurrent      sdk.Dec
+		liquidity             sdk.Dec
+		amountOneRemainingOut sdk.Dec
+
+		expectedSqrtPriceNext sdk.Dec
+	}{
+		"rounded down at precision end": {
+			sqrtPriceCurrent:      sdk.MustNewDecFromStr("70.710678118654752440"),
+			liquidity:             sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountOneRemainingOut: sdk.MustNewDecFromStr("8398"),
+
+			// sqrt_next = sqrt_cur - token_out / liq = 70.71067535230068205665666073
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("70.710675352300682056"),
+		},
+		"no round up due zeroes at precision end": {
+			sqrtPriceCurrent:      sdk.MustNewDecFromStr("12.5"),
+			liquidity:             sdk.MustNewDecFromStr("1"),
+			amountOneRemainingOut: sdk.MustNewDecFromStr("10"),
+
+			// sqrt_next = sqrt_cur - token_out / liq
+			expectedSqrtPriceNext: sdk.MustNewDecFromStr("2.5"),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+
+			sqrtPriceNext := math.GetNextSqrtPriceFromAmount1OutRoundingDown(tc.sqrtPriceCurrent, tc.liquidity, tc.amountOneRemainingOut)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
 		})
 	}
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/one_for_zero.go
@@ -59,7 +59,9 @@ func (s oneForZeroStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick,
 		sqrtPriceNext = sqrtPriceTarget
 	} else {
 		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
-		sqrtPriceNext = math.GetNextSqrtPriceFromAmount1RoundingDown(sqrtPriceCurrent, liquidity, amountRemainingLessFee)
+		// TODO: when swapping in given out, GetNextSqrtPriceFromAmount1OutRoundingDown must be used.
+		// To be addressed in: https://github.com/osmosis-labs/osmosis/issues/4427
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount1InRoundingDown(sqrtPriceCurrent, liquidity, amountRemainingLessFee)
 	}
 
 	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext

--- a/x/concentrated-liquidity/internal/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/zero_for_one.go
@@ -59,7 +59,9 @@ func (s zeroForOneStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick,
 		sqrtPriceNext = sqrtPriceTarget
 	} else {
 		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
-		sqrtPriceNext = math.GetNextSqrtPriceFromAmount0RoundingUp(sqrtPriceCurrent, liquidity, amountRemainingLessFee)
+		// TODO: when swapping in given out, GetNextSqrtPriceFromAmount0OutRoundingUp must be used.
+		// To be addressed in: https://github.com/osmosis-labs/osmosis/issues/4427
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount0InRoundingUp(sqrtPriceCurrent, liquidity, amountRemainingLessFee)
 	}
 
 	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: https://github.com/osmosis-labs/osmosis/issues/4427

## What is the purpose of the change

One of the problems with swap in given out was that we use the same method for computing next sqrt price as in out given in.

When we swap for in given out, we are moving in the opposite direction on the curve from out given in. As a result, we must be performing a subtraction as opposed to addition in the next sqrt price functions.

This PR splits the math helper for getting the next sqrt price in a variant for in given out and out given in. It adds tests for the desired rounding direction at precision end and adds extensive documentation.

The work on this is to be continue in subsequent PRs towards https://github.com/osmosis-labs/osmosis/issues/4427

## Brief Changelog

- split `GetNextSqrtPrice` into variants for in given out and out given in
- add tests, including for rounding behavior, QA via Python
- document

## Testing and Verifying

This change added tests
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable