### PR TITLE
remove global rand seed from the simulator

### DIFF
--- a/x/gamm/simulation/sim_msgs.go
+++ b/x/gamm/simulation/sim_msgs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	legacysimulationtype "github.com/cosmos/cosmos-sdk/types/simulation"

--- a/x/gamm/simulation/sim_msgs.go
+++ b/x/gamm/simulation/sim_msgs.go
@@ -3,7 +3,7 @@ package gammsimulation
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -426,6 +426,8 @@ func getRandPool(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (uint64
 	if numPools == 0 {
 		return 0, nil, sdk.NewCoin("denom", sdk.ZeroInt()), sdk.NewCoin("denom", sdk.ZeroInt()), []string{}, "", fmt.Errorf("no pools exist")
 	}
+
+	rand := sim.GetRand()
 
 	pool := pools[rand.Intn(numPools)]
 

--- a/x/valset-pref/simulation/sim_msgs.go
+++ b/x/valset-pref/simulation/sim_msgs.go
@@ -2,8 +2,6 @@ package simulation
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -41,6 +39,8 @@ func RandomMsgDelegateToValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimCtx, 
 		return nil, fmt.Errorf("%s is not present", sdk.DefaultBondDenom)
 	}
 
+	rand := sim.GetRand()
+
 	delegationCoin := rand.Intn(int(amount.Int64()))
 
 	return &types.MsgDelegateToValidatorSet{
@@ -59,6 +59,8 @@ func RandomMsgUnDelegateFromValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimC
 	if err != nil {
 		return nil, fmt.Errorf("no delegations found")
 	}
+
+	rand := sim.GetRand()
 
 	delegation := preferences.Preferences[rand.Intn(len(preferences.Preferences))]
 	val, err := sdk.ValAddressFromBech32(delegation.ValOperAddress)
@@ -152,7 +154,7 @@ func RandomMsgReDelegateToValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimCtx
 }
 
 func RandomValidator(ctx sdk.Context, sim *osmosimtypes.SimCtx) *stakingtypes.Validator {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
+	rand := sim.GetRand()
 
 	validators := sim.StakingKeeper().GetAllValidators(ctx)
 	if len(validators) == 0 {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

In Go, the global rand variable is seeded by a default source, which is an implementation of a Source interface defined in the math/rand package. This source is based on the current time in nanoseconds and the process ID, and it is initialized the first time the math/rand package is imported.

In the simulator, we create a custom-seeded rand so that the simulator runs are deterministic.

This PR attempts to fix non-determinism by removing the use of global rand and using a simulator seeded rand.


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable