### PR TITLE
fix(e2e): remove resources in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,9 +280,16 @@ test-sim-bench:
 test-e2e: e2e-setup test-e2e-ci e2e-remove-resources
 
 # test-e2e-ci runs a full e2e test suite
+# deletes any pre-existing Osmosis containers before running.
+# deletes any pre-existing Osmosis containers after running.
+#
+# Utilizes Go cache.
+test-e2e-ci: e2e-remove-resources test-e2e-ci e2e-remove-resources
+
+# test-e2e-base runs a full e2e test suite
 # does not do any validation about the state of the Docker environment
 # As a result, avoid using this locally.
-test-e2e-ci:
+test-e2e-base:
 	@VERSION=$(VERSION) OSMOSIS_E2E=True OSMOSIS_E2E_DEBUG_LOG=False OSMOSIS_E2E_UPGRADE_VERSION=$(E2E_UPGRADE_VERSION)  go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E)
 
 # test-e2e-debug runs a full e2e test suite but does

--- a/Makefile
+++ b/Makefile
@@ -277,14 +277,14 @@ test-sim-bench:
 #
 # Deletes Docker resources at the end.
 # Utilizes Go cache.
-test-e2e: e2e-setup test-e2e-ci e2e-remove-resources
+test-e2e: e2e-setup test-e2e-base e2e-remove-resources
 
 # test-e2e-ci runs a full e2e test suite
 # deletes any pre-existing Osmosis containers before running.
 # deletes any pre-existing Osmosis containers after running.
 #
 # Utilizes Go cache.
-test-e2e-ci: e2e-remove-resources test-e2e-ci e2e-remove-resources
+test-e2e-ci: e2e-remove-resources test-e2e-base e2e-remove-resources
 
 # test-e2e-base runs a full e2e test suite
 # does not do any validation about the state of the Docker environment


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Attempt to fix self-hosted runner problems by removing docker resources prior to restarting e2e