### PR TITLE
Speedup accumulator prefix keys

### DIFF
--- a/osmoutils/accum/prefix.go
+++ b/osmoutils/accum/prefix.go
@@ -8,23 +8,16 @@ const (
 	positionPrefix    = "pos"
 )
 
-// formatAccumPrefix returns the key prefix used for any
-// accum module values to be stored in the KVStore.
-// Returns "accum/{key}" as bytes.
-func formatModulePrefixKey(key string) []byte {
-	return []byte(fmt.Sprintf("%s/%s", modulePrefix, key))
-}
-
 // formatAccumPrefix returns the key prefix used
 // specifically for accumulator values in the KVStore.
 // Returns "accum/acc/{name}" as bytes.
 func formatAccumPrefixKey(name string) []byte {
-	return formatModulePrefixKey(fmt.Sprintf("%s/%s", accumulatorPrefix, name))
+	return []byte(fmt.Sprintf(modulePrefix+"/"+accumulatorPrefix+"/%s", name))
 }
 
 // FormatPositionPrefixKey returns the key prefix used
 // specifically for position values in the KVStore.
-// Returns "accum/pos/{accumName}/{name}" as bytes.
+// Returns "accum/acc/pos/{accumName}/{name}" as bytes.
 func FormatPositionPrefixKey(accumName, name string) []byte {
-	return formatAccumPrefixKey(fmt.Sprintf("%s/%s/%s", positionPrefix, accumName, name))
+	return []byte(fmt.Sprintf(modulePrefix+"/"+accumulatorPrefix+"/"+positionPrefix+"/%s/%s", accumName, name))
 }

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -66,7 +66,7 @@ func (ss *SwapState) updateFeeGrowthGlobal(feeChargeTotal sdk.Dec) {
 		// We round down here since we want to avoid overdistributing (the "fee charge" refers to
 		// the total fees that will be accrued to the fee accumulator)
 		feesAccruedPerUnitOfLiquidity := feeChargeTotal.QuoTruncate(ss.liquidity)
-		ss.feeGrowthGlobal = ss.feeGrowthGlobal.Add(feesAccruedPerUnitOfLiquidity)
+		ss.feeGrowthGlobal.AddMut(feesAccruedPerUnitOfLiquidity)
 		return
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

We were spending a lot of time in accumulator key formatting, for basically doing sprintf's with constants. This PR fixes that.

It also highlights a bug in the docs before (that ideally should get fixed prelaunch)

Also converts one `Add` to an `AddMut`

## Testing and Verifying

This change is already covered by existing tests, such as *(please describe tests)*.

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A