### PR TITLE
[tests/e2e]: simplify the logic for adding accounts to genesis sdk side and integrate into e2e

### DIFF
--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -126,7 +126,7 @@ func addAccount(path, moniker, amountStr string, accAddr sdk.AccAddress, forkHei
 	feeToken := sdk.NewCoin(E2EFeeToken, sdk.NewInt(GenesisFeeBalance))
 	amountStr = amountStr + "," + feeToken.String()
 	genFile := config.GenesisFile()
-	
+
 	return authhelpers.AddGenesisAccount(util.Cdc, accAddr, false, genFile, amountStr, "", 0, 0)
 }
 

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authhelpers "github.com/cosmos/cosmos-sdk/x/auth/helpers"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
+	// "github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -124,72 +124,11 @@ func addAccount(path, moniker, amountStr string, accAddr sdk.AccAddress, forkHei
 	config.SetRoot(path)
 	config.Moniker = moniker
 
-	coins, err := sdk.ParseCoinsNormalized(amountStr)
-	if err != nil {
-		return fmt.Errorf("failed to parse coins: %w", err)
-	}
-	coins = coins.Add(sdk.NewCoin(E2EFeeToken, sdk.NewInt(GenesisFeeBalance)))
-
-	balances := banktypes.Balance{Address: accAddr.String(), Coins: coins.Sort()}
-	genAccount := authtypes.NewBaseAccount(accAddr, nil, 0, 0)
-
-	// TODO: Make the SDK make it far cleaner to add an account to GenesisState
+	feeToken := sdk.NewCoin(E2EFeeToken, sdk.NewInt(GenesisFeeBalance))
+	amountStr = amountStr + "," + feeToken.String()
 	genFile := config.GenesisFile()
-	appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal genesis state: %w", err)
-	}
-
-	genDoc.InitialHeight = int64(forkHeight)
-
-	authGenState := authtypes.GetGenesisStateFromAppState(util.Cdc, appState)
-
-	accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
-	if err != nil {
-		return fmt.Errorf("failed to get accounts from any: %w", err)
-	}
-
-	if accs.Contains(accAddr) {
-		return fmt.Errorf("failed to add account to genesis state; account already exists: %s", accAddr)
-	}
-
-	// Add the new account to the set of genesis accounts and sanitize the
-	// accounts afterwards.
-	accs = append(accs, genAccount)
-	accs = authtypes.SanitizeGenesisAccounts(accs)
-
-	genAccs, err := authtypes.PackAccounts(accs)
-	if err != nil {
-		return fmt.Errorf("failed to convert accounts into any's: %w", err)
-	}
-
-	authGenState.Accounts = genAccs
-
-	authGenStateBz, err := util.Cdc.MarshalJSON(&authGenState)
-	if err != nil {
-		return fmt.Errorf("failed to marshal auth genesis state: %w", err)
-	}
-
-	appState[authtypes.ModuleName] = authGenStateBz
-
-	bankGenState := banktypes.GetGenesisStateFromAppState(util.Cdc, appState)
-	bankGenState.Balances = append(bankGenState.Balances, balances)
-	bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
-
-	bankGenStateBz, err := util.Cdc.MarshalJSON(bankGenState)
-	if err != nil {
-		return fmt.Errorf("failed to marshal bank genesis state: %w", err)
-	}
-
-	appState[banktypes.ModuleName] = bankGenStateBz
-
-	appStateJSON, err := json.Marshal(appState)
-	if err != nil {
-		return fmt.Errorf("failed to marshal application genesis state: %w", err)
-	}
-
-	genDoc.AppState = appStateJSON
-	return genutil.ExportGenesisFile(genDoc, genFile)
+	
+	return authhelpers.AddGenesisAccount(util.Cdc, accAddr, false, genFile, amountStr, "", 0, 0)
 }
 
 func updateModuleGenesis[V proto.Message](appGenState map[string]json.RawMessage, moduleName string, protoVal V, updateGenesis func(V)) error {

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -11,7 +11,6 @@ import (
 	authhelpers "github.com/cosmos/cosmos-sdk/x/auth/helpers"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
-	// "github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1628 

## What is the purpose of the change

Update logic add account to genesis in e2e testing

## Brief Changelog


## Testing and Verifying
This change is already covered by existing tests, it pass all e2e task after run `make test-e2e-short`
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)