### PR TITLE
Fix pool incentives genesis to support Concentrated Liquidity Pools

### DIFF
--- a/x/pool-incentives/keeper/genesis_test.go
+++ b/x/pool-incentives/keeper/genesis_test.go
@@ -36,6 +36,20 @@ var (
 				},
 			},
 		},
+		PoolToGauges: &types.PoolToGauges{
+			PoolToGauge: []types.PoolToGauge{
+				{
+					PoolId:   1,
+					GaugeId:  1,
+					Duration: time.Second,
+				},
+				{
+					PoolId:   2,
+					GaugeId:  2,
+					Duration: time.Second,
+				},
+			},
+		},
 	}
 )
 

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -110,7 +110,7 @@ func (k Keeper) CreateConcentratedLiquidityPoolGauge(ctx sdk.Context, poolId uin
 		sdk.Coins{},
 		// dummy variable so that the existing logic does not break
 		// CreateGauge checks if LockQueryType is `ByDuration` or not, we bypass this check by passing
-		// lockQueryType as byTime. Although we donot need this check, we still cannot pass empty struct.
+		// lockQueryType as byTime. Although we do not need this check, we still cannot pass empty struct.
 		lockuptypes.QueryCondition{
 			LockQueryType: lockuptypes.ByTime,
 			Denom:         appparams.BaseCoinUnit,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/4770

## What is the purpose of the change
Currently, export genesis would fail, as we do not have the logic to support CL pools in the pool incentives export genesis. 
This PR fixes it so that in export genesis, we check if it's a CL pool, if so handle it accordingly.


## Brief Changelog

- Fix pool incentives genesis to support Concentrated Liquidity Pools

## Testing and Verifying
Test cases have been fixed

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)