### PR TITLE
prototype: estimate swap tick bound estimate

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,25 +6,14 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/tests/e2e",
+            "program": "${workspaceFolder}/x/concentrated-liquidity",
             "args": [
                 "-test.timeout",
                 "30m",
                 "-test.run",
-                "IntegrationTestSuite",
+                "TestKeeperTestSuite/TestFunctional_EstimateTickBound_OutGivenIn_Frontend",
                 "-test.v"
             ],
-            "buildFlags": "-tags e2e",
-            "env": {
-                "OSMOSIS_E2E": "True",
-                "OSMOSIS_E2E_SKIP_IBC": "true",
-                "OSMOSIS_E2E_SKIP_UPGRADE": "true",
-                "OSMOSIS_E2E_SKIP_CLEANUP": "true",
-                "OSMOSIS_E2E_SKIP_STATE_SYNC": "true",
-                "OSMOSIS_E2E_UPGRADE_VERSION": "v16",
-                "OSMOSIS_E2E_DEBUG_LOG": "false",
-            },
-            "preLaunchTask": "e2e-setup"
         }
     ]
 }

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/internal/math"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
+	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types/query"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
@@ -47,6 +48,8 @@ type SwapTest struct {
 	// since we use different values for the seondary position's tick, save (tick, expectedFeeGrowth) tuple
 	expectedSecondLowerTickFeeGrowth secondPosition
 	expectedSecondUpperTickFeeGrowth secondPosition
+
+	expectedLiquidityNet []query.TickLiquidityNet
 
 	newLowerPrice  sdk.Dec
 	newUpperPrice  sdk.Dec

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -401,7 +401,6 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 // },
 
 func (k Keeper) EstimateBoundTick() sdk.Int {
-
 	return sdk.ZeroInt()
 }
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -375,6 +375,36 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 	return liquidityDepths, nil
 }
 
+// //          		   5000
+// //  		   4545 -----|----- 5500
+// //  4000 ----------- 4545
+// "fee 3 - two positions with consecutive price ranges: eth -> usdc (5% fee)": {
+// 	// parameters and results of this test case
+// 	// are estimated by utilizing scripts from scripts/cl/main.py
+// 	tokenIn:                  sdk.NewCoin("eth", sdk.NewInt(2000000)),
+// 	tokenOutDenom:            "usdc",
+// 	priceLimit:               sdk.NewDec(4094),
+// 	swapFee:                  sdk.MustNewDecFromStr("0.05"),
+// 	secondPositionLowerPrice: sdk.NewDec(4000),
+// 	secondPositionUpperPrice: sdk.NewDec(4545),
+// 	// params
+// 	// expectedTokenIn:                   1101304.35717321706748347321599 + 898695.642826782932516526784010 = 2000000 eth
+// 	// expectedTokenOut:                  4999999999.99999999999999999970 + 3702563350.03654978405015422548 = 8702563350.03654978405015422518 round down = 8702.563350 usdc
+// 	// expectedFeeGrowthAccumulatorValue: 0.000034550151296760 + 0.0000374851520884196734228699332666 = 0.0000720353033851796734228699332666
+// 	expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(2000000)),
+// 	expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8691708221)),
+// 	expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000073738597832046"),
+// 	expectedTick:                      sdk.NewInt(301393),
+// 	expectedSqrtPrice:                 sdk.MustNewDecFromStr("64.336946417392457832"), // https://www.wolframalpha.com/input?i=%28%281198735489.597250295669959397%29%29+%2F+%28%28%281198735489.597250295669959397%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28851137.999999999999999999%29%29
+// 	newLowerPrice:                     sdk.NewDec(4000),
+// 	newUpperPrice:                     sdk.NewDec(4545),
+// },
+
+func (k Keeper) EstimateBoundTick() sdk.Int {
+
+	return sdk.ZeroInt()
+}
+
 func (k Keeper) getTickByTickIndex(ctx sdk.Context, poolId uint64, tickIndex sdk.Int) (model.TickInfo, error) {
 	store := ctx.KVStore(k.storeKey)
 	keyTick := types.KeyTick(poolId, tickIndex.Int64())

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1916,6 +1916,7 @@ func (s *KeeperTestSuite) TestFunctional_EstimateTickBound_OutGivenIn_Frontend()
 					LiquidityNet: sdk.MustNewDecFromStr("1199528406.187413669220031452"),
 					TickIndex:    sdk.NewInt(315010),
 				},
+				// It should be getting a third one - currently underestimates
 			},
 		},
 	}

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1808,17 +1808,17 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection_BoundTick() {
 }
 
 // This test estimates the calculation of the tick bound for estimate swap query on
-// fronend. We prototype and test it directly in Go code for the ease of setup.
+// frontend. We prototype and test it directly in Go code for the ease of setup.
 // It does not have to be exact but should be close enough to the actual calculation.
-// The goal is to estimate the bound tick to achive to goals:
-// - minimize the number of redunda+nt ticks the query has to fetch on top of what's required
+// The goal is to estimate the bound tick to achive two goals:
+// - minimize the number of redundant ticks the query has to fetch on top of what's required
 // by the swap estimate stemming from over estimating the bound tick.
 // - minimize the number of round trips (redundant queries) stemming from underestimating
 // the bound tick.
 //
 // For context, the e2e swap estimate is as follows:
 // 1. Assumme frontend has knowledge of the pool, its current tick, current sqrt price and active liquidity
-// Can get from Pools or Pool query
+// It can be fetched from Pools or Pool query
 //
 // 2. Swap amount in is provided by the user
 // For estimating tick bound in swap in given out, assume that amount out is the amount in.
@@ -1859,7 +1859,7 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection_BoundTick() {
 // b) use a variation of a binary search by doubling the earlier bound tick estimate until you query enoudh ticks
 // For re-querying, it is possible to start from the previous bound tick by setting start tick to the old bound tick value.
 //
-// 5. Estimate swap amount for price impact protection on FE.
+// 5. Estimate swap amount for price impact protection on frontend.
 // Having current active tick liquidity, amount in/out and liquidity net amounts from step 4, give enough
 // information to calculate the price impact protection.
 func (s *KeeperTestSuite) TestFunctional_EstimateTickBound_OutGivenIn_Frontend() {
@@ -1869,8 +1869,6 @@ func (s *KeeperTestSuite) TestFunctional_EstimateTickBound_OutGivenIn_Frontend()
 		//  		   4545 -----|----- 5500
 		//  4000 ----------- 4545
 		"copy of fee 3 swap out given in- two positions with consecutive price ranges: eth -> usdc (5% fee) (one for zero)": {
-			// parameters and results of this test case
-			// are estimated by utilizing scripts from scripts/cl/main.py
 			tokenIn:                  sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			tokenOutDenom:            "usdc",
 			priceLimit:               sdk.NewDec(4094),

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1877,15 +1877,12 @@ func (s *KeeperTestSuite) TestFunctional_EstimateTickBound_OutGivenIn_Frontend()
 			swapFee:                  sdk.MustNewDecFromStr("0.05"),
 			secondPositionLowerPrice: sdk.NewDec(4000),
 			secondPositionUpperPrice: sdk.NewDec(4545),
-			// params
-			// expectedTokenIn:                   1101304.35717321706748347321599 + 898695.642826782932516526784010 = 2000000 eth
-			// expectedTokenOut:                  4999999999.99999999999999999970 + 3702563350.03654978405015422548 = 8702563350.03654978405015422518 round down = 8702.563350 usdc
-			// expectedFeeGrowthAccumulatorValue: 0.000034550151296760 + 0.0000374851520884196734228699332666 = 0.0000720353033851796734228699332666
+
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8691708221)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000073738597832046"),
 			expectedTick:                      sdk.NewInt(301393),
-			expectedSqrtPrice:                 sdk.MustNewDecFromStr("64.336946417392457832"), // https://www.wolframalpha.com/input?i=%28%281198735489.597250295669959397%29%29+%2F+%28%28%281198735489.597250295669959397%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28851137.999999999999999999%29%29
+			expectedSqrtPrice:                 sdk.MustNewDecFromStr("64.336946417392457832"),
 			newLowerPrice:                     sdk.NewDec(4000),
 			newUpperPrice:                     sdk.NewDec(4545),
 			expectedLiquidityNet: []query.TickLiquidityNet{
@@ -1903,8 +1900,6 @@ func (s *KeeperTestSuite) TestFunctional_EstimateTickBound_OutGivenIn_Frontend()
 		//  4545 -----|----- 5500
 		// 			   5501 ----------- 6250
 		"copy of fee 6 swap out given in - two sequential positions with a gap usdc -> eth (3% fee) (zero for one)": {
-			// parameters and results of this test case
-			// are estimated by utilizing scripts from scripts/cl/main.py
 			tokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			tokenOutDenom:            "eth",
 			priceLimit:               sdk.NewDec(6106),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4804

## What is the purpose of the change

This is a prototype for estimating the bound tick of the liquidity net in direction query: https://github.com/osmosis-labs/osmosis/pull/4714

The description in the added test explains the thought process in detail. In the tests, the algorithm ends up being quite off. It falls back to using the max/min tick in zero for one case and underestimates the tick in the one for zero case.

However, this should not be the case in production for the following reasons:
a) We expect to have many positions
b) Positions are concentrated around the active tick
c) The liquidity around the active tick is roughly uniform
d) An average swap isn't going to swap the active sqrt price significantly

Currently, we don't have a setup that reproduces the above economic assumptions. As a result, this is not an accurate test of the algorithm.

I think we should keep using the min/max bound for testing frontend for now. As we move closer to having a realistic setup, we can start utilizing the algorithm proposed here.