### PR TITLE
[chores] Update alpine docker base image to alpine:3.17

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@ networks/
 proto/
 scripts/
 tools/
-tests/cl-go-client
+tests/
 .github/
 .git/
 .vscode/

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -23,7 +23,7 @@ on:
     - v[0-9]+.x
   
 env:
-  RUNNER_BASE_IMAGE_ALPINE: alpine:3.16
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
   OSMOSIS_DEV_IMAGE_REPOSITORY: osmolabs/osmosis-dev
   OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY: osmolabs/osmosis-e2e-init-chain
 

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -17,7 +17,7 @@
 # - `osmolabs/osmosis:X.Y.Z`             uses `gcr.io/distroless/static-debian11`
 # - `osmolabs/osmosis:X.Y.Z-distroless`  uses `gcr.io/distroless/static-debian11`
 # - `osmolabs/osmosis:X.Y.Z-nonroot`     uses `gcr.io/distroless/static-debian11:nonroot`
-# - `osmolabs/osmosis:X.Y.Z-alpine`      uses `alpine:3.16` 
+# - `osmolabs/osmosis:X.Y.Z-alpine`      uses `alpine:3.17` 
 #
 # All the images above have support for linux/amd64 and linux/arm64.
 #
@@ -35,7 +35,7 @@ env:
   DOCKER_REPOSITORY: osmolabs/osmosis
   RUNNER_BASE_IMAGE_DISTROLESS: gcr.io/distroless/static-debian11
   RUNNER_BASE_IMAGE_NONROOT: gcr.io/distroless/static-debian11:nonroot
-  RUNNER_BASE_IMAGE_ALPINE: alpine:3.16
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
 
 jobs:
   osmosisd-images:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * [#4549](https://github.com/osmosis-labs/osmosis/pull/4549) Add single pool price estimate queries
   * [#4767](https://github.com/osmosis-labs/osmosis/pull/4767) Disable create pool with non-zero exit fee
   * [#4847](https://github.com/osmosis-labs/osmosis/pull/4847) Update `make build` command to build only `osmosisd` binary
+  * [#4893](https://github.com/osmosis-labs/osmosis/pull/4893) Update alpine docker base image to `alpine:3.17`
 
 ### API Breaks
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-reproducible-amd64: go.sum $(BUILDDIR)/
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg GIT_VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(COMMIT) \
-		--build-arg RUNNER_IMAGE=alpine:3.16 \
+		--build-arg RUNNER_IMAGE=alpine:3.17 \
 		--platform linux/amd64 \
 		-t osmosis:local-amd64 \
 		--load \
@@ -136,7 +136,7 @@ build-reproducible-arm64: go.sum $(BUILDDIR)/
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg GIT_VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(COMMIT) \
-		--build-arg RUNNER_IMAGE=alpine:3.16 \
+		--build-arg RUNNER_IMAGE=alpine:3.17 \
 		--platform linux/arm64 \
 		-t osmosis:local-arm64 \
 		--load \
@@ -331,7 +331,7 @@ e2e-remove-resources:
 ###############################################################################
 
 RUNNER_BASE_IMAGE_DISTROLESS := gcr.io/distroless/static-debian11
-RUNNER_BASE_IMAGE_ALPINE := alpine:3.16
+RUNNER_BASE_IMAGE_ALPINE := alpine:3.17
 RUNNER_BASE_IMAGE_NONROOT := gcr.io/distroless/static-debian11:nonroot
 
 docker-build:

--- a/tests/localosmosis/README.md
+++ b/tests/localosmosis/README.md
@@ -265,7 +265,7 @@ services:
     #     context: ../../
     #     dockerfile: Dockerfile
     #     args:
-    #     RUNNER_IMAGE: alpine:3.16
+    #     RUNNER_IMAGE: alpine:3.17
     #     GO_VERSION: 1.19
 ```
 

--- a/tests/localosmosis/docker-compose.yml
+++ b/tests/localosmosis/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ../../
       dockerfile: Dockerfile
       args:
-        RUNNER_IMAGE: alpine:3.16
+        RUNNER_IMAGE: alpine:3.17
         GO_VERSION: 1.19
     volumes:
       - ./scripts/nativeDenomPoolA.json:/osmosis/nativeDenomPoolA.json

--- a/tests/localosmosis/state_export/docker-compose.yml
+++ b/tests/localosmosis/state_export/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ../../../
       dockerfile: Dockerfile
       args:
-        RUNNER_IMAGE: alpine:3.16
+        RUNNER_IMAGE: alpine:3.17
         GO_VERSION: 1.19
     volumes:
       - ./scripts/start.sh:/osmosis/start.sh

--- a/tests/localrelayer/docker-compose.yml
+++ b/tests/localrelayer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ../../
       dockerfile: Dockerfile
       args:
-        RUNNER_IMAGE: alpine:3.16
+        RUNNER_IMAGE: alpine:3.17
         GO_VERSION: 1.19
     volumes:
       - ./scripts/setup_chain.sh:/osmosis/setup.sh
@@ -59,7 +59,7 @@ services:
       context: ../../
       dockerfile: Dockerfile
       args:
-        RUNNER_IMAGE: alpine:3.16
+        RUNNER_IMAGE: alpine:3.17
         GO_VERSION: 1.19
     volumes:
       - ./scripts/setup_chain.sh:/osmosis/setup.sh


### PR DESCRIPTION
## What is the purpose of the change

This PR updates our Docker base image to the latest `alpine:3.17` and adds the `tests/` folder to the `.dockerignore`.


## Brief Changelog

- Update Docker base image to `alpine:3.17` 
- Add the `tests/` folder to `.dockerignore`
 
## Testing and Verifying

```bash
make docker-build-alpine
```

works as expected.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? yes
  - How is the feature or change documented? not applicable