### PR TITLE
test[CL]: swap functional test

### DIFF
--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -1046,16 +1046,16 @@ func (s *KeeperTestSuite) TestFunctionalFees() {
 	}
 
 	// Swap multiple times USDC for ETH, therefore increasing the spot price
-	ticksActivatedAfterEachSwap, totalFeesExpected := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
 	s.CollectAndAssertFees(s.Ctx, clPool.GetId(), totalFeesExpected, positionIds, [][]sdk.Int{ticksActivatedAfterEachSwap}, onlyUSDC, positions)
 
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
-	ticksActivatedAfterEachSwap, totalFeesExpected = s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ = s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
 	s.CollectAndAssertFees(s.Ctx, clPool.GetId(), totalFeesExpected, positionIds, [][]sdk.Int{ticksActivatedAfterEachSwap}, onlyETH, positions)
 
 	// Do the same swaps as before, however this time we collect fees after both swap directions are complete.
-	ticksActivatedAfterEachSwapUp, totalFeesExpectedUp := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
-	ticksActivatedAfterEachSwapDown, totalFeesExpectedDown := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwapUp, totalFeesExpectedUp, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwapDown, totalFeesExpectedDown, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
 	totalFeesExpected = totalFeesExpectedUp.Add(totalFeesExpectedDown...)
 
 	// We expect all positions to have both denoms in their fee accumulators except USDC for the overlapping range position since
@@ -1129,8 +1129,8 @@ func (s *KeeperTestSuite) tickStatusInvariance(ticksActivatedAfterEachSwap [][]s
 }
 
 // swapAndTrackXTimesInARow performs `numSwaps` swaps and tracks the tick activated after each swap.
-// It also returns the total fees collected.
-func (s *KeeperTestSuite) swapAndTrackXTimesInARow(poolId uint64, coinIn sdk.Coin, coinOutDenom string, priceLimit sdk.Dec, numSwaps int) (ticksActivatedAfterEachSwap []sdk.Int, totalFees sdk.Coins) {
+// It also returns the total fees collected, the total token in, and the total token out.
+func (s *KeeperTestSuite) swapAndTrackXTimesInARow(poolId uint64, coinIn sdk.Coin, coinOutDenom string, priceLimit sdk.Dec, numSwaps int) (ticksActivatedAfterEachSwap []sdk.Int, totalFees sdk.Coins, totalTokenIn sdk.Coin, totalTokenOut sdk.Coin) {
 	// Retrieve pool
 	clPool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
 	s.Require().NoError(err)
@@ -1143,16 +1143,20 @@ func (s *KeeperTestSuite) swapAndTrackXTimesInARow(poolId uint64, coinIn sdk.Coi
 	ticksActivatedAfterEachSwap = append(ticksActivatedAfterEachSwap, clPool.GetCurrentTick())
 	totalFees = sdk.NewCoins(sdk.NewCoin(USDC, sdk.ZeroInt()), sdk.NewCoin(ETH, sdk.ZeroInt()))
 	// Swap numSwaps times, recording the tick activated after and swap and fees we expect to collect based on the amount in
+	totalTokenIn = sdk.NewCoin(coinIn.Denom, sdk.ZeroInt())
+	totalTokenOut = sdk.NewCoin(coinOutDenom, sdk.ZeroInt())
 	for i := 0; i < numSwaps; i++ {
-		coinIn, _, _, _, _, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(s.Ctx, s.TestAccs[4], clPool, coinIn, coinOutDenom, clPool.GetSwapFee(s.Ctx), priceLimit)
+		coinIn, coinOut, _, _, _, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(s.Ctx, s.TestAccs[4], clPool, coinIn, coinOutDenom, clPool.GetSwapFee(s.Ctx), priceLimit)
 		s.Require().NoError(err)
 		fee := coinIn.Amount.ToDec().Mul(clPool.GetSwapFee(s.Ctx))
 		totalFees = totalFees.Add(sdk.NewCoin(coinIn.Denom, fee.TruncateInt()))
 		clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 		s.Require().NoError(err)
 		ticksActivatedAfterEachSwap = append(ticksActivatedAfterEachSwap, clPool.GetCurrentTick())
+		totalTokenIn = totalTokenIn.Add(coinIn)
+		totalTokenOut = totalTokenOut.Add(coinOut)
 	}
-	return ticksActivatedAfterEachSwap, totalFees
+	return ticksActivatedAfterEachSwap, totalFees, totalTokenIn, totalTokenOut
 }
 
 // collectFeesAndCheckInvariance collects fees from the concentrated liquidity pool and checks the resulting tick status invariance.

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -175,7 +175,7 @@ var (
 			// liquidity (1st):  1517882343.751510418088349649
 			// sqrtPriceNext:    74.161984870956629487 which is 5500
 			// sqrtPriceCurrent: 70.710678118654752440 which is 5000
-			// expectedTokenIn:  5238677582.189386755771808942932776 rounded up https://www.wolframalpha.com/input?i=5.238677582189386755771808942932776425143606503+%C3%97+10%5E9&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
+			// expectedTokenIn:  5238677582.189386755771808942932776 rounded up https://www.wolframalpha.com/input?i=1517882343.751510418088349649+*+%2874.161984870956629487+-+70.710678118654752440%29
 			// expectedTokenOut: 998976.6183474263883566299269 rounded down https://www.wolframalpha.com/input?i=%281517882343.751510418088349649+*+%2874.161984870956629487+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+74.161984870956629487%29
 			// params
 			// liquidity (2nd):  1197767444.955508123222985080
@@ -2748,4 +2748,265 @@ func (s *KeeperTestSuite) validateAmountsWithTolerance(amountA sdk.Int, amountB 
 	} else {
 		s.Require().Equal(0, multCompare, "amountA: %s, amountB: %s", amountA, amountB)
 	}
+}
+
+func (s *KeeperTestSuite) TestFunctionalSwaps() {
+	positions := Positions{
+		numSwaps:       5,
+		numAccounts:    5,
+		numFullRange:   4,
+		numNarrowRange: 3,
+		numConsecutive: 2,
+		numOverlapping: 1,
+	}
+
+	// Init suite.
+	s.Setup()
+
+	// Determine amount of ETH and USDC to swap per swap.
+	// These values were chosen as to not deplete the entire liquidity, but enough to move the price considerably.
+	swapCoin0 := sdk.NewCoin(ETH, DefaultAmt0.Quo(sdk.NewInt(int64(positions.numSwaps))))
+	swapCoin1 := sdk.NewCoin(USDC, DefaultAmt1.Quo(sdk.NewInt(int64(positions.numSwaps))))
+
+	// Default setup only creates 3 accounts, but we need 5 for this test.
+	s.TestAccs = apptesting.CreateRandomAccounts(positions.numAccounts)
+
+	// Create a default CL pool, but with a 0.3 percent swap fee.
+	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultExponentAtPriceOne, sdk.MustNewDecFromStr("0.003"))
+
+	positionIds := make([][]uint64, 4)
+	// Setup full range position across all four accounts
+	for i := 0; i < positions.numFullRange; i++ {
+		positionId := s.SetupFullRangePositionAcc(clPool.GetId(), s.TestAccs[i])
+		positionIds[0] = append(positionIds[0], positionId)
+	}
+
+	// Setup narrow range position across three of four accounts
+	for i := 0; i < positions.numNarrowRange; i++ {
+		positionId := s.SetupDefaultPositionAcc(clPool.GetId(), s.TestAccs[i])
+		positionIds[1] = append(positionIds[1], positionId)
+	}
+
+	// Setup consecutive range position (in relation to narrow range position) across two of four accounts
+	for i := 0; i < positions.numConsecutive; i++ {
+		positionId := s.SetupConsecutiveRangePositionAcc(clPool.GetId(), s.TestAccs[i])
+		positionIds[2] = append(positionIds[2], positionId)
+	}
+
+	// Setup overlapping range position (in relation to narrow range position) on one of four accounts
+	for i := 0; i < positions.numOverlapping; i++ {
+		positionId := s.SetupOverlappingRangePositionAcc(clPool.GetId(), s.TestAccs[i])
+		positionIds[3] = append(positionIds[3], positionId)
+	}
+
+	// Depiction of the pool before any swaps
+	//
+	//  0 -----------------------------|-------------------------------------------- ∞
+	//                   4545 ---------|-------- 5500
+	//                                 |    5500 --------------- 6250
+	//         4000 ----------------- 4999
+	//                                 |
+	//                              5000
+
+	// Swap multiple times USDC for ETH, therefore increasing the spot price
+	_, _, totalTokenIn, totalTokenOut := s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	clPool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	s.Require().NoError(err)
+
+	// Depiction of the pool after the swaps (from 5000 to 5146), increasing the spot price
+	//                                   >
+	//  0 -----------------------------|--|----------------------------------------- ∞
+	//                   4545 ---------|--|----- 5500
+	//                                 |  | 5500 --------------- 6250
+	//         4000 ----------------- 4999|
+	//                                 |  |
+	//                              5000 > 5146
+	//
+	// from math import *
+	// from decimal import *
+	// liq = Decimal("4836489743.729150266025048947")
+	// sqrt_cur = Decimal("5000").sqrt()
+	// token_in = Decimal("5000000000")
+	// swap_fee = Decimal("0.003")
+	// token_in_after_fee = token_in * (Decimal("1") - swap_fee)
+	// sqrt_next = sqrt_cur + token_in_after_fee / liq
+	// token_out = token_out = liq * (sqrt_next - sqrt_cur) / (sqrt_cur * sqrt_next)
+
+	// # Summary:
+	// print(sqrt_next) # 71.74138432587113364823838192
+	// print(token_out) # 982676.1324268988579833395181
+
+	// Get expected values from the calculations above
+	expectedSqrtPrice := osmomath.MustNewDecFromStr("71.74138432587113364823838192")
+	actualSqrtPrice := osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
+	expectedTokenIn := swapCoin1.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
+	expectedTokenOut := sdk.NewInt(982676)
+
+	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
+	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenIn, totalTokenIn.Amount))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenOut, totalTokenOut.Amount))
+
+	// Withdraw all full range positions
+	for _, positionId := range positionIds[0] {
+		position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(s.Ctx, positionId)
+		s.Require().NoError(err)
+		owner, err := sdk.AccAddressFromBech32(position.Address)
+		s.Require().NoError(err)
+		s.App.ConcentratedLiquidityKeeper.WithdrawPosition(s.Ctx, owner, positionId, position.Liquidity)
+	}
+
+	// Swap multiple times ETH for USDC, therefore decreasing the spot price
+	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	s.Require().NoError(err)
+
+	// Depiction of the pool after the swaps (from 5146 to 4990), decreasing the spot price
+	//								   <
+	//                   4545 -----|------|----- 5500
+	//                             |      | 5500 --------------- 6250
+	//         4000 ---------------|- 4999|
+	//                             |      |
+	//                          4990   <  5146
+	// from math import *
+	// from decimal import *
+	// # Range 1: From 5146 to 4999
+	// token_in = Decimal("1000000")
+	// swap_fee = Decimal("0.003")
+	// token_in_after_fee = token_in - (token_in * swap_fee)
+	// liq_1 = Decimal("4553647031.254531254265048947")
+	// sqrt_cur = Decimal("71.741384325871133645")
+	// sqrt_next_1 = Decimal("4999").sqrt()
+
+	// token_out_1 = liq_1 * (sqrt_cur - sqrt_next_1)
+	// token_in_1 = ceil(liq_1 * (sqrt_cur - sqrt_next_1) / (sqrt_next_1 * sqrt_cur))
+
+	// token_in = token_in_after_fee - token_in_1
+
+	// # Range 2: from 4999 till end
+	// liq_2 = Decimal("5224063246.973358697925449540")
+	// sqrt_next_2 = liq_2 / ((liq_2 / sqrt_next_1) + token_in)
+	// token_out_2 = liq_2 * (sqrt_next_1 - sqrt_next_2)
+	// token_in_2 = ceil(liq_2 * (sqrt_next_1 - sqrt_next_2) /
+	// 				  (sqrt_next_2 * sqrt_next_1))
+	// token_out = token_out_1 + token_out_2
+
+	// # Summary:
+	// print(sqrt_next_2)  # 70.64112736841825140176332377
+	// print(token_out)    # 5052068983.121266708067570832
+
+	// Get expected values from the calculations above
+	expectedSqrtPrice = osmomath.MustNewDecFromStr("70.64112736841825140176332377")
+	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
+	expectedTokenIn = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
+	expectedTokenOut = sdk.NewInt(5052068983)
+
+	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
+	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenIn, totalTokenIn.Amount))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenOut, totalTokenOut.Amount))
+
+	// Withdraw all narrow range positions
+	for _, positionId := range positionIds[1] {
+		position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(s.Ctx, positionId)
+		s.Require().NoError(err)
+		owner, err := sdk.AccAddressFromBech32(position.Address)
+		s.Require().NoError(err)
+		s.App.ConcentratedLiquidityKeeper.WithdrawPosition(s.Ctx, owner, positionId, position.Liquidity)
+	}
+
+	// Swap multiple times USDC for ETH, therefore increasing the spot price
+	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	s.Require().NoError(err)
+
+	// Depiction of the pool after the swaps (from 4990 to 5810), increasing the spot price
+	//								      >
+	//                             |        5500 -|------------- 6250
+	//         4000 ---------------|- 4999        |
+	//                             |              |
+	//                          4990      >       5810
+	// from math import *
+	// from decimal import *
+	// # Range 1: From 4990.16... to 4999
+	// token_in = Decimal("5000000000")
+	// swap_fee = Decimal("0.003")
+	// token_in_after_fee = token_in - (token_in * swap_fee)
+	// liq_1 = Decimal("670416215.718827443660400593")
+	// sqrt_cur = Decimal("70.641127368418251403")
+	// sqrt_next_1 = Decimal("4999").sqrt()
+
+	// token_out_1 = liq_1 * (sqrt_next_1 - sqrt_cur) / (sqrt_next_1 * sqrt_cur)
+	// token_in_1 = ceil(liq_1 * abs(sqrt_cur - sqrt_next_1))
+
+	// token_in = token_in_after_fee - token_in_1
+
+	// # Range 2: from 5500 till end
+	// sqrt_next_1 = Decimal("5500").sqrt()
+	// liq_2 = Decimal("2395534889.911016246446002272")
+	// sqrt_next_2 = sqrt_next_1 + token_in / liq_2
+
+	// token_out_2 = liq_2 * (sqrt_next_2 - sqrt_next_1) / (sqrt_next_1 * sqrt_next_2)
+	// token_in_2 = ceil(liq_2 * abs(sqrt_next_2 - sqrt_next_1))
+	// token_out = token_out_1 + token_out_2
+
+	// # Summary:
+	// print(sqrt_next_2)  # 76.22545423006231767390422658
+	// print(token_out)    # 882804.6589413517320313885494
+
+	// Get expected values from the calculations above
+	expectedSqrtPrice = osmomath.MustNewDecFromStr("76.22545423006231767390422658")
+	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
+	expectedTokenIn = swapCoin1.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
+	expectedTokenOut = sdk.NewInt(882804)
+
+	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
+	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenIn, totalTokenIn.Amount))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenOut, totalTokenOut.Amount))
+
+	// Withdraw all consecutive range position (in relation to narrow range position)
+	for _, positionId := range positionIds[2] {
+		position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(s.Ctx, positionId)
+		s.Require().NoError(err)
+		owner, err := sdk.AccAddressFromBech32(position.Address)
+		s.Require().NoError(err)
+		s.App.ConcentratedLiquidityKeeper.WithdrawPosition(s.Ctx, owner, positionId, position.Liquidity)
+	}
+
+	// Swap multiple times ETH for USDC, therefore decreasing the spot price
+	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	s.Require().NoError(err)
+
+	// Depiction of the pool after the swaps (from 5810 to 4093), decreasing the spot price
+	//                               <
+	//         4000 -|--------------- 4999          |
+	//				 |							    |
+	//            4093		         <	            5810
+	//
+	// from math import *
+	// from decimal import *
+	// liq = Decimal("670416215.718827443660400593")
+	// sqrt_cur = Decimal("4999").sqrt()
+	// token_in = Decimal("1000000")
+	// swap_fee = Decimal("0.003")
+	// token_in_after_fee = token_in * (Decimal("1") - swap_fee)
+	// sqrt_next = liq / ((liq / sqrt_cur) + token_in_after_fee)
+	// token_out = token_out = liq * (sqrt_cur - sqrt_next)
+
+	// # Summary:
+	// print(sqrt_next)  # 63.97671895942244949922335999
+	// print(token_out)  # 4509814620.762503497903902725
+
+	// Get expected values from the calculations above
+	expectedSqrtPrice = osmomath.MustNewDecFromStr("63.97671895942244949922335999")
+	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
+	expectedTokenIn = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
+	expectedTokenOut = sdk.NewInt(4509814620)
+
+	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
+	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenIn, totalTokenIn.Amount))
+	s.Require().Equal(0, multiplicativeTolerance.Compare(expectedTokenOut, totalTokenOut.Amount))
 }

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2830,7 +2830,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	// swap_fee = Decimal("0.003")
 	// token_in_after_fee = token_in * (Decimal("1") - swap_fee)
 	// sqrt_next = sqrt_cur + token_in_after_fee / liq
-	// token_out = token_out = liq * (sqrt_next - sqrt_cur) / (sqrt_cur * sqrt_next)
+	// token_out = liq * (sqrt_next - sqrt_cur) / (sqrt_cur * sqrt_next)
 
 	// # Summary:
 	// print(sqrt_next) # 71.74138432587113364823838192

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2759,7 +2759,6 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 		numConsecutive: 2,
 		numOverlapping: 1,
 	}
-
 	// Init suite.
 	s.Setup()
 

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2993,7 +2993,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	// swap_fee = Decimal("0.003")
 	// token_in_after_fee = token_in * (Decimal("1") - swap_fee)
 	// sqrt_next = liq / ((liq / sqrt_cur) + token_in_after_fee)
-	// token_out = token_out = liq * (sqrt_cur - sqrt_next)
+	// token_out = liq * (sqrt_cur - sqrt_next)
 
 	// # Summary:
 	// print(sqrt_next)  # 63.97671895942244949922335999


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4095 

This pull request adds a new `TestFunctionalSwaps` function to the `KeeperTestSuite`. This test function performs multiple swaps on a custom concentrated liquidity pool, tracking the resulting changes in the spot price and liquidity. The test covers various scenarios, including full range positions, narrow range positions, consecutive range positions, and overlapping range positions. 

The test ensures that the resulting spot price and liquidity changes match the expected values calculated beforehand, with a multiplicative tolerance of 0.0001%. 

## Brief Changelog

- Modifies `swapAndTrackXTimesInARow` function to also return the total `amountIn` and `amountOut` resulting from the x number of swaps specified
- Adds the `TestFunctionalSwaps` described above

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)