### PR TITLE
chore: skip wasm tests in wsl and add a vs code task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,16 @@
             "label": "e2e-setup",
             "type": "shell",
             "command": "make e2e-setup"
+        },
+        {
+            "label": "test-unit",
+            "type": "shell",
+            "command": "make test-unit",
+            "problemMatcher": [],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -3,6 +3,7 @@ package apptesting
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -386,6 +387,22 @@ func (s *KeeperTestHelper) StateNotAltered() {
 	s.App.Commit()
 	newState := s.App.ExportState(s.Ctx)
 	s.Require().Equal(oldState, newState)
+}
+
+func (s *KeeperTestHelper) SkipIfWSL() {
+	SkipIfWSL(s.T())
+}
+
+// SkipIfWSL skips tests if running on WSL
+// This is a workaround to enable quickly running full unit test suite locally
+// on WSL without failures. The failures are stemming from trying to upload
+// wasm code. An OS permissioning issue.
+func SkipIfWSL(t *testing.T) {
+	skip := os.Getenv("SKIP_WASM_WSL_TESTS")
+	fmt.Println("SKIP_WASM_WSL_TESTS", skip)
+	if skip == "true" {
+		t.Skip("Skipping Wasm tests")
+	}
 }
 
 // CreateRandomAccounts is a function return a list of randomly generated AccAddresses

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -398,6 +398,7 @@ func (s *KeeperTestHelper) SkipIfWSL() {
 // on WSL without failures. The failures are stemming from trying to upload
 // wasm code. An OS permissioning issue.
 func SkipIfWSL(t *testing.T) {
+	t.Helper()
 	skip := os.Getenv("SKIP_WASM_WSL_TESTS")
 	fmt.Println("SKIP_WASM_WSL_TESTS", skip)
 	if skip == "true" {

--- a/app/upgrades/v13/upgrade_test.go
+++ b/app/upgrades/v13/upgrade_test.go
@@ -46,6 +46,7 @@ func dummyUpgrade(suite *UpgradeTestSuite) {
 }
 
 func (suite *UpgradeTestSuite) TestUpgrade() {
+	suite.SkipIfWSL()
 	testCases := []struct {
 		name         string
 		pre_upgrade  func()

--- a/app/upgrades/v15/upgrade_test.go
+++ b/app/upgrades/v15/upgrade_test.go
@@ -37,6 +37,7 @@ var DefaultAcctFunds sdk.Coins = sdk.NewCoins(
 
 func (suite *UpgradeTestSuite) SetupTest() {
 	suite.Setup()
+	suite.SkipIfWSL()
 }
 
 func TestUpgradeTestSuite(t *testing.T) {

--- a/tests/ibc-hooks/ibc_middleware_test.go
+++ b/tests/ibc-hooks/ibc_middleware_test.go
@@ -67,6 +67,7 @@ func TestIBCHooksTestSuite(t *testing.T) {
 }
 
 func (suite *HooksTestSuite) SetupTest() {
+	suite.SkipIfWSL()
 	// TODO: This needs to get removed. Waiting on https://github.com/cosmos/ibc-go/issues/3123
 	txfeetypes.ConsensusMinFee = sdk.ZeroDec()
 	suite.Setup()

--- a/wasmbinding/test/custom_msg_test.go
+++ b/wasmbinding/test/custom_msg_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/x/tokenfactory/types"
 
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,7 @@ import (
 )
 
 func TestCreateDenomMsg(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	creator := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, creator)
 
@@ -49,6 +51,7 @@ func TestCreateDenomMsg(t *testing.T) {
 }
 
 func TestMintMsg(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	creator := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, creator)
 
@@ -177,6 +180,7 @@ func TestMintMsg(t *testing.T) {
 }
 
 func TestBurnMsg(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	creator := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, creator)
 

--- a/wasmbinding/test/custom_query_test.go
+++ b/wasmbinding/test/custom_query_test.go
@@ -16,6 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v15/app"
+	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/wasmbinding/bindings"
 )
 
@@ -34,6 +35,7 @@ func SetupCustomApp(t *testing.T, addr sdk.AccAddress) (*app.OsmosisApp, sdk.Con
 }
 
 func TestQueryFullDenom(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	actor := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, actor)
 

--- a/wasmbinding/test/messages_test.go
+++ b/wasmbinding/test/messages_test.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/wasmbinding"
 	"github.com/osmosis-labs/osmosis/v15/wasmbinding/bindings"
 	"github.com/osmosis-labs/osmosis/v15/x/tokenfactory/types"
@@ -14,6 +15,7 @@ import (
 )
 
 func TestCreateDenom(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	actor := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, actor)
 
@@ -62,6 +64,7 @@ func TestCreateDenom(t *testing.T) {
 }
 
 func TestChangeAdmin(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	const validDenom = "validdenom"
 
 	tokenCreator := RandomAccountAddress()
@@ -166,6 +169,7 @@ func TestChangeAdmin(t *testing.T) {
 }
 
 func TestMint(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	creator := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, creator)
 
@@ -285,6 +289,7 @@ func TestMint(t *testing.T) {
 }
 
 func TestBurn(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	creator := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, creator)
 

--- a/wasmbinding/test/queries_test.go
+++ b/wasmbinding/test/queries_test.go
@@ -9,6 +9,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v15/wasmbinding"
 )
 
@@ -63,6 +64,7 @@ func TestFullDenom(t *testing.T) {
 }
 
 func TestDenomAdmin(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	addr := RandomAccountAddress()
 	app, ctx := SetupCustomApp(t, addr)
 

--- a/wasmbinding/test/store_run_test.go
+++ b/wasmbinding/test/store_run_test.go
@@ -15,6 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v15/app"
+	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
 )
 
 func TestNoStorageWithoutProposal(t *testing.T) {
@@ -58,6 +59,7 @@ func storeCodeViaProposal(t *testing.T, ctx sdk.Context, osmosis *app.OsmosisApp
 }
 
 func TestStoreCodeProposal(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	osmosis, ctx := CreateTestInput()
 	myActorAddress := RandomAccountAddress()
 	wasmKeeper := osmosis.WasmKeeper
@@ -83,6 +85,7 @@ type HackatomExampleInitMsg struct {
 }
 
 func TestInstantiateContract(t *testing.T) {
+	apptesting.SkipIfWSL(t)
 	osmosis, ctx := CreateTestInput()
 	funder := RandomAccountAddress()
 	benefit, arb := RandomAccountAddress(), RandomAccountAddress()

--- a/x/ibc-rate-limit/ibc_middleware_test.go
+++ b/x/ibc-rate-limit/ibc_middleware_test.go
@@ -50,6 +50,7 @@ func NewTransferPath(chainA, chainB *osmosisibctesting.TestChain) *ibctesting.Pa
 }
 
 func (suite *MiddlewareTestSuite) SetupTest() {
+	suite.SkipIfWSL()
 	// TODO: This needs to get removed. Waiting on https://github.com/cosmos/ibc-go/issues/3123
 	txfeetypes.ConsensusMinFee = sdk.ZeroDec()
 	suite.Setup()

--- a/x/tokenfactory/keeper/before_send_test.go
+++ b/x/tokenfactory/keeper/before_send_test.go
@@ -18,6 +18,7 @@ type SendMsgTestCase struct {
 }
 
 func (suite *KeeperTestSuite) TestBeforeSendHook() {
+	suite.SkipIfWSL()
 	for _, tc := range []struct {
 		desc     string
 		wasmFile string


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR fixes a lot of local environment pains for me on WSL.

In particular, I cannot run WASM related tests with `make test-unit `due to some permissioning issue.

This is the best solution I've found after countless hours of debugging.

In particular, it detects if the system is a WSL, and then sets `SKIP_WASM_WSL_TESTS` environment variable to true. Next, the Go tests read that environment variable and skip the problematic tests.

I also added a task so that I can set up some key bindings for running unit tests.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A