### PR TITLE
[CL Message Audit]: MsgMigrateSharesToFullRangeConcentratedPosition

### DIFF
--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -27,8 +27,8 @@ const (
 	addressPrefix                   = "osmo"
 	localosmosisFromHomePath        = "/.osmosisd-local"
 	consensusFee                    = "1500uosmo"
-	denom0                          = "uosmo"
-	denom1                          = "uion"
+	denom0                          = "uusdc"
+	denom1                          = "uosmo"
 	accountNamePrefix               = "lo-test"
 	numPositions                    = 1_000
 	minAmountDeposited              = int64(1_000_000)

--- a/tests/localosmosis/scripts/nativeDenomPoolA.json
+++ b/tests/localosmosis/scripts/nativeDenomPoolA.json
@@ -1,6 +1,6 @@
 {
-    "weights": "5uosmo,5stake",
-    "initial-deposit": "100000000000uosmo,100000000000stake",
+    "weights": "5uosmo,5uusdc",
+    "initial-deposit": "100000000000uosmo,100000000000uusdc",
     "swap-fee": "0.01",
     "exit-fee": "0.00",
     "future-governor": ""

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -90,15 +90,15 @@ add_genesis_accounts () {
     osmosisd add-genesis-account osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
     osmosisd add-genesis-account osmo18s5lynnmx37hq4wlrw9gdn68sg2uxp5rgk26vv 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo1qwexv7c6sm95lwhzn9027vyu2ccneaqad4w8ka 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo14hcxlnwlqtq75ttaxf674vk6mafspg8xwgnn53 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo12rr534cer5c0vj53eq4y32lcwguyy7nndt0u2t 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo1nt33cjd5auzh36syym6azgc8tve0jlvklnq7jq 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo10qfrpash5g2vk3hppvu45x0g860czur8ff5yx0 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo1f4tvsdukfwh6s9swrc24gkuz23tp8pd3e9r5fa 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo1myv43sqgnj5sm4zl98ftl45af9cfzk7nhjxjqh 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo14gs9zqh8m49yy9kscjqu9h72exyf295afg6kgk 100000000000uosmo,100000000000uion,100000000000stake --home $OSMOSIS_HOME
-    osmosisd add-genesis-account osmo1jllfytsz4dryxhz5tl7u73v29exsf80vz52ucc 1000000000000uosmo,1000000000000uion,1000000000000stake --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo1qwexv7c6sm95lwhzn9027vyu2ccneaqad4w8ka 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo14hcxlnwlqtq75ttaxf674vk6mafspg8xwgnn53 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo12rr534cer5c0vj53eq4y32lcwguyy7nndt0u2t 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo1nt33cjd5auzh36syym6azgc8tve0jlvklnq7jq 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo10qfrpash5g2vk3hppvu45x0g860czur8ff5yx0 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo1f4tvsdukfwh6s9swrc24gkuz23tp8pd3e9r5fa 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo1myv43sqgnj5sm4zl98ftl45af9cfzk7nhjxjqh 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo14gs9zqh8m49yy9kscjqu9h72exyf295afg6kgk 100000000000uosmo,100000000000uion,100000000000stake,100000000000uusdc,100000000000uweth --home $OSMOSIS_HOME
+    osmosisd add-genesis-account osmo1jllfytsz4dryxhz5tl7u73v29exsf80vz52ucc 1000000000000uosmo,1000000000000uion,1000000000000stake,1000000000000uusdc,1000000000000uweth --home $OSMOSIS_HOME
 
     echo $MNEMONIC | osmosisd keys add $MONIKER --recover --keyring-backend=test --home $OSMOSIS_HOME
     echo $POOLSMNEMONIC | osmosisd keys add pools --recover --keyring-backend=test --home $OSMOSIS_HOME

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -1142,29 +1142,69 @@ func (s *KeeperTestSuite) TestFungifyChargedPositions_SwapAndClaimFees() {
 }
 
 func (s *KeeperTestSuite) TestCreateFullRangePosition() {
-	s.SetupTest()
-	defaultAddress := s.TestAccs[0]
-	DefaultJoinTime := s.Ctx.BlockTime()
+	var (
+		positionId         uint64
+		liquidity          sdk.Dec
+		concentratedLockId uint64
+		err                error
+	)
 	defaultPositionCoins := sdk.NewCoins(DefaultCoin0, DefaultCoin1)
+	invalidCoinsAmount := sdk.NewCoins(DefaultCoin0)
+	invalidCoin0Denom := sdk.NewCoins(sdk.NewCoin("invalidDenom", sdk.NewInt(1000000000000000000)), DefaultCoin1)
+	invalidCoin1Denom := sdk.NewCoins(DefaultCoin0, sdk.NewCoin("invalidDenom", sdk.NewInt(1000000000000000000)))
 
 	tests := []struct {
 		name                  string
 		remainingLockDuration time.Duration
+		coinsForPosition      sdk.Coins
 		isLocked              bool
 		isUnlocking           bool
+		expectedErr           error
 	}{
 		{
-			name: "full range position",
+			name:             "full range position",
+			coinsForPosition: defaultPositionCoins,
 		},
 		{
 			name:                  "full range position: locked",
 			remainingLockDuration: 24 * time.Hour * 14,
+			coinsForPosition:      defaultPositionCoins,
 			isLocked:              true,
 		},
 		{
 			name:                  "full range position: unlocking",
 			remainingLockDuration: 24 * time.Hour,
+			coinsForPosition:      defaultPositionCoins,
 			isUnlocking:           true,
+		},
+		{
+			name:             "err: only one asset provided for a full range",
+			coinsForPosition: invalidCoinsAmount,
+			expectedErr:      types.NumCoinsError{NumCoins: 1},
+		},
+		{
+			name:                  "err: only one asset provided for a full range locked",
+			remainingLockDuration: 24 * time.Hour * 14,
+			coinsForPosition:      invalidCoinsAmount,
+			isLocked:              true,
+			expectedErr:           types.NumCoinsError{NumCoins: 1},
+		},
+		{
+			name:                  "err: only one asset provided for a full range unlocking",
+			remainingLockDuration: 24 * time.Hour,
+			coinsForPosition:      invalidCoinsAmount,
+			isUnlocking:           true,
+			expectedErr:           types.NumCoinsError{NumCoins: 1},
+		},
+		{
+			name:             "err: wrong denom 0 provided for a full range",
+			coinsForPosition: invalidCoin0Denom,
+			expectedErr:      types.Amount0IsNegativeError{Amount0: sdk.ZeroInt()},
+		},
+		{
+			name:             "err: wrong denom 1 provided for a full range",
+			coinsForPosition: invalidCoin1Denom,
+			expectedErr:      types.Amount1IsNegativeError{Amount1: sdk.ZeroInt()},
 		},
 	}
 
@@ -1173,28 +1213,30 @@ func (s *KeeperTestSuite) TestCreateFullRangePosition() {
 		s.Run(test.name, func() {
 			// Init suite for each test.
 			s.SetupTest()
+			DefaultJoinTime := s.Ctx.BlockTime()
 			s.Ctx = s.Ctx.WithBlockTime(DefaultJoinTime)
 
-			// Create a default CL pools
-			clPool := s.PrepareConcentratedPool()
-
-			var (
-				positionId         uint64
-				liquidity          sdk.Dec
-				concentratedLockId uint64
-				err                error
-			)
+			// Create a default CL pool
+			// We prepare it with a position already registered to prevent any oddities that we are not testing for here.
+			clPool := s.PrepareConcentratedPoolWithCoinsAndFullRangePosition(ETH, USDC)
 
 			// Fund the owner account
-			s.FundAcc(defaultAddress, defaultPositionCoins)
+			defaultAddress := s.TestAccs[0]
+			s.FundAcc(defaultAddress, test.coinsForPosition)
 
 			// System under test
 			if test.isLocked {
-				positionId, _, _, liquidity, _, concentratedLockId, err = s.App.ConcentratedLiquidityKeeper.CreateFullRangePositionLocked(s.Ctx, clPool.GetId(), defaultAddress, defaultPositionCoins, test.remainingLockDuration)
+				positionId, _, _, liquidity, _, concentratedLockId, err = s.App.ConcentratedLiquidityKeeper.CreateFullRangePositionLocked(s.Ctx, clPool.GetId(), defaultAddress, test.coinsForPosition, test.remainingLockDuration)
 			} else if test.isUnlocking {
-				positionId, _, _, liquidity, _, concentratedLockId, err = s.App.ConcentratedLiquidityKeeper.CreateFullRangePositionUnlocking(s.Ctx, clPool.GetId(), defaultAddress, defaultPositionCoins, test.remainingLockDuration)
+				positionId, _, _, liquidity, _, concentratedLockId, err = s.App.ConcentratedLiquidityKeeper.CreateFullRangePositionUnlocking(s.Ctx, clPool.GetId(), defaultAddress, test.coinsForPosition, test.remainingLockDuration)
 			} else {
-				positionId, _, _, liquidity, _, err = s.App.ConcentratedLiquidityKeeper.CreateFullRangePosition(s.Ctx, clPool.GetId(), defaultAddress, defaultPositionCoins)
+				positionId, _, _, liquidity, _, err = s.App.ConcentratedLiquidityKeeper.CreateFullRangePosition(s.Ctx, clPool.GetId(), defaultAddress, test.coinsForPosition)
+			}
+
+			if test.expectedErr != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, test.expectedErr.Error())
+				return
 			}
 
 			s.Require().NoError(err)

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -773,3 +773,11 @@ type ModifySamePositionAccumulatorError struct {
 func (e ModifySamePositionAccumulatorError) Error() string {
 	return fmt.Sprintf("attempted to modify the same accumulator with name %s", e.PositionAccName)
 }
+
+type NumCoinsError struct {
+	NumCoins int
+}
+
+func (e NumCoinsError) Error() string {
+	return fmt.Sprintf("num coins provided (%d) must be 2 for a full range position", e.NumCoins)
+}

--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -435,6 +435,23 @@ osmosisd tx gamm swap-exact-amount-out 140530uosmo 407239 --swap-route-pool-ids 
 [comment]: <> (Other resources Creating a liquidity bootstrapping pool and Creating a pool with a pool file)
 :::
 
+### Migrate-position
+
+Migrate unlocked gamm shares to corresponding concentrated liquidity pool.
+
+
+```sh
+osmosisd tx gamm migrate-position [unlocked-shares] [flags]
+```
+
+::: details Example
+
+Migrate 10000000000000000000 unlocked gamm shares from pool 2 to the canonical CL pool:
+
+```sh
+ osmosisd tx gamm migrate-position 10000000000000000000gamm/pool/2 --min-amounts-out=100uosmo,100uusdc --from pool -b block --keyring-backend test --chain-id localosmosis --fees 1000000uosmo --gas 700000
+```
+:::
 ## Queries
 
 ## Queries

--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MigrateUnlockedPositionFromBalancerToConcentrated migrates unlocked lp tokens from a balancer pool to a concentrated liquidity pool.
-// Fails if the lp tokens are locked (must utilize UnlockAndMigrate function in the superfluid module)
+// Fails if the lp tokens are locked (must instead utilize UnlockAndMigrate function in the superfluid module)
 func (k Keeper) MigrateUnlockedPositionFromBalancerToConcentrated(ctx sdk.Context,
 	sender sdk.AccAddress, sharesToMigrate sdk.Coin,
 	tokenOutMins sdk.Coins) (positionId uint64, amount0, amount1 sdk.Int, liquidity sdk.Dec, joinTime time.Time, poolIdLeaving, poolIdEntering uint64, err error) {

--- a/x/gamm/types/key.go
+++ b/x/gamm/types/key.go
@@ -17,7 +17,7 @@ const (
 
 	QuerierRoute = ModuleName
 
-	GAMMTokenPrefix = "gamm/pool"
+	GAMMTokenPrefix = "gamm/pool/"
 )
 
 var (
@@ -33,7 +33,7 @@ var (
 )
 
 func MustGetPoolIdFromShareDenom(denom string) uint64 {
-	numberStr := strings.TrimLeft(denom, "gamm/pool/")
+	numberStr := strings.TrimLeft(denom, GAMMTokenPrefix)
 	number, err := strconv.Atoi(numberStr)
 	if err != nil {
 		panic(err)
@@ -42,7 +42,7 @@ func MustGetPoolIdFromShareDenom(denom string) uint64 {
 }
 
 func GetPoolIdFromShareDenom(denom string) (uint64, error) {
-	numberStr := strings.TrimLeft(denom, "gamm/pool/")
+	numberStr := strings.TrimLeft(denom, GAMMTokenPrefix)
 	number, err := strconv.Atoi(numberStr)
 	if err != nil {
 		return 0, err
@@ -55,7 +55,7 @@ func GetDenomPrefix(denom string) []byte {
 }
 
 func GetPoolShareDenom(poolId uint64) string {
-	return fmt.Sprintf("gamm/pool/%d", poolId)
+	return fmt.Sprintf("%s%d", GAMMTokenPrefix, poolId)
 }
 
 func GetKeyPrefixPools(poolId uint64) []byte {

--- a/x/gamm/types/key_test.go
+++ b/x/gamm/types/key_test.go
@@ -24,3 +24,44 @@ func TestGetPoolShareDenom(t *testing.T) {
 	require.NoError(t, sdk.ValidateDenom(denom))
 	require.Equal(t, "gamm/pool/18446744073709551615", denom)
 }
+
+func TestGetPoolIdFromShareDenom(t *testing.T) {
+	tests := []struct {
+		name          string
+		denom         string
+		expectedId    uint64
+		expectedError string
+	}{
+		{
+			name:       "Valid pool id",
+			denom:      "gamm/pool/123",
+			expectedId: 123,
+		},
+		{
+			name:          "Invalid pool id",
+			denom:         "gamm/pool/abc",
+			expectedId:    0,
+			expectedError: "strconv.Atoi: parsing \"bc\": invalid syntax",
+		},
+		{
+			name:          "Empty pool id",
+			denom:         "gamm/pool/",
+			expectedId:    0,
+			expectedError: "strconv.Atoi: parsing \"\": invalid syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := types.GetPoolIdFromShareDenom(tt.denom)
+			errStr := ""
+			if err != nil {
+				errStr = err.Error()
+			}
+			if id != tt.expectedId || errStr != tt.expectedError {
+				t.Errorf("GetPoolIdFromShareDenom(%q) = (%v, %q), want (%v, %q)",
+					tt.denom, id, errStr, tt.expectedId, tt.expectedError)
+			}
+		})
+	}
+}

--- a/x/superfluid/keeper/msg_server_test.go
+++ b/x/superfluid/keeper/msg_server_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/superfluid/types"
 )
 
+var defaultFunds = sdk.NewCoins(defaultPoolAssets[0].Token, sdk.NewCoin("stake", sdk.NewInt(5000000000)))
+
 func (suite *KeeperTestSuite) TestMsgSuperfluidDelegate() {
 	type param struct {
 		coinsToLock sdk.Coins
@@ -174,7 +176,7 @@ func (suite *KeeperTestSuite) TestMsgCreateFullRangePositionAndSuperfluidDelegat
 
 			ctx := sdk.WrapSDKContext(suite.Ctx)
 
-			clPool := suite.PrepareConcentratedPoolWithCoinsAndFullRangePosition("stake", "eth")
+			clPool := suite.PrepareConcentratedPoolWithCoinsAndFullRangePosition(defaultFunds[0].Denom, defaultFunds[1].Denom)
 			clLockupDenom := cltypes.GetConcentratedLockupDenomFromPoolId(clPool.GetId())
 			err := suite.App.SuperfluidKeeper.AddNewSuperfluidAsset(suite.Ctx, types.SuperfluidAsset{
 				Denom:     clLockupDenom,
@@ -184,7 +186,7 @@ func (suite *KeeperTestSuite) TestMsgCreateFullRangePositionAndSuperfluidDelegat
 
 			// If there is no coinsToLock in the param, use pool denom
 			if test.param.coinsToLock.Empty() {
-				test.param.coinsToLock = sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(1000000)), sdk.NewCoin("stake", sdk.NewInt(5000000000)))
+				test.param.coinsToLock = defaultFunds
 			}
 			if test.param.poolId == 0 {
 				test.param.poolId = clPool.GetId()
@@ -564,8 +566,8 @@ func (suite *KeeperTestSuite) TestAddToConcentratedLiquiditySuperfluidPosition_E
 			posId, _, _, _, _, poolJoinAcc := suite.SetupSuperfluidConcentratedPosition(suite.Ctx, true, false, false, owner)
 
 			if !tc.isLastPositionInPool {
-				suite.FundAcc(suite.TestAccs[1], defaultAcctFunds)
-				_, _, _, _, _, err := concentratedLiquidityKeeper.CreateFullRangePosition(suite.Ctx, 1, suite.TestAccs[1], defaultAcctFunds)
+				suite.FundAcc(suite.TestAccs[1], defaultFunds)
+				_, _, _, _, _, err := concentratedLiquidityKeeper.CreateFullRangePosition(suite.Ctx, 1, suite.TestAccs[1], defaultFunds)
 				suite.Require().NoError(err)
 			}
 
@@ -573,12 +575,12 @@ func (suite *KeeperTestSuite) TestAddToConcentratedLiquiditySuperfluidPosition_E
 			suite.Ctx = suite.Ctx.WithEventManager(sdk.NewEventManager())
 			suite.Equal(0, len(suite.Ctx.EventManager().Events()))
 
-			suite.FundAcc(poolJoinAcc, defaultAcctFunds)
+			suite.FundAcc(poolJoinAcc, defaultFunds)
 			msg := &types.MsgAddToConcentratedLiquiditySuperfluidPosition{
 				PositionId:    posId,
 				Sender:        poolJoinAcc.String(),
-				TokenDesired0: defaultAcctFunds[0],
-				TokenDesired1: defaultAcctFunds[1],
+				TokenDesired0: defaultFunds[0],
+				TokenDesired1: defaultFunds[1],
 			}
 
 			response, err := msgServer.AddToConcentratedLiquiditySuperfluidPosition(sdk.WrapSDKContext(suite.Ctx), msg)

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -418,7 +418,7 @@ func (s *TestSuite) TestPoolStateChange_Concentrated_SeparateBlocks() {
 	////////////////////////////////////////////////////////////
 	// Second block: create a first position that initializes twap record.
 
-	positionId, liquidityCreated := s.CreateFullRangePosition(clPool, defaultThreeAssetCoins)
+	positionId, liquidityCreated := s.CreateFullRangePosition(clPool, defaultTwoAssetCoins)
 
 	s.validateChangedPool()
 
@@ -430,7 +430,7 @@ func (s *TestSuite) TestPoolStateChange_Concentrated_SeparateBlocks() {
 	////////////////////////////////////////////////////////////
 	// Third block: create a second position that does not change twap record.
 
-	positionId2, liquidityCreated2 := s.CreateFullRangePosition(clPool, defaultThreeAssetCoins)
+	positionId2, liquidityCreated2 := s.CreateFullRangePosition(clPool, defaultTwoAssetCoins)
 
 	s.validateUnchangedPool()
 
@@ -486,7 +486,7 @@ func (s *TestSuite) TestPoolStateChange_Concentrated_SeparateBlocks() {
 	////////////////////////////////////////////////////////////
 	// Seventh block: create new position, updating twap with valid spot price
 
-	s.CreateFullRangePosition(clPool, defaultThreeAssetCoins)
+	s.CreateFullRangePosition(clPool, defaultTwoAssetCoins)
 
 	s.validateChangedPool()
 
@@ -532,12 +532,12 @@ func (s *TestSuite) TestPoolStateChange_Concentrated_SameBlock() {
 	////////////////////////////////////////////////////////////
 	// 2: create a first position that initializes twap record.
 
-	positionId, liquidityCreated := s.CreateFullRangePosition(clPool, defaultThreeAssetCoins)
+	positionId, liquidityCreated := s.CreateFullRangePosition(clPool, defaultTwoAssetCoins)
 
 	////////////////////////////////////////////////////////////
 	// 3: create a second position that does not change twap record.
 
-	positionId2, liquidityCreated2 := s.CreateFullRangePosition(clPool, defaultThreeAssetCoins)
+	positionId2, liquidityCreated2 := s.CreateFullRangePosition(clPool, defaultTwoAssetCoins)
 
 	// Note that creating second position has no effect.
 
@@ -559,7 +559,7 @@ func (s *TestSuite) TestPoolStateChange_Concentrated_SameBlock() {
 	////////////////////////////////////////////////////////////
 	// 7: create new position, updating twap with valid spot price
 
-	s.CreateFullRangePosition(clPool, defaultThreeAssetCoins)
+	s.CreateFullRangePosition(clPool, defaultTwoAssetCoins)
 
 	////////////////////////////////////////////////////////////
 	// 8: swap after re-adding liquidity


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

ClickUp Checklist:
https://app.clickup.com/37420681/v/dc/13nzm9-19527/13nzm9-36307

## What is the purpose of the change

This PR includes changes made from the internal audit of MsgMigrateSharesToFullRangeConcentratedPosition.

## Brief Changelog

- Updated cl go client script to use same denoms as the pool being created
  - @AlpinYukseloglu also realized that the only reason this was working was because we weren't checking denoms in createPosition itself
- Changes one of the GAMM pools that is created in localosmosis to match the denoms of the CL pool.
  - This is to allow us to create a canonical connection between a GAMM and CL pool to further test messages (such as this migration message)   
- Adds defense in depth to check coin inputs for `CreateFullRangePosition`
- Expands existing tests
- Adds test for `GetPoolIdFromShareDenom`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)