### PR TITLE
fix(CL): incentives gov bug

### DIFF
--- a/x/concentrated-liquidity/store.go
+++ b/x/concentrated-liquidity/store.go
@@ -199,7 +199,7 @@ func ParseFullIncentiveRecordFromBz(key []byte, value []byte) (incentiveRecord t
 	incentiveDenom := relevantIncentiveKeyComponents[2]
 
 	// Note that we skip the first byte since we prefix addresses by length in key
-	incentiveCreator, err := sdk.AccAddressFromBech32(string(relevantIncentiveKeyComponents[3]))
+	incentiveCreator, err := sdk.AccAddressFromBech32(relevantIncentiveKeyComponents[3])
 	if err != nil {
 		return types.IncentiveRecord{}, err
 	}

--- a/x/concentrated-liquidity/store_test.go
+++ b/x/concentrated-liquidity/store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gogo/protobuf/proto"
 
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
@@ -138,4 +139,39 @@ func (s *KeeperTestSuite) TestParseFullTickFromBytes() {
 			}
 		})
 	}
+}
+
+// TestParseIncentiveRecordFromBytes_KeySeparatorInAddress validates that parsing
+// succeeds even if the address contains the key separator. This is ensured
+// by base64 encoding of the key separator.
+func (s *KeeperTestSuite) TestParseIncentiveRecordFromBytes_KeySeparatorInAddress() {
+	s.T().Skip()
+	s.Setup()
+
+	expectedIncentiveRecord := incentiveRecordOne
+	validValueBz, err := proto.Marshal(&expectedIncentiveRecord.IncentiveRecordBody)
+	s.Require().NoError(err)
+
+	uptimeIndex, err := cl.FindUptimeIndex(expectedIncentiveRecord.MinUptime)
+	s.Require().NoError(err)
+
+	incentiveRecordKey := types.KeyIncentiveRecord(expectedIncentiveRecord.PoolId, uptimeIndex, expectedIncentiveRecord.IncentiveDenom, sdk.AccAddress(expectedIncentiveRecord.IncentiveCreatorAddr))
+
+	// System under test with basic valid record.
+	record, err := cl.ParseFullIncentiveRecordFromBz(incentiveRecordKey, validValueBz)
+	s.Require().NoError(err)
+
+	s.Require().Equal(expectedIncentiveRecord, record)
+
+	// System under test with address containing a key separator.
+	keySeparatorAddress := sdk.AccAddress(fmt.Sprintf("__________%s________", types.KeySeparator))
+	expectedIncentiveRecord.IncentiveCreatorAddr = keySeparatorAddress.String()
+
+	incentiveRecordKey = types.KeyIncentiveRecord(expectedIncentiveRecord.PoolId, uptimeIndex, expectedIncentiveRecord.IncentiveDenom, keySeparatorAddress)
+
+	// System under test with address containing a key separator.
+	record, err = cl.ParseFullIncentiveRecordFromBz(incentiveRecordKey, validValueBz)
+	s.Require().NoError(err)
+
+	s.Require().Equal(expectedIncentiveRecord, record)
 }

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -12,7 +12,9 @@ const (
 	ModuleName = "concentratedliquidity"
 	RouterKey  = ModuleName
 
-	StoreKey     = ModuleName
+	StoreKey = ModuleName
+	// Note: KeySeparator must not be a valid character in base64 encoding
+	// Otherwise, it can break address byte deserialization.
 	KeySeparator = "|"
 
 	uint64ByteSize = 8


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixes the incentives bug stemming from serializing addresses as raw bytes. This would lead to raw bytes in the address being interpreted as our key separator and parsing problems.

This PR ensures that we write bech32 to disc. Bech32 is base32 encoded so it does not contain the key separator in its alphabet.

There is another problem PR stemming from #4526

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable 