### PR TITLE
fix: use AccAddress stringer interface instead of bytes->string conve…

### DIFF
--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -333,7 +333,7 @@ func emitLiquidityChangeEvent(ctx sdk.Context, eventType string, positionId uint
 		eventType,
 		sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 		sdk.NewAttribute(types.AttributeKeyPositionId, strconv.FormatUint(positionId, 10)),
-		sdk.NewAttribute(sdk.AttributeKeySender, string(sender)),
+		sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
 		sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
 		sdk.NewAttribute(types.AttributeLowerTick, strconv.FormatInt(lowerTick, 10)),
 		sdk.NewAttribute(types.AttributeUpperTick, strconv.FormatInt(upperTick, 10)),


### PR DESCRIPTION


## What is the purpose of the change

This change fixes utf-8 encode/decode error of `sender` attribute from CL `CreatePosition` events. `sender` was an `AccAccount` which has stringer interface that properly turn bytes to bech32 encoded string, but `string(...)` won't trigger that stringer interface which resulted in non utf-8 encoding. The change is to call `.String()` explicitly.


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)