### PR TITLE
(CL Positions Client): Fix: Fix range for upper tick

### DIFF
--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -93,7 +93,7 @@ func main() {
 			// minTick <= lowerTick <= upperTick
 			lowerTick = rand.Int63n(maxTick-minTick+1) + minTick
 			// lowerTick <= upperTick <= maxTick
-			upperTick = maxTick - rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))+1)
+			upperTick = maxTick - rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))-1)
 
 			tokenDesired0 = sdk.NewCoin(denom0, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
 			tokenDesired1 = sdk.NewCoin(denom1, sdk.NewInt(rand.Int63n(maxAmountDeposited)))

--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -93,7 +93,7 @@ func main() {
 			// minTick <= lowerTick <= upperTick
 			lowerTick = rand.Int63n(maxTick-minTick+1) + minTick
 			// lowerTick <= upperTick <= maxTick
-			upperTick = maxTick - rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))-1)
+			upperTick = maxTick - rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick))))
 
 			tokenDesired0 = sdk.NewCoin(denom0, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
 			tokenDesired1 = sdk.NewCoin(denom1, sdk.NewInt(rand.Int63n(maxAmountDeposited)))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change
Current range for the upper tick used to create positions is received via the following way
`upperTick = maxTick - rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))+1)`

However, this causes a bug in the process of producing random swaps, as the range for the upper tick specified can go below or have the same value as the lower tick.

Suppose a situation where maxTick is at 10, and minTick is 2.
lower tick(`lowerTick = rand.Int63n(maxTick-minTick+1) + minTick`) gives us a random value between 0 ~ 10.

Meanwhile, using the previous equation for the upper tick, we would get a random value betweem 1 ~ 10. 
In the case of where min tick is 10, for the upper tick, we would be able to get a value of 10 for the upper tick.

Removing the  +1 solves this provlem




## Brief Changelog
Change upper tick range for go client used for CL.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)