### PR TITLE
refactor/test: CalcAmount0Delta and CalcAmount1Delta rounding in pool's favor

### DIFF
--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -375,7 +375,8 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 		"withdraw full liquidity amount with underlying lock that has finished unlocking": {
 			setupConfig: baseCase,
 			sutConfigOverwrite: &lpTest{
-				amount0Expected:  DefaultAmt0,
+				// Note: subtracing one due to truncations in favor of the pool when withdrawing.
+				amount0Expected:  DefaultAmt0.Sub(sdk.OneInt()),
 				amount1Expected:  DefaultAmt1.Sub(sdk.OneInt()),
 				liquidityAmount:  FullRangeLiquidityAmt,
 				underlyingLockId: 1,

--- a/x/concentrated-liquidity/math/math.go
+++ b/x/concentrated-liquidity/math/math.go
@@ -58,18 +58,22 @@ func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 		sqrtPriceA, sqrtPriceB = sqrtPriceB, sqrtPriceA
 	}
 	diff := sqrtPriceB.Sub(sqrtPriceA)
-	denom := sqrtPriceA.Mul(sqrtPriceB)
 	// if calculating for amountIn, we round up
-	// if calculating for amountOut, we don't round at all
+	// if calculating for amountOut, we don't round but truncate at pprecision end.
 	// this is to prevent removing more from the pool than expected due to rounding
 	// example: we calculate 1000000.9999999 uusdc (~$1) amountIn and 2000000.999999 uosmo amountOut
 	// we would want the user to put in 1000001 uusdc rather than 1000000 uusdc to ensure we are charging enough for the amount they are removing
 	// additionally, without rounding, there exists cases where the swapState.amountSpecifiedRemaining.GT(sdk.ZeroDec()) for loop within
 	// the CalcOut/In functions never actually reach zero due to dust that would have never gotten counted towards the amount (numbers after the 10^6 place)
 	if roundUp {
+		denom := sqrtPriceA.MulTruncate(sqrtPriceB)
 		return liq.Mul(diff).Quo(denom).Ceil()
 	}
-	// Investigate if this should be a QuoTruncate: https://github.com/osmosis-labs/osmosis/issues/4646
+	// These truncated at precision end to round in favor of the pool when:
+	// - calculating amount out during swap
+	// - withdrawing liquidity
+	// The denominator is rounded up to get a higher final amount.
+	denom := sqrtPriceA.MulRoundUp(sqrtPriceB)
 	return liq.MulTruncate(diff).QuoTruncate(denom)
 }
 
@@ -90,9 +94,9 @@ func CalcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 	// additionally, without rounding, there exists cases where the swapState.amountSpecifiedRemaining.GT(sdk.ZeroDec()) for loop within
 	// the CalcOut/In functions never actually reach zero due to dust that would have never gotten counted towards the amount (numbers after the 10^6 place)
 	if roundUp {
-		return liq.Mul(diff).Ceil()
+		return liq.MulRoundUp(diff).Ceil()
 	}
-	return liq.Mul(diff)
+	return liq.MulTruncate(diff)
 }
 
 // GetNextSqrtPriceFromAmount0InRoundingUp utilizes sqrtPriceCurrent, liquidity, and amount of denom0 that still needs

--- a/x/concentrated-liquidity/math/math.go
+++ b/x/concentrated-liquidity/math/math.go
@@ -70,7 +70,7 @@ func CalcAmount0Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 		return liq.Mul(diff).Quo(denom).Ceil()
 	}
 	// Investigate if this should be a QuoTruncate: https://github.com/osmosis-labs/osmosis/issues/4646
-	return liq.Mul(diff).Quo(denom)
+	return liq.MulTruncate(diff).QuoTruncate(denom)
 }
 
 // CalcAmount1 takes the asset with the smaller liquidity in the pool as well as the sqrtpCur and the nextPrice and calculates the amount of asset 1

--- a/x/concentrated-liquidity/math/math_test.go
+++ b/x/concentrated-liquidity/math/math_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 )
@@ -150,16 +151,35 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1RoundingD
 func (suite *ConcentratedMathTestSuite) TestCalcAmount0Delta() {
 	testCases := map[string]struct {
 		liquidity       sdk.Dec
-		sqrtPCurrent    sdk.Dec
-		sqrtPUpper      sdk.Dec
+		sqrtPA          sdk.Dec
+		sqrtPB          sdk.Dec
+		exactEqual      bool
 		amount0Expected string
 	}{
 		"happy path": {
 			liquidity:       sdk.MustNewDecFromStr("1517882343.751510418088349649"), // we use the smaller liquidity between liq0 and liq1
-			sqrtPCurrent:    sdk.MustNewDecFromStr("70.710678118654752440"),         // 5000
-			sqrtPUpper:      sdk.MustNewDecFromStr("74.161984870956629487"),         // 5500
+			sqrtPA:          sdk.MustNewDecFromStr("70.710678118654752440"),         // 5000
+			sqrtPB:          sdk.MustNewDecFromStr("74.161984870956629487"),         // 5500
 			amount0Expected: "998976.618347426388356619",                            // truncated at precision end.
 			// https://www.wolframalpha.com/input?i=%281517882343.751510418088349649+*+%2874.161984870956629487+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+74.161984870956629487%29
+		},
+		"round down: large liquidity amount in wide price range": {
+			// Note the values are hand-picked to cause multiplication of 2 large numbers
+			// causing the magnitude of truncations to be larger
+			// while staying under bit length of sdk.Dec
+			// from decimal import *
+			// from math import *
+			// getcontext().prec = 100
+			// max_sqrt_p = Decimal("30860351331.852813530648276680")
+			// min_sqrt_p = Decimal("0.000000152731791058")
+			// liq = Decimal("931361973132462178951297")
+			// liq * (max_sqrt_p - min_sqrt_p) / (max_sqrt_p * min_sqrt_p)
+			liquidity: sdk.MustNewDecFromStr("931361973132462178951297"),
+			// price: 0.000000000000023327
+			sqrtPA: sdk.MustNewDecFromStr("0.000000152731791058"),
+			// price: 952361284325389721913
+			sqrtPB:          sdk.MustNewDecFromStr("30860351331.852813530648276680"),
+			amount0Expected: sdk.MustNewDecFromStr("6098022989717817431593106314408.888128101590393209").String(), // truncated at precision end.
 		},
 	}
 
@@ -167,8 +187,21 @@ func (suite *ConcentratedMathTestSuite) TestCalcAmount0Delta() {
 		tc := tc
 
 		suite.Run(name, func() {
-			amount0 := math.CalcAmount0Delta(tc.liquidity, tc.sqrtPCurrent, tc.sqrtPUpper, false)
-			suite.Require().Equal(tc.amount0Expected, amount0.String())
+			amount0 := math.CalcAmount0Delta(tc.liquidity, tc.sqrtPA, tc.sqrtPB, false)
+
+			if tc.exactEqual {
+				suite.Require().Equal(tc.amount0Expected, amount0.String())
+				return
+			}
+
+			tolerance := osmomath.ErrTolerance{
+				MultiplicativeTolerance: sdk.SmallestDec(),
+				RoundingDir:             osmomath.RoundDown,
+			}
+
+			res := tolerance.CompareBigDec(osmomath.MustNewDecFromStr(tc.amount0Expected), osmomath.BigDecFromSDKDec(amount0))
+
+			suite.Require().Equal(0, res, "amount0: %s, expected: %s", amount0, tc.amount0Expected)
 		})
 	}
 }
@@ -180,16 +213,33 @@ func (suite *ConcentratedMathTestSuite) TestCalcAmount0Delta() {
 func (suite *ConcentratedMathTestSuite) TestCalcAmount1Delta() {
 	testCases := map[string]struct {
 		liquidity       sdk.Dec
-		sqrtPCurrent    sdk.Dec
-		sqrtPLower      sdk.Dec
+		sqrtPA          sdk.Dec
+		sqrtPB          sdk.Dec
 		amount1Expected string
 	}{
-		"happy path": {
+		"round down": {
 			liquidity:       sdk.MustNewDecFromStr("1517882343.751510418088349649"), // we use the smaller liquidity between liq0 and liq1
-			sqrtPCurrent:    sdk.MustNewDecFromStr("70.710678118654752440"),         // 5000
-			sqrtPLower:      sdk.MustNewDecFromStr("67.416615162732695594"),         // 4545
+			sqrtPA:          sdk.MustNewDecFromStr("70.710678118654752440"),         // 5000
+			sqrtPB:          sdk.MustNewDecFromStr("67.416615162732695594"),         // 4545
 			amount1Expected: sdk.MustNewDecFromStr("5000000000.000000000000000000").Sub(sdk.SmallestDec()).String(),
 			// https://www.wolframalpha.com/input?i=1517882343.751510418088349649+*+%2870.710678118654752440+-+67.416615162732695594%29
+		},
+		"round down: large liquidity amount in wide price range": {
+			// Note the values are hand-picked to cause multiplication of 2 large numbers
+			// while staying under bit length of sdk.Dec
+			// from decimal import *
+			// from math import *
+			// getcontext().prec = 100
+			// max_sqrt_p = Decimal("30860351331.852813530648276680")
+			// min_sqrt_p = Decimal("0.000000152731791058")
+			// liq = Decimal("931361973132462178951297")
+			// liq * (max_sqrt_p - min_sqrt_p)
+			liquidity: sdk.MustNewDecFromStr("931361973132462178951297"),
+			// price: 0.000000000000023327
+			sqrtPA: sdk.MustNewDecFromStr("0.000000152731791058"),
+			// price: 952361284325389721913
+			sqrtPB:          sdk.MustNewDecFromStr("30860351331.852813530648276680"),
+			amount1Expected: sdk.MustNewDecFromStr("28742157707995443393876876754535992.801567623738751734").String(), // truncated at precision end.
 		},
 	}
 
@@ -197,7 +247,7 @@ func (suite *ConcentratedMathTestSuite) TestCalcAmount1Delta() {
 		tc := tc
 
 		suite.Run(name, func() {
-			amount1 := math.CalcAmount1Delta(tc.liquidity, tc.sqrtPCurrent, tc.sqrtPLower, false)
+			amount1 := math.CalcAmount1Delta(tc.liquidity, tc.sqrtPA, tc.sqrtPB, false)
 			suite.Require().Equal(tc.amount1Expected, amount1.String())
 		})
 	}
@@ -388,4 +438,10 @@ func (suite *ConcentratedMathTestSuite) TestGetNextSqrtPriceFromAmount1OutRoundi
 			suite.Require().Equal(tc.expectedSqrtPriceNext.String(), sqrtPriceNext.String())
 		})
 	}
+}
+
+func (suite *ConcentratedMathTestSuite) sqrt(x sdk.Dec) sdk.Dec {
+	res, err := x.ApproxSqrt()
+	suite.Require().NoError(err)
+	return res
 }

--- a/x/concentrated-liquidity/math/math_test.go
+++ b/x/concentrated-liquidity/math/math_test.go
@@ -158,7 +158,7 @@ func (suite *ConcentratedMathTestSuite) TestCalcAmount0Delta() {
 			liquidity:       sdk.MustNewDecFromStr("1517882343.751510418088349649"), // we use the smaller liquidity between liq0 and liq1
 			sqrtPCurrent:    sdk.MustNewDecFromStr("70.710678118654752440"),         // 5000
 			sqrtPUpper:      sdk.MustNewDecFromStr("74.161984870956629487"),         // 5500
-			amount0Expected: "998976.618347426388356620",
+			amount0Expected: "998976.618347426388356619",                            // truncated at precision end.
 			// https://www.wolframalpha.com/input?i=%281517882343.751510418088349649+*+%2874.161984870956629487+-+70.710678118654752440+%29%29+%2F+%2870.710678118654752440+*+74.161984870956629487%29
 		},
 	}

--- a/x/concentrated-liquidity/math/math_test.go
+++ b/x/concentrated-liquidity/math/math_test.go
@@ -188,7 +188,7 @@ func (suite *ConcentratedMathTestSuite) TestCalcAmount1Delta() {
 			liquidity:       sdk.MustNewDecFromStr("1517882343.751510418088349649"), // we use the smaller liquidity between liq0 and liq1
 			sqrtPCurrent:    sdk.MustNewDecFromStr("70.710678118654752440"),         // 5000
 			sqrtPLower:      sdk.MustNewDecFromStr("67.416615162732695594"),         // 4545
-			amount1Expected: "5000000000.000000000000000000",
+			amount1Expected: sdk.MustNewDecFromStr("5000000000.000000000000000000").Sub(sdk.SmallestDec()).String(),
 			// https://www.wolframalpha.com/input?i=1517882343.751510418088349649+*+%2870.710678118654752440+-+67.416615162732695594%29
 		},
 	}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -394,7 +394,8 @@ func (k Keeper) calcOutAmtGivenIn(ctx sdk.Context,
 
 	// coin amounts require int values
 	// round amountIn up to avoid under charging
-	amt0 := tokenAmountInSpecified.Sub(swapState.amountSpecifiedRemaining).RoundInt()
+	// round amountOut down to avoid over refunding.
+	amt0 := tokenAmountInSpecified.Sub(swapState.amountSpecifiedRemaining).Ceil().TruncateInt()
 	amt1 := swapState.amountCalculated.TruncateInt()
 
 	ctx.Logger().Debug("final amount in", amt0)

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -578,7 +578,7 @@ var (
 			// liquidity: 		 1517882343.751510418088349649
 			// sqrtPriceNext:    70.668238976219012614 which is 4994
 			// sqrtPriceCurrent: 70.710678118654752440 which is 5000
-			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13022)),
+			expectedTokenIn:                   sdk.NewCoin("eth", sdk.NewInt(13023)),
 			expectedTokenOut:                  sdk.NewCoin("usdc", sdk.NewInt(64417624)),
 			expectedFeeGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000085792039652"),
 			expectedTick: func() sdk.Int {

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -82,7 +82,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			// Reached target, so 100 is not consumed.
 			expectedAmountInConsumed: defaultAmountOne.Ceil(),
 			// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
-			expectedAmountOut:      defaultAmountZero,
+			expectedAmountOut:      defaultAmountZero.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
 			expectedFeeChargeTotal: sdk.ZeroDec(),
 		},
 		"2: no fee - do not reach target": {
@@ -108,7 +108,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			expectedSqrtPriceNext:    sqrtPriceNext,
 			expectedAmountInConsumed: defaultAmountOne.Ceil(),
 			// liquidity * (sqrtPriceNext - sqrtPriceCurrent) / (sqrtPriceNext * sqrtPriceCurrent)
-			expectedAmountOut:      defaultAmountZero,
+			expectedAmountOut:      defaultAmountZero.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
 			expectedFeeChargeTotal: swapstrategy.ComputeFeeChargeFromAmountIn(defaultAmountOne.Ceil(), defaultFee),
 		},
 		"4: 3% fee - do not reach target": {
@@ -183,7 +183,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 
 			expectedSqrtPriceNext: sqrtPriceNext,
 			// Reached target, so 100 is not consumed.
-			expectedAmountZeroOutConsumed: defaultAmountZero,
+			expectedAmountZeroOutConsumed: defaultAmountZero.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
 			// liquidity * (sqrtPriceNext - sqrtPriceCurrent)
 			expectedAmountOneIn:    defaultAmountOne.Ceil(),
 			expectedFeeChargeTotal: sdk.ZeroDec(),
@@ -197,7 +197,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
 
-			expectedAmountZeroOutConsumed: amountZeroTargetNotReached,
+			expectedAmountZeroOutConsumed: amountZeroTargetNotReached.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
 
 			expectedAmountOneIn:    amountOneTargetNotReached.Ceil(),
 			expectedFeeChargeTotal: sdk.ZeroDec(),
@@ -210,7 +210,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 			swapFee:                defaultFee,
 
 			expectedSqrtPriceNext:         sqrtPriceNext,
-			expectedAmountZeroOutConsumed: defaultAmountZero,
+			expectedAmountZeroOutConsumed: defaultAmountZero.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
 			expectedAmountOneIn:           defaultAmountOne.Ceil(),
 			expectedFeeChargeTotal:        swapstrategy.ComputeFeeChargeFromAmountIn(defaultAmountOne.Ceil(), defaultFee),
 		},
@@ -222,7 +222,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 			swapFee:                defaultFee,
 
 			expectedSqrtPriceNext:         sqrtPriceTargetNotReached,
-			expectedAmountZeroOutConsumed: amountZeroTargetNotReached,
+			expectedAmountZeroOutConsumed: amountZeroTargetNotReached.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
 			expectedAmountOneIn:           amountOneTargetNotReached.Ceil(),
 			expectedFeeChargeTotal:        swapstrategy.ComputeFeeChargeFromAmountIn(amountOneTargetNotReached.Ceil(), defaultFee),
 		},

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -95,8 +95,9 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			// sqrt_price_current + token_in / liquidity
 			expectedSqrtPriceNext:    sqrtPriceTargetNotReached,
 			expectedAmountInConsumed: defaultAmountOne.Sub(sdk.NewDec(100)).Ceil(),
-			expectedAmountOut:        amountZeroTargetNotReached,
-			expectedFeeChargeTotal:   sdk.ZeroDec(),
+			// subtracting 3 * smallest dec to account for truncations in favor of the pool.
+			expectedAmountOut:      amountZeroTargetNotReached.Sub(sdk.SmallestDec().MulInt64(3)),
+			expectedFeeChargeTotal: sdk.ZeroDec(),
 		},
 		"3: 3% fee - reach target": {
 			sqrtPriceCurrent:     sqrtPriceCurrent,
@@ -120,7 +121,8 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 
 			expectedSqrtPriceNext:    sqrtPriceTargetNotReached,
 			expectedAmountInConsumed: defaultAmountOne.Sub(sdk.NewDec(100)).Ceil(),
-			expectedAmountOut:        amountZeroTargetNotReached,
+			// subtracting 3 * smallest dec to account for truncations in favor of the pool.
+			expectedAmountOut: amountZeroTargetNotReached.Sub(sdk.SmallestDec().MulInt64(3)),
 			// Difference between given amount remaining in and amount in actually consumed which qpproximately equals to fee.
 			expectedFeeChargeTotal: defaultAmountOne.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultFee)).Sub(defaultAmountOne.Sub(sdk.NewDec(100)).Ceil()),
 		},
@@ -197,7 +199,8 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
 
-			expectedAmountZeroOutConsumed: amountZeroTargetNotReached.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
+			// subtracting 3 * smallest dec to account for truncations in favor of the pool.
+			expectedAmountZeroOutConsumed: amountZeroTargetNotReached.Sub(sdk.SmallestDec().MulInt64(3)),
 
 			expectedAmountOneIn:    amountOneTargetNotReached.Ceil(),
 			expectedFeeChargeTotal: sdk.ZeroDec(),
@@ -221,8 +224,9 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 			amountZeroOutRemaining: defaultAmountZero.Sub(sdk.NewDec(1000)),
 			swapFee:                defaultFee,
 
-			expectedSqrtPriceNext:         sqrtPriceTargetNotReached,
-			expectedAmountZeroOutConsumed: amountZeroTargetNotReached.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
+			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
+			// subtracting 3 * smallest dec to account for truncations in favor of the pool.
+			expectedAmountZeroOutConsumed: amountZeroTargetNotReached.Sub(sdk.SmallestDec().MulInt64(3)),
 			expectedAmountOneIn:           amountOneTargetNotReached.Ceil(),
 			expectedFeeChargeTotal:        swapstrategy.ComputeFeeChargeFromAmountIn(amountOneTargetNotReached.Ceil(), defaultFee),
 		},

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -188,7 +188,7 @@ func (suite *StrategyTestSuite) TestComputeSwapState_Inverse() {
 			expectedSqrtPriceNextOutGivenIn: sdk.MustNewDecFromStr("70.688664163408836320"), // approx 4996.89
 
 			// from amount out: sqrt_next = sqrt_cur - token_out / liq2 quo round down
-			expectedSqrtPriceNextInGivenOut: sdk.MustNewDecFromStr("70.688664163408836319"), // approx 4996.89
+			expectedSqrtPriceNextInGivenOut: sdk.MustNewDecFromStr("70.688664163408836320"), // approx 4996.89
 
 			expectedAmountIn:  sdk.NewDec(13370),
 			expectedAmountOut: sdk.NewDec(66829187),

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
@@ -204,8 +204,9 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 			swapFee:               sdk.ZeroDec(),
 
 			// sqrt_cur - amt_one / liq quo round up
-			expectedSqrtPriceNext:  sqrtPriceTargetNotReached,
-			amountOneOutConsumed:   amountOneOutTargetNotReached,
+			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
+			// subtracting 1 * smallest dec to account for truncations in favor of the pool.
+			amountOneOutConsumed:   amountOneOutTargetNotReached.Sub(sdk.SmallestDec()),
 			expectedAmountInZero:   amountZeroTargetNotReached.Ceil(),
 			expectedFeeChargeTotal: sdk.ZeroDec(),
 		},
@@ -231,8 +232,9 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 			amountOneOutRemaining: defaultAmountOne.Sub(sdk.NewDec(10000)),
 			swapFee:               defaultFee,
 
-			expectedSqrtPriceNext:  sqrtPriceTargetNotReached,
-			amountOneOutConsumed:   amountOneOutTargetNotReached,
+			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
+			// subtracting 1 * smallest dec to account for truncations in favor of the pool.
+			amountOneOutConsumed:   amountOneOutTargetNotReached.Sub(sdk.SmallestDec()),
 			expectedAmountInZero:   amountZeroTargetNotReached.Ceil(),
 			expectedFeeChargeTotal: swapstrategy.ComputeFeeChargeFromAmountIn(amountZeroTargetNotReached.Ceil(), defaultFee),
 		},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4646

## What is the purpose of the change

Our `CalcAmount0Delta` and `CalcAmount1Delta` were not necessarily rounding in pool's favor. This PR adds truncation at precision end in the desired direction depending on the value of the `roundUp` flag.

There are 2 primary use cases of these functions:
- adding / withdrawing liquidity
- swapping

When adding liquidity, we want to round up so that the user is requested to provide a greater  token amount for liquidity `L`
When withdrawing liquidity, we want to round down so that the user receives smaller token amount for liquidity L (in favor of the pool).

In swaps,
token in should be rounded up so that the user has to provide more.
token out should be rounded down so that the user receives fewer tokens (in favor of the pool)

I attempted to construct the test case that would have a high amplification when operating on large amounts.
It seems that we had an undiscovered bug that was rounding in user's favor for large amounts.

These test cases would break if we were to revert back to the old rounding logic:
https://github.com/osmosis-labs/osmosis/blob/e526991cdcdc6fa62df6bb7f286b00d189b603fb/x/concentrated-liquidity/math/math_test.go#L260-L295


## Brief Changelog

- changed rounding direction
- refactored tests
- added unit tests to attempt to amplify the rounding error

## Testing and Verifying

- Covered by existing and added new,

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable