### PR TITLE
fix: last position ID bug

### DIFF
--- a/tests/cl-genesis-positions/edit_localosmosis_genesis.go
+++ b/tests/cl-genesis-positions/edit_localosmosis_genesis.go
@@ -59,9 +59,13 @@ func EditLocalOsmosisGenesis(updatedCLGenesis *clgenesis.GenesisState, updatedBa
 	appState[poolmanagertypes.ModuleName] = cdc.MustMarshalJSON(&localOsmosisPoolManagerGenesis)
 
 	// Copy positions
+	largestPositionId := uint64(0)
 	for _, positionData := range updatedCLGenesis.PositionData {
 		positionData.Position.PoolId = nextPoolId
 		localOsmosisCLGenesis.PositionData = append(localOsmosisCLGenesis.PositionData, positionData)
+		if positionData.Position.PositionId > largestPositionId {
+			largestPositionId = positionData.Position.PositionId
+		}
 	}
 
 	// Create map of pool balances
@@ -125,7 +129,7 @@ func EditLocalOsmosisGenesis(updatedCLGenesis *clgenesis.GenesisState, updatedBa
 		localOsmosisCLGenesis.PoolData = append(localOsmosisCLGenesis.PoolData, updatedPoolData)
 	}
 
-	localOsmosisCLGenesis.NextPositionId = uint64(len(localOsmosisCLGenesis.PositionData) + 1)
+	localOsmosisCLGenesis.NextPositionId = largestPositionId + 1
 
 	appState[cltypes.ModuleName] = cdc.MustMarshalJSON(&localOsmosisCLGenesis)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The CL script runs through position creation, many of which fail. These position IDs are skipped. The script then attempts to use the length of positions + 1 to set the last position ID to, but this is incorrect. We should instead use the last largest position ID and add one to this instead.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)