### PR TITLE
fix(x/twap): genesis issue blocking edge net set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * [#4912](https://github.com/osmosis-labs/osmosis/pull/4912) Export Position_lock_id mappings to GenesisState
   * [#4974](https://github.com/osmosis-labs/osmosis/pull/4974) Add lock id to `MsgSuperfluidUndelegateAndUnbondLockResponse`
   * [#2741](https://github.com/osmosis-labs/osmosis/pull/2741) Prevent updating the twap record if `ctx.BlockTime <= record.Time` or `ctx.BlockHeight <= record.Height`. Exception, can update the record created when creating the pool in the same block.
+  * [#5129](https://github.com/osmosis-labs/osmosis/pull/5129) Relax twap record validation in init genesis to allow one of the spot prices to be non-zero when twap error is observed.
   
 ### API breaks
 

--- a/x/twap/types/genesis.go
+++ b/x/twap/types/genesis.go
@@ -54,15 +54,14 @@ func (t TwapRecord) validate() error {
 		return errors.New("twap record time cannot be 0")
 	}
 
-	// if there was an error in this record, the spot prices should be 0.
-	// else, the the spot prices must be positive.
+	// if there was an error in this record, one of the spot prices should be 0.
+	// else, the spot prices must be positive for both spot prices.
 	if t.LastErrorTime.Equal(t.Time) {
-		if t.P0LastSpotPrice.IsNil() || !t.P0LastSpotPrice.IsZero() {
-			return fmt.Errorf("twap record p0 last spot price must be zero due to having an error, was (%s)", t.P0LastSpotPrice)
-		}
+		isP0LastSpotPriseZero := t.P0LastSpotPrice.IsNil() || t.P0LastSpotPrice.IsZero()
+		isP1LastSpotPriseZero := t.P1LastSpotPrice.IsNil() || t.P1LastSpotPrice.IsZero()
 
-		if t.P1LastSpotPrice.IsNil() || !t.P1LastSpotPrice.IsZero() {
-			return fmt.Errorf("twap record p1 last spot price must be zero due to having an error, was (%s)", t.P1LastSpotPrice)
+		if !isP0LastSpotPriseZero && !isP1LastSpotPriseZero {
+			return fmt.Errorf("one of twap record p0 and p1 last spot price must be zero due to having an error, was (%s, %s)", t.P0LastSpotPrice, t.P1LastSpotPrice)
 		}
 	} else {
 		if t.P0LastSpotPrice.IsNil() || !t.P0LastSpotPrice.IsPositive() {

--- a/x/twap/types/genesis_test.go
+++ b/x/twap/types/genesis_test.go
@@ -222,16 +222,38 @@ func TestTWAPRecord_Validate(t *testing.T) {
 
 			expectedErr: true,
 		},
-		"invalid last spot price with error": {
+		"one of the last spot prices is zero when last error time is not nil": {
 			twapRecord: func() TwapRecord {
 				r := baseRecord
 				r.LastErrorTime = r.Time
-				r.P0LastSpotPrice = sdk.NewDec(5) // has to be distinct to be symmetric
-				r.P1LastSpotPrice = sdk.ZeroDec() // need this to be 0, to test the other case on error
+				r.P0LastSpotPrice = sdk.NewDec(5)
+				r.P1LastSpotPrice = sdk.ZeroDec() // note that this one is zero due to spot price error.
 				return r
 			}(),
 
-			expectedErr: true,
+			expectedErr: false, // not expecting an error since one of the spot prices is zero.
+		},
+		"both of the last spot prices are zero when last error time is not nil": {
+			twapRecord: func() TwapRecord {
+				r := baseRecord
+				r.LastErrorTime = r.Time
+				r.P0LastSpotPrice = sdk.ZeroDec() // note that this one is zero due to spot price error.
+				r.P1LastSpotPrice = sdk.ZeroDec() // note that this one is zero due to spot price error.
+				return r
+			}(),
+
+			expectedErr: false, // not expecting an error since both of the spot prices are zero.
+		},
+		"error: both of the last spot prices non-zero when last error time is not nil": {
+			twapRecord: func() TwapRecord {
+				r := baseRecord
+				r.LastErrorTime = r.Time
+				r.P0LastSpotPrice = sdk.NewDec(5)
+				r.P1LastSpotPrice = sdk.NewDecWithPrec(2, 1) // need this to be 0, to test the other case on error
+				return r
+			}(),
+
+			expectedErr: true, // expecting an error since both of the spot prices are non-zero.
 		},
 		"invalid p0 last spot price: nil": {
 			twapRecord: func() TwapRecord {

--- a/x/twap/types/genesis_test.go
+++ b/x/twap/types/genesis_test.go
@@ -249,7 +249,7 @@ func TestTWAPRecord_Validate(t *testing.T) {
 				r := baseRecord
 				r.LastErrorTime = r.Time
 				r.P0LastSpotPrice = sdk.NewDec(5)
-				r.P1LastSpotPrice = sdk.NewDecWithPrec(2, 1) // need this to be 0, to test the other case on error
+				r.P1LastSpotPrice = sdk.NewDecWithPrec(2, 1)
 				return r
 			}(),
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5041

## What is the purpose of the change

More context: https://osmosis-network.slack.com/archives/C027ELA290B/p1682692206195569

Currently, our validation for `TwapRecord`s in `InitGenesis()` is stricter than it should be.

If there is a twap error, it expects both "p0" spot price and "p1" spot price to be zero.

However, that is not the guarantee from the core logic:
https://github.com/osmosis-labs/osmosis/blob/b101d06dc867400e4309877ccf559f09c89edda3/x/twap/logic.go#L53-L64

In the core logic above, if "p0" gets a twap error but "p1" does not, "p0" is set to zero but  "p1" isn't.

Therefore, we should change our init genesis logic to match the core's constraints.

## Brief Changelog

- make the change
- add tests

## Testing and Verifying

- Refactored test cases

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable