### PR TITLE
fix: Remove Denom metadata check upon CL Pool creation

### DIFF
--- a/x/concentrated-liquidity/msg_server.go
+++ b/x/concentrated-liquidity/msg_server.go
@@ -39,16 +39,6 @@ var (
 func (server msgServer) CreateConcentratedPool(goCtx context.Context, msg *clmodel.MsgCreateConcentratedPool) (*clmodel.MsgCreateConcentratedPoolResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	_, denomExists := server.keeper.bankKeeper.GetDenomMetaData(ctx, msg.Denom0)
-	if !denomExists {
-		return nil, fmt.Errorf("received denom0 with invalid metadata: %s", msg.Denom0)
-	}
-
-	_, denomExists = server.keeper.bankKeeper.GetDenomMetaData(ctx, msg.Denom1)
-	if !denomExists {
-		return nil, fmt.Errorf("received denom1 with invalid metadata: %s", msg.Denom1)
-	}
-
 	poolId, err := server.keeper.poolmanagerKeeper.CreatePool(ctx, msg)
 	if err != nil {
 		return nil, err

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
@@ -33,18 +32,6 @@ func (suite *KeeperTestSuite) TestCreateConcentratedPool_Events() {
 			exponentAtPriceOne:       DefaultExponentAtPriceOne,
 			expectedPoolCreatedEvent: 1,
 			expectedMessageEvents:    4, // 1 for pool created, 1 for coin spent, 1 for coin received, 1 for after pool create hook
-		},
-		"error: missing denom0": {
-			denom1:             USDC,
-			tickSpacing:        DefaultTickSpacing,
-			exponentAtPriceOne: DefaultExponentAtPriceOne,
-			expectedError:      fmt.Errorf("received denom0 with invalid metadata: %s", ""),
-		},
-		"error: missing denom1": {
-			denom0:             ETH,
-			tickSpacing:        DefaultTickSpacing,
-			exponentAtPriceOne: DefaultExponentAtPriceOne,
-			expectedError:      fmt.Errorf("received denom1 with invalid metadata: %s", ""),
 		},
 		"error: missing tickSpacing": {
 			denom0:             ETH,
@@ -80,28 +67,6 @@ func (suite *KeeperTestSuite) TestCreateConcentratedPool_Events() {
 			suite.FundAcc(suite.TestAccs[0], poolmanagerParams.PoolCreationFee)
 
 			msgServer := cl.NewMsgCreatorServerImpl(suite.App.ConcentratedLiquidityKeeper)
-
-			// set denom metadata
-			if tc.denom0 != "" {
-				denomMetaData := banktypes.Metadata{
-					DenomUnits: []*banktypes.DenomUnit{{
-						Denom:    tc.denom0,
-						Exponent: 0,
-					}},
-					Base: tc.denom0,
-				}
-				suite.App.BankKeeper.SetDenomMetaData(ctx, denomMetaData)
-			}
-			if tc.denom1 != "" {
-				denomMetaData := banktypes.Metadata{
-					DenomUnits: []*banktypes.DenomUnit{{
-						Denom:    tc.denom1,
-						Exponent: 0,
-					}},
-					Base: tc.denom1,
-				}
-				suite.App.BankKeeper.SetDenomMetaData(ctx, denomMetaData)
-			}
 
 			// Reset event counts to 0 by creating a new manager.
 			ctx = ctx.WithEventManager(sdk.NewEventManager())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Currently we have a check in the CreatePool in the CL msg server, where we check if the given denom0 and denom1's denom meta data exists on chain. 

Unfortunately, we do not have all the denom metadata of ibc tokens registered on chain, thus this check needs to be removed. 

## Brief Changelog
- Remove Denom metadata check upon CL Pool Creation

## Testing and Verifying
Deletes existing tests 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)