### PR TITLE
[x/txfees] Use TWAP for tx fees conversion instead of spotPrice

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -349,6 +349,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.BankKeeper,
 		appKeepers.keys[txfeestypes.StoreKey],
 		appKeepers.PoolManagerKeeper,
+		appKeepers.TwapKeeper,
 		appKeepers.GAMMKeeper,
 	)
 	appKeepers.TxFeesKeeper = &txFeesKeeper

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -16,10 +16,6 @@ type (
 	GeometricTwapStrategy  = geometric
 )
 
-func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
-	k.storeNewRecord(ctx, record)
-}
-
 func (k Keeper) GetMostRecentRecordStoreRepresentation(ctx sdk.Context, poolId uint64, asset0Denom string, asset1Denom string) (types.TwapRecord, error) {
 	return k.getMostRecentRecordStoreRepresentation(ctx, poolId, asset0Denom, asset1Denom)
 }

--- a/x/twap/keeper.go
+++ b/x/twap/keeper.go
@@ -65,7 +65,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	})
 
 	for _, twap := range genState.Twaps {
-		k.storeNewRecord(ctx, twap)
+		k.StoreNewRecord(ctx, twap)
 	}
 }
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -93,7 +93,7 @@ func (k Keeper) afterCreatePool(ctx sdk.Context, poolId uint64) error {
 		// that there is a swap against this pool in this same block.
 		// furthermore, this protects against an edge case where a pool is created
 		// during EndBlock, after twapkeeper's endblock.
-		k.storeNewRecord(ctx, record)
+		k.StoreNewRecord(ctx, record)
 	}
 	k.trackChangedPool(ctx, poolId)
 	return err
@@ -145,7 +145,7 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 
 	for _, record := range records {
 		newRecord := k.updateRecord(ctx, record)
-		k.storeNewRecord(ctx, newRecord)
+		k.StoreNewRecord(ctx, newRecord)
 	}
 	return nil
 }

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -163,7 +163,7 @@ func (k Keeper) getAllHistoricalPoolIndexedTWAPs(ctx sdk.Context) ([]types.TwapR
 }
 
 // storeNewRecord stores a record, in both the most recent record store and historical stores.
-func (k Keeper) storeNewRecord(ctx sdk.Context, twap types.TwapRecord) {
+func (k Keeper) StoreNewRecord(ctx sdk.Context, twap types.TwapRecord) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.FormatMostRecentTWAPKey(twap.PoolId, twap.Asset0Denom, twap.Asset1Denom)
 	osmoutils.MustSet(store, key, &twap)

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -48,7 +48,7 @@ func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (sdk.Dec, e
 		return sdk.Dec{}, err
 	}
 
-	// since twap only keeps track of values within 48 hours
+	// since twap only keeps track of records within 48 hours
 	spotPrice, err := k.twapKeeper.GetArithmeticTwapToNow(ctx, feeToken.PoolID, feeToken.Denom, baseDenom, ctx.BlockTime().Add(-48*time.Hour))
 	if err != nil {
 		return sdk.Dec{}, err

--- a/x/txfees/keeper/keeper.go
+++ b/x/txfees/keeper/keeper.go
@@ -17,6 +17,7 @@ type Keeper struct {
 	accountKeeper       types.AccountKeeper
 	bankKeeper          types.BankKeeper
 	poolManager         types.PoolManager
+	twapKeeper          types.TwapKeeper
 	spotPriceCalculator types.SpotPriceCalculator
 }
 
@@ -27,6 +28,7 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	storeKey sdk.StoreKey,
 	poolManager types.PoolManager,
+	twapKeeper types.TwapKeeper,
 	spotPriceCalculator types.SpotPriceCalculator,
 ) Keeper {
 	return Keeper{
@@ -34,6 +36,7 @@ func NewKeeper(
 		bankKeeper:          bankKeeper,
 		storeKey:            storeKey,
 		poolManager:         poolManager,
+		twapKeeper:          twapKeeper,
 		spotPriceCalculator: spotPriceCalculator,
 	}
 }

--- a/x/txfees/types/expected_keepers.go
+++ b/x/txfees/types/expected_keepers.go
@@ -1,10 +1,13 @@
 package types
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
+	twaptypes "github.com/osmosis-labs/osmosis/v15/x/twap/types"
 )
 
 // SpotPriceCalculator defines the contract that must be fulfilled by a spot price calculator
@@ -56,4 +59,16 @@ type TxFeesKeeper interface {
 	ConvertToBaseToken(ctx sdk.Context, inputFee sdk.Coin) (sdk.Coin, error)
 	GetBaseDenom(ctx sdk.Context) (denom string, err error)
 	GetFeeToken(ctx sdk.Context, denom string) (FeeToken, error)
+}
+
+type TwapKeeper interface {
+	GetArithmeticTwapToNow(
+		ctx sdk.Context,
+		poolId uint64,
+		baseAssetDenom string,
+		quoteAssetDenom string,
+		startTime time.Time,
+	) (sdk.Dec, error)
+
+	StoreNewRecord(ctx sdk.Context, twap twaptypes.TwapRecord)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

[Closes: #4848](https://github.com/osmosis-labs/osmosis/issues/4848)

## What is the purpose of the change
The txfees modules allows nodes to easily support many tokens for usage as txfees. This is done by having this module maintain an allow-list of token denoms which can be used as tx fees, each with some associated metadata.
Then this metadata is used in tandem with a "Spot Price Calculator" provided to the module, to convert the provided tx fees into their equivalent value in the base denomination.

Now that we have TWAP implemented we want to use TWAP price instead of spot price.

## Brief Changelog
- use twap price calculation for `CalcFeeSpotPrice` 

## Testing and Verifying
- modified existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)