### PR TITLE
[CL Incentives] Allow early withdrawals for frozen positions

### DIFF
--- a/app/upgrades/v13/upgrade_test.go
+++ b/app/upgrades/v13/upgrade_test.go
@@ -2,8 +2,9 @@ package v13_test
 
 import (
 	"fmt"
-	ibchookstypes "github.com/osmosis-labs/osmosis/x/ibc-hooks/types"
 	"testing"
+
+	ibchookstypes "github.com/osmosis-labs/osmosis/x/ibc-hooks/types"
 
 	ibcratelimittypes "github.com/osmosis-labs/osmosis/v15/x/ibc-rate-limit/types"
 
@@ -55,8 +56,8 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 			"Test that the upgrade succeeds",
 			func() {
 				// The module doesn't need an account anymore, but when the upgrade happened we did:
-				//acc := suite.App.AccountKeeper.GetAccount(suite.Ctx, ibc_hooks.WasmHookModuleAccountAddr)
-				//suite.App.AccountKeeper.RemoveAccount(suite.Ctx, acc)
+				// acc := suite.App.AccountKeeper.GetAccount(suite.Ctx, ibc_hooks.WasmHookModuleAccountAddr)
+				// suite.App.AccountKeeper.RemoveAccount(suite.Ctx, acc)
 
 				// Because of SDK version map bug, we can't do the following, and instaed do a massive hack
 				// vm := suite.App.UpgradeKeeper.GetModuleVersionMap(suite.Ctx)
@@ -70,15 +71,15 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 				versionStore.Delete([]byte(ibchookstypes.ModuleName))
 
 				// Same comment as above: this was the case when the upgrade happened, but we don't have accounts anymore
-				//hasAcc := suite.App.AccountKeeper.HasAccount(suite.Ctx, ibc_hooks.WasmHookModuleAccountAddr)
-				//suite.Require().False(hasAcc)
+				// hasAcc := suite.App.AccountKeeper.HasAccount(suite.Ctx, ibc_hooks.WasmHookModuleAccountAddr)
+				// suite.Require().False(hasAcc)
 
 			},
 			func() { dummyUpgrade(suite) },
 			func() {
 				// Same comment as pre-upgrade. We had an account, but now we don't anymore
-				//hasAcc := suite.App.AccountKeeper.HasAccount(suite.Ctx, ibc_hooks.WasmHookModuleAccountAddr)
-				//suite.Require().True(hasAcc)
+				// hasAcc := suite.App.AccountKeeper.HasAccount(suite.Ctx, ibc_hooks.WasmHookModuleAccountAddr)
+				// suite.Require().True(hasAcc)
 			},
 		},
 		{

--- a/app/upgrades/v15/constants.go
+++ b/app/upgrades/v15/constants.go
@@ -16,9 +16,11 @@ import (
 const UpgradeName = "v15"
 
 // pool ids to migrate
-const stOSMO_OSMOPoolId = 833
-const stJUNO_JUNOPoolId = 817
-const stSTARS_STARSPoolId = 810
+const (
+	stOSMO_OSMOPoolId   = 833
+	stJUNO_JUNOPoolId   = 817
+	stSTARS_STARSPoolId = 810
+)
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,

--- a/app/upgrades/v15/upgrade_test.go
+++ b/app/upgrades/v15/upgrade_test.go
@@ -51,9 +51,7 @@ func (suite *UpgradeTestSuite) TestMigrateNextPoolIdAndCreatePool() {
 		expectedNextPoolId uint64 = 1
 	)
 
-	var (
-		gammKeeperType = reflect.TypeOf(&gamm.Keeper{})
-	)
+	gammKeeperType := reflect.TypeOf(&gamm.Keeper{})
 
 	ctx := suite.Ctx
 	gammKeeper := suite.App.GAMMKeeper
@@ -245,7 +243,6 @@ func (suite *UpgradeTestSuite) TestSetRateLimits() {
 	// This is the last one. If the others failed the upgrade would've panicked before adding this one
 	state, err = suite.App.WasmKeeper.QuerySmart(suite.Ctx, addr, []byte(`{"get_quotas": {"channel_id": "any", "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"}}`))
 	suite.Require().Greaterf(len(state), 0, "state should not be empty")
-
 }
 
 func (suite *UpgradeTestSuite) validateCons(coinsA, coinsB sdk.Coins) {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1259,6 +1259,7 @@ github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/securego/gosec v0.0.0-20200103095621-79fbf3af8d83/go.mod h1:vvbZ2Ae7AzSq3/kywjUDxSNq2SJ27RxCz2un0H3ePqE=
+github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989 h1:rq2/kILQnPtq5oL4+IAjgVOjh5e2yj2aaCYi7squEvI=
 github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+yDFh9SZXUTvspXTjbFXgZGP/UvhU1S65A4A=
 github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/securego/gosec/v2 v2.13.1/go.mod h1:EO1sImBMBWFjOTFzMWfTRrZW6M15gm60ljzrmy/wtHo=
@@ -1348,6 +1349,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tomarrell/wrapcheck/v2 v2.7.0/go.mod h1:ao7l5p0aOlUNJKI0qVwB4Yjlqutd0IvAB9Rdwyilxvg=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd v1.1.1/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
+github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa h1:RC4maTWLKKwb7p1cnoygsbKIgNlJqSYBeAFON3Ar8As=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tonistiigi/fsutil v0.0.0-20201103201449-0834f99b7b85/go.mod h1:a7cilN64dG941IOXfhJhlH0qB92hxJ9A1ewrdUmJ6xo=
 github.com/tonistiigi/fsutil v0.0.0-20220115021204-b19f7f9cb274/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=

--- a/tests/e2e/configurer/chain/queries.go
+++ b/tests/e2e/configurer/chain/queries.go
@@ -278,6 +278,7 @@ func (n *NodeConfig) QueryConcentratedPositions(address string) []cltypes.FullPo
 	require.NoError(n.t, err)
 	return positionsResponse.Positions
 }
+
 func (n *NodeConfig) QueryConcentratedPool(poolId uint64) (cltypes.ConcentratedPoolExtension, error) {
 	path := fmt.Sprintf("/osmosis/concentratedliquidity/v1beta1/pools/%d", poolId)
 	bz, err := n.QueryGRPCGateway(path)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -201,13 +201,13 @@ func (s *IntegrationTestSuite) TestConcentratedLiquidity() {
 	)
 
 	// helpers
-	var (
-		updatedPool = func(poolId uint64) types.ConcentratedPoolExtension {
-			concentratedPool, err := node.QueryConcentratedPool(poolId)
-			s.Require().NoError(err)
-			return concentratedPool
-		}
-	)
+
+	updatedPool := func(poolId uint64) types.ConcentratedPoolExtension {
+		concentratedPool, err := node.QueryConcentratedPool(poolId)
+		s.Require().NoError(err)
+		return concentratedPool
+	}
+
 	poolID := node.CreateConcentratedPool(initialization.ValidatorWalletName, denom0, denom1, tickSpacing, precisionFactorAtPriceOne, swapFee)
 
 	concentratedPool := updatedPool(poolID)
@@ -318,7 +318,6 @@ func (s *IntegrationTestSuite) TestConcentratedLiquidity() {
 	node.WithdrawPosition(address1, "[-1200]", "400", allLiquidityAddress1Position1.String(), poolID, positionsAddress1[0].JoinTime, positionsAddress1[0].FreezeDuration.String())
 	positionsAddress1 = node.QueryConcentratedPositions(address1)
 	s.Require().Equal(len(positionsAddress1), 1)
-
 }
 
 // TestGeometricTwapMigration tests that the geometric twap record
@@ -520,7 +519,7 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
 
 	// Removing the rate limit so it doesn't affect other tests
 	node.WasmExecute(contract, `{"remove_path": {"channel_id": "channel-0", "denom": "uosmo"}}`, initialization.ValidatorWalletName)
-	//reset the param to the original contract if it existed
+	// reset the param to the original contract if it existed
 	if param != "" {
 		err = chainA.SubmitParamChangeProposal(
 			ibcratelimittypes.ModuleName,
@@ -534,7 +533,6 @@ func (s *IntegrationTestSuite) TestIBCTokenTransferRateLimiting() {
 		}, time.Second*30, time.Millisecond*500)
 
 	}
-
 }
 
 func (s *IntegrationTestSuite) TestLargeWasmUpload() {
@@ -704,7 +702,6 @@ func (s *IntegrationTestSuite) TestAddToExistingLock() {
 // because twap keep time = epoch time / 4 and we use a timer
 // to wait for at least the twap keep time.
 func (s *IntegrationTestSuite) TestArithmeticTWAP() {
-
 	s.T().Skip("TODO: investigate further: https://github.com/osmosis-labs/osmosis/issues/4342")
 
 	const (

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -505,7 +505,7 @@ func updateTWAPGenesis(appGenState map[string]json.RawMessage) func(twapGenState
 					Asset0Denom:                 denomPair.Denom0,
 					Asset1Denom:                 denomPair.Denom0,
 					Height:                      1,
-					Time:                        time.Date(2023, 02, 1, 0, 0, 0, 0, time.UTC), // some time in the past.
+					Time:                        time.Date(2023, 0o2, 1, 0, 0, 0, 0, time.UTC), // some time in the past.
 					P0LastSpotPrice:             sp0,
 					P1LastSpotPrice:             sp1,
 					P0ArithmeticTwapAccumulator: sdk.ZeroDec(),

--- a/tests/ibc-hooks/ibc_middleware_test.go
+++ b/tests/ibc-hooks/ibc_middleware_test.go
@@ -471,7 +471,6 @@ func (suite *HooksTestSuite) TestAcks() {
 		&suite.Suite, addr,
 		[]byte(fmt.Sprintf(`{"get_count": {"addr": "%s"}}`, addr)))
 	suite.Require().Equal(`{"count":2}`, state)
-
 }
 
 func (suite *HooksTestSuite) TestTimeouts() {
@@ -504,7 +503,6 @@ func (suite *HooksTestSuite) TestTimeouts() {
 		&suite.Suite, addr,
 		[]byte(fmt.Sprintf(`{"get_count": {"addr": "%s"}}`, addr)))
 	suite.Require().Equal(`{"count":10}`, state)
-
 }
 
 func (suite *HooksTestSuite) TestSendWithoutMemo() {
@@ -896,7 +894,6 @@ func (suite *HooksTestSuite) CreateIBCPoolOnChainB() {
 
 	_, err = chain.GetOsmosisApp().GAMMKeeper.GetPoolAndPoke(chain.GetContext(), poolId)
 	suite.Require().NoError(err)
-
 }
 
 func (suite *HooksTestSuite) SetupIBCRouteOnChainB(poolmanagerAddr, owner sdk.AccAddress) {
@@ -920,7 +917,6 @@ func (suite *HooksTestSuite) SetupIBCRouteOnChainB(poolmanagerAddr, owner sdk.Ac
 	suite.Require().NoError(err)
 	err = suite.path.EndpointB.UpdateClient()
 	suite.Require().NoError(err)
-
 }
 
 // TestCrosschainForwardWithMemo tests the that the next_memo field is correctly forwarded to the other chain on the IBC transfer.
@@ -947,7 +943,7 @@ func (suite *HooksTestSuite) TestCrosschainForwardWithMemo() {
 	fmt.Println("receiver now has: ", balanceToken0IBCBefore)
 	suite.Require().Equal(int64(0), balanceToken0IBCBefore.Amount.Int64())
 
-	//suite.Require().Equal(int64(0), balanceToken1.Amount.Int64())
+	// suite.Require().Equal(int64(0), balanceToken1.Amount.Int64())
 
 	// Generate swap instructions for the contract
 	nextMemo := fmt.Sprintf(`{"wasm": {"contract": "%s", "msg": {"osmosis_swap":{"output_denom":"token0","slippage":{"twap": {"window_seconds": 1, "slippage_percentage":"20"}},"receiver":"%s", "on_failed_delivery": "do_nothing"}}}}`,
@@ -1043,7 +1039,7 @@ func (suite *HooksTestSuite) ExecuteOutpostSwap(initializer, receiverAddr sdk.Ac
 
 	// But the receiver now has some token1IBC
 	balanceToken1After := osmosisAppB.BankKeeper.GetBalance(suite.chainB.GetContext(), receiverAddr, token1IBC)
-	//fmt.Println("receiver now has: ", balanceToken1After)
+	// fmt.Println("receiver now has: ", balanceToken1After)
 	suite.Require().Greater(balanceToken1After.Amount.Int64(), int64(0))
 }
 

--- a/x/concentrated-liquidity/client/cli/query.go
+++ b/x/concentrated-liquidity/client/cli/query.go
@@ -25,7 +25,8 @@ func GetUserPositions() (*osmocli.QueryDescriptor, *types.QueryUserPositionsRequ
 		Use:   "user-positions [address]",
 		Short: "Query user's positions",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} user-positions osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj`}, &types.QueryUserPositionsRequest{}
+{{.CommandPrefix}} user-positions osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj`,
+	}, &types.QueryUserPositionsRequest{}
 }
 
 func GetCmdPool() (*osmocli.QueryDescriptor, *types.QueryPoolRequest) {
@@ -33,7 +34,8 @@ func GetCmdPool() (*osmocli.QueryDescriptor, *types.QueryPoolRequest) {
 		Use:   "pool [poolID]",
 		Short: "Query pool",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} pool 1`}, &types.QueryPoolRequest{}
+{{.CommandPrefix}} pool 1`,
+	}, &types.QueryPoolRequest{}
 }
 
 func GetCmdPools() (*osmocli.QueryDescriptor, *types.QueryPoolsRequest) {
@@ -41,5 +43,6 @@ func GetCmdPools() (*osmocli.QueryDescriptor, *types.QueryPoolsRequest) {
 		Use:   "pools",
 		Short: "Query pools",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} pools`}, &types.QueryPoolsRequest{}
+{{.CommandPrefix}} pools`,
+	}, &types.QueryPoolsRequest{}
 }

--- a/x/concentrated-liquidity/clmodule/module.go
+++ b/x/concentrated-liquidity/clmodule/module.go
@@ -155,8 +155,8 @@ func (am AppModule) Actions() []simtypes.Action {
 	return []simtypes.Action{
 		simtypes.NewMsgBasedAction("CreateConcentratedPool", am.keeper, simulation.RandomMsgCreateConcentratedPool),
 		simtypes.NewMsgBasedAction("CreatePosition", am.keeper, simulation.RandMsgCreatePosition),
-		//simtypes.NewMsgBasedAction("CLSwapExactAmountIn", am.keeper, simulation.RandomSwapExactAmountIn),
-		//simtypes.NewMsgBasedAction("CLSwapExactAmountOut", am.keeper, simulation.RandomSwapExactAmountOut),
+		// simtypes.NewMsgBasedAction("CLSwapExactAmountIn", am.keeper, simulation.RandomSwapExactAmountIn),
+		// simtypes.NewMsgBasedAction("CLSwapExactAmountOut", am.keeper, simulation.RandomSwapExactAmountOut),
 		simtypes.NewMsgBasedAction("WithdrawPosition", am.keeper, simulation.RandMsgWithdrawPosition),
 		simtypes.NewMsgBasedAction("CollectFees", am.keeper, simulation.RandMsgCollectFees),
 		simtypes.NewMsgBasedAction("CollectIncentives", am.keeper, simulation.RandMsgCollectIncentives),

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -244,6 +244,6 @@ func PrepareAccumAndClaimRewards(accum accum.AccumulatorObject, positionKey stri
 	return prepareAccumAndClaimRewards(accum, positionKey, growthOutside)
 }
 
-func (k Keeper) ClaimAllIncentives(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, forfeitIncentives bool) (sdk.Coins, error) {
-	return k.claimAllIncentives(ctx, poolId, owner, lowerTick, upperTick, forfeitIncentives)
+func (k Keeper) ClaimAllIncentivesForPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, position *model.Position, lowerTick int64, upperTick int64, forfeitIncentives bool) (sdk.Coins, error) {
+	return k.claimAllIncentivesForPosition(ctx, poolId, owner, position, lowerTick, upperTick, forfeitIncentives)
 }

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -239,3 +239,11 @@ func GetUptimeTrackerValues(uptimeTrackers []model.UptimeTracker) []sdk.DecCoins
 func (k Keeper) CreateIncentive(ctx sdk.Context, poolId uint64, sender sdk.AccAddress, incentiveDenom string, incentiveAmount sdk.Int, emissionRate sdk.Dec, startTime time.Time, minUptime time.Duration) (types.IncentiveRecord, error) {
 	return k.createIncentive(ctx, poolId, sender, incentiveDenom, incentiveAmount, emissionRate, startTime, minUptime)
 }
+
+func PrepareAccumAndClaimRewards(accum accum.AccumulatorObject, positionKey string, growthOutside sdk.DecCoins) (sdk.Coins, error) {
+	return prepareAccumAndClaimRewards(accum, positionKey, growthOutside)
+}
+
+func (k Keeper) ExtractClaimedIncentives(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64) (sdk.Coins, error) {
+	return k.extractClaimedIncentives(ctx, poolId, owner, lowerTick, upperTick)
+}

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -244,6 +244,6 @@ func PrepareAccumAndClaimRewards(accum accum.AccumulatorObject, positionKey stri
 	return prepareAccumAndClaimRewards(accum, positionKey, growthOutside)
 }
 
-func (k Keeper) ExtractClaimedIncentives(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64) (sdk.Coins, error) {
-	return k.extractClaimedIncentives(ctx, poolId, owner, lowerTick, upperTick)
+func (k Keeper) ClaimAllIncentives(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, lowerTick int64, upperTick int64, forfeitIncentives bool) (sdk.Coins, error) {
+	return k.claimAllIncentives(ctx, poolId, owner, lowerTick, upperTick, forfeitIncentives)
 }

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -22,7 +22,8 @@ var (
 	testGenesis      = types.GenesisState{
 		Params: types.Params{
 			AuthorizedTickSpacing: []uint64{1, 10, 50},
-			AuthorizedSwapFees:    []sdk.Dec{sdk.MustNewDecFromStr("0.0001"), sdk.MustNewDecFromStr("0.0003"), sdk.MustNewDecFromStr("0.0005")}},
+			AuthorizedSwapFees:    []sdk.Dec{sdk.MustNewDecFromStr("0.0001"), sdk.MustNewDecFromStr("0.0003"), sdk.MustNewDecFromStr("0.0005")},
+		},
 		Pools: []*codectypes.Any{},
 	}
 )

--- a/x/concentrated-liquidity/grpc_query.go
+++ b/x/concentrated-liquidity/grpc_query.go
@@ -20,9 +20,7 @@ const (
 	liquidityDepthRangeQueryLimit = 10000
 )
 
-var (
-	liquidityDepthRangeQueryLimitInt = sdk.NewInt(liquidityDepthRangeQueryLimit)
-)
+var liquidityDepthRangeQueryLimitInt = sdk.NewInt(liquidityDepthRangeQueryLimit)
 
 var _ types.QueryServer = Querier{}
 

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -3064,7 +3064,7 @@ func (s *KeeperTestSuite) TestPrepareAccumAndClaimRewards() {
 	}
 }
 
-func (s *KeeperTestSuite) TestExtractClaimedIncentives() {
+func (s *KeeperTestSuite) TestClaimAllIncentives() {
 	uptimeHelper := getExpectedUptimes()
 	defaultSender := s.TestAccs[0]
 	tests := []struct {
@@ -3072,6 +3072,7 @@ func (s *KeeperTestSuite) TestExtractClaimedIncentives() {
 		poolId         uint64
 		growthInside   []sdk.DecCoins
 		growthOutside  []sdk.DecCoins
+		forfeitIncentives bool
 		positionExists bool
 		expectError    error
 	}{
@@ -3079,6 +3080,7 @@ func (s *KeeperTestSuite) TestExtractClaimedIncentives() {
 			name:           "happy path",
 			growthInside:   uptimeHelper.hundredTokensMultiDenom,
 			positionExists: true,
+			forfeitIncentives: false,
 			growthOutside:  uptimeHelper.twoHundredTokensMultiDenom,
 		},
 		{
@@ -3108,7 +3110,7 @@ func (s *KeeperTestSuite) TestExtractClaimedIncentives() {
 			}
 
 			// System under test.
-			amountClaimed, err := clKeeper.ExtractClaimedIncentives(s.Ctx, validPoolId, defaultSender, DefaultLowerTick, DefaultUpperTick)
+			amountClaimed, err := clKeeper.ClaimAllIncentives(s.Ctx, validPoolId, defaultSender, DefaultLowerTick, DefaultUpperTick, tc.forfeitIncentives)
 
 			if tc.expectError != nil {
 				s.Require().Error(err)

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -3062,8 +3062,16 @@ func (s *KeeperTestSuite) TestClaimAllIncentives() {
 		},
 		"claim and forfeit rewards": {
 			growthInside:   uptimeHelper.hundredTokensMultiDenom,
-			forfeitIncentives: true,
 			growthOutside:  uptimeHelper.twoHundredTokensMultiDenom,
+			forfeitIncentives: true,
+		},
+		"claim and forfeit rewards when no rewards have accrued": {
+			forfeitIncentives: true,
+		},
+		"claim and forfeit rewards with varying amounts and different denoms": {
+			growthInside:   uptimeHelper.varyingTokensMultiDenom,
+			growthOutside:  uptimeHelper.varyingTokensSingleDenom,
+			forfeitIncentives: true,
 		},
 	}
 	for _, tc := range tests {
@@ -3079,8 +3087,14 @@ func (s *KeeperTestSuite) TestClaimAllIncentives() {
 			s.Require().NoError(err)
 
 			clPool.SetCurrentTick(DefaultCurrTick)
-			s.addUptimeGrowthOutsideRange(s.Ctx, validPoolId, defaultSender, DefaultCurrTick.Int64(), DefaultLowerTick, DefaultUpperTick, tc.growthOutside)
-			s.addUptimeGrowthInsideRange(s.Ctx, validPoolId, defaultSender, DefaultCurrTick.Int64(), DefaultLowerTick, DefaultUpperTick, tc.growthInside)
+			if tc.growthOutside != nil {
+				s.addUptimeGrowthOutsideRange(s.Ctx, validPoolId, defaultSender, DefaultCurrTick.Int64(), DefaultLowerTick, DefaultUpperTick, tc.growthOutside)
+			}
+
+			if tc.growthInside != nil {
+				s.addUptimeGrowthInsideRange(s.Ctx, validPoolId, defaultSender, DefaultCurrTick.Int64(), DefaultLowerTick, DefaultUpperTick, tc.growthInside)
+			}
+			
 			err = clKeeper.SetPool(s.Ctx, clPool)
 			s.Require().NoError(err)
 
@@ -3102,7 +3116,7 @@ func (s *KeeperTestSuite) TestClaimAllIncentives() {
 			s.Require().NoError(err)
 
 			// We expect claimed rewards to be equal to growth inside
-			expectedCoins := sdk.NewCoins()
+			expectedCoins := sdk.Coins(nil)
 			for _, growthInside := range tc.growthInside {
 				expectedCoins = expectedCoins.Add(sdk.NormalizeCoins(growthInside)...)
 			}

--- a/x/concentrated-liquidity/internal/math/math.go
+++ b/x/concentrated-liquidity/internal/math/math.go
@@ -6,9 +6,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
-var (
-	smallestDec = sdk.SmallestDec()
-)
+var smallestDec = sdk.SmallestDec()
 
 // liquidity0 takes an amount of asset0 in the pool as well as the sqrtpCur and the nextPrice
 // sqrtPriceA is the smaller of sqrtpCur and the nextPrice

--- a/x/concentrated-liquidity/internal/math/math_test.go
+++ b/x/concentrated-liquidity/internal/math/math_test.go
@@ -243,7 +243,6 @@ func (suite *ConcentratedMathTestSuite) TestGetLiquidityFromAmounts() {
 			liq1 := math.Liquidity1(tc.amount1Desired, tc.currentSqrtP, tc.sqrtPLow)
 			liq := sdk.MinDec(liq0, liq1)
 			suite.Require().Equal(liq.String(), liquidity.String())
-
 		})
 	}
 }
@@ -277,7 +276,6 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount0InRoundin
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-
 			sqrtPriceNext := math.GetNextSqrtPriceFromAmount0InRoundingUp(tc.sqrtPriceCurrent, tc.liquidity, tc.amountZeroRemaininIn)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
@@ -314,7 +312,6 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount0OutRoundi
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-
 			sqrtPriceNext := math.GetNextSqrtPriceFromAmount0OutRoundingUp(tc.sqrtPriceCurrent, tc.liquidity, tc.amountZeroRemainingOut)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
@@ -351,7 +348,6 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1InRoundin
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-
 			sqrtPriceNext := math.GetNextSqrtPriceFromAmount1InRoundingDown(tc.sqrtPriceCurrent, tc.liquidity, tc.amountOneRemainingIn)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
@@ -388,7 +384,6 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1OutRoundi
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-
 			sqrtPriceNext := math.GetNextSqrtPriceFromAmount1OutRoundingDown(tc.sqrtPriceCurrent, tc.liquidity, tc.amountOneRemainingOut)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())

--- a/x/concentrated-liquidity/internal/math/tick_test.go
+++ b/x/concentrated-liquidity/internal/math/tick_test.go
@@ -156,7 +156,6 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 			expectedSqrtPrice, err := tc.expectedPrice.ApproxSqrt()
 			suite.Require().NoError(err)
 			suite.Require().Equal(expectedSqrtPrice.String(), sqrtPrice.String())
-
 		})
 	}
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/fees_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/fees_test.go
@@ -7,9 +7,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/internal/swapstrategy"
 )
 
-var (
-	onePercentFee = sdk.NewDecWithPrec(1, 2)
-)
+var onePercentFee = sdk.NewDecWithPrec(1, 2)
 
 func (suite *StrategyTestSuite) TestComputeFeeChargePerSwapStepOutGivenIn() {
 	var (

--- a/x/concentrated-liquidity/internal/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/one_for_zero_test.go
@@ -40,7 +40,6 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_OneForZero() {
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 
 			suite.Require().Equal(tc.expectedResult, actualSqrtTargetPrice)
-
 		})
 	}
 }

--- a/x/concentrated-liquidity/internal/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/swap_strategy_test.go
@@ -99,7 +99,6 @@ func (suite *StrategyTestSuite) TestNextInitializedTick() {
 
 	suite.Run("lte=true", func() {
 		suite.Run("returns tick to right if at initialized tick", func() {
-
 			swapStrategy := swapstrategy.New(false, false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
 
 			n, initd := swapStrategy.NextInitializedTick(ctx, 1, 78)

--- a/x/concentrated-liquidity/internal/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/internal/swapstrategy/zero_for_one_test.go
@@ -48,7 +48,6 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_ZeroForOne() {
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 
 			suite.Require().Equal(tc.expectedResult, actualSqrtTargetPrice)
-
 		})
 	}
 }

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -325,6 +325,28 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				amount1Expected: baseCase.amount1Expected.QuoRaw(2), // 2500 usdc
 			},
 		},
+		"position still unfreezing": {
+			// setup parameters for creation a pool and position.
+			setupConfig: &frozenBaseCase,
+
+			// system under test parameters
+			// for withdrawing a position.
+			sutConfigOverwrite: &lpTest{
+				amount0Expected: baseCase.amount0Expected, // 0.998976 eth
+				amount1Expected: baseCase.amount1Expected, // 5000 usdc
+			},
+		},
+		"withdraw liquidity that is still frozen": {
+			// setup parameters for creation a pool and position.
+			setupConfig: &frozenBaseCase,
+
+			// system under test parameters
+			// for withdrawing a position.
+			sutConfigOverwrite: &lpTest{
+				amount0Expected: baseCase.amount0Expected, // 0.998976 eth
+				amount1Expected: baseCase.amount1Expected, // 5000 usdc
+			},
+		},
 		"error: no position created": {
 			// setup parameters for creation a pool and position.
 			setupConfig: baseCase,
@@ -347,27 +369,6 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 				expectedError:  types.PositionNotFoundError{PoolId: 1, LowerTick: 305450, UpperTick: 315000, JoinTime: defaultJoinTime, FreezeDuration: DefaultFreezeDuration},
 			},
 			createPositionFreezeOverwrite: true,
-		},
-		"error: position still unfreezing": {
-			// setup parameters for creation a pool and position.
-			setupConfig: &frozenBaseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
-			sutConfigOverwrite: &lpTest{
-				freezeDuration: DefaultFreezeDuration,
-				expectedError:  types.PositionStillFrozenError{FreezeDuration: DefaultFreezeDuration},
-			},
-		},
-		"error: withdraw liquidity that is still frozen": {
-			// setup parameters for creation a pool and position.
-			setupConfig: &frozenBaseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
-			sutConfigOverwrite: &lpTest{
-				expectedError: types.PositionStillFrozenError{FreezeDuration: DefaultFreezeDuration},
-			},
 		},
 		"error: pool id for pool that does not exist": {
 			// setup parameters for creating a pool and position.

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -958,7 +958,6 @@ func (s *KeeperTestSuite) TestinitializeInitialPositionForPool() {
 			} else {
 				s.Require().NoError(err)
 			}
-
 		})
 	}
 }

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -77,7 +77,7 @@ func (s *KeeperTestSuite) TestInitOrUpdatePosition() {
 				freezeDuration: DefaultFreezeDuration,
 			},
 			// we dont need the timeElapsedSinceInit because we are tracking joinTime at createPosition()
-			//timeElapsedSinceInit: time.Hour,
+			// timeElapsedSinceInit: time.Hour,
 			incentiveRecords:  defaultIncentiveRecords,
 			positionExists:    true,
 			expectedLiquidity: DefaultLiquidityAmt.Add(DefaultLiquidityAmt),

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -980,7 +980,6 @@ var (
 )
 
 func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
-
 	tests := make(map[string]SwapTest, len(swapOutGivenInCases)+len(swapOutGivenInFeeCases)+len(swapOutGivenInErrorCases))
 	for name, test := range swapOutGivenInCases {
 		tests[name] = test
@@ -1136,7 +1135,6 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 }
 
 func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
-
 	tests := make(map[string]SwapTest)
 	for name, test := range swapOutGivenInCases {
 		tests[name] = test
@@ -1215,7 +1213,6 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 }
 
 func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
-
 	tests := make(map[string]SwapTest, len(swapInGivenOutTestCases)+len(swapInGivenOutFeeTestCases)+len(swapInGivenOutErrorTestCases))
 	for name, test := range swapInGivenOutTestCases {
 		tests[name] = test
@@ -1386,7 +1383,6 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 }
 
 func (s *KeeperTestSuite) TestSwapInAmtGivenOut_TickUpdates() {
-
 	tests := make(map[string]SwapTest)
 	for name, test := range swapInGivenOutTestCases {
 		tests[name] = test
@@ -1761,7 +1757,6 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 // TestCalcOutAmtGivenInWriteCtx tests that writeCtx successfully performs state changes as expected.
 // We expect writeCtx to only change fee accum state, since pool state change is not handled via writeCtx function.
 func (s *KeeperTestSuite) TestCalcOutAmtGivenInWriteCtx() {
-
 	// we only use fee cases here since write Ctx only takes effect in the fee accumulator
 	tests := make(map[string]SwapTest, len(swapOutGivenInFeeCases))
 
@@ -1847,7 +1842,6 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenInWriteCtx() {
 // TestCalcInAmtGivenOutWriteCtx tests that writeCtx succesfully perfroms state changes as expected.
 // We expect writeCtx to only change fee accum state, since pool state change is not handled via writeCtx function.
 func (s *KeeperTestSuite) TestCalcInAmtGivenOutWriteCtx() {
-
 	// we only use fee cases here since write Ctx only takes effect in the fee accumulator
 	tests := make(map[string]SwapTest, len(swapInGivenOutFeeTestCases))
 
@@ -1929,8 +1923,8 @@ func (s *KeeperTestSuite) TestCalcInAmtGivenOutWriteCtx() {
 		})
 	}
 }
-func (s *KeeperTestSuite) TestInverseRelationshipSwapOutAmtGivenIn() {
 
+func (s *KeeperTestSuite) TestInverseRelationshipSwapOutAmtGivenIn() {
 	tests := swapOutGivenInCases
 
 	for name, test := range tests {
@@ -2022,7 +2016,6 @@ func (suite *KeeperTestSuite) TestUpdateFeeGrowthGlobal() {
 }
 
 func (s *KeeperTestSuite) TestInverseRelationshipSwapInAmtGivenOut() {
-
 	tests := swapInGivenOutTestCases
 
 	for name, test := range tests {

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -225,14 +225,6 @@ func (e InvalidSwapFeeError) Error() string {
 	return fmt.Sprintf("invalid swap fee(%s), must be in [0, 1) range", e.ActualFee)
 }
 
-type PositionStillFrozenError struct {
-	FreezeDuration time.Duration
-}
-
-func (e PositionStillFrozenError) Error() string {
-	return fmt.Sprintf("position is still under freeze duration %s", e.FreezeDuration)
-}
-
 type IncentiveRecordNotFoundError struct {
 	PoolId         uint64
 	IncentiveDenom string

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -33,12 +33,14 @@ func NewParams(authorizedTickSpacing []uint64, authorizedSwapFees []sdk.Dec) Par
 func DefaultParams() Params {
 	return Params{
 		AuthorizedTickSpacing: AuthorizedTickSpacing,
-		AuthorizedSwapFees: []sdk.Dec{sdk.ZeroDec(),
+		AuthorizedSwapFees: []sdk.Dec{
+			sdk.ZeroDec(),
 			sdk.MustNewDecFromStr("0.0001"),
 			sdk.MustNewDecFromStr("0.0003"),
 			sdk.MustNewDecFromStr("0.0005"),
 			sdk.MustNewDecFromStr("0.003"),
-			sdk.MustNewDecFromStr("0.01")},
+			sdk.MustNewDecFromStr("0.01"),
+		},
 	}
 }
 

--- a/x/downtime-detector/client/cli/query_test.go
+++ b/x/downtime-detector/client/cli/query_test.go
@@ -18,32 +18,37 @@ func TestRecoveredSinceQueryCmd(t *testing.T) {
 			Cmd: "30s 10m",
 			ExpectedQuery: &queryproto.RecoveredSinceDowntimeOfLengthRequest{
 				Downtime: types.Downtime_DURATION_30S,
-				Recovery: time.Minute * 10},
+				Recovery: time.Minute * 10,
+			},
 		},
 		"invalid duration": {
 			Cmd: "31s 10m",
 			ExpectedQuery: &queryproto.RecoveredSinceDowntimeOfLengthRequest{
 				Downtime: types.Downtime_DURATION_30S,
-				Recovery: time.Minute * 10},
+				Recovery: time.Minute * 10,
+			},
 			ExpectedErr: true,
 		},
 		"90m": {
 			Cmd: "90m 10m",
 			ExpectedQuery: &queryproto.RecoveredSinceDowntimeOfLengthRequest{
 				Downtime: types.Downtime_DURATION_1_5H,
-				Recovery: time.Minute * 10},
+				Recovery: time.Minute * 10,
+			},
 		},
 		"1.5h": {
 			Cmd: "1.5h 10m",
 			ExpectedQuery: &queryproto.RecoveredSinceDowntimeOfLengthRequest{
 				Downtime: types.Downtime_DURATION_1_5H,
-				Recovery: time.Minute * 10},
+				Recovery: time.Minute * 10,
+			},
 		},
 		"1h30m": {
 			Cmd: "1h30m 10m",
 			ExpectedQuery: &queryproto.RecoveredSinceDowntimeOfLengthRequest{
 				Downtime: types.Downtime_DURATION_1_5H,
-				Recovery: time.Minute * 10},
+				Recovery: time.Minute * 10,
+			},
 		},
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)

--- a/x/downtime-detector/client/grpc/grpc_query.go
+++ b/x/downtime-detector/client/grpc/grpc_query.go
@@ -1,4 +1,4 @@
-package grpc 
+package grpc
 
 // THIS FILE IS GENERATED CODE, DO NOT EDIT
 // SOURCE AT `proto/osmosis/downtime-detector/v1beta1/query.yml`
@@ -29,4 +29,3 @@ func (q Querier) RecoveredSinceDowntimeOfLength(grpcCtx context.Context,
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.RecoveredSinceDowntimeOfLength(ctx, *req)
 }
-

--- a/x/downtime-detector/keeper_test.go
+++ b/x/downtime-detector/keeper_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/downtime-detector/types"
 )
 
-var baseTime = time.Unix(1257894000, 0).UTC()
-var sec = time.Second
-var min = time.Minute
+var (
+	baseTime = time.Unix(1257894000, 0).UTC()
+	sec      = time.Second
+	min      = time.Minute
+)
 
 type blocktimes []time.Duration
 
@@ -33,10 +35,12 @@ func (suite *KeeperTestSuite) runBlocktimes(times blocktimes) {
 	}
 }
 
-var abruptRecovery5minDowntime10min blocktimes = []time.Duration{sec, 10 * min, 5 * min}
-var smootherRecovery5minDowntime10min blocktimes = []time.Duration{sec, 10 * min, min, min, min, min, min}
-var fifteenMinEndtime = abruptRecovery5minDowntime10min.EndTime()
-var tenMinEndtime = abruptRecovery5minDowntime10min.EndTime().Add(-5 * min)
+var (
+	abruptRecovery5minDowntime10min   blocktimes = []time.Duration{sec, 10 * min, 5 * min}
+	smootherRecovery5minDowntime10min blocktimes = []time.Duration{sec, 10 * min, min, min, min, min, min}
+	fifteenMinEndtime                            = abruptRecovery5minDowntime10min.EndTime()
+	tenMinEndtime                                = abruptRecovery5minDowntime10min.EndTime().Add(-5 * min)
+)
 
 func (suite *KeeperTestSuite) TestBeginBlock() {
 	tests := map[string]struct {

--- a/x/downtime-detector/types/constants.go
+++ b/x/downtime-detector/types/constants.go
@@ -17,8 +17,10 @@ const (
 	QuerierRoute = ModuleName
 )
 
-var DowntimeToDuration = btree.NewMap[Downtime, time.Duration](16)
-var DefaultLastDowntime = time.Unix(0, 0)
+var (
+	DowntimeToDuration  = btree.NewMap[Downtime, time.Duration](16)
+	DefaultLastDowntime = time.Unix(0, 0)
+)
 
 // init initializes the DowntimeToDuration map with mappings
 // from the Duration enum values to their corresponding

--- a/x/epochs/client/cli/query.go
+++ b/x/epochs/client/cli/query.go
@@ -22,7 +22,8 @@ func GetCmdEpochInfos() (*osmocli.QueryDescriptor, *types.QueryEpochsInfoRequest
 		Short: "Query running epoch infos.",
 		Long: `{{.Short}}{{.ExampleHeader}}
 {{.CommandPrefix}}`,
-		QueryFnName: "EpochInfos"}, &types.QueryEpochsInfoRequest{}
+		QueryFnName: "EpochInfos",
+	}, &types.QueryEpochsInfoRequest{}
 }
 
 func GetCmdCurrentEpoch() (*osmocli.QueryDescriptor, *types.QueryCurrentEpochRequest) {
@@ -30,5 +31,6 @@ func GetCmdCurrentEpoch() (*osmocli.QueryDescriptor, *types.QueryCurrentEpochReq
 		Use:   "current-epoch",
 		Short: "Query current epoch by specified identifier.",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} day`}, &types.QueryCurrentEpochRequest{}
+{{.CommandPrefix}} day`,
+	}, &types.QueryCurrentEpochRequest{}
 }

--- a/x/gamm/client/cli/query.go
+++ b/x/gamm/client/cli/query.go
@@ -50,7 +50,8 @@ func GetCmdPool() (*osmocli.QueryDescriptor, *types.QueryPoolRequest) {
 		Use:   "pool [poolID]",
 		Short: "Query pool",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} pool 1`}, &types.QueryPoolRequest{}
+{{.CommandPrefix}} pool 1`,
+	}, &types.QueryPoolRequest{}
 }
 
 // TODO: Push this to the SDK.
@@ -80,7 +81,8 @@ func GetCmdPools() (*osmocli.QueryDescriptor, *types.QueryPoolsRequest) {
 		Use:   "pools",
 		Short: "Query pools",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} pools`}, &types.QueryPoolsRequest{}
+{{.CommandPrefix}} pools`,
+	}, &types.QueryPoolsRequest{}
 }
 
 // nolint: staticcheck
@@ -196,7 +198,8 @@ func GetCmdSpotPrice() (*osmocli.QueryDescriptor, *types.QuerySpotPriceRequest) 
 		Short: "Query spot-price (LEGACY, arguments are reversed!!)",
 		Long: `Query spot price (Legacy).{{.ExampleHeader}}
 {{.CommandPrefix}} spot-price 1 uosmo ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2
-`}, &types.QuerySpotPriceRequest{}
+`,
+	}, &types.QuerySpotPriceRequest{}
 }
 
 // GetCmdEstimateSwapExactAmountIn returns estimation of output coin when amount of x token input.

--- a/x/gamm/client/cli/tx_test.go
+++ b/x/gamm/client/cli/tx_test.go
@@ -61,7 +61,6 @@ func TestParseCoinsNoSort(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			coins, err := cli.ParseCoinsNoSort(tc.coinsStr)
 
 			require.NoError(t, err)

--- a/x/gamm/keeper/genesis_test.go
+++ b/x/gamm/keeper/genesis_test.go
@@ -17,13 +17,11 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 )
 
-var (
-	DefaultMigrationRecords = types.MigrationRecords{BalancerToConcentratedPoolLinks: []types.BalancerToConcentratedPoolLink{
-		{BalancerPoolId: 1, ClPoolId: 4},
-		{BalancerPoolId: 2, ClPoolId: 5},
-		{BalancerPoolId: 3, ClPoolId: 6},
-	}}
-)
+var DefaultMigrationRecords = types.MigrationRecords{BalancerToConcentratedPoolLinks: []types.BalancerToConcentratedPoolLink{
+	{BalancerPoolId: 1, ClPoolId: 4},
+	{BalancerPoolId: 2, ClPoolId: 5},
+	{BalancerPoolId: 3, ClPoolId: 6},
+}}
 
 func TestGammInitGenesis(t *testing.T) {
 	app := osmoapp.Setup(false)

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -137,7 +137,7 @@ func (k Keeper) JoinPoolNoSwap(
 	}
 
 	// check that needed lp liquidity does not exceed the given `tokenInMaxs` parameter. Return error if so.
-	//if tokenInMaxs == 0, don't do this check.
+	// if tokenInMaxs == 0, don't do this check.
 	if tokenInMaxs.Len() != 0 {
 		if !(neededLpLiquidity.DenomsSubsetOf(tokenInMaxs)) {
 			return nil, sdk.ZeroInt(), sdkerrors.Wrapf(types.ErrLimitMaxAmount, "TokenInMaxs does not include all the tokens that are part of the target pool,"+

--- a/x/gamm/keeper/pool_test.go
+++ b/x/gamm/keeper/pool_test.go
@@ -379,7 +379,6 @@ func (suite *KeeperTestSuite) TestConvertToCFMMPool() {
 // change the underlying bytes. This shows that migrations are
 // not necessary.
 func (suite *KeeperTestSuite) TestMarshalUnmarshalPool() {
-
 	suite.SetupTest()
 	k := suite.App.GAMMKeeper
 
@@ -526,5 +525,4 @@ func (suite *KeeperTestSuite) TestSetStableSwapScalingFactors() {
 			}
 		})
 	}
-
 }

--- a/x/gamm/pool-models/balancer/pool_test.go
+++ b/x/gamm/pool-models/balancer/pool_test.go
@@ -569,7 +569,8 @@ func (suite *BalancerTestSuite) TestBalancerCalculateAmountOutAndIn_InverseRelat
 				suite.Require().NotNil(pool)
 
 				errTolerance := osmomath.ErrTolerance{
-					AdditiveTolerance: sdk.OneDec(), MultiplicativeTolerance: sdk.Dec{}}
+					AdditiveTolerance: sdk.OneDec(), MultiplicativeTolerance: sdk.Dec{},
+				}
 				sut := func() {
 					test_helpers.TestCalculateAmountOutAndIn_InverseRelationship(suite.T(), ctx, pool, poolAssetIn.Token.Denom, poolAssetOut.Token.Denom, tc.initialCalcOut, swapFeeDec, errTolerance)
 				}

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -168,7 +168,8 @@ func BinarySearchSingleAssetJoin(
 
 // SwapAllCoinsToSingleAsset iterates through each token in the input set and trades it against the same pool sequentially
 func SwapAllCoinsToSingleAsset(pool types.CFMMPoolI, ctx sdk.Context, inTokens sdk.Coins, swapToDenom string,
-	swapFee sdk.Dec) (sdk.Int, error) {
+	swapFee sdk.Dec,
+) (sdk.Int, error) {
 	tokenOutAmt := inTokens.AmountOfNoDenomValidation(swapToDenom)
 	for _, coin := range inTokens {
 		if coin.Denom == swapToDenom {

--- a/x/gamm/pool-models/stableswap/amm_test.go
+++ b/x/gamm/pool-models/stableswap/amm_test.go
@@ -726,7 +726,8 @@ func (suite *StableSwapTestSuite) Test_StableSwap_CalculateAmountOutAndIn_Invers
 				pool := createTestPool(suite.T(), tc.poolLiquidity, swapFeeDec, exitFeeDec, tc.scalingFactors)
 				suite.Require().NotNil(pool)
 				errTolerance := osmomath.ErrTolerance{
-					AdditiveTolerance: sdk.Dec{}, MultiplicativeTolerance: sdk.NewDecWithPrec(1, 12)}
+					AdditiveTolerance: sdk.Dec{}, MultiplicativeTolerance: sdk.NewDecWithPrec(1, 12),
+				}
 				test_helpers.TestCalculateAmountOutAndIn_InverseRelationship(suite.T(), ctx, pool, tc.denomIn, tc.denomOut, tc.initialCalcOut, swapFeeDec, errTolerance)
 			})
 		}

--- a/x/gamm/pool-models/stableswap/msgs_test.go
+++ b/x/gamm/pool-models/stableswap/msgs_test.go
@@ -338,7 +338,6 @@ func (suite *TestSuite) TestMsgCreateStableswapPool() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-
 			pool, err := tc.msg.CreatePool(suite.Ctx, 1)
 
 			if tc.expectError {

--- a/x/gamm/pool-models/stableswap/pool_test.go
+++ b/x/gamm/pool-models/stableswap/pool_test.go
@@ -1364,7 +1364,6 @@ func TestStableswapSpotPrice(t *testing.T) {
 }
 
 func TestValidateScalingFactors(t *testing.T) {
-
 	tests := map[string]struct {
 		scalingFactors []uint64
 		numAssets      int

--- a/x/ibc-hooks/client/cli/query.go
+++ b/x/ibc-hooks/client/cli/query.go
@@ -2,12 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/osmosis-labs/osmosis/x/ibc-hooks/keeper"
 	"github.com/spf13/cobra"
-	"strings"
 
 	"github.com/osmosis-labs/osmosis/x/ibc-hooks/types"
 )

--- a/x/ibc-hooks/keeper/keeper.go
+++ b/x/ibc-hooks/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/types/address"
 
 	"github.com/tendermint/tendermint/libs/log"

--- a/x/ibc-hooks/wasm_hook.go
+++ b/x/ibc-hooks/wasm_hook.go
@@ -3,6 +3,7 @@ package ibc_hooks
 import (
 	"encoding/json"
 	"fmt"
+
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"

--- a/x/ibc-rate-limit/client/grpc/grpc_query.go
+++ b/x/ibc-rate-limit/client/grpc/grpc_query.go
@@ -1,4 +1,4 @@
-package grpc 
+package grpc
 
 // THIS FILE IS GENERATED CODE, DO NOT EDIT
 // SOURCE AT `proto/osmosis/ibc-rate-limit/v1beta1/query.yml`
@@ -29,4 +29,3 @@ func (q Querier) Params(grpcCtx context.Context,
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.Params(ctx, *req)
 }
-

--- a/x/ibc-rate-limit/types/keys.go
+++ b/x/ibc-rate-limit/types/keys.go
@@ -7,8 +7,6 @@ const (
 
 )
 
-var (
-	// RouterKey is the message route. Can only contain
-	// alphanumeric characters.
-	RouterKey = strings.ReplaceAll(ModuleName, "-", "")
-)
+// RouterKey is the message route. Can only contain
+// alphanumeric characters.
+var RouterKey = strings.ReplaceAll(ModuleName, "-", "")

--- a/x/incentives/client/cli/cli_test.go
+++ b/x/incentives/client/cli/cli_test.go
@@ -52,7 +52,8 @@ func TestGetCmdActiveGauges(t *testing.T) {
 			Cmd: "--offset=2",
 			ExpectedQuery: &types.ActiveGaugesRequest{
 				Pagination: &query.PageRequest{Key: []uint8{}, Offset: 2, Limit: 100},
-			}},
+			},
+		},
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }
@@ -65,7 +66,8 @@ func TestGetCmdActiveGaugesPerDenom(t *testing.T) {
 			ExpectedQuery: &types.ActiveGaugesPerDenomRequest{
 				Denom:      "uosmo",
 				Pagination: &query.PageRequest{Key: []uint8{}, Offset: 2, Limit: 100},
-			}},
+			},
+		},
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }
@@ -77,7 +79,8 @@ func TestGetCmdUpcomingGauges(t *testing.T) {
 			Cmd: "--offset=2",
 			ExpectedQuery: &types.UpcomingGaugesRequest{
 				Pagination: &query.PageRequest{Key: []uint8{}, Offset: 2, Limit: 100},
-			}},
+			},
+		},
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }
@@ -90,7 +93,8 @@ func TestGetCmdUpcomingGaugesPerDenom(t *testing.T) {
 			ExpectedQuery: &types.UpcomingGaugesPerDenomRequest{
 				Denom:      "uosmo",
 				Pagination: &query.PageRequest{Key: []uint8{}, Offset: 2, Limit: 100},
-			}},
+			},
+		},
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }

--- a/x/incentives/client/cli/query.go
+++ b/x/incentives/client/cli/query.go
@@ -48,7 +48,8 @@ func GetCmdToDistributeCoins() (*osmocli.QueryDescriptor, *types.ModuleToDistrib
 	return &osmocli.QueryDescriptor{
 		Use:   "to-distribute-coins",
 		Short: "Query coins that is going to be distributed",
-		Long:  `{{.Short}}`}, &types.ModuleToDistributeCoinsRequest{}
+		Long:  `{{.Short}}`,
+	}, &types.ModuleToDistributeCoinsRequest{}
 }
 
 // GetCmdGaugeByID returns a gauge by ID.
@@ -58,7 +59,8 @@ func GetCmdGaugeByID() (*osmocli.QueryDescriptor, *types.GaugeByIDRequest) {
 		Short: "Query gauge by id.",
 		Long: `{{.Short}}{{.ExampleHeader}}
 {{.CommandPrefix}} gauge-by-id 1
-`}, &types.GaugeByIDRequest{}
+`,
+	}, &types.GaugeByIDRequest{}
 }
 
 // GetCmdActiveGauges returns active gauges.
@@ -66,7 +68,8 @@ func GetCmdActiveGauges() (*osmocli.QueryDescriptor, *types.ActiveGaugesRequest)
 	return &osmocli.QueryDescriptor{
 		Use:   "active-gauges",
 		Short: "Query active gauges",
-		Long:  `{{.Short}}`}, &types.ActiveGaugesRequest{}
+		Long:  `{{.Short}}`,
+	}, &types.ActiveGaugesRequest{}
 }
 
 // GetCmdActiveGaugesPerDenom returns active gauges for a specified denom.
@@ -75,7 +78,8 @@ func GetCmdActiveGaugesPerDenom() (*osmocli.QueryDescriptor, *types.ActiveGauges
 		Use:   "active-gauges-per-den [den]denom [denom]",
 		Short: "Query active gauges per denom",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} active-gauges-per-denom gamm/pool/1`}, &types.ActiveGaugesPerDenomRequest{}
+{{.CommandPrefix}} active-gauges-per-denom gamm/pool/1`,
+	}, &types.ActiveGaugesPerDenomRequest{}
 }
 
 // GetCmdUpcomingGauges returns scheduled gauges.
@@ -83,7 +87,8 @@ func GetCmdUpcomingGauges() (*osmocli.QueryDescriptor, *types.UpcomingGaugesRequ
 	return &osmocli.QueryDescriptor{
 		Use:   "upcoming-gauges",
 		Short: "Query upcoming gauges",
-		Long:  `{{.Short}}`}, &types.UpcomingGaugesRequest{}
+		Long:  `{{.Short}}`,
+	}, &types.UpcomingGaugesRequest{}
 }
 
 // GetCmdUpcomingGaugesPerDenom returns scheduled gauges for specified denom..
@@ -91,7 +96,8 @@ func GetCmdUpcomingGaugesPerDenom() (*osmocli.QueryDescriptor, *types.UpcomingGa
 	return &osmocli.QueryDescriptor{
 		Use:   "upcoming-gauges-per-denom [denom]",
 		Short: "Query scheduled gauges per denom",
-		Long:  `{{.Short}}`}, &types.UpcomingGaugesPerDenomRequest{}
+		Long:  `{{.Short}}`,
+	}, &types.UpcomingGaugesPerDenomRequest{}
 }
 
 // GetCmdRewardsEst returns rewards estimation.

--- a/x/incentives/keeper/msg_server_test.go
+++ b/x/incentives/keeper/msg_server_test.go
@@ -17,8 +17,10 @@ import (
 
 var _ = suite.TestingSuite(nil)
 
-var seventyTokens = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(70000000)))
-var tenTokens = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10000000)))
+var (
+	seventyTokens = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(70000000)))
+	tenTokens     = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10000000)))
+)
 
 func (suite *KeeperTestSuite) TestCreateGauge_Fee() {
 	tests := []struct {

--- a/x/lockup/client/cli/query.go
+++ b/x/lockup/client/cli/query.go
@@ -59,7 +59,8 @@ func GetCmdModuleBalance() (*osmocli.QueryDescriptor, *types.ModuleBalanceReques
 	return &osmocli.QueryDescriptor{
 		Use:   "module-balance",
 		Short: "Query module balance",
-		Long:  `{{.Short}}`}, &types.ModuleBalanceRequest{}
+		Long:  `{{.Short}}`,
+	}, &types.ModuleBalanceRequest{}
 }
 
 // GetCmdModuleLockedAmount returns locked balance of the module,
@@ -68,7 +69,8 @@ func GetCmdModuleLockedAmount() (*osmocli.QueryDescriptor, *types.ModuleLockedAm
 	return &osmocli.QueryDescriptor{
 		Use:   "module-locked-amount",
 		Short: "Query locked amount",
-		Long:  `{{.Short}}`}, &types.ModuleLockedAmountRequest{}
+		Long:  `{{.Short}}`,
+	}, &types.ModuleLockedAmountRequest{}
 }
 
 // GetCmdAccountUnlockableCoins returns unlockable coins which has finsihed unlocking.
@@ -115,7 +117,8 @@ func GetCmdAccountUnlockingCoins() (*osmocli.QueryDescriptor, *types.AccountUnlo
 		Use:   "account-unlocking-coins <address>",
 		Short: "Query account's unlocking coins",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} account-unlocking-coins <address>`}, &types.AccountUnlockingCoinsRequest{}
+{{.CommandPrefix}} account-unlocking-coins <address>`,
+	}, &types.AccountUnlockingCoinsRequest{}
 }
 
 // GetCmdAccountLockedCoins returns locked coins that that are still in a locked state from the specified account.
@@ -135,7 +138,8 @@ func GetCmdAccountLockedPastTime() (*osmocli.QueryDescriptor, *types.AccountLock
 		Short: "Query locked records of an account with unlock time beyond timestamp",
 		Long: `{{.Short}}{{.ExampleHeader}}
 {{.CommandPrefix}} account-locked-pastime <address> <timestamp>
-`}, &types.AccountLockedPastTimeRequest{}
+`,
+	}, &types.AccountLockedPastTimeRequest{}
 }
 
 // GetCmdAccountLockedPastTimeNotUnlockingOnly returns locks of an account with unlock time beyond provided timestamp
@@ -147,7 +151,8 @@ func GetCmdAccountLockedPastTimeNotUnlockingOnly() (*osmocli.QueryDescriptor, *t
 		Long: `{{.Short}}
 Timestamp is UNIX time in seconds.{{.ExampleHeader}}
 {{.CommandPrefix}} account-locked-pastime-not-unlocking <address> <timestamp>
-`}, &types.AccountLockedPastTimeNotUnlockingOnlyRequest{}
+`,
+	}, &types.AccountLockedPastTimeNotUnlockingOnlyRequest{}
 }
 
 // GetCmdAccountUnlockedBeforeTime returns locks with unlock time before the provided timestamp.

--- a/x/poolmanager/client/cli/cli_test.go
+++ b/x/poolmanager/client/cli/cli_test.go
@@ -63,7 +63,6 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 }
 
 func TestIntegrationTestSuite(t *testing.T) {
-
 	// TODO: re-enable this once poolmanager is fully merged.
 	t.SkipNow()
 
@@ -210,6 +209,7 @@ func TestGetCmdEstimateSwapExactAmountIn(t *testing.T) {
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }
+
 func TestGetCmdEstimateSwapExactAmountOut(t *testing.T) {
 	desc, _ := cli.GetCmdEstimateSwapExactAmountOut()
 	tcs := map[string]osmocli.QueryCliTestCase[*queryproto.EstimateSwapExactAmountOutRequest]{
@@ -225,6 +225,7 @@ func TestGetCmdEstimateSwapExactAmountOut(t *testing.T) {
 	}
 	osmocli.RunQueryTestCases(t, desc, tcs)
 }
+
 func (s *IntegrationTestSuite) TestNewCreatePoolCmd() {
 	val := s.network.Validators[0]
 

--- a/x/poolmanager/client/cli/query_test.go
+++ b/x/poolmanager/client/cli/query_test.go
@@ -62,7 +62,6 @@ func (s *QueryTestSuite) TestQueriesNeverAlterState() {
 }
 
 func TestQueryTestSuite(t *testing.T) {
-
 	// TODO: re-enable this once poolmanager is fully merged.
 	t.SkipNow()
 

--- a/x/poolmanager/client/cli/tx.go
+++ b/x/poolmanager/client/cli/tx.go
@@ -56,6 +56,7 @@ func NewSwapExactAmountOutCmd() (*osmocli.TxCliDesc, *types.MsgSwapExactAmountOu
 		Flags:            osmocli.FlagDesc{RequiredFlags: []*flag.FlagSet{FlagSetMultihopSwapRoutes()}},
 	}, &types.MsgSwapExactAmountOut{}
 }
+
 func NewBuildSwapExactAmountInMsg(clientCtx client.Context, tokenInStr, tokenOutMinAmtStr string, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
 	routes, err := swapAmountInRoutes(fs)
 	if err != nil {

--- a/x/poolmanager/client/cli/tx_test.go
+++ b/x/poolmanager/client/cli/tx_test.go
@@ -61,7 +61,6 @@ func TestParseCoinsNoSort(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			coins, err := cli.ParseCoinsNoSort(tc.coinsStr)
 
 			require.NoError(t, err)

--- a/x/poolmanager/client/grpc/grpc_query.go
+++ b/x/poolmanager/client/grpc/grpc_query.go
@@ -1,4 +1,4 @@
-package grpc 
+package grpc
 
 // THIS FILE IS GENERATED CODE, DO NOT EDIT
 // SOURCE AT `proto/osmosis/poolmanager/v1beta1/query.yml`
@@ -59,4 +59,3 @@ func (q Querier) EstimateSwapExactAmountIn(grpcCtx context.Context,
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.EstimateSwapExactAmountIn(ctx, *req)
 }
-

--- a/x/poolmanager/create_pool_test.go
+++ b/x/poolmanager/create_pool_test.go
@@ -116,7 +116,6 @@ func (suite *KeeperTestSuite) TestPoolCreationFee() {
 
 // TestCreatePool tests that all possible pools are created correctly.
 func (suite *KeeperTestSuite) TestCreatePool() {
-
 	validBalancerPoolMsg := balancer.NewMsgCreateBalancerPool(suite.TestAccs[0], balancer.NewPoolParams(sdk.ZeroDec(), sdk.ZeroDec(), nil), []balancer.PoolAsset{
 		{
 			Token:  sdk.NewCoin(foo, defaultInitPoolAmount),

--- a/x/poolmanager/export_test.go
+++ b/x/poolmanager/export_test.go
@@ -11,7 +11,8 @@ func (k Keeper) GetNextPoolIdAndIncrement(ctx sdk.Context) uint64 {
 }
 
 func (k Keeper) GetOsmoRoutedMultihopTotalSwapFee(ctx sdk.Context, route types.MultihopRoute) (
-	totalPathSwapFee sdk.Dec, sumOfSwapFees sdk.Dec, err error) {
+	totalPathSwapFee sdk.Dec, sumOfSwapFees sdk.Dec, err error,
+) {
 	return k.getOsmoRoutedMultihopTotalSwapFee(ctx, route)
 }
 

--- a/x/protorev/keeper/developer_fees_test.go
+++ b/x/protorev/keeper/developer_fees_test.go
@@ -131,7 +131,6 @@ func (suite *KeeperTestSuite) TestUpdateDeveloperFees() {
 			profit:      sdk.NewInt(200),
 			alterState: func() {
 				suite.App.ProtoRevKeeper.SetDaysSinceModuleGenesis(suite.Ctx, 731)
-
 			},
 			expected: sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(10)),
 		},
@@ -141,7 +140,6 @@ func (suite *KeeperTestSuite) TestUpdateDeveloperFees() {
 			profit:      sdk.NewInt(200),
 			alterState: func() {
 				suite.App.ProtoRevKeeper.SetDaysSinceModuleGenesis(suite.Ctx, 365*10+1)
-
 			},
 			expected: sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(10)),
 		},

--- a/x/protorev/keeper/epoch_hook.go
+++ b/x/protorev/keeper/epoch_hook.go
@@ -16,9 +16,7 @@ type LiquidityPoolStruct struct {
 	PoolId    uint64
 }
 
-var (
-	_ epochstypes.EpochHooks = EpochHooks{}
-)
+var _ epochstypes.EpochHooks = EpochHooks{}
 
 func (k Keeper) EpochHooks() epochstypes.EpochHooks {
 	return EpochHooks{k}

--- a/x/protorev/keeper/epoch_hook_test.go
+++ b/x/protorev/keeper/epoch_hook_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"fmt"
 	"strings"
-
 	"testing"
 
 	"github.com/osmosis-labs/osmosis/v15/x/protorev/types"

--- a/x/protorev/keeper/grpc_query_test.go
+++ b/x/protorev/keeper/grpc_query_test.go
@@ -279,7 +279,6 @@ func (suite *KeeperTestSuite) TestGetProtoRevDeveloperAccount() {
 	res, err = suite.queryClient.GetProtoRevDeveloperAccount(sdk.WrapSDKContext(suite.Ctx), req)
 	suite.Require().NoError(err)
 	suite.Require().Equal(developerAccount.String(), res.DeveloperAccount)
-
 }
 
 // TestGetProtoRevPoolWeights tests the query to retrieve the pool weights

--- a/x/protorev/keeper/msg_server_test.go
+++ b/x/protorev/keeper/msg_server_test.go
@@ -222,7 +222,6 @@ func (suite *KeeperTestSuite) TestMsgSetHotRoutes() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }

--- a/x/protorev/keeper/posthandler.go
+++ b/x/protorev/keeper/posthandler.go
@@ -168,7 +168,8 @@ func extractSwapInPools(routes []poolmanagertypes.SwapAmountInRoute, tokenInDeno
 		swappedPools = append(swappedPools, SwapToBackrun{
 			PoolId:        route.PoolId,
 			TokenOutDenom: route.TokenOutDenom,
-			TokenInDenom:  prevTokenIn})
+			TokenInDenom:  prevTokenIn,
+		})
 
 		prevTokenIn = route.TokenOutDenom
 	}
@@ -186,7 +187,8 @@ func extractSwapOutPools(routes []poolmanagertypes.SwapAmountOutRoute, tokenOutD
 		swappedPools = append(swappedPools, SwapToBackrun{
 			PoolId:        route.PoolId,
 			TokenOutDenom: prevTokenOut,
-			TokenInDenom:  route.TokenInDenom})
+			TokenInDenom:  route.TokenInDenom,
+		})
 
 		prevTokenOut = route.TokenInDenom
 	}

--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -544,7 +544,6 @@ func (suite *KeeperTestSuite) TestAnteHandle() {
 			} else if strings.Contains(tc.name, "Block Pool Points Limit") {
 				suite.App.ProtoRevKeeper.SetMaxPointsPerBlock(suite.Ctx, 100)
 			}
-
 		})
 	}
 }
@@ -905,7 +904,6 @@ func (suite *KeeperTestSuite) TestExtractSwappedPools() {
 
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
-
 			suite.Ctx = suite.Ctx.WithIsCheckTx(tc.params.isCheckTx)
 			suite.Ctx = suite.Ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 			suite.Ctx = suite.Ctx.WithMinGasPrices(tc.params.minGasPrices)

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -73,7 +73,6 @@ func (k Keeper) ConvertProfits(ctx sdk.Context, inputCoin sdk.Coin, profit sdk.I
 		types.OsmosisDenomination,
 		conversionPool.GetSwapFee(ctx),
 	)
-
 	if err != nil {
 		return profit, err
 	}

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -23,7 +23,8 @@ var routeTwoAssetSameWeight = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        24,
 		TokenOutDenom: "uosmo",
-	}}
+	},
+}
 
 // Mainnet Arb Route - Multi Asset, Same Weights (Block: 6906570)
 // expectedAmtIn:  sdk.NewInt(4800000),
@@ -40,7 +41,8 @@ var routeMultiAssetSameWeight = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        27,
 		TokenOutDenom: "uosmo",
-	}}
+	},
+}
 
 // Arb Route - Multi Asset, Same Weights - Pool 22 instead of 26 (Block: 6906570)
 // expectedAmtIn:  sdk.NewInt(519700000),
@@ -57,7 +59,8 @@ var routeMostProfitable = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        27,
 		TokenOutDenom: "uosmo",
-	}}
+	},
+}
 
 // Mainnet Arb Route - Multi Asset, Different Weights (Block: 6908256)
 // expectedAmtIn:  sdk.NewInt(4100000),
@@ -74,7 +77,8 @@ var routeDiffDenom = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        33,
 		TokenOutDenom: "Atom",
-	}}
+	},
+}
 
 // No Arbitrage Opportunity
 // expectedAmtIn:  sdk.NewInt(0),
@@ -91,7 +95,8 @@ var routeNoArb = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        8,
 		TokenOutDenom: "uosmo",
-	}}
+	},
+}
 
 // StableSwap Test Route
 // expectedAmtIn:  sdk.NewInt(137600000),
@@ -108,7 +113,8 @@ var routeStableSwap = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        30,
 		TokenOutDenom: "uosmo",
-	}}
+	},
+}
 
 // Four Pool Test Route (Mainnet Block: 1855422)
 // expectedAmtIn:  sdk.NewInt(1_147_000_000)
@@ -171,7 +177,6 @@ var panicRoute = poolmanagertypes.SwapAmountInRoutes{
 }
 
 func (suite *KeeperTestSuite) TestFindMaxProfitRoute() {
-
 	type param struct {
 		route           poolmanagertypes.SwapAmountInRoutes
 		expectedAmtIn   sdk.Int
@@ -317,7 +322,6 @@ func (suite *KeeperTestSuite) TestFindMaxProfitRoute() {
 }
 
 func (suite *KeeperTestSuite) TestExecuteTrade() {
-
 	type param struct {
 		route          poolmanagertypes.SwapAmountInRoutes
 		inputCoin      sdk.Coin
@@ -434,7 +438,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 		params     paramm
 		expectPass bool
 	}{
-		{name: "Single Route Test",
+		{
+			name: "Single Route Test",
 			params: paramm{
 				routes:                     []poolmanagertypes.SwapAmountInRoutes{routeTwoAssetSameWeight},
 				expectedMaxProfitAmount:    sdk.NewInt(24848),
@@ -444,7 +449,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 			},
 			expectPass: true,
 		},
-		{name: "Two routes with same arb denom test - more profitable route second",
+		{
+			name: "Two routes with same arb denom test - more profitable route second",
 			params: paramm{
 				routes:                     []poolmanagertypes.SwapAmountInRoutes{routeMultiAssetSameWeight, routeTwoAssetSameWeight},
 				expectedMaxProfitAmount:    sdk.NewInt(24848),
@@ -454,7 +460,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 			},
 			expectPass: true,
 		},
-		{name: "Three routes with same arb denom test - most profitable route first",
+		{
+			name: "Three routes with same arb denom test - most profitable route first",
 			params: paramm{
 				routes:                     []poolmanagertypes.SwapAmountInRoutes{routeMostProfitable, routeMultiAssetSameWeight, routeTwoAssetSameWeight},
 				expectedMaxProfitAmount:    sdk.NewInt(67511675),
@@ -464,7 +471,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 			},
 			expectPass: true,
 		},
-		{name: "Two routes, different arb denoms test - more profitable route second",
+		{
+			name: "Two routes, different arb denoms test - more profitable route second",
 			params: paramm{
 				routes:                     []poolmanagertypes.SwapAmountInRoutes{routeNoArb, routeDiffDenom},
 				expectedMaxProfitAmount:    sdk.NewInt(4880),
@@ -474,7 +482,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 			},
 			expectPass: true,
 		},
-		{name: "Four-pool route test",
+		{
+			name: "Four-pool route test",
 			params: paramm{
 				routes:                     []poolmanagertypes.SwapAmountInRoutes{fourPoolRoute},
 				expectedMaxProfitAmount:    sdk.NewInt(13_202_729),
@@ -484,7 +493,8 @@ func (suite *KeeperTestSuite) TestIterateRoutes() {
 			},
 			expectPass: true,
 		},
-		{name: "Two-pool route test",
+		{
+			name: "Two-pool route test",
 			params: paramm{
 				routes:                     []poolmanagertypes.SwapAmountInRoutes{twoPoolRoute},
 				expectedMaxProfitAmount:    sdk.NewInt(198_653_535),
@@ -532,7 +542,8 @@ func (suite *KeeperTestSuite) TestConvertProfits() {
 		param      param
 		expectPass bool
 	}{
-		{name: "Convert atom to uosmo",
+		{
+			name: "Convert atom to uosmo",
 			param: param{
 				inputCoin:           sdk.NewCoin("Atom", sdk.NewInt(100)),
 				profit:              sdk.NewInt(10),
@@ -540,7 +551,8 @@ func (suite *KeeperTestSuite) TestConvertProfits() {
 			},
 			expectPass: true,
 		},
-		{name: "Convert juno to uosmo (random denom)",
+		{
+			name: "Convert juno to uosmo (random denom)",
 			param: param{
 				inputCoin:           sdk.NewCoin("juno", sdk.NewInt(100)),
 				profit:              sdk.NewInt(10),
@@ -548,7 +560,8 @@ func (suite *KeeperTestSuite) TestConvertProfits() {
 			},
 			expectPass: true,
 		},
-		{name: "Convert denom without pool to uosmo",
+		{
+			name: "Convert denom without pool to uosmo",
 			param: param{
 				inputCoin:           sdk.NewCoin("random", sdk.NewInt(100)),
 				profit:              sdk.NewInt(10),

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -361,7 +361,6 @@ func (suite *KeeperTestSuite) TestCalculateRoutePoolPoints() {
 			} else {
 				suite.Require().Error(err)
 			}
-
 		})
 	}
 }

--- a/x/protorev/types/constants.go
+++ b/x/protorev/types/constants.go
@@ -30,12 +30,16 @@ const MaxPoolPointsPerBlock uint64 = 200
 // ---------------- Module Profit Splitting Constants ---------------- //
 
 // Year 1 (20% of total profit)
-const Phase1Length uint64 = 365
-const ProfitSplitPhase1 int64 = 20
+const (
+	Phase1Length      uint64 = 365
+	ProfitSplitPhase1 int64  = 20
+)
 
 // Year 2 (10% of total profit)
-const Phase2Length uint64 = 730
-const ProfitSplitPhase2 int64 = 10
+const (
+	Phase2Length      uint64 = 730
+	ProfitSplitPhase2 int64  = 10
+)
 
 // All other years (5% of total profit)
 const ProfitSplitPhase3 int64 = 5

--- a/x/superfluid/keeper/gov/gov_test.go
+++ b/x/superfluid/keeper/gov/gov_test.go
@@ -160,9 +160,7 @@ func (suite *KeeperTestSuite) TestHandleUnpoolWhiteListChange() {
 		testDescription = "test description"
 	)
 
-	var (
-		basePoolIds = []uint64{1, 2, 3}
-	)
+	basePoolIds := []uint64{1, 2, 3}
 
 	tests := map[string]struct {
 		preCreatedPoolCount int

--- a/x/superfluid/keeper/grpc_query_test.go
+++ b/x/superfluid/keeper/grpc_query_test.go
@@ -65,6 +65,7 @@ func (suite *KeeperTestSuite) TestTotalDelegationByValidatorForAsset() {
 		}
 	}
 }
+
 func (suite *KeeperTestSuite) TestGRPCSuperfluidAsset() {
 	suite.SetupTest()
 

--- a/x/superfluid/types/msgs.go
+++ b/x/superfluid/types/msgs.go
@@ -276,6 +276,7 @@ func (msg MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition) Route() stri
 func (msg MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition) Type() string {
 	return TypeMsgUnlockAndMigrateShares
 }
+
 func (msg MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {

--- a/x/twap/client/cli/query.go
+++ b/x/twap/client/cli/query.go
@@ -61,7 +61,6 @@ Example:
 				StartTime:  startTime,
 				EndTime:    &endTime,
 			})
-
 			if err != nil {
 				return err
 			}
@@ -113,7 +112,6 @@ Example:
 				StartTime:  startTime,
 				EndTime:    &endTime,
 			})
-
 			if err != nil {
 				return err
 			}

--- a/x/twap/client/grpc/grpc_query.go
+++ b/x/twap/client/grpc/grpc_query.go
@@ -1,4 +1,4 @@
-package grpc 
+package grpc
 
 // THIS FILE IS GENERATED CODE, DO NOT EDIT
 // SOURCE AT `proto/osmosis/twap/v1beta1/query.yml`
@@ -69,4 +69,3 @@ func (q Querier) ArithmeticTwap(grpcCtx context.Context,
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.ArithmeticTwap(ctx, *req)
 }
-

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -571,15 +571,15 @@ func (s *TestSuite) TestPruneRecords() {
 
 	pool1OlderMin2MsRecord, // deleted
 		pool2OlderMin1MsRecordAB, pool2OlderMin1MsRecordAC, pool2OlderMin1MsRecordBC, // deleted
-		pool3OlderBaseRecord,    // kept as newest under keep period
+		pool3OlderBaseRecord, // kept as newest under keep period
 		pool4OlderPlus1Record := // kept as newest under keep period
-		s.createTestRecordsFromTime(baseTime.Add(2 * -recordHistoryKeepPeriod))
+	s.createTestRecordsFromTime(baseTime.Add(2 * -recordHistoryKeepPeriod))
 
 	pool1Min2MsRecord, // kept as newest under keep period
 		pool2Min1MsRecordAB, pool2Min1MsRecordAC, pool2Min1MsRecordBC, // kept as newest under keep period
-		pool3BaseRecord,    // kept as it is at the keep period boundary
+		pool3BaseRecord, // kept as it is at the keep period boundary
 		pool4Plus1Record := // kept as it is above the keep period boundary
-		s.createTestRecordsFromTime(baseTime.Add(-recordHistoryKeepPeriod))
+	s.createTestRecordsFromTime(baseTime.Add(-recordHistoryKeepPeriod))
 
 	// non-ascending insertion order.
 	recordsToPreSet := []types.TwapRecord{

--- a/x/twap/strategy_test.go
+++ b/x/twap/strategy_test.go
@@ -298,7 +298,6 @@ func (s *TestSuite) TestComputeGeometricStrategyTwap() {
 		tc := tc
 		s.Run(name, func() {
 			osmoassert.ConditionalPanic(s.T(), tc.expPanic, func() {
-
 				geometricStrategy := &twap.GeometricTwapStrategy{TwapKeeper: *s.App.TwapKeeper}
 				actualTwap := geometricStrategy.ComputeTwap(tc.startRecord, tc.endRecord, tc.quoteAsset)
 

--- a/x/valset-pref/client/grpc/grpc_query.go
+++ b/x/valset-pref/client/grpc/grpc_query.go
@@ -1,4 +1,4 @@
-package grpc 
+package grpc
 
 // THIS FILE IS GENERATED CODE, DO NOT EDIT
 // SOURCE AT `proto/osmosis/valset-pref/v1beta1/query.yml`
@@ -29,4 +29,3 @@ func (q Querier) UserValidatorPreferences(grpcCtx context.Context,
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.UserValidatorPreferences(ctx, *req)
 }
-

--- a/x/valset-pref/msg_server_test.go
+++ b/x/valset-pref/msg_server_test.go
@@ -220,7 +220,7 @@ func (suite *KeeperTestSuite) TestDelegateToValidatorSet() {
 		{
 			name:             "Delegate very small amount to existing valSet",
 			delegator:        sdk.AccAddress([]byte("addr4---------------")),
-			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(010_013)), // small case
+			amountToDelegate: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(0o10_013)), // small case
 			expectedShares:   []sdk.Dec{sdk.NewDec(821), sdk.NewDec(1355), sdk.NewDec(492), sdk.NewDec(1439)},
 			setValSet:        true,
 			expectPass:       true,

--- a/x/valset-pref/types/msgs_test.go
+++ b/x/valset-pref/types/msgs_test.go
@@ -153,5 +153,4 @@ func TestMsgSetValidatorSetPreference(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/x/valset-pref/validator_set_test.go
+++ b/x/valset-pref/validator_set_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func (suite *KeeperTestSuite) TestValidateLockForForceUnlock() {
-
 	locks := suite.SetupLocks(sdk.AccAddress([]byte("addr1---------------")))
 
 	tests := []struct {
@@ -211,7 +210,6 @@ func (suite *KeeperTestSuite) TestIsValidatorSetEqual() {
 			suite.Require().Equal(test.expectEqual, isEqual)
 		})
 	}
-
 }
 
 func (suite *KeeperTestSuite) TestIsPreferenceValid() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4456, #4514

## What is the purpose of the change

This PR implements early position exits for frozen positions. It allows users to exit even before their `freezeDuration` is over if they are willing to forfeit the incentives they have accrued.

## Brief Changelog

- Abstract common logic between fee and incentive claiming as described in #4514
- Implement new helper, `claimAllIncentivesForPosition`, that claims and returns all the accrued incentives for a given position. This helper takes in a `forfeitIncentives` parameter which, when true, redeposits the claimed incentives into the appropriate accumulators right after claiming. If it is false, the rewards are claimed but no balance transfers are processed (this is to keep the helper useful in standard claiming logic while avoiding duplicate code)

## Testing and Verifying

- All new functionality is tested in `incentives_test.go` and `lp_test.go`
- Note that since much of the logic for the helpers are already thoroughly tested by `collectIncentives` and `collectFees`, the cases included are mainly sanity checks and cases for new functionality e.g. forfeiting rewards.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not documented)