### PR TITLE
Revert "[tests/e2e]: simplify the logic for adding..." (#4217)

### DIFF
--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authhelpers "github.com/cosmos/cosmos-sdk/x/auth/helpers"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -119,13 +120,76 @@ var (
 func addAccount(path, moniker, amountStr string, accAddr sdk.AccAddress, forkHeight int) error {
 	serverCtx := server.NewDefaultContext()
 	config := serverCtx.Config
+
 	config.SetRoot(path)
 	config.Moniker = moniker
 
-	feeToken := sdk.NewCoin(E2EFeeToken, sdk.NewInt(GenesisFeeBalance))
-	amountStr = amountStr + "," + feeToken.String()
+	coins, err := sdk.ParseCoinsNormalized(amountStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse coins: %w", err)
+	}
+	coins = coins.Add(sdk.NewCoin(E2EFeeToken, sdk.NewInt(GenesisFeeBalance)))
+
+	balances := banktypes.Balance{Address: accAddr.String(), Coins: coins.Sort()}
+	genAccount := authtypes.NewBaseAccount(accAddr, nil, 0, 0)
+
+	// TODO: Make the SDK make it far cleaner to add an account to GenesisState
 	genFile := config.GenesisFile()
-	return authhelpers.AddGenesisAccount(util.Cdc, accAddr, false, genFile, amountStr, "", 0, 0)
+	appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal genesis state: %w", err)
+	}
+
+	genDoc.InitialHeight = int64(forkHeight)
+
+	authGenState := authtypes.GetGenesisStateFromAppState(util.Cdc, appState)
+
+	accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+	if err != nil {
+		return fmt.Errorf("failed to get accounts from any: %w", err)
+	}
+
+	if accs.Contains(accAddr) {
+		return fmt.Errorf("failed to add account to genesis state; account already exists: %s", accAddr)
+	}
+
+	// Add the new account to the set of genesis accounts and sanitize the
+	// accounts afterwards.
+	accs = append(accs, genAccount)
+	accs = authtypes.SanitizeGenesisAccounts(accs)
+
+	genAccs, err := authtypes.PackAccounts(accs)
+	if err != nil {
+		return fmt.Errorf("failed to convert accounts into any's: %w", err)
+	}
+
+	authGenState.Accounts = genAccs
+
+	authGenStateBz, err := util.Cdc.MarshalJSON(&authGenState)
+	if err != nil {
+		return fmt.Errorf("failed to marshal auth genesis state: %w", err)
+	}
+
+	appState[authtypes.ModuleName] = authGenStateBz
+
+	bankGenState := banktypes.GetGenesisStateFromAppState(util.Cdc, appState)
+	bankGenState.Balances = append(bankGenState.Balances, balances)
+	bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
+
+	bankGenStateBz, err := util.Cdc.MarshalJSON(bankGenState)
+	if err != nil {
+		return fmt.Errorf("failed to marshal bank genesis state: %w", err)
+	}
+
+	appState[banktypes.ModuleName] = bankGenStateBz
+
+	appStateJSON, err := json.Marshal(appState)
+	if err != nil {
+		return fmt.Errorf("failed to marshal application genesis state: %w", err)
+	}
+
+	genDoc.AppState = appStateJSON
+	return genutil.ExportGenesisFile(genDoc, genFile)
 }
 
 func updateModuleGenesis[V proto.Message](appGenState map[string]json.RawMessage, moduleName string, protoVal V, updateGenesis func(V)) error {


### PR DESCRIPTION
This reverts commit b8e84eacae56779b2788889b8b5003658de8c999.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This reverts #4217 since CI running on merge to `main` broke: https://github.com/osmosis-labs/osmosis/actions/runs/4338982856/jobs/7576658435

Discussed offline and going to resubmit with the fix to CI

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable