### PR TITLE
Replace Chain Schema Tendermint version with Consensus

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -11,7 +11,10 @@
       "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0/osmosisd-15.0.0-linux-arm64?checksum=sha256:94aee34e288148b155a2b0fdfe268a0bdc0d4a90de6db8f8a9cee74c2e829294"
     },
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "ibc_go_version": "4.3.0",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: (https://github.com/cosmos/chain-registry/pull/1740/files)

## What is the purpose of the change

Adapts Osmosis' version of chain schema to match Chain Registry


## Brief Changelog

specifically, changes the 'tendermint version' property to the 'consensus' object, which holds the same data.


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (/ no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (/ no)
  - How is the feature or change documented? (not documented)