### PR TITLE
Refactor Makefile, update build and install targets, and fix Node.js conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
-DOCKER := $(shell which docker)
+GO_MODULE := $(shell cat go.mod | grep module | cut -d ' ' -f 2)
 BUILDDIR ?= $(CURDIR)/build
+DOCKER := $(shell which docker)
 E2E_UPGRADE_VERSION := "v16"
 
 
@@ -87,21 +88,23 @@ endif
 ###############################################################################
 
 check_version:
-ifneq ($(GO_MINOR_VERSION),20)
+ifneq ($(GO_MINOR_VERSION),19)
 	@echo "ERROR: Go version 1.20 is required for this version of Osmosis."
 	exit 1
 endif
 
 all: install lint test
 
-BUILD_TARGETS := build install
-
-build: BUILD_ARGS=-o $(BUILDDIR)/
-
-$(BUILD_TARGETS): check_version go.sum $(BUILDDIR)/
-	GOWORK=off go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
-$(BUILDDIR)/:
+build: check_version go.sum
 	mkdir -p $(BUILDDIR)/
+	GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/ $(GO_MODULE)/cmd/osmosisd
+
+build-all: check_version go.sum
+	mkdir -p $(BUILDDIR)/
+	GOWORK=off go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./...
+
+install: check_version go.sum
+	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 
 # Cross-building for arm64 from amd64 (or viceversa) takes
 # a lot of time due to QEMU virtualization but it's the only way (afaik)


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis/issues/3125

## What is the purpose of the change

This PR refactors the Makefile to simplify the build and install process, as well as address an issue where the `make install` command may cause a conflict with Node.js's `node` command.

Now the `make build` (`make install`) command builds (installs) only the `osmosisd` binary while a new tag `make build-all` builds all the binaries in the repo (`chain`, `node`, `osmosisd`, `querygen`).

## Brief Changelog

The changes include:

- Remove unnecessary targets and simplify the structure of the Makefile
- Introduce `GO_MODULE` variable to automatically extract the module path from the go.mod file
- Update build target to use `GO_MODULE` variable and build the `osmosisd` package directly
- Add a new `build-all` target to build all packages in the current directory and its subdirectories, similar to the original build target
- Update install target to use `GO_MODULE` variable and install the `osmosisd` package alone, avoiding conflicts with Node.js's node command

These changes make the Makefile more concise, improve maintainability, simplify the build and install process, and resolve the conflict with Node.js's node command.

## Testing and Verifying

New `build` target:

```bash
❯  make build

mkdir -/github.com/osmosis-labs/osmosis-build/build/

GOWORK=off go build -mod=readonly  -tags "netgo ledger" \
-ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=osmosis \
-X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd \
-X github.com/cosmos/cosmos-sdk/version.Version=crosschain-swaps-v1.0.0-210-g95bb54e84 \
-X github.com/cosmos/cosmos-sdk/version.Commit=95bb54e8490a4961ea57987f613028b49632ba39 \
-X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" \
-w -s' -trimpath -o /github.com/osmosis-labs/osmosis-build/build/ github.com/osmosis-labs/osmosis/v15/cmd/osmosisd
```

New `build-all` target:

```bash
❯ make build-all

mkdir -p /github.com/osmosis-labs/osmosis-build/build/

GOWORK=off go build -mod=readonly -tags "netgo ledger" \
-ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=osmosis \
-X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd \
-X github.com/cosmos/cosmos-sdk/version.Version=crosschain-swaps-v1.0.0-210-g95bb54e84 \
-X github.com/cosmos/cosmos-sdk/version.Commit=95bb54e8490a4961ea57987f613028b49632ba39 \
-X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" \
-w -s' -trimpath -o /github.com/osmosis-labs/osmosis-build/build/ ./...
```

Old `make build` (same as the new `make build-all`) command:

```bash
# Old version
❯ make build 

GOWORK=off go build -mod=readonly -tags "netgo ledger" \
-ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=osmosis \
-X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd \
-X github.com/cosmos/cosmos-sdk/version.Version=15.0.0 \
-X github.com/cosmos/cosmos-sdk/version.Commit=ff18d8244fcda7313ec951fb1b3bee8369b8316b \
-X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" \
-w -s' -trimpath -o /github.com/osmosis-labs/osmosis/build/ ./...
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable   