### PR TITLE
osmomath: disable thelper for some helper functions

### DIFF
--- a/osmomath/decimal.go
+++ b/osmomath/decimal.go
@@ -888,12 +888,14 @@ func MaxDec(d1, d2 BigDec) BigDec {
 // DecEq returns true if two given decimals are equal.
 // Intended to be used with require/assert:  require.True(t, DecEq(...))
 func DecEq(t *testing.T, exp, got BigDec) (*testing.T, bool, string, string, string) {
+	t.Helper()
 	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()
 }
 
 // DecApproxEq returns true if the differences between two given decimals are smaller than the tolerance range.
 // Intended to be used with require/assert:  require.True(t, DecEq(...))
 func DecApproxEq(t *testing.T, d1 BigDec, d2 BigDec, tol BigDec) (*testing.T, bool, string, string, string) {
+	t.Helper()
 	diff := d1.Sub(d2).Abs()
 	return t, diff.LTE(tol), "expected |d1 - d2| <:\t%v\ngot |d1 - d2| = \t\t%v", tol.String(), diff.String()
 }

--- a/osmomath/decimal.go
+++ b/osmomath/decimal.go
@@ -887,15 +887,17 @@ func MaxDec(d1, d2 BigDec) BigDec {
 
 // DecEq returns true if two given decimals are equal.
 // Intended to be used with require/assert:  require.True(t, DecEq(...))
+//
+//nolint:thelper
 func DecEq(t *testing.T, exp, got BigDec) (*testing.T, bool, string, string, string) {
-	t.Helper()
 	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()
 }
 
 // DecApproxEq returns true if the differences between two given decimals are smaller than the tolerance range.
 // Intended to be used with require/assert:  require.True(t, DecEq(...))
+//
+//nolint:thelper
 func DecApproxEq(t *testing.T, d1 BigDec, d2 BigDec, tol BigDec) (*testing.T, bool, string, string, string) {
-	t.Helper()
 	diff := d1.Sub(d2).Abs()
 	return t, diff.LTE(tol), "expected |d1 - d2| <:\t%v\ngot |d1 - d2| = \t\t%v", tol.String(), diff.String()
 }

--- a/osmomath/int.go
+++ b/osmomath/int.go
@@ -435,7 +435,8 @@ func (i BigInt) MarshalAmino() ([]byte, error)   { return i.Marshal() }
 func (i *BigInt) UnmarshalAmino(bz []byte) error { return i.Unmarshal(bz) }
 
 // intended to be used with require/assert:  require.True(IntEq(...))
+//
+//nolint:thelper
 func IntEq(t *testing.T, exp, got BigInt) (*testing.T, bool, string, string, string) {
-	t.Helper()
 	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()
 }

--- a/osmomath/int.go
+++ b/osmomath/int.go
@@ -436,5 +436,6 @@ func (i *BigInt) UnmarshalAmino(bz []byte) error { return i.Unmarshal(bz) }
 
 // intended to be used with require/assert:  require.True(IntEq(...))
 func IntEq(t *testing.T, exp, got BigInt) (*testing.T, bool, string, string, string) {
+	t.Helper()
 	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5163 

<del>Marks helper functions in `osmomath` with `t.Helper()`. </del>

Disables thelper warnings for some functions. Reason for not marking those functions with `t.Helper()`: https://github.com/osmosis-labs/osmosis/issues/5163#issuecomment-1545983797