### PR TITLE
Jl/generalize protorev epoch hook for all pool modules

### DIFF
--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -550,6 +550,11 @@ func (k Keeper) AllPools(
 	return sortedPools, nil
 }
 
+// AllPoolModules returns all pool modules registered in the pool manager keeper.
+func (k Keeper) AllPoolModules() []types.PoolModuleI {
+	return k.poolModules
+}
+
 func (k Keeper) isOsmoRoutedMultihop(ctx sdk.Context, route types.MultihopRoute, inDenom, outDenom string) (isRouted bool) {
 	if route.Length() != 2 {
 		return false

--- a/x/protorev/types/expected_keepers.go
+++ b/x/protorev/types/expected_keepers.go
@@ -52,6 +52,7 @@ type PoolManagerKeeper interface {
 		poolId uint64,
 	) (poolmanagertypes.PoolI, error)
 	GetPoolModule(ctx sdk.Context, poolId uint64) (poolmanagertypes.PoolModuleI, error)
+	AllPoolModules() []poolmanagertypes.PoolModuleI
 }
 
 // EpochKeeper defines the Epoch contract that must be fulfilled when


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To show what I view as the ideal generalized protorev interface for the epoch_hook to arbitrary pool modules that use the poolmanager interfaces.

## Brief Changelog

- Add a function in poolmanager that gets all the pool modules that can be used by other modules
- Add new function to protorev expected keepers
- Use this function to get all pools for individual pool modules within protorev epoch hook