### PR TITLE
Catch panics in ProtoRevTrade

### DIFF
--- a/x/protorev/keeper/posthandler.go
+++ b/x/protorev/keeper/posthandler.go
@@ -105,7 +105,14 @@ func (k Keeper) AnteHandleCheck(ctx sdk.Context) error {
 
 // ProtoRevTrade wraps around the build routes, iterate routes, and execute trade functionality to execute cyclic arbitrage trades
 // if they exist. It returns an error if there was an issue executing any single trade.
-func (k Keeper) ProtoRevTrade(ctx sdk.Context, swappedPools []SwapToBackrun) error {
+func (k Keeper) ProtoRevTrade(ctx sdk.Context, swappedPools []SwapToBackrun) (err error) {
+	// recover from panic
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("Protorev failed due to internal reason: %v", r)
+		}
+	}()
+
 	// Get the total number of pool points that can be consumed in this transaction
 	remainingPoolPoints, err := k.RemainingPoolPointsForTx(ctx)
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

- Adds panic catching in the ProtoRevTrade function so that nothing ProtoRev does has the ability to stop the regular tx
- ProtoRevTrade is the only real function that has the ability to bork a user tx by running out of gas (or other panics that may not be forseen now but may arise later)

## Brief Changelog

## Testing and Verifying

This change is already covered by existing tests, all tests still pass

## Documentation and Release Note