### PR TITLE
fix: patch data struct

### DIFF
--- a/tests/cl-genesis-positions/edit_localosmosis_genesis.go
+++ b/tests/cl-genesis-positions/edit_localosmosis_genesis.go
@@ -18,6 +18,7 @@ import (
 	osmosisApp "github.com/osmosis-labs/osmosis/v15/app"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
+
 	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	clgenesis "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types/genesis"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
@@ -59,9 +60,9 @@ func EditLocalOsmosisGenesis(updatedCLGenesis *clgenesis.GenesisState, updatedBa
 	appState[poolmanagertypes.ModuleName] = cdc.MustMarshalJSON(&localOsmosisPoolManagerGenesis)
 
 	// Copy positions
-	for _, position := range updatedCLGenesis.Positions {
-		position.PoolId = nextPoolId
-		localOsmosisCLGenesis.Positions = append(localOsmosisCLGenesis.Positions, position)
+	for _, positionData := range updatedCLGenesis.PositionData {
+		positionData.Position.PoolId = nextPoolId
+		localOsmosisCLGenesis.PositionData = append(localOsmosisCLGenesis.PositionData, positionData)
 	}
 
 	// Create map of pool balances
@@ -122,7 +123,7 @@ func EditLocalOsmosisGenesis(updatedCLGenesis *clgenesis.GenesisState, updatedBa
 		localOsmosisCLGenesis.PoolData = append(localOsmosisCLGenesis.PoolData, updatedPoolData)
 	}
 
-	localOsmosisCLGenesis.NextPositionId = uint64(len(localOsmosisCLGenesis.Positions) + 1)
+	localOsmosisCLGenesis.NextPositionId = uint64(len(localOsmosisCLGenesis.PositionData) + 1)
 
 	appState[cltypes.ModuleName] = cdc.MustMarshalJSON(&localOsmosisCLGenesis)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The PR #4912 added a new data struct that broke an assumption of a currently merged script.

This fixes that issue.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)