### PR TITLE
chore: update golanci-lint settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
   "tabnine.experimentalAutoImports": true,
   "go.lintTool": "golangci-lint",
+  "go.lintFlags": [
+    "--fast"
+  ],
   "go.formatTool": "goimports",
   "go.useLanguageServer": true,
   "[go.mod]": {


### PR DESCRIPTION
## What is the purpose of the change

Just following the guidelines here:

* https://golangci-lint.run/usage/integrations/

This should make it easier to work with golangci-lint in vscode. 

## Testing and Verifying

If your editor is faster, then this PR is doing its job




Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A