### PR TITLE
[CL]: default swap fees

### DIFF
--- a/app/upgrades/v16/concentrated_pool.go
+++ b/app/upgrades/v16/concentrated_pool.go
@@ -46,6 +46,7 @@ func createConcentratedPoolFromCFMM(ctx sdk.Context, cfmmPoolIdToLinkWith uint64
 		return nil, NoDesiredDenomInPoolError{desiredDenom0}
 	}
 
+	// Swap fee is 0.2%, which is an authorized swap fee.
 	swapFee := cfmmPool.GetSwapFee(ctx)
 
 	createPoolMsg := clmodel.NewMsgCreateConcentratedPool(poolCreatorAddress, desiredDenom0, denom1, TickSpacing, swapFee)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -195,8 +195,8 @@ func (s *IntegrationTestSuite) TestConcentratedLiquidity() {
 		denom0      string  = "uion"
 		denom1      string  = "uosmo"
 		tickSpacing uint64  = 100
-		swapFee             = "0.01"
-		swapFeeDec  sdk.Dec = sdk.MustNewDecFromStr("0.01")
+		swapFee             = "0.001" // 0.1%
+		swapFeeDec  sdk.Dec = sdk.MustNewDecFromStr("0.001")
 	)
 
 	// Get the permisionless pool creation parameter.

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -18,9 +18,17 @@ var (
 	MaxSqrtPrice, _           = MaxSpotPrice.ApproxRoot(2)
 	MinSqrtPrice, _           = MinSpotPrice.ApproxRoot(2)
 	// Supported uptimes preset to 1 ns, 1 min, 1 hr, 1D, 1W
-	SupportedUptimes              = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24, time.Hour * 24 * 7}
-	ExponentAtPriceOne            = sdk.NewInt(-6)
-	AuthorizedTickSpacing         = []uint64{1, 10, 100, 1000}
+	SupportedUptimes      = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24, time.Hour * 24 * 7}
+	ExponentAtPriceOne    = sdk.NewInt(-6)
+	AuthorizedTickSpacing = []uint64{1, 10, 100, 1000}
+	AuthorizedSwapFees    = []sdk.Dec{
+		sdk.ZeroDec(),
+		sdk.MustNewDecFromStr("0.0001"), // 0.01%
+		sdk.MustNewDecFromStr("0.0005"), // 0.05%
+		sdk.MustNewDecFromStr("0.001"),  // 0.1%
+		sdk.MustNewDecFromStr("0.002"),  // 0.2%
+		sdk.MustNewDecFromStr("0.003"),  // 0.3%
+		sdk.MustNewDecFromStr("0.005")}  // 0.5%
 	BaseGasFeeForNewIncentive     = 10_000
 	DefaultBalancerSharesDiscount = sdk.MustNewDecFromStr("0.05")
 )

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -34,18 +34,10 @@ func NewParams(authorizedTickSpacing []uint64, authorizedSwapFees []sdk.Dec, dis
 }
 
 // DefaultParams returns default concentrated-liquidity module parameters.
-// TODO: Decide on what these should be initially.
-// https://github.com/osmosis-labs/osmosis/issues/3684
 func DefaultParams() Params {
 	return Params{
 		AuthorizedTickSpacing: AuthorizedTickSpacing,
-		AuthorizedSwapFees: []sdk.Dec{
-			sdk.ZeroDec(),
-			sdk.MustNewDecFromStr("0.0001"),
-			sdk.MustNewDecFromStr("0.0003"),
-			sdk.MustNewDecFromStr("0.0005"),
-			sdk.MustNewDecFromStr("0.002"),
-			sdk.MustNewDecFromStr("0.01")},
+		AuthorizedSwapFees:    AuthorizedSwapFees,
 		AuthorizedQuoteDenoms: []string{
 			"uosmo",
 			"ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7", // DAI

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	defaultInitPoolAmount  = sdk.NewInt(1000000000000)
-	defaultPoolSwapFee     = sdk.NewDecWithPrec(1, 2) // 1% pool swap fee default
+	defaultPoolSwapFee     = sdk.NewDecWithPrec(1, 3) // 0.1% pool swap fee default
 	defaultSwapAmount      = sdk.NewInt(1000000)
 	gammKeeperType         = reflect.TypeOf(&gamm.Keeper{})
 	concentratedKeeperType = reflect.TypeOf(&cl.Keeper{})

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -1281,20 +1281,20 @@ func (suite *KeeperTestSuite) TestSingleSwapExactAmountIn() {
 		// We have:
 		//  - foo: 1000000000000
 		//  - bar: 1000000000000
-		//  - swapFee: 1%
+		//  - swapFee: 0.1%
 		//  - foo in: 100000
 		//  - bar amount out will be calculated according to the formula
-		// 		https://www.wolframalpha.com/input?i=solve+%2810%5E12+%2B+10%5E5+x+0.99%29%2810%5E12+-+x%29+%3D+10%5E24
-		// We round down the token amount out, get the result is 98999
+		// 		https://www.wolframalpha.com/input?i=solve+%2810%5E12+%2B+10%5E5+x+0.999%29%2810%5E12+-+x%29+%3D+10%5E24
+		// We round down the token amount out, get the result is 99899
 		{
-			name:                   "Swap - [foo -> bar], 1 percent fee",
+			name:                   "Swap - [foo -> bar], 0.1 percent fee",
 			poolId:                 1,
 			poolCoins:              sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
 			poolFee:                defaultPoolSwapFee,
 			tokenIn:                sdk.NewCoin(foo, sdk.NewInt(100000)),
 			tokenOutMinAmount:      sdk.NewInt(1),
 			tokenOutDenom:          bar,
-			expectedTokenOutAmount: sdk.NewInt(98999),
+			expectedTokenOutAmount: sdk.NewInt(99899),
 		},
 		{
 			name:              "Wrong pool id",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4899 

## What is the purpose of the change

After speaking with Johnny, we decided on an initial set of authorized swap fees we can launch with. This can always we changed later via governance. The fees are as follows:

.01%
.05%
.1%
.2%
.3%
.5%

Additionally, there was a question on migrating future pools that do not fall into one of these above fee categories. There is no logic in the migration link function that requires the cl pool being linked to have the same swap fee as the balancer pool, so this so be a non issue.


## Brief Changelog

- Adds authorized swap fees as a const
- Sets DefaultParams to the authorized swap fees set in the const 


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)