### PR TITLE
Fix Level DB set up, use random directory

### DIFF
--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 
 	abci "github.com/tendermint/tendermint/abci/types"

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -48,7 +49,7 @@ func Setup(isCheckTx bool) *OsmosisApp {
 // SetupTestingAppWithLevelDb initializes a new OsmosisApp intended for testing,
 // with LevelDB as a db.
 func SetupTestingAppWithLevelDb(isCheckTx bool) (app *OsmosisApp, cleanupFn func()) {
-	dir := "osmosis_testing"
+	dir, err := os.MkdirTemp(os.TempDir(), "osmosis_leveldb_testing")
 	db, err := sdk.NewLevelDB("osmosis_leveldb_testing", dir)
 	if err != nil {
 		panic(err)

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -49,6 +49,9 @@ func Setup(isCheckTx bool) *OsmosisApp {
 // with LevelDB as a db.
 func SetupTestingAppWithLevelDb(isCheckTx bool) (app *OsmosisApp, cleanupFn func()) {
 	dir, err := os.MkdirTemp(os.TempDir(), "osmosis_leveldb_testing")
+	if err != nil {
+		panic(err)
+	}
 	db, err := sdk.NewLevelDB("osmosis_leveldb_testing", dir)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4121 

## What is the purpose of the change

Refer from #4121 , all tests are using the same directory. 
After referring to approaches given in the issue, I think it's best to use random directories instead of adding arguments to the function


## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)