### PR TITLE
Add legacy amino codec for proto-rev module

### DIFF
--- a/x/protorev/types/codec.go
+++ b/x/protorev/types/codec.go
@@ -30,6 +30,7 @@ const (
 
 func init() {
 	RegisterCodec(amino)
+	sdk.RegisterLegacyAminoCodec(amino)
 	amino.Seal()
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
Adds support for legacy amino codec for the proto-rev module. 

## Brief Changelog
- Add legacy amino codec registration for proto-rev module.

## Testing and Verifying
untested 
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)