### PR TITLE
feat: tick rounding direction

### DIFF
--- a/tests/cl-genesis-positions/convert.go
+++ b/tests/cl-genesis-positions/convert.go
@@ -101,7 +101,7 @@ func ConvertSubgraphToOsmosisGenesis(positionCreatorAddresses []sdk.AccAddress, 
 		Sender:      osmosis.TestAccs[0].String(),
 		Denom0:      denom0,
 		Denom1:      denom1,
-		TickSpacing: 1,
+		TickSpacing: 100,
 		SwapFee:     sdk.MustNewDecFromStr("0.0005"),
 	}
 
@@ -148,12 +148,12 @@ func ConvertSubgraphToOsmosisGenesis(positionCreatorAddresses []sdk.AccAddress, 
 			continue
 		}
 
-		lowerTickOsmosis, err := math.PriceToTick(lowerPrice, pool.GetTickSpacing())
+		lowerTickOsmosis, err := math.PriceToTickRoundDown(lowerPrice, pool.GetTickSpacing())
 		if err != nil {
 			panic(err)
 		}
 
-		upperTickOsmosis, err := math.PriceToTick(upperPrice, pool.GetTickSpacing())
+		upperTickOsmosis, err := math.PriceToTickRoundUp(upperPrice, pool.GetTickSpacing())
 		if err != nil {
 			panic(err)
 		}

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -452,7 +452,7 @@ func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOutsideForTick() {
 		validPoolId = 1
 	)
 
-	initialPoolTickInt, err := math.PriceToTick(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()), DefaultTickSpacing)
+	initialPoolTickInt, err := math.PriceToTickRoundBankers(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()), DefaultTickSpacing)
 	initialPoolTick := initialPoolTickInt.Int64()
 	suite.Require().NoError(err)
 

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -46,10 +46,10 @@ var (
 	FullRangeLiquidityAmt                          = sdk.MustNewDecFromStr("70710678.118654752940000000")
 	DefaultTickSpacing                             = uint64(100)
 	PoolCreationFee                                = poolmanagertypes.DefaultParams().PoolCreationFee
-	DefaultExponentConsecutivePositionLowerTick, _ = math.PriceToTick(sdk.NewDec(5500), DefaultTickSpacing)
-	DefaultExponentConsecutivePositionUpperTick, _ = math.PriceToTick(sdk.NewDec(6250), DefaultTickSpacing)
-	DefaultExponentOverlappingPositionLowerTick, _ = math.PriceToTick(sdk.NewDec(4000), DefaultTickSpacing)
-	DefaultExponentOverlappingPositionUpperTick, _ = math.PriceToTick(sdk.NewDec(4999), DefaultTickSpacing)
+	DefaultExponentConsecutivePositionLowerTick, _ = math.PriceToTickRoundUp(sdk.NewDec(5500), DefaultTickSpacing)
+	DefaultExponentConsecutivePositionUpperTick, _ = math.PriceToTickRoundUp(sdk.NewDec(6250), DefaultTickSpacing)
+	DefaultExponentOverlappingPositionLowerTick, _ = math.PriceToTickRoundUp(sdk.NewDec(4000), DefaultTickSpacing)
+	DefaultExponentOverlappingPositionUpperTick, _ = math.PriceToTickRoundUp(sdk.NewDec(4999), DefaultTickSpacing)
 	BAR                                            = "bar"
 	FOO                                            = "foo"
 )

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -335,13 +335,16 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 
 	// Calculate the spot price and sqrt price from the amount provided
 	initialSpotPrice := amount1Desired.ToDec().Quo(amount0Desired.ToDec())
-	initialSqrtPrice, err := initialSpotPrice.ApproxSqrt()
+
+	// Calculate the initial tick from the initial spot price
+	initialTick, err := math.PriceToTickRoundBankers(initialSpotPrice, pool.GetTickSpacing())
 	if err != nil {
 		return err
 	}
 
-	// Calculate the initial tick from the initial spot price
-	initialTick, err := math.PriceToTick(initialSpotPrice, pool.GetTickSpacing())
+	// Since tick can be rounded due to tick spacing
+	// we calculate the initial sqrt price from the initial tick
+	initialSqrtPrice, err := math.TickToSqrtPrice(initialTick)
 	if err != nil {
 		return err
 	}

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -93,9 +93,9 @@ func TickToPrice(tickIndex sdk.Int) (price sdk.Dec, err error) {
 	return price, nil
 }
 
-// PriceToTick takes a price and returns the corresponding tick index.
-// If tickSpacing is provided, the tick index will be rounded up to the nearest multiple of tickSpacing.
-func PriceToTick(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
+// PriceToTick takes a price and returns the corresponding tick index assuming
+// tick spacing of 1.
+func PriceToTick(price sdk.Dec) (sdk.Int, error) {
 	if price.Equal(sdk.OneDec()) {
 		return sdk.ZeroInt(), nil
 	}
@@ -112,14 +112,89 @@ func PriceToTick(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	// This does not take into account the tickSpacing
 	tickIndex := CalculatePriceToTick(price)
 
+	return tickIndex, nil
+}
+
+// PriceToTickRoundUp takes a price and returns the corresponding tick index.
+// If tickSpacing is provided, the tick index will be rounded up to the nearest multiple of tickSpacing.
+func PriceToTickRoundUp(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
+	tickIndex, err := PriceToTick(price)
+	if err != nil {
+		return sdk.Int{}, err
+	}
+
 	// Round the tick index up to the nearest tick spacing if the tickIndex is in between authorized tick values
 	tickSpacingInt := sdk.NewIntFromUint64(tickSpacing)
-	tickIndexRemainder := tickIndex.Mod(sdk.NewIntFromUint64(tickSpacing))
-	if !tickIndexRemainder.Equal(sdk.ZeroInt()) {
-		tickIndex = tickIndex.Add(tickSpacingInt.Sub(tickIndexRemainder))
+	tickIndexModulus := tickIndex.Mod(tickSpacingInt)
+	if !tickIndexModulus.Equal(sdk.ZeroInt()) {
+		tickIndex = tickIndex.Add(tickSpacingInt.Sub(tickIndexModulus))
+	}
+
+	// Defense-in-depth check to ensure that the tick index is within the authorized range
+	// Should never get here.
+	if tickIndex.GT(sdk.NewInt(types.MaxTick)) || tickIndex.LT(sdk.NewInt(types.MinTick)) {
+		return sdk.Int{}, types.TickIndexNotWithinBoundariesError{ActualTick: tickIndex.Int64(), MinTick: types.MinTick, MaxTick: types.MaxTick}
 	}
 
 	return tickIndex, nil
+}
+
+// PriceToTickRoundDon takes a price and returns the corresponding tick index.
+// If tickSpacing is provided, the tick index will be rounded down to the nearest multiple of tickSpacing.
+func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
+	tickIndex, err := PriceToTick(price)
+	if err != nil {
+		return sdk.Int{}, err
+	}
+
+	// Round the tick index down to the nearest tick spacing if the tickIndex is in between authorized tick values
+	tickSpacingInt := sdk.NewIntFromUint64(tickSpacing)
+	tickIndexModulus := tickIndex.Mod(tickSpacingInt)
+	if !tickIndexModulus.Equal(sdk.ZeroInt()) {
+		tickIndex = tickIndex.Sub(tickIndexModulus)
+	}
+
+	// Defense-in-depth check to ensure that the tick index is within the authorized range
+	// Should never get here.
+	if tickIndex.GT(sdk.NewInt(types.MaxTick)) || tickIndex.LT(sdk.NewInt(types.MinTick)) {
+		return sdk.Int{}, types.TickIndexNotWithinBoundariesError{ActualTick: tickIndex.Int64(), MinTick: types.MinTick, MaxTick: types.MaxTick}
+	}
+
+	return tickIndex, nil
+}
+
+// PriceToTickRoundUp takes a price and returns the corresponding tick index.
+// If tickSpacing is provided, the tick index will be rounded up to the nearest multiple of tickSpacing.
+func PriceToTickRoundBankers(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
+	tickIndex, err := PriceToTick(price)
+	if err != nil {
+		return sdk.Int{}, err
+	}
+
+	// Round the tick index up to the nearest tick spacing if the tickIndex is in between authorized tick values
+	tickSpacingInt := sdk.NewIntFromUint64(tickSpacing)
+	tickIndexModulus := tickIndex.Abs().Mod(tickSpacingInt)
+
+	if tickIndex.IsZero() {
+		return tickIndex, nil
+	}
+
+	// We use this ratio to determine whether to round up or down using sdk.Dec's rounding logic.
+	roundingValue := tickIndexModulus.ToDec().Quo(tickSpacingInt.ToDec()).RoundInt()
+
+	// if tick index was negative and rounding value got rounded down to zero, we round up the tick index.
+	// if tick index was positive and rounding value got rounded up to one, we round up the tick index.
+	if tickIndex.IsNegative() && roundingValue.IsZero() || tickIndex.IsPositive() && roundingValue.Equal(sdk.OneInt()) {
+		return PriceToTickRoundUp(price, tickSpacing)
+
+		// if tick index was negative and rounding value got rounded up to one, we round down the tick index.
+		// if tick index was positive and rounding value got rounded down to zero, we round down the tick index.
+	} else if tickIndex.IsNegative() && roundingValue.Equal(sdk.OneInt()) || tickIndex.IsPositive() && roundingValue.IsZero() {
+		return PriceToTickRoundDown(price, tickSpacing)
+	}
+
+	return sdk.Int{}, fmt.Errorf("unexpected rounding ratio: %s", roundingValue)
+
 }
 
 // powTen treats negative exponents as 1/(10**|exponent|) instead of 10**-exponent

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
+const (
+	defaultTickSpacing = 100
+)
+
+var (
+	// spot price - (10^(spot price exponent - 6 - 1))
+	// Note we get spot price exponent by counting the number of digits in the max spot price and subtracting 1.
+	closestPriceBelowMaxPriceDefaultTickSpacing = types.MaxSpotPrice.Sub(sdk.NewDec(10).PowerMut(uint64(len(types.MaxSpotPrice.TruncateInt().String()) - 1 - int(types.ExponentAtPriceOne.Neg().Int64()) - 1)))
+	// min tick + 10 ^ -expoentAtPriceOne
+	closesTickAboveMinPriceDefaultTickSpacing = sdk.NewInt(types.MinTick).Add(sdk.NewInt(10).ToDec().Power(types.ExponentAtPriceOne.Neg().Uint64()).TruncateInt())
+)
+
 // use following equations to test testing vectors using sage
 // geometricExponentIncrementDistanceInTicks(exponentAtPriceOne) = (9 * (10^(-exponentAtPriceOne)))
 // geometricExponentDelta(tickIndex, exponentAtPriceOne)  = floor(tickIndex / geometricExponentIncrementDistanceInTicks(exponentAtPriceOne))
@@ -186,10 +198,13 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPrice() {
 }
 
 func (suite *ConcentratedMathTestSuite) TestPriceToTick() {
+	const (
+		one = uint64(1)
+	)
+
 	testCases := map[string]struct {
-		price         sdk.Dec
-		tickExpected  string
-		expectedError error
+		price        sdk.Dec
+		tickExpected string
 	}{
 		"BTC <> USD, tick 38035200 -> price 30352": {
 			price:        sdk.MustNewDecFromStr("30352"),
@@ -261,13 +276,193 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick() {
 		tc := tc
 
 		suite.Run(name, func() {
-			tickSpacing := uint64(100)
-			tick, err := math.PriceToTick(tc.price, tickSpacing)
-			if tc.expectedError != nil {
-				suite.Require().Error(err)
-				suite.Require().Equal(tc.expectedError.Error(), err.Error())
-				return
-			}
+			tick, err := math.PriceToTick(tc.price)
+			// With tick spacing of one, no rounding should occur.
+			tickRoundUp, err1 := math.PriceToTickRoundUp(tc.price, one)
+			tickRoundDown, err2 := math.PriceToTickRoundDown(tc.price, one)
+			tickBankers, err3 := math.PriceToTickRoundBankers(tc.price, one)
+
+			suite.Require().NoError(err)
+			suite.Require().NoError(err1)
+			suite.Require().NoError(err2)
+			suite.Require().NoError(err3)
+			suite.Require().Equal(tc.tickExpected, tick.String())
+			suite.Require().Equal(tc.tickExpected, tickRoundUp.String())
+			suite.Require().Equal(tc.tickExpected, tickRoundDown.String())
+			suite.Require().Equal(tc.tickExpected, tickBankers.String())
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundUp() {
+	testCases := map[string]struct {
+		price        sdk.Dec
+		tickSpacing  uint64
+		tickExpected string
+	}{
+		"tick spacing 100, price of 1": {
+			price:        sdk.OneDec(),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 1.000030, tick 30 -> 100": {
+			price:        sdk.MustNewDecFromStr("1.000030"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "100",
+		},
+		"tick spacing 100, price of 0.9999970, tick -30 -> 0": {
+			price:        sdk.MustNewDecFromStr("0.9999970"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 50, price of 0.9999770, tick -270 -> -250": {
+			price:        sdk.MustNewDecFromStr("0.9999730"),
+			tickSpacing:  50,
+			tickExpected: "-250",
+		},
+		"tick spacing 100, MinSpotPrice, MinTick": {
+			price:        types.MinSpotPrice,
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: sdk.NewInt(types.MinTick).String(),
+		},
+		"tick spacing 100, Spot price one tick below max, one tick below max -> MaxTick": {
+			price:        closestPriceBelowMaxPriceDefaultTickSpacing,
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: sdk.NewInt(types.MaxTick).String(),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+
+		suite.Run(name, func() {
+
+			tick, err := math.PriceToTickRoundUp(tc.price, tc.tickSpacing)
+
+			suite.Require().NoError(err)
+			suite.Require().Equal(tc.tickExpected, tick.String())
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundDown() {
+	testCases := map[string]struct {
+		price        sdk.Dec
+		tickSpacing  uint64
+		tickExpected string
+	}{
+		"tick spacing 100, price of 1": {
+			price:        sdk.OneDec(),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 1.000030, tick 30 -> 0": {
+			price:        sdk.MustNewDecFromStr("1.000030"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 0.9999970, tick -30 -> -100": {
+			price:        sdk.MustNewDecFromStr("0.9999970"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "-100",
+		},
+		"tick spacing 50, price of 0.9999770, tick -270 -> -300": {
+			price:        sdk.MustNewDecFromStr("0.9999730"),
+			tickSpacing:  50,
+			tickExpected: "-300",
+		},
+		"tick spacing 100, MinSpotPrice, MinTick": {
+			price:        types.MinSpotPrice,
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: sdk.NewInt(types.MinTick).String(),
+		},
+		"tick spacing 100, Spot price one tick above min, one tick above min -> MinTick": {
+			price:        types.MinSpotPrice.Add(sdk.SmallestDec()),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: closesTickAboveMinPriceDefaultTickSpacing.String(),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+
+		suite.Run(name, func() {
+
+			tick, err := math.PriceToTickRoundDown(tc.price, tc.tickSpacing)
+
+			suite.Require().NoError(err)
+			suite.Require().Equal(tc.tickExpected, tick.String())
+		})
+	}
+}
+
+func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundBankers() {
+	testCases := map[string]struct {
+		price        sdk.Dec
+		tickSpacing  uint64
+		tickExpected string
+	}{
+		"tick spacing 100, price of 1": {
+			price:        sdk.OneDec(),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 1.000030, tick 30 -> 0": {
+			price:        sdk.MustNewDecFromStr("1.000030"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 1.000050, tick 50 -> 0": {
+			price:        sdk.MustNewDecFromStr("1.000050"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 1.000051, tick 51 -> 100": {
+			price:        sdk.MustNewDecFromStr("1.000051"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "100",
+		},
+		"tick spacing 100, price of 0.9999970, tick -30 -> 0": {
+			price:        sdk.MustNewDecFromStr("0.9999970"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 0.9999950, tick -50 -> 0": {
+			price:        sdk.MustNewDecFromStr("0.9999950"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "0",
+		},
+		"tick spacing 100, price of 0.9999951, tick -51 -> -100": {
+			price:        sdk.MustNewDecFromStr("0.9999949"),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "-100",
+		},
+		"tick spacing 50, price of 0.9999770, tick -270 -> -250": {
+			price:        sdk.MustNewDecFromStr("0.9999730"),
+			tickSpacing:  50,
+			tickExpected: "-250",
+		},
+		"tick spacing 100, MinSpotPrice, MinTick": {
+			price:        types.MinSpotPrice,
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: sdk.NewInt(types.MinTick).String(),
+		},
+		"tick spacing 100, Spot price one tick above min, one tick above min -> MinTick": {
+			price:        types.MinSpotPrice.Add(sdk.SmallestDec()),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: closesTickAboveMinPriceDefaultTickSpacing.String(),
+		},
+		"tick spacing 100, Spot price one tick below max, one tick below max -> MaxTick": {
+			price:        closestPriceBelowMaxPriceDefaultTickSpacing,
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: sdk.NewInt(types.MaxTick).String(),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+
+		suite.Run(name, func() {
+
+			tick, err := math.PriceToTickRoundBankers(tc.price, tc.tickSpacing)
+
 			suite.Require().NoError(err)
 			suite.Require().Equal(tc.tickExpected, tick.String())
 		})
@@ -400,7 +595,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			tickSpacing := uint64(1)
 
 			// 1. Compute tick from price.
-			tickFromPrice, err := math.PriceToTick(tc.price, tickSpacing)
+			tickFromPrice, err := math.PriceToTickRoundUp(tc.price, tickSpacing)
 			suite.Require().NoError(err)
 			suite.Require().Equal(tc.tickExpected, tickFromPrice.String())
 
@@ -416,7 +611,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			suite.Require().Equal(expectedPrice, price)
 
 			// 3. Compute tick from inverse price (inverse tick)
-			inverseTickFromPrice, err := math.PriceToTick(price, tickSpacing)
+			inverseTickFromPrice, err := math.PriceToTickRoundUp(price, tickSpacing)
 			suite.Require().NoError(err)
 
 			// Make sure original tick and inverse tick match.
@@ -433,7 +628,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			// suite.Require().Equal(expectedPrice.String(), priceFromSqrtPrice.String())
 
 			// 5. Compute tick from sqrt price from the original tick.
-			inverseTickFromSqrtPrice, err := math.PriceToTick(priceFromSqrtPrice, tickSpacing)
+			inverseTickFromSqrtPrice, err := math.PriceToTickRoundUp(priceFromSqrtPrice, tickSpacing)
 			suite.Require().NoError(err)
 
 			suite.Require().Equal(tickFromPrice, inverseTickFromSqrtPrice, "expected: %s, actual: %s", tickFromPrice, inverseTickFromSqrtPrice)

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -279,9 +279,9 @@ func (p *Pool) ApplySwap(newLiquidity sdk.Dec, newCurrentTick sdk.Int, newCurren
 	// Check if the new tick provided is within boundaries of the pool's precision factor.
 	if newCurrentTick.LT(sdk.NewInt(types.MinTick)) || newCurrentTick.GT(sdk.NewInt(types.MaxTick)) {
 		return types.TickIndexNotWithinBoundariesError{
-			MaxTick:  types.MaxTick,
-			MinTick:  types.MinTick,
-			WantTick: newCurrentTick.Int64(),
+			MaxTick:    types.MaxTick,
+			MinTick:    types.MinTick,
+			ActualTick: newCurrentTick.Int64(),
 		}
 	}
 

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -279,7 +279,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 	}
 
 	// set the swap strategy
-	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, swapFee)
+	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, swapFee, p.GetTickSpacing())
 
 	// get current sqrt price from pool
 	curSqrtPrice := p.GetCurrentSqrtPrice()
@@ -381,8 +381,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 		} else if !sqrtPriceStart.Equal(sqrtPrice) {
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
-			price := swapStrategy.SquareSqrtPrice(sqrtPrice)
-			swapState.tick, err = math.PriceToTick(price, p.GetTickSpacing())
+			swapState.tick, err = swapStrategy.SqrtPriceToTick(sqrtPrice)
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -444,7 +443,7 @@ func (k Keeper) calcInAmtGivenOut(
 	}
 
 	// set the swap strategy
-	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, swapFee)
+	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, swapFee, p.GetTickSpacing())
 
 	// get current sqrt price from pool
 	curSqrtPrice := p.GetCurrentSqrtPrice()
@@ -542,8 +541,7 @@ func (k Keeper) calcInAmtGivenOut(
 		} else if !sqrtPriceStart.Equal(sqrtPrice) {
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
-			price := swapStrategy.SquareSqrtPrice(sqrtPrice)
-			swapState.tick, err = math.PriceToTick(price, p.GetTickSpacing())
+			swapState.tick, err = swapStrategy.SqrtPriceToTick(sqrtPrice)
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -83,7 +83,7 @@ var (
 			// expectedTokenOut: 8396.71424216 rounded down https://www.wolframalpha.com/input?i=%281517882343.751510418088349649+*+%2870.738348247484497717+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+70.738348247484497717%29
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8396)),
-			expectedTick:      sdk.NewInt(31004000),
+			expectedTick:      sdk.NewInt(31003900),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.738348247484497717"), // https://www.wolframalpha.com/input?i=70.710678118654752440+%2B+42000000+%2F+1517882343.751510418088349649
 			// tick's accum coins stay same since crossing tick does not occur in this case
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
@@ -127,7 +127,7 @@ var (
 			// expectedTokenOut: 8398.3567 rounded down https://www.wolframalpha.com/input?i=%283035764687.503020836176699298+*+%2870.724513183069625078+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+70.724513183069625078%29
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8398)),
-			expectedTick:      sdk.NewInt(31002000),
+			expectedTick:      sdk.NewInt(31001900),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.724513183069625078"), // https://www.wolframalpha.com/input?i=70.710678118654752440+%2B++++%2842000000++%2F+3035764687.503020836176699298%29
 			// two positions with same liquidity entered
 			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
@@ -187,7 +187,7 @@ var (
 			// expectedTokenOut: 998976.6183474263883566299269 + 821653.4522259 = 1820630.070 round down = 1.820630 eth
 			expectedTokenIn:            sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:           sdk.NewCoin("eth", sdk.NewInt(1820630)),
-			expectedTick:               sdk.NewInt(32105500),
+			expectedTick:               sdk.NewInt(32105400),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("78.137149196095607129"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441+%2B+4761322417+%2F+1197767444.955508123222985080
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -260,7 +260,7 @@ var (
 			// expectedTokenOut: 998976.6183474263883566299269692777 + 865185.2591363751404579873403641 = 1864161.877 round down = 1.864161 eth
 			expectedTokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                 sdk.NewCoin("eth", sdk.NewInt(1864161)),
-			expectedTick:                     sdk.NewInt(32056000),
+			expectedTick:                     sdk.NewInt(32055900),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("77.819789636800169392"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441+%2B++++%282452251164.000000000000000000+%2F+670416088.605668727039240782%29
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -295,7 +295,7 @@ var (
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                     sdk.NewInt(31712700),
+			expectedTick:                     sdk.NewInt(31712600),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("75.582373164412551491"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441++%2B+%28+952251164.000000000000000000++%2F+670416088.605668727039240782%29
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
@@ -391,7 +391,7 @@ var (
 			// expectedTokenOut: 998976.61834742638835 + 821569.240826953837970 = 1820545.85917438022632 round down = 1.820545 eth
 			expectedTokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                 sdk.NewCoin("eth", sdk.NewInt(1820545)),
-			expectedTick:                     sdk.NewInt(32105600),
+			expectedTick:                     sdk.NewInt(32105500),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.138055169663761658"), // https://www.wolframalpha.com/input?i=74.16872656315463530313879691++%2B+%28+4761322417.000000000000000000++%2F+1199528406.187413669220037261%29
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -417,7 +417,7 @@ var (
 			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(12892)),
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(64417624)),
 			expectedTick: func() sdk.Int {
-				tick, _ := math.PriceToTick(sdk.NewDec(4994), DefaultTickSpacing)
+				tick, _ := math.PriceToTickRoundUp(sdk.NewDec(4994), DefaultTickSpacing)
 				return tick
 			}(),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2812891.26207649936510%29%29
@@ -446,7 +446,7 @@ var (
 			// expectedFeeGrowthAccumulatorValue: 0.000276701288297452
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(8312)),
-			expectedTick:                      sdk.NewInt(31003900),
+			expectedTick:                      sdk.NewInt(31003800),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.738071546196200264"), // https://www.wolframalpha.com/input?i=70.71067811865475244008443621+%2B++++%2841580000.000000000000000000+%2F+1517882343.751510418088349649%29
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000276701288297452"),
 		},
@@ -520,7 +520,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1695807)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.624166726347032857"),
-			expectedTick:                      sdk.NewInt(31826000),
+			expectedTick:                      sdk.NewInt(31825900),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("76.328178655208424124"), // https://www.wolframalpha.com/input?i=+74.16198487095662948711397441+%2B++++%281452251164.000000000000000001+%2F+670416088.605668727039240782%29
 			newLowerPrice:                     sdk.NewDec(5001),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -560,7 +560,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1771252)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.221769187794051751"),
-			expectedTick:                      sdk.NewInt(32066600),
+			expectedTick:                      sdk.NewInt(32066500),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("77.887956882326389372"), // https://www.wolframalpha.com/input?i=74.16872656315463530313879691+%2B++++%284461322417.000000000000000001+%2F+1199528406.187413669220037261%29
 			newLowerPrice:                     sdk.NewDec(5501),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -582,7 +582,7 @@ var (
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64417624)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000085792039652"),
 			expectedTick: func() sdk.Int {
-				tick, _ := math.PriceToTick(sdk.NewDec(4994), DefaultTickSpacing)
+				tick, _ := math.PriceToTickRoundUp(sdk.NewDec(4994), DefaultTickSpacing)
 				return tick
 			}(),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813020+*+%281+-+0.01%29%29%29
@@ -649,7 +649,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin(ETH, sdk.NewInt(13370)),
 			expectedTokenIn:            sdk.NewCoin(USDC, sdk.NewInt(66891663)),
-			expectedTick:               sdk.NewInt(31006300),
+			expectedTick:               sdk.NewInt(31006200),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.754747188468900467"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -703,7 +703,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin("eth", sdk.NewInt(8398)),
 			expectedTokenIn:            sdk.NewCoin("usdc", sdk.NewInt(41998216)),
-			expectedTick:               sdk.NewInt(31002000),
+			expectedTick:               sdk.NewInt(31001900),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.724512595179305566"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -797,7 +797,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999999570)),
-			expectedTick:                     sdk.NewInt(32105500),
+			expectedTick:                     sdk.NewInt(32105400),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -969,7 +969,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999994688)),
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1864161)),
-			expectedTick:                     sdk.NewInt(32056000),
+			expectedTick:                     sdk.NewInt(32055900),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("77.819781711876553576"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -1024,7 +1024,7 @@ var (
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                     sdk.NewInt(31712700),
+			expectedTick:                     sdk.NewInt(31712600),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("75.582372355128594341"),
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
@@ -1069,7 +1069,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999994756)),
-			expectedTick:                     sdk.NewInt(32105600),
+			expectedTick:                     sdk.NewInt(32105500),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -1164,7 +1164,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:           sdk.NewCoin(ETH, sdk.NewInt(8398)),
 			expectedTokenIn:            sdk.NewCoin(USDC, sdk.NewInt(43297130)),
-			expectedTick:               sdk.NewInt(31002000),
+			expectedTick:               sdk.NewInt(31001900),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.724512595179305566"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -1211,7 +1211,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:                   sdk.NewCoin(USDC, sdk.NewInt(10010009580)),
-			expectedTick:                      sdk.NewInt(32105500),
+			expectedTick:                      sdk.NewInt(32105400),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1333,7 +1333,7 @@ var (
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth:  secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth:  secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                      sdk.NewInt(31712700),
+			expectedTick:                      sdk.NewInt(31712600),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("75.582372355128594341"),
 			newLowerPrice:                     sdk.NewDec(5001),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -1376,7 +1376,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:                   sdk.NewCoin(USDC, sdk.NewInt(10002995655)),
-			expectedTick:                      sdk.NewInt(32105600),
+			expectedTick:                      sdk.NewInt(32105500),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1474,9 +1474,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -1508,9 +1508,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTick(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1559,9 +1559,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTick(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1625,9 +1625,9 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -1708,9 +1708,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -1741,9 +1741,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTick(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1797,9 +1797,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTick(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1873,9 +1873,9 @@ func (s *KeeperTestSuite) TestSwapInAmtGivenOut_TickUpdates() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2309,9 +2309,9 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenInWriteCtx() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2394,9 +2394,9 @@ func (s *KeeperTestSuite) TestCalcInAmtGivenOutWriteCtx() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2470,9 +2470,9 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapOutAmtGivenIn() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2561,9 +2561,9 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapInAmtGivenOut() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTick(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTick(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero.go
@@ -20,6 +20,7 @@ type oneForZeroStrategy struct {
 	sqrtPriceLimit sdk.Dec
 	storeKey       sdk.StoreKey
 	swapFee        sdk.Dec
+	tickSpacing    uint64
 }
 
 var _ swapStrategy = (*oneForZeroStrategy)(nil)
@@ -222,12 +223,13 @@ func (s oneForZeroStrategy) ValidateSqrtPrice(sqrtPrice, currentSqrtPrice sdk.De
 	return nil
 }
 
-// SquareSqrtPrice returns the square of the sqrt price (price).
+// SqrtPriceToTick returns tick from the square root price.
 // When swapping one for zero, we are increasing the price.
-// As a result, as we swap, we want to round down the square root
-// price when converting to price so that the swap does not
+// As a result, as we swap, we want to round down the tick
+// when converting from square root price so that the swap does not
 // move  further than it should have been given the token in.
 // In other words, we want to round down in favor of the pool
-func (s oneForZeroStrategy) SquareSqrtPrice(sqrtPrice sdk.Dec) sdk.Dec {
-	return math.SquareTruncate(sqrtPrice)
+func (s oneForZeroStrategy) SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error) {
+	price := math.SquareTruncate(sqrtPrice)
+	return math.PriceToTickRoundDown(price, s.tickSpacing)
 }

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -35,7 +35,7 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_OneForZero() {
 		suite.Run(name, func() {
 			suite.SetupTest()
 
-			sut := swapstrategy.New(false, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
+			sut := swapstrategy.New(false, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec(), defaultTickSpacing)
 
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 
@@ -130,7 +130,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 		tc := tc
 		suite.Run(name, func() {
 			suite.SetupTest()
-			strategy := swapstrategy.New(false, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee)
+			strategy := swapstrategy.New(false, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee, defaultTickSpacing)
 
 			sqrtPriceNext, amountInConsumed, amountZeroOut, feeChargeTotal := strategy.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountOneInRemaining)
 
@@ -232,7 +232,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 		tc := tc
 		suite.Run(name, func() {
 			suite.SetupTest()
-			strategy := swapstrategy.New(false, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee)
+			strategy := swapstrategy.New(false, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee, defaultTickSpacing)
 
 			sqrtPriceNext, amountZeroOutConsumed, amountOneIn, feeChargeTotal := strategy.ComputeSwapStepInGivenOut(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountZeroOutRemaining)
 

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy.go
@@ -72,20 +72,20 @@ type swapStrategy interface {
 	// and the min/max sqrt price on the other side.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
 	ValidateSqrtPrice(sqrtPriceLimit, currentSqrtPrice sdk.Dec) error
-	// SquareSqrtPrice returns the square of the sqrt price (price).
+	// SqrtPriceToTick returns the tick from the square root price.
 	// Ensures desired rounding in favor of the pool during swap.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
-	SquareSqrtPrice(sqrtPrice sdk.Dec) sdk.Dec
+	SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error)
 }
 
 // New returns a swap strategy based on the provided zeroForOne parameter
 // with sqrtPriceLimit for the maximum square root price until which to perform
 // the swap and the stor key of the module that stores swap data.
-func New(zeroForOne bool, sqrtPriceLimit sdk.Dec, storeKey sdk.StoreKey, swapFee sdk.Dec) swapStrategy {
+func New(zeroForOne bool, sqrtPriceLimit sdk.Dec, storeKey sdk.StoreKey, swapFee sdk.Dec, tickSpacing uint64) swapStrategy {
 	if zeroForOne {
-		return &zeroForOneStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee}
+		return &zeroForOneStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee, tickSpacing: tickSpacing}
 	}
-	return &oneForZeroStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee}
+	return &oneForZeroStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, swapFee: swapFee, tickSpacing: tickSpacing}
 }
 
 // GetPriceLimit returns the price limit based on which token is being swapped in.

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -29,6 +29,7 @@ var (
 	defaultAmountZero     = sdk.MustNewDecFromStr("13369.999999999998920002")
 	defaultLiquidity      = sdk.MustNewDecFromStr("3035764687.503020836176699298")
 	defaultFee            = sdk.MustNewDecFromStr("0.03")
+	defaultTickSpacing    = uint64(100)
 )
 
 func TestStrategyTestSuite(t *testing.T) {
@@ -57,42 +58,42 @@ func (suite *StrategyTestSuite) TestNextInitializedTick() {
 	suite.Run("lte=true", func() {
 		suite.Run("returns tick to right if at initialized tick", func() {
 
-			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(ctx, 1, 78)
 			suite.Require().Equal(sdk.NewInt(84), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns tick to right if at initialized tick", func() {
-			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, -55)
 			suite.Require().Equal(sdk.NewInt(-4), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the tick directly to the right", func() {
-			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 77)
 			suite.Require().Equal(sdk.NewInt(78), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the tick directly to the right", func() {
-			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, -56)
 			suite.Require().Equal(sdk.NewInt(-55), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the next words initialized tick if on the right boundary", func() {
-			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, -257)
 			suite.Require().Equal(sdk.NewInt(-200), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns the next initialized tick from the next word", func() {
-			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(false, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			suite.App.ConcentratedLiquidityKeeper.SetTickInfo(suite.Ctx, 1, 340, model.TickInfo{})
 
@@ -104,21 +105,21 @@ func (suite *StrategyTestSuite) TestNextInitializedTick() {
 
 	suite.Run("lte=false", func() {
 		suite.Run("returns tick directly to the left of input tick if not initialized", func() {
-			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 79)
 			suite.Require().Equal(sdk.NewInt(78), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns previous tick even though given is initialized", func() {
-			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 78)
 			suite.Require().Equal(sdk.NewInt(70), n)
 			suite.Require().True(initd)
 		})
 		suite.Run("returns next initialized tick far away", func() {
-			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec())
+			swapStrategy := swapstrategy.New(true, sdk.ZeroDec(), clStoreKey, sdk.ZeroDec(), defaultTickSpacing)
 
 			n, initd := swapStrategy.NextInitializedTick(suite.Ctx, 1, 100)
 			suite.Require().Equal(sdk.NewInt(84), n)
@@ -232,7 +233,7 @@ func (suite *StrategyTestSuite) TestComputeSwapState_Inverse() {
 	for name, tc := range testCases {
 		tc := tc
 		suite.Run(name, func() {
-			sut := swapstrategy.New(tc.zeroForOne, sdk.ZeroDec(), suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
+			sut := swapstrategy.New(tc.zeroForOne, sdk.ZeroDec(), suite.App.GetKey(types.ModuleName), sdk.ZeroDec(), defaultTickSpacing)
 			sqrtPriceNextOutGivenIn, amountInOutGivenIn, amountOutOutGivenIn, _ := sut.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountIn)
 			suite.Require().Equal(tc.expectedSqrtPriceNextOutGivenIn.String(), sqrtPriceNextOutGivenIn.String())
 

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one.go
@@ -20,6 +20,7 @@ type zeroForOneStrategy struct {
 	sqrtPriceLimit sdk.Dec
 	storeKey       sdk.StoreKey
 	swapFee        sdk.Dec
+	tickSpacing    uint64
 }
 
 var _ swapStrategy = (*zeroForOneStrategy)(nil)
@@ -217,12 +218,13 @@ func (s zeroForOneStrategy) ValidateSqrtPrice(sqrtPrice, currentSqrtPrice sdk.De
 	return nil
 }
 
-// SquareSqrtPrice returns the square of the sqrt price (price).
+// SqrtPriceToTick returns tick from the square root price.
 // When swapping zero for one, we are decreasing the price.
-// As a result, as we swap, we want to round up the square root
-// price when converting to price so that the swap does not
+// As a result, as we swap, we want to round up the tick
+// when converting from square root price so that the swap does not
 // move  further than it should have been given the token in.
 // In other words, we want to round up in favor of the pool
-func (s zeroForOneStrategy) SquareSqrtPrice(sqrtPrice sdk.Dec) sdk.Dec {
-	return math.SquareRoundUp(sqrtPrice)
+func (s zeroForOneStrategy) SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error) {
+	price := math.SquareRoundUp(sqrtPrice)
+	return math.PriceToTickRoundUp(price, s.tickSpacing)
 }

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
@@ -43,7 +43,7 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_ZeroForOne() {
 		suite.Run(name, func() {
 			suite.SetupTest()
 
-			sut := swapstrategy.New(true, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
+			sut := swapstrategy.New(true, tc.sqrtPriceLimit, suite.App.GetKey(types.ModuleName), sdk.ZeroDec(), defaultTickSpacing)
 
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 
@@ -140,7 +140,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 		tc := tc
 		suite.Run(name, func() {
 			suite.SetupTest()
-			strategy := swapstrategy.New(true, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee)
+			strategy := swapstrategy.New(true, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee, defaultTickSpacing)
 
 			sqrtPriceNext, amountZeroIn, amountOneOut, feeChargeTotal := strategy.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountZeroInRemaining)
 
@@ -242,7 +242,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 		tc := tc
 		suite.Run(name, func() {
 			suite.SetupTest()
-			strategy := swapstrategy.New(true, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee)
+			strategy := swapstrategy.New(true, types.MaxSqrtPrice, suite.App.GetKey(types.ModuleName), tc.swapFee, defaultTickSpacing)
 
 			sqrtPriceNext, amountOneOut, amountZeroIn, feeChargeTotal := strategy.ComputeSwapStepInGivenOut(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountOneOutRemaining)
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -185,14 +185,14 @@ func validateTickRangeIsValid(tickSpacing uint64, lowerTick int64, upperTick int
 
 // GetTickLiquidityForFullRange returns an array of liquidity depth for all ticks existing from min tick ~ max tick.
 func (k Keeper) GetTickLiquidityForFullRange(ctx sdk.Context, poolId uint64) ([]queryproto.LiquidityDepthWithRange, error) {
-	// sanity check that pool exists and upper tick is greater than lower tick
-	if !k.poolExists(ctx, poolId) {
-		return []queryproto.LiquidityDepthWithRange{}, types.PoolNotFoundError{PoolId: poolId}
+	pool, err := k.getPoolById(ctx, poolId)
+	if err != nil {
+		return []queryproto.LiquidityDepthWithRange{}, err
 	}
 
 	// use false for zeroForOne since we're going from lower tick -> upper tick
 	zeroForOne := false
-	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec())
+	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec(), pool.GetTickSpacing())
 
 	// set current tick to min tick, and find the first initialized tick starting from min tick -1.
 	// we do -1 to make min tick inclusive.
@@ -282,11 +282,6 @@ func (k Keeper) GetTickLiquidityForFullRange(ctx sdk.Context, poolId uint64) ([]
 // * types.PoolNotFoundError: If the given pool does not exist.
 // * types.TokenInDenomNotInPoolError: If the given tokenIn is not an asset in the pool.
 func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, tokenIn string, userGivenStartTick sdk.Int, boundTick sdk.Int) ([]queryproto.TickLiquidityNet, error) {
-	// check if pool exists
-	if !k.poolExists(ctx, poolId) {
-		return []queryproto.TickLiquidityNet{}, types.PoolNotFoundError{PoolId: poolId}
-	}
-
 	// get min and max tick for the pool
 	p, err := k.getPoolById(ctx, poolId)
 	if err != nil {
@@ -326,7 +321,7 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 	}
 
 	liquidityDepths := []queryproto.TickLiquidityNet{}
-	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec())
+	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec(), p.GetTickSpacing())
 
 	currentTick := p.GetCurrentTick()
 	currentTickSqrtPrice, err := math.TickToSqrtPrice(currentTick)

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1171,7 +1171,7 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			// Normally, initialized during position creation.
 			// We only initialize ticks in this test for simplicity.
 			curPrice := sdk.OneDec()
-			curTick, err := math.PriceToTick(curPrice, pool.GetTickSpacing())
+			curTick, err := math.PriceToTickRoundUp(curPrice, pool.GetTickSpacing())
 			s.Require().NoError(err)
 			if !test.currentPoolTick.IsNil() {
 				sqrtPrice, err := math.TickToSqrtPrice(test.currentPoolTick)

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -217,13 +217,13 @@ func (e TickIndexMinimumError) Error() string {
 }
 
 type TickIndexNotWithinBoundariesError struct {
-	MaxTick  int64
-	MinTick  int64
-	WantTick int64
+	MaxTick    int64
+	MinTick    int64
+	ActualTick int64
 }
 
 func (e TickIndexNotWithinBoundariesError) Error() string {
-	return fmt.Sprintf("tickIndex must be within the range (%d, %d). Got (%d)", e.MinTick, e.MaxTick, e.WantTick)
+	return fmt.Sprintf("tickIndex must be within the range (%d, %d). Got (%d)", e.MinTick, e.MaxTick, e.ActualTick)
 }
 
 type TickNotFoundError struct {

--- a/x/concentrated-liquidity/types/export_test.go
+++ b/x/concentrated-liquidity/types/export_test.go
@@ -1,0 +1,5 @@
+package types
+
+func ValidateTicks(i interface{}) error {
+	return validateTicks(i)
+}

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -91,9 +91,35 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 // If the parameter is not of the correct type or any of the strings cannot be converted, an error is returned.
 func validateTicks(i interface{}) error {
 	// Convert the given parameter to a slice of uint64s.
-	_, ok := i.([]uint64)
+	authorizedTickSpacing, ok := i.([]uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+
+	// Both max and min ticks must be multiples of of every authorized tick spacing.
+	// Otherwise, might end up running into edge cases when setting full range positions
+	// and not being able to reach max and min ticks.
+	for _, tickSpacing := range authorizedTickSpacing {
+		if tickSpacing == 0 {
+			return fmt.Errorf("tick spacing cannot be zero")
+		}
+
+		tickSpacingInt64 := int64(tickSpacing)
+
+		if MaxTick%tickSpacingInt64 != 0 {
+			return fmt.Errorf("max tick (%d) is not a multiple of tick spacing (%d)", MaxTick, tickSpacing)
+		}
+		if MinTick%tickSpacingInt64 != 0 {
+			return fmt.Errorf("in tick (%d) is not a multiple of tick spacing (%d)", MinTick, tickSpacing)
+		}
+
+		if tickSpacingInt64 > MaxTick {
+			return fmt.Errorf("tick spacing (%d) cannot be greater than max tick spacing (%d)", tickSpacing, MaxTick)
+		}
+
+		if tickSpacingInt64 < MinTick {
+			return fmt.Errorf("tick spacing (%d) cannot be less than min tick spacing (%d)", tickSpacing, MinTick)
+		}
 	}
 
 	return nil

--- a/x/concentrated-liquidity/types/params_test.go
+++ b/x/concentrated-liquidity/types/params_test.go
@@ -1,0 +1,58 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
+)
+
+func TestValidateTicks(t *testing.T) {
+	tests := map[string]struct {
+		i           interface{}
+		expectError bool
+	}{
+		"happy path": {
+			i: []uint64{1, 100},
+		},
+		"error: zero tick spacing": {
+			i:           []uint64{1, 0},
+			expectError: true,
+		},
+		"error: wrong type": {
+			i:           []int64{1, 0},
+			expectError: true,
+		},
+		"error: not a multiple of max tick": {
+			i:           []int64{types.MaxTick - 1},
+			expectError: true,
+		},
+		"error: not a multiple of min tick": {
+			i:           []int64{types.MinTick + 1},
+			expectError: true,
+		},
+		"error: greter than max tick": {
+			i:           []int64{types.MaxTick * 2},
+			expectError: true,
+		},
+		"error: smaller than min tick": {
+			i:           []int64{types.MinTick * 2},
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+
+			err := types.ValidateTicks(tc.i)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4979

## What is the purpose of the change

Currently, we always round up the tick if it is not a multiple of tick spacing when converting price to tick.

This PR introduces 3 helpers:
- `PriceToTickRoundDown`
- `PriceToTickRoundUp`
- `PriceToTickBankers`

That rounds the resulting tick to be a multiple of tick spacing in the desired direction.

For example, if I get tick -30 when calling  `PriceToTickRoundDown` with tick spacin gof 100, it should give me -100.

Notable changes:
- The swaps are refactored to account for the direction of the swap with rounding.
- Bankers rounding is used when initializing the tick for the first time (with the first position)
- Added validation for authorized tick spacings to only be allowed to be factors of min tick and max tick to prevent edge cases in full range

## Brief Changelog

- introduce helpers
- test helpers
- refactor previous usage of the price to tick conversion to use the desired rounding direction
- add validation for authorized ticks
- refactor old tests


## Testing and Verifying

- Covered by old + added new

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable