### PR TITLE
style: eliminate double imports in tests

### DIFF
--- a/app/upgrades/v15/export_test.go
+++ b/app/upgrades/v15/export_test.go
@@ -12,11 +12,10 @@ import (
 
 	gammkeeper "github.com/osmosis-labs/osmosis/v15/x/gamm/keeper"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager"
-	poolmanagerkeeper "github.com/osmosis-labs/osmosis/v15/x/poolmanager"
 )
 
-func MigrateNextPoolId(ctx sdk.Context, gammKeeper *gammkeeper.Keeper, poolmanagerKeeper *poolmanagerkeeper.Keeper) {
-	migrateNextPoolId(ctx, gammKeeper, poolmanagerKeeper)
+func MigrateNextPoolId(ctx sdk.Context, gammKeeper *gammkeeper.Keeper, poolmanager *poolmanager.Keeper) {
+	migrateNextPoolId(ctx, gammKeeper, poolmanager)
 }
 
 func RegisterOsmoIonMetadata(ctx sdk.Context, bankKeeper bankkeeper.Keeper) {
@@ -27,8 +26,8 @@ func SetICQParams(ctx sdk.Context, icqKeeper *icqkeeper.Keeper) {
 	setICQParams(ctx, icqKeeper)
 }
 
-func MigrateBalancerPoolToSolidlyStable(ctx sdk.Context, gammKeeper *gammkeeper.Keeper, poolmanagerKeeper *poolmanager.Keeper, bankKeeper bankkeeper.Keeper, poolId uint64) {
-	migrateBalancerPoolToSolidlyStable(ctx, gammKeeper, poolmanagerKeeper, bankKeeper, poolId)
+func MigrateBalancerPoolToSolidlyStable(ctx sdk.Context, gammKeeper *gammkeeper.Keeper, poolmanager *poolmanager.Keeper, bankKeeper bankkeeper.Keeper, poolId uint64) {
+	migrateBalancerPoolToSolidlyStable(ctx, gammKeeper, poolmanager, bankKeeper, poolId)
 }
 
 func SetRateLimits(ctx sdk.Context, accountKeeper *authkeeper.AccountKeeper, rateLimitingICS4Wrapper *ibcratelimit.ICS4Wrapper, wasmKeeper *wasmkeeper.Keeper) {

--- a/app/upgrades/v15/upgrade_test.go
+++ b/app/upgrades/v15/upgrade_test.go
@@ -21,7 +21,6 @@ import (
 	v15 "github.com/osmosis-labs/osmosis/v15/app/upgrades/v15"
 	gamm "github.com/osmosis-labs/osmosis/v15/x/gamm/keeper"
 	balancer "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
@@ -109,7 +108,7 @@ func (suite *UpgradeTestSuite) TestMigrateBalancerToStablePools() {
 				SwapFee: swapFee,
 				ExitFee: exitFee,
 			},
-			[]balancertypes.PoolAsset{
+			[]balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
 
 const (
@@ -221,7 +220,7 @@ func (s *KeeperTestSuite) TestInitOrUpdateFeeAccumulatorPosition() {
 				poolFeeAccumulator, err := clKeeper.GetFeeAccumulator(s.Ctx, defaultPoolId)
 				s.Require().NoError(err)
 
-				positionKey := cltypes.KeyFeePositionAccumulator(tc.positionFields.positionId)
+				positionKey := types.KeyFeePositionAccumulator(tc.positionFields.positionId)
 
 				positionSize, err := poolFeeAccumulator.GetPositionSize(positionKey)
 				s.Require().NoError(err)
@@ -882,7 +881,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectFees() {
 
 			currentTick: 2,
 
-			expectedError: cltypes.PositionIdNotFoundError{PositionId: 2},
+			expectedError: types.PositionIdNotFoundError{PositionId: 2},
 		},
 		"non owner attempts to collect": {
 			initialLiquidity: sdk.OneDec(),
@@ -899,7 +898,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectFees() {
 
 			currentTick: 2,
 
-			expectedError: cltypes.NotPositionOwnerError{Address: s.TestAccs[1].String(), PositionId: DefaultPositionId},
+			expectedError: types.NotPositionOwnerError{Address: s.TestAccs[1].String(), PositionId: DefaultPositionId},
 		},
 	}
 
@@ -936,7 +935,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectFees() {
 			ownerBalancerBeforeCollect := s.App.BankKeeper.GetBalance(ctx, tc.owner, ETH)
 
 			var preQueryPosition accum.Record
-			positionKey := cltypes.KeyFeePositionAccumulator(DefaultPositionId)
+			positionKey := types.KeyFeePositionAccumulator(DefaultPositionId)
 
 			// Note the position accumulator before the query to ensure the query in non-mutating.
 			accum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(ctx, validPoolId)
@@ -1166,7 +1165,7 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 
 			currentTick: 2,
 
-			expectedError: cltypes.PositionIdNotFoundError{PositionId: 2},
+			expectedError: types.PositionIdNotFoundError{PositionId: 2},
 		},
 	}
 
@@ -1194,7 +1193,7 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 			err = clKeeper.ChargeFee(ctx, validPoolId, tc.globalFeeGrowth[0])
 			s.Require().NoError(err)
 
-			positionKey := cltypes.KeyFeePositionAccumulator(DefaultPositionId)
+			positionKey := types.KeyFeePositionAccumulator(DefaultPositionId)
 
 			// Note the position accumulator before calling prepare
 			accum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(ctx, validPoolId)
@@ -1344,8 +1343,8 @@ func (s *KeeperTestSuite) TestInitOrUpdateFeeAccumulatorPosition_UpdatingPositio
 }
 
 func (s *KeeperTestSuite) TestPreparePositionAccumulator() {
-	validPositionKey := cltypes.KeyFeePositionAccumulator(1)
-	invalidPositionKey := cltypes.KeyFeePositionAccumulator(2)
+	validPositionKey := types.KeyFeePositionAccumulator(1)
+	invalidPositionKey := types.KeyFeePositionAccumulator(2)
 	tests := []struct {
 		name               string
 		poolId             uint64
@@ -1463,16 +1462,16 @@ func (s *KeeperTestSuite) TestFunctional_Fees_Swaps() {
 	}
 
 	// Swap multiple times USDC for ETH, therefore increasing the spot price
-	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, types.MaxSpotPrice, positions.numSwaps)
 	s.CollectAndAssertFees(s.Ctx, clPool.GetId(), totalFeesExpected, positionIds, [][]sdk.Int{ticksActivatedAfterEachSwap}, onlyUSDC, positions)
 
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
-	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ = s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ = s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
 	s.CollectAndAssertFees(s.Ctx, clPool.GetId(), totalFeesExpected, positionIds, [][]sdk.Int{ticksActivatedAfterEachSwap}, onlyETH, positions)
 
 	// Do the same swaps as before, however this time we collect fees after both swap directions are complete.
-	ticksActivatedAfterEachSwapUp, totalFeesExpectedUp, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
-	ticksActivatedAfterEachSwapDown, totalFeesExpectedDown, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwapUp, totalFeesExpectedUp, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin1, ETH, types.MaxSpotPrice, positions.numSwaps)
+	ticksActivatedAfterEachSwapDown, totalFeesExpectedDown, _, _ := s.swapAndTrackXTimesInARow(clPool.GetId(), DefaultCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
 	totalFeesExpected = totalFeesExpectedUp.Add(totalFeesExpectedDown...)
 
 	// We expect all positions to have both denoms in their fee accumulators except USDC for the overlapping range position since
@@ -1514,7 +1513,7 @@ func (s *KeeperTestSuite) TestFunctional_Fees_LP() {
 	s.Require().NoError(err)
 
 	// Swap once.
-	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ := s.swapAndTrackXTimesInARow(pool.GetId(), DefaultCoin1, ETH, cltypes.MaxSpotPrice, 1)
+	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ := s.swapAndTrackXTimesInARow(pool.GetId(), DefaultCoin1, ETH, types.MaxSpotPrice, 1)
 
 	// Withdraw half.
 	halfLiquidity := liquidity.Mul(sdk.NewDecWithPrec(5, 1))
@@ -1533,7 +1532,7 @@ func (s *KeeperTestSuite) TestFunctional_Fees_LP() {
 	s.Require().NoError(err)
 
 	// Swap once in the other direction.
-	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ = s.swapAndTrackXTimesInARow(pool.GetId(), DefaultCoin0, USDC, cltypes.MinSpotPrice, 1)
+	ticksActivatedAfterEachSwap, totalFeesExpected, _, _ = s.swapAndTrackXTimesInARow(pool.GetId(), DefaultCoin0, USDC, types.MinSpotPrice, 1)
 
 	// This should claim under the hood for position 2 since full liquidity is removed.
 	balanceBeforeWithdraw := s.App.BankKeeper.GetBalance(ctx, owner, ETH)

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	gammtypes "github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	poolincentivestypes "github.com/osmosis-labs/osmosis/v15/x/pool-incentives/types"
@@ -981,7 +980,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 					qualifyingBalancerLiquidity = (sdk.OneDec().Sub(types.DefaultBalancerSharesDiscount)).Mul(qualifyingBalancerLiquidityPreDiscount)
 					qualifyingLiquidity = qualifyingLiquidity.Add(qualifyingBalancerLiquidity)
 
-					actualLiquidityAdded0, actualLiquidityAdded1, err := clPool.CalcActualAmounts(s.Ctx, cltypes.MinTick, cltypes.MaxTick, qualifyingBalancerLiquidity)
+					actualLiquidityAdded0, actualLiquidityAdded1, err := clPool.CalcActualAmounts(s.Ctx, types.MinTick, types.MaxTick, qualifyingBalancerLiquidity)
 					s.Require().NoError(err)
 					s.FundAcc(clPool.GetIncentivesAddress(), sdk.NewCoins(sdk.NewCoin(clPool.GetToken0(), actualLiquidityAdded0.TruncateInt()), sdk.NewCoin(clPool.GetToken1(), actualLiquidityAdded1.TruncateInt())))
 				}
@@ -2849,7 +2848,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 
 			expectedIncentivesClaimed:   sdk.Coins{},
 			expectedForfeitedIncentives: sdk.Coins{},
-			expectedError:               cltypes.PositionIdNotFoundError{PositionId: DefaultPositionId},
+			expectedError:               types.PositionIdNotFoundError{PositionId: DefaultPositionId},
 		},
 	}
 
@@ -3275,8 +3274,8 @@ func (s *KeeperTestSuite) TestCreateIncentive() {
 }
 
 func (s *KeeperTestSuite) TestPrepareAccumAndClaimRewards() {
-	validPositionKey := cltypes.KeyFeePositionAccumulator(1)
-	invalidPositionKey := cltypes.KeyFeePositionAccumulator(2)
+	validPositionKey := types.KeyFeePositionAccumulator(1)
+	invalidPositionKey := types.KeyFeePositionAccumulator(2)
 	tests := map[string]struct {
 		poolId             uint64
 		growthInside       sdk.DecCoins
@@ -3412,7 +3411,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 			growthOutside:    uptimeHelper.twoHundredTokensMultiDenom,
 			numShares:        sdk.OneDec(),
 
-			expectedError: cltypes.PositionIdNotFoundError{PositionId: DefaultPositionId + 1},
+			expectedError: types.PositionIdNotFoundError{PositionId: DefaultPositionId + 1},
 		},
 
 		"error: negative duration": {
@@ -3424,7 +3423,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 			growthOutside:    uptimeHelper.twoHundredTokensMultiDenom,
 			numShares:        sdk.OneDec(),
 
-			expectedError: cltypes.NegativeDurationError{Duration: time.Hour * 504 * -1},
+			expectedError: types.NegativeDurationError{Duration: time.Hour * 504 * -1},
 		},
 	}
 	for _, tc := range tests {

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
@@ -22,7 +21,7 @@ import (
 )
 
 var (
-	DefaultMinTick, DefaultMaxTick                 = cltypes.MinTick, cltypes.MaxTick
+	DefaultMinTick, DefaultMaxTick                 = types.MinTick, types.MaxTick
 	DefaultLowerPrice                              = sdk.NewDec(4545)
 	DefaultLowerTick                               = int64(30545000)
 	DefaultUpperPrice                              = sdk.NewDec(5500)
@@ -281,7 +280,7 @@ func (s *KeeperTestSuite) validatePositionFeeAccUpdate(ctx sdk.Context, poolId u
 	accum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(ctx, poolId)
 	s.Require().NoError(err)
 
-	accumulatorPosition, err := accum.GetPositionSize(cltypes.KeyFeePositionAccumulator(positionId))
+	accumulatorPosition, err := accum.GetPositionSize(types.KeyFeePositionAccumulator(positionId))
 	s.Require().NoError(err)
 
 	s.Require().Equal(liquidity.String(), accumulatorPosition.String())
@@ -325,7 +324,7 @@ func (s *KeeperTestSuite) crossTickAndChargeFee(poolId uint64, tickIndexToCross 
 func (s *KeeperTestSuite) validatePositionFeeGrowth(poolId uint64, positionId uint64, expectedUnclaimedRewards sdk.DecCoins) {
 	accum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, poolId)
 	s.Require().NoError(err)
-	positionRecord, err := accum.GetPosition(cltypes.KeyFeePositionAccumulator(positionId))
+	positionRecord, err := accum.GetPosition(types.KeyFeePositionAccumulator(positionId))
 	s.Require().NoError(err)
 	if expectedUnclaimedRewards.IsZero() {
 		s.Require().Equal(expectedUnclaimedRewards, positionRecord.UnclaimedRewards)

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -9,7 +9,6 @@ import (
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
@@ -127,7 +126,7 @@ func (suite *KeeperTestSuite) TestAddToPosition_Events() {
 			suite.Equal(0, len(suite.Ctx.EventManager().Events()))
 
 			suite.FundAcc(suite.TestAccs[0], sdk.NewCoins(DefaultCoin0, DefaultCoin1))
-			msg := &cltypes.MsgAddToPosition{
+			msg := &types.MsgAddToPosition{
 				PositionId:    posId,
 				Sender:        suite.TestAccs[0].String(),
 				TokenDesired0: DefaultCoin0,
@@ -202,7 +201,7 @@ func (suite *KeeperTestSuite) TestCollectFees_Events() {
 			shouldSetupUnownedPosition:    true,
 			numPositionsToCreate:          2,
 			expectedTotalCollectFeesEvent: 0,
-			expectedError:                 cltypes.NotPositionOwnerError{},
+			expectedError:                 types.NotPositionOwnerError{},
 		},
 	}
 
@@ -227,7 +226,7 @@ func (suite *KeeperTestSuite) TestCollectFees_Events() {
 			suite.Ctx = suite.Ctx.WithEventManager(sdk.NewEventManager())
 			suite.Equal(0, len(suite.Ctx.EventManager().Events()))
 
-			msg := &cltypes.MsgCollectFees{
+			msg := &types.MsgCollectFees{
 				Sender:      suite.TestAccs[0].String(),
 				PositionIds: tc.positionIds,
 			}
@@ -237,8 +236,8 @@ func (suite *KeeperTestSuite) TestCollectFees_Events() {
 			if tc.expectedError == nil {
 				suite.Require().NoError(err)
 				suite.Require().NotNil(response)
-				suite.AssertEventEmitted(suite.Ctx, cltypes.TypeEvtTotalCollectFees, tc.expectedTotalCollectFeesEvent)
-				suite.AssertEventEmitted(suite.Ctx, cltypes.TypeEvtCollectFees, tc.expectedCollectFeesEvent)
+				suite.AssertEventEmitted(suite.Ctx, types.TypeEvtTotalCollectFees, tc.expectedTotalCollectFeesEvent)
+				suite.AssertEventEmitted(suite.Ctx, types.TypeEvtCollectFees, tc.expectedCollectFeesEvent)
 				suite.AssertEventEmitted(suite.Ctx, sdk.EventTypeMessage, tc.expectedMessageEvents)
 			} else {
 				suite.Require().Error(err)
@@ -298,7 +297,7 @@ func (suite *KeeperTestSuite) TestCollectIncentives_Events() {
 			positionIds:                []uint64{DefaultPositionId, DefaultPositionId + 1, DefaultPositionId + 2},
 			numPositionsToCreate:       2,
 			shouldSetupUnownedPosition: true,
-			expectedError:              cltypes.NotPositionOwnerError{},
+			expectedError:              types.NotPositionOwnerError{},
 		},
 		"error": {
 			upperTick:                           DefaultUpperTick,
@@ -307,7 +306,7 @@ func (suite *KeeperTestSuite) TestCollectIncentives_Events() {
 			numPositionsToCreate:                2,
 			expectedTotalCollectIncentivesEvent: 0,
 			expectedCollectIncentivesEvent:      0,
-			expectedError:                       cltypes.PositionIdNotFoundError{PositionId: DefaultPositionId + 2},
+			expectedError:                       types.PositionIdNotFoundError{PositionId: DefaultPositionId + 2},
 		},
 	}
 
@@ -343,7 +342,7 @@ func (suite *KeeperTestSuite) TestCollectIncentives_Events() {
 			ctx = ctx.WithEventManager(sdk.NewEventManager())
 			suite.Equal(0, len(ctx.EventManager().Events()))
 
-			msg := &cltypes.MsgCollectIncentives{
+			msg := &types.MsgCollectIncentives{
 				Sender:      suite.TestAccs[0].String(),
 				PositionIds: tc.positionIds,
 			}
@@ -354,8 +353,8 @@ func (suite *KeeperTestSuite) TestCollectIncentives_Events() {
 			if tc.expectedError == nil {
 				suite.Require().NoError(err)
 				suite.Require().NotNil(response)
-				suite.AssertEventEmitted(ctx, cltypes.TypeEvtTotalCollectIncentives, tc.expectedTotalCollectIncentivesEvent)
-				suite.AssertEventEmitted(ctx, cltypes.TypeEvtCollectIncentives, tc.expectedCollectIncentivesEvent)
+				suite.AssertEventEmitted(ctx, types.TypeEvtTotalCollectIncentives, tc.expectedTotalCollectIncentivesEvent)
+				suite.AssertEventEmitted(ctx, types.TypeEvtCollectIncentives, tc.expectedCollectIncentivesEvent)
 				suite.AssertEventEmitted(ctx, sdk.EventTypeMessage, tc.expectedMessageEvents)
 			} else {
 				suite.Require().Error(err)

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -9,7 +9,6 @@ import (
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
@@ -436,37 +435,37 @@ func (s *KeeperTestSuite) TestDecreaseConcentratedPoolTickSpacing() {
 
 	tests := []struct {
 		name                       string
-		poolIdToTickSpacingRecord  []cltypes.PoolIdToTickSpacingRecord
+		poolIdToTickSpacingRecord  []types.PoolIdToTickSpacingRecord
 		position                   positionRange
 		expectedDecreaseSpacingErr error
 		expectedCreatePositionErr  error
 	}{
 		{
 			name:                      "happy path: tick spacing 100 -> 10",
-			poolIdToTickSpacingRecord: []cltypes.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 10}},
+			poolIdToTickSpacingRecord: []types.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 10}},
 			position:                  positionRange{lowerTick: -10, upperTick: 10},
 		},
 		{
 			name:                       "error: new tick spacing not authorized",
-			poolIdToTickSpacingRecord:  []cltypes.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 11}},
+			poolIdToTickSpacingRecord:  []types.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 11}},
 			position:                   positionRange{lowerTick: -10, upperTick: 10},
 			expectedDecreaseSpacingErr: fmt.Errorf("tick spacing %d is not valid", 11),
 		},
 		{
 			name:                       "error: new tick spacing higher than current",
-			poolIdToTickSpacingRecord:  []cltypes.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 1000}},
+			poolIdToTickSpacingRecord:  []types.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 1000}},
 			position:                   positionRange{lowerTick: -10, upperTick: 10},
 			expectedDecreaseSpacingErr: fmt.Errorf("tick spacing %d is not valid", 1000),
 		},
 		{
 			name:                      "error: cant create position whose lower tick is not divisible by new tick spacing",
-			poolIdToTickSpacingRecord: []cltypes.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 10}},
+			poolIdToTickSpacingRecord: []types.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 10}},
 			position:                  positionRange{lowerTick: -95, upperTick: 100},
 			expectedCreatePositionErr: types.TickSpacingError{TickSpacing: 10, LowerTick: -95, UpperTick: 100},
 		},
 		{
 			name:                      "error: cant create position whose upper tick is not divisible by new tick spacing",
-			poolIdToTickSpacingRecord: []cltypes.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 10}},
+			poolIdToTickSpacingRecord: []types.PoolIdToTickSpacingRecord{{PoolId: 1, NewTickSpacing: 10}},
 			position:                  positionRange{lowerTick: -100, upperTick: 95},
 			expectedCreatePositionErr: types.TickSpacingError{TickSpacing: 10, LowerTick: -100, UpperTick: 95},
 		},

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -11,7 +11,6 @@ import (
 	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
@@ -2075,10 +2074,10 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 
 				// Check that we consume enough gas that a CL pool swap warrants
 				// We consume `types.GasFeeForSwap` directly, so the extra I/O operation mean we end up consuming more.
-				s.Require().Greater(gasConsumedForSwap, uint64(cltypes.ConcentratedGasFeeForSwap))
+				s.Require().Greater(gasConsumedForSwap, uint64(types.ConcentratedGasFeeForSwap))
 
 				// Assert events
-				s.AssertEventEmitted(s.Ctx, cltypes.TypeEvtTokenSwapped, 1)
+				s.AssertEventEmitted(s.Ctx, types.TypeEvtTokenSwapped, 1)
 
 				// Retrieve pool again post swap
 				pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
@@ -2251,10 +2250,10 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 				gasConsumedForSwap := s.Ctx.GasMeter().GasConsumed() - prevGasConsumed
 				// Check that we consume enough gas that a CL pool swap warrants
 				// We consume `types.GasFeeForSwap` directly, so the extra I/O operation mean we end up consuming more.
-				s.Require().Greater(gasConsumedForSwap, uint64(cltypes.ConcentratedGasFeeForSwap))
+				s.Require().Greater(gasConsumedForSwap, uint64(types.ConcentratedGasFeeForSwap))
 
 				// Assert events
-				s.AssertEventEmitted(s.Ctx, cltypes.TypeEvtTokenSwapped, 1)
+				s.AssertEventEmitted(s.Ctx, types.TypeEvtTokenSwapped, 1)
 
 				// Retrieve pool again post swap
 				pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
@@ -2705,7 +2704,7 @@ func (suite *KeeperTestSuite) TestUpdatePoolForSwap() {
 }
 
 func (s *KeeperTestSuite) inverseRelationshipInvariants(firstTokenIn, firstTokenOut, secondTokenIn, secondTokenOut sdk.Coin, poolBefore poolmanagertypes.PoolI, userBalanceBeforeSwap sdk.Coins, poolBalanceBeforeSwap sdk.Coins, outGivenIn bool) {
-	pool, ok := poolBefore.(cltypes.ConcentratedPoolExtension)
+	pool, ok := poolBefore.(types.ConcentratedPoolExtension)
 	s.Require().True(ok)
 
 	liquidityBefore, err := s.App.ConcentratedLiquidityKeeper.GetTotalPoolLiquidity(s.Ctx, pool.GetId())
@@ -2831,7 +2830,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	//                              5000
 
 	// Swap multiple times USDC for ETH, therefore increasing the spot price
-	_, _, totalTokenIn, totalTokenOut := s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	_, _, totalTokenIn, totalTokenOut := s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, types.MaxSpotPrice, positions.numSwaps)
 	clPool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 	s.Require().NoError(err)
 
@@ -2879,7 +2878,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	}
 
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
-	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
 	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 	s.Require().NoError(err)
 
@@ -2938,7 +2937,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	}
 
 	// Swap multiple times USDC for ETH, therefore increasing the spot price
-	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, cltypes.MaxSpotPrice, positions.numSwaps)
+	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, types.MaxSpotPrice, positions.numSwaps)
 	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 	s.Require().NoError(err)
 
@@ -2997,7 +2996,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	}
 
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
-	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, cltypes.MinSpotPrice, positions.numSwaps)
+	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
 	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 	s.Require().NoError(err)
 

--- a/x/gamm/keeper/gas_test.go
+++ b/x/gamm/keeper/gas_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -102,7 +101,7 @@ func (suite *KeeperTestSuite) TestRepeatedJoinPoolDistinctDenom() {
 		sdk.NewCoin("randToken1", sdk.NewInt(100)),
 	)
 	suite.FundAcc(defaultAddr, coins)
-	defaultPoolParams := balancertypes.PoolParams{
+	defaultPoolParams := balancer.PoolParams{
 		SwapFee: sdk.NewDec(0),
 		ExitFee: sdk.NewDec(0),
 	}
@@ -113,7 +112,7 @@ func (suite *KeeperTestSuite) TestRepeatedJoinPoolDistinctDenom() {
 
 		suite.FundAcc(defaultAddr, coins)
 
-		poolAssets := []balancertypes.PoolAsset{
+		poolAssets := []balancer.PoolAsset{
 			{
 				Weight: sdk.NewInt(100),
 				Token:  sdk.NewCoin(prevRandToken, sdk.NewInt(10)),

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/v2types"
@@ -189,7 +188,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 		expected_num_pools_response int
 		min_liquidity               string
 		pool_type                   string
-		poolAssets                  []balancertypes.PoolAsset
+		poolAssets                  []balancer.PoolAsset
 		expectedErr                 bool
 	}{
 		{
@@ -198,7 +197,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			expected_num_pools_response: 1,
 			min_liquidity:               "50000foo, 50000bar",
 			pool_type:                   "Balancer",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -215,7 +214,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			num_pools:                   1,
 			expected_num_pools_response: 0,
 			min_liquidity:               "500000000foo, 500000000bar",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -233,7 +232,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			expected_num_pools_response: 0,
 			min_liquidity:               "",
 			pool_type:                   "balaswap",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -251,7 +250,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			expected_num_pools_response: 4,
 			min_liquidity:               "500foo",
 			pool_type:                   "Balancer",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -268,7 +267,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			num_pools:                   1,
 			expected_num_pools_response: 0,
 			min_liquidity:               "500whoami",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -285,7 +284,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			num_pools:                   1,
 			expected_num_pools_response: 6,
 			min_liquidity:               "0foo,0bar",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -302,7 +301,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			num_pools:                   1,
 			expected_num_pools_response: 7,
 			pool_type:                   "Balancer",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),
@@ -320,7 +319,7 @@ func (suite *KeeperTestSuite) TestPoolsWithFilter() {
 			expected_num_pools_response: 1,
 			min_liquidity:               "wrong300foo",
 			pool_type:                   "Balancer",
-			poolAssets: []balancertypes.PoolAsset{
+			poolAssets: []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),

--- a/x/gamm/keeper/keeper_test.go
+++ b/x/gamm/keeper/keeper_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 )
@@ -37,7 +36,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 func (suite *KeeperTestSuite) prepareCustomBalancerPool(
 	balances sdk.Coins,
-	poolAssets []balancertypes.PoolAsset,
+	poolAssets []balancer.PoolAsset,
 	poolParams balancer.PoolParams,
 ) uint64 {
 	suite.fundAllAccountsWith(balances)

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -11,7 +11,6 @@ import (
 	_ "github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
@@ -30,15 +29,15 @@ var (
 	defaultFutureGovernor = ""
 
 	// pool assets
-	defaultFooAsset = balancertypes.PoolAsset{
+	defaultFooAsset = balancer.PoolAsset{
 		Weight: sdk.NewInt(100),
 		Token:  sdk.NewCoin("foo", sdk.NewInt(10000)),
 	}
-	defaultBarAsset = balancertypes.PoolAsset{
+	defaultBarAsset = balancer.PoolAsset{
 		Weight: sdk.NewInt(100),
 		Token:  sdk.NewCoin("bar", sdk.NewInt(10000)),
 	}
-	defaultPoolAssets                     = []balancertypes.PoolAsset{defaultFooAsset, defaultBarAsset}
+	defaultPoolAssets                     = []balancer.PoolAsset{defaultFooAsset, defaultBarAsset}
 	defaultStableSwapPoolAssets sdk.Coins = sdk.NewCoins(
 		sdk.NewCoin("foo", sdk.NewInt(10000)),
 		sdk.NewCoin("bar", sdk.NewInt(10000)),
@@ -67,7 +66,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 	// TODO: should be moved to balancer package
 	tests := []struct {
 		name        string
-		msg         balancertypes.MsgCreateBalancerPool
+		msg         balancer.MsgCreateBalancerPool
 		emptySender bool
 		expectPass  bool
 	}{
@@ -110,7 +109,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
 				SwapFee: sdk.NewDecWithPrec(1, 2),
 				ExitFee: defaultZeroExitFee,
-			}, []balancertypes.PoolAsset{}, defaultFutureGovernor),
+			}, []balancer.PoolAsset{}, defaultFutureGovernor),
 			emptySender: false,
 			expectPass:  false,
 		}, {
@@ -118,7 +117,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
 				SwapFee: sdk.NewDecWithPrec(1, 2),
 				ExitFee: defaultZeroExitFee,
-			}, []balancertypes.PoolAsset{{
+			}, []balancer.PoolAsset{{
 				Weight: sdk.NewInt(0),
 				Token:  sdk.NewCoin("foo", sdk.NewInt(10000)),
 			}, {
@@ -132,7 +131,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
 				SwapFee: sdk.NewDecWithPrec(1, 2),
 				ExitFee: defaultZeroExitFee,
-			}, []balancertypes.PoolAsset{{
+			}, []balancer.PoolAsset{{
 				Weight: sdk.NewInt(-1),
 				Token:  sdk.NewCoin("foo", sdk.NewInt(10000)),
 			}, {
@@ -146,7 +145,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
 				SwapFee: sdk.NewDecWithPrec(1, 2),
 				ExitFee: defaultZeroExitFee,
-			}, []balancertypes.PoolAsset{{
+			}, []balancer.PoolAsset{{
 				Weight: sdk.NewInt(100),
 				Token:  sdk.NewCoin("foo", sdk.NewInt(0)),
 			}, {
@@ -160,7 +159,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
 				SwapFee: sdk.NewDecWithPrec(1, 2),
 				ExitFee: defaultZeroExitFee,
-			}, []balancertypes.PoolAsset{{
+			}, []balancer.PoolAsset{{
 				Weight: sdk.NewInt(100),
 				Token: sdk.Coin{
 					Denom:  "foo",
@@ -177,7 +176,7 @@ func (suite *KeeperTestSuite) TestCreateBalancerPool() {
 			msg: balancer.NewMsgCreateBalancerPool(testAccount, balancer.PoolParams{
 				SwapFee: sdk.NewDecWithPrec(1, 2),
 				ExitFee: defaultZeroExitFee,
-			}, []balancertypes.PoolAsset{{
+			}, []balancer.PoolAsset{{
 				Weight: sdk.NewInt(100),
 				Token:  sdk.NewCoin("foo", sdk.NewInt(10000)),
 			}, {
@@ -685,7 +684,7 @@ func (suite *KeeperTestSuite) TestExitPool() {
 func (suite *KeeperTestSuite) TestJoinPoolExitPool_InverseRelationship() {
 	testCases := []struct {
 		name             string
-		pool             balancertypes.MsgCreateBalancerPool
+		pool             balancer.MsgCreateBalancerPool
 		joinPoolShareAmt sdk.Int
 	}{
 		{
@@ -693,7 +692,7 @@ func (suite *KeeperTestSuite) TestJoinPoolExitPool_InverseRelationship() {
 			pool: balancer.NewMsgCreateBalancerPool(nil, balancer.PoolParams{
 				SwapFee: sdk.ZeroDec(),
 				ExitFee: sdk.ZeroDec(),
-			}, []balancertypes.PoolAsset{
+			}, []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(10000)),
@@ -710,7 +709,7 @@ func (suite *KeeperTestSuite) TestJoinPoolExitPool_InverseRelationship() {
 			pool: balancer.NewMsgCreateBalancerPool(nil, balancer.PoolParams{
 				SwapFee: sdk.ZeroDec(),
 				ExitFee: sdk.ZeroDec(),
-			}, []balancertypes.PoolAsset{
+			}, []balancer.PoolAsset{
 				{
 					Weight: sdk.NewInt(100),
 					Token:  sdk.NewCoin("foo", sdk.NewInt(7000)),
@@ -876,7 +875,7 @@ func (suite *KeeperTestSuite) TestJoinSwapExactAmountInConsistency() {
 
 			poolID := suite.prepareCustomBalancerPool(
 				defaultAcctFunds,
-				[]balancertypes.PoolAsset{
+				[]balancer.PoolAsset{
 					{
 						Weight: sdk.NewInt(100),
 						Token:  sdk.NewCoin("foo", sdk.NewInt(5000000)),

--- a/x/gamm/keeper/pool_test.go
+++ b/x/gamm/keeper/pool_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/tests/mocks"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/keeper"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
@@ -264,10 +263,10 @@ func (suite *KeeperTestSuite) TestGetPoolAndPoke() {
 
 	// N.B.: We make a copy because SmoothWeightChangeParams get mutated.
 	// We would like to avoid mutating global pool assets that are used in other tests.
-	defaultPoolAssetsCopy := make([]balancertypes.PoolAsset, 2)
+	defaultPoolAssetsCopy := make([]balancer.PoolAsset, 2)
 	copy(defaultPoolAssetsCopy, defaultPoolAssets)
 
-	startPoolWeightAssets := []balancertypes.PoolAsset{
+	startPoolWeightAssets := []balancer.PoolAsset{
 		{
 			Weight: defaultPoolAssets[0].Weight.Quo(sdk.NewInt(2)),
 			Token:  defaultPoolAssets[0].Token,

--- a/x/poolmanager/create_pool_test.go
+++ b/x/poolmanager/create_pool_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	stableswap "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 	gammtypes "github.com/osmosis-labs/osmosis/v15/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
@@ -27,7 +26,7 @@ func (suite *KeeperTestSuite) TestPoolCreationFee() {
 	tests := []struct {
 		name            string
 		poolCreationFee sdk.Coins
-		msg             balancertypes.MsgCreateBalancerPool
+		msg             balancer.MsgCreateBalancerPool
 		expectPass      bool
 	}{
 		{
@@ -436,7 +435,7 @@ func (suite *KeeperTestSuite) TestValidateCreatedPool() {
 		{
 			name:   "pool ID 1",
 			poolId: 1,
-			pool: &balancertypes.Pool{
+			pool: &balancer.Pool{
 				Address: types.NewPoolAddress(1).String(),
 				Id:      1,
 			},
@@ -444,7 +443,7 @@ func (suite *KeeperTestSuite) TestValidateCreatedPool() {
 		{
 			name:   "pool ID 309",
 			poolId: 309,
-			pool: &balancertypes.Pool{
+			pool: &balancer.Pool{
 				Address: types.NewPoolAddress(309).String(),
 				Id:      309,
 			},
@@ -452,7 +451,7 @@ func (suite *KeeperTestSuite) TestValidateCreatedPool() {
 		{
 			name:   "error: unexpected ID",
 			poolId: 1,
-			pool: &balancertypes.Pool{
+			pool: &balancer.Pool{
 				Address: types.NewPoolAddress(1).String(),
 				Id:      2,
 			},
@@ -461,7 +460,7 @@ func (suite *KeeperTestSuite) TestValidateCreatedPool() {
 		{
 			name:   "error: unexpected address",
 			poolId: 2,
-			pool: &balancertypes.Pool{
+			pool: &balancer.Pool{
 				Address: types.NewPoolAddress(1).String(),
 				Id:      2,
 			},

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -18,7 +18,6 @@ import (
 	poolincentivestypes "github.com/osmosis-labs/osmosis/v15/x/pool-incentives/types"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager"
 	"github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
-	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
 )
 
 type poolSetup struct {
@@ -342,7 +341,7 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 		name                    string
 		poolCoins               []sdk.Coins
 		poolFee                 []sdk.Dec
-		routes                  []poolmanagertypes.SwapAmountInRoute
+		routes                  []types.SwapAmountInRoute
 		incentivizedGauges      []uint64
 		tokenIn                 sdk.Coin
 		tokenOutMinAmount       sdk.Int
@@ -354,7 +353,7 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 			name:      "One route: Swap - [foo -> bar], 1 percent fee",
 			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount))},
 			poolFee:   []sdk.Dec{defaultPoolSwapFee},
-			routes: []poolmanagertypes.SwapAmountInRoute{
+			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
 					TokenOutDenom: bar,
@@ -370,7 +369,7 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)), // pool 2.
 			},
 			poolFee: []sdk.Dec{defaultPoolSwapFee, defaultPoolSwapFee},
-			routes: []poolmanagertypes.SwapAmountInRoute{
+			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
 					TokenOutDenom: bar,
@@ -582,7 +581,7 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountOut() {
 		name                    string
 		poolCoins               []sdk.Coins
 		poolFee                 []sdk.Dec
-		routes                  []poolmanagertypes.SwapAmountOutRoute
+		routes                  []types.SwapAmountOutRoute
 		incentivizedGauges      []uint64
 		tokenOut                sdk.Coin
 		tokenInMaxAmount        sdk.Int
@@ -594,7 +593,7 @@ func (suite *KeeperTestSuite) TestMultihopSwapExactAmountOut() {
 			name:      "One route: Swap - [foo -> bar], 1 percent fee",
 			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount))},
 			poolFee:   []sdk.Dec{defaultPoolSwapFee},
-			routes: []poolmanagertypes.SwapAmountOutRoute{
+			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
 					TokenInDenom: bar,
@@ -1189,7 +1188,7 @@ func (suite *KeeperTestSuite) makeGaugesIncentivized(incentivizedGauges []uint64
 	suite.App.PoolIncentivesKeeper.SetDistrInfo(suite.Ctx, distInfo)
 }
 
-func (suite *KeeperTestSuite) calcOutAmountAsSeparateSwaps(osmoFeeReduced bool, routes []poolmanagertypes.SwapAmountOutRoute, tokenOut sdk.Coin) sdk.Coin {
+func (suite *KeeperTestSuite) calcOutAmountAsSeparateSwaps(osmoFeeReduced bool, routes []types.SwapAmountOutRoute, tokenOut sdk.Coin) sdk.Coin {
 	cacheCtx, _ := suite.Ctx.CacheContext()
 	if osmoFeeReduced {
 		// extract route from swap
@@ -1229,7 +1228,7 @@ func (suite *KeeperTestSuite) calcOutAmountAsSeparateSwaps(osmoFeeReduced bool, 
 	}
 }
 
-func (suite *KeeperTestSuite) calcInAmountAsSeparateSwaps(osmoFeeReduced bool, routes []poolmanagertypes.SwapAmountInRoute, tokenIn sdk.Coin) sdk.Coin {
+func (suite *KeeperTestSuite) calcInAmountAsSeparateSwaps(osmoFeeReduced bool, routes []types.SwapAmountInRoute, tokenIn sdk.Coin) sdk.Coin {
 	cacheCtx, _ := suite.Ctx.CacheContext()
 	if osmoFeeReduced {
 		// extract route from swap
@@ -1709,7 +1708,6 @@ func (suite *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 		},
 		"error: duplicate split routes": {
 			routes: []types.SwapAmountInSplitRoute{
-
 				defaultSingleRouteTwoHops,
 				{
 					Pools: defaultSingleRouteTwoHops.Pools,
@@ -1911,7 +1909,6 @@ func (suite *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 
 		"error: duplicate split routes": {
 			routes: []types.SwapAmountOutSplitRoute{
-
 				defaultSingleRouteTwoHops,
 				{
 					Pools: defaultSingleRouteTwoHops.Pools,

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v15/x/protorev/types"
 
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
-	balancertypes "github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v15/x/gamm/pool-models/stableswap"
 
 	osmosisapp "github.com/osmosis-labs/osmosis/v15/app"
@@ -35,7 +34,7 @@ type KeeperTestSuite struct {
 }
 
 type Pool struct {
-	PoolAssets []balancertypes.PoolAsset
+	PoolAssets []balancer.PoolAsset
 	Asset1     string
 	Asset2     string
 	Amount1    sdk.Int
@@ -173,7 +172,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 	// Init pools
 	suite.pools = []Pool{
 		{ // Pool 1
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -188,7 +187,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  1,
 		},
 		{ // Pool 2
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -203,7 +202,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  2,
 		},
 		{ // Pool 3
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -218,7 +217,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  3,
 		},
 		{ // Pool 4
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -233,7 +232,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  4,
 		},
 		{ // Pool 5
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -248,7 +247,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  5,
 		},
 		{ // Pool 6
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -263,7 +262,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  6,
 		},
 		{ // Pool 7
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -278,7 +277,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  7,
 		},
 		{ // Pool 8
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -293,7 +292,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  8,
 		},
 		{ // Pool 9
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -308,7 +307,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  9,
 		},
 		{ // Pool 10
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -323,7 +322,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  10,
 		},
 		{ // Pool 11
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("canto", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -338,7 +337,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  11,
 		},
 		{ // Pool 12
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -353,7 +352,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  12,
 		},
 		{ // Pool 13
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -368,7 +367,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  13,
 		},
 		{ // Pool 14
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -383,7 +382,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  14,
 		},
 		{ // Pool 15
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("akash", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -398,7 +397,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  15,
 		},
 		{ // Pool 16
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -413,7 +412,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  16,
 		},
 		{ // Pool 17
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -428,7 +427,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  17,
 		},
 		{ // Pool 18
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("juno", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -443,7 +442,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  18,
 		},
 		{ // Pool 19
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -458,7 +457,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  19,
 		},
 		{ // Pool 20
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ethereum", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -473,7 +472,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  20,
 		},
 		{ // Pool 21
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("bitcoin", sdk.NewInt(1000)),
 					Weight: sdk.NewInt(1),
@@ -488,7 +487,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  21,
 		},
 		{ // Pool 22
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(18986995439401)),
 					Weight: sdk.NewInt(1),
@@ -503,7 +502,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  22,
 		},
 		{ // Pool 23
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0", sdk.NewInt(72765460013038)),
 					Weight: sdk.NewInt(1),
@@ -518,7 +517,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  23,
 		},
 		{ // Pool 24
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0", sdk.NewInt(165624820984787)),
 					Weight: sdk.NewInt(1),
@@ -533,7 +532,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  24,
 		},
 		{ // Pool 25
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("Atom", sdk.NewInt(165624820984787)),
 					Weight: sdk.NewInt(1),
@@ -548,7 +547,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  25,
 		},
 		{ // Pool 26
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC", sdk.NewInt(13305396712237)),
 					Weight: sdk.NewInt(50),
@@ -563,7 +562,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  26,
 		},
 		{ // Pool 27
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", sdk.NewInt(15766179414665)),
 					Weight: sdk.NewInt(50),
@@ -578,7 +577,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  27,
 		},
 		{ // Pool 28
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE", pool28Amount1),
 					Weight: sdk.NewInt(25),
@@ -601,7 +600,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  28,
 		},
 		{ // Pool 29
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("uosmo", sdk.NewInt(1000000000)),
 					Weight: sdk.NewInt(1),
@@ -616,7 +615,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  29,
 		},
 		{ // Pool 30
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("uosmo", sdk.NewInt(1000000000)),
 					Weight: sdk.NewInt(1),
@@ -631,7 +630,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  30,
 		},
 		{ // Pool 31
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE", pool28Amount1), // Amount didn't change on mainnet
 					Weight: sdk.NewInt(25),
@@ -654,7 +653,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  31,
 		},
 		{ // Pool 32
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293", sdk.NewInt(23583984695)),
 					Weight: sdk.NewInt(70),
@@ -669,7 +668,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  32,
 		},
 		{ // Pool 33
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293", sdk.NewInt(41552173575)),
 					Weight: sdk.NewInt(70),
@@ -684,7 +683,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  33,
 		},
 		{ // Pool 34
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("Atom", sdk.NewInt(364647340206)),
 					Weight: sdk.NewInt(1),
@@ -699,7 +698,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  34,
 		},
 		{ // Pool 35
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("test/1", sdk.NewInt(1026391517901)),
 					Weight: sdk.NewInt(1),
@@ -714,7 +713,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  35,
 		},
 		{ // Pool 36
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(2774812791932)),
 					Weight: sdk.NewInt(1),
@@ -729,7 +728,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  36,
 		},
 		{ // Pool 37
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("Atom", sdk.NewInt(406165719545)),
 					Weight: sdk.NewInt(1),
@@ -744,7 +743,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  37,
 		},
 		{ // Pool 38
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin(types.OsmosisDenomination, sdk.NewInt(6111815027)),
 					Weight: sdk.NewInt(1),
@@ -759,7 +758,7 @@ func (suite *KeeperTestSuite) setUpPools() {
 			PoolId:  38,
 		},
 		{ // Pool 39
-			PoolAssets: []balancertypes.PoolAsset{
+			PoolAssets: []balancer.PoolAsset{
 				{
 					Token:  sdk.NewCoin("test/3", sdk.NewInt(18631000485558)),
 					Weight: sdk.NewInt(1),
@@ -908,8 +907,8 @@ func (suite *KeeperTestSuite) createStableswapPool(initialLiquidity sdk.Coins, p
 }
 
 // createGAMMPool creates a balancer pool with the given pool assets and params
-func (suite *KeeperTestSuite) createGAMMPool(poolAssets []balancertypes.PoolAsset, swapFee, exitFee sdk.Dec) uint64 {
-	poolParams := balancertypes.PoolParams{
+func (suite *KeeperTestSuite) createGAMMPool(poolAssets []balancer.PoolAsset, swapFee, exitFee sdk.Dec) uint64 {
+	poolParams := balancer.PoolParams{
 		SwapFee: swapFee,
 		ExitFee: exitFee,
 	}
@@ -919,7 +918,7 @@ func (suite *KeeperTestSuite) createGAMMPool(poolAssets []balancertypes.PoolAsse
 
 // prepareCustomBalancerPool creates a custom balancer pool with the given pool assets and params
 func (suite *KeeperTestSuite) prepareCustomBalancerPool(
-	poolAssets []balancertypes.PoolAsset,
+	poolAssets []balancer.PoolAsset,
 	poolParams balancer.PoolParams,
 ) uint64 {
 	poolID, err := suite.App.PoolManagerKeeper.CreatePool(


### PR DESCRIPTION
## What is the purpose of the change

This PR eliminates double imports in Osmosis' tests.  It works toward the goal of being able to lint tests by default, and should help with maintenace and upgrades, too. 


## Brief Changelog

* eliminate double imports

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.



## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no: it's not worthy
  - How is the feature or change documented? not applicable