### PR TITLE
fix(CL): invalid sqrt price initialization breaking liquidity net in direction query

### DIFF
--- a/tests/cl-go-client/README.md
+++ b/tests/cl-go-client/README.md
@@ -13,7 +13,12 @@ setting up a concentrated liquidity pool with positions.
 
 Make sure that you run `localosmosis` in the background and have keys
 added to your keyring with:
+
 ```bash
+make set-env localosmosis # sets environment to $HOME/.osmosisd-local
+
+make localnet-start
+
 make localnet-keys
 ```
 
@@ -22,14 +27,10 @@ See `tests/localosmosis` for more info.
 ## Running
 
 ```bash
-go run tests/cl-go-client/main.go
+make localnet-cl-create-positions
 ```
 
 In the current state, it does the following:
 - Queries status of the chain to make sure it's running.
 - Queries pool with id 1. If does not exist, creates it
 - Sets up one CL position
-
-## TODOs
-
-- Create many positions across multiple accounts with randomized parameters.

--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -71,10 +71,12 @@ func main() {
 	// Instantiate a query client
 	clQueryClient := poolmanagerqueryproto.NewQueryClient(igniteClient.Context())
 
-	// Print warnings
+	// Print warnings with common problems
 	log.Println(fmt.Sprintf("\n\n\nWARNING 1: your localosmosis and client home are assummed to be %s. Run 'osmosisd get-env' and confirm it matches the path you see printed here\n\n\n", clientHome))
 
 	log.Println(fmt.Sprintf("\n\n\nWARNING 2: you are attempting to interact with pool id %d.\nConfirm that the pool exists. if this is not the pool you want to interact with, please change the expectedPoolId variable in the code\n\n\n", expectedPoolId))
+
+	log.Println("\n\n\nWARNING 3: sometimes the script hangs when just started. In that case, kill it and restart\n\n\n")
 
 	// Query pool with id 1 and create new if does not exist.
 	_, err = clQueryClient.Pool(ctx, &poolmanagerqueryproto.PoolRequest{PoolId: expectedPoolId})

--- a/x/concentrated-liquidity/grpc_query.go
+++ b/x/concentrated-liquidity/grpc_query.go
@@ -212,7 +212,7 @@ func (q Querier) LiquidityNetInDirection(goCtx context.Context, req *clquery.Que
 		return nil, err
 	}
 
-	return &clquery.QueryLiquidityNetInDirectionResponse{LiquidityDepths: liquidityDepths, CurrentLiquidity: pool.GetLiquidity()}, nil
+	return &clquery.QueryLiquidityNetInDirectionResponse{LiquidityDepths: liquidityDepths, CurrentLiquidity: pool.GetLiquidity(), CurrentTick: pool.GetCurrentTick().Int64()}, nil
 }
 
 func (q Querier) ClaimableFees(ctx context.Context, req *clquery.QueryClaimableFeesRequest) (*clquery.QueryClaimableFeesResponse, error) {

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -306,7 +306,7 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 		return types.InitialLiquidityZeroError{Amount0: amount0Desired, Amount1: amount1Desired}
 	}
 
-	initialSpotPrice := osmomath.NewBigDec(amount1Desired.Int64()).Quo(osmomath.NewBigDec(amount0Desired.Int64()))
+	initialSpotPrice := osmomath.BigDecFromSDKDec(amount1Desired.ToDec()).Quo(osmomath.BigDecFromSDKDec((amount0Desired.ToDec())))
 
 	// Calculate the initial tick from the initial spot price
 	initialTick, err := math.PriceToTick(initialSpotPrice.SDKDec(), pool.GetExponentAtPriceOne())

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -8,6 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/internal/math"
 	types "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
@@ -305,15 +306,17 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 		return types.InitialLiquidityZeroError{Amount0: amount0Desired, Amount1: amount1Desired}
 	}
 
-	// Calculate the spot price and sqrt price from the amount provided
-	initialSpotPrice := amount1Desired.ToDec().Quo(amount0Desired.ToDec())
-	initialSqrtPrice, err := initialSpotPrice.ApproxSqrt()
+	initialSpotPrice := osmomath.NewBigDec(amount1Desired.Int64()).Quo(osmomath.NewBigDec(amount0Desired.Int64()))
+
+	// Calculate the initial tick from the initial spot price
+	initialTick, err := math.PriceToTick(initialSpotPrice.SDKDec(), pool.GetExponentAtPriceOne())
 	if err != nil {
 		return err
 	}
 
-	// Calculate the initial tick from the initial spot price
-	initialTick, err := math.PriceToTick(initialSpotPrice, pool.GetExponentAtPriceOne())
+	// Re-Calculate the spot price from initial tick so that it is aligned with out internal
+	// tick to price conversion.
+	initialSqrtPrice, err := math.TickToSqrtPrice(initialTick, pool.GetExponentAtPriceOne())
 	if err != nil {
 		return err
 	}

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -314,7 +314,7 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 		return err
 	}
 
-	// Re-Calculate the spot price from initial tick so that it is aligned with out internal
+	// Re-Calculate the spot price from initial tick so that it is aligned with our internal
 	// tick to price conversion.
 	initialSqrtPrice, err := math.TickToSqrtPrice(initialTick, pool.GetExponentAtPriceOne())
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Liquidity net in direction query was breaking in some cases due to a failing current square root price check.

Apparently, the pool's current square root price did not translate to the current tick correctly.

This is because we used an inaccurate `ApproxSqrt` function in initialization. Instead, this change initializes the current square root price by using our internal math functions to translate it from the current tick.

On quick test, was unable to reproduce the problem anymore.

Also, added some debug logs to the query for easier debugging if the error persists.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable