### PR TITLE
[v15 testnet upgrade] Fix guide and cosmovisor binaries.json using `v15.0.0-rc3-testnet` 

### DIFF
--- a/networks/osmosis-1/upgrades/v15/testnet/guide.md
+++ b/networks/osmosis-1/upgrades/v15/testnet/guide.md
@@ -1,0 +1,129 @@
+# v14 to v15 Testnet Upgrade Guide
+
+|                 |                                                            |
+|-----------------|------------------------------------------------------------|
+| Chain-id        | `osmo-test-4`                                              |
+| Upgrade Version | `v15.0.0-rc3`                                              |
+| Upgrade Height  | 9422500                                                    |
+| Countdown       | https://testnet.mintscan.io/osmosis-testnet/blocks/9422500 |
+
+## Memory Requirements
+
+This upgrade will **not** be resource intensive. With that being said, we still recommend having 64GB of memory. If having 64GB of physical memory is not possible, the next best thing is to set up swap.
+
+Short version swap setup instructions:
+
+``` {.sh}
+sudo swapoff -a
+sudo fallocate -l 32G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+```
+
+To persist swap after restart:
+
+``` {.sh}
+sudo cp /etc/fstab /etc/fstab.bak
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
+In depth swap setup instructions:
+<https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04>
+
+## First Time Cosmovisor Setup
+
+If you have never setup Cosmovisor before, follow the following instructions.
+
+If you have already setup Cosmovisor, skip to the next section.
+
+We highly recommend validators use cosmovisor to run their nodes. This
+will make low-downtime upgrades smoother, as validators don't have to
+manually upgrade binaries during the upgrade, and instead can
+pre-install new binaries, and cosmovisor will automatically update them
+based on on-chain SoftwareUpgrade proposals.
+
+You should review the docs for cosmovisor located here:
+<https://docs.cosmos.network/master/run-node/cosmovisor.html>
+
+If you choose to use cosmovisor, please continue with these
+instructions:
+
+To install Cosmovisor:
+
+``` {.sh}
+go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+```
+
+After this, you must make the necessary folders for cosmosvisor in your
+daemon home directory (\~/.osmosisd).
+
+``` {.sh}
+mkdir -p ~/.osmosisd
+mkdir -p ~/.osmosisd/cosmovisor
+mkdir -p ~/.osmosisd/cosmovisor/genesis
+mkdir -p ~/.osmosisd/cosmovisor/genesis/bin
+mkdir -p ~/.osmosisd/cosmovisor/upgrades
+```
+
+Copy the current v14 osmosisd binary into the
+cosmovisor/genesis folder and v14 folder.
+
+```{.sh}
+cp $GOPATH/bin/osmosisd ~/.osmosisd/cosmovisor/genesis/bin
+mkdir -p ~/.osmosisd/cosmovisor/upgrades/v14/bin
+cp $GOPATH/bin/osmosisd ~/.osmosisd/cosmovisor/upgrades/v14/bin
+```
+
+Cosmovisor is now ready to be set up for v15.
+
+Set these environment variables:
+
+```{.sh}
+echo "# Setup Cosmovisor" >> ~/.profile
+echo "export DAEMON_NAME=osmosisd" >> ~/.profile
+echo "export DAEMON_HOME=$HOME/.osmosisd" >> ~/.profile
+echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=false" >> ~/.profile
+echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
+echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
+echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
+source ~/.profile
+```
+
+## Cosmovisor Upgrade
+
+Create the v15 folder, make the build, and copy the daemon over to that folder
+
+```{.sh}
+mkdir -p ~/.osmosisd/cosmovisor/upgrades/v15/bin
+cd $HOME/osmosis
+git pull
+git checkout v15.0.0-rc3
+make build
+cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/v15/bin
+```
+
+Now, at the upgrade height, Cosmovisor will upgrade to the v15 binary
+
+## Manual Option
+
+1. Wait for Osmosis to reach the upgrade height (9422500)
+
+2. Look for a panic message, followed by endless peer logs. Stop the daemon
+
+3. Run the following commands:
+
+```{.sh}
+cd $HOME/osmosis
+git pull
+git checkout v15.0.0-rc3
+make install
+```
+
+4. Start the osmosis daemon again, watch the upgrade happen, and then continue to hit blocks
+
+## Further Help
+
+If you need more help, please:
+- go to <https://docs.osmosis.zone> 
+- join our discord at <https://discord.gg/pAxjcFnAFH>.

--- a/networks/osmosis-1/upgrades/v15/testnet/guide.md
+++ b/networks/osmosis-1/upgrades/v15/testnet/guide.md
@@ -3,7 +3,7 @@
 |                 |                                                              |
 |-----------------|--------------------------------------------------------------|
 | Chain-id        | `osmo-test-4`                                                |
-| Upgrade Version | `v15.0.0-rc3`                                                |
+| Upgrade Version | `v15.0.0-rc3-testnet`                                        |
 | Upgrade Height  | 9422500                                                      |
 | Countdown       | <https://testnet.mintscan.io/osmosis-testnet/blocks/9422500> |
 
@@ -98,7 +98,7 @@ Create the v15 folder, make the build, and copy the daemon over to that folder
 mkdir -p ~/.osmosisd/cosmovisor/upgrades/v15/bin
 cd $HOME/osmosis
 git pull
-git checkout v15.0.0-rc3
+git checkout v15.0.0-rc3-testnet
 make build
 cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/v15/bin
 ```
@@ -116,7 +116,7 @@ Now, at the upgrade height, Cosmovisor will upgrade to the v15 binary
 ```{.sh}
 cd $HOME/osmosis
 git pull
-git checkout v15.0.0-rc3
+git checkout v15.0.0-rc3-testnet
 make install
 ```
 

--- a/networks/osmosis-1/upgrades/v15/testnet/guide.md
+++ b/networks/osmosis-1/upgrades/v15/testnet/guide.md
@@ -1,11 +1,11 @@
 # v14 to v15 Testnet Upgrade Guide
 
-|                 |                                                            |
-|-----------------|------------------------------------------------------------|
-| Chain-id        | `osmo-test-4`                                              |
-| Upgrade Version | `v15.0.0-rc3`                                              |
-| Upgrade Height  | 9422500                                                    |
-| Countdown       | https://testnet.mintscan.io/osmosis-testnet/blocks/9422500 |
+|                 |                                                              |
+|-----------------|--------------------------------------------------------------|
+| Chain-id        | `osmo-test-4`                                                |
+| Upgrade Version | `v15.0.0-rc3`                                                |
+| Upgrade Height  | 9422500                                                      |
+| Countdown       | <https://testnet.mintscan.io/osmosis-testnet/blocks/9422500> |
 
 ## Memory Requirements
 

--- a/networks/osmosis-1/upgrades/v15/testnet/testnet_v15_rc3_binaries.json
+++ b/networks/osmosis-1/upgrades/v15/testnet/testnet_v15_rc3_binaries.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0-rc3/osmosisd-15.0.0-rc3-linux-amd64?checksum=sha256:8d84c72c4f59160f40d9de2b3575f38cd36bf226ada5f81e854f47e7fbc9d0c6",
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0-rc3/osmosisd-15.0.0-rc3-linux-arm64?checksum=sha256:58401b80b0c6e38e5b7b4c7a8f1cd7f19865514e487370ef149648bdb3149eaa"
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0-rc3-testnet/osmosisd-15.0.0-rc3-testnet-linux-amd64?checksum=sha256:2ffca05e771ed1122c76fb20477c6f7e615924e8190d5f66542be871d0b27cfb",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0-rc3-testnet/osmosisd-15.0.0-rc3-testnet-linux-arm64?checksum=sha256:fb4d91c7d6a652c7f27302f7a26bd6b3b585c9dc9442f4ddc21fa4b274cb8c48"
     }
 }

--- a/networks/osmosis-1/upgrades/v15/testnet/testnet_v15_rc3_binaries.json
+++ b/networks/osmosis-1/upgrades/v15/testnet/testnet_v15_rc3_binaries.json
@@ -1,0 +1,6 @@
+{
+    "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0-rc3/osmosisd-15.0.0-rc3-linux-amd64?checksum=sha256:8d84c72c4f59160f40d9de2b3575f38cd36bf226ada5f81e854f47e7fbc9d0c6",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0-rc3/osmosisd-15.0.0-rc3-linux-arm64?checksum=sha256:58401b80b0c6e38e5b7b4c7a8f1cd7f19865514e487370ef149648bdb3149eaa"
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes https://github.com/osmosis-labs/osmosis/pull/4518 using `v15.0.0-rc3-testnet` tag instead of `v15.0.0-rc3` due to the problem of the testnet upgrade handler containing mainnet logic.

## Brief Changelog

- Update `guide.md`
- Update `binaries.json`

## Testing and Verifying

Not applicable

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable