### PR TITLE
perf: change KVStore value from posID to boolean byte

### DIFF
--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -114,9 +114,9 @@ func (k Keeper) isPositionOwner(ctx sdk.Context, sender sdk.AccAddress, poolId u
 }
 
 // GetAllPositionsForPoolId gets all the position for a specific poolId.
-func (k Keeper) GetAllPositionIdsForPoolId(ctx sdk.Context, poolId uint64) ([]uint64, error) {
+func (k Keeper) GetAllPositionIdsForPoolId(ctx sdk.Context, prefix []byte, poolId uint64) ([]uint64, error) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.PositionPrefix)
+	iterator := sdk.KVStorePrefixIterator(store, prefix)
 	defer iterator.Close()
 
 	var positionIds []uint64
@@ -185,10 +185,17 @@ func (k Keeper) GetPosition(ctx sdk.Context, positionId uint64) (model.Position,
 
 // GetUserPositions gets all the existing user positions, with the option to filter by a specific pool.
 func (k Keeper) GetUserPositions(ctx sdk.Context, addr sdk.AccAddress, poolId uint64) ([]model.Position, error) {
+	var prefix []byte
+	if poolId == 0 {
+		prefix = types.KeyUserPositions(addr)
+	} else {
+		prefix = types.KeyAddressAndPoolId(addr, poolId)
+	}
+
 	positions := []model.Position{}
 
 	// Gather all position IDs for the given user and pool ID.
-	positionIds, err := k.GetAllPositionIdsForPoolId(ctx, poolId)
+	positionIds, err := k.GetAllPositionIdsForPoolId(ctx, prefix, poolId)
 	if err != nil {
 		return nil, err
 	}

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -113,7 +113,7 @@ func (k Keeper) isPositionOwner(ctx sdk.Context, sender sdk.AccAddress, poolId u
 	return isOwner, nil
 }
 
-// GetAllPositionsForPoolId gets all the position for a specific poolId.
+// GetAllPositionsForPoolId gets all the position for a specific poolId and store prefix.
 func (k Keeper) GetAllPositionIdsForPoolId(ctx sdk.Context, prefix []byte, poolId uint64) ([]uint64, error) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, prefix)

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -1,7 +1,9 @@
 package concentrated_liquidity
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -86,16 +88,22 @@ func (k Keeper) hasPosition(ctx sdk.Context, positionId uint64) bool {
 func (k Keeper) HasAnyPositionForPool(ctx sdk.Context, poolId uint64) (bool, error) {
 	store := ctx.KVStore(k.storeKey)
 	poolPositionKey := types.KeyPoolPosition(poolId)
-	parse := func(bz []byte) (uint64, error) {
-		return sdk.BigEndianToUint64(bz), nil
+	parse := func(bz []byte) (bool, error) {
+		if len(bz) < 1 {
+			return false, fmt.Errorf("insufficient data for parsing boolean")
+		}
+		return bz[0] != 0, nil
 	}
 	return osmoutils.HasAnyAtPrefix(store, poolPositionKey, parse)
 }
 
 // isPositionOwner returns true if the given positionId is owned by the given sender inside the given pool.
 func (k Keeper) isPositionOwner(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, positionId uint64) (bool, error) {
-	parse := func(bz []byte) (uint64, error) {
-		return sdk.BigEndianToUint64(bz), nil
+	parse := func(bz []byte) (bool, error) {
+		if len(bz) < 1 {
+			return false, fmt.Errorf("insufficient data for parsing boolean")
+		}
+		return bz[0] != 0, nil
 	}
 	isOwner, err := osmoutils.HasAnyAtPrefix(ctx.KVStore(k.storeKey), types.KeyAddressPoolIdPositionId(sender, poolId, positionId), parse)
 	if err != nil {
@@ -107,11 +115,80 @@ func (k Keeper) isPositionOwner(ctx sdk.Context, sender sdk.AccAddress, poolId u
 
 // GetAllPositionsForPoolId gets all the position for a specific poolId.
 func (k Keeper) GetAllPositionIdsForPoolId(ctx sdk.Context, poolId uint64) ([]uint64, error) {
-	parse := func(bz []byte) (uint64, error) {
-		return sdk.BigEndianToUint64(bz), nil
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.PositionPrefix)
+	defer iterator.Close()
+
+	var positionIds []uint64
+
+	for ; iterator.Valid(); iterator.Next() {
+		key := iterator.Key()
+
+		// Extract the components from the key
+		parts := bytes.Split(key, []byte(types.KeySeparator))
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("invalid key format: %s", key)
+		}
+
+		// Parse the poolId and positionId from the key
+		keyPoolId, err := strconv.ParseUint(string(parts[2]), 16, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse poolId: %w", err)
+		}
+		positionId, err := strconv.ParseUint(string(parts[3]), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse positionId: %w", err)
+		}
+
+		// Check if the parsed poolId matches the desired poolId
+		if keyPoolId == poolId {
+			// If it matches, add the positionId to the result
+			positionIds = append(positionIds, positionId)
+		}
 	}
 
-	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), types.KeyPoolPosition(poolId), parse)
+	// Sort the positionIds in ascending order
+	sort.Slice(positionIds, func(i, j int) bool {
+		return positionIds[i] < positionIds[j]
+	})
+
+	return positionIds, nil
+}
+
+func (k Keeper) GetPositionIdsFromKeyPrefix(ctx sdk.Context, prefix []byte, poolId uint64) ([]uint64, error) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, prefix)
+	defer iterator.Close()
+
+	var positionIds []uint64
+
+	for ; iterator.Valid(); iterator.Next() {
+		key := iterator.Key()
+
+		// Extract the components from the key
+		parts := bytes.Split(key, []byte(types.KeySeparator))
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("invalid key format: %s", key)
+		}
+
+		// Parse the poolId and positionId from the key
+		keyPoolId, err := strconv.ParseUint(string(parts[2]), 16, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse poolId: %w", err)
+		}
+		positionId, err := strconv.ParseUint(string(parts[3]), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse positionId: %w", err)
+		}
+
+		// Check if the parsed poolId matches the desired poolId
+		if keyPoolId == poolId || poolId == 0 {
+			// If it matches, add the positionId to the result
+			positionIds = append(positionIds, positionId)
+		}
+	}
+
+	return positionIds, nil
 }
 
 // GetPositionLiquidity checks if the provided positionId exists. Returns position liquidity if found. Error otherwise.
@@ -154,7 +231,7 @@ func (k Keeper) GetUserPositions(ctx sdk.Context, addr sdk.AccAddress, poolId ui
 	positions := []model.Position{}
 
 	// Gather all position IDs for the given user and pool ID.
-	positionIds, err := osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), prefix, ParsePositionIdFromBz)
+	positionIds, err := k.GetPositionIdsFromKeyPrefix(ctx, prefix, poolId)
 	if err != nil {
 		return nil, err
 	}
@@ -203,13 +280,13 @@ func (k Keeper) SetPosition(ctx sdk.Context,
 	positionIdKey := types.KeyPositionId(positionId)
 	osmoutils.MustSet(store, positionIdKey, &position)
 
-	// Set the address-pool-position ID to position mapping.
+	// Set the address-pool-position ID mapping (value set to true).
 	addressPoolIdPositionIdKey := types.KeyAddressPoolIdPositionId(owner, poolId, positionId)
-	store.Set(addressPoolIdPositionIdKey, sdk.Uint64ToBigEndian(positionId))
+	store.Set(addressPoolIdPositionIdKey, []byte{1})
 
-	// Set the pool ID to position ID mapping.
+	// Set the pool-position ID mapping (value set to true).
 	poolIdKey := types.KeyPoolPositionPositionId(poolId, positionId)
-	store.Set(poolIdKey, sdk.Uint64ToBigEndian(positionId))
+	store.Set(poolIdKey, []byte{1})
 
 	// Set the position ID to underlying lock ID mapping if underlyingLockId is provided.
 	positionHasUnderlyingLock, _, err := k.positionHasActiveUnderlyingLockAndUpdate(ctx, positionId)
@@ -262,7 +339,7 @@ func (k Keeper) deletePosition(ctx sdk.Context,
 	}
 	store.Delete(addressPoolIdPositionIdKey)
 
-	// Remove the pool ID to position ID mapping.
+	// Remove the pool-position ID mapping.
 	poolIdKey := types.KeyPoolPositionPositionId(poolId, positionId)
 	if !store.Has(poolIdKey) {
 		return types.PoolPositionIdNotFoundError{PoolId: poolId, PositionId: positionId}

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2061,10 +2061,10 @@ func (s *KeeperTestSuite) TestGetAllPositionIdsForPoolId() {
 	expectedPositionOneIds := []uint64{1, 2, 3}
 	expectedPositionTwoIds := []uint64{4, 5, 6}
 
-	positionOne, err := clKeeper.GetAllPositionIdsForPoolId(s.Ctx, clPoolOne.GetId())
+	positionOne, err := clKeeper.GetAllPositionIdsForPoolId(s.Ctx, types.PositionPrefix, clPoolOne.GetId())
 	s.Require().NoError(err)
 
-	positionTwo, err := clKeeper.GetAllPositionIdsForPoolId(s.Ctx, clPooltwo.GetId())
+	positionTwo, err := clKeeper.GetAllPositionIdsForPoolId(s.Ctx, types.PositionPrefix, clPooltwo.GetId())
 	s.Require().NoError(err)
 
 	s.Require().Equal(expectedPositionOneIds, positionOne)

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -544,15 +544,15 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 			s.Require().Equal(DefaultJoinTime, position.JoinTime)
 			s.Require().Equal(DefaultLiquidityAmt, position.Liquidity)
 
-			// Retrieve the position ID from the store via owner/poolId key and compare to expected values.
+			// Retrieve the position ID from the store via owner/poolId key and compare to expected value (true).
 			ownerPoolIdToPositionIdKey := types.KeyAddressPoolIdPositionId(s.TestAccs[0], defaultPoolId, DefaultPositionId)
-			positionIdBytes := store.Get(ownerPoolIdToPositionIdKey)
-			s.Require().Equal(DefaultPositionId, sdk.BigEndianToUint64(positionIdBytes))
+			valueBytes := store.Get(ownerPoolIdToPositionIdKey)
+			s.Require().Equal([]byte{1}, valueBytes)
 
-			// Retrieve the position ID from the store via poolId key and compare to expected values.
+			// Retrieve the position ID from the store via poolId key and compare to expected value (true).
 			poolIdtoPositionIdKey := types.KeyPoolPositionPositionId(defaultPoolId, DefaultPositionId)
-			positionIdBytes = store.Get(poolIdtoPositionIdKey)
-			s.Require().Equal(DefaultPositionId, sdk.BigEndianToUint64(positionIdBytes))
+			valueBytes = store.Get(poolIdtoPositionIdKey)
+			s.Require().Equal([]byte{1}, valueBytes)
 
 			// Retrieve the position ID to underlying lock ID mapping from the store and compare to expected values.
 			positionIdToLockIdKey := types.KeyPositionIdForLock(DefaultPositionId)
@@ -565,7 +565,7 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 
 			// Retrieve the lock ID to position ID mapping from the store and compare to expected values.
 			lockIdToPositionIdKey := types.KeyLockIdForPositionId(test.underlyingLockId)
-			positionIdBytes = store.Get(lockIdToPositionIdKey)
+			positionIdBytes := store.Get(lockIdToPositionIdKey)
 			if test.underlyingLockId != 0 {
 				s.Require().Equal(DefaultPositionId, sdk.BigEndianToUint64(positionIdBytes))
 			} else {
@@ -1955,15 +1955,15 @@ func (s *KeeperTestSuite) TestSetPosition() {
 		s.Require().Equal(tc.joinTime, position.JoinTime)
 		s.Require().Equal(tc.liquidity, position.Liquidity)
 
-		// Retrieve the position from the store via owner/poolId/positionId and compare to expected values.
+		// Retrieve the position from the store via owner/poolId/positionId and compare to expected value (true).
 		key = types.KeyAddressPoolIdPositionId(tc.owner, tc.poolId, tc.positionId)
-		positionIdBytes := store.Get(key)
-		s.Require().Equal(tc.positionId, sdk.BigEndianToUint64(positionIdBytes))
+		valueBytes := store.Get(key)
+		s.Require().Equal([]byte{1}, valueBytes)
 
-		// Retrieve the position from the store via poolId/positionId and compare to expected values.
+		// Retrieve the position from the store via poolId/positionId and compare to expected value (true).
 		key = types.KeyPoolPositionPositionId(tc.poolId, tc.positionId)
-		positionIdBytes = store.Get(key)
-		s.Require().Equal(tc.positionId, sdk.BigEndianToUint64(positionIdBytes))
+		valueBytes = store.Get(key)
+		s.Require().Equal([]byte{1}, valueBytes)
 
 		// Retrieve the position ID to underlying lock ID mapping from the store and compare to expected values.
 		key = types.KeyPositionIdForLock(tc.positionId)

--- a/x/concentrated-liquidity/simulation/sim_msgs.go
+++ b/x/concentrated-liquidity/simulation/sim_msgs.go
@@ -92,7 +92,7 @@ func RandMsgWithdrawPosition(k clkeeper.Keeper, sim *osmosimtypes.SimCtx, ctx sd
 	}
 
 	// Utilize the PoolId to PositionId mapping
-	positionIds, err := k.GetAllPositionIdsForPoolId(ctx, clPool.GetId())
+	positionIds, err := k.GetAllPositionIdsForPoolId(ctx, cltypes.PositionPrefix, clPool.GetId())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4733

## What is the purpose of the change

We currently store the following KVStores:

`Owner | Pool ID | Position ID -> Position ID`:

```
addr1|1|1->1
addr1|1|2->2
addr1|2|3->3
addr2|1|4->4
addr2|1|5->5
```

As well as `Pool ID | Position ID -> Position ID` like so:

```
1|1->1
1|2->2
2|3->3
1|4->4
1|5->5
```

Storing the position ID in both the key and value is redundant and requires at a minimum 8 bytes. We instead change this to a single byte []byte{1} to represent that the key is present. If we need to determine a position ID that belongs to a pool ID, we can simply parse the keys rather than values like before.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A