### PR TITLE
Fix `MsgSetBeforeSendHook` msg type

### DIFF
--- a/x/tokenfactory/types/msgs.go
+++ b/x/tokenfactory/types/msgs.go
@@ -275,7 +275,7 @@ func NewMsgSetBeforeSendHook(sender string, denom string, cosmwasmAddress string
 }
 
 func (m MsgSetBeforeSendHook) Route() string { return RouterKey }
-func (m MsgSetBeforeSendHook) Type() string  { return TypeMsgBurn }
+func (m MsgSetBeforeSendHook) Type() string  { return TypeMsgSetBeforeSendHook }
 func (m MsgSetBeforeSendHook) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.Sender)
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixes `MsgSetBeforeSendHook` msg type being returned. 
I feel like we should remove these annoying boilerplates in the near future :( 

## Brief Changelog

Fix `MsgSetBeforeSendHook` msg type

## Testing and Verifying
No tests are needed for this change

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)