### PR TITLE
Revert dockerignore changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,8 @@ networks/
 proto/
 scripts/
 tools/
-tests/
+tests/localosmosis/
+tests/localrelayer/
 .github/
 .git/
 .vscode/


### PR DESCRIPTION
## What is the purpose of the change

Changing the `.dockerignore` I think broke `e2e` scripts: https://github.com/osmosis-labs/osmosis/actions/runs/4669893927/jobs/8268946162

This PR reverts the changes.

## Brief Changelog

- Revert `.dockerignore` changes

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable