### PR TITLE
check github actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/"
   schedule:


### PR DESCRIPTION
## What is the purpose of the change

Dependabot can ensure that github actions aren't out of date.  I noticed several that are, but instead of manually fixing the actions, dependabot will do it faster and more reliably over time. 


## Brief Changelog

* use dependabot to check for updates to `github-actions`


## Testing and Verifying

If change was successful, we should see dependabot make several PR's after this is merged. 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable