### PR TITLE
[CL Message Audit]: MsgCreateConcentratedPool

### DIFF
--- a/x/concentrated-liquidity/client/cli/tx.go
+++ b/x/concentrated-liquidity/client/cli/tx.go
@@ -39,7 +39,8 @@ var poolIdFlagOverride = map[string]string{
 func NewCreateConcentratedPoolCmd() (*osmocli.TxCliDesc, *clmodel.MsgCreateConcentratedPool) {
 	return &osmocli.TxCliDesc{
 		Use:     "create-concentrated-pool [denom-0] [denom-1] [tick-spacing] [swap-fee]",
-		Short:   "create a concentrated liquidity pool with the given tick spacing",
+		Short:   "create a concentrated liquidity pool with the given denom pair, tick spacing, and swap fee",
+		Long:    "denom-1 (the quote denom), tick spacing, and swap fees must all be authorized by the concentrated liquidity module",
 		Example: "create-concentrated-pool uion uosmo 1 0.01 --from val --chain-id osmosis-1",
 	}, &clmodel.MsgCreateConcentratedPool{}
 }

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -96,6 +96,10 @@ func (k Keeper) ValidateSwapFee(ctx sdk.Context, params types.Params, swapFee sd
 	return k.validateSwapFee(ctx, params, swapFee)
 }
 
+func (k Keeper) ValidateTickSpacing(ctx sdk.Context, params types.Params, tickSpacing uint64) bool {
+	return k.validateTickSpacing(ctx, params, tickSpacing)
+}
+
 func (k Keeper) FungifyChargedPosition(ctx sdk.Context, owner sdk.AccAddress, positionIds []uint64) (uint64, error) {
 	return k.fungifyChargedPosition(ctx, owner, positionIds)
 }

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -38,6 +38,52 @@ var (
 	onlyETH     = [][]string{{ETH}, {ETH}, {ETH}, {ETH}}
 )
 
+func (s *KeeperTestSuite) TestCreateAndGetFeeAccumulator() {
+	type initFeeAccumTest struct {
+		poolId              uint64
+		initializePoolAccum bool
+
+		expectError bool
+	}
+	tests := map[string]initFeeAccumTest{
+		"default pool setup": {
+			poolId:              defaultPoolId,
+			initializePoolAccum: true,
+		},
+		"setup with different poolId": {
+			poolId:              defaultPoolId + 1,
+			initializePoolAccum: true,
+		},
+		"pool not initialized": {
+			initializePoolAccum: false,
+			poolId:              defaultPoolId,
+			expectError:         true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		s.Run(name, func() {
+			s.SetupTest()
+			clKeeper := s.App.ConcentratedLiquidityKeeper
+
+			// system under test
+			if tc.initializePoolAccum {
+				err := clKeeper.CreateFeeAccumulator(s.Ctx, tc.poolId)
+				s.Require().NoError(err)
+			}
+			poolFeeAccumulator, err := clKeeper.GetFeeAccumulator(s.Ctx, tc.poolId)
+
+			if !tc.expectError {
+				s.Require().NoError(err)
+			} else {
+				s.Require().Error(err)
+				s.Require().Equal(accum.AccumulatorObject{}, poolFeeAccumulator)
+			}
+		})
+	}
+}
+
 func (s *KeeperTestSuite) TestInitOrUpdateFeeAccumulatorPosition() {
 	// Setup is done once so that we test
 	// the relationship between test cases.

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -305,7 +305,7 @@ func (s *KeeperTestSuite) validateListenerCallCount(
 }
 
 // setListenerMockOnConcentratedLiquidityKeeper injects the mock into the concentrated liquidity keeper
-// so that listner invocation can be tested via the mock
+// so that listener invocation can be tested via the mock
 func (s *KeeperTestSuite) setListenerMockOnConcentratedLiquidityKeeper() {
 	s.App.ConcentratedLiquidityKeeper.SetListenersUnsafe(types.NewConcentratedLiquidityListeners(&clmocks.ConcentratedLiquidityListenerMock{}))
 }
@@ -333,4 +333,19 @@ func (s *KeeperTestSuite) validatePositionFeeGrowth(poolId uint64, positionId ui
 			s.Require().Equal(expectedUnclaimedRewards[1].Amount.Mul(DefaultLiquidityAmt), positionRecord.UnclaimedRewards.AmountOf(expectedUnclaimedRewards[1].Denom))
 		}
 	}
+}
+
+func (s *KeeperTestSuite) TestValidatePermissionlessPoolCreationEnabled() {
+	s.SetupTest()
+	// Normally, by default, permissionless pool creation is disabled.
+	// SetupTest, however, calls SetupConcentratedLiquidityDenomsAndPoolCreation which enables permissionless pool creation.
+	s.Require().NoError(s.App.ConcentratedLiquidityKeeper.ValidatePermissionlessPoolCreationEnabled(s.Ctx))
+
+	// Disable permissionless pool creation.
+	defaultParams := types.DefaultParams()
+	defaultParams.IsPermissionlessPoolCreationEnabled = false
+	s.App.ConcentratedLiquidityKeeper.SetParams(s.Ctx, defaultParams)
+
+	// Validate that permissionless pool creation is disabled.
+	s.Require().Error(s.App.ConcentratedLiquidityKeeper.ValidatePermissionlessPoolCreationEnabled(s.Ctx))
 }

--- a/x/concentrated-liquidity/model/msgs.go
+++ b/x/concentrated-liquidity/model/msgs.go
@@ -5,8 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
@@ -42,7 +40,7 @@ func (msg MsgCreateConcentratedPool) Type() string  { return TypeMsgCreateConcen
 func (msg MsgCreateConcentratedPool) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
+		return fmt.Errorf("Invalid sender address (%s)", err)
 	}
 
 	if msg.TickSpacing <= 0 {
@@ -50,7 +48,7 @@ func (msg MsgCreateConcentratedPool) ValidateBasic() error {
 	}
 
 	if msg.Denom0 == msg.Denom1 {
-		return fmt.Errorf("denom0 and denom1 must be different")
+		return cltypes.MatchingDenomError{Denom: msg.Denom0}
 	}
 
 	if sdk.ValidateDenom(msg.Denom0) != nil {
@@ -70,8 +68,7 @@ func (msg MsgCreateConcentratedPool) ValidateBasic() error {
 }
 
 func (msg MsgCreateConcentratedPool) GetSignBytes() []byte {
-	return nil
-	// return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgCreateConcentratedPool) GetSigners() []sdk.AccAddress {

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -30,6 +30,7 @@ func NewConcentratedLiquidityPool(poolId uint64, denom0, denom1 string, tickSpac
 		return Pool{}, types.MatchingDenomError{Denom: denom0}
 	}
 
+	// Swap fee must be [0,1)
 	if swapFee.IsNegative() || swapFee.GTE(one) {
 		return Pool{}, types.InvalidSwapFeeError{ActualFee: swapFee}
 	}

--- a/x/concentrated-liquidity/msg_server.go
+++ b/x/concentrated-liquidity/msg_server.go
@@ -33,9 +33,8 @@ var (
 	_ clmodel.MsgCreatorServer = msgServer{}
 )
 
-// CreateConcentratedPool attempts to create a pool returning a MsgCreateConcentratedPoolResponse or an error upon failure.
-// The pool creation fee is used to fund the community pool.
-// It will create a dedicated module account for the pool and sends the initial liquidity to the created module account.
+// CreateConcentratedPool attempts to create a concentrated liquidity pool via the poolmanager module, returning a MsgCreateConcentratedPoolResponse or an error upon failure.
+// The pool creation fee is used to fund the community pool. It will also create a dedicated module account for the pool.
 func (server msgServer) CreateConcentratedPool(goCtx context.Context, msg *clmodel.MsgCreateConcentratedPool) (*clmodel.MsgCreateConcentratedPoolResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -72,7 +72,7 @@ func (suite *KeeperTestSuite) TestCreateConcentratedPool_Events() {
 			if tc.expectedError == nil {
 				suite.NoError(err)
 				suite.NotNil(response)
-				suite.AssertEventEmitted(ctx, cltypes.TypeEvtPoolCreated, tc.expectedPoolCreatedEvent)
+				suite.AssertEventEmitted(ctx, poolmanagertypes.TypeEvtPoolCreated, tc.expectedPoolCreatedEvent)
 				suite.AssertEventEmitted(ctx, sdk.EventTypeMessage, tc.expectedMessageEvents)
 			} else {
 				suite.Require().Error(err)

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -8,6 +8,7 @@ import (
 
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
+	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
@@ -40,7 +41,7 @@ func (suite *KeeperTestSuite) TestCreateConcentratedPool_Events() {
 			denom0:        ETH,
 			denom1:        USDC,
 			tickSpacing:   DefaultTickSpacing + 1,
-			expectedError: fmt.Errorf("invalid tick spacing. Got %d", DefaultTickSpacing+1),
+			expectedError: types.UnauthorizedTickSpacingError{ProvidedTickSpacing: DefaultTickSpacing + 1, AuthorizedTickSpacings: suite.App.ConcentratedLiquidityKeeper.GetParams(suite.Ctx).AuthorizedTickSpacing},
 		},
 	}
 

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -32,9 +32,10 @@ func (suite *KeeperTestSuite) TestCreateConcentratedPool_Events() {
 			expectedPoolCreatedEvent: 1,
 			expectedMessageEvents:    4, // 1 for pool created, 1 for coin spent, 1 for coin received, 1 for after pool create hook
 		},
-		"error: missing tickSpacing": {
+		"error: tickSpacing not positive": {
 			denom0:        ETH,
 			denom1:        USDC,
+			tickSpacing:   0,
 			expectedError: fmt.Errorf("tick spacing must be positive"),
 		},
 		"error: tickSpacing not authorized": {

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -15,7 +15,18 @@ import (
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
-// InitializePool initializes a concentrated liquidity pool and sets it in state.
+// InitializePool initializes a new concentrated liquidity pool with the given PoolI interface and creator address.
+// It validates tick spacing, swap fee, and authorized quote denominations before creating and setting
+// the pool's fee and uptime accumulators. If the pool is successfully created, it calls the AfterConcentratedPoolCreated
+// listener function.
+//
+// Returns an error if any of the following conditions are met:
+// - The poolI cannot be converted to a ConcentratedPool.
+// - The tick spacing is invalid.
+// - The swap fee is invalid.
+// - The quote denomination is unauthorized.
+// - There is an error creating the fee or uptime accumulator.
+// - There is an error setting the pool in the keeper's state.
 func (k Keeper) InitializePool(ctx sdk.Context, poolI poolmanagertypes.PoolI, creatorAddress sdk.AccAddress) error {
 	concentratedPool, err := convertPoolInterfaceToConcentrated(poolI)
 	if err != nil {
@@ -25,6 +36,8 @@ func (k Keeper) InitializePool(ctx sdk.Context, poolI poolmanagertypes.PoolI, cr
 	params := k.GetParams(ctx)
 	tickSpacing := concentratedPool.GetTickSpacing()
 	swapFee := concentratedPool.GetSwapFee(ctx)
+	poolId := concentratedPool.GetId()
+	quoteAsset := concentratedPool.GetToken1()
 
 	if !k.validateTickSpacing(ctx, params, tickSpacing) {
 		return fmt.Errorf("invalid tick spacing. Got %d", tickSpacing)
@@ -34,15 +47,15 @@ func (k Keeper) InitializePool(ctx sdk.Context, poolI poolmanagertypes.PoolI, cr
 		return fmt.Errorf("invalid swap fee. Got %s", swapFee)
 	}
 
-	if !validateAuthorizedQuoteDenoms(ctx, concentratedPool.GetToken1(), params.AuthorizedQuoteDenoms) {
-		return types.UnauthorizedQuoteDenomError{Denom: concentratedPool.GetToken1()}
+	if !validateAuthorizedQuoteDenoms(ctx, quoteAsset, params.AuthorizedQuoteDenoms) {
+		return types.UnauthorizedQuoteDenomError{Denom: quoteAsset}
 	}
 
-	if err := k.createFeeAccumulator(ctx, concentratedPool.GetId()); err != nil {
+	if err := k.createFeeAccumulator(ctx, poolId); err != nil {
 		return err
 	}
 
-	if err := k.createUptimeAccumulators(ctx, concentratedPool.GetId()); err != nil {
+	if err := k.createUptimeAccumulators(ctx, poolId); err != nil {
 		return err
 	}
 
@@ -52,7 +65,7 @@ func (k Keeper) InitializePool(ctx sdk.Context, poolI poolmanagertypes.PoolI, cr
 		return err
 	}
 
-	k.listeners.AfterConcentratedPoolCreated(ctx, creatorAddress, concentratedPool.GetId())
+	k.listeners.AfterConcentratedPoolCreated(ctx, creatorAddress, poolId)
 
 	return nil
 }
@@ -110,7 +123,8 @@ func (k Keeper) poolExists(ctx sdk.Context, poolId uint64) bool {
 	return found
 }
 
-// TODO: spec and test
+// setPool stores a ConcentratedPoolExtension in the Keeper's KVStore.
+// It returns an error if the provided pool is not of type *model.Pool.
 func (k Keeper) setPool(ctx sdk.Context, pool types.ConcentratedPoolExtension) error {
 	poolModel, ok := pool.(*model.Pool)
 	if !ok {
@@ -287,6 +301,8 @@ func (k Keeper) validateTickSpacing(ctx sdk.Context, params types.Params, tickSp
 	return false
 }
 
+// validateTickSpacingUpdate returns true if the given tick spacing is one of the authorized tick spacings set in the
+// params and is less than the current tick spacing. False otherwise.
 func (k Keeper) validateTickSpacingUpdate(ctx sdk.Context, pool types.ConcentratedPoolExtension, params types.Params, newTickSpacing uint64) bool {
 	currentTickSpacing := pool.GetTickSpacing()
 	for _, authorizedTick := range params.AuthorizedTickSpacing {

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -40,15 +40,15 @@ func (k Keeper) InitializePool(ctx sdk.Context, poolI poolmanagertypes.PoolI, cr
 	quoteAsset := concentratedPool.GetToken1()
 
 	if !k.validateTickSpacing(ctx, params, tickSpacing) {
-		return fmt.Errorf("invalid tick spacing. Got %d", tickSpacing)
+		return types.UnauthorizedTickSpacingError{ProvidedTickSpacing: tickSpacing, AuthorizedTickSpacings: params.AuthorizedTickSpacing}
 	}
 
 	if !k.validateSwapFee(ctx, params, swapFee) {
-		return fmt.Errorf("invalid swap fee. Got %s", swapFee)
+		return types.UnauthorizedSwapFeeError{ProvidedSwapFee: swapFee, AuthorizedSwapFees: params.AuthorizedSwapFees}
 	}
 
 	if !validateAuthorizedQuoteDenoms(ctx, quoteAsset, params.AuthorizedQuoteDenoms) {
-		return types.UnauthorizedQuoteDenomError{Denom: quoteAsset}
+		return types.UnauthorizedQuoteDenomError{ProvidedQuoteDenom: quoteAsset, AuthorizedQuoteDenoms: params.AuthorizedQuoteDenoms}
 	}
 
 	if err := k.createFeeAccumulator(ctx, poolId); err != nil {

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -56,13 +56,13 @@ func (s *KeeperTestSuite) TestInitializePool() {
 			name:           "Invalid tick spacing",
 			poolI:          &invalidTickSpacingConcentratedPool,
 			creatorAddress: validCreatorAddress,
-			expectedErr:    fmt.Errorf("invalid tick spacing. Got %d", invalidTickSpacing),
+			expectedErr:    types.UnauthorizedTickSpacingError{ProvidedTickSpacing: invalidTickSpacing, AuthorizedTickSpacings: s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx).AuthorizedTickSpacing},
 		},
 		{
 			name:           "Invalid swap fee",
 			poolI:          &invalidSwapFeeConcentratedPool,
 			creatorAddress: validCreatorAddress,
-			expectedErr:    fmt.Errorf("invalid swap fee. Got %d", invalidSwapFee),
+			expectedErr:    types.UnauthorizedSwapFeeError{ProvidedSwapFee: invalidSwapFee, AuthorizedSwapFees: s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx).AuthorizedSwapFees},
 		},
 		{
 			name:  "unauthorized quote denom",
@@ -71,7 +71,7 @@ func (s *KeeperTestSuite) TestInitializePool() {
 			// so that the test case fails.
 			authorizedDenomsOverwrite: []string{"otherDenom"},
 			creatorAddress:            validCreatorAddress,
-			expectedErr:               types.UnauthorizedQuoteDenomError{Denom: USDC},
+			expectedErr:               types.UnauthorizedQuoteDenomError{ProvidedQuoteDenom: USDC, AuthorizedQuoteDenoms: []string{"otherDenom"}},
 		},
 	}
 

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -1,6 +1,7 @@
 package concentrated_liquidity_test
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,19 +18,21 @@ func (s *KeeperTestSuite) TestInitializePool() {
 	validConcentratedPool := s.PrepareConcentratedPool()
 	validPoolI := validConcentratedPool.(poolmanagertypes.PoolI)
 
-	// Create a concentrated liquidity pool with invalid tick spacing
+	// Create a concentrated liquidity pool with unauthorized tick spacing
 	invalidTickSpacing := uint64(25)
 	invalidTickSpacingConcentratedPool, err := clmodel.NewConcentratedLiquidityPool(2, ETH, USDC, invalidTickSpacing, DefaultZeroSwapFee)
 
-	// Create a concentrated liquidity pool with invalid swap fee
+	// Create a concentrated liquidity pool with unauthorized swap fee
 	invalidSwapFee := sdk.MustNewDecFromStr("0.1")
 	invalidSwapFeeConcentratedPool, err := clmodel.NewConcentratedLiquidityPool(3, ETH, USDC, DefaultTickSpacing, invalidSwapFee)
 	s.Require().NoError(err)
 
 	// Create an invalid PoolI that doesn't implement ConcentratedPoolExtension
-	var invalidPoolI poolmanagertypes.PoolI
+	invalidPoolId := s.PrepareBalancerPool()
+	invalidPoolI, err := s.App.GAMMKeeper.GetPool(s.Ctx, invalidPoolId)
+	s.Require().NoError(err)
 
-	validCreatorAddress := sdk.AccAddress([]byte("addr1---------------"))
+	validCreatorAddress := s.TestAccs[0]
 
 	tests := []struct {
 		name                      string
@@ -70,9 +73,6 @@ func (s *KeeperTestSuite) TestInitializePool() {
 			creatorAddress:            validCreatorAddress,
 			expectedErr:               types.UnauthorizedQuoteDenomError{Denom: USDC},
 		},
-		// We cannot test
-		// We don't check creator address because we don't mint anything when making concentrated liquidity pools
-
 	}
 
 	for _, test := range tests {
@@ -94,7 +94,7 @@ func (s *KeeperTestSuite) TestInitializePool() {
 				// Ensure no error is returned
 				s.Require().NoError(err)
 
-				// ensure that fee accumulator has been properly initialized
+				// Ensure that fee accumulator has been properly initialized
 				feeAccumulator, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, test.poolI.GetId())
 				s.Require().NoError(err)
 				s.Require().Equal(sdk.DecCoins(nil), feeAccumulator.GetValue())
@@ -113,6 +113,16 @@ func (s *KeeperTestSuite) TestInitializePool() {
 				// Ensure specified error is returned
 				s.Require().Error(err)
 				s.Require().ErrorContains(err, test.expectedErr.Error())
+
+				// Ensure that fee accumulator has not been initialized
+				_, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, test.poolI.GetId())
+				s.Require().Error(err)
+
+				// Ensure that uptime accumulators have not been initialized
+				_, err = s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, test.poolI.GetId())
+				s.Require().Error(err)
+
+				s.validateListenerCallCount(0, 0, 0, 0)
 			}
 		})
 	}
@@ -267,6 +277,8 @@ func (s *KeeperTestSuite) TestCalculateSpotPrice() {
 }
 
 func (s *KeeperTestSuite) TestValidateSwapFee() {
+	s.SetupTest()
+	params := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
 	tests := []struct {
 		name        string
 		swapFee     sdk.Dec
@@ -274,13 +286,85 @@ func (s *KeeperTestSuite) TestValidateSwapFee() {
 	}{
 		{
 			name:        "Valid swap fee",
-			swapFee:     sdk.MustNewDecFromStr("0.002"),
+			swapFee:     params.AuthorizedSwapFees[0],
 			expectValid: true,
 		},
 		{
 			name:        "Invalid swap fee",
-			swapFee:     sdk.MustNewDecFromStr("0.5"),
+			swapFee:     params.AuthorizedSwapFees[0].Add(sdk.SmallestDec()),
 			expectValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// Method under test.
+			isValid := s.App.ConcentratedLiquidityKeeper.ValidateSwapFee(s.Ctx, params, test.swapFee)
+
+			s.Require().Equal(test.expectValid, isValid)
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestValidateTickSpacing() {
+	s.SetupTest()
+	params := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
+	tests := []struct {
+		name        string
+		tickSpacing uint64
+		expectValid bool
+	}{
+		{
+			name:        "Valid tick spacing",
+			tickSpacing: params.AuthorizedTickSpacing[0],
+			expectValid: true,
+		},
+		{
+			name:        "Invalid tick spacing",
+			tickSpacing: params.AuthorizedTickSpacing[0] + 1,
+			expectValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// Method under test.
+			isValid := s.App.ConcentratedLiquidityKeeper.ValidateTickSpacing(s.Ctx, params, test.tickSpacing)
+
+			s.Require().Equal(test.expectValid, isValid)
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestSetPool() {
+	var invalidPool types.ConcentratedPoolExtension
+	validPool := clmodel.Pool{
+		Address:              s.TestAccs[0].String(),
+		IncentivesAddress:    s.TestAccs[1].String(),
+		Id:                   1,
+		CurrentTickLiquidity: sdk.ZeroDec(),
+		Token0:               ETH,
+		Token1:               USDC,
+		CurrentSqrtPrice:     sdk.OneDec(),
+		CurrentTick:          sdk.ZeroInt(),
+		TickSpacing:          DefaultTickSpacing,
+		ExponentAtPriceOne:   sdk.NewInt(-6),
+		SwapFee:              sdk.MustNewDecFromStr("0.003"),
+		LastLiquidityUpdate:  s.Ctx.BlockTime(),
+	}
+	tests := []struct {
+		name          string
+		pool          types.ConcentratedPoolExtension
+		expectedError error
+	}{
+		{
+			name: "happy path",
+			pool: &validPool,
+		},
+		{
+			name:          "invalidPool",
+			pool:          invalidPool,
+			expectedError: errors.New("invalid pool type when setting concentrated pool"),
 		},
 	}
 
@@ -288,15 +372,25 @@ func (s *KeeperTestSuite) TestValidateSwapFee() {
 		s.Run(test.name, func() {
 			s.SetupTest()
 
-			// Method under test.
-			params := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
-			isValid := s.App.ConcentratedLiquidityKeeper.ValidateSwapFee(s.Ctx, params, test.swapFee)
+			// Retrieving the pool by ID should return an error.
+			retrievedPool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, 1)
+			s.Require().Error(err)
+			s.Require().Nil(retrievedPool)
 
-			if test.expectValid {
-				s.Require().True(isValid)
-			} else {
-				s.Require().False(isValid)
+			// Method under test.
+			err = s.App.ConcentratedLiquidityKeeper.SetPool(s.Ctx, test.pool)
+			if test.expectedError != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, test.expectedError.Error())
+				return
 			}
+			s.Require().NoError(err)
+
+			// Retrieving the pool by ID should return the same pool.
+			retrievedPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, test.pool.GetId())
+			s.Require().NoError(err)
+			s.Require().Equal(test.pool, retrievedPool)
+
 		})
 	}
 }

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -621,11 +621,30 @@ func (e MatchingDenomError) Error() string {
 }
 
 type UnauthorizedQuoteDenomError struct {
-	Denom string
+	ProvidedQuoteDenom    string
+	AuthorizedQuoteDenoms []string
 }
 
 func (e UnauthorizedQuoteDenomError) Error() string {
-	return fmt.Sprintf("attempted to create pool with unauthorized quote denom (%s)", e.Denom)
+	return fmt.Sprintf("attempted to create pool with unauthorized quote denom (%s), must be one of the following: (%s)", e.ProvidedQuoteDenom, e.AuthorizedQuoteDenoms)
+}
+
+type UnauthorizedSwapFeeError struct {
+	ProvidedSwapFee    sdk.Dec
+	AuthorizedSwapFees []sdk.Dec
+}
+
+func (e UnauthorizedSwapFeeError) Error() string {
+	return fmt.Sprintf("attempted to create pool with unauthorized swap fee (%s), must be one of the following: (%s)", e.ProvidedSwapFee, e.AuthorizedSwapFees)
+}
+
+type UnauthorizedTickSpacingError struct {
+	ProvidedTickSpacing    uint64
+	AuthorizedTickSpacings []uint64
+}
+
+func (e UnauthorizedTickSpacingError) Error() string {
+	return fmt.Sprintf("attempted to create pool with unauthorized tick spacing (%d), must be one of the following: (%d)", e.ProvidedTickSpacing, e.AuthorizedTickSpacings)
 }
 
 type NonPositiveLiquidityForNewPositionError struct {

--- a/x/concentrated-liquidity/types/events.go
+++ b/x/concentrated-liquidity/types/events.go
@@ -25,7 +25,6 @@ const (
 	AttributeUpperTick             = "upper_tick"
 	TypeEvtPoolJoined              = "pool_joined"
 	TypeEvtPoolExited              = "pool_exited"
-	TypeEvtPoolCreated             = "pool_created"
 	TypeEvtTokenSwapped            = "token_swapped"
 	AttributeIncentiveDenom        = "incentive_denom"
 	AttributeIncentiveAmount       = "incentive_amount"

--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -599,12 +599,11 @@ osmosisd query gamm total-share 1
 
 ## Events
 
-There are 5 types of events that exist in GAMM:
+There are 4 types of events that exist in GAMM:
 
 * `sdk.EventTypeMessage` - "message"
 * `types.TypeEvtPoolJoined` - "pool_joined"
 * `types.TypeEvtPoolExited` - "pool_exited"
-* `types.TypeEvtPoolCreated` - "pool_created"
 * `types.TypeEvtTokenSwapped` - "token_swapped"
 
 ### `sdk.EventTypeMessage`
@@ -642,11 +641,6 @@ It consists of the following attributes:
   * The value is the pool id of the pool where swap occurs.
 * `types.AttributeKeyTokensOut`
   * The value is the string representation of the tokens being swapped out.
-
-### `types.TypeEvtPoolCreated`
-
-This event is emitted after `CreatePool` completes creating
-the requested pool successfully.
 
 ### `types.TypeEvtTokenSwapped`
 

--- a/x/gamm/keeper/msg_server.go
+++ b/x/gamm/keeper/msg_server.go
@@ -75,18 +75,6 @@ func (server msgServer) CreatePool(goCtx context.Context, msg poolmanagertypes.C
 		return 0, err
 	}
 
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.TypeEvtPoolCreated,
-			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
-		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.PoolCreator().String()),
-		),
-	})
-
 	return poolId, nil
 }
 

--- a/x/gamm/types/events.go
+++ b/x/gamm/types/events.go
@@ -3,7 +3,6 @@ package types
 const (
 	TypeEvtPoolJoined    = "pool_joined"
 	TypeEvtPoolExited    = "pool_exited"
-	TypeEvtPoolCreated   = "pool_created"
 	TypeEvtTokenSwapped  = "token_swapped"
 	TypeEvtMigrateShares = "migrate_shares"
 

--- a/x/poolmanager/create_pool.go
+++ b/x/poolmanager/create_pool.go
@@ -9,15 +9,11 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
-	gammtypes "github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
-func (k Keeper) validateCreatedPool(
-	ctx sdk.Context,
-	poolId uint64,
-	pool types.PoolI,
-) error {
+// validateCreatedPool checks that the pool was created with the correct pool ID and address.
+func (k Keeper) validateCreatedPool(ctx sdk.Context, poolId uint64, pool types.PoolI) error {
 	if pool.GetId() != poolId {
 		return sdkerrors.Wrapf(types.ErrInvalidPool,
 			"Pool was attempted to be created with incorrect pool ID.")
@@ -40,7 +36,7 @@ func (k Keeper) validateCreatedPool(
 // - Minting LP shares to pool creator
 // - Setting metadata for the shares
 func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, error) {
-	// Get pool type.
+	// Get pool module interface from the pool type.
 	poolType := msg.GetPoolType()
 	poolModule, ok := k.routes[poolType]
 	if !ok {
@@ -52,19 +48,22 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 		return 0, err
 	}
 
+	// createPoolZeroLiquidityNoCreationFee contains shared pool creation logic between this function (CreatePool) and
+	// CreateConcentratedPoolAsPoolManager. Despite the name, within this (CreatePool) function, we do charge a creation
+	// fee and send initial liquidity to the pool's address. This function is strictly used to reduce code duplication.
 	pool, err := k.createPoolZeroLiquidityNoCreationFee(ctx, msg)
 	if err != nil {
 		return 0, err
 	}
 
-	// Send pool creation fee to community pool
-	params := k.GetParams(ctx)
+	// Send pool creation fee from pool creator to community pool
+	poolCreationFee := k.GetParams(ctx).PoolCreationFee
 	sender := msg.PoolCreator()
-	if err := k.communityPoolKeeper.FundCommunityPool(ctx, params.PoolCreationFee, sender); err != nil {
+	if err := k.communityPoolKeeper.FundCommunityPool(ctx, poolCreationFee, sender); err != nil {
 		return 0, err
 	}
 
-	// Send initial liquidity to the pool's address.
+	// Send initial liquidity from pool creator to pool module account.
 	initialPoolLiquidity := msg.InitialLiquidity()
 	err = k.bankKeeper.SendCoins(ctx, sender, pool.GetAddress(), initialPoolLiquidity)
 	if err != nil {
@@ -75,14 +74,14 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 }
 
 // CreateConcentratedPoolAsPoolManager creates a concentrated liquidity pool from given message without sending any initial liquidity to the pool
-// and paying a creation fee. This is meant to be used for creating the pools internally. For example, in the upgrade handler.
-// The creator of the pool must be a poolmanager module account. Returns error if not. Otherwise, functions the same as
-// the regular CreatePool.
+// and paying a creation fee. This is meant to be used for creating the pools internally (such as in the upgrade handler).
+// The creator of the pool must be the poolmanager module account. Returns error if not. Otherwise, functions the same as
+// the regular createPoolZeroLiquidityNoCreationFee.
 func (k Keeper) CreateConcentratedPoolAsPoolManager(ctx sdk.Context, msg types.CreatePoolMsg) (types.PoolI, error) {
-	// Validate that creator is a polmanager module account as a sanity check.
+	// Validate that creator is the poolmanager module account as a sanity check.
 	creator := msg.PoolCreator()
-	poolmanagerModuleAcc := k.accountKeeper.GetModuleAccount(ctx, types.ModuleName)
-	if !poolmanagerModuleAcc.GetAddress().Equals(creator) {
+	poolmanagerModuleAccInterface := k.accountKeeper.GetModuleAccount(ctx, types.ModuleName)
+	if !poolmanagerModuleAccInterface.GetAddress().Equals(creator) {
 		return nil, types.InvalidPoolCreatorError{CreatorAddresss: creator.String()}
 	}
 
@@ -98,10 +97,10 @@ func (k Keeper) CreateConcentratedPoolAsPoolManager(ctx sdk.Context, msg types.C
 }
 
 // createPoolZeroLiquidityNoCreationFee is an internal helper to create a pool from message with zero initial liquidity
-// and no creation fee charged. It validates the message gets the next pool ID and creates the pool with the given pool ID and the desired type.
-// It persists the module routing in state for future use. Initializes the pool in its respective module. Emits a create pool event.
-// Returns error if failes to validate the pool creation message, fails to create a module account for the pool or if faile to initialize the pool.
-// It is used by CreatePoolZeroLiquidityNoCreationFee and CreatePool.
+// and no creation fee charged. It validates the message, gets the next pool ID, and creates the pool with the given pool ID and the desired type.
+// It persists the module routing in state for future use, initializes the pool in its respective module, and emits a create pool event.
+// Returns error if it fails to validate the pool creation message, fails to create a module account for the pool, or fails to initialize the pool.
+// It is used by CreateConcentratedPoolAsPoolManager and CreatePool.
 func (k Keeper) createPoolZeroLiquidityNoCreationFee(ctx sdk.Context, msg types.CreatePoolMsg) (types.PoolI, error) {
 	// Run validate basic on the message.
 	err := msg.Validate(ctx)
@@ -109,21 +108,25 @@ func (k Keeper) createPoolZeroLiquidityNoCreationFee(ctx sdk.Context, msg types.
 		return nil, err
 	}
 
-	// Get the next pool ID and increment the pool ID counter
-	// Create the pool with the given pool ID
+	// Get the next pool ID and increment the pool ID counter.
 	poolId := k.getNextPoolIdAndIncrement(ctx)
+
+	// Create the pool with the given pool ID.
 	pool, err := msg.CreatePool(ctx, poolId)
 	if err != nil {
 		return nil, err
 	}
 
+	// Store the pool ID to pool type mapping in state.
 	k.SetPoolRoute(ctx, poolId, msg.GetPoolType())
 
+	// Validates the pool address and pool ID stored match what was expected.
 	if err := k.validateCreatedPool(ctx, poolId, pool); err != nil {
 		return nil, err
 	}
 
-	// create and save the pool's module account to the account keeper
+	// Create and save the pool's module account to the account keeper.
+	// This utilizes the pool address already created and validated in the previous steps.
 	if err := osmoutils.CreateModuleAccount(ctx, k.accountKeeper, pool.GetAddress()); err != nil {
 		return nil, fmt.Errorf("creating pool module account for id %d: %w", poolId, err)
 	}
@@ -141,8 +144,8 @@ func (k Keeper) createPoolZeroLiquidityNoCreationFee(ctx sdk.Context, msg types.
 func emitCreatePoolEvents(ctx sdk.Context, poolId uint64, msg types.CreatePoolMsg) {
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			gammtypes.TypeEvtPoolCreated,
-			sdk.NewAttribute(gammtypes.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+			types.TypeEvtPoolCreated,
+			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/x/poolmanager/create_pool.go
+++ b/x/poolmanager/create_pool.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
@@ -15,12 +14,10 @@ import (
 // validateCreatedPool checks that the pool was created with the correct pool ID and address.
 func (k Keeper) validateCreatedPool(ctx sdk.Context, poolId uint64, pool types.PoolI) error {
 	if pool.GetId() != poolId {
-		return sdkerrors.Wrapf(types.ErrInvalidPool,
-			"Pool was attempted to be created with incorrect pool ID.")
+		return types.IncorrectPoolIdError{ExpectedPoolId: poolId, ActualPoolId: pool.GetId()}
 	}
 	if !pool.GetAddress().Equals(types.NewPoolAddress(poolId)) {
-		return sdkerrors.Wrapf(types.ErrInvalidPool,
-			"Pool was attempted to be created with incorrect pool address.")
+		return types.IncorrectPoolAddressError{ExpectedPoolAddress: types.NewPoolAddress(poolId).String(), ActualPoolAddress: pool.GetAddress().String()}
 	}
 	return nil
 }

--- a/x/poolmanager/create_pool.go
+++ b/x/poolmanager/create_pool.go
@@ -47,7 +47,7 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg types.CreatePoolMsg) (uint64, er
 
 	// createPoolZeroLiquidityNoCreationFee contains shared pool creation logic between this function (CreatePool) and
 	// CreateConcentratedPoolAsPoolManager. Despite the name, within this (CreatePool) function, we do charge a creation
-	// fee and send initial liquidity to the pool's address. This function is strictly used to reduce code duplication.
+	// fee and send initial liquidity to the pool's address. createPoolZeroLiquidityNoCreationFee is strictly used to reduce code duplication.
 	pool, err := k.createPoolZeroLiquidityNoCreationFee(ctx, msg)
 	if err != nil {
 		return 0, err

--- a/x/poolmanager/create_pool_test.go
+++ b/x/poolmanager/create_pool_test.go
@@ -5,11 +5,13 @@ import (
 	"reflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
+	stableswap "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 	gammtypes "github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
@@ -140,6 +142,15 @@ func (suite *KeeperTestSuite) TestCreatePool() {
 			},
 		}, "")
 
+		DefaultStableswapLiquidity = sdk.NewCoins(
+			sdk.NewCoin(foo, defaultInitPoolAmount),
+			sdk.NewCoin(bar, defaultInitPoolAmount),
+		)
+
+		validStableswapPoolMsg = stableswap.NewMsgCreateStableswapPool(suite.TestAccs[0], stableswap.PoolParams{SwapFee: sdk.NewDec(0), ExitFee: sdk.NewDec(0)}, DefaultStableswapLiquidity, []uint64{}, "")
+
+		invalidStableswapPoolMsg = stableswap.NewMsgCreateStableswapPool(suite.TestAccs[0], stableswap.PoolParams{SwapFee: sdk.NewDec(0), ExitFee: sdk.NewDecWithPrec(1, 2)}, DefaultStableswapLiquidity, []uint64{}, "")
+
 		validConcentratedPoolMsg = clmodel.NewMsgCreateConcentratedPool(suite.TestAccs[0], foo, bar, 1, defaultPoolSwapFee)
 
 		defaultFundAmount = sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount.Mul(sdk.NewInt(2))), sdk.NewCoin(bar, defaultInitPoolAmount.Mul(sdk.NewInt(2))))
@@ -166,15 +177,28 @@ func (suite *KeeperTestSuite) TestCreatePool() {
 			expectedModuleType: gammKeeperType,
 		},
 		{
+			name:               "stableswap pool - success",
+			creatorFundAmount:  defaultFundAmount,
+			msg:                validStableswapPoolMsg,
+			expectedModuleType: gammKeeperType,
+		},
+		{
 			name:               "concentrated pool - success",
 			creatorFundAmount:  defaultFundAmount,
 			msg:                validConcentratedPoolMsg,
 			expectedModuleType: concentratedKeeperType,
 		},
 		{
-			name:               "error: pool with non zero exit fee",
+			name:               "error: balancer pool with non zero exit fee",
 			creatorFundAmount:  defaultFundAmount,
 			msg:                invalidBalancerPoolMsg,
+			expectedModuleType: gammKeeperType,
+			expectError:        true,
+		},
+		{
+			name:               "error: stableswap pool with non zero exit fee",
+			creatorFundAmount:  defaultFundAmount,
+			msg:                invalidStableswapPoolMsg,
 			expectedModuleType: gammKeeperType,
 			expectError:        true,
 		},
@@ -186,9 +210,6 @@ func (suite *KeeperTestSuite) TestCreatePool() {
 			expectedModuleType:                   concentratedKeeperType,
 			expectError:                          true,
 		},
-		// TODO: add stableswap test
-		// TODO: add concentrated-liquidity test
-		// TODO: cover errors and edge cases
 	}
 
 	for i, tc := range tests {
@@ -304,7 +325,7 @@ func (suite *KeeperTestSuite) TestCreatePoolZeroLiquidityNoCreationFee() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestGetAllModuleRoutes() {
+func (suite *KeeperTestSuite) TestSetAndGetAllPoolRoutes() {
 	tests := []struct {
 		name         string
 		preSetRoutes []types.ModuleRoute
@@ -370,6 +391,100 @@ func (suite *KeeperTestSuite) TestGetAllModuleRoutes() {
 			// Validate.
 			suite.Require().Len(moduleRoutes, len(tc.preSetRoutes))
 			suite.Require().EqualValues(tc.preSetRoutes, moduleRoutes)
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestGetNextPoolIdAndIncrement() {
+	tests := []struct {
+		name               string
+		expectedNextPoolId uint64
+	}{
+		{
+			name:               "small next pool ID",
+			expectedNextPoolId: 2,
+		},
+		{
+			name:               "large next pool ID",
+			expectedNextPoolId: 2999999,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			tc := tc
+			suite.Setup()
+
+			suite.App.PoolManagerKeeper.SetNextPoolId(suite.Ctx, tc.expectedNextPoolId)
+			nextPoolId := suite.App.PoolManagerKeeper.GetNextPoolId(suite.Ctx)
+			suite.Require().Equal(tc.expectedNextPoolId, nextPoolId)
+
+			// Sytem under test.
+			nextPoolId = suite.App.PoolManagerKeeper.GetNextPoolIdAndIncrement(suite.Ctx)
+			suite.Require().Equal(tc.expectedNextPoolId, nextPoolId)
+			suite.Require().Equal(tc.expectedNextPoolId+1, suite.App.PoolManagerKeeper.GetNextPoolId(suite.Ctx))
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestValidateCreatedPool() {
+	tests := []struct {
+		name          string
+		poolId        uint64
+		pool          types.PoolI
+		expectedError error
+	}{
+		{
+			name:   "pool ID 1",
+			poolId: 1,
+			pool: &balancertypes.Pool{
+				Address: types.NewPoolAddress(1).String(),
+				Id:      1,
+			},
+		},
+		{
+			name:   "pool ID 309",
+			poolId: 309,
+			pool: &balancertypes.Pool{
+				Address: types.NewPoolAddress(309).String(),
+				Id:      309,
+			},
+		},
+		{
+			name:   "error: unexpected ID",
+			poolId: 1,
+			pool: &balancertypes.Pool{
+				Address: types.NewPoolAddress(1).String(),
+				Id:      2,
+			},
+			expectedError: sdkerrors.Wrapf(types.ErrInvalidPool,
+				"Pool was attempted to be created with incorrect pool ID."),
+		},
+		{
+			name:   "error: unexpected address",
+			poolId: 2,
+			pool: &balancertypes.Pool{
+				Address: types.NewPoolAddress(1).String(),
+				Id:      2,
+			},
+			expectedError: sdkerrors.Wrapf(types.ErrInvalidPool,
+				"Pool was attempted to be created with incorrect pool address."),
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			tc := tc
+			suite.Setup()
+
+			// System under test.
+			err := suite.App.PoolManagerKeeper.ValidateCreatedPool(suite.Ctx, tc.poolId, tc.pool)
+			if tc.expectedError != nil {
+				suite.Require().Error(err)
+				suite.Require().ErrorContains(err, tc.expectedError.Error())
+				return
+			}
+			suite.Require().NoError(err)
 		})
 	}
 }

--- a/x/poolmanager/create_pool_test.go
+++ b/x/poolmanager/create_pool_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
@@ -457,8 +456,7 @@ func (suite *KeeperTestSuite) TestValidateCreatedPool() {
 				Address: types.NewPoolAddress(1).String(),
 				Id:      2,
 			},
-			expectedError: sdkerrors.Wrapf(types.ErrInvalidPool,
-				"Pool was attempted to be created with incorrect pool ID."),
+			expectedError: types.IncorrectPoolIdError{ExpectedPoolId: 1, ActualPoolId: 2},
 		},
 		{
 			name:   "error: unexpected address",
@@ -467,8 +465,7 @@ func (suite *KeeperTestSuite) TestValidateCreatedPool() {
 				Address: types.NewPoolAddress(1).String(),
 				Id:      2,
 			},
-			expectedError: sdkerrors.Wrapf(types.ErrInvalidPool,
-				"Pool was attempted to be created with incorrect pool address."),
+			expectedError: types.IncorrectPoolAddressError{ExpectedPoolAddress: types.NewPoolAddress(2).String(), ActualPoolAddress: types.NewPoolAddress(1).String()},
 		},
 	}
 

--- a/x/poolmanager/export_test.go
+++ b/x/poolmanager/export_test.go
@@ -38,3 +38,7 @@ func (k *Keeper) SetPoolModulesUnsafe(poolModules []types.PoolModuleI) {
 func (k Keeper) GetAllPoolRoutes(ctx sdk.Context) []types.ModuleRoute {
 	return k.getAllPoolRoutes(ctx)
 }
+
+func (k Keeper) ValidateCreatedPool(ctx sdk.Context, poolId uint64, pool types.PoolI) error {
+	return k.validateCreatedPool(ctx, poolId, pool)
+}

--- a/x/poolmanager/types/errors.go
+++ b/x/poolmanager/types/errors.go
@@ -14,7 +14,6 @@ const (
 
 var (
 	ErrEmptyRoutes               = errors.New("provided empty routes")
-	ErrInvalidPool               = errors.New("attempting to create an invalid pool")
 	ErrTooFewPoolAssets          = errors.New("pool should have at least 2 assets, as they must be swapping between at least two assets")
 	ErrTooManyPoolAssets         = errors.New("pool has too many assets (currently capped at 8 assets per pool)")
 	ErrDuplicateRoutesNotAllowed = errors.New("duplicate multihop routes are not allowed")
@@ -107,4 +106,22 @@ type InvalidPoolTypeError struct {
 
 func (e InvalidPoolTypeError) Error() string {
 	return fmt.Sprintf("invalid pool type (%s)", PoolType_name[int32(e.PoolType)])
+}
+
+type IncorrectPoolIdError struct {
+	ExpectedPoolId uint64
+	ActualPoolId   uint64
+}
+
+func (e IncorrectPoolIdError) Error() string {
+	return fmt.Sprintf("Pool was attempted to be created with incorrect pool ID. Expected (%d), actual (%d)", e.ExpectedPoolId, e.ActualPoolId)
+}
+
+type IncorrectPoolAddressError struct {
+	ExpectedPoolAddress string
+	ActualPoolAddress   string
+}
+
+func (e IncorrectPoolAddressError) Error() string {
+	return fmt.Sprintf("Pool was attempted to be created with incorrect pool address. Expected (%s), actual (%s)", e.ExpectedPoolAddress, e.ActualPoolAddress)
 }

--- a/x/poolmanager/types/events.go
+++ b/x/poolmanager/types/events.go
@@ -2,4 +2,6 @@ package types
 
 const (
 	AttributeValueCategory = ModuleName
+	TypeEvtPoolCreated     = "pool_created"
+	AttributeKeyPoolId     = "pool_id"
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Clickup link: 
https://app.clickup.com/37420681/v/dc/13nzm9-18987/13nzm9-35107

## What is the purpose of the change

This PR introduces minor additions / changes relating to MsgCreateConcentratedPool:
* Test additions / refactors
* In-line comment additions / changes
* Documentation grooming
* Replace manual errors for custom error types
* Drive by changes


## Brief Changelog

- CL, Poolmanager, and GAMM readme.md edits
- Pool created event source switched from gamm to poolmanager
- Event emission removed from CreatePool in gamm's msgServer (its already emitted in CreatePool within poolManager which all calls get routed through)
- Various test additions


## Testing and Verifying

Tests were added to cover any logic in the MsgCreateConcentratedPool path that was not already covered.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)