### PR TITLE
(CL) `make localnet-cl-create-positions` fix: concurrency issue

### DIFF
--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -25,7 +25,7 @@ import (
 const (
 	expectedPoolId     uint64 = 1
 	addressPrefix             = "osmo"
-	clientHomePath            = "/root/.osmosisd-local"
+	clientHomePath            = "/Users/jonator/.osmosisd-local"
 	consensusFee              = "1500uosmo"
 	denom0                    = "uosmo"
 	denom1                    = "uion"
@@ -40,6 +40,7 @@ var (
 	defaultAccountName = fmt.Sprintf("%s%d", accountNamePrefix, 1)
 	exponentAtPriceOne = sdk.OneInt().Neg()
 	defaultMinAmount   = sdk.ZeroInt()
+	accountMutex sync.Mutex
 )
 
 func main() {
@@ -142,9 +143,13 @@ func createPool(igniteClient cosmosclient.Client, accountName string) uint64 {
 }
 
 func createPosition(client cosmosclient.Client, poolId uint64, senderKeyringAccountName string, lowerTick int64, upperTick int64, tokenDesired0, tokenDesired1 sdk.Coin, tokenMinAmount0, tokenMinAmount1 sdk.Int) (amountCreated0, amountCreated1 sdk.Int, liquidityCreated sdk.Dec) {
+	accountMutex.Lock() // Lock access to getAccountAddressFromKeyring
+	senderAddress := getAccountAddressFromKeyring(client, senderKeyringAccountName)
+	accountMutex.Unlock() // Unlock access to getAccountAddressFromKeyring
+
 	msg := &cltypes.MsgCreatePosition{
 		PoolId:          poolId,
-		Sender:          getAccountAddressFromKeyring(client, senderKeyringAccountName),
+		Sender:          senderAddress,
 		LowerTick:       lowerTick,
 		UpperTick:       upperTick,
 		TokenDesired0:   tokenDesired0,
@@ -153,6 +158,7 @@ func createPosition(client cosmosclient.Client, poolId uint64, senderKeyringAcco
 		TokenMinAmount1: tokenMinAmount1,
 	}
 	txResp, err := client.BroadcastTx(senderKeyringAccountName, msg)
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## What is the purpose of the change

Multiple go routines (threads) were trying to access the ignite client account info at the same time. I use a Mutex to avoid routes from trying to access the same memory at the same time and throwing exceptions.

```go
package main

// ... (existing imports) ...

import "sync"

// ... (existing constants and variables) ...

var (
    // ... (other existing variables) ...
    accountMutex sync.Mutex
)

// ... (rest of the existing code) ...

func createPosition(client cosmosclient.Client, poolId uint64, senderKeyringAccountName string, lowerTick int64, upperTick int64, tokenDesired0, tokenDesired1 sdk.Coin, tokenMinAmount0, tokenMinAmount1 sdk.Int) (amountCreated0, amountCreated1 sdk.Int, liquidityCreated sdk.Dec) {
    accountMutex.Lock() // Lock access to getAccountAddressFromKeyring
    senderAddress := getAccountAddressFromKeyring(client, senderKeyringAccountName)
    accountMutex.Unlock() // Unlock access to getAccountAddressFromKeyring

    msg := &cltypes.MsgCreatePosition{
        PoolId:          poolId,
        Sender:          senderAddress,
        LowerTick:       lowerTick,
        UpperTick:       upperTick,
        TokenDesired0:   tokenDesired0,
        TokenDesired1:   tokenDesired1,
        TokenMinAmount0: tokenMinAmount0,
        TokenMinAmount1: tokenMinAmount1,
    }
    // ... (rest of the existing function) ...
}
```

## Brief Changelog

* Add global mutex var

## Testing and Verifying

* I no longer get exceptions (seg faults)

However, there are still issues with sequence numbers after several hundred positions are created. I tried unlocking the Mutex after the broadcast but since that's a very slow operation, it causes the Mutex lock to be held a long time, defeating any benefits of concurrency. Also, it may have been causing a deadlock, resulting in even slower processing times then a serial solution.