### PR TITLE
ProtoRev: Adding Txs to CLI

### DIFF
--- a/x/protorev/client/cli/query.go
+++ b/x/protorev/client/cli/query.go
@@ -28,6 +28,7 @@ func NewCmdQuery() *cobra.Command {
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, NewQueryMaxPoolPointsPerBlockCmd)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, NewQueryBaseDenomsCmd)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, NewQueryEnabledCmd)
+	osmocli.AddQueryCmd(cmd, types.NewQueryClient, NewQueryPoolWeightsCmd)
 
 	return cmd
 }
@@ -86,7 +87,7 @@ func NewQueryAllRouteStatisticsCmd() (*osmocli.QueryDescriptor, *types.QueryGetP
 // NewQueryTokenPairArbRoutesCmd returns the command to query the token pair arb routes
 func NewQueryTokenPairArbRoutesCmd() (*osmocli.QueryDescriptor, *types.QueryGetProtoRevTokenPairArbRoutesRequest) {
 	return &osmocli.QueryDescriptor{
-		Use:   "token-pair-arb-routes",
+		Use:   "hot-routes",
 		Short: "Query the ProtoRev hot routes currently being used",
 	}, &types.QueryGetProtoRevTokenPairArbRoutesRequest{}
 }
@@ -137,6 +138,14 @@ func NewQueryEnabledCmd() (*osmocli.QueryDescriptor, *types.QueryGetProtoRevEnab
 		Use:   "enabled",
 		Short: "Query whether protorev is currently enabled",
 	}, &types.QueryGetProtoRevEnabledRequest{}
+}
+
+// NewQueryPoolWeightsCmd returns the command to query the pool weights of protorev
+func NewQueryPoolWeightsCmd() (*osmocli.QueryDescriptor, *types.QueryGetProtoRevPoolWeightsRequest) {
+	return &osmocli.QueryDescriptor{
+		Use:   "pool-weights",
+		Short: "Query the pool weights used to determine how computationally expensive a route is",
+	}, &types.QueryGetProtoRevPoolWeightsRequest{}
 }
 
 // convert a string array "[1,2,3]" to []uint64

--- a/x/protorev/client/cli/tx.go
+++ b/x/protorev/client/cli/tx.go
@@ -37,7 +37,7 @@ func NewCmdTx() *cobra.Command {
 	return txCmd
 }
 
-// CmdSetDeveloperHotRoutes() implements the command to set the protorev hot routes
+// CmdSetDeveloperHotRoutes implements the command to set the protorev hot routes
 func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
 	desc := osmocli.TxCliDesc{
 		Use:   "set-hot-routes [path/to/routes.json]",
@@ -73,7 +73,7 @@ func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
 			}
 		]
 		`,
-		Example:          fmt.Sprintf(`$ %s tx protorev set-protorev-hot-routes routes.json --from mykey`, version.AppName),
+		Example:          fmt.Sprintf(`$ %s tx protorev set-hot-routes routes.json --from mykey`, version.AppName),
 		NumArgs:          1,
 		ParseAndBuildMsg: BuildSetHotRoutesMsg,
 	}
@@ -81,7 +81,7 @@ func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
 	return &desc
 }
 
-// CmdSetDeveloperAccount() implements the command to set the protorev developer account
+// CmdSetDeveloperAccount implements the command to set the protorev developer account
 func CmdSetDeveloperAccount() (*osmocli.TxCliDesc, *types.MsgSetDeveloperAccount) {
 	return &osmocli.TxCliDesc{
 		Use:     "set-developer-account [sdk.AccAddress]",
@@ -145,7 +145,7 @@ func CmdSetMaxPoolPointsPerBlock() (*osmocli.TxCliDesc, *types.MsgSetMaxPoolPoin
 func CmdSetPoolWeights() *osmocli.TxCliDesc {
 	desc := osmocli.TxCliDesc{
 		Use:   "set-pool-weights [path/to/routes.json]",
-		Short: "set the protorev hot routes",
+		Short: "set the protorev pool weights",
 		Long: `Must provide a json file with all the pool weights that will be set. 
 		Sample json file:
 		{
@@ -154,7 +154,7 @@ func CmdSetPoolWeights() *osmocli.TxCliDesc {
 			"concentrated_weight" : 1
 		}
 		`,
-		Example:          fmt.Sprintf(`$ %s tx protorev set-pool-weights routes.json --from mykey`, version.AppName),
+		Example:          fmt.Sprintf(`$ %s tx protorev set-pool-weights weights.json --from mykey`, version.AppName),
 		NumArgs:          1,
 		ParseAndBuildMsg: BuildSetPoolWeightsMsg,
 	}
@@ -180,7 +180,7 @@ func CmdSetBaseDenoms() *osmocli.TxCliDesc {
 			}
 		]
 		`,
-		Example:          fmt.Sprintf(`$ %s tx protorev set-protorev-hot-routes routes.json --from mykey`, version.AppName),
+		Example:          fmt.Sprintf(`$ %s tx protorev set-base-denoms denoms.json --from mykey`, version.AppName),
 		NumArgs:          1,
 		ParseAndBuildMsg: BuildSetBaseDenomsMsg,
 	}

--- a/x/protorev/client/cli/tx.go
+++ b/x/protorev/client/cli/tx.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
+
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -22,11 +23,89 @@ import (
 // NewCmdTx returns the cli transaction commands for this module
 func NewCmdTx() *cobra.Command {
 	txCmd := osmocli.TxIndexCmd(types.ModuleName)
+	osmocli.AddTxCmd(txCmd, CmdSetDeveloperAccount)
+	osmocli.AddTxCmd(txCmd, CmdSetMaxPoolPointsPerTx)
+	osmocli.AddTxCmd(txCmd, CmdSetMaxPoolPointsPerBlock)
+	osmocli.AddTxCmd(txCmd, CmdSetPoolWeights)
+	osmocli.AddTxCmd(txCmd, CmdSetBaseDenoms)
 	txCmd.AddCommand(
+		CmdSetDeveloperHotRoutes().BuildCommandCustomFn(),
 		CmdSetProtoRevAdminAccountProposal(),
 		CmdSetProtoRevEnabledProposal(),
 	)
 	return txCmd
+}
+
+// CmdSetDeveloperHotRoutes() implements the command to set the protorev hot routes
+func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
+	desc := osmocli.TxCliDesc{
+		Use:   "set-protorev-hot-routes [path/to/routes.json]",
+		Short: "set the protorev hot routes",
+		Long: `Must provide a json file with all of the routes that will be set. 
+		Sample json file:
+		[
+			{
+				"token_in": "uosmo",
+				"token_out": "ibc/123...",
+				"arb_routes" : [
+					{
+						"trades": [
+							{
+								"pool": 1,
+								"token_in": "uosmo",
+								"token_out": "uatom",
+							},
+							{
+								"pool": 2,
+								"token_in": "uatom",
+								"token_out": "ibc/123...",
+							},
+							{
+								"pool": 3,
+								"token_in": "ibc/123...",
+								"token_out": "uosmo",
+							},
+						],
+						"step_size": 1000000,
+					}
+				]
+			}
+		]
+		`,
+		Example:          fmt.Sprintf(`$ %s tx protorev set-protorev-hot-routes routes.json --from mykey`, version.AppName),
+		NumArgs:          1,
+		ParseAndBuildMsg: BuildSetHotRoutesMsg,
+	}
+
+	return &desc
+}
+
+// CmdSetDeveloperAccount() implements the command to set the protorev developer account
+func CmdSetDeveloperAccount() (*osmocli.TxCliDesc, *types.MsgSetDeveloperAccount) {
+	return &osmocli.TxCliDesc{
+		Use:  "set-protorev-developer-account [sdk.AccAddress]",
+		Args: cobra.ExactArgs(1),
+	}
+}
+
+// CmdSetMaxPoolPointsPerTx implements the command to set the max pool points per tx
+func CmdSetMaxPoolPointsPerTx() (*osmocli.TxCliDesc, *types.MsgSetMaxPoolPointsPerTx) {
+	return nil, nil
+}
+
+// CmdSetMaxPoolPointsPerBlock implements the command to set the max pool points per block
+func CmdSetMaxPoolPointsPerBlock() (*osmocli.TxCliDesc, *types.MsgSetMaxPoolPointsPerBlock) {
+	return nil, nil
+}
+
+// CmdSetPoolWeights implements the command to set the pool weights used to estimate execution costs
+func CmdSetPoolWeights() (*osmocli.TxCliDesc, *types.MsgSetPoolWeights) {
+	return nil, nil
+}
+
+// CmdSetBaseDenoms implements the command to set the base denoms used in the highest liquidity method
+func CmdSetBaseDenoms() (*osmocli.TxCliDesc, *types.MsgSetBaseDenoms) {
+	return nil, nil
 }
 
 // CmdSetProtoRevAdminAccountProposal implements the command to submit a SetProtoRevAdminAccountProposal

--- a/x/protorev/client/cli/tx.go
+++ b/x/protorev/client/cli/tx.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
@@ -26,10 +27,10 @@ func NewCmdTx() *cobra.Command {
 	osmocli.AddTxCmd(txCmd, CmdSetDeveloperAccount)
 	osmocli.AddTxCmd(txCmd, CmdSetMaxPoolPointsPerTx)
 	osmocli.AddTxCmd(txCmd, CmdSetMaxPoolPointsPerBlock)
-	osmocli.AddTxCmd(txCmd, CmdSetPoolWeights)
-	osmocli.AddTxCmd(txCmd, CmdSetBaseDenoms)
 	txCmd.AddCommand(
 		CmdSetDeveloperHotRoutes().BuildCommandCustomFn(),
+		CmdSetPoolWeights().BuildCommandCustomFn(),
+		CmdSetBaseDenoms().BuildCommandCustomFn(),
 		CmdSetProtoRevAdminAccountProposal(),
 		CmdSetProtoRevEnabledProposal(),
 	)
@@ -39,9 +40,9 @@ func NewCmdTx() *cobra.Command {
 // CmdSetDeveloperHotRoutes() implements the command to set the protorev hot routes
 func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
 	desc := osmocli.TxCliDesc{
-		Use:   "set-protorev-hot-routes [path/to/routes.json]",
+		Use:   "set-hot-routes [path/to/routes.json]",
 		Short: "set the protorev hot routes",
-		Long: `Must provide a json file with all of the routes that will be set. 
+		Long: `Must provide a json file with all of the hot routes that will be set. 
 		Sample json file:
 		[
 			{
@@ -53,20 +54,20 @@ func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
 							{
 								"pool": 1,
 								"token_in": "uosmo",
-								"token_out": "uatom",
+								"token_out": "uatom"
 							},
 							{
 								"pool": 2,
 								"token_in": "uatom",
-								"token_out": "ibc/123...",
+								"token_out": "ibc/123..."
 							},
 							{
-								"pool": 3,
+								"pool": 0,
 								"token_in": "ibc/123...",
-								"token_out": "uosmo",
-							},
+								"token_out": "uosmo"
+							}
 						],
-						"step_size": 1000000,
+						"step_size": 1000000
 					}
 				]
 			}
@@ -83,35 +84,114 @@ func CmdSetDeveloperHotRoutes() *osmocli.TxCliDesc {
 // CmdSetDeveloperAccount() implements the command to set the protorev developer account
 func CmdSetDeveloperAccount() (*osmocli.TxCliDesc, *types.MsgSetDeveloperAccount) {
 	return &osmocli.TxCliDesc{
-		Use:  "set-protorev-developer-account [sdk.AccAddress]",
-		Args: cobra.ExactArgs(1),
-	}
+		Use:     "set-developer-account [sdk.AccAddress]",
+		Short:   "set the protorev developer account",
+		NumArgs: 1,
+		ParseAndBuildMsg: func(clientCtx client.Context, args []string, flags *pflag.FlagSet) (sdk.Msg, error) {
+			developer, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return nil, err
+			}
+
+			return &types.MsgSetDeveloperAccount{
+				DeveloperAccount: developer.String(),
+				Admin:            clientCtx.GetFromAddress().String(),
+			}, nil
+		},
+	}, &types.MsgSetDeveloperAccount{}
 }
 
 // CmdSetMaxPoolPointsPerTx implements the command to set the max pool points per tx
 func CmdSetMaxPoolPointsPerTx() (*osmocli.TxCliDesc, *types.MsgSetMaxPoolPointsPerTx) {
-	return nil, nil
+	return &osmocli.TxCliDesc{
+		Use:     "set-max-pool-points-per-tx [uint64]",
+		Short:   "set the max pool points that can be consumed per tx",
+		NumArgs: 1,
+		ParseAndBuildMsg: func(clientCtx client.Context, args []string, flags *pflag.FlagSet) (sdk.Msg, error) {
+			maxPoolPointsPerTx, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+
+			return &types.MsgSetMaxPoolPointsPerTx{
+				MaxPoolPointsPerTx: maxPoolPointsPerTx,
+				Admin:              clientCtx.GetFromAddress().String(),
+			}, nil
+		},
+	}, &types.MsgSetMaxPoolPointsPerTx{}
 }
 
 // CmdSetMaxPoolPointsPerBlock implements the command to set the max pool points per block
 func CmdSetMaxPoolPointsPerBlock() (*osmocli.TxCliDesc, *types.MsgSetMaxPoolPointsPerBlock) {
-	return nil, nil
+	return &osmocli.TxCliDesc{
+		Use:     "set-max-pool-points-per-block [uint64]",
+		Short:   "set the max pool points that can be consumed per block",
+		NumArgs: 1,
+		ParseAndBuildMsg: func(clientCtx client.Context, args []string, flags *pflag.FlagSet) (sdk.Msg, error) {
+			maxPoolPointsPerBlock, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+
+			return &types.MsgSetMaxPoolPointsPerBlock{
+				MaxPoolPointsPerBlock: maxPoolPointsPerBlock,
+				Admin:                 clientCtx.GetFromAddress().String(),
+			}, nil
+		},
+	}, &types.MsgSetMaxPoolPointsPerBlock{}
 }
 
 // CmdSetPoolWeights implements the command to set the pool weights used to estimate execution costs
-func CmdSetPoolWeights() (*osmocli.TxCliDesc, *types.MsgSetPoolWeights) {
-	return nil, nil
+func CmdSetPoolWeights() *osmocli.TxCliDesc {
+	desc := osmocli.TxCliDesc{
+		Use:   "set-pool-weights [path/to/routes.json]",
+		Short: "set the protorev hot routes",
+		Long: `Must provide a json file with all the pool weights that will be set. 
+		Sample json file:
+		{
+			"stable_weight" : 1,
+			"balancer_weight" : 1,
+			"concentrated_weight" : 1
+		}
+		`,
+		Example:          fmt.Sprintf(`$ %s tx protorev set-pool-weights routes.json --from mykey`, version.AppName),
+		NumArgs:          1,
+		ParseAndBuildMsg: BuildSetPoolWeightsMsg,
+	}
+
+	return &desc
 }
 
 // CmdSetBaseDenoms implements the command to set the base denoms used in the highest liquidity method
-func CmdSetBaseDenoms() (*osmocli.TxCliDesc, *types.MsgSetBaseDenoms) {
-	return nil, nil
+func CmdSetBaseDenoms() *osmocli.TxCliDesc {
+	desc := osmocli.TxCliDesc{
+		Use:   "set-base-denoms [path/to/denoms.json]",
+		Short: "set the protorev base denoms",
+		Long: `Must provide a json file with all the base denoms that will be set. 
+		Sample json file:
+		[
+			{
+				"step_size" : 10000,
+				"denom" : "uosmo"
+			},
+			{
+				"step_size" : 10000,
+				"denom" : "atom"
+			}
+		]
+		`,
+		Example:          fmt.Sprintf(`$ %s tx protorev set-protorev-hot-routes routes.json --from mykey`, version.AppName),
+		NumArgs:          1,
+		ParseAndBuildMsg: BuildSetBaseDenomsMsg,
+	}
+
+	return &desc
 }
 
 // CmdSetProtoRevAdminAccountProposal implements the command to submit a SetProtoRevAdminAccountProposal
 func CmdSetProtoRevAdminAccountProposal() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "set-protorev-admin-account-proposal [sdk.AccAddress]",
+		Use:     "set-admin-account-proposal [sdk.AccAddress]",
 		Args:    cobra.ExactArgs(1),
 		Short:   "submit a set protorev admin account proposal to set the admin account for x/protorev",
 		Example: fmt.Sprintf(`$ %s tx protorev set-protorev-admin-account osmo123... --from mykey`, version.AppName),
@@ -137,7 +217,7 @@ func CmdSetProtoRevAdminAccountProposal() *cobra.Command {
 // CmdSetProtoRevEnabledProposal implements the command to submit a SetProtoRevEnabledProposal
 func CmdSetProtoRevEnabledProposal() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "set-protorev-enabled-proposal [boolean]",
+		Use:     "set-enabled-proposal [boolean]",
 		Args:    cobra.ExactArgs(1),
 		Short:   "submit a set protorev enabled proposal to enable or disable the protocol",
 		Example: fmt.Sprintf(`$ %s tx protorev set-protorev-enabled true --from mykey`, version.AppName),

--- a/x/protorev/client/cli/utils.go
+++ b/x/protorev/client/cli/utils.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	flag "github.com/spf13/pflag"
+
+	"github.com/osmosis-labs/osmosis/v15/x/protorev/types"
+)
+
+type Trade struct {
+	Pool     uint64 `json:"pool"`
+	TokenIn  string `json:"token_in"`
+	TokenOut string `json:"token_out"`
+}
+
+type ArbRoutes struct {
+	Trades   []Trade `json:"trades"`
+	StepSize sdk.Int `json:"step_size"`
+}
+
+type hotRoutesInput struct {
+	TokenIn   string      `json:"token_in"`
+	TokenOut  string      `json:"token_out"`
+	ArbRoutes []ArbRoutes `json:"arb_routes"`
+}
+
+type createHotRoutesInput struct {
+	HotRoutes []hotRoutesInput
+}
+
+type XCreateHotRoutesInputs createHotRoutesInput
+
+type XCreateHotRoutesExceptions struct {
+	XCreateHotRoutesInputs
+	Other *string // Other won't raise an error
+}
+
+// UnmarshalJSON should error if there are fields unexpected.
+func (release *createHotRoutesInput) UnmarshalJSON(data []byte) error {
+	var createHotRoutesE XCreateHotRoutesExceptions
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields() // Force
+
+	if err := dec.Decode(&createHotRoutesE); err != nil {
+		return err
+	}
+
+	*release = createHotRoutesInput(createHotRoutesE.XCreateHotRoutesInputs)
+	return nil
+}
+
+// CreateHotRoutesMsg builds a set hot routes message from the provided input object
+func (release *createHotRoutesInput) extractTokenPairArbRoutes() []types.TokenPairArbRoutes {
+	tokenPairArbRoutes := make([]types.TokenPairArbRoutes, 0)
+
+	// Iterate through each hot route and construct the token pair arb routes
+	for _, hotRoute := range release.HotRoutes {
+		current := types.TokenPairArbRoutes{}
+		current.TokenIn = hotRoute.TokenIn
+		current.TokenOut = hotRoute.TokenOut
+
+		for _, arbRoute := range hotRoute.ArbRoutes {
+			currentArbRoute := types.Route{}
+			currentArbRoute.StepSize = arbRoute.StepSize
+
+			for _, trade := range arbRoute.Trades {
+				currentTrade := types.Trade{}
+				currentTrade.Pool = trade.Pool
+				currentTrade.TokenIn = trade.TokenIn
+				currentTrade.TokenOut = trade.TokenOut
+				currentArbRoute.Trades = append(currentArbRoute.Trades, currentTrade)
+			}
+
+			current.ArbRoutes = append(current.ArbRoutes, currentArbRoute)
+		}
+
+		tokenPairArbRoutes = append(tokenPairArbRoutes, current)
+	}
+
+	return tokenPairArbRoutes
+}
+
+// BuildSetHotRoutesMsg builds a set hot routes message from the provided json file
+func BuildSetHotRoutesMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("must provide a json file")
+	}
+
+	// Read the json file
+	input := &createHotRoutesInput{}
+	path := args[0]
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the json file
+	err = input.UnmarshalJSON(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract and build the msg
+	tokenPairArbRoutes := input.extractTokenPairArbRoutes()
+	return types.NewMsgSetHotRoutes(clientCtx.GetFromAddress().String(), tokenPairArbRoutes), nil
+}

--- a/x/protorev/client/cli/utils.go
+++ b/x/protorev/client/cli/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/protorev/types"
 )
 
+// ------------ types/functions to handle a SetHotRoutes CLI TX ------------ //
 type Trade struct {
 	Pool     uint64 `json:"pool"`
 	TokenIn  string `json:"token_in"`
@@ -58,7 +59,7 @@ func (release *createArbRoutesInput) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// extractTokenPairArbRoutes builds a set hot routes message from the provided input object
+// extractTokenPairArbRoutes builds all of the TokenPairArbRoutes that were extracted from the json file
 func (release *createArbRoutesInput) extractTokenPairArbRoutes() []types.TokenPairArbRoutes {
 	if release == nil {
 		return nil
@@ -93,7 +94,7 @@ func (release *createArbRoutesInput) extractTokenPairArbRoutes() []types.TokenPa
 	return tokenPairArbRoutes
 }
 
-// BuildSetHotRoutesMsg builds a set hot routes message from the provided json file
+// BuildSetHotRoutesMsg builds a MsgSetHotRoutes from the provided json file
 func BuildSetHotRoutesMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("must provide a json file")
@@ -121,6 +122,7 @@ func BuildSetHotRoutesMsg(clientCtx client.Context, args []string, fs *flag.Flag
 	}, nil
 }
 
+// ------------ types/functions to handle a SetPoolWeights CLI TX ------------ //
 type createPoolWeightsInput types.PoolWeights
 
 type XCreatePoolWeightsInputs createPoolWeightsInput
@@ -144,7 +146,7 @@ func (release *createPoolWeightsInput) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// BuildSetPoolWeightsMsg builds a set pool weights message from the provided json file
+// BuildSetPoolWeightsMsg builds a MsgSetPoolWeights from the provided json file
 func BuildSetPoolWeightsMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("must provide a json file")
@@ -171,6 +173,7 @@ func BuildSetPoolWeightsMsg(clientCtx client.Context, args []string, fs *flag.Fl
 	}, nil
 }
 
+// ------------ types/functions to handle a SetBaseDenoms CLI TX ------------ //
 type baseDenomInput struct {
 	Denom    string `json:"denom"`
 	StepSize uint64 `json:"step_size"`
@@ -205,7 +208,7 @@ func (release *createBaseDenomsInput) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// BuildSetBaseDenomsMsg builds a set base denoms message from the provided json file
+// BuildSetBaseDenomsMsg builds a MsgSetBaseDenoms from the provided json file
 func BuildSetBaseDenomsMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("must provide a json file")

--- a/x/protorev/keeper/msg_server.go
+++ b/x/protorev/keeper/msg_server.go
@@ -71,6 +71,15 @@ func (m MsgServer) SetMaxPoolPointsPerTx(c context.Context, msg *types.MsgSetMax
 		return nil, err
 	}
 
+	maxPointsPerBlock, err := m.k.GetMaxPointsPerBlock(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if msg.MaxPoolPointsPerTx > maxPointsPerBlock {
+		return nil, fmt.Errorf("max pool points per tx cannot be greater than max pool points per block")
+	}
+
 	// Set the max pool points per tx
 	if err := m.k.SetMaxPointsPerTx(ctx, msg.MaxPoolPointsPerTx); err != nil {
 		return nil, err
@@ -86,6 +95,15 @@ func (m MsgServer) SetMaxPoolPointsPerBlock(c context.Context, msg *types.MsgSet
 	// Ensure the account has the admin role and can make the tx
 	if err := m.AdminCheck(ctx, msg.Admin); err != nil {
 		return nil, err
+	}
+
+	maxPointsPerTx, err := m.k.GetMaxPointsPerTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if msg.MaxPoolPointsPerBlock < maxPointsPerTx {
+		return nil, fmt.Errorf("max pool points per block cannot be less than max pool points per tx")
 	}
 
 	// Set the max pool points per block

--- a/x/protorev/keeper/msg_server_test.go
+++ b/x/protorev/keeper/msg_server_test.go
@@ -410,9 +410,16 @@ func (suite *KeeperTestSuite) TestMsgSetMaxPoolPointsPerBlock() {
 		{
 			"Valid message (correct admin)",
 			suite.adminAccount.String(),
-			1,
+			50,
 			true,
 			true,
+		},
+		{
+			"Invalid message (correct admin but less points than max pool points per tx)",
+			suite.adminAccount.String(),
+			17,
+			true,
+			false,
 		},
 		{
 			"Valid message (correct admin, valid max pool points per block)",

--- a/x/protorev/protorev.md
+++ b/x/protorev/protorev.md
@@ -627,20 +627,27 @@ osmosisd query protorev params
 | query protorev | all-profits | Queries all ProtoRev profits |
 | query protorev | statistics-by-route [route] where route is the list of pool ids i.e. [1,2,3] | Queries ProtoRev statistics by route |
 | query protorev | all-statistics | Queries all ProtoRev statistics |
-| query protorev | token-pair-arb-routes | Queries the ProtoRev token pair arb routes |
+| query protorev | hot-routes | Queries the ProtoRev token pair arb routes |
 | query protorev | admin-account | Queries the ProtoRev admin account |
 | query protorev | developer-account | Queries the ProtoRev developer account |
 | query protorev | max-pool-points-per-tx | Queries the ProtoRev max pool points per transaction |
 | query protorev | max-pool-points-per-block | Queries the ProtoRev max pool points per block |
 | query protorev | base-denoms | Queries the ProtoRev base denoms used to create cyclic arbitrage routes |
 | query protorev | enabled | Queries whether the ProtoRev module is currently enabled |
+| query protorev | pool-weights | Queries the pool weights used to determine how computationally expensive a route is |
 
 ### Proposals
 
 | Command | Subcommand | Description |
 | --- | --- | --- |
-| tx protorev | set-protorev-admin-account-proposal [sdk.AccAddress] | Submit a proposal to set the admin account for ProtoRev |
-| tx protorev | set-protorev-enabled-proposal [boolean] | Submit a proposal to disable/enable the ProtoRev module |
+| tx protorev | set-pool-weights [path/to/file.json] | Submit a tx to set the pool weights for ProtoRev |
+| tx protorev | set-hot-routes [path/to/file.json] | Submit a tx to set the hot routes for ProtoRev |
+| tx protorev | set-base-denoms [path/to/file.json] | Submit a tx to set the base denoms for ProtoRev |
+| tx protorev | set-max-pool-points-per-block [uint64] | Submit a tx to set the max pool points per block for ProtoRev |
+| tx protorev | set-max-pool-points-per-tx [uint64] | Submit a tx to set the max pool points per transaction for ProtoRev |
+| tx protorev | set-developer-account [sdk.AccAddress] | Submit a tx to set the developer account for ProtoRev |
+| tx protorev | set-admin-account-proposal [sdk.AccAddress] | Submit a proposal to set the admin account for ProtoRev |
+| tx protorev | set-enabled-proposal [boolean] | Submit a proposal to disable/enable the ProtoRev module |
 
 ## gRPC & REST
 


### PR DESCRIPTION
## What is the purpose of the change
In this PR, I add the remaining admin transactions to the CLI. Additionally, I add one modification to `MsgSetMaxPoolPointsPer(Tx/Block)` so that the max pool points per tx cannot be set to something higher than the max pool points per block and vice versa.


## Brief Changelog
  - *Added all protorev txs to the cli*
  - *Added an additional check to `SetMaxPoolPointsPerTx` and `SetMaxPoolPointsPerBlock`*
  - *Update the protorev spec*

## Testing and Verifying
This change is already covered by existing tests. Additionally, I tested all of the CLI commands locally with accounts that were designated as the admin account and those that were not, with various params (correct and incorrect), and more. The CLI commands function as expected.


## Documentation and Release Note
Updated the `x/protorev` spec to include all of the updates made in this PR.