### PR TITLE
fix: add split route message to codec and interface registration

### DIFF
--- a/x/poolmanager/types/codec.go
+++ b/x/poolmanager/types/codec.go
@@ -13,8 +13,8 @@ import (
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgSwapExactAmountIn{}, "osmosis/poolmanager/swap-exact-amount-in", nil)
 	cdc.RegisterConcrete(&MsgSwapExactAmountOut{}, "osmosis/poolmanager/swap-exact-amount-out", nil)
-	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountIn{}, "osmosis/poolmanager/split-route-swap-exact-amount-in", nil)
-	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountOut{}, "osmosis/poolmanager/split-route-swap-exact-amount-out", nil)
+	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountIn{}, "osmosis/poolmanager/swap-split-amount-in", nil)
+	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountOut{}, "osmosis/poolmanager/swap-split-amount-out", nil)
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/poolmanager/types/codec.go
+++ b/x/poolmanager/types/codec.go
@@ -13,6 +13,8 @@ import (
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgSwapExactAmountIn{}, "osmosis/poolmanager/swap-exact-amount-in", nil)
 	cdc.RegisterConcrete(&MsgSwapExactAmountOut{}, "osmosis/poolmanager/swap-exact-amount-out", nil)
+	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountIn{}, "osmosis/poolmanager/split-route-swap-exact-amount-in", nil)
+	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountOut{}, "osmosis/poolmanager/split-route-swap-exact-amount-out", nil)
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {
@@ -20,6 +22,8 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		(*sdk.Msg)(nil),
 		&MsgSwapExactAmountIn{},
 		&MsgSwapExactAmountOut{},
+		&MsgSplitRouteSwapExactAmountIn{},
+		&MsgSplitRouteSwapExactAmountOut{},
 	)
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/poolmanager/types/codec.go
+++ b/x/poolmanager/types/codec.go
@@ -13,8 +13,8 @@ import (
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgSwapExactAmountIn{}, "osmosis/poolmanager/swap-exact-amount-in", nil)
 	cdc.RegisterConcrete(&MsgSwapExactAmountOut{}, "osmosis/poolmanager/swap-exact-amount-out", nil)
-	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountIn{}, "osmosis/poolmanager/swap-split-amount-in", nil)
-	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountOut{}, "osmosis/poolmanager/swap-split-amount-out", nil)
+	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountIn{}, "osmosis/poolmanager/split-amount-in", nil)
+	cdc.RegisterConcrete(&MsgSplitRouteSwapExactAmountOut{}, "osmosis/poolmanager/split-amount-out", nil)
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Missed adding the new messaged to codec and interface registrations. This PR fixes it

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable