### PR TITLE
[CL] Fix `concentratedliquidity create-position` command in localosmosis

### DIFF
--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -154,7 +154,7 @@ create_concentrated_pool_positions () {
     COUNTER=0
     # Loop through each set of parameters in the array
     for param in "$@"; do
-        run_with_retries "osmosisd tx concentratedliquidity create-position $param 5000000000uosmo 1000000uion 0 0 0 --pool-id=4 --from pools --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --fees 5000uosmo --gas 900000 --yes"
+        run_with_retries "osmosisd tx concentratedliquidity create-position $param 5000000000uosmo 1000000uion 0 0 --pool-id=4 --from pools --chain-id=$CHAIN_ID --home $OSMOSIS_HOME --keyring-backend=test -b block --fees 5000uosmo --gas 900000 --yes"
     done
 }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR removes the extra arg in the command:

```bash
osmosisd concentratedliquidity create-position ...`
```

used in localosmosis to create some test positions.

## Brief Changelog

- Update `setup.sh` in localosmosis

## Testing and Verifying

- `make localnet-start-with-state`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no 
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable