### PR TITLE
refactor: remove directional tick rounding

### DIFF
--- a/tests/cl-genesis-positions/convert.go
+++ b/tests/cl-genesis-positions/convert.go
@@ -148,7 +148,7 @@ func ConvertSubgraphToOsmosisGenesis(positionCreatorAddresses []sdk.AccAddress, 
 			continue
 		}
 
-		lowerTickOsmosis, err := math.PriceToTickRoundDown(lowerPrice, pool.GetTickSpacing())
+		lowerTickOsmosis, err := math.PriceToTickRoundUp(lowerPrice, pool.GetTickSpacing())
 		if err != nil {
 			panic(err)
 		}

--- a/tests/cl-genesis-positions/convert.go
+++ b/tests/cl-genesis-positions/convert.go
@@ -148,12 +148,12 @@ func ConvertSubgraphToOsmosisGenesis(positionCreatorAddresses []sdk.AccAddress, 
 			continue
 		}
 
-		lowerTickOsmosis, err := math.PriceToTickRoundUp(lowerPrice, pool.GetTickSpacing())
+		lowerTickOsmosis, err := math.PriceToTickRoundDown(lowerPrice, pool.GetTickSpacing())
 		if err != nil {
 			panic(err)
 		}
 
-		upperTickOsmosis, err := math.PriceToTickRoundUp(upperPrice, pool.GetTickSpacing())
+		upperTickOsmosis, err := math.PriceToTickRoundDown(upperPrice, pool.GetTickSpacing())
 		if err != nil {
 			panic(err)
 		}

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -452,8 +452,7 @@ func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOutsideForTick() {
 		validPoolId = 1
 	)
 
-	// we use bankers here because this is the rounding method used when initializing a position.
-	initialPoolTickInt, err := math.PriceToTickRoundBankers(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()), DefaultTickSpacing)
+	initialPoolTickInt, err := math.PriceToTickRoundUp(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()), DefaultTickSpacing)
 	initialPoolTick := initialPoolTickInt.Int64()
 	suite.Require().NoError(err)
 

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -452,7 +452,7 @@ func (suite *KeeperTestSuite) TestGetInitialFeeGrowthOutsideForTick() {
 		validPoolId = 1
 	)
 
-	initialPoolTickInt, err := math.PriceToTickRoundUp(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()), DefaultTickSpacing)
+	initialPoolTickInt, err := math.PriceToTickRoundDown(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()), DefaultTickSpacing)
 	initialPoolTick := initialPoolTickInt.Int64()
 	suite.Require().NoError(err)
 

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -46,10 +46,10 @@ var (
 	FullRangeLiquidityAmt                          = sdk.MustNewDecFromStr("70710678.118654752940000000")
 	DefaultTickSpacing                             = uint64(100)
 	PoolCreationFee                                = poolmanagertypes.DefaultParams().PoolCreationFee
-	DefaultExponentConsecutivePositionLowerTick, _ = math.PriceToTickRoundUp(sdk.NewDec(5500), DefaultTickSpacing)
-	DefaultExponentConsecutivePositionUpperTick, _ = math.PriceToTickRoundUp(sdk.NewDec(6250), DefaultTickSpacing)
-	DefaultExponentOverlappingPositionLowerTick, _ = math.PriceToTickRoundUp(sdk.NewDec(4000), DefaultTickSpacing)
-	DefaultExponentOverlappingPositionUpperTick, _ = math.PriceToTickRoundUp(sdk.NewDec(4999), DefaultTickSpacing)
+	DefaultExponentConsecutivePositionLowerTick, _ = math.PriceToTickRoundDown(sdk.NewDec(5500), DefaultTickSpacing)
+	DefaultExponentConsecutivePositionUpperTick, _ = math.PriceToTickRoundDown(sdk.NewDec(6250), DefaultTickSpacing)
+	DefaultExponentOverlappingPositionLowerTick, _ = math.PriceToTickRoundDown(sdk.NewDec(4000), DefaultTickSpacing)
+	DefaultExponentOverlappingPositionUpperTick, _ = math.PriceToTickRoundDown(sdk.NewDec(4999), DefaultTickSpacing)
 	BAR                                            = "bar"
 	FOO                                            = "foo"
 )

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -325,8 +325,9 @@ func (k Keeper) sendCoinsBetweenPoolAndUser(ctx sdk.Context, denom0, denom1 stri
 	return nil
 }
 
-// createInitialPosition ensures that the first position created on this pool includes both asset0 and asset1
+// initializeInitialPositionForPool ensures that the first position created on this pool includes both asset0 and asset1
 // This is required so we can set the pool's sqrtPrice and calculate it's initial tick from this
+// Additionally, it initializes the current sqrt price and current tick from the initial reserve values.
 func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.ConcentratedPoolExtension, amount0Desired, amount1Desired sdk.Int) error {
 	// Check that the position includes some amount of both asset0 and asset1
 	if !amount0Desired.GT(sdk.ZeroInt()) || !amount1Desired.GT(sdk.ZeroInt()) {
@@ -336,23 +337,27 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 	// Calculate the spot price and sqrt price from the amount provided
 	initialSpotPrice := amount1Desired.ToDec().Quo(amount0Desired.ToDec())
 
-	// Calculate the initial tick from the initial spot price
-	// We use banker's rounding here so that the tick is rounded to
-	// the nearest value relative to the true value given the tick spacing of 1.
-	initialTick, err := math.PriceToTickRoundBankers(initialSpotPrice, pool.GetTickSpacing())
+	initialCurSqrtPrice, err := initialSpotPrice.ApproxSqrt()
 	if err != nil {
 		return err
 	}
 
-	// Since tick can be rounded due to tick spacing
-	// we calculate the initial sqrt price from the initial tick
-	initialSqrtPrice, err := math.TickToSqrtPrice(initialTick)
+	// Calculate the initial tick from the initial spot price
+	// We use banker's rounding here so that the tick is rounded to
+	// the nearest value relative to the true value given the tick spacing of 1.
+	initialTick, err := math.PriceToTickRoundUp(initialSpotPrice, pool.GetTickSpacing())
 	if err != nil {
 		return err
 	}
 
 	// Set the pool's current sqrt price and current tick to the above calculated values
-	pool.SetCurrentSqrtPrice(initialSqrtPrice)
+	// Note that initial initial cur sqrt price might not fall directly on the initial tick.
+	// For example, if we have tick spacing of 1, default exponent at price one of -6, and
+	// the current spot price of 100_000_025.123 X/Y.
+	// However, there are ticks only at 100_000_000 X/Y and 100_000_100 X/Y.
+	// In such a case, we do not want to round the sqrt price to 100_000_000 X/Y, but rather
+	// let it float withing the possible tick range.
+	pool.SetCurrentSqrtPrice(initialCurSqrtPrice)
 	pool.SetCurrentTick(initialTick)
 	err = k.setPool(ctx, pool)
 	if err != nil {

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -345,7 +345,7 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 	// Calculate the initial tick from the initial spot price
 	// We use banker's rounding here so that the tick is rounded to
 	// the nearest value relative to the true value given the tick spacing of 1.
-	initialTick, err := math.PriceToTickRoundUp(initialSpotPrice, pool.GetTickSpacing())
+	initialTick, err := math.PriceToTickRoundDown(initialSpotPrice, pool.GetTickSpacing())
 	if err != nil {
 		return err
 	}

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -343,8 +343,8 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 	}
 
 	// Calculate the initial tick from the initial spot price
-	// We use banker's rounding here so that the tick is rounded to
-	// the nearest value relative to the true value given the tick spacing of 1.
+	// We round dow here so that the tick is rounded to
+	// the nearest possible value given the tick spacing.
 	initialTick, err := math.PriceToTickRoundDown(initialSpotPrice, pool.GetTickSpacing())
 	if err != nil {
 		return err

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -1009,29 +1009,68 @@ func (s *KeeperTestSuite) TestUpdatePosition() {
 }
 
 func (s *KeeperTestSuite) TestInitializeInitialPositionForPool() {
+
+	var (
+		sqrt = func(x int64) sdk.Dec {
+			sqrt, err := sdk.NewDec(x).ApproxSqrt()
+			s.Require().NoError(err)
+			return sqrt
+		}
+	)
+
 	type sendTest struct {
-		amount0Desired sdk.Int
-		amount1Desired sdk.Int
-		expectedError  error
+		amount0Desired        sdk.Int
+		amount1Desired        sdk.Int
+		tickSpacing           uint64
+		expectedCurrSqrtPrice sdk.Dec
+		expectedTick          sdk.Int
+		expectedError         error
 	}
 	tests := map[string]sendTest{
 		"happy path": {
-			amount0Desired: DefaultAmt0,
-			amount1Desired: DefaultAmt1,
+			amount0Desired:        DefaultAmt0,
+			amount1Desired:        DefaultAmt1,
+			tickSpacing:           DefaultTickSpacing,
+			expectedCurrSqrtPrice: DefaultCurrSqrtPrice,
+			expectedTick:          DefaultCurrTick,
+		},
+		"100_000_050 and tick spacing 100, price level where curr sqrt price does not translate to allowed tick (assumes exponent at price one of -6 and tick spacing of 100)": {
+			amount0Desired:        sdk.OneInt(),
+			amount1Desired:        sdk.NewInt(100_000_050),
+			tickSpacing:           DefaultTickSpacing,
+			expectedCurrSqrtPrice: sqrt(100_000_050),
+			expectedTick:          sdk.NewInt(72000000),
+		},
+		"100_000_051 and tick spacing 100, price level where curr sqrt price does not translate to allowed tick (assumes exponent at price one of -6 and tick spacing of 100)": {
+			amount0Desired:        sdk.OneInt(),
+			amount1Desired:        sdk.NewInt(100_000_051),
+			tickSpacing:           DefaultTickSpacing,
+			expectedCurrSqrtPrice: sqrt(100_000_051),
+			expectedTick:          sdk.NewInt(72000100),
+		},
+		"100_000_051 and tick spacing 1, price level where curr sqrt price translates to allowed tick (assumes exponent at price one of -6 and tick spacing of 1)": {
+			amount0Desired:        sdk.OneInt(),
+			amount1Desired:        sdk.NewInt(100_000_051),
+			tickSpacing:           1,
+			expectedCurrSqrtPrice: sqrt(100_000_051),
+			expectedTick:          sdk.NewInt(72000001),
 		},
 		"error: amount0Desired is zero": {
 			amount0Desired: sdk.ZeroInt(),
 			amount1Desired: DefaultAmt1,
+			tickSpacing:    DefaultTickSpacing,
 			expectedError:  types.InitialLiquidityZeroError{Amount0: sdk.ZeroInt(), Amount1: DefaultAmt1},
 		},
 		"error: amount1Desired is zero": {
 			amount0Desired: DefaultAmt0,
 			amount1Desired: sdk.ZeroInt(),
+			tickSpacing:    DefaultTickSpacing,
 			expectedError:  types.InitialLiquidityZeroError{Amount0: DefaultAmt0, Amount1: sdk.ZeroInt()},
 		},
 		"error: both amount0Desired and amount01Desired is zero": {
 			amount0Desired: sdk.ZeroInt(),
 			amount1Desired: sdk.ZeroInt(),
+			tickSpacing:    DefaultTickSpacing,
 			expectedError:  types.InitialLiquidityZeroError{Amount0: sdk.ZeroInt(), Amount1: sdk.ZeroInt()},
 		},
 	}
@@ -1042,7 +1081,7 @@ func (s *KeeperTestSuite) TestInitializeInitialPositionForPool() {
 			s.SetupTest()
 
 			// create a CL pool
-			pool := s.PrepareConcentratedPool()
+			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, tc.tickSpacing, sdk.ZeroDec())
 
 			// System under test
 			err := s.App.ConcentratedLiquidityKeeper.InitializeInitialPositionForPool(s.Ctx, pool, tc.amount0Desired, tc.amount1Desired)
@@ -1052,6 +1091,12 @@ func (s *KeeperTestSuite) TestInitializeInitialPositionForPool() {
 				s.Require().ErrorAs(err, &tc.expectedError)
 			} else {
 				s.Require().NoError(err)
+
+				pool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
+				s.Require().NoError(err)
+
+				s.Require().Equal(tc.expectedCurrSqrtPrice.String(), pool.GetCurrentSqrtPrice().String())
+				s.Require().Equal(tc.expectedTick.String(), pool.GetCurrentTick().String())
 			}
 		})
 	}

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -115,31 +115,6 @@ func PriceToTick(price sdk.Dec) (sdk.Int, error) {
 	return tickIndex, nil
 }
 
-// PriceToTickRoundUp takes a price and returns the corresponding tick index.
-// If tickSpacing is provided, the tick index will be rounded up to the nearest multiple of tickSpacing.
-// TODO: consider removing.
-func PriceToTickRoundUp(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
-	tickIndex, err := PriceToTick(price)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-
-	// Round the tick index up to the nearest tick spacing if the tickIndex is in between authorized tick values
-	tickSpacingInt := sdk.NewIntFromUint64(tickSpacing)
-	tickIndexModulus := tickIndex.Mod(tickSpacingInt)
-	if !tickIndexModulus.Equal(sdk.ZeroInt()) {
-		tickIndex = tickIndex.Add(tickSpacingInt.Sub(tickIndexModulus))
-	}
-
-	// Defense-in-depth check to ensure that the tick index is within the authorized range
-	// Should never get here.
-	if tickIndex.GT(sdk.NewInt(types.MaxTick)) || tickIndex.LT(sdk.NewInt(types.MinTick)) {
-		return sdk.Int{}, types.TickIndexNotWithinBoundariesError{ActualTick: tickIndex.Int64(), MinTick: types.MinTick, MaxTick: types.MaxTick}
-	}
-
-	return tickIndex, nil
-}
-
 // PriceToTickRoundDown takes a price and returns the corresponding tick index.
 // If tickSpacing is provided, the tick index will be rounded down to the nearest multiple of tickSpacing.
 func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
@@ -162,43 +137,6 @@ func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	}
 
 	return tickIndex, nil
-}
-
-// PriceToTickRoundUp takes a price and returns the corresponding tick index.
-// If tickSpacing is provided, the tick index will be rounded to the nearest multiple of tickSpacing.
-// The "nearest" is determined by the bankers rounding logic in sdk.Dec.
-// TODO: consider removing. This was added with the assumption that tick rounding
-// matters during swap. However, instead of rounding to the nearest tick, we should
-// perform deterministic rounding (down) to the nearest tickSpacing.
-func PriceToTickRoundBankers(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
-	tickIndex, err := PriceToTick(price)
-	if err != nil {
-		return sdk.Int{}, err
-	}
-
-	// Round the tick index up to the nearest tick spacing if the tickIndex is in between authorized tick values
-	tickSpacingInt := sdk.NewIntFromUint64(tickSpacing)
-	tickIndexModulus := tickIndex.Abs().Mod(tickSpacingInt)
-
-	if tickIndex.IsZero() {
-		return tickIndex, nil
-	}
-
-	// We use this ratio to determine whether to round up or down using sdk.Dec's rounding logic.
-	roundingValue := tickIndexModulus.ToDec().Quo(tickSpacingInt.ToDec()).RoundInt()
-
-	// if tick index was negative and rounding value got rounded down to zero, we round up the tick index.
-	// if tick index was positive and rounding value got rounded up to one, we round up the tick index.
-	if tickIndex.IsNegative() && roundingValue.IsZero() || tickIndex.IsPositive() && roundingValue.Equal(sdk.OneInt()) {
-		return PriceToTickRoundUp(price, tickSpacing)
-
-		// if tick index was negative and rounding value got rounded up to one, we round down the tick index.
-		// if tick index was positive and rounding value got rounded down to zero, we round down the tick index.
-	} else if tickIndex.IsNegative() && roundingValue.Equal(sdk.OneInt()) || tickIndex.IsPositive() && roundingValue.IsZero() {
-		return PriceToTickRoundDown(price, tickSpacing)
-	}
-
-	return sdk.Int{}, fmt.Errorf("unexpected rounding ratio: %s", roundingValue)
 }
 
 // powTen treats negative exponents as 1/(10**|exponent|) instead of 10**-exponent

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -141,6 +141,7 @@ func PriceToTickRoundUp(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 
 // PriceToTickRoundDown takes a price and returns the corresponding tick index.
 // If tickSpacing is provided, the tick index will be rounded down to the nearest multiple of tickSpacing.
+// TODO: consider removing.
 func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	tickIndex, err := PriceToTick(price)
 	if err != nil {
@@ -166,6 +167,9 @@ func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 // PriceToTickRoundUp takes a price and returns the corresponding tick index.
 // If tickSpacing is provided, the tick index will be rounded to the nearest multiple of tickSpacing.
 // The "nearest" is determined by the bankers rounding logic in sdk.Dec.
+// TODO: consider removing. This was added with the assumption that tick rounding
+// matters during swap. However, instead of rounding to the nearest tick, we should
+// perform deterministic rounding (up) to the nearest tickSpacing.
 func PriceToTickRoundBankers(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	tickIndex, err := PriceToTick(price)
 	if err != nil {

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -117,6 +117,7 @@ func PriceToTick(price sdk.Dec) (sdk.Int, error) {
 
 // PriceToTickRoundUp takes a price and returns the corresponding tick index.
 // If tickSpacing is provided, the tick index will be rounded up to the nearest multiple of tickSpacing.
+// TODO: consider removing.
 func PriceToTickRoundUp(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	tickIndex, err := PriceToTick(price)
 	if err != nil {
@@ -141,7 +142,6 @@ func PriceToTickRoundUp(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 
 // PriceToTickRoundDown takes a price and returns the corresponding tick index.
 // If tickSpacing is provided, the tick index will be rounded down to the nearest multiple of tickSpacing.
-// TODO: consider removing.
 func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	tickIndex, err := PriceToTick(price)
 	if err != nil {
@@ -169,7 +169,7 @@ func PriceToTickRoundDown(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 // The "nearest" is determined by the bankers rounding logic in sdk.Dec.
 // TODO: consider removing. This was added with the assumption that tick rounding
 // matters during swap. However, instead of rounding to the nearest tick, we should
-// perform deterministic rounding (up) to the nearest tickSpacing.
+// perform deterministic rounding (down) to the nearest tickSpacing.
 func PriceToTickRoundBankers(price sdk.Dec, tickSpacing uint64) (sdk.Int, error) {
 	tickIndex, err := PriceToTick(price)
 	if err != nil {

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -278,73 +278,12 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick() {
 		suite.Run(name, func() {
 			tick, err := math.PriceToTick(tc.price)
 			// With tick spacing of one, no rounding should occur.
-			tickRoundUp, err1 := math.PriceToTickRoundUp(tc.price, one)
-			tickRoundDown, err2 := math.PriceToTickRoundDown(tc.price, one)
-			tickBankers, err3 := math.PriceToTickRoundBankers(tc.price, one)
+			tickRoundUp, err1 := math.PriceToTickRoundDown(tc.price, one)
 
 			suite.Require().NoError(err)
 			suite.Require().NoError(err1)
-			suite.Require().NoError(err2)
-			suite.Require().NoError(err3)
 			suite.Require().Equal(tc.tickExpected, tick.String())
 			suite.Require().Equal(tc.tickExpected, tickRoundUp.String())
-			suite.Require().Equal(tc.tickExpected, tickRoundDown.String())
-			suite.Require().Equal(tc.tickExpected, tickBankers.String())
-		})
-	}
-}
-
-func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundUp() {
-	testCases := map[string]struct {
-		price        sdk.Dec
-		tickSpacing  uint64
-		tickExpected string
-	}{
-		"tick spacing 100, price of 1": {
-			price:        sdk.OneDec(),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 100, price of 1.000030, tick 30 -> 100": {
-			price:        sdk.MustNewDecFromStr("1.000030"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "100",
-		},
-		"tick spacing 100, price of 0.9999970, tick -30 -> 0": {
-			price:        sdk.MustNewDecFromStr("0.9999970"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 50, price of 0.9999730, tick -270 -> -250": {
-			price:        sdk.MustNewDecFromStr("0.9999730"),
-			tickSpacing:  50,
-			tickExpected: "-250",
-		},
-		"tick spacing 100, MinSpotPrice, MinTick": {
-			price:        types.MinSpotPrice,
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: sdk.NewInt(types.MinTick).String(),
-		},
-		"tick spacing 100, Spot price one tick below max, one tick below max -> MaxTick": {
-			price:        closestPriceBelowMaxPriceDefaultTickSpacing,
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: sdk.NewInt(types.MaxTick).String(),
-		},
-		"tick spacing 100, Spot price one tick above min, one tick above min -> MinTick": {
-			price:        types.MinSpotPrice.Add(sdk.SmallestDec()),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: closestTickAboveMinPriceDefaultTickSpacing.String(),
-		},
-	}
-	for name, tc := range testCases {
-		tc := tc
-
-		suite.Run(name, func() {
-
-			tick, err := math.PriceToTickRoundUp(tc.price, tc.tickSpacing)
-
-			suite.Require().NoError(err)
-			suite.Require().Equal(tc.tickExpected, tick.String())
 		})
 	}
 }
@@ -412,81 +351,6 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundDown() {
 		suite.Run(name, func() {
 
 			tick, err := math.PriceToTickRoundDown(tc.price, tc.tickSpacing)
-
-			suite.Require().NoError(err)
-			suite.Require().Equal(tc.tickExpected, tick.String())
-		})
-	}
-}
-
-func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundBankers() {
-	testCases := map[string]struct {
-		price        sdk.Dec
-		tickSpacing  uint64
-		tickExpected string
-	}{
-		"tick spacing 100, price of 1": {
-			price:        sdk.OneDec(),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 100, price of 1.000030, tick 30 -> 0": {
-			price:        sdk.MustNewDecFromStr("1.000030"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 100, price of 1.000050, tick 50 -> 0": {
-			price:        sdk.MustNewDecFromStr("1.000050"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 100, price of 1.000051, tick 51 -> 100": {
-			price:        sdk.MustNewDecFromStr("1.000051"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "100",
-		},
-		"tick spacing 100, price of 0.9999970, tick -30 -> 0": {
-			price:        sdk.MustNewDecFromStr("0.9999970"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 100, price of 0.9999950, tick -50 -> 0": {
-			price:        sdk.MustNewDecFromStr("0.9999950"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "0",
-		},
-		"tick spacing 100, price of 0.9999951, tick -51 -> -100": {
-			price:        sdk.MustNewDecFromStr("0.9999949"),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "-100",
-		},
-		"tick spacing 50, price of 0.9999770, tick -270 -> -250": {
-			price:        sdk.MustNewDecFromStr("0.9999730"),
-			tickSpacing:  50,
-			tickExpected: "-250",
-		},
-		"tick spacing 100, MinSpotPrice, MinTick": {
-			price:        types.MinSpotPrice,
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: sdk.NewInt(types.MinTick).String(),
-		},
-		"tick spacing 100, Spot price one tick above min, one tick above min -> MinTick": {
-			price:        types.MinSpotPrice.Add(sdk.SmallestDec()),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: closestTickAboveMinPriceDefaultTickSpacing.String(),
-		},
-		"tick spacing 100, Spot price one tick below max, one tick below max -> MaxTick": {
-			price:        closestPriceBelowMaxPriceDefaultTickSpacing,
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: sdk.NewInt(types.MaxTick).String(),
-		},
-	}
-	for name, tc := range testCases {
-		tc := tc
-
-		suite.Run(name, func() {
-
-			tick, err := math.PriceToTickRoundBankers(tc.price, tc.tickSpacing)
 
 			suite.Require().NoError(err)
 			suite.Require().Equal(tc.tickExpected, tick.String())
@@ -620,7 +484,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			tickSpacing := uint64(1)
 
 			// 1. Compute tick from price.
-			tickFromPrice, err := math.PriceToTickRoundUp(tc.price, tickSpacing)
+			tickFromPrice, err := math.PriceToTickRoundDown(tc.price, tickSpacing)
 			suite.Require().NoError(err)
 			suite.Require().Equal(tc.tickExpected, tickFromPrice.String())
 
@@ -636,7 +500,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			suite.Require().Equal(expectedPrice, price)
 
 			// 3. Compute tick from inverse price (inverse tick)
-			inverseTickFromPrice, err := math.PriceToTickRoundUp(price, tickSpacing)
+			inverseTickFromPrice, err := math.PriceToTickRoundDown(price, tickSpacing)
 			suite.Require().NoError(err)
 
 			// Make sure original tick and inverse tick match.
@@ -653,7 +517,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToSqrtPricePriceToTick_InverseRe
 			// suite.Require().Equal(expectedPrice.String(), priceFromSqrtPrice.String())
 
 			// 5. Compute tick from sqrt price from the original tick.
-			inverseTickFromSqrtPrice, err := math.PriceToTickRoundUp(priceFromSqrtPrice, tickSpacing)
+			inverseTickFromSqrtPrice, err := math.PriceToTickRoundDown(priceFromSqrtPrice, tickSpacing)
 			suite.Require().NoError(err)
 
 			suite.Require().Equal(tickFromPrice, inverseTickFromSqrtPrice, "expected: %s, actual: %s", tickFromPrice, inverseTickFromSqrtPrice)

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -335,6 +335,21 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundUp() {
 			tickSpacing:  defaultTickSpacing,
 			tickExpected: closestTickAboveMinPriceDefaultTickSpacing.String(),
 		},
+		"tick spacing 100, Spot price 100_000_050 -> 72000000": {
+			price:        sdk.NewDec(100_000_050),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "72000000",
+		},
+		"tick spacing 100, Spot price 100_000_051 -> 72000100 (rounded up to tick spacing)": {
+			price:        sdk.NewDec(100_000_051),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "72000100",
+		},
+		"tick spacing 1, Spot price 100_000_051 -> 72000001 no tick spacing rounding": {
+			price:        sdk.NewDec(100_000_051),
+			tickSpacing:  1,
+			tickExpected: "72000001",
+		},
 	}
 	for name, tc := range testCases {
 		tc := tc
@@ -658,6 +673,22 @@ func (suite *ConcentratedMathTestSuite) TestCalculatePriceToTick() {
 		"Price less than 1": {
 			price:             sdk.MustNewDecFromStr("0.71"),
 			expectedTickIndex: sdk.NewInt(-2900000),
+		},
+		"100_000_000": {
+			price:             sdk.NewDec(100_000_000),
+			expectedTickIndex: sdk.NewInt(72000000),
+		},
+		"100_000_050": {
+			price:             sdk.NewDec(100_000_050),
+			expectedTickIndex: sdk.NewInt(72000000),
+		},
+		"100_000_051": {
+			price:             sdk.NewDec(100_000_051),
+			expectedTickIndex: sdk.NewInt(72000001),
+		},
+		"100_000_100": {
+			price:             sdk.NewDec(100_000_100),
+			expectedTickIndex: sdk.NewInt(72000001),
 		},
 	}
 	for name, t := range testCases {

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -335,21 +335,6 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundUp() {
 			tickSpacing:  defaultTickSpacing,
 			tickExpected: closestTickAboveMinPriceDefaultTickSpacing.String(),
 		},
-		"tick spacing 100, Spot price 100_000_050 -> 72000000": {
-			price:        sdk.NewDec(100_000_050),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "72000000",
-		},
-		"tick spacing 100, Spot price 100_000_051 -> 72000100 (rounded up to tick spacing)": {
-			price:        sdk.NewDec(100_000_051),
-			tickSpacing:  defaultTickSpacing,
-			tickExpected: "72000100",
-		},
-		"tick spacing 1, Spot price 100_000_051 -> 72000001 no tick spacing rounding": {
-			price:        sdk.NewDec(100_000_051),
-			tickSpacing:  1,
-			tickExpected: "72000001",
-		},
 	}
 	for name, tc := range testCases {
 		tc := tc
@@ -404,6 +389,21 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTick_RoundDown() {
 			price:        closestPriceBelowMaxPriceDefaultTickSpacing,
 			tickSpacing:  defaultTickSpacing,
 			tickExpected: sdk.NewInt(types.MaxTick - 100).String(),
+		},
+		"tick spacing 100, Spot price 100_000_050 -> 72000000": {
+			price:        sdk.NewDec(100_000_050),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "72000000",
+		},
+		"tick spacing 100, Spot price 100_000_051 -> 72000100 (rounded up to tick spacing)": {
+			price:        sdk.NewDec(100_000_051),
+			tickSpacing:  defaultTickSpacing,
+			tickExpected: "72000000",
+		},
+		"tick spacing 1, Spot price 100_000_051 -> 72000001 no tick spacing rounding": {
+			price:        sdk.NewDec(100_000_051),
+			tickSpacing:  1,
+			tickExpected: "72000001",
 		},
 	}
 	for name, tc := range testCases {
@@ -674,19 +674,19 @@ func (suite *ConcentratedMathTestSuite) TestCalculatePriceToTick() {
 			price:             sdk.MustNewDecFromStr("0.71"),
 			expectedTickIndex: sdk.NewInt(-2900000),
 		},
-		"100_000_000": {
+		"100_000_000 -> 72000000": {
 			price:             sdk.NewDec(100_000_000),
 			expectedTickIndex: sdk.NewInt(72000000),
 		},
-		"100_000_050": {
+		"100_000_050 -> 72000000": {
 			price:             sdk.NewDec(100_000_050),
 			expectedTickIndex: sdk.NewInt(72000000),
 		},
-		"100_000_051": {
+		"100_000_051 -> 72000001": {
 			price:             sdk.NewDec(100_000_051),
 			expectedTickIndex: sdk.NewInt(72000001),
 		},
-		"100_000_100": {
+		"100_000_100 -> 72000001": {
 			price:             sdk.NewDec(100_000_100),
 			expectedTickIndex: sdk.NewInt(72000001),
 		},

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -184,18 +184,17 @@ func (p *Pool) SetLastLiquidityUpdate(newTime time.Time) {
 // updateLiquidityIfActivePosition updates the pool's liquidity if the position is active.
 // Returns true if updated, false otherwise.
 // TODO: add tests.
-func (p *Pool) UpdateLiquidityIfActivePosition(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) bool {
-	// TODO: return error.
+func (p *Pool) UpdateLiquidityIfActivePosition(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) (bool, error) {
 	lowerSqrtPrice, upperSqrtPrice, err := math.TicksToSqrtPrice(lowerTick, upperTick)
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 
 	if p.isCurrentTickInRange(lowerSqrtPrice, upperSqrtPrice) {
 		p.CurrentTickLiquidity = p.CurrentTickLiquidity.Add(liquidityDelta)
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 // calcActualAmounts calculates and returns actual amounts based on where the current tick is located relative to position's

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -382,7 +382,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
 			price := sqrtPrice.Mul(sqrtPrice)
-			swapState.tick, err = math.PriceToTickRoundUp(price, p.GetTickSpacing())
+			swapState.tick, err = math.PriceToTickRoundDown(price, p.GetTickSpacing())
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -543,7 +543,7 @@ func (k Keeper) calcInAmtGivenOut(
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
 			price := sqrtPrice.Mul(sqrtPrice)
-			swapState.tick, err = math.PriceToTickRoundUp(price, p.GetTickSpacing())
+			swapState.tick, err = math.PriceToTickRoundDown(price, p.GetTickSpacing())
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -382,7 +382,7 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
 			price := sqrtPrice.Mul(sqrtPrice)
-			swapState.tick, err = math.PriceToTick(price)
+			swapState.tick, err = math.PriceToTickRoundUp(price, p.GetTickSpacing())
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -381,7 +381,8 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 		} else if !sqrtPriceStart.Equal(sqrtPrice) {
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
-			swapState.tick, err = swapStrategy.SqrtPriceToTick(sqrtPrice)
+			price := sqrtPrice.Mul(sqrtPrice)
+			swapState.tick, err = math.PriceToTick(price)
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -541,7 +542,8 @@ func (k Keeper) calcInAmtGivenOut(
 		} else if !sqrtPriceStart.Equal(sqrtPrice) {
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
-			swapState.tick, err = swapStrategy.SqrtPriceToTick(sqrtPrice)
+			price := sqrtPrice.Mul(sqrtPrice)
+			swapState.tick, err = math.PriceToTick(price)
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -543,7 +543,7 @@ func (k Keeper) calcInAmtGivenOut(
 			// otherwise if the sqrtPrice calculated from computeSwapStep does not equal the sqrtPrice we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the sqrtPrice calculated from computeSwapStep
 			price := sqrtPrice.Mul(sqrtPrice)
-			swapState.tick, err = math.PriceToTick(price)
+			swapState.tick, err = math.PriceToTickRoundUp(price, p.GetTickSpacing())
 			if err != nil {
 				return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 			}

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -417,7 +417,7 @@ var (
 			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(12892)),
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(64417624)),
 			expectedTick: func() sdk.Int {
-				tick, _ := math.PriceToTickRoundUp(sdk.NewDec(4994), DefaultTickSpacing)
+				tick, _ := math.PriceToTickRoundDown(sdk.NewDec(4994), DefaultTickSpacing)
 				return tick
 			}(),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2812891.26207649936510%29%29
@@ -582,7 +582,7 @@ var (
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64417624)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000085792039652"),
 			expectedTick: func() sdk.Int {
-				tick, _ := math.PriceToTickRoundUp(sdk.NewDec(4994), DefaultTickSpacing)
+				tick, _ := math.PriceToTickRoundDown(sdk.NewDec(4994), DefaultTickSpacing)
 				return tick
 			}(),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.668238976219012614"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813020+*+%281+-+0.01%29%29%29
@@ -1474,9 +1474,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -1508,9 +1508,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1559,9 +1559,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1625,9 +1625,9 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -1708,9 +1708,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -1741,9 +1741,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1797,9 +1797,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 					test.newUpperPrice = DefaultUpperPrice
 				}
 
-				newLowerTick, err := math.PriceToTickRoundUp(test.newLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.newLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.newUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.newUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
@@ -1873,9 +1873,9 @@ func (s *KeeperTestSuite) TestSwapInAmtGivenOut_TickUpdates() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2309,9 +2309,9 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenInWriteCtx() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2394,9 +2394,9 @@ func (s *KeeperTestSuite) TestCalcInAmtGivenOutWriteCtx() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2470,9 +2470,9 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapOutAmtGivenIn() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())
@@ -2561,9 +2561,9 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapInAmtGivenOut() {
 
 			// add second position depending on the test
 			if !test.secondPositionLowerPrice.IsNil() {
-				newLowerTick, err := math.PriceToTickRoundUp(test.secondPositionLowerPrice, pool.GetTickSpacing())
+				newLowerTick, err := math.PriceToTickRoundDown(test.secondPositionLowerPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
-				newUpperTick, err := math.PriceToTickRoundUp(test.secondPositionUpperPrice, pool.GetTickSpacing())
+				newUpperTick, err := math.PriceToTickRoundDown(test.secondPositionUpperPrice, pool.GetTickSpacing())
 				s.Require().NoError(err)
 
 				_, _, _, _, _, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultAmt0, DefaultAmt1, sdk.ZeroInt(), sdk.ZeroInt(), newLowerTick.Int64(), newUpperTick.Int64())

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -83,7 +83,7 @@ var (
 			// expectedTokenOut: 8396.71424216 rounded down https://www.wolframalpha.com/input?i=%281517882343.751510418088349649+*+%2870.738348247484497717+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+70.738348247484497717%29
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8396)),
-			expectedTick:      sdk.NewInt(31003900),
+			expectedTick:      sdk.NewInt(31003914),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.738348247484497717"), // https://www.wolframalpha.com/input?i=70.710678118654752440+%2B+42000000+%2F+1517882343.751510418088349649
 			// tick's accum coins stay same since crossing tick does not occur in this case
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
@@ -102,7 +102,7 @@ var (
 			// expectedTokenOut: 66808388.8901 rounded down https://www.wolframalpha.com/input?i=1517882343.751510418088349649+*+%2870.710678118654752440+-+70.6666639108571443311%29
 			expectedTokenIn:            sdk.NewCoin("eth", sdk.NewInt(13370)),
 			expectedTokenOut:           sdk.NewCoin("usdc", sdk.NewInt(66808388)),
-			expectedTick:               sdk.NewInt(30993800),
+			expectedTick:               sdk.NewInt(30993777),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.666663910857144332"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813370%29%29
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -127,7 +127,7 @@ var (
 			// expectedTokenOut: 8398.3567 rounded down https://www.wolframalpha.com/input?i=%283035764687.503020836176699298+*+%2870.724513183069625078+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+70.724513183069625078%29
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8398)),
-			expectedTick:      sdk.NewInt(31001900),
+			expectedTick:      sdk.NewInt(31001957),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.724513183069625078"), // https://www.wolframalpha.com/input?i=70.710678118654752440+%2B++++%2842000000++%2F+3035764687.503020836176699298%29
 			// two positions with same liquidity entered
 			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
@@ -150,7 +150,7 @@ var (
 			// expectedTokenOut: 66829187.9678 rounded down https://www.wolframalpha.com/input?i=3035764687.503020836176699298+*+%2870.710678118654752440+-+70.688664163408836319%29
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(13370)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(66829187)),
-			expectedTick:      sdk.NewInt(30996900),
+			expectedTick:      sdk.NewInt(30996887),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.688664163408836320"), // https://www.wolframalpha.com/input?i=%28%283035764687.503020836176699298%29%29+%2F+%28%28%283035764687.503020836176699298%29+%2F+%2870.710678118654752440%29%29+%2B+%2813370.0000%29%29
 			// two positions with same liquidity entered
 			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
@@ -187,7 +187,7 @@ var (
 			// expectedTokenOut: 998976.6183474263883566299269 + 821653.4522259 = 1820630.070 round down = 1.820630 eth
 			expectedTokenIn:            sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:           sdk.NewCoin("eth", sdk.NewInt(1820630)),
-			expectedTick:               sdk.NewInt(32105400),
+			expectedTick:               sdk.NewInt(32105414),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("78.137149196095607129"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441+%2B+4761322417+%2F+1197767444.955508123222985080
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -220,7 +220,7 @@ var (
 			expectedTokenIn:          sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:         sdk.NewCoin("usdc", sdk.NewInt(9103422788)),
 			// crosses one tick with fee growth outside
-			expectedTick:      sdk.NewInt(30095200),
+			expectedTick:      sdk.NewInt(30095167),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("63.993489023323078693"), // https://www.wolframalpha.com/input?i=%28%281198735489.597250295669959397%29%29+%2F+%28%28%281198735489.597250295669959397%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28951138.000000000000000000%29%29
 			// crossing tick happens single time for each upper tick and lower tick.
 			// Thus the tick's fee growth is DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins
@@ -260,7 +260,7 @@ var (
 			// expectedTokenOut: 998976.6183474263883566299269692777 + 865185.2591363751404579873403641 = 1864161.877 round down = 1.864161 eth
 			expectedTokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                 sdk.NewCoin("eth", sdk.NewInt(1864161)),
-			expectedTick:                     sdk.NewInt(32055900),
+			expectedTick:                     sdk.NewInt(32055920),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("77.819789636800169392"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441+%2B++++%282452251164.000000000000000000+%2F+670416088.605668727039240782%29
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -295,7 +295,7 @@ var (
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                     sdk.NewInt(31712600),
+			expectedTick:                     sdk.NewInt(31712695),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("75.582373164412551491"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441++%2B+%28+952251164.000000000000000000++%2F+670416088.605668727039240782%29
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
@@ -322,7 +322,7 @@ var (
 			secondPositionUpperPrice: sdk.NewDec(4999),
 			expectedTokenIn:          sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:         sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:             sdk.NewInt(30129100),
+			expectedTick:             sdk.NewInt(30129083),
 			expectedSqrtPrice:        sdk.MustNewDecFromStr("64.257943794993248954"), // https://www.wolframalpha.com/input?i=%28%28670416215.71882744366040059300%29%29+%2F+%28%28%28670416215.71882744366040059300%29+%2F+%2867.41661516273269559379442134%29%29+%2B+%28488827.000000000000000000%29%29
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -352,7 +352,7 @@ var (
 			secondPositionUpperPrice: sdk.NewDec(4999),
 			expectedTokenIn:          sdk.NewCoin("eth", sdk.NewInt(1800000)),
 			expectedTokenOut:         sdk.NewCoin("usdc", sdk.NewInt(8479320318)),
-			expectedTick:             sdk.NewInt(30292100),
+			expectedTick:             sdk.NewInt(30292060),
 			expectedSqrtPrice:        sdk.MustNewDecFromStr("65.513815285481060960"), // https://www.wolframalpha.com/input?i=%28%28670416215.718827443660400593000%29%29+%2F+%28%28%28670416215.718827443660400593000%29+%2F+%2867.41661516273269559379442134%29%29+%2B+%28288827.000000000000000000%29%29
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -391,7 +391,7 @@ var (
 			// expectedTokenOut: 998976.61834742638835 + 821569.240826953837970 = 1820545.85917438022632 round down = 1.820545 eth
 			expectedTokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                 sdk.NewCoin("eth", sdk.NewInt(1820545)),
-			expectedTick:                     sdk.NewInt(32105500),
+			expectedTick:                     sdk.NewInt(32105556),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.138055169663761658"), // https://www.wolframalpha.com/input?i=74.16872656315463530313879691++%2B+%28+4761322417.000000000000000000++%2F+1199528406.187413669220037261%29
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -446,7 +446,7 @@ var (
 			// expectedFeeGrowthAccumulatorValue: 0.000276701288297452
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(8312)),
-			expectedTick:                      sdk.NewInt(31003800),
+			expectedTick:                      sdk.NewInt(31003875),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.738071546196200264"), // https://www.wolframalpha.com/input?i=70.71067811865475244008443621+%2B++++%2841580000.000000000000000000+%2F+1517882343.751510418088349649%29
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000276701288297452"),
 		},
@@ -471,7 +471,7 @@ var (
 			// expectedFeeGrowthAccumulatorValue: 0.000000132124865162033700093060000008
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13370)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64824917)),
-			expectedTick:                      sdk.NewInt(30997000),
+			expectedTick:                      sdk.NewInt(30996981),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.689324382628080102"), // https://www.wolframalpha.com/input?i=%28%283035764687.503020836176699298%29%29+%2F+%28%28%283035764687.503020836176699298%29+%2F+%2870.71067811865475244008443621%29%29+%2B+%2812968.900000000000000000%29%29
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000132091924532"),
 			// two positions with same liquidity entered
@@ -497,7 +497,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8691708221)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000073738597832046"),
-			expectedTick:                      sdk.NewInt(30139300),
+			expectedTick:                      sdk.NewInt(30139243),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("64.336946417392457832"), // https://www.wolframalpha.com/input?i=%28%281198735489.597250295669959397%29%29+%2F+%28%28%281198735489.597250295669959397%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28851137.999999999999999999%29%29
 			newLowerPrice:                     sdk.NewDec(4000),
 			newUpperPrice:                     sdk.NewDec(4545),
@@ -520,7 +520,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1695807)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.624166726347032857"),
-			expectedTick:                      sdk.NewInt(31825900),
+			expectedTick:                      sdk.NewInt(31825991),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("76.328178655208424124"), // https://www.wolframalpha.com/input?i=+74.16198487095662948711397441+%2B++++%281452251164.000000000000000001+%2F+670416088.605668727039240782%29
 			newLowerPrice:                     sdk.NewDec(5001),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -540,7 +540,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(1800000)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8440657775)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000005569829831408"),
-			expectedTick:                      sdk.NewInt(30299700),
+			expectedTick:                      sdk.NewInt(30299620),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("65.571484748647169032"), // https://www.wolframalpha.com/input?i=%28%28670416215.718827443660400593000%29%29+%2F+%28%28%28670416215.718827443660400593000%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28279827.000000000000000001%29%29
 			newLowerPrice:                     sdk.NewDec(4000),
 			newUpperPrice:                     sdk.NewDec(4999),
@@ -560,7 +560,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1771252)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.221769187794051751"),
-			expectedTick:                      sdk.NewInt(32066500),
+			expectedTick:                      sdk.NewInt(32066534),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("77.887956882326389372"), // https://www.wolframalpha.com/input?i=74.16872656315463530313879691+%2B++++%284461322417.000000000000000001+%2F+1199528406.187413669220037261%29
 			newLowerPrice:                     sdk.NewDec(5501),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -628,7 +628,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 			expectedTokenIn:            sdk.NewCoin(ETH, sdk.NewInt(8404)),
-			expectedTick:               sdk.NewInt(30996100),
+			expectedTick:               sdk.NewInt(30996088),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.683007989825007162"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -649,7 +649,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin(ETH, sdk.NewInt(13370)),
 			expectedTokenIn:            sdk.NewCoin(USDC, sdk.NewInt(66891663)),
-			expectedTick:               sdk.NewInt(31006200),
+			expectedTick:               sdk.NewInt(31006234),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.754747188468900467"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -677,7 +677,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin("usdc", sdk.NewInt(66829187)),
 			expectedTokenIn:            sdk.NewCoin("eth", sdk.NewInt(13370)),
-			expectedTick:               sdk.NewInt(30996900),
+			expectedTick:               sdk.NewInt(30996887),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.688664163727643650"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -703,7 +703,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin("eth", sdk.NewInt(8398)),
 			expectedTokenIn:            sdk.NewCoin("usdc", sdk.NewInt(41998216)),
-			expectedTick:               sdk.NewInt(31001900),
+			expectedTick:               sdk.NewInt(31001957),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.724512595179305566"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -748,7 +748,7 @@ var (
 			// print(token_in)
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(9103422788)),
 			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(2000000)),
-			expectedTick:     sdk.NewInt(30095200),
+			expectedTick:     sdk.NewInt(30095167),
 
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("63.993489023888951975"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
@@ -797,7 +797,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999999570)),
-			expectedTick:                     sdk.NewInt(32105400),
+			expectedTick:                     sdk.NewInt(32105414),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -854,7 +854,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:      sdk.NewInt(30129100),
+			expectedTick:      sdk.NewInt(30129083),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("64.257943796086567725"),
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -910,7 +910,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin(ETH, sdk.NewInt(1800000)),
 			expectedTokenOut:  sdk.NewCoin(USDC, sdk.NewInt(8479320318)),
-			expectedTick:      sdk.NewInt(30292100),
+			expectedTick:      sdk.NewInt(30292060),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("65.513815286452064191"),
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -969,7 +969,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999994688)),
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1864161)),
-			expectedTick:                     sdk.NewInt(32055900),
+			expectedTick:                     sdk.NewInt(32055918),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("77.819781711876553576"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -1024,7 +1024,7 @@ var (
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                     sdk.NewInt(31712600),
+			expectedTick:                     sdk.NewInt(31712695),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("75.582372355128594341"),
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
@@ -1069,7 +1069,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999994756)),
-			expectedTick:                     sdk.NewInt(32105500),
+			expectedTick:                     sdk.NewInt(32105555),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -1132,7 +1132,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 			expectedTokenIn:                   sdk.NewCoin(ETH, sdk.NewInt(8489)),
-			expectedTick:                      sdk.NewInt(30996100),
+			expectedTick:                      sdk.NewInt(30996088),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.683007989825007162"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1164,7 +1164,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:           sdk.NewCoin(ETH, sdk.NewInt(8398)),
 			expectedTokenIn:            sdk.NewCoin(USDC, sdk.NewInt(43297130)),
-			expectedTick:               sdk.NewInt(31001900),
+			expectedTick:               sdk.NewInt(31001957),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.724512595179305566"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -1211,7 +1211,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:                   sdk.NewCoin(USDC, sdk.NewInt(10010009580)),
-			expectedTick:                      sdk.NewInt(32105400),
+			expectedTick:                      sdk.NewInt(32105414),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1269,7 +1269,7 @@ var (
 			// print(fee_growth)
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(2222223)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:      sdk.NewInt(30129100),
+			expectedTick:      sdk.NewInt(30129083),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("64.257943796086567725"),
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -1333,7 +1333,7 @@ var (
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth:  secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth:  secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                      sdk.NewInt(31712600),
+			expectedTick:                      sdk.NewInt(31712695),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("75.582372355128594341"),
 			newLowerPrice:                     sdk.NewDec(5001),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -1376,7 +1376,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:                   sdk.NewCoin(USDC, sdk.NewInt(10002995655)),
-			expectedTick:                      sdk.NewInt(32105500),
+			expectedTick:                      sdk.NewInt(32105555),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1467,7 +1467,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 			s.FundAcc(s.TestAccs[1], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
 
 			// Create default CL pool
-			pool := s.PrepareConcentratedPool()
+			// TODO: implement support for tick spacing other than 1.
+			tickSpacing := uint64(1)
+			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, tickSpacing, sdk.ZeroDec())
 
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())
@@ -1701,7 +1703,9 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 			s.FundAcc(s.TestAccs[1], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
 
 			// Create default CL pool
-			pool := s.PrepareConcentratedPool()
+			// TODO: add tests with tick spacing other than one.
+			tickSpacing := uint64(1)
+			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, tickSpacing, sdk.ZeroDec())
 
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -83,7 +83,7 @@ var (
 			// expectedTokenOut: 8396.71424216 rounded down https://www.wolframalpha.com/input?i=%281517882343.751510418088349649+*+%2870.738348247484497717+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+70.738348247484497717%29
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8396)),
-			expectedTick:      sdk.NewInt(31003914),
+			expectedTick:      sdk.NewInt(31004000),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.738348247484497717"), // https://www.wolframalpha.com/input?i=70.710678118654752440+%2B+42000000+%2F+1517882343.751510418088349649
 			// tick's accum coins stay same since crossing tick does not occur in this case
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
@@ -102,7 +102,7 @@ var (
 			// expectedTokenOut: 66808388.8901 rounded down https://www.wolframalpha.com/input?i=1517882343.751510418088349649+*+%2870.710678118654752440+-+70.6666639108571443311%29
 			expectedTokenIn:            sdk.NewCoin("eth", sdk.NewInt(13370)),
 			expectedTokenOut:           sdk.NewCoin("usdc", sdk.NewInt(66808388)),
-			expectedTick:               sdk.NewInt(30993777),
+			expectedTick:               sdk.NewInt(30993800),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.666663910857144332"), // https://www.wolframalpha.com/input?i=%28%281517882343.751510418088349649%29%29+%2F+%28%28%281517882343.751510418088349649%29+%2F+%2870.710678118654752440%29%29+%2B+%2813370%29%29
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -127,7 +127,7 @@ var (
 			// expectedTokenOut: 8398.3567 rounded down https://www.wolframalpha.com/input?i=%283035764687.503020836176699298+*+%2870.724513183069625078+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+70.724513183069625078%29
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8398)),
-			expectedTick:      sdk.NewInt(31001957),
+			expectedTick:      sdk.NewInt(31002000),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.724513183069625078"), // https://www.wolframalpha.com/input?i=70.710678118654752440+%2B++++%2842000000++%2F+3035764687.503020836176699298%29
 			// two positions with same liquidity entered
 			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
@@ -150,7 +150,7 @@ var (
 			// expectedTokenOut: 66829187.9678 rounded down https://www.wolframalpha.com/input?i=3035764687.503020836176699298+*+%2870.710678118654752440+-+70.688664163408836319%29
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(13370)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(66829187)),
-			expectedTick:      sdk.NewInt(30996887),
+			expectedTick:      sdk.NewInt(30996900),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.688664163408836320"), // https://www.wolframalpha.com/input?i=%28%283035764687.503020836176699298%29%29+%2F+%28%28%283035764687.503020836176699298%29+%2F+%2870.710678118654752440%29%29+%2B+%2813370.0000%29%29
 			// two positions with same liquidity entered
 			poolLiqAmount0:             sdk.NewInt(1000000).MulRaw(2),
@@ -187,7 +187,7 @@ var (
 			// expectedTokenOut: 998976.6183474263883566299269 + 821653.4522259 = 1820630.070 round down = 1.820630 eth
 			expectedTokenIn:            sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:           sdk.NewCoin("eth", sdk.NewInt(1820630)),
-			expectedTick:               sdk.NewInt(32105414),
+			expectedTick:               sdk.NewInt(32105500),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("78.137149196095607129"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441+%2B+4761322417+%2F+1197767444.955508123222985080
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -220,7 +220,7 @@ var (
 			expectedTokenIn:          sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:         sdk.NewCoin("usdc", sdk.NewInt(9103422788)),
 			// crosses one tick with fee growth outside
-			expectedTick:      sdk.NewInt(30095167),
+			expectedTick:      sdk.NewInt(30095200),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("63.993489023323078693"), // https://www.wolframalpha.com/input?i=%28%281198735489.597250295669959397%29%29+%2F+%28%28%281198735489.597250295669959397%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28951138.000000000000000000%29%29
 			// crossing tick happens single time for each upper tick and lower tick.
 			// Thus the tick's fee growth is DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins
@@ -260,7 +260,7 @@ var (
 			// expectedTokenOut: 998976.6183474263883566299269692777 + 865185.2591363751404579873403641 = 1864161.877 round down = 1.864161 eth
 			expectedTokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                 sdk.NewCoin("eth", sdk.NewInt(1864161)),
-			expectedTick:                     sdk.NewInt(32055920),
+			expectedTick:                     sdk.NewInt(32056000),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("77.819789636800169392"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441+%2B++++%282452251164.000000000000000000+%2F+670416088.605668727039240782%29
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -295,7 +295,7 @@ var (
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                     sdk.NewInt(31712695),
+			expectedTick:                     sdk.NewInt(31712700),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("75.582373164412551491"), // https://www.wolframalpha.com/input?i=74.16198487095662948711397441++%2B+%28+952251164.000000000000000000++%2F+670416088.605668727039240782%29
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
@@ -322,7 +322,7 @@ var (
 			secondPositionUpperPrice: sdk.NewDec(4999),
 			expectedTokenIn:          sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:         sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:             sdk.NewInt(30129083),
+			expectedTick:             sdk.NewInt(30129100),
 			expectedSqrtPrice:        sdk.MustNewDecFromStr("64.257943794993248954"), // https://www.wolframalpha.com/input?i=%28%28670416215.71882744366040059300%29%29+%2F+%28%28%28670416215.71882744366040059300%29+%2F+%2867.41661516273269559379442134%29%29+%2B+%28488827.000000000000000000%29%29
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -352,7 +352,7 @@ var (
 			secondPositionUpperPrice: sdk.NewDec(4999),
 			expectedTokenIn:          sdk.NewCoin("eth", sdk.NewInt(1800000)),
 			expectedTokenOut:         sdk.NewCoin("usdc", sdk.NewInt(8479320318)),
-			expectedTick:             sdk.NewInt(30292060),
+			expectedTick:             sdk.NewInt(30292100),
 			expectedSqrtPrice:        sdk.MustNewDecFromStr("65.513815285481060960"), // https://www.wolframalpha.com/input?i=%28%28670416215.718827443660400593000%29%29+%2F+%28%28%28670416215.718827443660400593000%29+%2F+%2867.41661516273269559379442134%29%29+%2B+%28288827.000000000000000000%29%29
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -391,7 +391,7 @@ var (
 			// expectedTokenOut: 998976.61834742638835 + 821569.240826953837970 = 1820545.85917438022632 round down = 1.820545 eth
 			expectedTokenIn:                  sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                 sdk.NewCoin("eth", sdk.NewInt(1820545)),
-			expectedTick:                     sdk.NewInt(32105556),
+			expectedTick:                     sdk.NewInt(32105600),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.138055169663761658"), // https://www.wolframalpha.com/input?i=74.16872656315463530313879691++%2B+%28+4761322417.000000000000000000++%2F+1199528406.187413669220037261%29
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -446,7 +446,7 @@ var (
 			// expectedFeeGrowthAccumulatorValue: 0.000276701288297452
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(42000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(8312)),
-			expectedTick:                      sdk.NewInt(31003875),
+			expectedTick:                      sdk.NewInt(31003900),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.738071546196200264"), // https://www.wolframalpha.com/input?i=70.71067811865475244008443621+%2B++++%2841580000.000000000000000000+%2F+1517882343.751510418088349649%29
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000276701288297452"),
 		},
@@ -471,7 +471,7 @@ var (
 			// expectedFeeGrowthAccumulatorValue: 0.000000132124865162033700093060000008
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13370)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64824917)),
-			expectedTick:                      sdk.NewInt(30996981),
+			expectedTick:                      sdk.NewInt(30997000),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.689324382628080102"), // https://www.wolframalpha.com/input?i=%28%283035764687.503020836176699298%29%29+%2F+%28%28%283035764687.503020836176699298%29+%2F+%2870.71067811865475244008443621%29%29+%2B+%2812968.900000000000000000%29%29
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000132091924532"),
 			// two positions with same liquidity entered
@@ -497,7 +497,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8691708221)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000073738597832046"),
-			expectedTick:                      sdk.NewInt(30139243),
+			expectedTick:                      sdk.NewInt(30139300),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("64.336946417392457832"), // https://www.wolframalpha.com/input?i=%28%281198735489.597250295669959397%29%29+%2F+%28%28%281198735489.597250295669959397%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28851137.999999999999999999%29%29
 			newLowerPrice:                     sdk.NewDec(4000),
 			newUpperPrice:                     sdk.NewDec(4545),
@@ -520,7 +520,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1695807)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.624166726347032857"),
-			expectedTick:                      sdk.NewInt(31825991),
+			expectedTick:                      sdk.NewInt(31826000),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("76.328178655208424124"), // https://www.wolframalpha.com/input?i=+74.16198487095662948711397441+%2B++++%281452251164.000000000000000001+%2F+670416088.605668727039240782%29
 			newLowerPrice:                     sdk.NewDec(5001),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -540,7 +540,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(1800000)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(8440657775)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000005569829831408"),
-			expectedTick:                      sdk.NewInt(30299620),
+			expectedTick:                      sdk.NewInt(30299700),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("65.571484748647169032"), // https://www.wolframalpha.com/input?i=%28%28670416215.718827443660400593000%29%29+%2F+%28%28%28670416215.718827443660400593000%29+%2F+%28+67.41661516273269559379442134%29%29+%2B+%28279827.000000000000000001%29%29
 			newLowerPrice:                     sdk.NewDec(4000),
 			newUpperPrice:                     sdk.NewDec(4999),
@@ -560,7 +560,7 @@ var (
 			expectedTokenIn:                   sdk.NewCoin("usdc", sdk.NewInt(10000000000)),
 			expectedTokenOut:                  sdk.NewCoin("eth", sdk.NewInt(1771252)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.221769187794051751"),
-			expectedTick:                      sdk.NewInt(32066534),
+			expectedTick:                      sdk.NewInt(32066600),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("77.887956882326389372"), // https://www.wolframalpha.com/input?i=74.16872656315463530313879691+%2B++++%284461322417.000000000000000001+%2F+1199528406.187413669220037261%29
 			newLowerPrice:                     sdk.NewDec(5501),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -628,7 +628,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 			expectedTokenIn:            sdk.NewCoin(ETH, sdk.NewInt(8404)),
-			expectedTick:               sdk.NewInt(30996088),
+			expectedTick:               sdk.NewInt(30996100),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.683007989825007162"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -649,7 +649,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin(ETH, sdk.NewInt(13370)),
 			expectedTokenIn:            sdk.NewCoin(USDC, sdk.NewInt(66891663)),
-			expectedTick:               sdk.NewInt(31006234),
+			expectedTick:               sdk.NewInt(31006200),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.754747188468900467"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -677,7 +677,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin("usdc", sdk.NewInt(66829187)),
 			expectedTokenIn:            sdk.NewCoin("eth", sdk.NewInt(13370)),
-			expectedTick:               sdk.NewInt(30996887),
+			expectedTick:               sdk.NewInt(30996900),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.688664163727643650"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -703,7 +703,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:           sdk.NewCoin("eth", sdk.NewInt(8398)),
 			expectedTokenIn:            sdk.NewCoin("usdc", sdk.NewInt(41998216)),
-			expectedTick:               sdk.NewInt(31001957),
+			expectedTick:               sdk.NewInt(31002000),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.724512595179305566"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -748,7 +748,7 @@ var (
 			// print(token_in)
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(9103422788)),
 			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(2000000)),
-			expectedTick:     sdk.NewInt(30095167),
+			expectedTick:     sdk.NewInt(30095200),
 
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("63.993489023888951975"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins.MulDec(sdk.NewDec(2)),
@@ -797,7 +797,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999999570)),
-			expectedTick:                     sdk.NewInt(32105414),
+			expectedTick:                     sdk.NewInt(32105400),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -854,7 +854,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:      sdk.NewInt(30129083),
+			expectedTick:      sdk.NewInt(30129100),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("64.257943796086567725"),
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -910,7 +910,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin(ETH, sdk.NewInt(1800000)),
 			expectedTokenOut:  sdk.NewCoin(USDC, sdk.NewInt(8479320318)),
-			expectedTick:      sdk.NewInt(30292060),
+			expectedTick:      sdk.NewInt(30292100),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("65.513815286452064191"),
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -969,7 +969,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999994688)),
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1864161)),
-			expectedTick:                     sdk.NewInt(32055918),
+			expectedTick:                     sdk.NewInt(32056000),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("77.819781711876553576"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -1024,7 +1024,7 @@ var (
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth: secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth: secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                     sdk.NewInt(31712695),
+			expectedTick:                     sdk.NewInt(31712700),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("75.582372355128594341"),
 			newLowerPrice:                    sdk.NewDec(5001),
 			newUpperPrice:                    sdk.NewDec(6250),
@@ -1069,7 +1069,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:                 sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:                  sdk.NewCoin(USDC, sdk.NewInt(9999994756)),
-			expectedTick:                     sdk.NewInt(32105555),
+			expectedTick:                     sdk.NewInt(32105500),
 			expectedSqrtPrice:                sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedLowerTickFeeGrowth:       DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:       DefaultFeeAccumCoins,
@@ -1132,7 +1132,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 			expectedTokenIn:                   sdk.NewCoin(ETH, sdk.NewInt(8489)),
-			expectedTick:                      sdk.NewInt(30996088),
+			expectedTick:                      sdk.NewInt(30996100),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("70.683007989825007162"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1164,7 +1164,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:           sdk.NewCoin(ETH, sdk.NewInt(8398)),
 			expectedTokenIn:            sdk.NewCoin(USDC, sdk.NewInt(43297130)),
-			expectedTick:               sdk.NewInt(31001957),
+			expectedTick:               sdk.NewInt(31001900),
 			expectedSqrtPrice:          sdk.MustNewDecFromStr("70.724512595179305566"),
 			expectedLowerTickFeeGrowth: DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth: DefaultFeeAccumCoins,
@@ -1211,7 +1211,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:                   sdk.NewCoin(USDC, sdk.NewInt(10010009580)),
-			expectedTick:                      sdk.NewInt(32105414),
+			expectedTick:                      sdk.NewInt(32105500),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1269,7 +1269,7 @@ var (
 			// print(fee_growth)
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(2222223)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:      sdk.NewInt(30129083),
+			expectedTick:      sdk.NewInt(30129100),
 			expectedSqrtPrice: sdk.MustNewDecFromStr("64.257943796086567725"),
 			// Started from DefaultFeeAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultFeeAccumCoins * 3 - DefaultFeeAccumCoins = DefaultFeeAccumCoins * 2
@@ -1333,7 +1333,7 @@ var (
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedSecondLowerTickFeeGrowth:  secondPosition{tickIndex: 310010, expectedFeeGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickFeeGrowth:  secondPosition{tickIndex: 322500, expectedFeeGrowth: cl.EmptyCoins},
-			expectedTick:                      sdk.NewInt(31712695),
+			expectedTick:                      sdk.NewInt(31712700),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("75.582372355128594341"),
 			newLowerPrice:                     sdk.NewDec(5001),
 			newUpperPrice:                     sdk.NewDec(6250),
@@ -1376,7 +1376,7 @@ var (
 			// print(fee_growth)
 			expectedTokenOut:                  sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:                   sdk.NewCoin(USDC, sdk.NewInt(10002995655)),
-			expectedTick:                      sdk.NewInt(32105555),
+			expectedTick:                      sdk.NewInt(32105500),
 			expectedSqrtPrice:                 sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedLowerTickFeeGrowth:        DefaultFeeAccumCoins,
 			expectedUpperTickFeeGrowth:        DefaultFeeAccumCoins,
@@ -1467,9 +1467,7 @@ func (s *KeeperTestSuite) TestCalcAndSwapOutAmtGivenIn() {
 			s.FundAcc(s.TestAccs[1], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
 
 			// Create default CL pool
-			// TODO: implement support for tick spacing other than 1.
-			tickSpacing := uint64(1)
-			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, tickSpacing, sdk.ZeroDec())
+			pool := s.PrepareConcentratedPool()
 
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())
@@ -1703,9 +1701,7 @@ func (s *KeeperTestSuite) TestCalcAndSwapInAmtGivenOut() {
 			s.FundAcc(s.TestAccs[1], sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(10000000000000)), sdk.NewCoin("usdc", sdk.NewInt(1000000000000))))
 
 			// Create default CL pool
-			// TODO: add tests with tick spacing other than one.
-			tickSpacing := uint64(1)
-			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, tickSpacing, sdk.ZeroDec())
+			pool := s.PrepareConcentratedPool()
 
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero.go
@@ -222,14 +222,3 @@ func (s oneForZeroStrategy) ValidateSqrtPrice(sqrtPrice, currentSqrtPrice sdk.De
 	}
 	return nil
 }
-
-// SqrtPriceToTick returns tick from the square root price.
-// When swapping one for zero, we are increasing the price.
-// As a result, as we swap, we want to round down the tick
-// when converting from square root price so that the swap does not
-// move  further than it should have been given the token in.
-// In other words, we want to round down in favor of the pool
-func (s oneForZeroStrategy) SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error) {
-	price := math.SquareTruncate(sqrtPrice)
-	return math.PriceToTickRoundDown(price, s.tickSpacing)
-}

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -130,12 +130,12 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			// Difference between given amount remaining in and amount in actually consumed which qpproximately equals to fee.
 			expectedFeeChargeTotal: defaultAmountOne.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)).Sub(defaultAmountOne.Sub(sdk.NewDec(100)).Ceil()),
 		},
-		"5: no fee - reach target": {
+		"5: custom amounts at high price levels - reach tarrget": {
 			sqrtPriceCurrent: sqrt(100_000_000),
 			sqrtPriceTarget:  sqrt(100_000_100),
 			liquidity:        math.GetLiquidityFromAmounts(sqrt(1), sqrt(100_000_000), sqrt(100_000_100), defaultAmountZero.TruncateInt(), defaultAmountOne.TruncateInt()),
 
-			// TODO: manually estimate this
+			// this value is exactly enough to reach the target
 			amountOneInRemaining: sdk.NewDec(1336900668450),
 			swapFee:              sdk.ZeroDec(),
 

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -3,6 +3,7 @@ package swapstrategy_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/swapstrategy"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
@@ -54,6 +55,11 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 		sqrtPriceTargetNotReached = sdk.MustNewDecFromStr("70.710678085714122880")
 		// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
 		amountZeroTargetNotReached = sdk.MustNewDecFromStr("13369.979999999989129753")
+
+		sqrt = func(x int64) sdk.Dec {
+			sqrt, _ := sdk.NewDec(x).ApproxSqrt()
+			return sqrt
+		}
 	)
 
 	tests := map[string]struct {
@@ -123,6 +129,21 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			expectedAmountOut:        amountZeroTargetNotReached,
 			// Difference between given amount remaining in and amount in actually consumed which qpproximately equals to fee.
 			expectedFeeChargeTotal: defaultAmountOne.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)).Sub(defaultAmountOne.Sub(sdk.NewDec(100)).Ceil()),
+		},
+		"5: no fee - reach target": {
+			sqrtPriceCurrent: sqrt(100_000_000),
+			sqrtPriceTarget:  sqrt(100_000_100),
+			liquidity:        math.GetLiquidityFromAmounts(sqrt(1), sqrt(100_000_000), sqrt(100_000_100), defaultAmountZero.TruncateInt(), defaultAmountOne.TruncateInt()),
+
+			// TODO: manually estimate this
+			amountOneInRemaining: sdk.NewDec(1336900668450),
+			swapFee:              sdk.ZeroDec(),
+
+			expectedSqrtPriceNext: sqrt(100_000_100),
+
+			expectedAmountInConsumed: sdk.NewDec(1336900668450),
+			expectedAmountOut:        defaultAmountZero.TruncateDec(),
+			expectedFeeChargeTotal:   sdk.ZeroDec(),
 		},
 	}
 

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy.go
@@ -72,10 +72,6 @@ type swapStrategy interface {
 	// and the min/max sqrt price on the other side.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
 	ValidateSqrtPrice(sqrtPriceLimit, currentSqrtPrice sdk.Dec) error
-	// SqrtPriceToTick returns the tick from the square root price.
-	// Ensures desired rounding in favor of the pool during swap.
-	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
-	SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error)
 }
 
 // New returns a swap strategy based on the provided zeroForOne parameter

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one.go
@@ -226,5 +226,5 @@ func (s zeroForOneStrategy) ValidateSqrtPrice(sqrtPrice, currentSqrtPrice sdk.De
 // In other words, we want to round up in favor of the pool
 func (s zeroForOneStrategy) SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error) {
 	price := math.SquareRoundUp(sqrtPrice)
-	return math.PriceToTickRoundUp(price, s.tickSpacing)
+	return math.CalculatePriceToTick(price), nil
 }

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one.go
@@ -217,14 +217,3 @@ func (s zeroForOneStrategy) ValidateSqrtPrice(sqrtPrice, currentSqrtPrice sdk.De
 	}
 	return nil
 }
-
-// SqrtPriceToTick returns tick from the square root price.
-// When swapping zero for one, we are decreasing the price.
-// As a result, as we swap, we want to round up the tick
-// when converting from square root price so that the swap does not
-// move  further than it should have been given the token in.
-// In other words, we want to round up in favor of the pool
-func (s zeroForOneStrategy) SqrtPriceToTick(sqrtPrice sdk.Dec) (sdk.Int, error) {
-	price := math.SquareRoundUp(sqrtPrice)
-	return math.CalculatePriceToTick(price), nil
-}

--- a/x/concentrated-liquidity/types/pool.go
+++ b/x/concentrated-liquidity/types/pool.go
@@ -28,5 +28,5 @@ type ConcentratedPoolExtension interface {
 	UpdateLiquidity(newLiquidity sdk.Dec)
 	ApplySwap(newLiquidity sdk.Dec, newCurrentTick sdk.Int, newCurrentSqrtPrice sdk.Dec) error
 	CalcActualAmounts(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) (actualAmountDenom0 sdk.Dec, actualAmountDenom1 sdk.Dec, err error)
-	UpdateLiquidityIfActivePosition(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) bool
+	UpdateLiquidityIfActivePosition(ctx sdk.Context, lowerTick, upperTick int64, liquidityDelta sdk.Dec) (bool, error)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We do not need to round to the nearest tick during swaps. If a case occurs when there is no mapping between a current sqrt price and a tick, that is fine. The current sqrt price can float in-between two possible ticks. We can consider that current square root price is within a tick in such a case.

For example, consider a case where the current sqrt price is `10000.002499999688` which is `100_000_050` when squared

In our tick spacing model, there is a tick at price `100_000_000` and there is a tick at `100_000_100`. However, there is no tick at price `100_000_050` . In that case, we consistently round down to the nearest tick and assume that price  `100_000_050` is within the same tick as price `100_000_000`.


## Testing and Verifying

This change added tests.

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable