### PR TITLE
test: TestGetLiquidityFromAmounts

### DIFF
--- a/x/concentrated-liquidity/math/math_test.go
+++ b/x/concentrated-liquidity/math/math_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
+	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
 type ConcentratedMathTestSuite struct {
@@ -307,13 +308,26 @@ func (suite *ConcentratedMathTestSuite) TestCalcAmount1Delta() {
 }
 
 func (suite *ConcentratedMathTestSuite) TestGetLiquidityFromAmounts() {
+	sqrt := func(x sdk.Dec) sdk.Dec {
+		sqrt, err := x.ApproxSqrt()
+		suite.Require().NoError(err)
+		return sqrt
+	}
+
 	testCases := map[string]struct {
-		currentSqrtP      sdk.Dec
-		sqrtPHigh         sdk.Dec
-		sqrtPLow          sdk.Dec
-		amount0Desired    sdk.Int
+		currentSqrtP sdk.Dec
+		sqrtPHigh    sdk.Dec
+		sqrtPLow     sdk.Dec
+		// the amount of token0 that will need to be sold to move the price from P_cur to P_low
+		amount0Desired sdk.Int
+		// the amount of token 1 that will need to be sold to move the price from P_cur to P_high.
 		amount1Desired    sdk.Int
 		expectedLiquidity string
+		// liq0 = rate of change of reserves of token 1 for a change between sqrt(P_cur) and sqrt(P_low)
+		// liq1 = rate of change of reserves of token 1 for a change between sqrt(P_cur) and sqrt(P_high)
+		// price of x in terms of y
+		expectedLiquidity0 sdk.Dec
+		expectedLiquidity1 sdk.Dec
 	}{
 		"happy path": {
 			currentSqrtP:      sdk.MustNewDecFromStr("70.710678118654752440"), // 5000
@@ -322,6 +336,39 @@ func (suite *ConcentratedMathTestSuite) TestGetLiquidityFromAmounts() {
 			amount0Desired:    sdk.NewInt(1000000),
 			amount1Desired:    sdk.NewInt(5000000000),
 			expectedLiquidity: "1517882343.751510418088349649",
+		},
+		"full range, price proportional to amounts, equal liquidities (some rounding error) price of 4": {
+			currentSqrtP:   sqrt(sdk.NewDec(4)),
+			sqrtPHigh:      cltypes.MaxSqrtPrice,
+			sqrtPLow:       cltypes.MinSqrtPrice,
+			amount0Desired: sdk.NewInt(4),
+			amount1Desired: sdk.NewInt(16),
+
+			expectedLiquidity:  sdk.MustNewDecFromStr("8.000000000000000001").String(),
+			expectedLiquidity0: sdk.MustNewDecFromStr("8.000000000000000001"),
+			expectedLiquidity1: sdk.MustNewDecFromStr("8.000000004000000002"),
+		},
+		"full range, price proportional to amounts, equal liquidities (some rounding error) price of 2": {
+			currentSqrtP:   sqrt(sdk.NewDec(2)),
+			sqrtPHigh:      cltypes.MaxSqrtPrice,
+			sqrtPLow:       cltypes.MinSqrtPrice,
+			amount0Desired: sdk.NewInt(1),
+			amount1Desired: sdk.NewInt(2),
+
+			expectedLiquidity:  sdk.MustNewDecFromStr("1.414213562373095049").String(),
+			expectedLiquidity0: sdk.MustNewDecFromStr("1.414213562373095049"),
+			expectedLiquidity1: sdk.MustNewDecFromStr("1.414213563373095049"),
+		},
+		"not full range, price proportional to amounts, non equal liquidities": {
+			currentSqrtP:   sqrt(sdk.NewDec(2)),
+			sqrtPHigh:      sqrt(sdk.NewDec(3)),
+			sqrtPLow:       sqrt(sdk.NewDec(1)),
+			amount0Desired: sdk.NewInt(1),
+			amount1Desired: sdk.NewInt(2),
+
+			expectedLiquidity:  sdk.MustNewDecFromStr("4.828427124746190095").String(),
+			expectedLiquidity0: sdk.MustNewDecFromStr("7.706742302257039729"),
+			expectedLiquidity1: sdk.MustNewDecFromStr("4.828427124746190095"),
 		},
 	}
 
@@ -341,6 +388,12 @@ func (suite *ConcentratedMathTestSuite) TestGetLiquidityFromAmounts() {
 			liq := sdk.MinDec(liq0, liq1)
 			suite.Require().Equal(liq.String(), liquidity.String())
 
+			if !tc.expectedLiquidity0.IsNil() {
+				suite.Require().Equal(tc.expectedLiquidity0.String(), liq0.String())
+			}
+			if !tc.expectedLiquidity1.IsNil() {
+				suite.Require().Equal(tc.expectedLiquidity1.String(), liq1.String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Came up in discussions with @czarcas7ic . Trying to find the relationship between sqrt price and amount proportions and why liquidity 0 is not equal to liquidity 1 when amount proportions are equal to price.

Current understanding:
The invariant must hold that both tokens are contributing to the liquidity equally. For non-full range, the distance between P_c and P_l or P_c and P_h is not proportional to the price because these are virtual reserves that might not be proportional to the price itself.

However, in the full range, having the amounts ration equal to price leads to same liquidities because all reserves are accounted for.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? not applicable