### PR TITLE
perf: attempt to improve performance by changing key format

### DIFF
--- a/THIS IS OFF CURRENT STATE OF THE BRANCH.md
+++ b/THIS IS OFF CURRENT STATE OF THE BRANCH.md
@@ -1,0 +1,14 @@
+THIS IS OFF CURRENT STATE OF THE BRANCH
+
+goarch: amd64
+pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity
+cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+BenchmarkSwapExactAmountIn
+BenchmarkSwapExactAmountIn-16                  6         255102230 ns/op
+BenchmarkSwapExactAmountIn-16                  6         197323240 ns/op
+BenchmarkSwapExactAmountIn-16                  4         258636366 ns/op
+BenchmarkSwapExactAmountIn-16                  2         521323463 ns/op
+BenchmarkSwapExactAmountIn-16                  4         256078211 ns/op
+BenchmarkSwapExactAmountIn-16                  6         227594041 ns/op
+PASS
+ok      github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity    827.417s

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -220,9 +219,7 @@ func BenchmarkSwapExactAmountIn(b *testing.B) {
 		fmt.Println("num_ticks_traversed", len(liquidityNet))
 		fmt.Println("current_tick", currentTick)
 
-		// Increase block time so that some incentives uptime accumulator update logic
-		// isn't a no-op.
-		s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(time.Second))
+		s.Commit()
 
 		// Fund swap amount.
 		simapp.FundAccount(s.App.BankKeeper, s.Ctx, s.TestAccs[0], sdk.NewCoins(largeSwapInCoin))

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -464,7 +464,7 @@ func (k Keeper) setIncentiveRecord(ctx sdk.Context, incentiveRecord types.Incent
 		return err
 	}
 
-	key := types.KeyIncentiveRecord(incentiveRecord.PoolId, uptimeIndex, incentiveRecord.IncentiveDenom, incentiveCreator)
+	key := types.KeyIncentiveRecord(incentiveRecord.PoolId, uint64(uptimeIndex), incentiveRecord.IncentiveDenom, incentiveCreator)
 	incentiveRecordBody := types.IncentiveRecordBody{
 		RemainingAmount: incentiveRecord.IncentiveRecordBody.RemainingAmount,
 		EmissionRate:    incentiveRecord.IncentiveRecordBody.EmissionRate,
@@ -504,7 +504,7 @@ func (k Keeper) GetIncentiveRecord(ctx sdk.Context, poolId uint64, denom string,
 		return types.IncentiveRecord{}, err
 	}
 
-	key := types.KeyIncentiveRecord(poolId, uptimeIndex, denom, incentiveCreator)
+	key := types.KeyIncentiveRecord(poolId, uint64(uptimeIndex), denom, incentiveCreator)
 
 	found, err := osmoutils.Get(store, key, &incentiveBodyStruct)
 	if err != nil {
@@ -544,7 +544,7 @@ func (k Keeper) getAllIncentiveRecordsForUptime(ctx sdk.Context, poolId uint64, 
 		return []types.IncentiveRecord{}, err
 	}
 
-	return osmoutils.GatherValuesFromStorePrefixWithKeyParser(ctx.KVStore(k.storeKey), types.KeyUptimeIncentiveRecords(poolId, uptimeIndex), ParseFullIncentiveRecordFromBz)
+	return osmoutils.GatherValuesFromStorePrefixWithKeyParser(ctx.KVStore(k.storeKey), types.KeyUptimeIncentiveRecords(poolId, uint64(uptimeIndex)), ParseFullIncentiveRecordFromBz)
 }
 
 // GetUptimeGrowthInsideRange returns the uptime growth within the given tick range for all supported uptimes.

--- a/x/concentrated-liquidity/store.go
+++ b/x/concentrated-liquidity/store.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -174,12 +173,9 @@ func ParseFullIncentiveRecordFromBz(key []byte, value []byte) (incentiveRecord t
 		return types.IncentiveRecord{}, fmt.Errorf("Wrong incentive prefix, got: %v, required %v", []byte(incentivePrefix), types.IncentivePrefix)
 	}
 
-	poolId, err := strconv.ParseUint(relevantIncentiveKeyComponents[0], 10, 64)
-	if err != nil {
-		return types.IncentiveRecord{}, err
-	}
+	poolId := sdk.BigEndianToUint64([]byte(relevantIncentiveKeyComponents[0]))
 
-	minUptimeIndex, err := strconv.ParseUint(relevantIncentiveKeyComponents[1], 10, 64)
+	minUptimeIndex := sdk.BigEndianToUint64([]byte(relevantIncentiveKeyComponents[1]))
 	if err != nil {
 		return types.IncentiveRecord{}, err
 	}

--- a/x/concentrated-liquidity/store.go
+++ b/x/concentrated-liquidity/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -173,9 +174,12 @@ func ParseFullIncentiveRecordFromBz(key []byte, value []byte) (incentiveRecord t
 		return types.IncentiveRecord{}, fmt.Errorf("Wrong incentive prefix, got: %v, required %v", []byte(incentivePrefix), types.IncentivePrefix)
 	}
 
-	poolId := sdk.BigEndianToUint64([]byte(relevantIncentiveKeyComponents[0]))
+	poolId, err := strconv.ParseUint(relevantIncentiveKeyComponents[0], 10, 64)
+	if err != nil {
+		return types.IncentiveRecord{}, err
+	}
 
-	minUptimeIndex := sdk.BigEndianToUint64([]byte(relevantIncentiveKeyComponents[1]))
+	minUptimeIndex, err := strconv.ParseUint(relevantIncentiveKeyComponents[1], 10, 64)
 	if err != nil {
 		return types.IncentiveRecord{}, err
 	}

--- a/x/concentrated-liquidity/store_test.go
+++ b/x/concentrated-liquidity/store_test.go
@@ -159,7 +159,7 @@ func (s *KeeperTestSuite) TestParseIncentiveRecordFromBytes_KeySeparatorInAddres
 	uptimeIndex, err := cl.FindUptimeIndex(expectedIncentiveRecord.MinUptime)
 	s.Require().NoError(err)
 
-	incentiveRecordKey := types.KeyIncentiveRecord(expectedIncentiveRecord.PoolId, uptimeIndex, expectedIncentiveRecord.IncentiveDenom, s.TestAccs[0])
+	incentiveRecordKey := types.KeyIncentiveRecord(expectedIncentiveRecord.PoolId, uint64(uptimeIndex), expectedIncentiveRecord.IncentiveDenom, s.TestAccs[0])
 
 	// System under test with basic valid record.
 	record, err := cl.ParseFullIncentiveRecordFromBz(incentiveRecordKey, validValueBz)
@@ -172,7 +172,7 @@ func (s *KeeperTestSuite) TestParseIncentiveRecordFromBytes_KeySeparatorInAddres
 	keySeparatorAddress := sdk.AccAddress(addrStr)
 
 	expectedIncentiveRecord.IncentiveCreatorAddr = keySeparatorAddress.String()
-	incentiveRecordKey = types.KeyIncentiveRecord(expectedIncentiveRecord.PoolId, uptimeIndex, expectedIncentiveRecord.IncentiveDenom, keySeparatorAddress)
+	incentiveRecordKey = types.KeyIncentiveRecord(expectedIncentiveRecord.PoolId, uint64(uptimeIndex), expectedIncentiveRecord.IncentiveDenom, keySeparatorAddress)
 
 	// System under test with address containing a key separator.
 	record, err = cl.ParseFullIncentiveRecordFromBz(incentiveRecordKey, validValueBz)

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -152,7 +152,7 @@ func KeyPoolIdForLiquidity(poolId uint64) []byte {
 // PositionId Prefix Keys
 
 func KeyPositionId(positionId uint64) []byte {
-	positionIDBytes := sdk.Uint64ToBigEndian(positionId)
+	positionIDBytes := []byte(fmt.Sprintf("%d", positionId))
 
 	keyLen := len(PositionIdPrefix) + len(KeySeparator) + len(positionIDBytes)
 	key := make([]byte, 0, keyLen)
@@ -204,7 +204,7 @@ func KeyPoolPosition(poolId uint64) []byte {
 // Used to map a pool id to a pool struct
 
 func KeyPool(poolId uint64) []byte {
-	poolIDBytes := sdk.Uint64ToBigEndian(poolId)
+	poolIDBytes := []byte(fmt.Sprintf("%d", poolId))
 
 	keyLen := len(PoolPrefix) + len(poolIDBytes)
 	key := make([]byte, 0, keyLen)
@@ -218,17 +218,19 @@ func KeyPool(poolId uint64) []byte {
 // Incentive Prefix Keys
 
 func KeyIncentiveRecord(poolId uint64, minUptimeIndex uint64, denom string, addr sdk.AccAddress) []byte {
+	poolIDBytes := []byte(strconv.FormatUint(poolId, uintBase))
+	minUptimeIndexBytes := []byte(strconv.FormatUint(minUptimeIndex, uintBase))
 
-	keyLen := len(IncentivePrefix) + len(KeySeparator) + uint64ByteSize + len(KeySeparator) +
-		uint64ByteSize + len(KeySeparator) + len(denom) + len(KeySeparator) + len(addr.Bytes())
+	keyLen := len(IncentivePrefix) + len(KeySeparator) + len(poolIDBytes) + len(KeySeparator) +
+		len(minUptimeIndexBytes) + len(KeySeparator) + len(denom) + len(KeySeparator) + len(addr.Bytes())
 
 	key := make([]byte, 0, keyLen)
 
 	key = append(key, IncentivePrefix...)
 	key = append(key, KeySeparator...)
-	key = append(key, sdk.Uint64ToBigEndian(poolId)...)
+	key = append(key, poolIDBytes...)
 	key = append(key, KeySeparator...)
-	key = append(key, sdk.Uint64ToBigEndian(minUptimeIndex)...)
+	key = append(key, minUptimeIndexBytes...)
 	key = append(key, KeySeparator...)
 	key = append(key, denom...)
 	key = append(key, KeySeparator...)
@@ -242,8 +244,8 @@ func KeyIncentiveRecord(poolId uint64, minUptimeIndex uint64, denom string, addr
 }
 
 func KeyUptimeIncentiveRecords(poolId uint64, minUptimeIndex uint64) []byte {
-	poolIDBytes := sdk.Uint64ToBigEndian(poolId)
-	minUptimeIndexBytes := sdk.Uint64ToBigEndian(minUptimeIndex)
+	poolIDBytes := []byte(strconv.FormatUint(poolId, uintBase))
+	minUptimeIndexBytes := []byte(strconv.FormatUint(minUptimeIndex, uintBase))
 
 	keyLen := len(IncentivePrefix) + len(KeySeparator) + len(poolIDBytes) + len(KeySeparator) + len(minUptimeIndexBytes)
 	key := make([]byte, 0, keyLen)
@@ -258,7 +260,7 @@ func KeyUptimeIncentiveRecords(poolId uint64, minUptimeIndex uint64) []byte {
 }
 
 func KeyPoolIncentiveRecords(poolId uint64) []byte {
-	poolIDBytes := sdk.Uint64ToBigEndian(poolId)
+	poolIDBytes := strconv.FormatUint(poolId, uintBase)
 
 	keyLen := len(IncentivePrefix) + len(KeySeparator) + len(poolIDBytes)
 	key := make([]byte, 0, keyLen)
@@ -292,9 +294,9 @@ func KeyUptimeAccumulator(poolId uint64, uptimeIndex uint64) string {
 // Balancer Full Range Prefix Keys
 
 func KeyBalancerFullRange(clPoolId, balancerPoolId, uptimeIndex uint64) []byte {
-	clPoolIDBytes := sdk.Uint64ToBigEndian(clPoolId)
-	balancerPoolIDBytes := sdk.Uint64ToBigEndian(balancerPoolId)
-	uptimeIndexBytes := sdk.Uint64ToBigEndian(uptimeIndex)
+	clPoolIDBytes := []byte(strconv.FormatUint(clPoolId, uintBase))
+	balancerPoolIDBytes := []byte(strconv.FormatUint(balancerPoolId, uintBase))
+	uptimeIndexBytes := []byte(strconv.FormatUint(uptimeIndex, uintBase))
 
 	keyLen := len(BalancerFullRangePrefix) + len(KeySeparator) + len(clPoolIDBytes) + len(KeySeparator) +
 		len(balancerPoolIDBytes) + len(KeySeparator) + len(uptimeIndexBytes)

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -152,7 +152,16 @@ func KeyPoolIdForLiquidity(poolId uint64) []byte {
 // PositionId Prefix Keys
 
 func KeyPositionId(positionId uint64) []byte {
-	return []byte(fmt.Sprintf("%s%s%d", PositionIdPrefix, KeySeparator, positionId))
+	positionIDBytes := sdk.Uint64ToBigEndian(positionId)
+
+	keyLen := len(PositionIdPrefix) + len(KeySeparator) + len(positionIDBytes)
+	key := make([]byte, 0, keyLen)
+
+	key = append(key, PositionIdPrefix...)
+	key = append(key, KeySeparator...)
+	key = append(key, positionIDBytes...)
+
+	return key
 }
 
 // Position Prefix Keys
@@ -195,21 +204,70 @@ func KeyPoolPosition(poolId uint64) []byte {
 // Used to map a pool id to a pool struct
 
 func KeyPool(poolId uint64) []byte {
-	return []byte(fmt.Sprintf("%s%d", PoolPrefix, poolId))
+	poolIDBytes := sdk.Uint64ToBigEndian(poolId)
+
+	keyLen := len(PoolPrefix) + len(poolIDBytes)
+	key := make([]byte, 0, keyLen)
+
+	key = append(key, PoolPrefix...)
+	key = append(key, poolIDBytes...)
+
+	return key
 }
 
 // Incentive Prefix Keys
 
-func KeyIncentiveRecord(poolId uint64, minUptimeIndex int, denom string, addr sdk.AccAddress) []byte {
-	return []byte(fmt.Sprintf("%s%s%d%s%d%s%s%s%s", IncentivePrefix, KeySeparator, poolId, KeySeparator, minUptimeIndex, KeySeparator, denom, KeySeparator, addr))
+func KeyIncentiveRecord(poolId uint64, minUptimeIndex uint64, denom string, addr sdk.AccAddress) []byte {
+
+	keyLen := len(IncentivePrefix) + len(KeySeparator) + uint64ByteSize + len(KeySeparator) +
+		uint64ByteSize + len(KeySeparator) + len(denom) + len(KeySeparator) + len(addr.Bytes())
+
+	key := make([]byte, 0, keyLen)
+
+	key = append(key, IncentivePrefix...)
+	key = append(key, KeySeparator...)
+	key = append(key, sdk.Uint64ToBigEndian(poolId)...)
+	key = append(key, KeySeparator...)
+	key = append(key, sdk.Uint64ToBigEndian(minUptimeIndex)...)
+	key = append(key, KeySeparator...)
+	key = append(key, denom...)
+	key = append(key, KeySeparator...)
+	// Note that the address below must be bech32 encoded
+	// This is because we split the key on KeySeparator
+	// Therefore, the address must not contain any KeySeparator which may happen with raw bytes
+	// This is not an issue with bech32 encoded addresses
+	key = append(key, []byte(addr.String())...)
+
+	return key
 }
 
-func KeyUptimeIncentiveRecords(poolId uint64, minUptimeIndex int) []byte {
-	return []byte(fmt.Sprintf("%s%s%d%s%d", IncentivePrefix, KeySeparator, poolId, KeySeparator, minUptimeIndex))
+func KeyUptimeIncentiveRecords(poolId uint64, minUptimeIndex uint64) []byte {
+	poolIDBytes := sdk.Uint64ToBigEndian(poolId)
+	minUptimeIndexBytes := sdk.Uint64ToBigEndian(minUptimeIndex)
+
+	keyLen := len(IncentivePrefix) + len(KeySeparator) + len(poolIDBytes) + len(KeySeparator) + len(minUptimeIndexBytes)
+	key := make([]byte, 0, keyLen)
+
+	key = append(key, IncentivePrefix...)
+	key = append(key, KeySeparator...)
+	key = append(key, poolIDBytes...)
+	key = append(key, KeySeparator...)
+	key = append(key, minUptimeIndexBytes...)
+
+	return key
 }
 
 func KeyPoolIncentiveRecords(poolId uint64) []byte {
-	return []byte(fmt.Sprintf("%s%s%d", IncentivePrefix, KeySeparator, poolId))
+	poolIDBytes := sdk.Uint64ToBigEndian(poolId)
+
+	keyLen := len(IncentivePrefix) + len(KeySeparator) + len(poolIDBytes)
+	key := make([]byte, 0, keyLen)
+
+	key = append(key, IncentivePrefix...)
+	key = append(key, KeySeparator...)
+	key = append(key, poolIDBytes...)
+
+	return key
 }
 
 // Fee Accumulator Prefix Keys
@@ -234,7 +292,23 @@ func KeyUptimeAccumulator(poolId uint64, uptimeIndex uint64) string {
 // Balancer Full Range Prefix Keys
 
 func KeyBalancerFullRange(clPoolId, balancerPoolId, uptimeIndex uint64) []byte {
-	return []byte(fmt.Sprintf("%s%s%d%s%d%s%d", BalancerFullRangePrefix, KeySeparator, clPoolId, KeySeparator, balancerPoolId, KeySeparator, uptimeIndex))
+	clPoolIDBytes := sdk.Uint64ToBigEndian(clPoolId)
+	balancerPoolIDBytes := sdk.Uint64ToBigEndian(balancerPoolId)
+	uptimeIndexBytes := sdk.Uint64ToBigEndian(uptimeIndex)
+
+	keyLen := len(BalancerFullRangePrefix) + len(KeySeparator) + len(clPoolIDBytes) + len(KeySeparator) +
+		len(balancerPoolIDBytes) + len(KeySeparator) + len(uptimeIndexBytes)
+	key := make([]byte, 0, keyLen)
+
+	key = append(key, BalancerFullRangePrefix...)
+	key = append(key, KeySeparator...)
+	key = append(key, clPoolIDBytes...)
+	key = append(key, KeySeparator...)
+	key = append(key, balancerPoolIDBytes...)
+	key = append(key, KeySeparator...)
+	key = append(key, uptimeIndexBytes...)
+
+	return key
 }
 
 // Helper Functions

--- a/x/pool-incentives/keeper/new.md
+++ b/x/pool-incentives/keeper/new.md
@@ -1,3 +1,5 @@
+THIS COMMIT: https://github.com/osmosis-labs/osmosis/pull/5228/commits/d89f8a7b187d66b32faecc34b7491c22969e17c5
+
 goos: linux
 goarch: amd64
 pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity

--- a/x/pool-incentives/keeper/new.md
+++ b/x/pool-incentives/keeper/new.md
@@ -1,0 +1,13 @@
+goos: linux
+goarch: amd64
+pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity
+cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+BenchmarkSwapExactAmountIn
+BenchmarkSwapExactAmountIn-16                  6         191842192 ns/op
+BenchmarkSwapExactAmountIn-16                  6         282940712 ns/op
+BenchmarkSwapExactAmountIn-16                  6         269994618 ns/op
+BenchmarkSwapExactAmountIn-16                  5         241198203 ns/op
+BenchmarkSwapExactAmountIn-16                  6         243370440 ns/op
+BenchmarkSwapExactAmountIn-16                  6         227268896 ns/op
+PASS
+ok      github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity    924.335s

--- a/x/pool-incentives/keeper/old.md
+++ b/x/pool-incentives/keeper/old.md
@@ -1,0 +1,13 @@
+goos: linux
+goarch: amd64
+pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity
+cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+BenchmarkSwapExactAmountIn
+BenchmarkSwapExactAmountIn-16                  6         310885596 ns/op
+BenchmarkSwapExactAmountIn-16                  6         193795403 ns/op
+BenchmarkSwapExactAmountIn-16                  4         272161266 ns/op
+BenchmarkSwapExactAmountIn-16                  6         208444943 ns/op
+BenchmarkSwapExactAmountIn-16                  6         202968213 ns/op
+BenchmarkSwapExactAmountIn-16                  6         209992346 ns/op
+PASS
+ok      github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity    750.992s

--- a/x/pool-incentives/keeper/old.md
+++ b/x/pool-incentives/keeper/old.md
@@ -1,3 +1,5 @@
+THIS IS OFF OF MAIN BRANCH
+
 goos: linux
 goarch: amd64
 pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

I assumed that changing the key format would improve performance. However, according to the benchmark, it doesn't. Leaving it in case someone has insight. I suspect the reason might be that `sdk.Uint64ToBigEndian` requires more bytes.

Instead of chasing this, I will move on to the next potential improvement

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A