### PR TITLE
Add weekly GitHub action to clean Go cache

### DIFF
--- a/.github/workflows/clean-cache-weekly.yml
+++ b/.github/workflows/clean-cache-weekly.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.19
 
       - name: Download Go cache
         uses: actions/cache@v2

--- a/.github/workflows/clean-cache-weekly.yml
+++ b/.github/workflows/clean-cache-weekly.yml
@@ -1,0 +1,36 @@
+name: Go Clean Cache
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  clean-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Download Go cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run go clean --cache
+        run: go clean --cache
+
+      - name: Save new Go cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-go-


### PR DESCRIPTION
Closes: #1801 

## Description

This PR introduces a new GitHub action workflow that cleans the Go cache weekly.

The workflow performs the following:

* Downloads the Go cache.
* Runs `go clean --cache` to clean the cache.
* Saves the new cache.

This action is scheduled to run once a week at 00:00 UTC on Sundays. 
