### PR TITLE
fix(ci): merge conflcit in calc amounts causing test failures

### DIFF
--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -144,8 +144,9 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			expectedSqrtPriceNext: sqrt(100_000_100),
 
 			expectedAmountInConsumed: sdk.NewDec(1336900668450),
-			expectedAmountOut:        defaultAmountZero.TruncateDec(),
-			expectedFeeChargeTotal:   sdk.ZeroDec(),
+			// subtracting smallest dec as a rounding error in favor of the pool.
+			expectedAmountOut:      defaultAmountZero.TruncateDec().Sub(sdk.SmallestDec()),
+			expectedFeeChargeTotal: sdk.ZeroDec(),
 		},
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Conflicts that were undetected in-between PR merges by CI. This fixes Go tests on main
