### PR TITLE
test: add tick tests with exponent at price one of 6 and tick spacing  of 100 at various price levels

### DIFF
--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -165,8 +165,8 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 		},
 		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035200 + 100 -> price 30353": {
 			exponentAtPriceOne: sdk.NewInt(-6),
-			tickIndex:          sdk.NewInt(38035200),
-			expectedPrice:      sdk.MustNewDecFromStr("30352"),
+			tickIndex:          sdk.NewInt(38035300),
+			expectedPrice:      sdk.MustNewDecFromStr("30353"),
 		},
 		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821000 -> price 0.000011790": {
 			exponentAtPriceOne: sdk.NewInt(-6),
@@ -233,8 +233,8 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick() {
 		},
 		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035300 + 100 -> price 30353": {
 			exponentAtPriceOne: sdk.NewInt(-6),
-			price:              sdk.MustNewDecFromStr("30352"),
-			tickExpected:       "38035200",
+			price:              sdk.MustNewDecFromStr("30353"),
+			tickExpected:       "38035300",
 		},
 		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821000 -> price 0.000011790": {
 			exponentAtPriceOne: sdk.NewInt(-6),
@@ -355,21 +355,6 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			price:              sdk.MustNewDecFromStr("0.0000000000889"),
 			exponentAtPriceOne: sdk.NewInt(-8),
 			tickExpected:       "-9111000000",
-		},
-		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035200 -> price 30352": {
-			exponentAtPriceOne: sdk.NewInt(-6),
-			price:              sdk.MustNewDecFromStr("30352"),
-			tickExpected:       "38035200",
-		},
-		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035300 -> price 30353": {
-			exponentAtPriceOne: sdk.NewInt(-6),
-			price:              sdk.MustNewDecFromStr("30352"),
-			tickExpected:       "38035200",
-		},
-		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821000 -> price 0.00001179": {
-			exponentAtPriceOne: sdk.NewInt(-6),
-			price:              sdk.MustNewDecFromStr("0.00001179"),
-			tickExpected:       "-44821000",
 		},
 	}
 	for name, tc := range testCases {

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -1,8 +1,6 @@
 package math_test
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -160,6 +158,46 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 			exponentAtPriceOne: sdk.NewInt(-6),
 			expectedPrice:      sdk.MustNewDecFromStr("25760000"),
 		},
+		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035200 -> price 30352": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(38035200),
+			expectedPrice:      sdk.MustNewDecFromStr("30352"),
+		},
+		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035200 + 100 -> price 30353": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(38035200),
+			expectedPrice:      sdk.MustNewDecFromStr("30352"),
+		},
+		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821000 -> price 0.000011790": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(-44821000),
+			expectedPrice:      sdk.MustNewDecFromStr("0.00001179"),
+		},
+		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821100 + 100 -> price 0.000011791": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(-44820900),
+			expectedPrice:      sdk.MustNewDecFromStr("0.000011791"),
+		},
+		"ETH <> BTC at exponent at price one of -6, tick spacing 100, tick -12104000 -> price 0.068960": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(-12104000),
+			expectedPrice:      sdk.MustNewDecFromStr("0.068960"),
+		},
+		"ETH <> BTC at exponent at price one of -6, tick spacing 100, tick -121044000 + 1 -> price 0.068961": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(-12103900),
+			expectedPrice:      sdk.MustNewDecFromStr("0.068961"),
+		},
+		"one tick spacing interval smaller than max sqrt price at exponent at price one of -6, tick spacing 100, max tick neg six - 100 -> one tick spacing interval smaller than max sqrt price": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(types.MaxTickNegSix).Sub(sdk.NewInt(100)),
+			expectedPrice:      sdk.MustNewDecFromStr("99999000000000000000000000000000000014"), // there is some excess here due to the math functions.
+		},
+		"max sqrt price at exponent at price one of -6, tick spacing 100, max tick neg six -> max spot price": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			tickIndex:          sdk.NewInt(types.MaxTickNegSix),
+			expectedPrice:      types.MaxSpotPrice,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -175,8 +213,8 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 			suite.Require().NoError(err)
 			expectedSqrtPrice, err := tc.expectedPrice.ApproxSqrt()
 			suite.Require().NoError(err)
-			suite.Require().Equal(expectedSqrtPrice.String(), sqrtPrice.String())
 
+			suite.Require().Equal(expectedSqrtPrice.String(), sqrtPrice.String())
 		})
 	}
 }
@@ -188,70 +226,45 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick() {
 		tickExpected       string
 		expectedError      error
 	}{
-		"50000 to tick with -4 k at price one": {
-			price:              sdk.NewDec(50000),
-			exponentAtPriceOne: sdk.NewInt(-4),
-			tickExpected:       "400000",
-		},
-		"5.01 to tick with -2 k at price one": {
-			price:              sdk.MustNewDecFromStr("5.01"),
-			exponentAtPriceOne: sdk.NewInt(-2),
-			tickExpected:       "401",
-		},
-		"50000.01 to tick with -6 k at price one": {
-			price:              sdk.MustNewDecFromStr("50000.01"),
+		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035200 -> price 30352": {
 			exponentAtPriceOne: sdk.NewInt(-6),
-			tickExpected:       "40000001",
+			price:              sdk.MustNewDecFromStr("30352"),
+			tickExpected:       "38035200",
 		},
-		"0.090000889 to tick with -8 k at price one": {
-			price:              sdk.MustNewDecFromStr("0.090000889"),
-			exponentAtPriceOne: sdk.NewInt(-8),
-			tickExpected:       "-999991110",
-		},
-		"0.9998 to tick with -4 k at price one": {
-			price:              sdk.MustNewDecFromStr("0.9998"),
-			exponentAtPriceOne: sdk.NewInt(-4),
-			tickExpected:       "-20",
-		},
-		"53030.10 to tick with -5 k at price one": {
-			price:              sdk.MustNewDecFromStr("53030.1"),
-			exponentAtPriceOne: sdk.NewInt(-5),
-			tickExpected:       "4030301",
-		},
-		"max spot price and minimum exponentAtPriceOne": {
-			price:              types.MaxSpotPrice,
-			exponentAtPriceOne: sdk.NewInt(-1),
-			tickExpected:       "3420",
-		},
-		"min spot price and minimum exponentAtPriceOne": {
-			price:              types.MinSpotPrice,
-			exponentAtPriceOne: sdk.NewInt(-1),
-			tickExpected:       "-1620",
-		},
-		"error: max spot price plus one and minimum exponentAtPriceOne": {
-			price:              types.MaxSpotPrice.Add(sdk.OneDec()),
-			exponentAtPriceOne: sdk.NewInt(-1),
-			expectedError:      types.PriceBoundError{ProvidedPrice: types.MaxSpotPrice.Add(sdk.OneDec()), MinSpotPrice: types.MinSpotPrice, MaxSpotPrice: types.MaxSpotPrice},
-		},
-		"error: price must be positive": {
-			price:              sdk.NewDec(-1),
+		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035300 + 100 -> price 30353": {
 			exponentAtPriceOne: sdk.NewInt(-6),
-			expectedError:      fmt.Errorf("price must be greater than zero"),
+			price:              sdk.MustNewDecFromStr("30352"),
+			tickExpected:       "38035200",
 		},
-		"error: exponentAtPriceOne less than minimum": {
-			price:              sdk.NewDec(50000),
-			exponentAtPriceOne: types.ExponentAtPriceOneMin.Sub(sdk.OneInt()),
-			expectedError:      types.ExponentAtPriceOneError{ProvidedExponentAtPriceOne: types.ExponentAtPriceOneMin.Sub(sdk.OneInt()), PrecisionValueAtPriceOneMin: types.ExponentAtPriceOneMin, PrecisionValueAtPriceOneMax: types.ExponentAtPriceOneMax},
+		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821000 -> price 0.000011790": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("0.000011790"),
+			tickExpected:       "-44821000",
 		},
-		"error: exponentAtPriceOne greater than maximum": {
-			price:              sdk.NewDec(50000),
-			exponentAtPriceOne: types.ExponentAtPriceOneMax.Add(sdk.OneInt()),
-			expectedError:      types.ExponentAtPriceOneError{ProvidedExponentAtPriceOne: types.ExponentAtPriceOneMax.Add(sdk.OneInt()), PrecisionValueAtPriceOneMin: types.ExponentAtPriceOneMin, PrecisionValueAtPriceOneMax: types.ExponentAtPriceOneMax},
+		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44820900 -> price 0.000011791": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("0.000011791"),
+			tickExpected:       "-44820900",
 		},
-		"random": {
-			price:              sdk.MustNewDecFromStr("0.0000000000889"),
-			exponentAtPriceOne: sdk.NewInt(-8),
-			tickExpected:       "-9111000000",
+		"ETH <> BTC at exponent at price one of -6, tick spacing 100, tick -12104000 -> price 0.068960": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("0.068960"),
+			tickExpected:       "-12104000",
+		},
+		"ETH <> BTC at exponent at price one of -6, tick spacing 100, tick -12104000 + 100 -> price 0.068961": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("0.068961"),
+			tickExpected:       "-12103900",
+		},
+		"max sqrt price -1 at exponent at price one of -6, tick spacing 100, max neg tick six - 100 -> max tick neg six - 100": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("99999000000000000000000000000000000000"),
+			tickExpected:       sdk.NewInt(types.MaxTickNegSix - 100).String(),
+		},
+		"max sqrt price at exponent at price one of -6, tick spacing 100, max tick neg six -> max spot price": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              types.MaxSqrtPrice.Power(2),
+			tickExpected:       sdk.NewInt(types.MaxTickNegSix).String(),
 		},
 		"Gyen <> USD": {
 			price:              sdk.MustNewDecFromStr("0.007406"),
@@ -342,6 +355,21 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			price:              sdk.MustNewDecFromStr("0.0000000000889"),
 			exponentAtPriceOne: sdk.NewInt(-8),
 			tickExpected:       "-9111000000",
+		},
+		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035200 -> price 30352": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("30352"),
+			tickExpected:       "38035200",
+		},
+		"BTC <> USD at exponent at price one of -6, tick spacing 100, tick 38035300 -> price 30353": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("30352"),
+			tickExpected:       "38035200",
+		},
+		"SHIB <> USD at exponent at price one of -6, tick spacing 100, tick -44821000 -> price 0.00001179": {
+			exponentAtPriceOne: sdk.NewInt(-6),
+			price:              sdk.MustNewDecFromStr("0.00001179"),
+			tickExpected:       "-44821000",
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We are going with the exponent of price one of 6 and tick spacing of 100.

This test ensures that the numbers make sense at various price levels

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable