### PR TITLE
bug[CL]: check owner when withdrawing position

### DIFF
--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -123,6 +123,7 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 // Additionally, when the last position is removed by calling this method, the current sqrt price and current
 // tick are set to zero.
 // Returns error if
+// - the provided owner does not own the position being withdrawn
 // - there is no position in the given tick ranges
 // - if the position's underlying lock is not mature
 // - if tick ranges are invalid
@@ -131,6 +132,11 @@ func (k Keeper) withdrawPosition(ctx sdk.Context, owner sdk.AccAddress, position
 	position, err := k.GetPosition(ctx, positionId)
 	if err != nil {
 		return sdk.Int{}, sdk.Int{}, err
+	}
+
+	// Check if the provided owner owns the position being withdrawn.
+	if owner.String() != position.Address {
+		return sdk.Int{}, sdk.Int{}, types.NotPositionOwnerError{PositionId: positionId, Address: owner.String()}
 	}
 
 	// If underlying lock exists in state, validate unlocked conditions are met before withdrawing liquidity.

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -412,8 +412,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		"error: attempt to withdraw a position that does not belong to the caller": {
 			setupConfig: baseCase,
 			sutConfigOverwrite: &lpTest{
-				liquidityAmount: baseCase.liquidityAmount.Add(sdk.OneDec()), // 1 more than available
-				expectedError:   types.NotPositionOwnerError{PositionId: 1, Address: nonOwner.String()},
+				expectedError: types.NotPositionOwnerError{PositionId: 1, Address: nonOwner.String()},
 			},
 			timeElapsed:          defaultTimeElapsed,
 			withdrawWithNonOwner: true,

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -321,6 +321,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 	uptimeHelper := getExpectedUptimes()
 	defaultUptimeGrowth := uptimeHelper.hundredTokensMultiDenom
 	DefaultJoinTime := s.Ctx.BlockTime()
+	nonOwner := s.TestAccs[1]
 
 	tests := map[string]struct {
 		setupConfig *lpTest
@@ -333,13 +334,10 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		createLockLocked        bool
 		createLockUnlocking     bool
 		createLockUnlocked      bool
+		withdrawWithNonOwner    bool
 	}{
 		"base case: withdraw full liquidity amount": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				amount0Expected: baseCase.amount0Expected, // 0.998976 eth
 				amount1Expected: baseCase.amount1Expected, // 5000 usdc
@@ -347,11 +345,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed: defaultTimeElapsed,
 		},
 		"withdraw full liquidity amount with underlying lock that has finished unlocking": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				amount0Expected:  DefaultAmt0,
 				amount1Expected:  DefaultAmt1.Sub(sdk.OneInt()),
@@ -362,11 +356,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed:        defaultTimeElapsed,
 		},
 		"error: withdraw full liquidity amount but still locked": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				liquidityAmount:  FullRangeLiquidityAmt,
 				underlyingLockId: 1,
@@ -376,11 +366,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed:      defaultTimeElapsed,
 		},
 		"error: withdraw full liquidity amount but still unlocking": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				liquidityAmount:  FullRangeLiquidityAmt,
 				underlyingLockId: 1,
@@ -390,11 +376,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed:         defaultTimeElapsed,
 		},
 		"withdraw partial liquidity amount": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				liquidityAmount: baseCase.liquidityAmount.QuoRoundUp(sdk.NewDec(2)),
 				amount0Expected: baseCase.amount0Expected.QuoRaw(2), // 0.499488
@@ -403,11 +385,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed: defaultTimeElapsed,
 		},
 		"withdraw full liquidity amount, forfeit incentives": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				amount0Expected: baseCase.amount0Expected, // 0.998976 eth
 				amount1Expected: baseCase.amount1Expected, // 5000 usdc
@@ -415,11 +393,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed: 0,
 		},
 		"error: no position created": {
-			// setup parameters for creation a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				lowerTick:     -1, // valid tick at which no position exists
 				positionId:    DefaultPositionId + 1,
@@ -428,16 +402,21 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			timeElapsed: defaultTimeElapsed,
 		},
 		"error: insufficient liquidity": {
-			// setup parameters for creating a pool and position.
 			setupConfig: baseCase,
-
-			// system under test parameters
-			// for withdrawing a position.
 			sutConfigOverwrite: &lpTest{
 				liquidityAmount: baseCase.liquidityAmount.Add(sdk.OneDec()), // 1 more than available
 				expectedError:   types.InsufficientLiquidityError{Actual: baseCase.liquidityAmount.Add(sdk.OneDec()), Available: baseCase.liquidityAmount},
 			},
 			timeElapsed: defaultTimeElapsed,
+		},
+		"error: attempt to withdraw a position that does not belong to the caller": {
+			setupConfig: baseCase,
+			sutConfigOverwrite: &lpTest{
+				liquidityAmount: baseCase.liquidityAmount.Add(sdk.OneDec()), // 1 more than available
+				expectedError:   types.NotPositionOwnerError{PositionId: 1, Address: nonOwner.String()},
+			},
+			timeElapsed:          defaultTimeElapsed,
+			withdrawWithNonOwner: true,
 		},
 		// TODO: test with custom amounts that potentially lead to truncations.
 	}
@@ -522,8 +501,15 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 
 			expectedPoolBalanceDelta := expectedFeesClaimed.Add(sdk.NewCoin(ETH, config.amount0Expected.Abs())).Add(sdk.NewCoin(USDC, config.amount1Expected.Abs()))
 
+			withdrawAccount := sdk.AccAddress{}
+			if tc.withdrawWithNonOwner {
+				withdrawAccount = nonOwner
+			} else {
+				withdrawAccount = owner
+			}
+
 			// System under test.
-			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, owner, config.positionId, config.liquidityAmount)
+			amtDenom0, amtDenom1, err := concentratedLiquidityKeeper.WithdrawPosition(ctx, withdrawAccount, config.positionId, config.liquidityAmount)
 			if config.expectedError != nil {
 				s.Require().Error(err)
 				s.Require().Equal(amtDenom0, sdk.Int{})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4987 

## What is the purpose of the change

We were not checking the owner of a position when calling the withdraw function. This PR adds the relevant logic and test.


## Brief Changelog

- Adds check that provided owner is the owner of the position being withdrawn
- Adds a test to the currently existing `TestWithdrawPosition` that attempts to withdraw a position with a non-owner account.


## Testing and Verifying

Relevant test added to lp_test.go

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)