### PR TITLE
fix(CL): address key format bug causing test flakiness

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -63,12 +63,12 @@ func SetAddressPrefixes() {
 		}
 
 		if len(bytes) > address.MaxAddrLen {
-			return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "address max length is %d, got %d", address.MaxAddrLen, len(bytes))
+			return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "address max length is %d, got %d, %x", address.MaxAddrLen, len(bytes), bytes)
 		}
 
 		// TODO: Do we want to allow addresses of lengths other than 20 and 32 bytes?
 		if len(bytes) != 20 && len(bytes) != 32 {
-			return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "address length must be 20 or 32 bytes, got %d", len(bytes))
+			return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "address length must be 20 or 32 bytes, got %d, %x", len(bytes), bytes)
 		}
 
 		return nil

--- a/x/concentrated-liquidity/store.go
+++ b/x/concentrated-liquidity/store.go
@@ -81,10 +81,6 @@ func ParseFullPositionFromBytes(key, value []byte) (model.Position, error) {
 	if err != nil {
 		return model.Position{}, err
 	}
-	// if err := sdk.VerifyAddressFormat([]byte(relevantPositionKeyComponents[0])); err != nil {
-	// 	return model.Position{}, err
-	// }
-	// address := sdk.AccAddress(relevantPositionKeyComponents[0])
 
 	poolId, err := strconv.ParseUint(relevantPositionKeyComponents[1], 10, 64)
 	if err != nil {

--- a/x/concentrated-liquidity/store.go
+++ b/x/concentrated-liquidity/store.go
@@ -77,10 +77,14 @@ func ParseFullPositionFromBytes(key, value []byte) (model.Position, error) {
 		return model.Position{}, fmt.Errorf("Wrong position prefix, got: %v, required %v", []byte(positionPrefix), types.PositionPrefix)
 	}
 
-	if err := sdk.VerifyAddressFormat([]byte(relevantPositionKeyComponents[0])); err != nil {
+	address, err := sdk.AccAddressFromHex(relevantPositionKeyComponents[0])
+	if err != nil {
 		return model.Position{}, err
 	}
-	address := sdk.AccAddress(relevantPositionKeyComponents[0])
+	// if err := sdk.VerifyAddressFormat([]byte(relevantPositionKeyComponents[0])); err != nil {
+	// 	return model.Position{}, err
+	// }
+	// address := sdk.AccAddress(relevantPositionKeyComponents[0])
 
 	poolId, err := strconv.ParseUint(relevantPositionKeyComponents[1], 10, 64)
 	if err != nil {

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -69,20 +69,20 @@ func KeyTickPrefix(poolId uint64) []byte {
 // KeyFullPosition uses pool Id, owner, lower tick, upper tick, joinTime and freezeDuration for keys
 func KeyFullPosition(poolId uint64, addr sdk.AccAddress, lowerTick, upperTick int64, joinTime time.Time, freezeDuration time.Duration) []byte {
 	joinTimeKey := osmoutils.FormatTimeString(joinTime)
-	return []byte(fmt.Sprintf("%s%s%s%s%d%s%d%s%d%s%s%s%d", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator, poolId, KeySeparator, lowerTick, KeySeparator, upperTick, KeySeparator, joinTimeKey, KeySeparator, uint64(freezeDuration)))
+	return []byte(fmt.Sprintf("%s%s%x%s%d%s%d%s%d%s%s%s%d", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator, poolId, KeySeparator, lowerTick, KeySeparator, upperTick, KeySeparator, joinTimeKey, KeySeparator, uint64(freezeDuration)))
 }
 
 // KeyPosition uses pool Id, owner, lower tick and upper tick for keys
 func KeyPosition(poolId uint64, addr sdk.AccAddress, lowerTick, upperTick int64) []byte {
-	return []byte(fmt.Sprintf("%s%s%s%s%d%s%d%s%d", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator, poolId, KeySeparator, lowerTick, KeySeparator, upperTick))
+	return []byte(fmt.Sprintf("%s%s%x%s%d%s%d%s%d", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator, poolId, KeySeparator, lowerTick, KeySeparator, upperTick))
 }
 
 func KeyAddressAndPoolId(addr sdk.AccAddress, poolId uint64) []byte {
-	return []byte(fmt.Sprintf("%s%s%s%s%d", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator, poolId))
+	return []byte(fmt.Sprintf("%s%s%x%s%d", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator, poolId))
 }
 
 func KeyUserPositions(addr sdk.AccAddress) []byte {
-	return []byte(fmt.Sprintf("%s%s%s", PositionPrefix, KeySeparator, addr.Bytes()))
+	return []byte(fmt.Sprintf("%s%s%x", PositionPrefix, KeySeparator, addr.Bytes()))
 }
 
 func KeyPool(poolId uint64) []byte {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4608

## What is the purpose of the change

Address key was serialized to store with a string format. As a result, it was causing issues when getting deserialized.
This PR changes the format to %x which corresponds to lowercase bytes.

## Testing and Verifying

```go
go test -timeout 10s -run TestKeeperTestSuite/TestGetAllUserPositions github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity -count=100
ok      github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity    5.193s
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 