### PR TITLE
use os.ReadFile instead of ioutil.ReadFile

### DIFF
--- a/x/tokenfactory/keeper/before_send_test.go
+++ b/x/tokenfactory/keeper/before_send_test.go
@@ -2,7 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -90,7 +90,7 @@ func (suite *KeeperTestSuite) TestBeforeSendHook() {
 			suite.SetupTest()
 
 			// upload and instantiate wasm code
-			wasmCode, err := ioutil.ReadFile(tc.wasmFile)
+			wasmCode, err := os.ReadFile(tc.wasmFile)
 			suite.Require().NoError(err, "test: %v", tc.desc)
 			codeID, _, err := suite.contractKeeper.Create(suite.Ctx, suite.TestAccs[0], wasmCode, nil)
 			suite.Require().NoError(err, "test: %v", tc.desc)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Remove ioutil because it is deprecated





## Testing and Verifying



## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
