### PR TITLE
Skip consensus min fee checks during simulate

### DIFF
--- a/tests/e2e/scripts/hermes_bootstrap.sh
+++ b/tests/e2e/scripts/hermes_bootstrap.sh
@@ -43,7 +43,7 @@ account_prefix = 'osmo'
 key_name = 'val01-osmosis-a'
 store_prefix = 'ibc'
 max_gas = 6000000
-gas_multiplier = 1.1
+gas_multiplier = 1.5
 default_gas = 400000
 gas_price = { price = 0.0025, denom = 'e2e-default-feetoken' }
 clock_drift = '1m' # to accomdate docker containers
@@ -59,7 +59,7 @@ account_prefix = 'osmo'
 key_name = 'val01-osmosis-b'
 store_prefix = 'ibc'
 max_gas = 6000000
-gas_multiplier = 1.1
+gas_multiplier = 1.5
 default_gas = 400000
 gas_price = { price = 0.0025, denom = 'e2e-default-feetoken' }
 clock_drift = '1m' # to accomdate docker containers

--- a/tests/e2e/scripts/hermes_bootstrap.sh
+++ b/tests/e2e/scripts/hermes_bootstrap.sh
@@ -43,7 +43,7 @@ account_prefix = 'osmo'
 key_name = 'val01-osmosis-a'
 store_prefix = 'ibc'
 max_gas = 6000000
-gas_multiplier = 1.5
+gas_multiplier = 1.2
 default_gas = 400000
 gas_price = { price = 0.0025, denom = 'e2e-default-feetoken' }
 clock_drift = '1m' # to accomdate docker containers
@@ -59,7 +59,7 @@ account_prefix = 'osmo'
 key_name = 'val01-osmosis-b'
 store_prefix = 'ibc'
 max_gas = 6000000
-gas_multiplier = 1.5
+gas_multiplier = 1.2
 default_gas = 400000
 gas_price = { price = 0.0025, denom = 'e2e-default-feetoken' }
 clock_drift = '1m' # to accomdate docker containers

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -102,8 +102,8 @@ func (mfd MempoolFeeDecorator) getMinBaseGasPrice(ctx sdk.Context, baseDenom str
 	if (ctx.IsCheckTx() || ctx.IsReCheckTx()) && !simulate {
 		minBaseGasPrice = sdk.MaxDec(minBaseGasPrice, mfd.GetMinBaseGasPriceForTx(ctx, baseDenom, feeTx))
 	}
-	// If we are in genesis, then we actually override all of the above, to set it to 0.
-	if ctx.IsGenesis() {
+	// If we are in genesis or are simulating a tx, then we actually override all of the above, to set it to 0.
+	if ctx.IsGenesis() || simulate {
 		minBaseGasPrice = sdk.ZeroDec()
 	}
 	return minBaseGasPrice

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -35,6 +35,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 		minGasPrices sdk.DecCoins // if blank, set to 0
 		gasRequested uint64       // if blank, set to base gas
 		isCheckTx    bool
+		isSimulate   bool // if blank, is false
 		expectPass   bool
 	}
 
@@ -136,6 +137,15 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			isCheckTx:    true,
 			expectPass:   true,
 		},
+		{
+			name:         "simulate 0 fee passes",
+			txFee:        sdk.Coins{},
+			minGasPrices: sdk.NewDecCoins(sdk.NewInt64DecCoin(uion, 1)),
+			gasRequested: mempoolFeeOpts.HighGasTxThreshold,
+			isCheckTx:    true,
+			isSimulate:   true,
+			expectPass:   true,
+		},
 	}
 	tests = append(tests, custTests...)
 
@@ -189,7 +199,7 @@ func (suite *KeeperTestSuite) TestFeeDecorator() {
 			mfd := keeper.NewMempoolFeeDecorator(*suite.App.TxFeesKeeper, mempoolFeeOpts)
 			dfd := keeper.NewDeductFeeDecorator(*suite.App.TxFeesKeeper, *suite.App.AccountKeeper, *suite.App.BankKeeper, nil)
 			antehandlerMFD := sdk.ChainAnteDecorators(mfd, dfd)
-			_, err := antehandlerMFD(suite.Ctx, tx, false)
+			_, err := antehandlerMFD(suite.Ctx, tx, tc.isSimulate)
 
 			if tc.expectPass {
 				// ensure fee was collected


### PR DESCRIPTION
A problem cited by people on the testnet, was that the consensus min fee violated their expectations around simulate txs.

Namely that they should be able to simulate execution with 0 fees, in order to determine the required amount of fees.

## Brief Changelog

- Skip consensus min fee check during tx simulation

## Testing and Verifying

Added a simulate test vector.

Raising an SDK issue for simulation tx guarantees

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? N/A