### PR TITLE
[x/pool-incentives][tests]: Add tests for external gauge query

### DIFF
--- a/x/pool-incentives/keeper/grpc_query.go
+++ b/x/pool-incentives/keeper/grpc_query.go
@@ -80,7 +80,7 @@ func (q Querier) LockableDurations(ctx context.Context, _ *types.QueryLockableDu
 	return &types.QueryLockableDurationsResponse{LockableDurations: q.Keeper.GetLockableDurations(sdkCtx)}, nil
 }
 
-// IncentivizedPools iterates over all gauges, returns default gauges created with pool.
+// IncentivizedPools iterates over all internally incentivized gauges and returns their corresponding pools.
 func (q Querier) IncentivizedPools(ctx context.Context, _ *types.QueryIncentivizedPoolsRequest) (*types.QueryIncentivizedPoolsResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
@@ -128,8 +128,7 @@ func (q Querier) IncentivizedPools(ctx context.Context, _ *types.QueryIncentiviz
 	}, nil
 }
 
-// ExternalIncentiveGauges iterates over all gauges, returns gauges externally
-// incentivized, excluding default gauges created with pool.
+// ExternalIncentiveGauges iterates over all gauges and returns gauges externally incentivized by excluding default (internal) gauges.
 func (q Querier) ExternalIncentiveGauges(ctx context.Context, req *types.QueryExternalIncentiveGaugesRequest) (*types.QueryExternalIncentiveGaugesResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")

--- a/x/pool-incentives/keeper/grpc_query_test.go
+++ b/x/pool-incentives/keeper/grpc_query_test.go
@@ -278,8 +278,7 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 		isPerpetual bool
 	}
 
-	for _, tc := range []struct {
-		desc                 string
+	tests := map[string]struct {
 		poolCreated          bool
 		internalGaugeWeights []sdk.Int
 		externalGauges       []externalGauge
@@ -289,22 +288,19 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 		expectedNumExternalGauges int
 		expectedGaugeIDs          []uint64
 	}{
-		{
-			desc:                 "No pool exist",
+		"No pool exist": {
 			poolCreated:          false,
 			internalGaugeWeights: []sdk.Int{},
 
 			expectedNumExternalGauges: 0,
 		},
-		{
-			desc:                 "All gauges are internal (no external gauges)",
+		"All gauges are internal (no external gauges)": {
 			poolCreated:          true,
 			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
 
 			expectedNumExternalGauges: 0,
 		},
-		{
-			desc:                 "Mixed internal and external gauges",
+		"Mixed internal and external gauges": {
 			poolCreated:          true,
 			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
 			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}},
@@ -313,8 +309,7 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 			expectedGaugeIDs:          []uint64{4, 5},
 			expectedNumExternalGauges: 2,
 		},
-		{
-			desc:                 "More external gauges than internal gauges",
+		"More external gauges than internal gauges": {
 			poolCreated:          true,
 			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
 			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}, {isPerpetual: true}, {isPerpetual: true}, {isPerpetual: false}},
@@ -323,8 +318,7 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 			expectedGaugeIDs:          []uint64{4, 5, 6, 7, 8},
 			expectedNumExternalGauges: 5,
 		},
-		{
-			desc:                 "Same number of external gauges as internal gauges",
+		"Same number of external gauges as internal gauges": {
 			poolCreated:          true,
 			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
 			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}, {isPerpetual: true}},
@@ -333,8 +327,7 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 			expectedGaugeIDs:          []uint64{4, 5, 6},
 			expectedNumExternalGauges: 3,
 		},
-		{
-			desc:                 "Internal gauge for concentrated pool exists",
+		"Internal gauge for concentrated pool exists": {
 			poolCreated:          true,
 			clPoolWithGauge:      true,
 			clGaugeWeight:        sdk.NewInt(100),
@@ -346,9 +339,9 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 			expectedGaugeIDs:          []uint64{5, 6, 7, 8, 9},
 			expectedNumExternalGauges: 5,
 		},
-	} {
-		tc := tc
-		s.Run(tc.desc, func() {
+	}
+	for name, tc := range tests {
+		s.Run(name, func() {
 			s.SetupTest()
 			keeper := s.App.PoolIncentivesKeeper
 			queryClient := s.queryClient

--- a/x/pool-incentives/keeper/grpc_query_test.go
+++ b/x/pool-incentives/keeper/grpc_query_test.go
@@ -334,7 +334,7 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
 			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}, {isPerpetual: true}, {isPerpetual: true}, {isPerpetual: false}},
 
-			// Since there is no concentrated pool, there are 4 internal gauges, one for each lockup duration and one for the epoch duration
+			// Since there is a concentrated pool, there are 4 internal gauges, one for each lockup duration and one for the epoch duration
 			// (Note that in our test defaults, the epoch duration does not overlap with any lockup durations)
 			expectedGaugeIDs:          []uint64{5, 6, 7, 8, 9},
 			expectedNumExternalGauges: 5,

--- a/x/pool-incentives/keeper/grpc_query_test.go
+++ b/x/pool-incentives/keeper/grpc_query_test.go
@@ -273,6 +273,164 @@ func (s *KeeperTestSuite) TestIncentivizedPools() {
 	}
 }
 
+func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
+	type externalGauge struct {
+		isPerpetual bool
+	}
+
+	for _, tc := range []struct {
+		desc                 string
+		poolCreated          bool
+		internalGaugeWeights []sdk.Int
+		externalGauges       []externalGauge
+		clPoolWithGauge      bool
+		clGaugeWeight        sdk.Int
+
+		expectedNumExternalGauges int
+		expectedGaugeIDs          []uint64
+	}{
+		{
+			desc:                 "No pool exist",
+			poolCreated:          false,
+			internalGaugeWeights: []sdk.Int{},
+
+			expectedNumExternalGauges: 0,
+		},
+		{
+			desc:                 "All gauges are internal (no external gauges)",
+			poolCreated:          true,
+			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
+
+			expectedNumExternalGauges: 0,
+		},
+		{
+			desc:                 "Mixed internal and external gauges",
+			poolCreated:          true,
+			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
+			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}},
+
+			// Since there is no concentrated pool, there are only 3 internal gauges, one for each lockup duration
+			expectedGaugeIDs:          []uint64{4, 5},
+			expectedNumExternalGauges: 2,
+		},
+		{
+			desc:                 "More external gauges than internal gauges",
+			poolCreated:          true,
+			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
+			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}, {isPerpetual: true}, {isPerpetual: true}, {isPerpetual: false}},
+
+			// Since there is no concentrated pool, there are only 3 internal gauges, one for each lockup duration
+			expectedGaugeIDs:          []uint64{4, 5, 6, 7, 8},
+			expectedNumExternalGauges: 5,
+		},
+		{
+			desc:                 "Same number of external gauges as internal gauges",
+			poolCreated:          true,
+			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
+			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}, {isPerpetual: true}},
+
+			// Since there is no concentrated pool, there are only 3 internal gauges, one for each lockup duration
+			expectedGaugeIDs:          []uint64{4, 5, 6},
+			expectedNumExternalGauges: 3,
+		},
+		{
+			desc:                 "Internal gauge for concentrated pool exists",
+			poolCreated:          true,
+			clPoolWithGauge:      true,
+			clGaugeWeight:        sdk.NewInt(100),
+			internalGaugeWeights: []sdk.Int{sdk.NewInt(100), sdk.NewInt(200), sdk.NewInt(300)},
+			externalGauges:       []externalGauge{{isPerpetual: true}, {isPerpetual: false}, {isPerpetual: true}, {isPerpetual: true}, {isPerpetual: false}},
+
+			// Since there is no concentrated pool, there are 4 internal gauges, one for each lockup duration and one for the epoch duration
+			// (Note that in our test defaults, the epoch duration does not overlap with any lockup durations)
+			expectedGaugeIDs:          []uint64{5, 6, 7, 8, 9},
+			expectedNumExternalGauges: 5,
+		},
+	} {
+		tc := tc
+		s.Run(tc.desc, func() {
+			s.SetupTest()
+			keeper := s.App.PoolIncentivesKeeper
+			queryClient := s.queryClient
+			var poolId uint64
+
+			var lockableDurations []time.Duration
+			if tc.poolCreated {
+				// prepare a balancer pool
+				poolId = s.PrepareBalancerPool()
+				// LockableDurations should be 1, 3, 7 hours from the default genesis state.
+				lockableDurations = keeper.GetLockableDurations(s.Ctx)
+				s.Require().Equal(3, len(lockableDurations))
+
+				// --- Internal Gauge Setup ---
+
+				var distRecords []types.DistrRecord
+
+				// If appropriate, create a concentrated pool with an internal gauge.
+				// Recall that concentrated pool gauges are created on epoch duration, which
+				// is set in default genesis to be 168 hours (1 week).
+				if tc.clPoolWithGauge {
+					clPool := s.PrepareConcentratedPool()
+					epochDuration := s.App.IncentivesKeeper.GetEpochInfo(s.Ctx).Duration
+
+					clGaugeId, err := keeper.GetPoolGaugeId(s.Ctx, clPool.GetId(), epochDuration)
+					s.Require().NoError(err)
+					distRecords = append(distRecords, types.DistrRecord{GaugeId: clGaugeId, Weight: tc.clGaugeWeight})
+				}
+
+				for i := 0; i < len(lockableDurations); i++ {
+					gaugeId, err := keeper.GetPoolGaugeId(s.Ctx, poolId, lockableDurations[i])
+					s.Require().NoError(err)
+					distRecords = append(distRecords, types.DistrRecord{GaugeId: gaugeId, Weight: tc.internalGaugeWeights[i]})
+
+					// Sort in ascending order of gaugeId
+					sort.Slice(distRecords[:], func(i, j int) bool {
+						return distRecords[i].GaugeId < distRecords[j].GaugeId
+					})
+				}
+
+				// --- External Gauge Setup ---
+
+				// Create external gauges if appropriate.
+				// Note that we do not add these gauges to distrRecords, which is how we
+				// ensure they are classified as external
+				if tc.externalGauges != nil {
+					for _, externalBalGauge := range tc.externalGauges {
+						_, err := s.App.IncentivesKeeper.CreateGauge(
+							s.Ctx, externalBalGauge.isPerpetual, sdk.AccAddress{}, sdk.Coins{}, lockuptypes.QueryCondition{
+								LockQueryType: lockuptypes.ByDuration,
+								Denom:         "stake",
+								Duration:      time.Hour,
+							}, time.Now(), 1)
+						s.Require().NoError(err)
+					}
+				}
+
+				// update records and ensure that non-perpetuals cannot get rewards.
+				_ = keeper.UpdateDistrRecords(s.Ctx, distRecords...)
+
+				// --- System under test ---
+
+				res, err := queryClient.ExternalIncentiveGauges(context.Background(), &types.QueryExternalIncentiveGaugesRequest{})
+
+				// --- Assertions ---
+
+				s.Require().NoError(err)
+				s.Require().Equal(tc.expectedNumExternalGauges, len(res.Data))
+
+				// Ensure retrieved gauge IDs are correct
+				if tc.expectedGaugeIDs != nil {
+					s.Require().Equal(tc.expectedNumExternalGauges, len(tc.expectedGaugeIDs))
+
+					for i, gaugeId := range tc.expectedGaugeIDs {
+						s.Require().Equal(gaugeId, res.Data[i].Id)
+					}
+				}
+			}
+		})
+	}
+}
+
 func (s *KeeperTestSuite) TestGaugeIncentivePercentage() {
 	s.SetupTest()
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

While investigating our external gauge query for compatibility with CL gauges, I noticed that the query was completely untested (which slowed me down). This PR adds robust tests for this query and makes minor fixes to godocs. 

## Testing and Verifying

- Tests are in `grpc_query_tests.go`

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A