### PR TITLE
refactor/test(cl/swapstrategy): separate compute swap steps for out given in and in given out

### DIFF
--- a/x/concentrated-liquidity/internal/math/math.go
+++ b/x/concentrated-liquidity/internal/math/math.go
@@ -69,7 +69,7 @@ func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	if roundUp {
 		return liq.Mul(diff).Quo(denom).Ceil()
 	}
-	return liq.Mul(diff).Quo(denom)
+	return liq.Mul(diff).QuoTruncate(denom)
 }
 
 // CalcAmount1 takes the asset with the smaller liquidity in the pool as well as the sqrtpCur and the nextPrice and calculates the amount of asset 1

--- a/x/concentrated-liquidity/internal/math/math.go
+++ b/x/concentrated-liquidity/internal/math/math.go
@@ -69,7 +69,7 @@ func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	if roundUp {
 		return liq.Mul(diff).Quo(denom).Ceil()
 	}
-	return liq.Mul(diff).QuoTruncate(denom)
+	return liq.Mul(diff).Quo(denom)
 }
 
 // CalcAmount1 takes the asset with the smaller liquidity in the pool as well as the sqrtpCur and the nextPrice and calculates the amount of asset 1

--- a/x/concentrated-liquidity/internal/math/math.go
+++ b/x/concentrated-liquidity/internal/math/math.go
@@ -69,6 +69,7 @@ func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	if roundUp {
 		return liq.Mul(diff).Quo(denom).Ceil()
 	}
+	// Investigate if this should be a QuoTruncate: https://github.com/osmosis-labs/osmosis/issues/4646
 	return liq.Mul(diff).Quo(denom)
 }
 

--- a/x/concentrated-liquidity/internal/swapstrategy/export_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/export_test.go
@@ -2,10 +2,6 @@ package swapstrategy
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
-func ComputeFeeChargePerSwapStepOutGivenIn(currentSqrtPrice sdk.Dec, hasReachedTarget bool, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
-	return computeFeeChargePerSwapStepOutGivenIn(currentSqrtPrice, hasReachedTarget, amountIn, amountSpecifiedRemaining, swapFee)
-}
-
-func GetAmountRemainingLessFee(amountRemaining, swapFee sdk.Dec, isOutGivenIn bool) sdk.Dec {
-	return getAmountRemainingLessFee(amountRemaining, swapFee, isOutGivenIn)
+func ComputeFeeChargePerSwapStepOutGivenIn(hasReachedTarget bool, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
+	return computeFeeChargePerSwapStepOutGivenIn(hasReachedTarget, amountIn, amountSpecifiedRemaining, swapFee)
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/fees.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/fees.go
@@ -9,8 +9,6 @@ import (
 // computeFeeChargePerSwapStepOutGivenIn returns the total fee charge per swap step given the parameters.
 // Assumes swapping for token out given token in.
 //
-// - currentSqrtPrice the sqrt price at which the swap step begins.
-//
 // - hasReachedTarget is the boolean flag indicating whether the sqrtPriceTarget has been reached during the swap step.
 //   - the sqrtPriceTarget can be one of:
 //   - sqrtPriceLimit
@@ -24,7 +22,7 @@ import (
 //
 // If swap fee is negative, it panics.
 // If swap fee is 0, returns 0. Otherwise, computes and returns the fee charge per step.
-func computeFeeChargePerSwapStepOutGivenIn(currentSqrtPrice sdk.Dec, hasReachedTarget bool, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
+func computeFeeChargePerSwapStepOutGivenIn(hasReachedTarget bool, amountIn, amountSpecifiedRemaining, swapFee sdk.Dec) sdk.Dec {
 	feeChargeTotal := sdk.ZeroDec()
 
 	if swapFee.IsNegative() {
@@ -58,15 +56,4 @@ func computeFeeChargePerSwapStepOutGivenIn(currentSqrtPrice sdk.Dec, hasReachedT
 	}
 
 	return feeChargeTotal
-}
-
-// getAmountRemainingLessFee returns amount remaining less fee.
-// Note, the fee is always charged on token in.
-// When we swap for out given in, amountRemaining is the token in. As a result, the fee is charged.
-// When we swap for in given out, amountRemaining is the token out. As a result, the fee is not charged.
-func getAmountRemainingLessFee(amountRemaining, swapFee sdk.Dec, isOutGivenIn bool) sdk.Dec {
-	if isOutGivenIn {
-		return amountRemaining.MulTruncate(sdk.OneDec().Sub(swapFee))
-	}
-	return amountRemaining
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/fees.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/fees.go
@@ -40,7 +40,7 @@ func computeFeeChargePerSwapStepOutGivenIn(hasReachedTarget bool, amountIn, amou
 		// 2) or sqrtPriceLimit is reached
 		// In both cases, we charge the fee on the amount in actually consumed before
 		// hitting the target.
-		// TODO: should round up?
+		// TODO: round up at precision end: https://github.com/osmosis-labs/osmosis/issues/4645
 		feeChargeTotal = amountIn.Mul(swapFee).Quo(sdk.OneDec().Sub(swapFee))
 	} else {
 		// Otherwise, the current tick had enough liquidity to fulfill the swap

--- a/x/concentrated-liquidity/internal/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/one_for_zero.go
@@ -17,7 +17,6 @@ import (
 // With this strategy, we are moving to the right of the current
 // tick index and square root price.
 type oneForZeroStrategy struct {
-	isOutGivenIn   bool
 	sqrtPriceLimit sdk.Dec
 	storeKey       sdk.StoreKey
 	swapFee        sdk.Dec
@@ -35,15 +34,17 @@ func (s oneForZeroStrategy) GetSqrtTargetPrice(nextTickSqrtPrice sdk.Dec) sdk.De
 	return nextTickSqrtPrice
 }
 
-// ComputeSwapStep calculates the next sqrt price, the new amount remaining, the amount of the token other than remaining given current price, and total fee charge.
+// ComputeSwapStepLegacy is the old implementation of ComputeSwapStepOutGivenIn and ComputeSwapStepInGivenOut.
+// Calculates the next sqrt price, the new amount remaining, the amount of the token other than remaining given current price, and total fee charge.
 //
 // oneForZeroStrategy assumes moving to the right of the current square root price.
 // amountRemaining is the amount of token in when swapping out given in and token out when swapping in given out.
 // amountRemaining is token one.
 // amountOne is token out when swapping in given out and token in when swapping out given in.
 // amountZero is token in when swapping in given out and token out when swapping out given in.
-// TODO: improve tests
-func (s oneForZeroStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick, liquidity, amountRemaining sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
+//
+// To be removed in: https://github.com/osmosis-labs/osmosis/issues/4423
+func (s oneForZeroStrategy) ComputeSwapStepLegacy(sqrtPriceCurrent, sqrtPriceNextTick, liquidity, amountRemaining sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
 	// sqrtPriceTarget is the minimum of sqrtPriceNextTick or sqrtPriceLimit.
 	sqrtPriceTarget := s.GetSqrtTargetPrice(sqrtPriceNextTick)
 
@@ -51,17 +52,16 @@ func (s oneForZeroStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick,
 	amountOne := math.CalcAmount1Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent, true) // N.B.: if this is false, causes infinite loop
 
 	// Calculate sqrtPriceNext on the amount of token remaining after fee.
-	amountRemainingLessFee := getAmountRemainingLessFee(amountRemaining, s.swapFee, s.isOutGivenIn)
 	var sqrtPriceNext sdk.Dec
 	// If have more of the amount remaining after fee than estimated until target,
 	// bound the next sqrtPriceNext by the target sqrt price.
-	if amountRemainingLessFee.GTE(amountOne) {
+	if amountRemaining.GTE(amountOne) {
 		sqrtPriceNext = sqrtPriceTarget
 	} else {
 		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
 		// TODO: when swapping in given out, GetNextSqrtPriceFromAmount1OutRoundingDown must be used.
 		// To be addressed in: https://github.com/osmosis-labs/osmosis/issues/4427
-		sqrtPriceNext = math.GetNextSqrtPriceFromAmount1InRoundingDown(sqrtPriceCurrent, liquidity, amountRemainingLessFee)
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount1InRoundingDown(sqrtPriceCurrent, liquidity, amountRemaining)
 	}
 
 	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext
@@ -78,17 +78,124 @@ func (s oneForZeroStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick,
 
 	// Handle fees.
 	// Note that fee is always charged on the amount in.
-	var feeChargeTotal sdk.Dec
-	if s.isOutGivenIn {
-		// amountOne is amountIn.
-		feeChargeTotal = computeFeeChargePerSwapStepOutGivenIn(sqrtPriceCurrent, hasReachedTarget, amountOne, amountRemaining, s.swapFee)
-	} else {
-		// amountZero is amountIn.
-		// TODO: multiplication with rounding up at precision end.
-		feeChargeTotal = amountZero.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
-	}
+
+	// amountZero is amountIn.
+	// TODO: multiplication with rounding up at precision end.
+	feeChargeTotal := amountZero.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
 
 	return sqrtPriceNext, amountOne, amountZero, feeChargeTotal
+}
+
+// ComputeSwapStepOutGivenIn calculates the next sqrt price, the amount of token in consumed, the amount out to return to the user, and total fee charge on token in.
+// Parameters:
+//   - sqrtPriceCurrent is the current sqrt price.
+//   - sqrtPriceTarget is the target sqrt price computed with GetSqrtTargetPrice(). It must be one of:
+//     1. Next tick sqrt price.
+//     2. Sqrt price limit representing price impact protection.
+//   - liquidity is the amount of liquidity between the sqrt price current and sqrt price target.
+//   - amountOneRemainingIn is the amount of token one in remaining to be swapped. This amount is fully consumed
+//     if sqrt price target is not reached. In that case, the returned amountOne is the amount remaining given.
+//     Otherwise, the returned amountOneIn will be smaller than amountOneRemainingIn given.
+//
+// Returns:
+//   - sqrtPriceNext is the next sqrt price. It equals sqrt price target if target is reached. Otherwise, it is in-between sqrt price current and target.
+//   - amountOneIn is the amount of token in consumed. It equals amountRemainingIn if target is reached. Otherwise, it is less than amountOneRemainingIn.
+//   - amountZeroOut the amount of token out computed. It is the amount of token out to return to the user.
+//   - feeChargeTotal is the total fee charge. The fee is charged on the amount of token in.
+//
+// OneForZero details:
+// - oneForZeroStrategy assumes moving to the right of the current square root price.
+func (s oneForZeroStrategy) ComputeSwapStepOutGivenIn(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountOneInRemaining sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
+	// Estimate the amount of token one needed until the target sqrt price is reached.
+	amountOneIn := math.CalcAmount1Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent, true) // N.B.: if this is false, causes infinite loop
+
+	// Calculate sqrtPriceNext on the amount of token remaining after fee.
+	amountOneInRemainingLessFee := amountOneInRemaining.Mul(sdk.OneDec().Sub(s.swapFee))
+
+	var sqrtPriceNext sdk.Dec
+	// If have more of the amount remaining after fee than estimated until target,
+	// bound the next sqrtPriceNext by the target sqrt price.
+	if amountOneInRemainingLessFee.GTE(amountOneIn) {
+		sqrtPriceNext = sqrtPriceTarget
+	} else {
+		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount1InRoundingDown(sqrtPriceCurrent, liquidity, amountOneInRemainingLessFee)
+	}
+
+	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext
+
+	// If the sqrt price target was not reached, recalculate how much of the amount remaining after fee was needed
+	// to complete the swap step. This implies that some of the amount remaining after fee is left over after the
+	// current swap step.
+	if !hasReachedTarget {
+		amountOneIn = math.CalcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true) // N.B.: if this is false, causes infinite loop
+	}
+
+	// Calculate the amount of the other token given the sqrt price range.
+	amountZeroOut := math.CalcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, false)
+
+	// Handle fees.
+	// Note that fee is always charged on the amount in.
+	feeChargeTotal := computeFeeChargePerSwapStepOutGivenIn(hasReachedTarget, amountOneIn, amountOneInRemaining, s.swapFee)
+
+	return sqrtPriceNext, amountOneIn, amountZeroOut, feeChargeTotal
+}
+
+// ComputeSwapStepInGivenOut calculates the next sqrt price, the amount of token out consumed, the amount in to charge to the user for requested out, and total fee charge on token in.
+// Parameters:
+//   - sqrtPriceCurrent is the current sqrt price.
+//   - sqrtPriceTarget is the target sqrt price computed with GetSqrtTargetPrice(). It must be one of:
+//     1. Next tick sqrt price.
+//     2. Sqrt price limit representing price impact protection.
+//   - liquidity is the amount of liquidity between the sqrt price current and sqrt price target.
+//   - amountZeroRemainingOut is the amount of token zero out remaining to be swapped to estimate how much of token one in is needed to be charged.
+//     This amount is fully consumed if sqrt price target is not reached. In that case, the returned amountOut is the amount zero remaining given.
+//     Otherwise, the returned amountOut will be smaller than amountZeroRemainingOut given.
+//
+// Returns:
+//   - sqrtPriceNext is the next sqrt price. It equals sqrt price target if target is reached. Otherwise, it is in-between sqrt price current and target.
+//   - amountZeroOut is the amount of token zero out consumed. It equals amountZeroRemainingOut if target is reached. Otherwise, it is less than amountZeroRemainingOut.
+//   - amountIn is the amount of token in computed. It is the amount of token one in to charge to the user for the desired amount out.
+//   - feeChargeTotal is the total fee charge. The fee is charged on the amount of token in.
+//
+// OneForZero details:
+// - oneForZeroStrategy assumes moving to the right of the current square root price.
+func (s oneForZeroStrategy) ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountZeroRemainingOut sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
+	// Estimate the amount of token zero needed until the target sqrt price is reached.
+	// N.B.: contrary to out given in, we do not round up because we do not want to exceed the initial amount out at the end.
+	amountZeroOut := math.CalcAmount0Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent, false)
+
+	// Calculate sqrtPriceNext on the amount of token remaining. Note that the
+	// fee is not charged as amountRemaining is amountOut, and we only charge fee on
+	// amount in.
+	var sqrtPriceNext sdk.Dec
+	// If have more of the amount remaining after fee than estimated until target,
+	// bound the next sqrtPriceNext by the target sqrt price.
+	if amountZeroRemainingOut.GTE(amountZeroOut) {
+		sqrtPriceNext = sqrtPriceTarget
+	} else {
+		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount0OutRoundingUp(sqrtPriceCurrent, liquidity, amountZeroRemainingOut)
+	}
+
+	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext
+
+	// If the sqrt price target was not reached, recalculate how much of the amount remaining after fee was needed
+	// to complete the swap step. This implies that some of the amount remaining after fee is left over after the
+	// current swap step.
+	if !hasReachedTarget {
+		// N.B.: contrary to out given in, we do not round up because we do not want to exceed the initial amount out at the end.
+		amountZeroOut = math.CalcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, false)
+	}
+
+	// Calculate the amount of the other token given the sqrt price range.
+	amountOneIn := math.CalcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true)
+
+	// Handle fees.
+	// Note that fee is always charged on the amount in.
+	feeChargeTotal := amountOneIn.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
+
+	return sqrtPriceNext, amountZeroOut, amountOneIn, feeChargeTotal
 }
 
 // InitializeTickValue returns the initial tick value for computing swaps based

--- a/x/concentrated-liquidity/internal/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/one_for_zero.go
@@ -193,6 +193,7 @@ func (s oneForZeroStrategy) ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPric
 
 	// Handle fees.
 	// Note that fee is always charged on the amount in.
+	// TODO: round up at precision end: https://github.com/osmosis-labs/osmosis/issues/4645
 	feeChargeTotal := amountOneIn.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
 
 	return sqrtPriceNext, amountZeroOut, amountOneIn, feeChargeTotal

--- a/x/concentrated-liquidity/internal/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/one_for_zero_test.go
@@ -35,12 +35,211 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_OneForZero() {
 		suite.Run(name, func() {
 			suite.SetupTest()
 
-			sut := swapstrategy.New(false, false, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
+			sut := swapstrategy.New(false, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
 
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 
 			suite.Require().Equal(tc.expectedResult, actualSqrtTargetPrice)
 
+		})
+	}
+}
+
+func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
+	var (
+		sqrtPriceCurrent = defaultSqrtPriceLower
+		sqrtPriceNext    = defaultSqrtPriceUpper
+
+		// sqrt_price_current + token_in / liquidity
+		sqrtPriceTargetNotReached = sdk.MustNewDecFromStr("70.710678085714122880")
+		// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
+		amountZeroTargetNotReached = sdk.MustNewDecFromStr("13369.979999999989129753")
+	)
+
+	tests := map[string]struct {
+		sqrtPriceCurrent     sdk.Dec
+		sqrtPriceTarget      sdk.Dec
+		liquidity            sdk.Dec
+		amountOneInRemaining sdk.Dec
+		swapFee              sdk.Dec
+
+		expectedSqrtPriceNext    sdk.Dec
+		expectedAmountInConsumed sdk.Dec
+		expectedAmountOut        sdk.Dec
+		expectedFeeChargeTotal   sdk.Dec
+
+		expectError error
+	}{
+		"1: no fee - reach target": {
+			sqrtPriceCurrent: sqrtPriceCurrent,
+			sqrtPriceTarget:  sqrtPriceNext,
+			liquidity:        defaultLiquidity,
+			// Add 100.
+			amountOneInRemaining: defaultAmountOne.Add(sdk.NewDec(100)),
+			swapFee:              sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrtPriceNext,
+			// Reached target, so 100 is not consumed.
+			expectedAmountInConsumed: defaultAmountOne.Ceil(),
+			// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
+			expectedAmountOut:      defaultAmountZero,
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"2: no fee - do not reach target": {
+			sqrtPriceCurrent:     sqrtPriceCurrent,
+			sqrtPriceTarget:      sqrtPriceNext,
+			liquidity:            defaultLiquidity,
+			amountOneInRemaining: defaultAmountOne.Sub(sdk.NewDec(100)),
+			swapFee:              sdk.ZeroDec(),
+
+			// sqrt_price_current + token_in / liquidity
+			expectedSqrtPriceNext:    sqrtPriceTargetNotReached,
+			expectedAmountInConsumed: defaultAmountOne.Sub(sdk.NewDec(100)).Ceil(),
+			expectedAmountOut:        amountZeroTargetNotReached,
+			expectedFeeChargeTotal:   sdk.ZeroDec(),
+		},
+		"3: 3% fee - reach target": {
+			sqrtPriceCurrent:     sqrtPriceCurrent,
+			sqrtPriceTarget:      sqrtPriceNext,
+			liquidity:            defaultLiquidity,
+			amountOneInRemaining: defaultAmountOne.Add(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)),
+			swapFee:              defaultFee,
+
+			expectedSqrtPriceNext:    sqrtPriceNext,
+			expectedAmountInConsumed: defaultAmountOne.Ceil(),
+			// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
+			expectedAmountOut:      defaultAmountZero,
+			expectedFeeChargeTotal: defaultAmountOne.Ceil().Quo(sdk.OneDec().Sub(defaultFee)).Mul(defaultFee),
+		},
+		"4: 3% fee - do not reach target": {
+			sqrtPriceCurrent:     sqrtPriceCurrent,
+			sqrtPriceTarget:      sqrtPriceNext,
+			liquidity:            defaultLiquidity,
+			amountOneInRemaining: defaultAmountOne.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)),
+			swapFee:              defaultFee,
+
+			expectedSqrtPriceNext:    sqrtPriceTargetNotReached,
+			expectedAmountInConsumed: defaultAmountOne.Sub(sdk.NewDec(100)).Ceil(),
+			expectedAmountOut:        amountZeroTargetNotReached,
+			// Difference between given amount remaining in and amount in actually consumed which qpproximately equals to fee.
+			expectedFeeChargeTotal: defaultAmountOne.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)).Sub(defaultAmountOne.Sub(sdk.NewDec(100)).Ceil()),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+			suite.SetupTest()
+			strategy := swapstrategy.New(false, types.MaxSqrtRatio, suite.App.GetKey(types.ModuleName), tc.swapFee)
+
+			sqrtPriceNext, amountInConsumed, amountZeroOut, feeChargeTotal := strategy.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountOneInRemaining)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
+			suite.Require().Equal(tc.expectedAmountInConsumed, amountInConsumed)
+			suite.Require().Equal(tc.expectedAmountOut, amountZeroOut)
+			suite.Require().Equal(tc.expectedFeeChargeTotal, feeChargeTotal)
+		})
+	}
+}
+
+func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
+	var (
+		sqrtPriceCurrent = defaultSqrtPriceLower
+		sqrtPriceNext    = defaultSqrtPriceUpper
+		// Target is not reached means that we stop at the sqrt price earlier
+		// than expected. As a result, we recalculate the amount out and amount in
+		// necessary to reach the earlier target.
+		// sqrt_next = liq * sqrt_cur / (liq  - token_out * sqrt_cur) quo round up
+		sqrtPriceTargetNotReached = sdk.MustNewDecFromStr("70.709031125539448610")
+		// liq * (sqrt_next - sqrt_cur)
+		amountOneTargetNotReached = sdk.MustNewDecFromStr("61829304.427824073089251659")
+		// N.B.: approx eq = defaultAmountZero.Sub(sdk.NewDec(1000))
+		// slight variance due to recomputing amount out when target is not reached.
+		// liq * (sqrt_next - sqrt_cur) / (sqrt_next * sqrt_cur)
+		amountZeroTargetNotReached = sdk.MustNewDecFromStr("12369.999999999999293322")
+	)
+
+	tests := map[string]struct {
+		sqrtPriceCurrent       sdk.Dec
+		sqrtPriceTarget        sdk.Dec
+		liquidity              sdk.Dec
+		amountZeroOutRemaining sdk.Dec
+		swapFee                sdk.Dec
+
+		expectedSqrtPriceNext         sdk.Dec
+		expectedAmountZeroOutConsumed sdk.Dec
+		expectedAmountOneIn           sdk.Dec
+		expectedFeeChargeTotal        sdk.Dec
+
+		expectError error
+	}{
+		"1: no fee - reach target": {
+			sqrtPriceCurrent: sqrtPriceCurrent,
+			sqrtPriceTarget:  sqrtPriceNext,
+			liquidity:        defaultLiquidity,
+			// Add 100.
+			amountZeroOutRemaining: defaultAmountZero.Add(sdk.NewDec(100)),
+			swapFee:                sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrtPriceNext,
+			// Reached target, so 100 is not consumed.
+			expectedAmountZeroOutConsumed: defaultAmountZero,
+			// liquidity * (sqrtPriceNext - sqrtPriceCurrent)
+			expectedAmountOneIn:    defaultAmountOne.Ceil(),
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"2: no fee - do not reach target": {
+			sqrtPriceCurrent:       sqrtPriceCurrent,
+			sqrtPriceTarget:        sqrtPriceNext,
+			liquidity:              defaultLiquidity,
+			amountZeroOutRemaining: defaultAmountZero.Sub(sdk.NewDec(1000)),
+			swapFee:                sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
+
+			expectedAmountZeroOutConsumed: amountZeroTargetNotReached,
+
+			expectedAmountOneIn:    amountOneTargetNotReached.Ceil(),
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"3: 3% fee - reach target": {
+			sqrtPriceCurrent:       sqrtPriceCurrent,
+			sqrtPriceTarget:        sqrtPriceNext,
+			liquidity:              defaultLiquidity,
+			amountZeroOutRemaining: defaultAmountZero.Quo(sdk.OneDec().Sub(defaultFee)),
+			swapFee:                defaultFee,
+
+			expectedSqrtPriceNext:         sqrtPriceNext,
+			expectedAmountZeroOutConsumed: defaultAmountZero,
+			expectedAmountOneIn:           defaultAmountOne.Ceil(),
+			expectedFeeChargeTotal:        defaultAmountOne.Ceil().Quo(sdk.OneDec().Sub(defaultFee)).Mul(defaultFee),
+		},
+		"4: 3% fee - do not reach target": {
+			sqrtPriceCurrent:       sqrtPriceCurrent,
+			sqrtPriceTarget:        sqrtPriceNext,
+			liquidity:              defaultLiquidity,
+			amountZeroOutRemaining: defaultAmountZero.Sub(sdk.NewDec(1000)),
+			swapFee:                defaultFee,
+
+			expectedSqrtPriceNext:         sqrtPriceTargetNotReached,
+			expectedAmountZeroOutConsumed: amountZeroTargetNotReached,
+			expectedAmountOneIn:           amountOneTargetNotReached.Ceil(),
+			expectedFeeChargeTotal:        amountOneTargetNotReached.Ceil().Quo(sdk.OneDec().Sub(defaultFee)).Mul(defaultFee),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+			suite.SetupTest()
+			strategy := swapstrategy.New(false, types.MaxSqrtRatio, suite.App.GetKey(types.ModuleName), tc.swapFee)
+
+			sqrtPriceNext, amountZeroOutConsumed, amountOneIn, feeChargeTotal := strategy.ComputeSwapStepInGivenOut(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountZeroOutRemaining)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
+			suite.Require().Equal(tc.expectedAmountZeroOutConsumed, amountZeroOutConsumed)
+			suite.Require().Equal(tc.expectedAmountOneIn, amountOneIn)
+			suite.Require().Equal(tc.expectedFeeChargeTotal, feeChargeTotal)
 		})
 	}
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/swap_strategy.go
@@ -11,9 +11,43 @@ type swapStrategy interface {
 	// upon comparing it to sqrt price limit.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
 	GetSqrtTargetPrice(nextTickSqrtPrice sdk.Dec) sdk.Dec
-	// ComputeSwapStep calculates the next sqrt price, the new amount remaining, the amount of the token other than remaining given current price, and total fee charge.
+	// ComputeSwapStepLegacy is the old implementation of ComputeSwapStepOutGivenIn and ComputeSwapStepInGivenOut.
+	// To be removed in: https://github.com/osmosis-labs/osmosis/issues/4423
+	ComputeSwapStepLegacy(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext, newAmountRemaining, amountComputed, feeChargeTotal sdk.Dec)
+	// ComputeSwapStepOutGivenIn calculates the next sqrt price, the amount of token in consumed, the amount out to return to the user, and total fee charge on token in.
+	// Parameters:
+	//   * sqrtPriceCurrent is the current sqrt price.
+	//   * sqrtPriceTarget is the target sqrt price computed with GetSqrtTargetPrice(). It must be one of:
+	//       - Next tick sqrt price.
+	//       - Sqrt price limit representing price impact protection.
+	//   * liquidity is the amount of liquidity between the sqrt price current and sqrt price target.
+	//   * amountRemainingIn is the amount of token in remaining to be swapped. This amount is fully consumed
+	//   if sqrt price target is not reached. In that case, the returned amountInConsumed is the amount remaining given.
+	//   Otherwise, the returned amountInConsumed will be smaller than amountRemainingIn given.
+	// Returns:
+	//   * sqrtPriceNext is the next sqrt price. It equals sqrt price target if target is reached. Otherwise, it is in-between sqrt price current and target.
+	//   * amountInConsumed is the amount of token in consumed. It equals amountRemainingIn if target is reached. Otherwise, it is less than amountRemainingIn.
+	//   * amountOutComputed is the amount of token out computed. It is the amount of token out to return to the user.
+	//   * feeChargeTotal is the total fee charge. The fee is charged on the amount of token in.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
-	ComputeSwapStep(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemaining sdk.Dec) (sqrtPriceNext, newAmountRemaining, amountComputed, feeChargeTotal sdk.Dec)
+	ComputeSwapStepOutGivenIn(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemainingIn sdk.Dec) (sqrtPriceNext, amountInConsumed, amountOutComputed, feeChargeTotal sdk.Dec)
+	// ComputeSwapStepInGivenOut calculates the next sqrt price, the amount of token out consumed, the amount in to charge to the user for requested out, and total fee charge on token in.
+	// Parameters:
+	//   * sqrtPriceCurrent is the current sqrt price.
+	//   * sqrtPriceTarget is the target sqrt price computed with GetSqrtTargetPrice(). It must be one of:
+	//       - Next tick sqrt price.
+	//       - Sqrt price limit representing price impact protection.
+	//   * liquidity is the amount of liquidity between the sqrt price current and sqrt price target.
+	//   * amountRemainingOut is the amount of token out remaining to be swapped to estimate how much of token in is needed to be charged.
+	//   This amount is fully consumed if sqrt price target is not reached. In that case, the returned amountOutConsumed is the amount remaining given.
+	//   Otherwise, the returned amountOutConsumed will be smaller than amountRemainingOut given.
+	// Returns:
+	//   * sqrtPriceNext is the next sqrt price. It equals sqrt price target if target is reached. Otherwise, it is in-between sqrt price current and target.
+	//   * amountOutConsumed is the amount of token out consumed. It equals amountRemainingOut if target is reached. Otherwise, it is less than amountRemainingOut.
+	//   * amountInComputed is the amount of token in computed. It is the amount of token in to charge to the user for the desired amount out.
+	//   * feeChargeTotal is the total fee charge. The fee is charged on the amount of token in.
+	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
+	ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountRemainingOut sdk.Dec) (sqrtPriceNext, amountOutConsumed, amountInComputed, feeChargeTotal sdk.Dec)
 	// InitializeTickValue returns the initial tick value for computing swaps based
 	// on the actual current tick.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
@@ -41,9 +75,9 @@ type swapStrategy interface {
 // New returns a swap strategy based on the provided zeroForOne parameter
 // with sqrtPriceLimit for the maximum square root price until which to perform
 // the swap and the stor key of the module that stores swap data.
-func New(zeroForOne bool, isOutGivenIn bool, sqrtPriceLimit sdk.Dec, storeKey sdk.StoreKey, swapFee sdk.Dec) swapStrategy {
+func New(zeroForOne bool, sqrtPriceLimit sdk.Dec, storeKey sdk.StoreKey, swapFee sdk.Dec) swapStrategy {
 	if zeroForOne {
-		return &zeroForOneStrategy{isOutGivenIn: isOutGivenIn, sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee}
+		return &zeroForOneStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee}
 	}
-	return &oneForZeroStrategy{isOutGivenIn: isOutGivenIn, sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee}
+	return &oneForZeroStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee}
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/swap_strategy_test.go
@@ -1,11 +1,13 @@
 package swapstrategy_test
 
 import (
+	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/internal/swapstrategy"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
@@ -17,10 +19,16 @@ type StrategyTestSuite struct {
 }
 
 var (
-	two   = sdk.NewDec(2)
-	three = sdk.NewDec(2)
-	four  = sdk.NewDec(4)
-	five  = sdk.NewDec(5)
+	two                   = sdk.NewDec(2)
+	three                 = sdk.NewDec(2)
+	four                  = sdk.NewDec(4)
+	five                  = sdk.NewDec(5)
+	defaultSqrtPriceLower = sdk.MustNewDecFromStr("70.688664163408836321") // approx 4996.89
+	defaultSqrtPriceUpper = sdk.MustNewDecFromStr("70.710678118654752440") // 5000
+	defaultAmountOne      = sdk.MustNewDecFromStr("66829187.967824033199646915")
+	defaultAmountZero     = sdk.MustNewDecFromStr("13369.999999999998920002")
+	defaultLiquidity      = sdk.MustNewDecFromStr("3035764687.503020836176699298")
+	defaultFee            = sdk.MustNewDecFromStr("0.03")
 )
 
 func TestStrategyTestSuite(t *testing.T) {
@@ -29,60 +37,6 @@ func TestStrategyTestSuite(t *testing.T) {
 
 func (suite *StrategyTestSuite) SetupTest() {
 	suite.Setup()
-}
-
-// TODO: split up this test case to be separate for each strategy.
-func (suite *StrategyTestSuite) TestComputeSwapState() {
-	testCases := map[string]struct {
-		sqrtPCurrent          sdk.Dec
-		nextSqrtPrice         sdk.Dec
-		liquidity             sdk.Dec
-		amountRemaining       sdk.Dec
-		sqrtPriceLimit        sdk.Dec
-		zeroForOne            bool
-		expectedSqrtPriceNext string
-		expectedAmountIn      string
-		expectedAmountOut     string
-	}{
-		"happy path: trade asset0 for asset1": {
-			sqrtPCurrent:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-			nextSqrtPrice:   sdk.MustNewDecFromStr("70.666662070529219856"), // 4993.7771281903730
-			liquidity:       sdk.MustNewDecFromStr("1517882343.751510418088349649"),
-			amountRemaining: sdk.NewDec(13370),
-			// sqrt price limit is less than sqrt price target so it does not affect the result
-			// TODO: test case where it does affect.
-			sqrtPriceLimit:        sdk.MustNewDecFromStr("70.661163307718052314").Sub(sdk.OneDec()), // 4993
-			zeroForOne:            true,
-			expectedSqrtPriceNext: "70.666663910857144332",
-			expectedAmountIn:      "13370.000000000000000000",
-			expectedAmountOut:     "66808388.890199400470645012",
-		},
-		"happy path: trade asset1 for asset0": {
-			sqrtPCurrent:    sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
-			nextSqrtPrice:   sdk.MustNewDecFromStr("70.738349405152439867"), // 5003.91407656543054317
-			liquidity:       sdk.MustNewDecFromStr("1517882343.751510418088349649"),
-			amountRemaining: sdk.NewDec(42000000),
-			// sqrt price limit is less than sqrt price target so it does not affect the result
-			// TODO: test case where it does affect.
-			sqrtPriceLimit:        sdk.MustNewDecFromStr("70.738956735309575810").Add(sdk.OneDec()), // 5003
-			zeroForOne:            false,
-			expectedSqrtPriceNext: "70.738348247484497717",
-			expectedAmountIn:      "42000000.000000000000000000",
-			expectedAmountOut:     "8396.714242162444943332",
-		},
-	}
-
-	for name, tc := range testCases {
-		tc := tc
-
-		suite.Run(name, func() {
-			swapStrategy := swapstrategy.New(tc.zeroForOne, true, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
-			sqrtPriceNext, amountIn, amountOut, _ := swapStrategy.ComputeSwapStep(tc.sqrtPCurrent, tc.nextSqrtPrice, tc.liquidity, tc.amountRemaining)
-			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext.String())
-			suite.Require().Equal(tc.expectedAmountIn, amountIn.String())
-			suite.Require().Equal(tc.expectedAmountOut, amountOut.String())
-		})
-	}
 }
 
 // TODO: split up this test case to be separate for each strategy.
@@ -100,42 +54,42 @@ func (suite *StrategyTestSuite) TestNextInitializedTick() {
 	suite.Run("lte=true", func() {
 		suite.Run("returns tick to right if at initialized tick", func() {
 
-			swapStrategy := swapstrategy.New(false, false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(ctx, 1, 78)
 			suite.Require().Equal(sdk.NewInt(84), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns tick to right if at initialized tick", func() {
-			swapStrategy := swapstrategy.New(false, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, -55)
 			suite.Require().Equal(sdk.NewInt(-4), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the tick directly to the right", func() {
-			swapStrategy := swapstrategy.New(false, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 77)
 			suite.Require().Equal(sdk.NewInt(78), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the tick directly to the right", func() {
-			swapStrategy := swapstrategy.New(false, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, -56)
 			suite.Require().Equal(sdk.NewInt(-55), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the next words initialized tick if on the right boundary", func() {
-			swapStrategy := swapstrategy.New(false, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, -257)
 			suite.Require().Equal(sdk.NewInt(-200), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the next initialized tick from the next word", func() {
-			swapStrategy := swapstrategy.New(false, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			suite.App.ConcentratedLiquidityKeeper.SetTickInfo(suite.Ctx, 1, 340, model.TickInfo{})
 
@@ -147,25 +101,154 @@ func (suite *StrategyTestSuite) TestNextInitializedTick() {
 
 	suite.Run("lte=false", func() {
 		suite.Run("returns tick directly to the left of input tick if not initialized", func() {
-			swapStrategy := swapstrategy.New(true, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 79)
 			suite.Require().Equal(sdk.NewInt(78), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns previous tick even though given is initialized", func() {
-			swapStrategy := swapstrategy.New(true, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 78)
 			suite.Require().Equal(sdk.NewInt(70), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns next initialized tick far away", func() {
-			swapStrategy := swapstrategy.New(true, true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 100)
 			suite.Require().Equal(sdk.NewInt(84), n)
 			suite.Require().True(initd)
 		})
 	})
+}
+
+// TestComputeSwapState_Inverse validates that out given in and in given out compute swap steps
+// for one strategy produce the same results as the other given inverse inputs.
+// That is, if we swap in A of token0 and expect to get out B of token 1,
+// we should be able to get A of token 0 in when swapping out for B of token 1.
+func (suite *StrategyTestSuite) TestComputeSwapState_Inverse() {
+	var (
+		errToleranceOne = osmomath.ErrTolerance{
+			AdditiveTolerance: sdk.OneDec(),
+			RoundingDir:       osmomath.RoundUp,
+		}
+
+		errToleranceSmall = osmomath.ErrTolerance{
+			AdditiveTolerance: sdk.NewDecFromIntWithPrec(sdk.OneInt(), 5),
+		}
+	)
+
+	testCases := map[string]struct {
+		sqrtPriceCurrent sdk.Dec
+		sqrtPriceTarget  sdk.Dec
+		liquidity        sdk.Dec
+		amountIn         sdk.Dec
+		amountOut        sdk.Dec
+		zeroForOne       bool
+		swapFee          sdk.Dec
+
+		expectedSqrtPriceNextOutGivenIn sdk.Dec
+		expectedSqrtPriceNextInGivenOut sdk.Dec
+		expectedAmountIn                sdk.Dec
+		expectedAmountOut               sdk.Dec
+	}{
+		"1: one_for_zero__not_equal_target__no_fee": {
+			sqrtPriceCurrent: sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			sqrtPriceTarget:  sdk.MustNewDecFromStr("70.724818840347693039"), // 5002
+			liquidity:        sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountIn:         sdk.NewDec(42000000),
+			amountOut:        sdk.NewDec(8398),
+			zeroForOne:       false,
+			swapFee:          sdk.ZeroDec(),
+
+			// from token_in:   sqrt_next = sqrt_cur + token_in / liq2 = 70.72451318306962507883763621
+			expectedSqrtPriceNextOutGivenIn: sdk.MustNewDecFromStr("70.724513183069625078"), // approx 5001.96
+			// from token_out:  sqrt_next = liq2 * sqrt_cur / (liq2 - token_out * sqrt_cur)
+			expectedSqrtPriceNextInGivenOut: sdk.MustNewDecFromStr("70.724513183069625078"), // approx 5001.96
+
+			expectedAmountIn:  sdk.NewDec(42000000),
+			expectedAmountOut: sdk.NewDec(8398),
+		},
+		"2: zero_for_one__not_equal_target__no_fee": {
+			sqrtPriceCurrent: sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			sqrtPriceTarget:  sdk.MustNewDecFromStr("70.682388188289167342"), // 4996
+			liquidity:        sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountIn:         sdk.NewDec(13370),
+			amountOut:        sdk.NewDec(66829187),
+			zeroForOne:       true,
+			swapFee:          sdk.ZeroDec(),
+
+			// from amount in: sqrt_next = liq2 * sqrt_cur / (liq2 + token_in * sqrt_cur) quo round up = 70.68866416340883631930670240
+			expectedSqrtPriceNextOutGivenIn: sdk.MustNewDecFromStr("70.688664163408836320"), // approx 4996.89
+
+			// from amount out: sqrt_next = sqrt_cur - token_out / liq2 quo round down
+			expectedSqrtPriceNextInGivenOut: sdk.MustNewDecFromStr("70.688664163408836319"), // approx 4996.89
+
+			expectedAmountIn:  sdk.NewDec(13370),
+			expectedAmountOut: sdk.NewDec(66829187),
+		},
+		"3: one_for_zero__equal_target__no_fee": {
+			sqrtPriceCurrent: sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			sqrtPriceTarget:  sdk.MustNewDecFromStr("70.724513183069625078"), // approx 5001.96
+			liquidity:        sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountIn:         sdk.NewDec(42000000),
+			amountOut:        sdk.NewDec(8398),
+			swapFee:          sdk.ZeroDec(),
+
+			zeroForOne: false,
+			// from token_in:   sqrt_next = sqrt_cur + token_in / liq2 = 70.72451318306962507883763621
+			expectedSqrtPriceNextOutGivenIn: sdk.MustNewDecFromStr("70.724513183069625078"), // approx 5001.96
+			// from token_out:  sqrt_next = liq2 * sqrt_cur / (liq2 - token_out * sqrt_cur)
+			expectedSqrtPriceNextInGivenOut: sdk.MustNewDecFromStr("70.724513183069625078"), // approx 5001.96
+
+			expectedAmountIn:  sdk.NewDec(42000000),
+			expectedAmountOut: sdk.NewDec(8398),
+		},
+		"4: zero_for_one__equal_target__no_fee": {
+			sqrtPriceCurrent: sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
+			sqrtPriceTarget:  sdk.MustNewDecFromStr("70.688664163408836320"), // approx 4996.89
+			liquidity:        sdk.MustNewDecFromStr("3035764687.503020836176699298"),
+			amountIn:         sdk.NewDec(13370),
+			amountOut:        sdk.NewDec(66829187),
+			zeroForOne:       true,
+			swapFee:          sdk.ZeroDec(),
+
+			// from amount in: sqrt_next = liq2 * sqrt_cur / (liq2 + token_in * sqrt_cur) = 70.68866416340883631930670240
+			expectedSqrtPriceNextOutGivenIn: sdk.MustNewDecFromStr("70.688664163408836320"), // approx 4996.89
+
+			// from amount out: sqrt_next = sqrt_cur - token_out / liq2
+			expectedSqrtPriceNextInGivenOut: sdk.MustNewDecFromStr("70.688664163408836320"), // approx 4996.89
+
+			expectedAmountIn:  sdk.NewDec(13370),
+			expectedAmountOut: sdk.NewDec(66829187),
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		suite.Run(name, func() {
+			sut := swapstrategy.New(tc.zeroForOne, sdk.ZeroDec(), suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
+			sqrtPriceNextOutGivenIn, amountInOutGivenIn, amountOutOutGivenIn, _ := sut.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountIn)
+			suite.Require().Equal(tc.expectedSqrtPriceNextOutGivenIn.String(), sqrtPriceNextOutGivenIn.String())
+
+			sqrtPriceNextInGivenOut, amountOutInGivenOut, amountInInGivenOut, _ := sut.ComputeSwapStepInGivenOut(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, amountOutOutGivenIn)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNextInGivenOut.String(), sqrtPriceNextInGivenOut.String())
+
+			// Tolerance of 1 with rounding up because we round up for in given out.
+			// This is to ensure that inflow into the pool is rounded in favor of the pool.
+			suite.Require().Equal(0, errToleranceOne.CompareBigDec(
+				osmomath.BigDecFromSDKDec(amountInOutGivenIn),
+				osmomath.BigDecFromSDKDec(amountInInGivenOut)),
+				fmt.Sprintf("amount in out given in: %s, amount in in given out: %s", amountInOutGivenIn, amountInInGivenOut))
+
+			// These should be approximately equal. The difference stems from minor roundings and truncations in the intermediary calculations.
+			suite.Require().Equal(0, errToleranceSmall.CompareBigDec(
+				osmomath.BigDecFromSDKDec(amountOutOutGivenIn),
+				osmomath.BigDecFromSDKDec(amountOutInGivenOut)),
+				fmt.Sprintf("amount out out given in: %s, amount out in given out: %s", amountOutOutGivenIn, amountOutInGivenOut))
+		})
+	}
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/zero_for_one.go
@@ -17,7 +17,6 @@ import (
 // With this strategy, we are moving to the left of the current
 // tick index and square root price.
 type zeroForOneStrategy struct {
-	isOutGivenIn   bool
 	sqrtPriceLimit sdk.Dec
 	storeKey       sdk.StoreKey
 	swapFee        sdk.Dec
@@ -35,15 +34,17 @@ func (s zeroForOneStrategy) GetSqrtTargetPrice(nextTickSqrtPrice sdk.Dec) sdk.De
 	return nextTickSqrtPrice
 }
 
-// ComputeSwapStep calculates the next sqrt price, the new amount remaining, the amount of the token other than remaining given current price, and total fee charge.
+// ComputeSwapStepLegacy is the old implementation of ComputeSwapStepOutGivenIn and ComputeSwapStepInGivenOut.
+// Calculates the next sqrt price, the new amount remaining, the amount of the token other than remaining given current price, and total fee charge.
 //
 // zeroForOneStrategy assumes moving to the left of the current square root price.
 // amountRemaining is the amount of token in when swapping out given in and token out when swapping in given out.
 // amountRemaining is token zero.
 // amountZero is token out when swapping in given out and token in when swapping out given in.
 // amountOne is token in when swapping in given out and token out when swapping out given in.
-// TODO: improve tests
-func (s zeroForOneStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick, liquidity, amountRemaining sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
+//
+// To be removed in: https://github.com/osmosis-labs/osmosis/issues/4423
+func (s zeroForOneStrategy) ComputeSwapStepLegacy(sqrtPriceCurrent, sqrtPriceNextTick, liquidity, amountRemaining sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
 	// sqrtPriceTarget is the maximum of sqrtPriceNextTick or sqrtPriceLimit.
 	sqrtPriceTarget := s.GetSqrtTargetPrice(sqrtPriceNextTick)
 
@@ -51,17 +52,17 @@ func (s zeroForOneStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick,
 	amountZero := math.CalcAmount0Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent, true) // N.B.: if this is false, causes infinite loop
 
 	// Calculate sqrtPriceNext on the amount of token remaining after fee.
-	amountRemainingLessFee := getAmountRemainingLessFee(amountRemaining, s.swapFee, s.isOutGivenIn)
+
 	var sqrtPriceNext sdk.Dec
 	// If have more of the amount remaining after fee than estimated until target,
 	// bound the next sqrtPriceNext by the target sqrt price.
-	if amountRemainingLessFee.GTE(amountZero) {
+	if amountRemaining.GTE(amountZero) {
 		sqrtPriceNext = sqrtPriceTarget
 	} else {
 		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
 		// TODO: when swapping in given out, GetNextSqrtPriceFromAmount0OutRoundingUp must be used.
 		// To be addressed in: https://github.com/osmosis-labs/osmosis/issues/4427
-		sqrtPriceNext = math.GetNextSqrtPriceFromAmount0InRoundingUp(sqrtPriceCurrent, liquidity, amountRemainingLessFee)
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount0InRoundingUp(sqrtPriceCurrent, liquidity, amountRemaining)
 	}
 
 	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext
@@ -78,17 +79,121 @@ func (s zeroForOneStrategy) ComputeSwapStep(sqrtPriceCurrent, sqrtPriceNextTick,
 
 	// Handle fees.
 	// Note that fee is always charged on the amount in.
-	var feeChargeTotal sdk.Dec
-	if s.isOutGivenIn {
-		// amountZero is amount in.
-		feeChargeTotal = computeFeeChargePerSwapStepOutGivenIn(sqrtPriceCurrent, hasReachedTarget, amountZero, amountRemaining, s.swapFee)
-	} else {
-		// amountOne is amount in.
-		// TODO: multiplication with rounding up at precision end.
-		feeChargeTotal = amountOne.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
-	}
+	// amountOne is amount in.
+	// TODO: multiplication with rounding up at precision end.
+	feeChargeTotal := amountOne.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
 
 	return sqrtPriceNext, amountZero, amountOne, feeChargeTotal
+}
+
+// ComputeSwapStepOutGivenIn calculates the next sqrt price, the amount of token in consumed, the amount out to return to the user, and total fee charge on token in.
+// Parameters:
+//   - sqrtPriceCurrent is the current sqrt price.
+//   - sqrtPriceTarget is the target sqrt price computed with GetSqrtTargetPrice(). It must be one of:
+//     1. Next tick sqrt price.
+//     2. Sqrt price limit representing price impact protection.
+//   - liquidity is the amount of liquidity between the sqrt price current and sqrt price target.
+//   - amountZeroInRemaining is the amount of token zero in remaining to be swapped. This amount is fully consumed
+//     if sqrt price target is not reached. In that case, the returned amountZeroIn is the amount remaining given.
+//     Otherwise, the returned amountIn will be smaller than amountZeroInRemaining given.
+//
+// Returns:
+//   - sqrtPriceNext is the next sqrt price. It equals sqrt price target if target is reached. Otherwise, it is in-between sqrt price current and target.
+//   - amountZeroIn is the amount of token zero in consumed. It equals amountZeroInRemaining if target is reached. Otherwise, it is less than amountZeroInRemaining.
+//   - amountOutComputed is the amount of token out computed. It is the amount of token out to return to the user.
+//   - feeChargeTotal is the total fee charge. The fee is charged on the amount of token in.
+//
+// ZeroForOne details:
+// - zeroForOneStrategy assumes moving to the left of the current square root price.
+func (s zeroForOneStrategy) ComputeSwapStepOutGivenIn(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountZeroInRemaining sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
+	// Estimate the amount of token zero needed until the target sqrt price is reached.
+	amountZeroIn := math.CalcAmount0Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent, true) // N.B.: if this is false, causes infinite loop
+
+	// Calculate sqrtPriceNext on the amount of token remaining after fee.
+	amountZeroInRemainingLessFee := amountZeroInRemaining.Mul(sdk.OneDec().Sub(s.swapFee))
+	var sqrtPriceNext sdk.Dec
+	// If have more of the amount remaining after fee than estimated until target,
+	// bound the next sqrtPriceNext by the target sqrt price.
+	if amountZeroInRemainingLessFee.GTE(amountZeroIn) {
+		sqrtPriceNext = sqrtPriceTarget
+	} else {
+		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount0InRoundingUp(sqrtPriceCurrent, liquidity, amountZeroInRemainingLessFee)
+	}
+
+	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext
+
+	// If the sqrt price target was not reached, recalculate how much of the amount remaining after fee was needed
+	// to complete the swap step. This implies that some of the amount remaining after fee is left over after the
+	// current swap step.
+	if !hasReachedTarget {
+		amountZeroIn = math.CalcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true) // N.B.: if this is false, causes infinite loop
+	}
+
+	// Calculate the amount of the other token given the sqrt price range.
+	amountOneOut := math.CalcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, false)
+
+	// Handle fees.
+	// Note that fee is always charged on the amount in.
+	feeChargeTotal := computeFeeChargePerSwapStepOutGivenIn(hasReachedTarget, amountZeroIn, amountZeroInRemaining, s.swapFee)
+
+	return sqrtPriceNext, amountZeroIn, amountOneOut, feeChargeTotal
+}
+
+// ComputeSwapStepInGivenOut calculates the next sqrt price, the amount of token out consumed, the amount in to charge to the user for requested out, and total fee charge on token in.
+// Parameters:
+//   - sqrtPriceCurrent is the current sqrt price.
+//   - sqrtPriceTarget is the target sqrt price computed with GetSqrtTargetPrice(). It must be one of:
+//     1. Next tick sqrt price.
+//     2. Sqrt price limit representing price impact protection.
+//   - liquidity is the amount of liquidity between the sqrt price current and sqrt price target.
+//   - amountOneRemainingOut is the amount of token one out remaining to be swapped to estimate how much of token zero in is needed to be charged.
+//     This amount is fully consumed if sqrt price target is not reached. In that case, the returned amountOneOut is the amount remaining given.
+//     Otherwise, the returned amountOneOut will be smaller than amountOneRemainingOut given.
+//
+// Returns:
+//   - sqrtPriceNext is the next sqrt price. It equals sqrt price target if target is reached. Otherwise, it is in-between sqrt price current and target.
+//   - amountOneOut is the amount of token one out consumed. It equals amountOneRemainingOut if target is reached. Otherwise, it is less than amountOneRemainingOut.
+//   - amountZeroIn is the amount of token zero in computed. It is the amount of token in to charge to the user for the desired amount out.
+//   - feeChargeTotal is the total fee charge. The fee is charged on the amount of token in.
+//
+// ZeroForOne details:
+// - zeroForOneStrategy assumes moving to the left of the current square root price.
+func (s zeroForOneStrategy) ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, liquidity, amountOneRemainingOut sdk.Dec) (sdk.Dec, sdk.Dec, sdk.Dec, sdk.Dec) {
+	// Estimate the amount of token one needed until the target sqrt price is reached.
+	amountOneOut := math.CalcAmount1Delta(liquidity, sqrtPriceTarget, sqrtPriceCurrent, false)
+
+	// Calculate sqrtPriceNext on the amount of token remaining. Note that the
+	// fee is not charged as amountRemaining is amountOut, and we only charge fee on
+	// amount in.
+	var sqrtPriceNext sdk.Dec
+	// If have more of the amount remaining after fee than estimated until target,
+	// bound the next sqrtPriceNext by the target sqrt price.
+	if amountOneRemainingOut.GTE(amountOneOut) {
+		sqrtPriceNext = sqrtPriceTarget
+	} else {
+		// Otherwise, compute the next sqrt price based on the amount remaining after fee.
+		sqrtPriceNext = math.GetNextSqrtPriceFromAmount1OutRoundingDown(sqrtPriceCurrent, liquidity, amountOneRemainingOut)
+	}
+
+	hasReachedTarget := sqrtPriceTarget == sqrtPriceNext
+
+	// If the sqrt price target was not reached, recalculate how much of the amount remaining after fee was needed
+	// to complete the swap step. This implies that some of the amount remaining after fee is left over after the
+	// current swap step.
+	if !hasReachedTarget {
+		amountOneOut = math.CalcAmount1Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, false)
+	}
+
+	// Calculate the amount of the other token given the sqrt price range.
+	amountZeroIn := math.CalcAmount0Delta(liquidity, sqrtPriceNext, sqrtPriceCurrent, true)
+
+	// Handle fees.
+	// Note that fee is always charged on the amount in.
+	// TODO: multiplication with rounding up at precision end.
+	feeChargeTotal := amountZeroIn.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
+
+	return sqrtPriceNext, amountOneOut, amountZeroIn, feeChargeTotal
 }
 
 // InitializeTickValue returns the initial tick value for computing swaps based
@@ -159,7 +264,7 @@ func (s zeroForOneStrategy) SetLiquidityDeltaSign(deltaLiquidity sdk.Dec) sdk.De
 func (s zeroForOneStrategy) ValidatePriceLimit(sqrtPriceLimit, currentSqrtPrice sdk.Dec) error {
 	// check that the price limit is below the current sqrt price but not lower than the minimum sqrt ratio if we are swapping asset0 for asset1
 	if sqrtPriceLimit.GT(currentSqrtPrice) || sqrtPriceLimit.LT(types.MinSqrtRatio) {
-		return types.InvalidPriceLimitError{SqrtPriceLimit: sqrtPriceLimit, LowerBound: types.MinSqrtRatio, UpperBound: sqrtPriceLimit}
+		return types.InvalidPriceLimitError{SqrtPriceLimit: sqrtPriceLimit, LowerBound: types.MinSqrtRatio, UpperBound: currentSqrtPrice}
 	}
 	return nil
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/zero_for_one.go
@@ -190,7 +190,7 @@ func (s zeroForOneStrategy) ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPric
 
 	// Handle fees.
 	// Note that fee is always charged on the amount in.
-	// TODO: multiplication with rounding up at precision end.
+	// TODO: round up at precision end: https://github.com/osmosis-labs/osmosis/issues/4645
 	feeChargeTotal := amountZeroIn.Mul(s.swapFee).Quo(sdk.OneDec().Sub(s.swapFee))
 
 	return sqrtPriceNext, amountOneOut, amountZeroIn, feeChargeTotal

--- a/x/concentrated-liquidity/internal/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/zero_for_one_test.go
@@ -43,12 +43,213 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_ZeroForOne() {
 		suite.Run(name, func() {
 			suite.SetupTest()
 
-			sut := swapstrategy.New(true, false, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
+			sut := swapstrategy.New(true, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
 
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 
 			suite.Require().Equal(tc.expectedResult, actualSqrtTargetPrice)
 
+		})
+	}
+}
+
+func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
+	var (
+		sqrtPriceCurrent = defaultSqrtPriceUpper
+		sqrtPriceNext    = defaultSqrtPriceLower
+
+		// liquidity * sqrtPriceCurrent / (liquidity + amount in * sqrtPriceCurrent)
+		sqrtPriceTargetNotReached = sdk.MustNewDecFromStr("70.688828764403676330")
+		// liquidity * (sqrtPriceCurrent - sqrtPriceNext)
+		amountOneTargetNotReached = sdk.MustNewDecFromStr("66329498.080160866932624794")
+	)
+
+	tests := map[string]struct {
+		sqrtPriceCurrent      sdk.Dec
+		sqrtPriceTarget       sdk.Dec
+		liquidity             sdk.Dec
+		amountZeroInRemaining sdk.Dec
+		swapFee               sdk.Dec
+
+		expectedSqrtPriceNext  sdk.Dec
+		amountZeroInConsumed   sdk.Dec
+		expectedAmountOneOut   sdk.Dec
+		expectedFeeChargeTotal sdk.Dec
+
+		expectError error
+	}{
+		"1: no fee - reach target": {
+			sqrtPriceCurrent: sqrtPriceCurrent,
+			sqrtPriceTarget:  sqrtPriceNext,
+			liquidity:        defaultLiquidity,
+			// add 100 more
+			amountZeroInRemaining: defaultAmountZero.Add(sdk.NewDec(100)),
+			swapFee:               sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrtPriceNext,
+			// consumed without 100 since reached target.
+			amountZeroInConsumed: defaultAmountZero.Ceil(),
+			// liquidity * (sqrtPriceNext - sqrtPriceCurrent)
+			expectedAmountOneOut:   defaultAmountOne,
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"2: no fee - do not reach target": {
+			sqrtPriceCurrent:      sqrtPriceCurrent,
+			sqrtPriceTarget:       sqrtPriceNext,
+			liquidity:             defaultLiquidity,
+			amountZeroInRemaining: defaultAmountZero.Sub(sdk.NewDec(100)),
+			swapFee:               sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
+			amountZeroInConsumed:  defaultAmountZero.Sub(sdk.NewDec(100)).Ceil(),
+
+			expectedAmountOneOut:   amountOneTargetNotReached,
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"3: 3% fee - reach target": {
+			sqrtPriceCurrent: sqrtPriceCurrent,
+			sqrtPriceTarget:  sqrtPriceNext,
+			liquidity:        defaultLiquidity,
+			// add 100 more
+			amountZeroInRemaining: defaultAmountZero.Add(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)),
+			swapFee:               defaultFee,
+
+			expectedSqrtPriceNext: sqrtPriceNext,
+			// Consumes without 100 since reached target and fee is applied.
+			amountZeroInConsumed: defaultAmountZero.Ceil(),
+			// liquidity * (sqrtPriceNext - sqrtPriceCurrent)
+			expectedAmountOneOut:   defaultAmountOne,
+			expectedFeeChargeTotal: defaultAmountZero.Ceil().Quo(sdk.OneDec().Sub(defaultFee)).Mul(defaultFee),
+		},
+		"4: 3% fee - do not reach target": {
+			sqrtPriceCurrent:      sqrtPriceCurrent,
+			sqrtPriceTarget:       sqrtPriceNext,
+			liquidity:             defaultLiquidity,
+			amountZeroInRemaining: defaultAmountZero.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)),
+			swapFee:               defaultFee,
+
+			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
+			amountZeroInConsumed:  defaultAmountZero.Sub(sdk.NewDec(100)).Ceil(),
+			expectedAmountOneOut:  amountOneTargetNotReached,
+			// Difference between amount in given and actually consumed.
+			expectedFeeChargeTotal: defaultAmountZero.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)).Sub(defaultAmountZero.Sub(sdk.NewDec(100)).Ceil()),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+			suite.SetupTest()
+			strategy := swapstrategy.New(true, types.MaxSqrtRatio, suite.App.GetKey(types.ModuleName), tc.swapFee)
+
+			sqrtPriceNext, amountZeroIn, amountOneOut, feeChargeTotal := strategy.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountZeroInRemaining)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
+			suite.Require().Equal(tc.amountZeroInConsumed, amountZeroIn)
+			suite.Require().Equal(tc.expectedAmountOneOut, amountOneOut)
+			suite.Require().Equal(tc.expectedFeeChargeTotal, feeChargeTotal)
+		})
+	}
+}
+
+func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
+	var (
+		sqrtPriceCurrent = defaultSqrtPriceUpper
+		sqrtPriceNext    = defaultSqrtPriceLower
+
+		// sqrt_cur - amt_one / liq quo round up
+		sqrtPriceTargetNotReached = sdk.MustNewDecFromStr("70.688667457471792243")
+		// liq * (sqrt_cur - sqrt_next) / (sqrt_cur * sqrt_next)
+		amountZeroTargetNotReached = sdk.MustNewDecFromStr("13367.998754214115430370")
+
+		// N.B.: approx eq = defaultAmountOneZfo.Sub(sdk.NewDec(10000))
+		// slight variance due to recomputing amount out when target is not reached.
+		// liq * (sqrt_cur - sqrt_next)
+		amountOneOutTargetNotReached = sdk.MustNewDecFromStr("66819187.967824033372217995")
+	)
+
+	tests := map[string]struct {
+		sqrtPriceCurrent      sdk.Dec
+		sqrtPriceTarget       sdk.Dec
+		liquidity             sdk.Dec
+		amountOneOutRemaining sdk.Dec
+		swapFee               sdk.Dec
+
+		expectedSqrtPriceNext  sdk.Dec
+		amountOneOutConsumed   sdk.Dec
+		expectedAmountInZero   sdk.Dec
+		expectedFeeChargeTotal sdk.Dec
+
+		expectError error
+	}{
+		"1: no fee - reach target": {
+			sqrtPriceCurrent: sqrtPriceCurrent,
+			sqrtPriceTarget:  sqrtPriceNext,
+			liquidity:        defaultLiquidity,
+			// Add 100.
+			amountOneOutRemaining: defaultAmountOne.Add(sdk.NewDec(100)),
+			swapFee:               sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrtPriceNext,
+			// Consumes without 100 since reaches target.
+			amountOneOutConsumed:   defaultAmountOne,
+			expectedAmountInZero:   defaultAmountZero.Ceil(),
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"2: no fee - do not reach target": {
+			sqrtPriceCurrent:      sqrtPriceCurrent,
+			sqrtPriceTarget:       sqrtPriceNext,
+			liquidity:             defaultLiquidity,
+			amountOneOutRemaining: defaultAmountOne.Sub(sdk.NewDec(10000)),
+			swapFee:               sdk.ZeroDec(),
+
+			// sqrt_cur - amt_one / liq quo round up
+			expectedSqrtPriceNext:  sqrtPriceTargetNotReached,
+			amountOneOutConsumed:   amountOneOutTargetNotReached,
+			expectedAmountInZero:   amountZeroTargetNotReached.Ceil(),
+			expectedFeeChargeTotal: sdk.ZeroDec(),
+		},
+		"3: 3% fee - reach target": {
+			sqrtPriceCurrent: sqrtPriceCurrent,
+			sqrtPriceTarget:  sqrtPriceNext,
+			liquidity:        defaultLiquidity,
+			// Add 100.
+			amountOneOutRemaining: defaultAmountOne.Quo(sdk.OneDec().Sub(defaultFee)),
+			swapFee:               defaultFee,
+
+			expectedSqrtPriceNext: sqrtPriceNext,
+			// Consumes without 100 since reaches target.
+			amountOneOutConsumed: defaultAmountOne,
+			// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
+			expectedAmountInZero:   defaultAmountZero.Ceil(),
+			expectedFeeChargeTotal: defaultAmountZero.Ceil().Quo(sdk.OneDec().Sub(defaultFee)).Mul(defaultFee),
+		},
+		"4: 3% fee - do not reach target": {
+			sqrtPriceCurrent:      sqrtPriceCurrent,
+			sqrtPriceTarget:       sqrtPriceNext,
+			liquidity:             defaultLiquidity,
+			amountOneOutRemaining: defaultAmountOne.Sub(sdk.NewDec(10000)),
+			swapFee:               defaultFee,
+
+			expectedSqrtPriceNext:  sqrtPriceTargetNotReached,
+			amountOneOutConsumed:   amountOneOutTargetNotReached,
+			expectedAmountInZero:   amountZeroTargetNotReached.Ceil(),
+			expectedFeeChargeTotal: amountZeroTargetNotReached.Ceil().Quo(sdk.OneDec().Sub(defaultFee)).Mul(defaultFee),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		suite.Run(name, func() {
+			suite.SetupTest()
+			strategy := swapstrategy.New(true, types.MaxSqrtRatio, suite.App.GetKey(types.ModuleName), tc.swapFee)
+
+			sqrtPriceNext, amountOneOut, amountZeroIn, feeChargeTotal := strategy.ComputeSwapStepInGivenOut(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountOneOutRemaining)
+
+			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
+			suite.Require().Equal(tc.amountOneOutConsumed, amountOneOut)
+			suite.Require().Equal(tc.expectedAmountInZero, amountZeroIn)
+			suite.Require().Equal(tc.expectedFeeChargeTotal, feeChargeTotal)
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4427

## What is the purpose of the change

This is progress towards: https://github.com/osmosis-labs/osmosis/issues/4424

Currently, our swap logic is needlessly complex because we have a single method for computing swaps out given in and in given out. In fact, merging the implementations was incorrect because the rounding behavior and swap direction are the opposite for in given out from out given in. While working on this refactor, a bug with given out was found #4423 that still needs to be fixed.

There are various edge cases between the two methods. As a result, it makes sense to split the internal calculations implementation into separate methods - `ComputeSwapStepOutGivenIn` and `ComputeSwapStepInGivenOut`.

Separating the methods allows us to improve readability, testability, and documentation.

In this PR, tests for each method were added, including the inverse tests. Additionally, method specs are customized for each compute swap step.

**Important note:** `ComputeSwapStepLegacy` is still kept and used for swap in given out to avoid breaking many swap tests that are tedious to fix. To limit the scope, these tests will be update in #4423, `ComputeSwapStepLegacy` removed and  `ComputeSwapStepInGivenOut` called in its place instead.

## Brief Changelog

- implement and test `ComputeSwapStepOutGivenIn` 
- implement and test ``ComputeSwapStepInGivenOut`
- implement inverse tests
- update documentation and method specs
- rewire swap out given in in `swaps.go` to call `ComputeSwapStepOutGivenIn`
- rename `ComputeSwapStep` to `ComputeSwapStepLegacy` and keep using it in swap in given out to avoid breaking tests

## Testing and Verifying

- Added tests for each compute swap step
- Added inverse tests
- Removed outdated tests with low utility

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? via method specs 