### PR TITLE
refactor: identify ApproxSqrt as the source of rounding issues in tick to price inverse conversion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,25 +6,14 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/tests/e2e",
+            "program": "${workspaceFolder}/x/concentrated-liquidity/math",
             "args": [
                 "-test.timeout",
                 "30m",
                 "-test.run",
-                "IntegrationTestSuite",
+                "TestConcentratedTestSuite/TestTickToSqrtPricePriceToTick_InverseRelationship",
                 "-test.v"
             ],
-            "buildFlags": "-tags e2e",
-            "env": {
-                "OSMOSIS_E2E": "True",
-                "OSMOSIS_E2E_SKIP_IBC": "true",
-                "OSMOSIS_E2E_SKIP_UPGRADE": "true",
-                "OSMOSIS_E2E_SKIP_CLEANUP": "true",
-                "OSMOSIS_E2E_SKIP_STATE_SYNC": "true",
-                "OSMOSIS_E2E_UPGRADE_VERSION": "v16",
-                "OSMOSIS_E2E_DEBUG_LOG": "false",
-            },
-            "preLaunchTask": "e2e-setup"
         }
     ]
 }

--- a/go.mod
+++ b/go.mod
@@ -317,7 +317,7 @@ replace (
 	// dragonberry
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../cosmos-sdk
 
 	// N.B. v0.19.5 contains a breaking change to the IAVL API
 	github.com/cosmos/iavl v0.19.5 => github.com/cosmos/iavl v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -930,8 +930,6 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:YlmchqTmlwdWSmrRmXKR+PcU96ntOd8u10vTaTZdcNY=
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230328024000-175ec88e4304 h1:iSSlHl+SoewNpP/2N8JaUEHhOQRmJAnS8zaJ11yWslY=

--- a/osmomath/decimal.go
+++ b/osmomath/decimal.go
@@ -29,7 +29,7 @@ const (
 	maxDecBitLen = maxBitLen + DecimalPrecisionBits
 
 	// max number of iterations in ApproxRoot function
-	maxApproxRootIterations = 100
+	maxApproxRootIterations = 300
 
 	// max number of iterations in Log2 function
 	maxLog2Iterations = 300

--- a/osmomath/go.mod
+++ b/osmomath/go.mod
@@ -92,7 +92,7 @@ require (
 
 replace (
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../../cosmos-sdk
 	// use cosmos-compatible protobufs
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/informalsystems/tendermint v0.34.24

--- a/osmomath/go.sum
+++ b/osmomath/go.sum
@@ -298,8 +298,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/osmoutils/go.mod
+++ b/osmoutils/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/onsi/gomega v1.26.0 // indirect
+	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -136,7 +137,7 @@ require (
 
 replace (
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../../cosmos-sdk
 	// use cosmos-compatible protobufs
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/informalsystems/tendermint v0.34.24

--- a/osmoutils/go.sum
+++ b/osmoutils/go.sum
@@ -669,7 +669,7 @@ github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdM
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
+github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -680,8 +680,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/tests/cl-genesis-positions/go.mod
+++ b/tests/cl-genesis-positions/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230411200859-ae3065d0ca05 // indirect
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304 // indirect
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230331072320-5d6f6cfa2627 // indirect
@@ -156,7 +157,7 @@ replace (
 	// dragonberry
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../../../cosmos-sdk
 
 	// N.B. v0.19.5 contains a breaking change to the IAVL API
 	github.com/cosmos/iavl v0.19.5 => github.com/cosmos/iavl v0.19.4

--- a/tests/cl-genesis-positions/go.sum
+++ b/tests/cl-genesis-positions/go.sum
@@ -680,7 +680,7 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWEr
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
+github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -691,8 +691,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230328024000-175ec88e4304 h1:iSSlHl+SoewNpP/2N8JaUEHhOQRmJAnS8zaJ11yWslY=
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230328024000-175ec88e4304/go.mod h1:/h3CZIo25kMrM4Ojm7qBgMxKofTVwOycVWSa4rhEsaM=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230411200859-ae3065d0ca05 h1:fqVGxZPgUWuYWxVcMxHz5vrDV/aoxGJ7Kt0J4Vu/bsY=

--- a/tests/cl-go-client/go.mod
+++ b/tests/cl-go-client/go.mod
@@ -147,7 +147,7 @@ replace (
 	// dragonberry
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../../../cosmos-sdk
 	// use cosmos-compatible protobufs
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 

--- a/tests/cl-go-client/go.sum
+++ b/tests/cl-go-client/go.sum
@@ -666,7 +666,7 @@ github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
+github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -677,8 +677,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230328024000-175ec88e4304 h1:iSSlHl+SoewNpP/2N8JaUEHhOQRmJAnS8zaJ11yWslY=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230411200859-ae3065d0ca05 h1:fqVGxZPgUWuYWxVcMxHz5vrDV/aoxGJ7Kt0J4Vu/bsY=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304 h1:RIrWLzIiZN5Xd2JOfSOtGZaf6V3qEQYg6EaDTAkMnCo=

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -27,8 +27,8 @@ var (
 	DefaultUpperPrice                              = sdk.NewDec(5500)
 	DefaultUpperTick                               = int64(31500000)
 	DefaultCurrPrice                               = sdk.NewDec(5000)
-	DefaultCurrTick                                = sdk.NewInt(31000000)
-	DefaultCurrSqrtPrice, _                        = DefaultCurrPrice.ApproxSqrt() // 70.710678118654752440
+	DefaultCurrTick                                = sdk.NewInt(310000)
+	DefaultCurrSqrtPrice, _                        = math.Sqrt(DefaultCurrPrice) // 70.710678118654752440
 	DefaultZeroSwapFee                             = sdk.ZeroDec()
 	DefaultFeeAccumCoins                           = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(50)))
 	DefaultPositionId                              = uint64(1)

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -341,13 +341,17 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 
 	// Calculate the spot price and sqrt price from the amount provided
 	initialSpotPrice := amount1Desired.ToDec().Quo(amount0Desired.ToDec())
-	initialSqrtPrice, err := initialSpotPrice.ApproxSqrt()
+
+	// Calculate the initial tick from the initial spot price
+	// Calculate the initial tick from the initial spot price
+	initialTick, err := math.PriceToTick(initialSpotPrice, pool.GetTickSpacing())
 	if err != nil {
 		return err
 	}
 
-	// Calculate the initial tick from the initial spot price
-	initialTick, err := math.PriceToTick(initialSpotPrice, pool.GetTickSpacing())
+	// calculate the initial sqrt price from the initial tick
+	// We always compute the sqrt price from the tick, rather than the other way around, to avoid rounding errors.
+	initialSqrtPrice, err := math.TickToSqrtPrice(initialTick)
 	if err != nil {
 		return err
 	}

--- a/x/concentrated-liquidity/math/math.go
+++ b/x/concentrated-liquidity/math/math.go
@@ -168,8 +168,17 @@ func AddLiquidity(liquidityA, liquidityB sdk.Dec) (finalLiquidity sdk.Dec) {
 	return liquidityA.Add(liquidityB)
 }
 
-// MulRoundUp multiplies a by b and rounds up to the nearest integer
-// at precision end.
-func MulRoundUp(a, b sdk.Dec) sdk.Dec {
-	return a.MulTruncate(b).Add(smallestDec)
+// Sqrt returns the square root of x.
+// This helper is added to make sure that the same sqrt implementation
+// is used consistently across the module to ensure that translations
+// from tick to sqrt price and vice versa are consistent.
+func Sqrt(x sdk.Dec) (sdk.Dec, error) {
+	sqrtX, err := x.ApproxSqrt()
+	if err != nil {
+		return sdk.Dec{}, nil
+	}
+
+	// return x.ApproxSqrt()
+
+	return sqrtX, err
 }

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	sdkNineDec = sdk.NewDec(9)
-	sdkTenDec  = sdk.NewDec(10)
+	sdkNineDec = osmomath.NewBigDec(9)
+	sdkTenDec  = osmomath.NewBigDec(10)
 )
 
 // TicksToSqrtPrice returns the sqrtPrice for the lower and upper ticks.
@@ -31,16 +31,32 @@ func TicksToSqrtPrice(lowerTick, upperTick int64) (sdk.Dec, sdk.Dec, error) {
 
 // TickToSqrtPrice returns the sqrtPrice given a tickIndex
 // If tickIndex is zero, the function returns sdk.OneDec().
-func TickToSqrtPrice(tickIndex sdk.Int) (price sdk.Dec, err error) {
+// It is the combination of calling TickToPrice followed by Sqrt.
+func TickToSqrtPrice(tickIndex sdk.Int) (sdk.Dec, error) {
+	price, err := TickToPrice(tickIndex)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+
+	fmt.Println("price", price)
+
+	// Determine the sqrtPrice from the price
+	sqrtPrice, err := Sqrt(price)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	return sqrtPrice, nil
+}
+
+// TickToSqrtPrice returns the price given the following two arguments:
+//   - tickIndex: the tick index to calculate the price for
+//   - exponentAtPriceOne: the value of the exponent (and therefore the precision) at which the starting price of 1 is set
+//
+// If tickIndex is zero, the function returns sdk.OneDec().
+func TickToPrice(tickIndex sdk.Int) (sdk.Dec, error) {
 	if tickIndex.IsZero() {
 		return sdk.OneDec(), nil
 	}
-
-	// The formula is as follows: geometricExponentIncrementDistanceInTicks = 9 * 10**(-exponentAtPriceOne)
-	// Due to sdk.Power restrictions, if the resulting power is negative, we take 9 * (1/10**exponentAtPriceOne)
-	exponentAtPriceOne := types.ExponentAtPriceOne
-	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(exponentAtPriceOne.Neg()))
-
 	// Check that the tick index is between min and max value
 	if tickIndex.LT(sdk.NewInt(types.MinTick)) {
 		return sdk.Dec{}, types.TickIndexMinimumError{MinTick: types.MinTick}
@@ -49,8 +65,13 @@ func TickToSqrtPrice(tickIndex sdk.Int) (price sdk.Dec, err error) {
 		return sdk.Dec{}, types.TickIndexMaximumError{MaxTick: types.MaxTick}
 	}
 
+	// The formula is as follows: geometricExponentIncrementDistanceInTicks = 9 * 10**(-exponentAtPriceOne)
+	// Due to sdk.Power restrictions, if the resulting power is negative, we take 9 * (1/10**exponentAtPriceOne)
+	exponentAtPriceOne := types.ExponentAtPriceOne
+	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(exponentAtPriceOne.Neg())).SDKDec().TruncateInt()
+
 	// Use floor division to determine what the geometricExponent is now (the delta)
-	geometricExponentDelta := tickIndex.ToDec().QuoIntMut(geometricExponentIncrementDistanceInTicks.TruncateInt()).TruncateInt()
+	geometricExponentDelta := tickIndex.ToDec().QuoIntMut(geometricExponentIncrementDistanceInTicks).TruncateInt()
 
 	// Calculate the exponentAtCurrentTick from the starting exponentAtPriceOne and the geometricExponentDelta
 	exponentAtCurrentTick := exponentAtPriceOne.Add(geometricExponentDelta)
@@ -65,21 +86,16 @@ func TickToSqrtPrice(tickIndex sdk.Int) (price sdk.Dec, err error) {
 	currentAdditiveIncrementInTicks := powTenBigDec(exponentAtCurrentTick)
 
 	// Now, starting at the minimum tick of the current increment, we calculate how many ticks in the current geometricExponent we have passed
-	numAdditiveTicks := tickIndex.ToDec().Sub(geometricExponentDelta.ToDec().Mul(geometricExponentIncrementDistanceInTicks))
+	numAdditiveTicks := osmomath.NewBigDec(tickIndex.Int64()).Sub(osmomath.NewBigDec(geometricExponentDelta.Int64()).Mul(osmomath.BigDecFromSDKDec(geometricExponentIncrementDistanceInTicks.ToDec())))
 
 	// Finally, we can calculate the price
-	price = PowTenInternal(geometricExponentDelta).Add(osmomath.BigDecFromSDKDec(numAdditiveTicks).Mul(currentAdditiveIncrementInTicks).SDKDec())
+	price := PowTenInternal(geometricExponentDelta).Add(numAdditiveTicks.Mul(currentAdditiveIncrementInTicks)).SDKDec()
 
 	if price.GT(types.MaxSpotPrice) || price.LT(types.MinSpotPrice) {
 		return sdk.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPrice, MaxSpotPrice: types.MaxSpotPrice}
 	}
 
-	// Determine the sqrtPrice from the price
-	sqrtPrice, err := price.ApproxSqrt()
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-	return sqrtPrice, nil
+	return price, nil
 }
 
 // PriceToTick takes a price and returns the corresponding tick index.
@@ -113,31 +129,34 @@ func PriceToTick(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 
 // powTen treats negative exponents as 1/(10**|exponent|) instead of 10**-exponent
 // This is because the sdk.Dec.Power function does not support negative exponents
-func PowTenInternal(exponent sdk.Int) sdk.Dec {
+func PowTenInternal(exponent sdk.Int) osmomath.BigDec {
 	if exponent.GTE(sdk.ZeroInt()) {
-		return sdkTenDec.Power(exponent.Uint64())
+		return sdkTenDec.PowerInteger(exponent.Uint64())
 	}
-	return sdk.OneDec().Quo(sdkTenDec.Power(exponent.Abs().Uint64()))
+	return osmomath.OneDec().Quo(sdkTenDec.PowerInteger(exponent.Abs().Uint64()))
 }
 
 func powTenBigDec(exponent sdk.Int) osmomath.BigDec {
 	if exponent.GTE(sdk.ZeroInt()) {
-		return osmomath.NewBigDec(10).Power(osmomath.NewBigDec(exponent.Int64()))
+		return sdkTenDec.PowerInteger(exponent.Uint64())
 	}
-	return osmomath.OneDec().Quo(osmomath.NewBigDec(10).Power(osmomath.NewBigDec(exponent.Abs().Int64())))
+	return osmomath.OneDec().Quo(osmomath.NewBigDec(10).PowerInteger(exponent.Abs().Uint64()))
 }
 
 // CalculatePriceToTick takes in a price and returns the corresponding tick index.
 // This function does not take into consideration tick spacing.
-func CalculatePriceToTick(price sdk.Dec) (tickIndex sdk.Int) {
+func CalculatePriceToTick(price sdk.Dec) sdk.Int {
+
+	priceBigDec := osmomath.BigDecFromSDKDec(price)
+
 	// The formula is as follows: geometricExponentIncrementDistanceInTicks = 9 * 10**(-exponentAtPriceOne)
 	// Due to sdk.Power restrictions, if the resulting power is negative, we take 9 * (1/10**exponentAtPriceOne)
 	exponentAtPriceOne := types.ExponentAtPriceOne
 	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(exponentAtPriceOne.Neg()))
 
 	// Initialize the current price to 1, the current precision to exponentAtPriceOne, and the number of ticks passed to 0
-	currentPrice := sdk.OneDec()
-	ticksPassed := sdk.ZeroInt()
+	currentPrice := osmomath.OneDec()
+	ticksPassed := osmomath.ZeroInt()
 
 	exponentAtCurrentTick := exponentAtPriceOne
 
@@ -150,10 +169,10 @@ func CalculatePriceToTick(price sdk.Dec) (tickIndex sdk.Int) {
 	// In the opposite direction (price < 1), we do the same thing (just decrement the geometric exponent instead of incrementing).
 	// The only difference is we must reduce the increment distance by a factor of 10.
 	if price.GT(sdk.OneDec()) {
-		for currentPrice.LT(price) {
+		for currentPrice.LT(priceBigDec) {
 			currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurrentTick)
-			maxPriceForCurrentAdditiveIncrementInTicks := osmomath.BigDecFromSDKDec(geometricExponentIncrementDistanceInTicks).Mul(currentAdditiveIncrementInTicks)
-			currentPrice = currentPrice.Add(maxPriceForCurrentAdditiveIncrementInTicks.SDKDec())
+			maxPriceForCurrentAdditiveIncrementInTicks := geometricExponentIncrementDistanceInTicks.Mul(currentAdditiveIncrementInTicks)
+			currentPrice = currentPrice.Add(maxPriceForCurrentAdditiveIncrementInTicks)
 			exponentAtCurrentTick = exponentAtCurrentTick.Add(sdk.OneInt())
 			ticksPassed = ticksPassed.Add(geometricExponentIncrementDistanceInTicks.TruncateInt())
 		}
@@ -161,19 +180,23 @@ func CalculatePriceToTick(price sdk.Dec) (tickIndex sdk.Int) {
 		// We must decrement the exponentAtCurrentTick by one when traversing negative ticks in order to constantly step up in precision when going further down in ticks
 		// Otherwise, from tick 0 to tick -(geometricExponentIncrementDistanceInTicks), we would use the same exponent as the exponentAtPriceOne
 		exponentAtCurrentTick := exponentAtPriceOne.Sub(sdk.OneInt())
-		for currentPrice.GT(price) {
+		for currentPrice.GT(priceBigDec) {
 			currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurrentTick)
-			maxPriceForCurrentAdditiveIncrementInTicks := osmomath.BigDecFromSDKDec(geometricExponentIncrementDistanceInTicks).Mul(currentAdditiveIncrementInTicks)
-			currentPrice = currentPrice.Sub(maxPriceForCurrentAdditiveIncrementInTicks.SDKDec())
+			maxPriceForCurrentAdditiveIncrementInTicks := geometricExponentIncrementDistanceInTicks.Mul(currentAdditiveIncrementInTicks)
+			currentPrice = currentPrice.Sub(maxPriceForCurrentAdditiveIncrementInTicks)
 			exponentAtCurrentTick = exponentAtCurrentTick.Sub(sdk.OneInt())
 			ticksPassed = ticksPassed.Sub(geometricExponentIncrementDistanceInTicks.TruncateInt())
 		}
 	}
 
+	// // truncate residue from math
+	// + Precision of 24
+
 	// Determine how many ticks we have passed in the exponentAtCurrentTick (in other words, the incomplete geometricExponent above)
-	ticksToBeFulfilledByExponentAtCurrentTick := osmomath.BigDecFromSDKDec(price.Sub(currentPrice)).Quo(currentAdditiveIncrementInTicks)
+	ticksToBeFulfilledByExponentAtCurrentTick := priceBigDec.Sub(currentPrice).Quo(currentAdditiveIncrementInTicks)
 
 	// Finally, add the ticks we have passed from the completed geometricExponent values, as well as the ticks we have passed in the current geometricExponent value
-	tickIndex = ticksPassed.Add(ticksToBeFulfilledByExponentAtCurrentTick.SDKDec().TruncateInt())
-	return tickIndex
+	tickIndex := ticksPassed.Add(ticksToBeFulfilledByExponentAtCurrentTick.RoundInt())
+
+	return tickIndex.ToDec().SDKDec().TruncateInt()
 }

--- a/x/concentrated-liquidity/model/pool_test.go
+++ b/x/concentrated-liquidity/model/pool_test.go
@@ -2,7 +2,7 @@ package model_test
 
 import (
 	fmt "fmt"
-	math "math"
+	gomath "math"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -188,12 +188,12 @@ func (s *ConcentratedPoolTestSuite) TestApplySwap() {
 			currentTick:      sdk.NewInt(1),
 			currentSqrtPrice: DefaultCurrSqrtPrice,
 			newLiquidity:     DefaultLiquidityAmt,
-			newTick:          sdk.NewInt(math.MaxInt64),
+			newTick:          sdk.NewInt(gomath.MaxInt64),
 			newSqrtPrice:     DefaultCurrSqrtPrice,
 			expectErr: types.TickIndexNotWithinBoundariesError{
 				MaxTick:  types.MaxTick,
 				MinTick:  types.MinTick,
-				WantTick: math.MaxInt64,
+				WantTick: gomath.MaxInt64,
 			},
 		},
 		{
@@ -202,12 +202,12 @@ func (s *ConcentratedPoolTestSuite) TestApplySwap() {
 			currentTick:      sdk.NewInt(1),
 			currentSqrtPrice: DefaultCurrSqrtPrice,
 			newLiquidity:     DefaultLiquidityAmt,
-			newTick:          sdk.NewInt(math.MinInt64),
+			newTick:          sdk.NewInt(gomath.MinInt64),
 			newSqrtPrice:     DefaultCurrSqrtPrice,
 			expectErr: types.TickIndexNotWithinBoundariesError{
 				MaxTick:  types.MaxTick,
 				MinTick:  types.MinTick,
-				WantTick: math.MinInt64,
+				WantTick: gomath.MinInt64,
 			},
 		},
 	}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -273,7 +273,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 	}
 
 	// take provided price limit and turn this into a sqrt price limit since formulas use sqrtPrice
-	sqrtPriceLimit, err := priceLimit.ApproxSqrt()
+	sqrtPriceLimit, err := math.Sqrt(priceLimit)
 	if err != nil {
 		return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("issue calculating square root of price limit")
 	}
@@ -437,7 +437,7 @@ func (k Keeper) calcInAmtGivenOut(
 	}
 
 	// take provided price limit and turn this into a sqrt price limit since formulas use sqrtPrice
-	sqrtPriceLimit, err := priceLimit.ApproxSqrt()
+	sqrtPriceLimit, err := math.Sqrt(priceLimit)
 	if err != nil {
 		return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, fmt.Errorf("issue calculating square root of price limit")
 	}

--- a/x/epochs/go.mod
+++ b/x/epochs/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -134,7 +135,7 @@ require (
 // use cosmos-compatible protobufs
 replace (
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../../../cosmos-sdk
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/informalsystems/tendermint v0.34.24
 )

--- a/x/epochs/go.sum
+++ b/x/epochs/go.sum
@@ -671,7 +671,7 @@ github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
+github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -682,8 +682,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230329102328-d2e229f9cb78 h1:F7MljkYGSLD8p8GEZAQwgMkqWIRdwK8rDrJnnedyKBQ=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=

--- a/x/ibc-hooks/go.mod
+++ b/x/ibc-hooks/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -146,7 +147,7 @@ replace (
 	// dragonberry
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	// Our cosmos-sdk branch is:  https://github.com/osmosis-labs/cosmos-sdk, current branch: v16.x. Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/43c58d9061e3b8e0f06c3d9efef8c728800ab554
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434
+	github.com/cosmos/cosmos-sdk => ../../../cosmos-sdk
 	// use cosmos-compatible protobufs
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/informalsystems/tendermint v0.34.24

--- a/x/ibc-hooks/go.sum
+++ b/x/ibc-hooks/go.sum
@@ -684,7 +684,7 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWEr
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
+github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -695,8 +695,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434 h1:RetElHdhDl6f00Tjj7ii2r+HX2aa/u+dhgwQb5hKv8Y=
-github.com/osmosis-labs/cosmos-sdk v0.45.1-0.20230326212251-7a2cf2993434/go.mod h1:ss3tUfPTwaa6NsoPZrCR7xOqLqCK0LwoNbc2Q8Zs5/Y=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230329102328-d2e229f9cb78 h1:F7MljkYGSLD8p8GEZAQwgMkqWIRdwK8rDrJnnedyKBQ=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230329102328-d2e229f9cb78/go.mod h1:zyBrzl2rsZWGbOU+/1hzA+xoQlCshzZuHe/5mzdb/zo=
 github.com/osmosis-labs/wasmd v0.31.0-osmo-v16 h1:X747cZYdnqc/+RV48iPVeGprpVb/fUWSaKGsZUWrdbg=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4925

## What is the purpose of the change

Blocked by: https://github.com/osmosis-labs/osmosis/pull/4957


Currently, our tick to sqrt price and sqrt price to tick conversions do not preserve an inverse relationship.

That is, if I do a tick to sqrt price and then sqrt price to tick, I will not get the original tick.

The problem was rootcaused to the `ApproxSqrt` function. Switching the usage of `sdk.Dec` to `osmomath.BigDec` has helped to reduce the error. However, the problem is still present.

There were a few other places where the inaccurate `ApproxSqrt` function was used. I encapsulated it in the new `Sqrt` function.

To reason about the impact of the inaccurate function, let's document where `Sqrt` is called from and what the callers do with the result.

### `Sqrt`

Currently, the `Sqrt` is used in the following areas of the system:

- [`TickToSqrtPrice`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/math/tick.go#L47)
   * This is a helper to get the sqrt price from ticks. It is called from multiple other places and will be analyzed separately.
- `calcOutAmtGivenIn` and `calcInAmtGivenOut`
   * [Link](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/swaps.go#L276)
   * Computes sqrt price limit from the given price limit
   * Conclusion: if the computation is off, the swap might slightly over or under charge. This should not be the problem assuming the same `Sqrt` function is used consistently

```mermaid
graph LR
    TickToSqrtPrice -- calls --> Sqrt
    calcOutAmtGivenIn -- calls --> Sqrt
    calcInAmtGivenOut -- calls --> Sqrt
```

### `TickToSqrtPrice`

`TickToSqrtPrice` is being called from

- [`initializeInitialPositionForPool`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/lp.go#L332)
   * this is used to initialize the current sqrt price for the initial position
   * This should not be a problem as long as the same `Sqrt` is used consistently.
- [`TicksToSqrtPrice`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/math/tick.go#L22)
   * this is a helper that is called during LP and calculating underlying assets from position. It will be analyzed separately
-  `calcOutAmtGivenIn` and `calcInAmtGivenOut`
   * [Link](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/swaps.go#L332)
   * For calculating next tick sqrt price from tick
- [ `GetTickLiquidityNetInDirection`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/tick.go#L297) query
  * Used 

```mermaid
graph LR
    initializeInitialPositionForPool -- calls --> TickToSqrtPrice
    TicksToSqrtPrice -- calls --> TickToSqrtPrice
    calcOutAmtGivenIn -- calls --> TickToSqrtPrice
    calcInAmtGivenOut -- calls --> TickToSqrtPrice
    GetTickLiquidityNetInDirection -- calls --> TickToSqrtPrice

```

### `TicksToSqrtPrice`

`TicksToSqrtPrice` is being called from

- [`createPosition`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/lp.go#L49)
   * for calculating lower and upper sqrt price from ticks
- [`updatePosition`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/lp.go#L287)
- [`CalculateUnderlyingAssetsFromPosition`](https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/position.go#L349)

```mermaid
graph LR;
    createPosition -- calls -->TicksToSqrtPrice;
    updatePosition-- calls -->TicksToSqrtPrice;
    CalculateUnderlyingAssetsFromPosition-- calls -->TicksToSqrtPrice;
```

## Summary of Potential Problems

### Swaps

If the inverse relationship is not maintained, we might end up being inaccurate in calculations such as this one:
https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/swaps.go#L381-L384

leading to inaccuracy with swaps. Currently, we do not have a repro to confirm this.

### Initializing Sqrt Price and Tick

Here, we compute initial tick from initial price and initial sqrt price from tick. If this is inaccurate, that might lead to problems later in swaps. This area has already suffered from a problem when integrating with frontend. Previously, we took square root of price to initialize the sqrt price, and that completely broke the swap estimates.
https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/lp.go#L339-L352

### Calculating Assets From Position

https://github.com/osmosis-labs/osmosis/blob/463ec96cfa156acabf4d560e001bdc940fe4d4f3/x/concentrated-liquidity/position.go#L347-L362

This function is used for slashing, updating superfluid osmo equivalent multipliers and by Mars's contracts. It's inaccuracy might cause unforeseen problems in other system components.

### Important Considerations

If we accept that the inverse relationship is not to be maintained, we must accept that the square root price is to always be initialized from ticks. Otherwise, we can get a different square root price in different system components depending on whether we computed the square root price by taking the sqrt of the price 

## Brief Changelog

- Introduce x/concentrated-liquidity` `math.Sqrt` function to use the same implementation of square root consistently
- Introduce `TickToPrice` function and refactor `TickToSqrtPrice` to call `TickToPrice` and then `Sqrt`
- Refactor `TestTickToSqrtPricePriceToTick_InverseRelationship` to root cause the error coming from taking the square root
- Rename `TestTickToSqrtPrice` to `TestTickToSqrtPrice_And_TickToPrice` and make it test both  `TickToPrice` function and refactor `TickToSqrtPrice`

## Testing and Verifying

TBD

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)