### PR TITLE
Register Concentrated Pool Extension for Pool Proto struct

### DIFF
--- a/x/concentrated-liquidity/model/codec.go
+++ b/x/concentrated-liquidity/model/codec.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 
+	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
@@ -20,6 +21,12 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"osmosis.swaprouter.v1beta1.PoolI",
 		(*poolmanagertypes.PoolI)(nil),
+		&Pool{},
+	)
+
+	registry.RegisterInterface(
+		"osmosis.concentratedliquidity.v1beta1.ConcentratedPoolExtension",
+		(*types.ConcentratedPoolExtension)(nil),
 		&Pool{},
 	)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Registers Concentrated Pool Extension for Pool Proto struct for CL.
Without this un-serializing a CL pool to any struct is impossible- causing panics during init Genesis while unmarshalling pool structs for CL.


## Brief Changelog
- Register Concentrated Pool Extension for Pool Proto struct


## Testing and Verifying
Manually tested and verified that Registering CL pool extension for CL Pool proto struct solves existing problems faced while unmarshalling CL pools

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)