### PR TITLE
docker: add `.md` files to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ tests/cl-go-client
 .vscode/
 go.work
 go.work.sum
+*.md


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

There are currently 3 markdown files in the root of a project, I just thought it would be nice to add it to `.dockerignore`

## Documentation

minor