### PR TITLE
remove redundant line

### DIFF
--- a/x/ibc-hooks/client/cli/query.go
+++ b/x/ibc-hooks/client/cli/query.go
@@ -35,7 +35,6 @@ func GetQueryCmd() *cobra.Command {
 		RunE:                       indexRunCmd,
 	}
 
-	cmd.Short = fmt.Sprintf("Querying commands for the %s module", types.ModuleName)
 	cmd.AddCommand(
 		GetCmdWasmSender(),
 	)


### PR DESCRIPTION
adding this line is not necessary:
[`cmd.Short = fmt.Sprintf("Querying commands for the %s module", types.ModuleName)`](https://github.com/osmosis-labs/osmosis/blob/main/x/ibc-hooks/client/cli/query.go#L32)

because the above already has:
[`Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),`](https://github.com/osmosis-labs/osmosis/blob/main/x/ibc-hooks/client/cli/query.go#L38)
