### PR TITLE
ci: update rust code with dependabot when there are security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,16 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
   ignore:
     - dependency-name: "github.com/tendermint/tendermint"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
   ignore:
     - dependency-name: "github.com/cosmos/ibc-go"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  allow:
+    - security

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
   open-pull-requests-limit: 10
 - package-ecosystem: cargo
-  directory: "/"
+  directory: "/cosmwasm"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   ignore:
     - dependency-name: "github.com/tendermint/tendermint"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -14,5 +14,5 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
## What is the purpose of the change

This PR changes gomod dependency checking to daily for consistency, and adds cargo to dependabot so that we keep rust code up to date automatically too. 


## Brief Changelog

* change gomod frequency to daily
* check cargo for updates daily


## Testing and Verifying

If PR is successful dependabot will check daily.  Might be an inital burst of cargo package upgrades, but also, that might not happen. 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable