### PR TITLE
fix/test: inverse relationship issues (1/2)

### DIFF
--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -159,7 +159,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 		},
 		"one tick spacing interval smaller than max sqrt price, max tick neg six - 100 -> one tick spacing interval smaller than max sqrt price": {
 			tickIndex:     sdk.NewInt(types.MaxTick).Sub(sdk.NewInt(100)),
-			expectedPrice: sdk.MustNewDecFromStr("99999000000000000000000000000000000014"), // there is some excess here due to the math functions.
+			expectedPrice: sdk.MustNewDecFromStr("99999000000000000000000000000000000000"),
 		},
 		"max sqrt price, max tick neg six -> max spot price": {
 			tickIndex:     sdk.NewInt(types.MaxTick),
@@ -307,11 +307,60 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 		},
 		"max spot price": {
 			price:        types.MaxSpotPrice,
-			tickExpected: "342000000",
+			tickExpected: sdk.NewInt(types.MaxTick).String(),
+		},
+		"max spot price - smallest dec": {
+			// 37 - 6 is calculated by counting the exponent of max spot price and subtracting exponent at price one
+			price:        types.MaxSpotPrice.Sub(sdk.NewDec(10).PowerMut(37 - 6)),
+			tickExpected: sdk.NewInt(types.MaxTick).Sub(sdk.OneInt()).String(), // still max
 		},
 		"min spot price": {
 			price:        types.MinSpotPrice,
 			tickExpected: "-162000000",
+		},
+		"smallest + min price increment": {
+			price:        sdk.MustNewDecFromStr("0.000000000000000002"),
+			tickExpected: "-161000000",
+		},
+		"min price increment 10^1": {
+			price:        sdk.MustNewDecFromStr("0.000000000000000009"),
+			tickExpected: "-154000000",
+		},
+		"smallest + min price increment 10^1": {
+			price:        sdk.MustNewDecFromStr("0.000000000000000010"),
+			tickExpected: "-153000000",
+		},
+		"smallest + min price increment * 10^2": {
+			price:        sdk.MustNewDecFromStr("0.000000000000000100"),
+			tickExpected: "-144000000",
+		},
+		"smallest + min price increment * 10^3": {
+			price:        sdk.MustNewDecFromStr("0.000000000000001000"),
+			tickExpected: "-135000000",
+		},
+		"smallest + min price increment * 10^4": {
+			price:        sdk.MustNewDecFromStr("0.000000000000010000"),
+			tickExpected: "-126000000",
+		},
+		"smallest + min price * increment 10^5": {
+			price:        sdk.MustNewDecFromStr("0.000000000000100000"),
+			tickExpected: "-117000000",
+		},
+		"smallest + min price * increment 10^6": {
+			price:        sdk.MustNewDecFromStr("0.000000000001000000"),
+			tickExpected: "-108000000",
+		},
+		"smallest + min price * increment 10^6 + tick": {
+			price:        sdk.MustNewDecFromStr("0.000000000001000001"),
+			tickExpected: "-107999999",
+		},
+		"smallest + min price * increment 10^17": {
+			price:        sdk.MustNewDecFromStr("0.100000000000000000"),
+			tickExpected: "-9000000",
+		},
+		"smallest + min price * increment 10^18": {
+			price:        sdk.MustNewDecFromStr("1.000000000000000000"),
+			tickExpected: "0",
 		},
 	}
 	for name, tc := range testCases {
@@ -319,16 +368,40 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 
 		suite.Run(name, func() {
 			tickSpacing := uint64(1)
-			tick, err := math.PriceToTick(tc.price, tickSpacing)
+
+			// 1. Compute tick from price.
+			tickFromPrice, err := math.PriceToTick(tc.price, tickSpacing)
 			suite.Require().NoError(err)
-			suite.Require().Equal(tc.tickExpected, tick.String())
+			suite.Require().Equal(tc.tickExpected, tickFromPrice.String())
 
-			sqrtPrice, err := math.TickToSqrtPrice(tick)
-			price := sqrtPrice.Power(2)
-			deltaPrice := tc.price.Sub(price).Abs()
+			// 2. Compute price from tick (inverse price)
+			price, err := math.TickToPrice(tickFromPrice)
+			suite.Require().NoError(err)
 
-			roundingTolerance := sdk.MustNewDecFromStr("0.0001")
-			suite.Require().True(deltaPrice.LTE(roundingTolerance))
+			// Make sure inverse price is correct.
+			suite.Require().Equal(price, tc.price)
+
+			// 3. Compute tick from inverse price (inverse tick)
+			inverseTickFromPrice, err := math.PriceToTick(price, tickSpacing)
+			suite.Require().NoError(err)
+
+			// Make sure original tick and inverse tick match.
+			suite.Require().Equal(tickFromPrice.String(), inverseTickFromPrice.String())
+
+			// 4. Validate PriceToTick and TickToSqrtPrice functions
+			sqrtPrice, err := math.TickToSqrtPrice(tickFromPrice)
+			suite.Require().NoError(err)
+
+			priceFromSqrtPrice := sqrtPrice.Power(2)
+
+			// TODO: investigate this separately
+			// https://github.com/osmosis-labs/osmosis/issues/4925
+			// suite.Require().Equal(priceFromSqrtPrice, tc.price)
+
+			inverseTickFromSqrtPrice, err := math.PriceToTick(priceFromSqrtPrice, tickSpacing)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(tickFromPrice, inverseTickFromSqrtPrice, "expected: %s, actual: %s", tickFromPrice, inverseTickFromSqrtPrice)
 		})
 	}
 }

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -414,9 +414,12 @@ var (
 			// sqrtPriceCurrent: 70.710678118654752440 which is 5000
 			// expectedTokenIn:  12891.26207649936510 rounded up https://www.wolframalpha.com/input?key=&i=%281517882343.751510418088349649+*+%2870.710678118654752440+-+70.668238976219012614+%29%29+%2F+%2870.710678118654752440+*+70.668238976219012614%29
 			// expectedTokenOut: 64417624.98716495170 rounded down https://www.wolframalpha.com/input?key=&i=1517882343.751510418088349649+*+%2870.710678118654752440+-+70.668238976219012614%29
-			expectedTokenIn:            sdk.NewCoin("eth", sdk.NewInt(12892)),
-			expectedTokenOut:           sdk.NewCoin("usdc", sdk.NewInt(64417624)),
-			expectedTick:               sdk.NewInt(30994100),
+			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(12892)),
+			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(64417624)),
+			expectedTick: func() sdk.Int {
+				tick, _ := math.PriceToTick(sdk.NewDec(4994), 1)
+				return tick
+			}(),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2812891.26207649936510%29%29
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -578,8 +581,11 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13022)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64417624)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000085792039652"),
-			expectedTick:                      sdk.NewInt(30994100),
-			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813020+*+%281+-+0.01%29%29%29
+			expectedTick: func() sdk.Int {
+				tick, _ := math.PriceToTick(sdk.NewDec(4994), 1)
+				return tick
+			}(),
+			expectedSqrtPrice: sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813020+*+%281+-+0.01%29%29%29
 		},
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4979

## What is the purpose of the change

This is a known issue of #4979 but it seems that I've run into it independently while debugging.

This PR resolves the issue by rounding in `CalculatePriceToTick`. The test vectors got resolved by this change.


## Brief Changelog

- Separate `TickToPrice` and `TickToSqrtPrice` functions where `TickToSqrtPrice` calls `TickToPrice`
- Add a lot of test vectors to reproduce the inverse relationship problem
- resolve it by rounding instead of truncating

## Testing and Verifying

This change added tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable