### PR TITLE
Fix make build-reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ install: check_version go.sum
 
 build-reproducible: build-reproducible-amd64 build-reproducible-arm64
 
-build-reproducible-amd64: go.sum $(BUILDDIR)/
+build-reproducible-amd64: go.sum
+	mkdir -p $(BUILDDIR)
 	$(DOCKER) buildx create --name osmobuilder || true
 	$(DOCKER) buildx use osmobuilder
 	$(DOCKER) buildx build \
@@ -129,7 +130,8 @@ build-reproducible-amd64: go.sum $(BUILDDIR)/
 	$(DOCKER) cp osmobinary:/bin/osmosisd $(BUILDDIR)/osmosisd-linux-amd64
 	$(DOCKER) rm -f osmobinary
 
-build-reproducible-arm64: go.sum $(BUILDDIR)/
+build-reproducible-arm64: go.sum
+	mkdir -p $(BUILDDIR)
 	$(DOCKER) buildx create --name osmobuilder || true
 	$(DOCKER) buildx use osmobuilder
 	$(DOCKER) buildx build \


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a `Makefile` target ` build-reproducible` that broke after https://github.com/osmosis-labs/osmosis/pull/4847

## Brief Changelog

- Fix `make build-reproducible` 

## Testing and Verifying

Run `make build-reproducible` 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable