### PR TITLE
fix: docs ibc-hooks to ibchooks

### DIFF
--- a/x/ibc-hooks/client/cli/query.go
+++ b/x/ibc-hooks/client/cli/query.go
@@ -50,7 +50,7 @@ func GetCmdWasmSender() *cobra.Command {
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Generate the local address for a wasm hooks sender.
 Example:
-$ %s query ibc-hooks wasm-hooks-sender channel-42 juno12smx2wdlyttvyzvzg54y2vnqwq2qjatezqwqxu
+$ %s query ibchooks wasm-hooks-sender channel-42 juno12smx2wdlyttvyzvzg54y2vnqwq2qjatezqwqxu
 `,
 				version.AppName,
 			),


### PR DESCRIPTION
Testing the ibchooks module seems like the example command shouldn't have a "-" between ibc and hooks
![image](https://user-images.githubusercontent.com/49301655/224287626-7f2ec24a-1ab4-4b1b-9ce5-9cbe51ca2dd4.png)
