### PR TITLE
[CL][Incentives]: Modify logic for getting lockup durations to be guaranteed to get longest duration

### DIFF
--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -220,11 +220,10 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 	}
 
 	// Get longest lockup period for pool
-	lockableDurations := k.poolIncentivesKeeper.GetLockableDurations(ctx)
-	longestLockableDuration := lockableDurations[len(lockableDurations)-1]
+	longestDuration := k.poolIncentivesKeeper.GetLongestLockableDuration(ctx)
 
 	// Get gauge corresponding to the longest lockup period
-	gaugeId, err := k.poolIncentivesKeeper.GetPoolGaugeId(ctx, balPoolId, longestLockableDuration)
+	gaugeId, err := k.poolIncentivesKeeper.GetPoolGaugeId(ctx, balPoolId, longestDuration)
 	if err != nil {
 		return sdk.Coins{}, err
 	}

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -220,7 +220,10 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 	}
 
 	// Get longest lockup period for pool
-	longestDuration := k.poolIncentivesKeeper.GetLongestLockableDuration(ctx)
+	longestDuration, err := k.poolIncentivesKeeper.GetLongestLockableDuration(ctx)
+	if err != nil {
+		return sdk.Coins{}, err
+	}
 
 	// Get gauge corresponding to the longest lockup period
 	gaugeId, err := k.poolIncentivesKeeper.GetPoolGaugeId(ctx, balPoolId, longestDuration)

--- a/x/concentrated-liquidity/types/expected_keepers.go
+++ b/x/concentrated-liquidity/types/expected_keepers.go
@@ -35,8 +35,8 @@ type GAMMKeeper interface {
 }
 
 type PoolIncentivesKeeper interface {
-	GetLockableDurations(ctx sdk.Context) []time.Duration
 	GetPoolGaugeId(ctx sdk.Context, poolId uint64, lockableDuration time.Duration) (uint64, error)
+	GetLongestLockableDuration(ctx sdk.Context) time.Duration
 }
 
 type IncentivesKeeper interface {

--- a/x/concentrated-liquidity/types/expected_keepers.go
+++ b/x/concentrated-liquidity/types/expected_keepers.go
@@ -36,7 +36,7 @@ type GAMMKeeper interface {
 
 type PoolIncentivesKeeper interface {
 	GetPoolGaugeId(ctx sdk.Context, poolId uint64, lockableDuration time.Duration) (uint64, error)
-	GetLongestLockableDuration(ctx sdk.Context) time.Duration
+	GetLongestLockableDuration(ctx sdk.Context) (time.Duration, error)
 }
 
 type IncentivesKeeper interface {

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -196,6 +196,19 @@ func (k Keeper) GetLockableDurations(ctx sdk.Context) []time.Duration {
 	return info.LockableDurations
 }
 
+func (k Keeper) GetLongestLockableDuration(ctx sdk.Context) time.Duration {
+	lockableDurations := k.GetLockableDurations(ctx)
+	longestDuration := time.Duration(0)
+
+	for _, duration := range lockableDurations {
+		if duration > longestDuration {
+			longestDuration = duration
+		}
+	}
+
+	return longestDuration
+}
+
 func (k Keeper) GetAllGauges(ctx sdk.Context) []incentivestypes.Gauge {
 	gauges := k.incentivesKeeper.GetGauges(ctx)
 	return gauges

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -196,8 +196,11 @@ func (k Keeper) GetLockableDurations(ctx sdk.Context) []time.Duration {
 	return info.LockableDurations
 }
 
-func (k Keeper) GetLongestLockableDuration(ctx sdk.Context) time.Duration {
+func (k Keeper) GetLongestLockableDuration(ctx sdk.Context) (time.Duration, error) {
 	lockableDurations := k.GetLockableDurations(ctx)
+	if len(lockableDurations) == 0 {
+		return 0, fmt.Errorf("Lockable Durations doesnot exist")
+	}
 	longestDuration := time.Duration(0)
 
 	for _, duration := range lockableDurations {
@@ -206,7 +209,7 @@ func (k Keeper) GetLongestLockableDuration(ctx sdk.Context) time.Duration {
 		}
 	}
 
-	return longestDuration
+	return longestDuration, nil
 }
 
 func (k Keeper) GetAllGauges(ctx sdk.Context) []incentivestypes.Gauge {

--- a/x/pool-incentives/keeper/keeper_test.go
+++ b/x/pool-incentives/keeper/keeper_test.go
@@ -269,3 +269,43 @@ func (suite *KeeperTestSuite) TestGetGaugesForCFMMPool() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestGetLongestLockableDuration() {
+	testCases := []struct {
+		name              string
+		lockableDurations []time.Duration
+		expectedDuration  time.Duration
+	}{
+		{
+			name:              "3 lockable Durations",
+			lockableDurations: []time.Duration{time.Hour, time.Minute, time.Second},
+			expectedDuration:  time.Hour,
+		},
+
+		{
+			name:              "2 lockable Durations",
+			lockableDurations: []time.Duration{time.Second, time.Minute},
+			expectedDuration:  time.Minute,
+		},
+		{
+			name:              "1 lockable Durations",
+			lockableDurations: []time.Duration{time.Minute},
+			expectedDuration:  time.Minute,
+		},
+		{
+			name:              "0 lockable Durations",
+			lockableDurations: []time.Duration{},
+			expectedDuration:  0,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+
+			suite.App.PoolIncentivesKeeper.SetLockableDurations(suite.Ctx, tc.lockableDurations)
+
+			result := suite.App.PoolIncentivesKeeper.GetLongestLockableDuration(suite.Ctx)
+			suite.Require().Equal(tc.expectedDuration, result)
+		})
+	}
+}

--- a/x/pool-incentives/keeper/keeper_test.go
+++ b/x/pool-incentives/keeper/keeper_test.go
@@ -275,6 +275,7 @@ func (suite *KeeperTestSuite) TestGetLongestLockableDuration() {
 		name              string
 		lockableDurations []time.Duration
 		expectedDuration  time.Duration
+		expectError       bool
 	}{
 		{
 			name:              "3 lockable Durations",
@@ -296,6 +297,7 @@ func (suite *KeeperTestSuite) TestGetLongestLockableDuration() {
 			name:              "0 lockable Durations",
 			lockableDurations: []time.Duration{},
 			expectedDuration:  0,
+			expectError:       true,
 		},
 	}
 
@@ -304,7 +306,13 @@ func (suite *KeeperTestSuite) TestGetLongestLockableDuration() {
 
 			suite.App.PoolIncentivesKeeper.SetLockableDurations(suite.Ctx, tc.lockableDurations)
 
-			result := suite.App.PoolIncentivesKeeper.GetLongestLockableDuration(suite.Ctx)
+			result, err := suite.App.PoolIncentivesKeeper.GetLongestLockableDuration(suite.Ctx)
+			if tc.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+
 			suite.Require().Equal(tc.expectedDuration, result)
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

[Closes: #4916](https://github.com/osmosis-labs/osmosis/issues/4916)

## What is the purpose of the change
Our current implementation of reward splitting assumes that the longest lockup duration is the last one in the array of durations placed in state. While this is currently true, it is technically possible for this to be updated such that the last duration is not the longest, since we are not guaranteed that the list is sorted.

## Brief Changelog
n/a

## Testing and Verifying
-added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)