### PR TITLE
Add TWAP wiring to CL

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -311,12 +311,6 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.BankKeeper, appKeepers.DistrKeeper, appKeepers.ConcentratedLiquidityKeeper)
 	appKeepers.GAMMKeeper = &gammKeeper
 
-	appKeepers.TwapKeeper = twap.NewKeeper(
-		appKeepers.keys[twaptypes.StoreKey],
-		appKeepers.tkeys[twaptypes.TransientStoreKey],
-		appKeepers.GetSubspace(twaptypes.ModuleName),
-		appKeepers.GAMMKeeper)
-
 	appKeepers.PoolManagerKeeper = poolmanager.NewKeeper(
 		appKeepers.keys[poolmanagertypes.StoreKey],
 		appKeepers.GetSubspace(poolmanagertypes.ModuleName),
@@ -328,6 +322,12 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	)
 	appKeepers.GAMMKeeper.SetPoolManager(appKeepers.PoolManagerKeeper)
 	appKeepers.ConcentratedLiquidityKeeper.SetPoolManagerKeeper(appKeepers.PoolManagerKeeper)
+
+	appKeepers.TwapKeeper = twap.NewKeeper(
+		appKeepers.keys[twaptypes.StoreKey],
+		appKeepers.tkeys[twaptypes.TransientStoreKey],
+		appKeepers.GetSubspace(twaptypes.ModuleName),
+		appKeepers.PoolManagerKeeper)
 
 	appKeepers.LockupKeeper = lockupkeeper.NewKeeper(
 		appKeepers.keys[lockuptypes.StoreKey],

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -304,6 +304,9 @@ func (suite *KeeperTestSuite) TestInitializePool() {
 				senderBalBeforeNewPool := bankKeeper.GetAllBalances(suite.Ctx, sender)
 
 				// initializePool with a poolI
+				// initializePool shoould be called by pool manager in practice.
+				// We set pool route here to make sure hooks from InitializePool do not break
+				suite.App.PoolManagerKeeper.SetPoolRoute(suite.Ctx, defaultPoolId, poolmanagertypes.Balancer)
 				err := gammKeeper.InitializePool(suite.Ctx, test.createPool(), sender)
 
 				if test.expectPass {

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -84,7 +84,7 @@ func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.T
 	return recordWithUpdatedAccumulators(record, t)
 }
 
-func NewTwapRecord(k types.AmmInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
+func NewTwapRecord(k types.PoolManagerInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {
 	return newTwapRecord(k, ctx, poolId, denom0, denom1)
 }
 
@@ -104,7 +104,7 @@ func TwapPow(exponent sdk.Dec) sdk.Dec {
 
 func GetSpotPrices(
 	ctx sdk.Context,
-	k types.AmmInterface,
+	k types.PoolManagerInterface,
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
@@ -112,12 +112,12 @@ func GetSpotPrices(
 	return getSpotPrices(ctx, k, poolId, denom0, denom1, previousErrorTime)
 }
 
-func (k *Keeper) GetAmmInterface() types.AmmInterface {
-	return k.ammkeeper
+func (k *Keeper) GetAmmInterface() types.PoolManagerInterface {
+	return k.poolmanagerKeeper
 }
 
-func (k *Keeper) SetAmmInterface(ammInterface types.AmmInterface) {
-	k.ammkeeper = ammInterface
+func (k *Keeper) SetAmmInterface(poolManagerInterface types.PoolManagerInterface) {
+	k.poolmanagerKeeper = poolManagerInterface
 }
 
 func (k *Keeper) AfterCreatePool(ctx sdk.Context, poolId uint64) error {

--- a/x/twap/keeper.go
+++ b/x/twap/keeper.go
@@ -17,16 +17,16 @@ type Keeper struct {
 
 	paramSpace paramtypes.Subspace
 
-	ammkeeper types.AmmInterface
+	poolmanagerKeeper types.PoolManagerInterface
 }
 
-func NewKeeper(storeKey sdk.StoreKey, transientKey *sdk.TransientStoreKey, paramSpace paramtypes.Subspace, ammKeeper types.AmmInterface) *Keeper {
+func NewKeeper(storeKey sdk.StoreKey, transientKey *sdk.TransientStoreKey, paramSpace paramtypes.Subspace, poolmanagerKeeper types.PoolManagerInterface) *Keeper {
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
 	}
 
-	return &Keeper{storeKey: storeKey, transientKey: transientKey, paramSpace: paramSpace, ammkeeper: ammKeeper}
+	return &Keeper{storeKey: storeKey, transientKey: transientKey, paramSpace: paramSpace, poolmanagerKeeper: poolmanagerKeeper}
 }
 
 // GetParams returns the total set of twap parameters.

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -50,7 +50,7 @@ func (s *TestSuite) TestAfterPoolCreatedHook() {
 			denomPairs := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for _, denomPair := range denomPairs {
-				expectedRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, s.Ctx, poolId, denomPair.Denom0, denomPair.Denom1)
+				expectedRecord, err := twap.NewTwapRecord(s.App.PoolManagerKeeper, s.Ctx, poolId, denomPair.Denom0, denomPair.Denom1)
 				s.Require().NoError(err)
 				expectedRecords = append(expectedRecords, expectedRecord)
 			}

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 	gammtypes "github.com/osmosis-labs/osmosis/v15/x/gamm/types"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 	"github.com/osmosis-labs/osmosis/v15/x/twap"
 	"github.com/osmosis-labs/osmosis/v15/x/twap/types"
 	"github.com/osmosis-labs/osmosis/v15/x/twap/types/twapmock"
@@ -94,7 +95,6 @@ func (s *TestSuite) TestGetSpotPrices() {
 
 func (s *TestSuite) TestNewTwapRecord() {
 	// prepare pool before test
-	poolId := s.PrepareBalancerPoolWithCoins(defaultTwoAssetCoins...)
 
 	tests := map[string]struct {
 		poolId        uint64
@@ -104,54 +104,64 @@ func (s *TestSuite) TestNewTwapRecord() {
 		expectedPanic bool
 	}{
 		"denom with lexicographical order": {
-			poolId,
+			1,
 			denom0,
 			denom1,
 			nil,
 			false,
 		},
 		"denom with non-lexicographical order": {
-			poolId,
+			1,
 			denom1,
 			denom0,
 			nil,
 			false,
 		},
 		"new record with same denom": {
-			poolId,
+			1,
 			denom0,
 			denom0,
 			fmt.Errorf("both assets cannot be of the same denom: assetA: %s, assetB: %s", denom0, denom0),
 			false,
 		},
 		"error in getting spot price": {
-			poolId + 1,
+			2,
 			denom1,
 			denom0,
 			nil,
 			true,
 		},
 	}
-	for name, test := range tests {
-		s.Run(name, func() {
-			twapRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, s.Ctx, test.poolId, test.denom0, test.denom1)
+	// iterate twice on the test cases, once with Balancer pools, once with Concentrated liquidity pools
+	for i := 0; i < 2; i++ {
+		for name, test := range tests {
+			s.Run(name, func() {
+				s.Setup()
+				if i == 0 {
+					s.PrepareBalancerPoolWithCoins(defaultTwoAssetCoins...)
+				} else {
+					s.PrepareConcentratedPoolWithCoins(denom0, denom1)
+				}
 
-			if test.expectedPanic {
-				s.Require().Equal(twapRecord.LastErrorTime, s.Ctx.BlockTime())
-			} else if test.expectedErr != nil {
-				s.Require().Error(err)
-				s.Require().Equal(test.expectedErr.Error(), err.Error())
-			} else {
-				s.Require().NoError(err)
+				twapRecord, err := twap.NewTwapRecord(s.App.PoolManagerKeeper, s.Ctx, test.poolId, test.denom0, test.denom1)
 
-				s.Require().Equal(test.poolId, twapRecord.PoolId)
-				s.Require().Equal(s.Ctx.BlockHeight(), twapRecord.Height)
-				s.Require().Equal(s.Ctx.BlockTime(), twapRecord.Time)
-				s.Require().Equal(sdk.ZeroDec(), twapRecord.P0ArithmeticTwapAccumulator)
-				s.Require().Equal(sdk.ZeroDec(), twapRecord.P1ArithmeticTwapAccumulator)
-				s.Require().Equal(sdk.ZeroDec(), twapRecord.GeometricTwapAccumulator)
-			}
-		})
+				if test.expectedPanic {
+					s.Require().Equal(twapRecord.LastErrorTime, s.Ctx.BlockTime())
+				} else if test.expectedErr != nil {
+					s.Require().Error(err)
+					s.Require().Equal(test.expectedErr.Error(), err.Error())
+				} else {
+					s.Require().NoError(err)
+
+					s.Require().Equal(test.poolId, twapRecord.PoolId)
+					s.Require().Equal(s.Ctx.BlockHeight(), twapRecord.Height)
+					s.Require().Equal(s.Ctx.BlockTime(), twapRecord.Time)
+					s.Require().Equal(sdk.ZeroDec(), twapRecord.P0ArithmeticTwapAccumulator)
+					s.Require().Equal(sdk.ZeroDec(), twapRecord.P1ArithmeticTwapAccumulator)
+					s.Require().Equal(sdk.ZeroDec(), twapRecord.GeometricTwapAccumulator)
+				}
+			})
+		}
 	}
 }
 
@@ -656,11 +666,13 @@ func (s *TestSuite) TestUpdateRecords() {
 	}
 
 	tests := map[string]struct {
-		preSetRecords []types.TwapRecord
-		poolId        uint64
-		ammMock       twapmock.ProgrammedAmmInterface
-		spOverrides   []spOverride
-		blockTime     time.Time
+		preSetRecords     []types.TwapRecord
+		poolId            uint64
+		ammMock           twapmock.ProgrammedPoolManagerInterface
+		spOverrides       []spOverride
+		poolDenomOverride []string
+
+		blockTime time.Time
 
 		expectedHistoricalRecords []expectedResults
 		expectError               error
@@ -670,14 +682,14 @@ func (s *TestSuite) TestUpdateRecords() {
 			poolId:        1,
 			blockTime:     baseTime,
 
-			expectError: gammtypes.PoolDoesNotExistError{PoolId: 1},
+			expectError: poolmanagertypes.FailedToFindRouteError{PoolId: baseRecord.PoolId},
 		},
 		"existing records in different pool; no-op": {
 			preSetRecords: []types.TwapRecord{baseRecord},
 			poolId:        baseRecord.PoolId + 1,
 			blockTime:     baseTime.Add(time.Second),
 
-			expectError: gammtypes.PoolDoesNotExistError{PoolId: baseRecord.PoolId + 1},
+			expectError: poolmanagertypes.FailedToFindRouteError{PoolId: baseRecord.PoolId + 1},
 		},
 		"the returned number of records does not match expected": {
 			preSetRecords: []types.TwapRecord{baseRecord},
@@ -1141,13 +1153,16 @@ func (s *TestSuite) TestUpdateRecords() {
 			ctx := s.Ctx.WithBlockTime(tc.blockTime)
 
 			if len(tc.spOverrides) > 0 {
-				ammMock := twapmock.NewProgrammedAmmInterface(s.App.GAMMKeeper)
-
+				ammMock := twapmock.NewProgrammedAmmInterface(s.App.PoolManagerKeeper)
 				for _, sp := range tc.spOverrides {
 					ammMock.ProgramPoolSpotPriceOverride(tc.poolId, sp.baseDenom, sp.quoteDenom, sp.overrideSp, sp.overrideErr)
 					ammMock.ProgramPoolDenomsOverride(tc.poolId, []string{sp.baseDenom, sp.quoteDenom}, nil)
 				}
 
+				twapKeeper.SetAmmInterface(ammMock)
+			} else if len(tc.poolDenomOverride) > 0 {
+				ammMock := twapmock.NewProgrammedAmmInterface(s.App.PoolManagerKeeper)
+				ammMock.ProgramPoolDenomsOverride(tc.poolId, tc.poolDenomOverride, nil)
 				twapKeeper.SetAmmInterface(ammMock)
 			}
 
@@ -1240,7 +1255,7 @@ func (s *TestSuite) TestAfterCreatePool() {
 			denomPairs := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for _, denomPair := range denomPairs {
-				expectedRecord, err := twap.NewTwapRecord(s.App.GAMMKeeper, s.Ctx, poolId, denomPair.Denom0, denomPair.Denom1)
+				expectedRecord, err := twap.NewTwapRecord(s.App.PoolManagerKeeper, s.Ctx, poolId, denomPair.Denom0, denomPair.Denom1)
 				s.Require().NoError(err)
 				expectedRecords = append(expectedRecords, expectedRecord)
 			}

--- a/x/twap/types/expected_interfaces.go
+++ b/x/twap/types/expected_interfaces.go
@@ -3,13 +3,13 @@ package types
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
 // AmmInterface is the functionality needed from a given pool ID, in order to maintain records and serve TWAPs.
-type AmmInterface interface {
-	GetPoolDenoms(ctx sdk.Context, poolId uint64) (denoms []string, err error)
+type PoolManagerInterface interface {
+	RouteGetPoolDenoms(ctx sdk.Context, poolId uint64) (denoms []string, err error)
 	// CalculateSpotPrice returns the spot price of the quote asset in terms of the base asset,
 	// using the specified pool.
 	// E.g. if pool 1 traded 2 atom for 3 osmo, the quote asset was atom, and the base asset was osmo,
 	// this would return 1.5. (Meaning that 1 atom costs 1.5 osmo)
-	CalculateSpotPrice(
+	RouteCalculateSpotPrice(
 		ctx sdk.Context,
 		poolID uint64,
 		quoteAssetDenom string,

--- a/x/twap/types/twapmock/amminterface.go
+++ b/x/twap/types/twapmock/amminterface.go
@@ -6,10 +6,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/twap/types"
 )
 
-var _ types.AmmInterface = &ProgrammedAmmInterface{}
+var _ types.PoolManagerInterface = &ProgrammedPoolManagerInterface{}
 
-type ProgrammedAmmInterface struct {
-	underlyingKeeper     types.AmmInterface
+type ProgrammedPoolManagerInterface struct {
+	underlyingKeeper     types.PoolManagerInterface
 	programmedSpotPrice  map[SpotPriceInput]SpotPriceResult
 	programmedPoolDenoms map[uint64]poolDenomsResult
 }
@@ -30,15 +30,15 @@ type poolDenomsResult struct {
 	err        error
 }
 
-func NewProgrammedAmmInterface(underlyingKeeper types.AmmInterface) *ProgrammedAmmInterface {
-	return &ProgrammedAmmInterface{
+func NewProgrammedAmmInterface(underlyingKeeper types.PoolManagerInterface) *ProgrammedPoolManagerInterface {
+	return &ProgrammedPoolManagerInterface{
 		underlyingKeeper:     underlyingKeeper,
 		programmedSpotPrice:  map[SpotPriceInput]SpotPriceResult{},
 		programmedPoolDenoms: map[uint64]poolDenomsResult{},
 	}
 }
 
-func (p *ProgrammedAmmInterface) ProgramPoolDenomsOverride(poolId uint64, overrideDenoms []string, overrideErr error) {
+func (p *ProgrammedPoolManagerInterface) ProgramPoolDenomsOverride(poolId uint64, overrideDenoms []string, overrideErr error) {
 	var poolDenoms map[string]struct{}
 	if existingForPool, ok := p.programmedPoolDenoms[poolId]; ok {
 		poolDenoms = existingForPool.poolDenoms
@@ -51,14 +51,14 @@ func (p *ProgrammedAmmInterface) ProgramPoolDenomsOverride(poolId uint64, overri
 	p.programmedPoolDenoms[poolId] = poolDenomsResult{poolDenoms, overrideErr}
 }
 
-func (p *ProgrammedAmmInterface) ProgramPoolSpotPriceOverride(poolId uint64,
+func (p *ProgrammedPoolManagerInterface) ProgramPoolSpotPriceOverride(poolId uint64,
 	quoteDenom, baseDenom string, overrideSp sdk.Dec, overrideErr error,
 ) {
 	input := SpotPriceInput{poolId, baseDenom, quoteDenom}
 	p.programmedSpotPrice[input] = SpotPriceResult{overrideSp, overrideErr}
 }
 
-func (p *ProgrammedAmmInterface) GetPoolDenoms(ctx sdk.Context, poolId uint64) (denoms []string, err error) {
+func (p *ProgrammedPoolManagerInterface) RouteGetPoolDenoms(ctx sdk.Context, poolId uint64) (denoms []string, err error) {
 	if res, ok := p.programmedPoolDenoms[poolId]; ok {
 		result := make([]string, 0, len(res.poolDenoms))
 		for denom := range res.poolDenoms {
@@ -66,10 +66,10 @@ func (p *ProgrammedAmmInterface) GetPoolDenoms(ctx sdk.Context, poolId uint64) (
 		}
 		return result, res.err
 	}
-	return p.underlyingKeeper.GetPoolDenoms(ctx, poolId)
+	return p.underlyingKeeper.RouteGetPoolDenoms(ctx, poolId)
 }
 
-func (p *ProgrammedAmmInterface) CalculateSpotPrice(ctx sdk.Context,
+func (p *ProgrammedPoolManagerInterface) RouteCalculateSpotPrice(ctx sdk.Context,
 	poolId uint64,
 	quoteDenom,
 	baseDenom string,
@@ -78,5 +78,5 @@ func (p *ProgrammedAmmInterface) CalculateSpotPrice(ctx sdk.Context,
 	if res, ok := p.programmedSpotPrice[input]; ok {
 		return res.Sp, res.Err
 	}
-	return p.underlyingKeeper.CalculateSpotPrice(ctx, poolId, quoteDenom, baseDenom)
+	return p.underlyingKeeper.RouteCalculateSpotPrice(ctx, poolId, quoteDenom, baseDenom)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change
Adds CL wiring to the CL module.
This includes changing `AmmInterface` to `PoolManagerInterface`, where now the twap module receives the API needed from the pool manager for a generalized form of getting pool denoms and spot price,  instead of getting it directly from the gamm module.


## Brief Changelog
- Add TWAP wiring to CL 


## Testing and Verifying
Necessary tests are included
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)