### PR TITLE
feat(osmoutils): helper to find ith smallest min or max

### DIFF
--- a/osmoutils/export_test.go
+++ b/osmoutils/export_test.go
@@ -1,6 +1,9 @@
 package osmoutils
 
-import db "github.com/tendermint/tm-db"
+import (
+	db "github.com/tendermint/tm-db"
+	"golang.org/x/exp/constraints"
+)
 
 func GatherValuesFromIterator[T any](iterator db.Iterator, parseValue func([]byte) (T, error), stopFn func([]byte) bool) ([]T, error) {
 	return gatherValuesFromIterator(iterator, parseValue, stopFn)
@@ -8,4 +11,8 @@ func GatherValuesFromIterator[T any](iterator db.Iterator, parseValue func([]byt
 
 func NoStopFn(key []byte) bool {
 	return noStopFn(key)
+}
+
+func IThSmallest[T constraints.Ordered](s []T, i int, less LessFunc[T]) T {
+	return iThSmallest(s, i, less)
 }

--- a/osmoutils/generic_helper.go
+++ b/osmoutils/generic_helper.go
@@ -21,14 +21,14 @@ func MakeNew[T any]() T {
 }
 
 func Min[T constraints.Ordered](a, b T) T {
-	if a < b {
+	if a <= b {
 		return a
 	}
 	return b
 }
 
 func Max[T constraints.Ordered](a, b T) T {
-	if a > b {
+	if a >= b {
 		return a
 	}
 	return b

--- a/osmoutils/generic_helper.go
+++ b/osmoutils/generic_helper.go
@@ -1,6 +1,10 @@
 package osmoutils
 
-import "reflect"
+import (
+	"reflect"
+
+	"golang.org/x/exp/constraints"
+)
 
 // MakeNew makes a new instance of generic T.
 // if T is a pointer, makes a new instance of the underlying struct via reflection,
@@ -14,4 +18,18 @@ func MakeNew[T any]() T {
 	} else {
 		return *new(T) // v is not ptr, alloc with new
 	}
+}
+
+func Min[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func Max[T constraints.Ordered](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -1,6 +1,7 @@
 package osmoutils
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -116,4 +117,104 @@ func GetRandomSubset[T any](slice []T) []T {
 
 	n := rand.Intn(len(slice))
 	return slice[:n]
+}
+
+// iThSmallest returns the ith smallest element in the slice.
+// The notion of ordering is defined by the given less function.
+// It uses a divide and conquer approach without relying on
+// randomization for selecting a pivot. This makes this function deterministic.
+// Instead of randomization for pivot selection,
+// it uses a median of medians algorithm for selecting the pivot.
+// The results in the following reccurence relation:
+// T(n) <= T(n/5) + T(7n/10) + O(n)
+// By master's theorem, this results in O(n) time complexity.
+// Allocates additional space and results in 0(n) space complexity.
+// In place.
+// Parameters:
+// s: slice of type T and size n
+// i: index of the ith smallest element to return where i is in the range [1, n]
+// less: a function that defines the ordering of the elements in the slice.
+// Example:
+// Input: [5, 7, 1, 4, 9] 2, less = func(a, b int) bool { return a < b }
+// Output: 5
+// More information about the algorithm:
+// https://brilliant.org/wiki/median-finding-algorithm/
+// https://www.youtube.com/watch?v=EzeYI7p9MjU
+func iThSmallest[T constraints.Ordered](s []T, i int, less LessFunc[T]) T {
+	if i < 0 || i > len(s) {
+		panic(fmt.Sprintf("i (%d) is out of bounds (%d)", i, len(s)))
+	}
+
+	// Select a pivot by dividing the original slice into subgroups of 5 elements.
+
+	originalLength := len(s)
+
+	// Pre-allocate enough buffer for the medians in case input is large.
+	mediansOfSubSlices := make([]T, 0, originalLength/5+originalLength%5)
+	for i := 0; i < originalLength; i += 5 {
+		// choose either 5 elements, or everything that is remaining
+		// if the last slice ends up being smaller than 5 elements.
+		sliceOfFive := s[i:Min(i+5, originalLength)]
+
+		// sort the subslice of five. Note, that this is sort
+		// is O(1) since only 5 elements.
+		sort.Slice(sliceOfFive, func(i, j int) bool {
+			return less(sliceOfFive[i], sliceOfFive[j])
+		})
+
+		// We append the median of the slice of 5 elements into the median
+		// medians of sub slices.
+		mediansOfSubSlices = append(mediansOfSubSlices, sliceOfFive[len(sliceOfFive)/2])
+	}
+
+	var pivot T
+	numberOfMedians := len(mediansOfSubSlices)
+	if numberOfMedians <= 5 {
+		// Base case of the pivot finding divide and conquer.
+		sort.Slice(mediansOfSubSlices, func(i, j int) bool {
+			return less(mediansOfSubSlices[i], mediansOfSubSlices[j])
+		})
+		pivot = mediansOfSubSlices[numberOfMedians/2]
+	} else {
+		// Use the same algorithm to find the median of the medians of subslices
+		// to pivot on for solving the original problem.
+		pivot = iThSmallest(mediansOfSubSlices, numberOfMedians/2, less)
+	}
+
+	// Note, that partitioning below takes O(n)
+	// By the master's theorem the overall result
+	// gets amortized to O(n) regardless.
+
+	// partition elements
+	smallerThanPivot := make([]T, 0)
+	greaterThanPivot := make([]T, 0)
+	numEqualToPivot := 0
+	for _, cur := range s {
+		if cur == pivot {
+			numEqualToPivot++
+			continue
+		}
+		if less(cur, pivot) {
+			smallerThanPivot = append(smallerThanPivot, cur)
+		} else {
+			greaterThanPivot = append(greaterThanPivot, cur)
+		}
+	}
+	numberOfElementsSmallerThanPivot := len(smallerThanPivot)
+
+	if i < numberOfElementsSmallerThanPivot {
+		return iThSmallest(smallerThanPivot, i, less)
+	} else if i > numberOfElementsSmallerThanPivot {
+		// Handle edge case where there are duplicate pivots and it is the result.
+		if len(greaterThanPivot) == 0 && numEqualToPivot > 1 {
+			return pivot
+		}
+
+		// Note that if we are searching in the second half, we must re-scale i to
+		// not account for the current elements smaller than pivot and the pivot itself.
+		return iThSmallest(greaterThanPivot, i-numberOfElementsSmallerThanPivot-numEqualToPivot, less)
+	}
+
+	// i == numberOfElementsSmallerThanPivot
+	return pivot
 }

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -205,8 +205,8 @@ func iThSmallest[T constraints.Ordered](s []T, i int, less LessFunc[T]) T {
 	if i < numberOfElementsSmallerThanPivot {
 		return iThSmallest(smallerThanPivot, i, less)
 	} else if i > numberOfElementsSmallerThanPivot {
-		// Handle edge case where there are duplicate pivots and it is the result.
-		if len(greaterThanPivot) == 0 && numEqualToPivot > 1 {
+		// We return pivot, if `i` lays between smallerThanPivot and greaterThanPivot sets
+		if i < originalLength-len(greaterThanPivot) && i > numberOfElementsSmallerThanPivot && numEqualToPivot > 1 {
 			return pivot
 		}
 

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -156,7 +156,7 @@ func iThSmallest[T constraints.Ordered](s []T, i int, less LessFunc[T]) T {
 		// if the last slice ends up being smaller than 5 elements.
 		sliceOfFive := s[i:Min(i+5, originalLength)]
 
-		// sort the subslice of five. Note, that this is sort
+		// sort the subslice of five. Note, that this sort
 		// is O(1) since only 5 elements.
 		sort.Slice(sliceOfFive, func(i, j int) bool {
 			return less(sliceOfFive[i], sliceOfFive[j])

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -150,7 +150,14 @@ func iThSmallest[T constraints.Ordered](s []T, i int, less LessFunc[T]) T {
 	originalLength := len(s)
 
 	// Pre-allocate enough buffer for the medians in case input is large.
-	mediansOfSubSlices := make([]T, 0, originalLength/5+originalLength%5)
+	var mediansOfSubSlices []T
+	if originalLength%5 != 0 {
+		// If a slice cannot be perfectly divided into sub-slices of length 5, add 1 to medians slice's capacity to account for a slice that will hold [1; 4] additional elements
+		mediansOfSubSlices = make([]T, 0, originalLength/5+1)
+	} else {
+		mediansOfSubSlices = make([]T, 0, originalLength/5+originalLength%5)
+	}
+
 	for i := 0; i < originalLength; i += 5 {
 		// choose either 5 elements, or everything that is remaining
 		// if the last slice ends up being smaller than 5 elements.

--- a/osmoutils/slice_helper_test.go
+++ b/osmoutils/slice_helper_test.go
@@ -272,7 +272,11 @@ func TestIThSmallest(t *testing.T) {
 			expected: 12,
 		},
 		"edge case: copied pivot": {
-			s:           []int{1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 8, 9, 10},
+			s: []int{
+				1, 2, 3, 4, 5,
+				6, 7, 7, 7, 7,
+				8, 9, 10,
+			},
 			i:           9,
 			less:        less,
 			expected:    7,

--- a/osmoutils/slice_helper_test.go
+++ b/osmoutils/slice_helper_test.go
@@ -271,6 +271,13 @@ func TestIThSmallest(t *testing.T) {
 			less:     greater,
 			expected: 12,
 		},
+		"edge case: copied pivot": {
+			s:           []int{1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 8, 9, 10},
+			i:           9,
+			less:        less,
+			expected:    7,
+			expectPanic: false,
+		},
 		"panic: empty": {
 			s:           []int{},
 			i:           0,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

UPD: related to #5365 

## What is the purpose of the change

This is a passion-project to review some divide-and-conquer algorithms.

This introduces a helper to efficiently find the ith min or max (determined by the `less` function) in O(n).

More info can be found here: 
- https://brilliant.org/wiki/median-finding-algorithm/
- https://www.youtube.com/watch?v=EzeYI7p9MjU


There is not use case for this at this time but might be a good helper to have in `osmoutils`.


## Testing and Verifying

This change added tests.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?  no
  - How is the feature or change documented? not applicable