### PR TITLE
Consistently generate build tags metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Misc Improvements
+
+  * [#4582](https://github.com/osmosis-labs/osmosis/pull/4582) Consistently generate build tags metadata, to return a comma-separated list without stray quotes. This affects the output from `version` CLI subcommand and server info API calls.
+
 ## v15.0.0
 
 This release containts the following new modules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
             -X github.com/cosmos/cosmos-sdk/version.AppName="osmosisd" \
             -X github.com/cosmos/cosmos-sdk/version.Version=${GIT_VERSION} \
             -X github.com/cosmos/cosmos-sdk/version.Commit=${GIT_COMMIT} \
-            -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,ledger,muslc' \
+            -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc \
             -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
         -trimpath \
         -o /osmosis/build/osmosisd \

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
 whitespace :=
-whitespace += $(whitespace)
+whitespace := $(whitespace) $(whitespace)
 comma := ,
 build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 


### PR DESCRIPTION
References: cosmos/gaia#2017

## What is the purpose of the change

Dockerfile receives a minor tweak for proper output.

BuildTags value is expected as a plain `netgo,ledger,muslc` string, however the current approach wraps quotes inside of quotes, and the resulting string is `'netgo,ledger,muslc'` which gets escaped a few more times (unnecessarily).

Additionally, Makefile receives a minor tweak for everyone who builds directly.

With Make 4.3+, the empty whitespace does not seem to work as originally intended. This causes build tags to be `netgo ledger,` on Ubuntu 22.04 and other systems that include the newer Make version. The build tags were intended as `netgo,ledger` which can be observed on Make 4.2 (shipped with Ubuntu 20.04).

This change swaps out the `+=` use in favor of an explicit `:=`. [_Reference_](https://www.gnu.org/software/make/manual/html_node/Appending.html)

## Brief Changelog

  - Consistently generate build tags metadata, to return a comma-separated list without stray quotes. This affects the output from `version` CLI subcommand and server info API calls.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

The difference in `build_tags` output can be observed:

```bash
# pre-built (v14.0.1)
$ osmosisd-14.0.1-linux-amd64 version --long 2>&1 | head -n5
name: osmosis
server_name: osmosisd
version: 14.0.1
commit: 0a4b5bed878af2ea2167749f937e7cdde21f9031
build_tags: '''netgo,ledger,muslc'''
```

```bash
# `docker build -t osmosis .` (PR branch)
$ docker run --rm -it osmosis version --long | head -n5
name: osmosis
server_name: osmosisd
version: ""
commit: ""
build_tags: netgo,ledger,muslc
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (**yes**) If someone is actually parsing these programmatically, then it's a user-facing behavior changes.
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (**yes**)
  - How is the feature or change documented? (**not applicable**) The behavior change is implementing the originally intended BuildTags behavior by Cosmoshub/Gaia and all derivatives. A changelog warning is in place, but further documentation is not beneficial here.