### PR TITLE
Protorev: Backrun pool join and exit messages

### DIFF
--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -903,6 +903,126 @@ func (suite *KeeperTestSuite) TestExtractSwappedPools() {
 			},
 			expectPass: true,
 		},
+		{
+			name: "Single JoinSwapExternAmountIn in 2-asset pool",
+			params: param{
+				msgs: []sdk.Msg{
+					&gammtypes.MsgJoinSwapExternAmountIn{
+						Sender:            addr0.String(),
+						PoolId:            1,
+						TokenIn:           sdk.NewCoin("Atom", sdk.NewInt(100)),
+						ShareOutMinAmount: sdk.NewInt(1),
+					},
+				},
+				txFee:              sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(10000))),
+				minGasPrices:       sdk.NewDecCoins(),
+				gasLimit:           500000,
+				isCheckTx:          false,
+				baseDenomGas:       true,
+				expectedNumOfPools: 1,
+				expectedSwappedPools: []keeper.SwapToBackrun{
+					{
+						PoolId:        1,
+						TokenOutDenom: "akash",
+						TokenInDenom:  "Atom",
+					},
+				},
+			},
+			expectPass: true,
+		},
+		{
+			name: "Single MsgJoinSwapShareAmountOut in 4-asset pool",
+			params: param{
+				msgs: []sdk.Msg{
+					&gammtypes.MsgJoinSwapShareAmountOut{
+						Sender:           addr0.String(),
+						PoolId:           31,
+						TokenInDenom:     "Atom",
+						ShareOutAmount:   sdk.NewInt(100),
+						TokenInMaxAmount: sdk.NewInt(10000),
+					},
+				},
+				txFee:              sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(10000))),
+				minGasPrices:       sdk.NewDecCoins(),
+				gasLimit:           500000,
+				isCheckTx:          false,
+				baseDenomGas:       true,
+				expectedNumOfPools: 3,
+				expectedSwappedPools: []keeper.SwapToBackrun{
+					{
+						PoolId:        31,
+						TokenOutDenom: "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+						TokenInDenom:  "Atom",
+					},
+					{
+						PoolId:        31,
+						TokenOutDenom: "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+						TokenInDenom:  "Atom",
+					},
+					{
+						PoolId:        31,
+						TokenOutDenom: "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+						TokenInDenom:  "Atom",
+					},
+				},
+			},
+			expectPass: true,
+		},
+		{
+			name: "Single ExitSwapExternAmountOut in 2-asset pool",
+			params: param{
+				msgs: []sdk.Msg{
+					&gammtypes.MsgExitSwapExternAmountOut{
+						Sender:           addr0.String(),
+						PoolId:           1,
+						TokenOut:         sdk.NewCoin("akash", sdk.NewInt(100)),
+						ShareInMaxAmount: sdk.NewInt(1),
+					},
+				},
+				txFee:              sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(10000))),
+				minGasPrices:       sdk.NewDecCoins(),
+				gasLimit:           500000,
+				isCheckTx:          false,
+				baseDenomGas:       true,
+				expectedNumOfPools: 1,
+				expectedSwappedPools: []keeper.SwapToBackrun{
+					{
+						PoolId:        1,
+						TokenOutDenom: "akash",
+						TokenInDenom:  "Atom",
+					},
+				},
+			},
+			expectPass: true,
+		},
+		{
+			name: "Single MsgExitSwapShareAmountIn in 2-asset pool",
+			params: param{
+				msgs: []sdk.Msg{
+					&gammtypes.MsgExitSwapShareAmountIn{
+						Sender:            addr0.String(),
+						PoolId:            1,
+						TokenOutDenom:     "akash",
+						ShareInAmount:     sdk.NewInt(10),
+						TokenOutMinAmount: sdk.NewInt(1),
+					},
+				},
+				txFee:              sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(10000))),
+				minGasPrices:       sdk.NewDecCoins(),
+				gasLimit:           500000,
+				isCheckTx:          false,
+				baseDenomGas:       true,
+				expectedNumOfPools: 1,
+				expectedSwappedPools: []keeper.SwapToBackrun{
+					{
+						PoolId:        1,
+						TokenOutDenom: "akash",
+						TokenInDenom:  "Atom",
+					},
+				},
+			},
+			expectPass: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -566,6 +566,8 @@ func (suite *KeeperTestSuite) TestExtractSwappedPools() {
 	acc1 := suite.App.AccountKeeper.NewAccountWithAddress(suite.Ctx, addr0)
 	suite.App.AccountKeeper.SetAccount(suite.Ctx, acc1)
 
+	protoRevDecorator := keeper.NewProtoRevDecorator(*suite.App.ProtoRevKeeper)
+
 	tests := []struct {
 		name       string
 		params     param
@@ -937,7 +939,7 @@ func (suite *KeeperTestSuite) TestExtractSwappedPools() {
 
 			tx := txBuilder.GetTx()
 
-			swappedPools := keeper.ExtractSwappedPools(tx)
+			swappedPools := protoRevDecorator.ProtoRevKeeper.ExtractSwappedPools(suite.Ctx, tx)
 			if tc.expectPass {
 				suite.Require().Equal(tc.params.expectedNumOfPools, len(swappedPools))
 				suite.Require().Equal(tc.params.expectedSwappedPools, swappedPools)

--- a/x/protorev/protorev.md
+++ b/x/protorev/protorev.md
@@ -227,7 +227,7 @@ type GenesisState struct {
 
 # State Transitions
 
-The `protorev` module triggers state transitions in the `postHandler` , governance proposals, and admin account transactions. After each `sdk.Tx`, the `postHandler` will determine whether there were any `MsgSwapExactAmountIn` or `MsgSwapExactAmountOut` in the transaction. If so, the module gets all of the pools that were used in the swap(s), temporarily stores the pool ids accessed along with their respective tokenIn/tokenOut denoms, and then builds cyclic arbitrage routes for each pool swapped against.
+The `protorev` module triggers state transitions in the `postHandler` , governance proposals, and admin account transactions. After each `sdk.Tx`, the `postHandler` will determine whether there were any `MsgSwapExactAmountIn`, `MsgSwapExactAmountOut`, `MsgJoinSwapExternAmountIn`, `MsgJoinSwapShareAmountOut`, `MsgExitSwapExternAmountOut`, or `MsgExitSwapShareAmountIn` in the transaction. If so, the module gets all of the pools that were used in the swap(s), temporarily stores the pool ids accessed along with their respective tokenIn/tokenOut denoms, and then builds cyclic arbitrage routes for each pool swapped against.
 
 ## Route Generation
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- After this change, ProtoRev will be able to backrun join and exit pool messages  that swap within their own internal logic. 
- Previously, this was not the case and searchers were successfully arbing these messages while ProtoRev was live.

## Brief Changelog

- Antehandler now looks for -- MsgJoinSwapExternAmountIn, MsgJoinSwapShareAmountOut, MsgExitSwapExternAmountOut, MsgExitSwapShareAmountIn -- when extracting swapped pools.
- Adds two additional extraction logic functions to extract pools given join and exit messages


## Testing and Verifying

- All current tests still pass (after a slight modification since ExtractSwappedPools now uses the keeper)
- New unit tests added to ExtractSwappedPools function for all new message types supported

## Documentation and Release Note

- Update protorev.md documentation to account for new messages supported