### PR TITLE
Set Param for CL Keeper in Upgrade handler, modify default swap fee to 0.02

### DIFF
--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v15/app/keepers"
 	"github.com/osmosis-labs/osmosis/v15/app/upgrades"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
 const (
@@ -40,9 +39,6 @@ func CreateUpgradeHandler(
 		if err != nil {
 			return nil, err
 		}
-
-		// set params for CL keeper before we call internal logic
-		keepers.ConcentratedLiquidityKeeper.SetParams(ctx, cltypes.DefaultParams())
 
 		if err := createCanonicalConcentratedLiquidityPoolAndMigrationLink(ctx, daiOsmoPoolId, desiredDenom0, keepers); err != nil {
 			return nil, err

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v15/app/keepers"
 	"github.com/osmosis-labs/osmosis/v15/app/upgrades"
+	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
 const (
@@ -39,6 +40,9 @@ func CreateUpgradeHandler(
 		if err != nil {
 			return nil, err
 		}
+
+		// set params for CL keeper before we call internal logic
+		keepers.ConcentratedLiquidityKeeper.SetParams(ctx, cltypes.DefaultParams())
 
 		if err := createCanonicalConcentratedLiquidityPoolAndMigrationLink(ctx, daiOsmoPoolId, desiredDenom0, keepers); err != nil {
 			return nil, err

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -1017,7 +1017,7 @@ func (s *KeeperTestSuite) TestFunctionalFees() {
 	s.TestAccs = apptesting.CreateRandomAccounts(positions.numAccounts)
 
 	// Create a default CL pool, but with a 0.3 percent swap fee.
-	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultExponentAtPriceOne, sdk.MustNewDecFromStr("0.003"))
+	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultExponentAtPriceOne, sdk.MustNewDecFromStr("0.002"))
 
 	positionIds := make([][]uint64, 4)
 	// Setup full range position across all four accounts

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -333,7 +333,7 @@ func (s *KeeperTestSuite) TestValidateSwapFee() {
 	}{
 		{
 			name:        "Valid swap fee",
-			swapFee:     sdk.MustNewDecFromStr("0.003"),
+			swapFee:     sdk.MustNewDecFromStr("0.002"),
 			expectValid: true,
 		},
 		{

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2788,7 +2788,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	s.TestAccs = apptesting.CreateRandomAccounts(positions.numAccounts)
 
 	// Create a default CL pool, but with a 0.3 percent swap fee.
-	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultExponentAtPriceOne, sdk.MustNewDecFromStr("0.003"))
+	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultExponentAtPriceOne, sdk.MustNewDecFromStr("0.002"))
 
 	positionIds := make([][]uint64, 4)
 	// Setup full range position across all four accounts
@@ -2856,7 +2856,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	expectedSqrtPrice := osmomath.MustNewDecFromStr("71.74138432587113364823838192")
 	actualSqrtPrice := osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn := swapCoin1.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut := sdk.NewInt(982676)
+	expectedTokenOut := sdk.NewInt(983645)
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
@@ -2915,7 +2915,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	expectedSqrtPrice = osmomath.MustNewDecFromStr("70.64112736841825140176332377")
 	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut = sdk.NewInt(5052068983)
+	expectedTokenOut = sdk.NewInt(5057205729)
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
@@ -2974,7 +2974,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	expectedSqrtPrice = osmomath.MustNewDecFromStr("76.22545423006231767390422658")
 	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn = swapCoin1.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut = sdk.NewInt(882804)
+	expectedTokenOut = sdk.NewInt(883663)
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
@@ -3019,7 +3019,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	expectedSqrtPrice = osmomath.MustNewDecFromStr("63.97671895942244949922335999")
 	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut = sdk.NewInt(4509814620)
+	expectedTokenOut = sdk.NewInt(4513904710)
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -37,7 +37,7 @@ func DefaultParams() Params {
 			sdk.MustNewDecFromStr("0.0001"),
 			sdk.MustNewDecFromStr("0.0003"),
 			sdk.MustNewDecFromStr("0.0005"),
-			sdk.MustNewDecFromStr("0.003"),
+			sdk.MustNewDecFromStr("0.002"),
 			sdk.MustNewDecFromStr("0.01")},
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
- Sets default Params in CL Keeper in Upgrade handler, modifies default swap fee to 0.02.

Also made this issue https://github.com/osmosis-labs/osmosis/issues/4899 to have further discussions on how we want to handle default swap fees and migration for the pools that does not have swap fees that are allowed in the CL Keeper.

## Brief Changelog

Set Param for CL Keeper in Upgrade handler, modify default swap fee to 0.02
## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)