### PR TITLE
test: add incentive and fee accum check

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -121,10 +121,6 @@ func (k Keeper) CreateFeeAccumulator(ctx sdk.Context, poolId uint64) error {
 	return k.createFeeAccumulator(ctx, poolId)
 }
 
-func (k Keeper) GetFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.AccumulatorObject, error) {
-	return k.getFeeAccumulator(ctx, poolId)
-}
-
 func (k Keeper) InitOrUpdateFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, lowerTick, upperTick int64, positionId uint64, liquidity sdk.Dec) error {
 	return k.initOrUpdateFeeAccumulatorPosition(ctx, poolId, lowerTick, upperTick, positionId, liquidity)
 }
@@ -181,10 +177,6 @@ func (ss *SwapState) GetFeeGrowthGlobal() sdk.Dec {
 // incentive methods
 func (k Keeper) CreateUptimeAccumulators(ctx sdk.Context, poolId uint64) error {
 	return k.createUptimeAccumulators(ctx, poolId)
-}
-
-func (k Keeper) GetUptimeAccumulators(ctx sdk.Context, poolId uint64) ([]accum.AccumulatorObject, error) {
-	return k.getUptimeAccumulators(ctx, poolId)
 }
 
 func (k Keeper) GetUptimeAccumulatorValues(ctx sdk.Context, poolId uint64) ([]sdk.DecCoins, error) {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -21,9 +21,9 @@ func (k Keeper) createFeeAccumulator(ctx sdk.Context, poolId uint64) error {
 	return nil
 }
 
-// getFeeAccumulator gets the fee accumulator object using the given poolOd
+// GetFeeAccumulator gets the fee accumulator object using the given poolOd
 // returns error if accumulator for the given poolId does not exist.
-func (k Keeper) getFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.AccumulatorObject, error) {
+func (k Keeper) GetFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.AccumulatorObject, error) {
 	acc, err := accum.GetAccumulator(ctx.KVStore(k.storeKey), types.KeyFeePoolAccumulator(poolId))
 	if err != nil {
 		return accum.AccumulatorObject{}, err
@@ -36,7 +36,7 @@ func (k Keeper) getFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.Accumul
 // the internal per-pool accumulator that tracks fee growth per one unit of
 // liquidity. Returns error if fails to get accumulator.
 func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
-	feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin)
 // - fails to update the position's accumulator.
 func (k Keeper) initOrUpdateFeeAccumulatorPosition(ctx sdk.Context, poolId uint64, lowerTick, upperTick int64, positionId uint64, liquidityDelta sdk.Dec) error {
 	// Get the fee accumulator for the position's pool.
-	feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (k Keeper) getFeeGrowthOutside(ctx sdk.Context, poolId uint64, lowerTick, u
 		return sdk.DecCoins{}, err
 	}
 
-	poolFeeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
+	poolFeeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
 	if err != nil {
 		return sdk.DecCoins{}, err
 	}
@@ -168,7 +168,7 @@ func (k Keeper) getInitialFeeGrowthOutsideForTick(ctx sdk.Context, poolId uint64
 
 	currentTick := pool.GetCurrentTick().Int64()
 	if currentTick >= tick {
-		feeAccumulator, err := k.getFeeAccumulator(ctx, poolId)
+		feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
 		if err != nil {
 			return sdk.DecCoins{}, err
 		}
@@ -248,7 +248,7 @@ func (k Keeper) prepareClaimableFees(ctx sdk.Context, positionId uint64) (sdk.Co
 	}
 
 	// Get the fee accumulator for the position's pool.
-	feeAccumulator, err := k.getFeeAccumulator(ctx, position.PoolId)
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, position.PoolId)
 	if err != nil {
 		return nil, err
 	}

--- a/x/concentrated-liquidity/genesis.go
+++ b/x/concentrated-liquidity/genesis.go
@@ -93,7 +93,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *genesis.GenesisState {
 		if err != nil {
 			panic(err)
 		}
-		accumObject, err := k.getFeeAccumulator(ctx, poolI.GetId())
+		accumObject, err := k.GetFeeAccumulator(ctx, poolI.GetId())
 		if err != nil {
 			panic(err)
 		}
@@ -117,7 +117,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *genesis.GenesisState {
 			panic(err)
 		}
 
-		incentivesAccum, err := k.getUptimeAccumulators(ctx, poolId)
+		incentivesAccum, err := k.GetUptimeAccumulators(ctx, poolId)
 		if err != nil {
 			panic(err)
 		}

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -38,10 +38,9 @@ func getUptimeTrackerValues(uptimeTrackers []model.UptimeTracker) []sdk.DecCoins
 	return trackerValues
 }
 
-// nolint: unused
-// getUptimeAccumulators gets the uptime accumulator objects for the given poolId
+// GetUptimeAccumulators gets the uptime accumulator objects for the given poolId
 // Returns error if accumulator for the given poolId does not exist.
-func (k Keeper) getUptimeAccumulators(ctx sdk.Context, poolId uint64) ([]accum.AccumulatorObject, error) {
+func (k Keeper) GetUptimeAccumulators(ctx sdk.Context, poolId uint64) ([]accum.AccumulatorObject, error) {
 	accums := make([]accum.AccumulatorObject, len(types.SupportedUptimes))
 	for uptimeIndex := range types.SupportedUptimes {
 		acc, err := accum.GetAccumulator(ctx.KVStore(k.storeKey), types.KeyUptimeAccumulator(poolId, uint64(uptimeIndex)))
@@ -59,7 +58,7 @@ func (k Keeper) getUptimeAccumulators(ctx sdk.Context, poolId uint64) ([]accum.A
 // getUptimeAccumulatorValues gets the accumulator values for the supported uptimes for the given poolId
 // Returns error if accumulator for the given poolId does not exist.
 func (k Keeper) getUptimeAccumulatorValues(ctx sdk.Context, poolId uint64) ([]sdk.DecCoins, error) {
-	uptimeAccums, err := k.getUptimeAccumulators(ctx, poolId)
+	uptimeAccums, err := k.GetUptimeAccumulators(ctx, poolId)
 	if err != nil {
 		return []sdk.DecCoins{}, err
 	}
@@ -185,7 +184,7 @@ func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64)
 
 	// Create a temporary position record on all uptime accumulators with this amount. We expect this to be cleared later
 	// with `claimAndResetFullRangeBalancerPool`
-	uptimeAccums, err := k.getUptimeAccumulators(ctx, clPoolId)
+	uptimeAccums, err := k.GetUptimeAccumulators(ctx, clPoolId)
 	if err != nil {
 		return 0, sdk.ZeroDec(), err
 	}
@@ -234,7 +233,7 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 	// Get all uptime accumulators for CL pool
 	// Create a temporary position record on all uptime accumulators with this amount. We expect this to be cleared later
 	// with `claimAndResetFullRangeBalancerPool`
-	uptimeAccums, err := k.getUptimeAccumulators(ctx, clPoolId)
+	uptimeAccums, err := k.GetUptimeAccumulators(ctx, clPoolId)
 	if err != nil {
 		return sdk.Coins{}, err
 	}
@@ -336,7 +335,7 @@ func (k Keeper) updateUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64) er
 		return err
 	}
 
-	uptimeAccums, err := k.getUptimeAccumulators(ctx, poolId)
+	uptimeAccums, err := k.GetUptimeAccumulators(ctx, poolId)
 	if err != nil {
 		return err
 	}
@@ -626,7 +625,7 @@ func (k Keeper) initOrUpdatePositionUptime(ctx sdk.Context, poolId uint64, liqui
 	}
 
 	// Create records for relevant uptime accumulators here.
-	uptimeAccumulators, err := k.getUptimeAccumulators(ctx, poolId)
+	uptimeAccumulators, err := k.GetUptimeAccumulators(ctx, poolId)
 	if err != nil {
 		return err
 	}
@@ -731,7 +730,7 @@ func (k Keeper) claimAllIncentivesForPosition(ctx sdk.Context, positionId uint64
 	}
 
 	// Retrieve the uptime accumulators for the position's pool.
-	uptimeAccumulators, err := k.getUptimeAccumulators(ctx, position.PoolId)
+	uptimeAccumulators, err := k.GetUptimeAccumulators(ctx, position.PoolId)
 	if err != nil {
 		return sdk.Coins{}, sdk.Coins{}, err
 	}

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -433,7 +433,7 @@ func (k Keeper) fungifyChargedPosition(ctx sdk.Context, owner sdk.AccAddress, po
 
 	// Get the new position's store name as well as uptime accumulators for the pool.
 	newPositionName := string(types.KeyPositionId(newPositionId))
-	uptimeAccumulators, err := k.getUptimeAccumulators(ctx, newPosition.PoolId)
+	uptimeAccumulators, err := k.GetUptimeAccumulators(ctx, newPosition.PoolId)
 	if err != nil {
 		return 0, err
 	}

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -37,7 +37,7 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 	// set the tick's fee growth outside to the fee accumulator's value
 	if liquidityBefore.IsZero() {
 		if tickIndex <= currentTick {
-			accum, err := k.getFeeAccumulator(ctx, poolId)
+			accum, err := k.GetFeeAccumulator(ctx, poolId)
 			if err != nil {
 				return err
 			}
@@ -70,7 +70,7 @@ func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, swapS
 		return sdk.Dec{}, err
 	}
 
-	feeAccum, err := k.getFeeAccumulator(ctx, poolId)
+	feeAccum, err := k.GetFeeAccumulator(ctx, poolId)
 	if err != nil {
 		return sdk.Dec{}, err
 	}
@@ -83,7 +83,7 @@ func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, swapS
 		return sdk.Dec{}, err
 	}
 
-	uptimeAccums, err := k.getUptimeAccumulators(ctx, poolId)
+	uptimeAccums, err := k.GetUptimeAccumulators(ctx, poolId)
 	if err != nil {
 		return sdk.Dec{}, err
 	}

--- a/x/superfluid/keeper/slash_test.go
+++ b/x/superfluid/keeper/slash_test.go
@@ -1,8 +1,10 @@
 package keeper_test
 
 import (
+	"github.com/osmosis-labs/osmosis/osmoutils/accum"
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
+	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v15/x/lockup/types"
 	"github.com/osmosis-labs/osmosis/v15/x/superfluid/keeper"
 
@@ -260,6 +262,24 @@ func (suite *KeeperTestSuite) TestPrepareConcentratedLockForSlash() {
 
 			slashAmt := positionPreSlash.Liquidity.Mul(tc.slashPercent)
 
+			// Note the value of the fee accumulator before the slash for the position.
+			feeAccumPreSlash, err := suite.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(suite.Ctx, clPoolId)
+			suite.Require().NoError(err)
+			feePositionKey := cltypes.KeyFeePositionAccumulator(positionId)
+			positionSizePreSlash, err := feeAccumPreSlash.GetPositionSize(feePositionKey)
+			suite.Require().NoError(err)
+
+			// Note the numShares value of the position at each of the uptime accumulators.
+			uptimeAccums, err := suite.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(suite.Ctx, clPoolId)
+			uptimePositionKey := string(cltypes.KeyPositionId(positionId))
+			suite.Require().NoError(err)
+			numShares := make([]sdk.Dec, len(uptimeAccums))
+			for i, uptimeAccum := range uptimeAccums {
+				position, err := accum.GetPosition(uptimeAccum, uptimePositionKey)
+				suite.Require().NoError(err)
+				numShares[i] = position.NumShares
+			}
+
 			// System under test
 			clPoolAddress, underlyingAssetsToSlash, err := suite.App.SuperfluidKeeper.PrepareConcentratedLockForSlash(suite.Ctx, lock, slashAmt)
 
@@ -273,6 +293,22 @@ func (suite *KeeperTestSuite) TestPrepareConcentratedLockForSlash() {
 			liquidityPostSlash := clPool.GetLiquidity()
 			if tc.expectedErr {
 				suite.Require().Error(err)
+
+				// Check that the position's fee accumulator has not changed.
+				feeAccumPostSlash, err := suite.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(suite.Ctx, clPoolId)
+				suite.Require().NoError(err)
+				positionSizePostSlash, err := feeAccumPostSlash.GetPositionSize(feePositionKey)
+				suite.Require().NoError(err)
+				suite.Require().Equal(positionSizePreSlash.String(), positionSizePostSlash.String())
+
+				// Check that the numShares value of the position has not been updated in each of the uptime accumulators.
+				uptimeAccums, err := suite.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(suite.Ctx, clPoolId)
+				suite.Require().NoError(err)
+				for i, uptimeAccum := range uptimeAccums {
+					position, err := accum.GetPosition(uptimeAccum, uptimePositionKey)
+					suite.Require().NoError(err)
+					suite.Require().Equal(numShares[i].String(), position.NumShares.String())
+				}
 			} else {
 				suite.Require().NoError(err)
 				suite.Require().Equal(clPool.GetAddress(), clPoolAddress)
@@ -299,6 +335,22 @@ func (suite *KeeperTestSuite) TestPrepareConcentratedLockForSlash() {
 
 				suite.Require().Equal(0, errTolerance.Compare(asset0PreSlash.Sub(asset0PostSlash).Amount, underlyingAssetsToSlash[0].Amount))
 				suite.Require().Equal(0, errTolerance.Compare(asset1PreSlash.Sub(asset1PostSlash).Amount, underlyingAssetsToSlash[1].Amount))
+
+				// Check that the fee accumulator has been updated by the amount it was slashed.
+				feeAccumPostSlash, err := suite.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(suite.Ctx, clPoolId)
+				suite.Require().NoError(err)
+				positionSizePostSlash, err := feeAccumPostSlash.GetPositionSize(feePositionKey)
+				suite.Require().NoError(err)
+				suite.Require().Equal(positionSizePreSlash.Sub(slashAmt).String(), positionSizePostSlash.String())
+
+				// Check that the numShares value of the position has been updated in each of the uptime accumulators.
+				uptimeAccums, err := suite.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(suite.Ctx, clPoolId)
+				suite.Require().NoError(err)
+				for i, uptimeAccum := range uptimeAccums {
+					position, err := accum.GetPosition(uptimeAccum, uptimePositionKey)
+					suite.Require().NoError(err)
+					suite.Require().Equal(numShares[i].Sub(slashAmt).String(), position.NumShares.String())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4984 

## What is the purpose of the change

Adds a check to `TestPrepareConcentratedLockForSlash` that ensure:

* If run, the fee and incentive accum properly reflect the slashed value
* If error, the fee and incentive accum does not change

## Brief Changelog

- Makes fee accumulator and uptime accumulator getter method from the CL module public
- Adds fee and reward accum checks to `TestPrepareConcentratedLockForSlash`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)