### PR TITLE
Enable CORS on localosmosis

### DIFF
--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -105,11 +105,33 @@ add_genesis_accounts () {
 }
 
 edit_config () {
+
     # Remove seeds
     dasel put string -f $CONFIG_FOLDER/config.toml '.p2p.seeds' ''
 
     # Expose the rpc
     dasel put string -f $CONFIG_FOLDER/config.toml '.rpc.laddr' "tcp://0.0.0.0:26657"
+
+    # Disable fast_sync
+    dasel put bool -f $CONFIG_FOLDER/config.toml '.fast_sync' 'false'
+}
+
+enable_cors () {
+
+    # Enable cors on RPC
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "*" '.rpc.cors_allowed_origins.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "Accept-Encoding" '.rpc.cors_allowed_headers.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "DELETE" '.rpc.cors_allowed_methods.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "OPTIONS" '.rpc.cors_allowed_methods.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "PATCH" '.rpc.cors_allowed_methods.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "PUT" '.rpc.cors_allowed_methods.[]'
+
+    # Enable unsafe cors and swagger on the api
+    dasel put bool -f $CONFIG_FOLDER/app.toml -v "true" '.api.swagger'
+    dasel put bool -f $CONFIG_FOLDER/app.toml -v "true" '.api.enabled-unsafe-cors'
+
+    # Enable cors on gRPC Web
+    dasel put bool -f $CONFIG_FOLDER/app.toml -v "true" '.grpc-web.enable-unsafe-cors'
 }
 
 run_with_retries() {
@@ -165,6 +187,7 @@ then
     edit_genesis
     add_genesis_accounts
     edit_config
+    enable_cors
 fi
 
 osmosisd start --home $OSMOSIS_HOME &

--- a/tests/localosmosis/state_export/scripts/start.sh
+++ b/tests/localosmosis/state_export/scripts/start.sh
@@ -33,6 +33,24 @@ edit_config () {
     dasel put string -f $CONFIG_FOLDER/config.toml '.rpc.laddr' "tcp://0.0.0.0:26657"
 }
 
+enable_cors () {
+
+    # Enable cors on RPC
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "*" '.rpc.cors_allowed_origins.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "Accept-Encoding" '.rpc.cors_allowed_headers.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "DELETE" '.rpc.cors_allowed_methods.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "OPTIONS" '.rpc.cors_allowed_methods.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "PATCH" '.rpc.cors_allowed_methods.[]'
+    dasel put string -f $CONFIG_FOLDER/config.toml -v "PUT" '.rpc.cors_allowed_methods.[]'
+
+    # Enable unsafe cors and swagger on the api
+    dasel put bool -f $CONFIG_FOLDER/app.toml -v "true" '.api.swagger'
+    dasel put bool -f $CONFIG_FOLDER/app.toml -v "true" '.api.enabled-unsafe-cors'
+
+    # Enable cors on gRPC Web
+    dasel put bool -f $CONFIG_FOLDER/app.toml -v "true" '.grpc-web.enable-unsafe-cors'
+}
+
 if [[ ! -d $CONFIG_FOLDER ]]
 then
 
@@ -67,6 +85,7 @@ then
     --prune-ibc
 
     edit_config
+    enable_cors
 fi
 
 osmosisd start --home $OSMOSIS_HOME --x-crisis-skip-assert-invariants


### PR DESCRIPTION
Closes: [#4879](https://github.com/osmosis-labs/osmosis/issues/4879)

## What is the purpose of the change

Enables cors on localOsmosis for:
- rpc
- api
- gRPC-web

## Brief Changelog

- Enable cors by default on localosmosis

## Testing and Verifying

Start localosmosis:

```bash
make localnet-start
```

Check file changes:

```bash
❯ cat ~/.osmosisd-local/config/config.toml | grep cors
  cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time", "Accept-Encoding"]
  cors_allowed_methods = ["HEAD", "GET", "POST", "DELETE", "OPTIONS", "PATCH", "PUT"]
  cors_allowed_origins = ["*"]
```

```bash
❯ cat ~/.osmosisd-local/config/app.toml | grep cors
  enabled-unsafe-cors = true
  enable-unsafe-cors = true
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable