### PR TITLE
Remove build from docker compose state export

### DIFF
--- a/tests/localosmosis/state_export/docker-compose.yml
+++ b/tests/localosmosis/state_export/docker-compose.yml
@@ -4,12 +4,6 @@ services:
 
   osmosisd:
     image: local:osmosis
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
-      args:
-        RUNNER_IMAGE: alpine:3.16
-        GO_VERSION: 1.19
     volumes:
       - ./scripts/start.sh:/osmosis/start.sh
       - ./scripts/testnetify.py:/osmosis/testnetify.py


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change
Removes build from the docker-compose file being used for state export.
The reason build is to be removed is since we already specified image to be ran in. 
Having secondary command for build would result in docker container pulling the image and then build and overwrite the container into the binary state it is in, not from the image that has been pulled


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)