### PR TITLE
[localosmosis] Fix bug in replace function

### DIFF
--- a/tests/localosmosis/state_export/scripts/testnetify.py
+++ b/tests/localosmosis/state_export/scripts/testnetify.py
@@ -27,24 +27,23 @@ config = {
     "epoch_duration": '21600s',
 }
 
-def replace(d, old_value, new_value):
+def replace(obj, old_value, new_value):
     """
-    Replace all the occurences of `old_value` with `new_value`
-    in `d` dictionary
+    Replace all the occurrences of `old_value` with `new_value`
+    in `obj`, which can be a dictionary or a list
     """
-    for k in d.keys():
-        if isinstance(d[k], dict):
-            replace(d[k], old_value, new_value)
-        elif isinstance(d[k], list):
-            for i in range(len(d[k])):
-                if isinstance(d[k][i], dict) or isinstance(d[k][i], list):
-                    replace(d[k][i], old_value, new_value)
-                else:
-                    if d[k][i] == old_value:
-                        d[k][i] = new_value
-        else:
-            if d[k] == old_value:
-                d[k] = new_value
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, (dict, list)):
+                replace(value, old_value, new_value)
+            elif value == old_value:
+                obj[key] = new_value
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            if isinstance(value, (dict, list)):
+                replace(value, old_value, new_value)
+            elif value == old_value:
+                obj[index] = new_value
 
 def replace_validator(genesis, old_validator, new_validator):
     


### PR DESCRIPTION
## What is the purpose of the change

This PR optimizes and fixes the replace function used in `testnetify` to handle both dictionaries and lists as input, ensuring a more flexible and efficient implementation. 

The previous version of the replace function had a bug where it did not handle the case when the input was a list. The optimized version now addresses this issue.

```bash

Chain ID: localosmosis
Moniker:  val
📝 Opening /osmosis/state_export.json... (it may take a while)
Traceback (most recent call last):
  File "/osmosis/testnetify.py", line 381, in <module>
    main()
  File "/osmosis/testnetify.py", line 257, in main
    replace_validator(genesis, old_validator, new_validator)
  File "/osmosis/testnetify.py", line 51, in replace_validator
    replace(genesis, old_validator.hex_address, new_validator.hex_address)
  File "/osmosis/testnetify.py", line 37, in replace
    replace(d[k], old_value, new_value)
  File "/osmosis/testnetify.py", line 37, in replace
    replace(d[k], old_value, new_value)
  File "/osmosis/testnetify.py", line 41, in replace
    replace(d[k][i], old_value, new_value)
  File "/osmosis/testnetify.py", line 41, in replace
    replace(d[k][i], old_value, new_value)
  File "/osmosis/testnetify.py", line 37, in replace
    replace(d[k], old_value, new_value)
  File "/osmosis/testnetify.py", line 41, in replace
    replace(d[k][i], old_value, new_value)
  File "/osmosis/testnetify.py", line 35, in replace
    for k in d.keys():
AttributeError: 'list' object has no attribute 'keys'
```

## Brief Changelog

- Fix bug in replace function of `testenetify` 

## Testing and Verifying

Trivial change. Manually verified.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no 
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable