### PR TITLE
CL: Add `CalculateSpotPrice` and `GetPoolDenoms` to CL Keeper

### DIFF
--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -208,6 +208,14 @@ func (e PriceBoundError) Error() string {
 	return fmt.Sprintf("provided price (%s) must be between %s and %s", e.ProvidedPrice, e.MinSpotPrice, e.MaxSpotPrice)
 }
 
+type SpotPriceNegativeError struct {
+	ProvidedPrice sdk.Dec
+}
+
+func (e SpotPriceNegativeError) Error() string {
+	return fmt.Sprintf("provided price (%s) must be positive", e.ProvidedPrice)
+}
+
 type InvalidSwapFeeError struct {
 	ActualFee sdk.Dec
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Part of: https://github.com/osmosis-labs/osmosis/pull/4299/files

## What is the purpose of the change
Adds `GetPoolDenoms` and `CalculateSpotPrice` to the concentrated liquidity keeper. 
This is a necessary step in order to wire CL <> Pool Manager Module <> Twap module.

## Brief Changelog
- Add `GetPoolDenoms` and `CalculateSpotPrice` to CL Keeper

## Testing and Verifying
Adds new tests 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)