### PR TITLE
ci: go mod auto-update runs on push to curr

### DIFF
--- a/.github/workflows/go-mod-auto-bump.yml
+++ b/.github/workflows/go-mod-auto-bump.yml
@@ -8,6 +8,8 @@
 name: Go Mod Auto Version Update
 on: 
   push:
+    branches:
+    - ${{ github.ref }}
     paths: 
       - osmoutils/**
       - osmomath/**


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4660

## What is the purpose of the change

Currently, `go.mod` auto-update runs on push to every branch.

Instead, it should be running on push to the current branch.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable