### PR TITLE
refactor: shorten fee and uptime accumulator prefixes; move to keys.go

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -150,10 +150,6 @@ func (k Keeper) GetInitialFeeGrowthOutsideForTick(ctx sdk.Context, poolId uint64
 	return k.getInitialFeeGrowthOutsideForTick(ctx, poolId, tick)
 }
 
-func GetFeeAccumulatorName(poolId uint64) string {
-	return getFeeAccumulatorName(poolId)
-}
-
 func (k Keeper) ChargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
 	return k.chargeFee(ctx, poolId, feeUpdate)
 }
@@ -198,10 +194,6 @@ func (k Keeper) CreateUptimeAccumulators(ctx sdk.Context, poolId uint64) error {
 
 func (k Keeper) GetUptimeAccumulators(ctx sdk.Context, poolId uint64) ([]accum.AccumulatorObject, error) {
 	return k.getUptimeAccumulators(ctx, poolId)
-}
-
-func GetUptimeAccumulatorName(poolId, uptimeIndex uint64) string {
-	return getUptimeAccumulatorName(poolId, uptimeIndex)
 }
 
 func (k Keeper) GetUptimeAccumulatorValues(ctx sdk.Context, poolId uint64) ([]sdk.DecCoins, error) {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmoutils/accum"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
 const (
@@ -67,7 +66,7 @@ func (k Keeper) initializeFeeAccumulatorPosition(ctx sdk.Context, poolId uint64,
 	}
 
 	// Get the key for the position's accumulator in the fee accumulator.
-	positionKey := cltypes.KeyFeePositionAccumulator(positionId)
+	positionKey := types.KeyFeePositionAccumulator(positionId)
 
 	// Check if the position already exists in the fee accumulator and has non-zero liquidity.
 	hasPosition, err := feeAccumulator.HasPosition(positionKey)
@@ -117,7 +116,7 @@ func (k Keeper) updateFeeAccumulatorPosition(ctx sdk.Context, liquidityDelta sdk
 	}
 
 	// Get the key for the position's accumulator in the fee accumulator.
-	positionKey := cltypes.KeyFeePositionAccumulator(positionId)
+	positionKey := types.KeyFeePositionAccumulator(positionId)
 
 	// Replace the position's accumulator in the fee accumulator with a new one
 	// that has the latest fee growth outside of the tick range.
@@ -214,7 +213,7 @@ func (k Keeper) collectFees(ctx sdk.Context, owner sdk.AccAddress, positionId ui
 	}
 
 	// Get the key for the position's accumulator in the fee accumulator.
-	positionKey := cltypes.KeyFeePositionAccumulator(positionId)
+	positionKey := types.KeyFeePositionAccumulator(positionId)
 
 	// Check if the position exists in the fee accumulator.
 	hasPosition, err := feeAccumulator.HasPosition(positionKey)
@@ -222,7 +221,7 @@ func (k Keeper) collectFees(ctx sdk.Context, owner sdk.AccAddress, positionId ui
 		return sdk.Coins{}, err
 	}
 	if !hasPosition {
-		return sdk.Coins{}, cltypes.PositionIdNotFoundError{PositionId: positionId}
+		return sdk.Coins{}, types.PositionIdNotFoundError{PositionId: positionId}
 	}
 
 	// Compute the fee growth outside of the range between the position's lower and upper ticks.
@@ -272,7 +271,7 @@ func (k Keeper) queryClaimableFees(ctx sdk.Context, positionId uint64) (sdk.Coin
 	}
 
 	// Get the key for the position's accumulator in the fee accumulator.
-	positionKey := cltypes.KeyFeePositionAccumulator(positionId)
+	positionKey := types.KeyFeePositionAccumulator(positionId)
 
 	// Check if the position exists in the fee accumulator.
 	hasPosition, err := feeAccumulator.HasPosition(positionKey)
@@ -280,7 +279,7 @@ func (k Keeper) queryClaimableFees(ctx sdk.Context, positionId uint64) (sdk.Coin
 		return nil, err
 	}
 	if !hasPosition {
-		return nil, cltypes.PositionIdNotFoundError{PositionId: positionId}
+		return nil, types.PositionIdNotFoundError{PositionId: positionId}
 	}
 
 	// Compute the fee growth outside of the range between the position's lower and upper ticks.

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -2,19 +2,16 @@ package concentrated_liquidity
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils/accum"
+	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
 const (
-	feeAccumPrefix = "fee"
-	keySeparator   = "/"
-	uintBase       = 10
+	keySeparator = "/"
 )
 
 var emptyCoins = sdk.DecCoins(nil)
@@ -22,7 +19,7 @@ var emptyCoins = sdk.DecCoins(nil)
 // createFeeAccumulator creates an accumulator object in the store using the given poolId.
 // The accumulator is initialized with the default(zero) values.
 func (k Keeper) createFeeAccumulator(ctx sdk.Context, poolId uint64) error {
-	err := accum.MakeAccumulator(ctx.KVStore(k.storeKey), getFeeAccumulatorName(poolId))
+	err := accum.MakeAccumulator(ctx.KVStore(k.storeKey), types.KeyFeePoolAccumulator(poolId))
 	if err != nil {
 		return err
 	}
@@ -32,7 +29,7 @@ func (k Keeper) createFeeAccumulator(ctx sdk.Context, poolId uint64) error {
 // getFeeAccumulator gets the fee accumulator object using the given poolOd
 // returns error if accumulator for the given poolId does not exist.
 func (k Keeper) getFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.AccumulatorObject, error) {
-	acc, err := accum.GetAccumulator(ctx.KVStore(k.storeKey), getFeeAccumulatorName(poolId))
+	acc, err := accum.GetAccumulator(ctx.KVStore(k.storeKey), types.KeyFeePoolAccumulator(poolId))
 	if err != nil {
 		return accum.AccumulatorObject{}, err
 	}
@@ -305,11 +302,6 @@ func (k Keeper) queryClaimableFees(ctx sdk.Context, positionId uint64) (sdk.Coin
 	}
 
 	return feesClaimed, nil
-}
-
-func getFeeAccumulatorName(poolId uint64) string {
-	poolIdStr := strconv.FormatUint(poolId, uintBase)
-	return strings.Join([]string{feeAccumPrefix, poolIdStr}, "/")
 }
 
 // calculateFeeGrowth for the given targetTicks.

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -9,10 +9,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
-const (
-	keySeparator = "/"
-)
-
 var emptyCoins = sdk.DecCoins(nil)
 
 // createFeeAccumulator creates an accumulator object in the store using the given poolId.

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -460,7 +460,7 @@ func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOutsideForTick() {
 			initialGlobalFeeGrowth:   oneEth,
 			shouldAvoidCreatingAccum: true,
 
-			expectError: accum.AccumDoesNotExistError{AccumName: cl.GetFeeAccumulatorName(validPoolId)},
+			expectError: accum.AccumDoesNotExistError{AccumName: types.KeyFeePoolAccumulator(validPoolId)},
 		},
 	}
 
@@ -552,7 +552,7 @@ func (suite *KeeperTestSuite) TestChargeFee() {
 			poolId:    3,
 			feeUpdate: oneEth,
 
-			expectError: accum.AccumDoesNotExistError{AccumName: cl.GetFeeAccumulatorName(3)},
+			expectError: accum.AccumDoesNotExistError{AccumName: types.KeyFeePoolAccumulator(3)},
 		},
 	}
 

--- a/x/concentrated-liquidity/genesis.go
+++ b/x/concentrated-liquidity/genesis.go
@@ -99,7 +99,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *genesis.GenesisState {
 		}
 
 		feeAccumObject := genesis.AccumObject{
-			Name: getFeeAccumulatorName(poolI.GetId()),
+			Name: types.KeyFeePoolAccumulator(poolI.GetId()),
 			AccumContent: &accum.AccumulatorContent{
 				AccumValue:  accumObject.GetValue(),
 				TotalShares: totalShares,

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -501,7 +501,7 @@ func (s *KeeperTestSuite) TestExportGenesis() {
 					},
 					positions: []model.Position{testPositionModel},
 					feeAccumValues: genesis.AccumObject{
-						Name: "fee/1",
+						Name: types.KeyFeePoolAccumulator(poolOne.Id),
 						AccumContent: &accum.AccumulatorContent{
 							AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(10))),
 							TotalShares: sdk.NewDec(10),
@@ -545,7 +545,7 @@ func (s *KeeperTestSuite) TestExportGenesis() {
 					},
 					positions: []model.Position{testPositionModel},
 					feeAccumValues: genesis.AccumObject{
-						Name: "fee/1",
+						Name: types.KeyFeePoolAccumulator(poolOne.Id),
 						AccumContent: &accum.AccumulatorContent{
 							AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(10))),
 							TotalShares: sdk.NewDec(10),
@@ -573,7 +573,7 @@ func (s *KeeperTestSuite) TestExportGenesis() {
 						withTickIndex(withPoolId(defaultFullTick, poolTwo.Id), 999),
 					},
 					feeAccumValues: genesis.AccumObject{
-						Name: "fee/2",
+						Name: types.KeyFeePoolAccumulator(poolTwo.Id),
 						AccumContent: &accum.AccumulatorContent{
 							AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(20))),
 							TotalShares: sdk.NewDec(20),

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -180,7 +180,7 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 					},
 					positions: []model.Position{testPositionModel},
 					feeAccumValues: genesis.AccumObject{
-						Name: "fee/1",
+						Name: types.KeyFeePoolAccumulator(1),
 						AccumContent: &accum.AccumulatorContent{
 							AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(10))),
 							TotalShares: sdk.NewDec(10),
@@ -225,7 +225,7 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 			expectedPositions: []model.Position{testPositionModel},
 			expectedfeeAccumValues: []genesis.AccumObject{
 				{
-					Name: "fee/1",
+					Name: types.KeyFeePoolAccumulator(1),
 					AccumContent: &accum.AccumulatorContent{
 						AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(10))),
 						TotalShares: sdk.NewDec(10),
@@ -267,7 +267,7 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 					},
 					positions: []model.Position{testPositionModel},
 					feeAccumValues: genesis.AccumObject{
-						Name: "fee/1",
+						Name: types.KeyFeePoolAccumulator(1),
 						AccumContent: &accum.AccumulatorContent{
 							AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(10))),
 							TotalShares: sdk.NewDec(10),
@@ -296,7 +296,7 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 					},
 					positions: []model.Position{withPositionId(positionWithPoolId(testPositionModel, 2), DefaultPositionId+1)},
 					feeAccumValues: genesis.AccumObject{
-						Name: "fee/2",
+						Name: types.KeyFeePoolAccumulator(2),
 						AccumContent: &accum.AccumulatorContent{
 							AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(20))),
 							TotalShares: sdk.NewDec(20),
@@ -333,14 +333,14 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 			},
 			expectedfeeAccumValues: []genesis.AccumObject{
 				{
-					Name: "fee/1",
+					Name: types.KeyFeePoolAccumulator(1),
 					AccumContent: &accum.AccumulatorContent{
 						AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(10))),
 						TotalShares: sdk.NewDec(10),
 					},
 				},
 				{
-					Name: "fee/2",
+					Name: types.KeyFeePoolAccumulator(2),
 					AccumContent: &accum.AccumulatorContent{
 						AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(20))),
 						TotalShares: sdk.NewDec(20),

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -76,35 +76,35 @@ func withPositionId(position model.Position, positionId uint64) model.Position {
 func incentiveAccumsWithPoolId(poolId uint64) []genesis.AccumObject {
 	return []genesis.AccumObject{
 		{
-			Name: cl.GetUptimeAccumulatorName(poolId, uint64(0)),
+			Name: types.KeyUptimeAccumulator(poolId, uint64(0)),
 			AccumContent: &accum.AccumulatorContent{
 				AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(20))),
 				TotalShares: sdk.NewDec(20),
 			},
 		},
 		{
-			Name: cl.GetUptimeAccumulatorName(poolId, uint64(1)),
+			Name: types.KeyUptimeAccumulator(poolId, uint64(1)),
 			AccumContent: &accum.AccumulatorContent{
 				AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(20))),
 				TotalShares: sdk.NewDec(30),
 			},
 		},
 		{
-			Name: cl.GetUptimeAccumulatorName(poolId, uint64(2)),
+			Name: types.KeyUptimeAccumulator(poolId, uint64(2)),
 			AccumContent: &accum.AccumulatorContent{
 				AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("baz", sdk.NewInt(10))),
 				TotalShares: sdk.NewDec(10),
 			},
 		},
 		{
-			Name: cl.GetUptimeAccumulatorName(poolId, uint64(3)),
+			Name: types.KeyUptimeAccumulator(poolId, uint64(3)),
 			AccumContent: &accum.AccumulatorContent{
 				AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("qux", sdk.NewInt(20))),
 				TotalShares: sdk.NewDec(20),
 			},
 		},
 		{
-			Name: cl.GetUptimeAccumulatorName(poolId, uint64(4)),
+			Name: types.KeyUptimeAccumulator(poolId, uint64(4)),
 			AccumContent: &accum.AccumulatorContent{
 				AccumValue:  sdk.NewDecCoins(sdk.NewDecCoin("quux", sdk.NewInt(20))),
 				TotalShares: sdk.NewDec(20),

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -2,8 +2,6 @@ package concentrated_liquidity
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,27 +13,17 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
-const (
-	uptimeAccumPrefix = "uptime"
-)
-
 // createUptimeAccumulators creates accumulator objects in store for each supported uptime for the given poolId.
 // The accumulators are initialized with the default (zero) values.
 func (k Keeper) createUptimeAccumulators(ctx sdk.Context, poolId uint64) error {
 	for uptimeIndex := range types.SupportedUptimes {
-		err := accum.MakeAccumulator(ctx.KVStore(k.storeKey), getUptimeAccumulatorName(poolId, uint64(uptimeIndex)))
+		err := accum.MakeAccumulator(ctx.KVStore(k.storeKey), types.KeyUptimeAccumulator(poolId, uint64(uptimeIndex)))
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func getUptimeAccumulatorName(poolId uint64, uptimeIndex uint64) string {
-	poolIdStr := strconv.FormatUint(poolId, uintBase)
-	uptimeIndexStr := strconv.FormatUint(uptimeIndex, uintBase)
-	return strings.Join([]string{uptimeAccumPrefix, poolIdStr, uptimeIndexStr}, "/")
 }
 
 // getUptimeTrackerValues extracts the values of an array of uptime trackers
@@ -54,7 +42,7 @@ func getUptimeTrackerValues(uptimeTrackers []model.UptimeTracker) []sdk.DecCoins
 func (k Keeper) getUptimeAccumulators(ctx sdk.Context, poolId uint64) ([]accum.AccumulatorObject, error) {
 	accums := make([]accum.AccumulatorObject, len(types.SupportedUptimes))
 	for uptimeIndex := range types.SupportedUptimes {
-		acc, err := accum.GetAccumulator(ctx.KVStore(k.storeKey), getUptimeAccumulatorName(poolId, uint64(uptimeIndex)))
+		acc, err := accum.GetAccumulator(ctx.KVStore(k.storeKey), types.KeyUptimeAccumulator(poolId, uint64(uptimeIndex)))
 		if err != nil {
 			return []accum.AccumulatorObject{}, err
 		}

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -373,7 +373,7 @@ func (s *KeeperTestSuite) TestGetUptimeAccumulatorName() {
 			s.SetupTest()
 
 			// system under test
-			accumName := cl.GetUptimeAccumulatorName(tc.poolId, tc.uptimeIndex)
+			accumName := types.KeyUptimeAccumulator(tc.poolId, tc.uptimeIndex)
 			s.Require().Equal(tc.expectedAccumName, accumName)
 		})
 	}

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -353,17 +353,17 @@ func (s *KeeperTestSuite) TestGetUptimeAccumulatorName() {
 		"pool id 1, uptime id 0": {
 			poolId:            defaultPoolId,
 			uptimeIndex:       uint64(0),
-			expectedAccumName: "uptime/1/0",
+			expectedAccumName: string(types.KeyUptimeAccumulator(1, 0)),
 		},
 		"pool id 1, uptime id 999": {
 			poolId:            defaultPoolId,
 			uptimeIndex:       uint64(999),
-			expectedAccumName: "uptime/1/999",
+			expectedAccumName: string(types.KeyUptimeAccumulator(1, 999)),
 		},
 		"pool id 999, uptime id 1": {
 			poolId:            uint64(999),
 			uptimeIndex:       uint64(1),
-			expectedAccumName: "uptime/999/1",
+			expectedAccumName: string(types.KeyUptimeAccumulator(999, 1)),
 		},
 	}
 

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -17,17 +17,20 @@ const (
 	KeySeparator = "|"
 
 	uint64ByteSize = 8
+	uintBase       = 10
 )
 
 // Key prefixes
 var (
-	TickPrefix           = []byte{0x01}
-	PositionPrefix       = []byte{0x02}
-	PoolPrefix           = []byte{0x03}
-	IncentivePrefix      = []byte{0x04}
-	PositionIdPrefix     = []byte{0x08}
-	PoolPositionPrefix   = []byte{0x09}
-	FeeAccumulatorPrefix = []byte{0x0A}
+	TickPrefix                   = []byte{0x01}
+	PositionPrefix               = []byte{0x02}
+	PoolPrefix                   = []byte{0x03}
+	IncentivePrefix              = []byte{0x04}
+	PositionIdPrefix             = []byte{0x08}
+	PoolPositionPrefix           = []byte{0x09}
+	FeePositionAccumulatorPrefix = []byte{0x0A}
+	PoolFeeAccumulatorPrefix     = []byte{0x0B}
+	UptimeAccumulatorPrefix      = []byte{0x0C}
 
 	// n.b. we negative prefix must be less than the positive prefix for proper iteration
 	TickNegativePrefix = []byte{0x05}
@@ -168,8 +171,21 @@ func KeyPoolIncentiveRecords(poolId uint64) []byte {
 	return []byte(fmt.Sprintf("%s%s%d", IncentivePrefix, KeySeparator, poolId))
 }
 
-// Fee Accumulation Prefix Keys
+// Fee Accumulator Prefix Keys
 
 func KeyFeePositionAccumulator(positionId uint64) string {
-	return strings.Join([]string{string(FeeAccumulatorPrefix), strconv.FormatUint(positionId, 10)}, KeySeparator)
+	return strings.Join([]string{string(FeePositionAccumulatorPrefix), strconv.FormatUint(positionId, 10)}, KeySeparator)
+}
+
+func KeyFeePoolAccumulator(poolId uint64) string {
+	poolIdStr := strconv.FormatUint(poolId, uintBase)
+	return strings.Join([]string{string(PoolFeeAccumulatorPrefix), poolIdStr}, "/")
+}
+
+// Uptme Accumulator Prefix Keys
+
+func KeyUptimeAccumulator(poolId uint64, uptimeIndex uint64) string {
+	poolIdStr := strconv.FormatUint(poolId, uintBase)
+	uptimeIndexStr := strconv.FormatUint(uptimeIndex, uintBase)
+	return strings.Join([]string{string(UptimeAccumulatorPrefix), poolIdStr, uptimeIndexStr}, "/")
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4096 

## What is the purpose of the change

As part of looking into: https://github.com/osmosis-labs/osmosis/issues/4096, noticed the accumulator indexes include multiple bytes. We only need one byte for the prefix to differentiate from other keys.

Additionally, we should have all keys and helpers defined in a single place - types/keys.go

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable