### PR TITLE
Add codeowners for auto-assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+app/wasm/**/* @nicolaslara @czarcas7ic
+x/concentrated-liquidity/**/* @czarcas7ic @p0mvn
+x/downtime-detector/**/* @nicolaslara
+x/epochs/**/* @mattverse @nicolaslara
+x/gamm/**/* @mattverse @czarcas7ic @p0mvn
+x/incentives/**/* @mattverse @p0mvn
+x/lockup/**/* @mattverse @stackman27 @czarcas7ic
+x/mint/**/* @p0mvn
+x/pool-incentives/**/* @czarcas7ic @p0mvn
+x/poolmanager/**/* @czarcas7ic @p0mvn @mattverse
+x/protorev/**/* @p0mvn
+x/superfluid/**/* @mattverse @stackman27
+x/tokenfactory/**/* @mattverse @nicolaslara @p0mvn
+x/twap/**/* @nicolaslara @p0mvn
+x/txfees/**/* @nicolaslara @p0mvn
+x/valset-pref/**/* @mattverse @stackman27
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,23 @@
 app/wasm/**/* @nicolaslara @czarcas7ic
-x/concentrated-liquidity/**/* @czarcas7ic @p0mvn
-x/downtime-detector/**/* @nicolaslara
-x/epochs/**/* @mattverse @nicolaslara
-x/gamm/**/* @mattverse @czarcas7ic @p0mvn
-x/incentives/**/* @mattverse @p0mvn
-x/lockup/**/* @mattverse @stackman27 @czarcas7ic
-x/mint/**/* @p0mvn
-x/pool-incentives/**/* @czarcas7ic @p0mvn
-x/poolmanager/**/* @czarcas7ic @p0mvn @mattverse
-x/protorev/**/* @p0mvn
-x/superfluid/**/* @mattverse @stackman27
-x/tokenfactory/**/* @mattverse @nicolaslara @p0mvn
-x/twap/**/* @nicolaslara @p0mvn
-x/txfees/**/* @nicolaslara @p0mvn
-x/valset-pref/**/* @mattverse @stackman27
+x/concentrated-liquidity/ @czarcas7ic @p0mvn
+x/downtime-detector/ @nicolaslara
+x/epochs/ @mattverse @nicolaslara
+x/gamm/ @mattverse @czarcas7ic @p0mvn
+x/incentives/ @mattverse @p0mvn
+x/lockup/ @mattverse @stackman27 @czarcas7ic
+x/mint/ @p0mvn
+x/pool-incentives/ @czarcas7ic @p0mvn
+x/poolmanager/ @czarcas7ic @p0mvn @mattverse
+x/protorev/ @p0mvn
+x/superfluid/ @mattverse @stackman27
+x/tokenfactory/ @mattverse @nicolaslara @p0mvn
+x/twap/ @nicolaslara @p0mvn
+x/txfees/ @nicolaslara @p0mvn
+x/valset-pref/ @mattverse @stackman27
 
+/.github/ @osmosis-labs/devops
+Dockerfile @osmosis-labs/devops
+.dockerignore @osmosis-labs/devops
+Makefile @osmosis-labs/devops
+/tests/localosmosis/ @osmosis-labs/devops
+/tests/localrelayer/ @osmosis-labs/devops

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -15,6 +15,7 @@ var emptyCoins = sdk.DecCoins(nil)
 // createFeeAccumulator creates an accumulator object in the store using the given poolId.
 // The accumulator is initialized with the default(zero) values.
 func (k Keeper) createFeeAccumulator(ctx sdk.Context, poolId uint64) error {
+	// change for testing
 	err := accum.MakeAccumulator(ctx.KVStore(k.storeKey), types.KeyFeePoolAccumulator(poolId))
 	if err != nil {
 		return err

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -15,7 +15,6 @@ var emptyCoins = sdk.DecCoins(nil)
 // createFeeAccumulator creates an accumulator object in the store using the given poolId.
 // The accumulator is initialized with the default(zero) values.
 func (k Keeper) createFeeAccumulator(ctx sdk.Context, poolId uint64) error {
-	// change for testing
 	err := accum.MakeAccumulator(ctx.KVStore(k.storeKey), types.KeyFeePoolAccumulator(poolId))
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/4415

## What is the purpose of the change
Auto assigns designated group of people as reviewers depending on the module responsibilities.
For example, a change to CL module gets auto-assigned to people who have signed up for CL reviews beforehand.

## Brief Changelog
Add codeowners for auto-assignment

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)