### PR TITLE
refactor: more discriptive error when no liquidity in swaps

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -259,6 +259,15 @@ func (k Keeper) computeOutAmtGivenIn(
 	if err != nil {
 		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 	}
+
+	hasPositionInPool, err := k.HasAnyPositionForPool(ctx, poolId)
+	if err != nil {
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
+	}
+	if !hasPositionInPool {
+		return sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
+	}
+
 	asset0 := p.GetToken0()
 	asset1 := p.GetToken1()
 	tokenAmountInSpecified := tokenInMin.Amount.ToDec()
@@ -429,6 +438,15 @@ func (k Keeper) calcInAmtGivenOut(
 	if err != nil {
 		return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
 	}
+
+	hasPositionInPool, err := k.HasAnyPositionForPool(ctx, poolId)
+	if err != nil {
+		return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, err
+	}
+	if !hasPositionInPool {
+		return writeCtx, sdk.Coin{}, sdk.Coin{}, sdk.Int{}, sdk.Dec{}, sdk.Dec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
+	}
+
 	asset0 := p.GetToken0()
 	asset1 := p.GetToken1()
 

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -1602,6 +1602,38 @@ func (s *KeeperTestSuite) TestComputeAndSwapOutAmtGivenIn() {
 	}
 }
 
+func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_NoPositions() {
+	s.SetupTest()
+
+	pool := s.PrepareConcentratedPool()
+
+	// perform swap
+	_, _, _, _, _, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
+		s.Ctx, s.TestAccs[0], pool,
+		DefaultCoin0, DefaultCoin1.Denom,
+		sdk.ZeroDec(), sdk.ZeroDec(),
+	)
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, types.NoSpotPriceWhenNoLiquidityError{PoolId: pool.GetId()})
+}
+
+func (s *KeeperTestSuite) TestSwapInAmtGivenOut_NoPositions() {
+	s.SetupTest()
+
+	pool := s.PrepareConcentratedPool()
+
+	// perform swap
+	_, _, _, _, _, err := s.App.ConcentratedLiquidityKeeper.SwapInAmtGivenOut(
+		s.Ctx, s.TestAccs[0], pool,
+		DefaultCoin0, DefaultCoin1.Denom,
+		sdk.ZeroDec(), sdk.ZeroDec(),
+	)
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, types.NoSpotPriceWhenNoLiquidityError{PoolId: pool.GetId()})
+}
+
 func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 	tests := make(map[string]SwapTest)
 	for name, test := range swapOutGivenInCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR adds a more explicit check and a more descriptive error in swaps when there are no positions created.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A