### PR TITLE
refactor: reinvest dust fees into pool accumulator

### DIFF
--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -238,7 +238,8 @@ func (k Keeper) GetClaimableFees(ctx sdk.Context, positionId uint64) (sdk.Coins,
 // Note that it mutates the internal state of the fee accumulator by setting the position's
 // unclaimed rewards to zero and update the position's accumulator value to reflect the
 // current pool fee accumulator value. If there is any dust left over, it is added back to the
-// global accumulator.
+// global accumulator as long as there are shares remaining in the accumulator. If not, the dust
+// is ignored.
 //
 // Returns error if:
 // - pool with the given id does not exist

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -1124,7 +1124,7 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 
 			currentTick: 1,
 
-			// expected = global - below lower - above upper = 10 - 0 3.3 = 6.7
+			// expected = global - below lower - above upper = 10 - 3.3 = 6.7
 			expectedInitAccumValue: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("6.7"))),
 			// expected reinvested dust = (6.7 * 2 % floor(6.7 * 2)) / 2
 			// This can be thought of as the diffence between the non-truncated total amount of fees and the truncated toal amount of fees

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -980,12 +980,13 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 
 	tests := map[string]struct {
 		// setup parameters.
-		initialLiquidity          sdk.Dec
-		lowerTickFeeGrowthOutside sdk.DecCoins
-		upperTickFeeGrowthOutside sdk.DecCoins
-		globalFeeGrowth           sdk.DecCoins
-		currentTick               int64
-		isInvalidPoolIdGiven      bool
+		initialLiquidity             sdk.Dec
+		lowerTickFeeGrowthOutside    sdk.DecCoins
+		upperTickFeeGrowthOutside    sdk.DecCoins
+		globalFeeGrowth              sdk.DecCoins
+		expectedReinvestedDustAmount sdk.Dec
+		currentTick                  int64
+		isInvalidPoolIdGiven         bool
 
 		// inputs parameters.
 		lowerTick           int64
@@ -1109,6 +1110,25 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 
 			expectedInitAccumValue: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
 		},
+		"dust reinvested: single swap right -> left: 2 ticks, two shares, current tick in between lower and upper tick": {
+			initialLiquidity: sdk.NewDec(2),
+
+			lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+			upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("3.3"))),
+
+			globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+			lowerTick:           0,
+			upperTick:           2,
+			positionIdToPrepare: DefaultPositionId,
+
+			currentTick: 1,
+
+			// expected = global - below lower - above upper = 10 - 0 3.3 = 6.7
+			expectedInitAccumValue: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("6.7"))),
+			// expected reinvested dust = 6.7 * 2 % floor(6.7 * 2)
+			expectedReinvestedDustAmount: sdk.MustNewDecFromStr("0.4"),
+		},
 		"swap occurs above the position, current tick > upper tick": {
 			initialLiquidity: sdk.OneDec(),
 
@@ -1189,8 +1209,10 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 			positionKey := types.KeyFeePositionAccumulator(DefaultPositionId)
 
 			// Note the position accumulator before calling prepare
-			_, err = s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(ctx, validPoolId)
+			originalAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(ctx, validPoolId)
 			s.Require().NoError(err)
+
+			originalAccumValue := originalAccum.GetValue()
 
 			// System under test
 			actualFeesClaimed, err := clKeeper.PrepareClaimableFees(ctx, tc.positionIdToPrepare)
@@ -1211,8 +1233,15 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 			s.Require().Equal(tc.expectedInitAccumValue, postPreparePosition.AccumValuePerShare)
 			s.Require().Equal(tc.initialLiquidity, postPreparePosition.NumShares)
 
-			expectedFeeClaimAmount := tc.expectedInitAccumValue.AmountOf(ETH).Mul(tc.initialLiquidity).TruncateInt()
+			expectedClaimedAmountDec := tc.expectedInitAccumValue.AmountOf(ETH).Mul(tc.initialLiquidity)
+			expectedFeeClaimAmount := expectedClaimedAmountDec.TruncateInt()
 			s.Require().Equal(expectedFeeClaimAmount, actualFeesClaimed.AmountOf(ETH))
+
+			// validate that truncated dust amount is reinvested back into the global accumulator
+			if expectedClaimedAmountDec.GT(expectedFeeClaimAmount.ToDec()) {
+				accumDelta, _ := accum.GetValue().SafeSub(originalAccumValue)
+				s.Require().Equal(tc.expectedReinvestedDustAmount, accumDelta.AmountOf(ETH))
+			}
 		})
 	}
 }

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -1126,9 +1126,30 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 
 			// expected = global - below lower - above upper = 10 - 0 3.3 = 6.7
 			expectedInitAccumValue: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("6.7"))),
-			// expected reinvested dust = 6.7 * 2 % floor(6.7 * 2)
-			expectedReinvestedDustAmount: sdk.MustNewDecFromStr("0.4"),
+			// expected reinvested dust = (6.7 * 2 % floor(6.7 * 2)) / 2
+			// This can be thought of as the diffence between the non-truncated total amount of fees and the truncated toal amount of fees
+			// divided by the number of shares.
+			expectedReinvestedDustAmount: sdk.MustNewDecFromStr("0.2"),
 		},
+		// "dust not reinvested (no liquidity left after claim): single swap right -> left: 2 ticks, two shares, current tick in between lower and upper tick": {
+		// 	initialLiquidity: sdk.ZeroDec(),
+
+		// 	lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
+		// 	upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("3.3"))),
+
+		// 	globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
+
+		// 	lowerTick:           0,
+		// 	upperTick:           2,
+		// 	positionIdToPrepare: DefaultPositionId,
+
+		// 	currentTick: 1,
+
+		// 	// expected = global - below lower - above upper = 10 - 0 3.3 = 6.7
+		// 	expectedInitAccumValue: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("6.7"))),
+
+		// 	expectedReinvestedDustAmount: sdk.ZeroDec(),
+		// },
 		"swap occurs above the position, current tick > upper tick": {
 			initialLiquidity: sdk.OneDec(),
 

--- a/x/concentrated-liquidity/fees_test.go
+++ b/x/concentrated-liquidity/fees_test.go
@@ -1131,25 +1131,6 @@ func (s *KeeperTestSuite) TestPrepareClaimableFees() {
 			// divided by the number of shares.
 			expectedReinvestedDustAmount: sdk.MustNewDecFromStr("0.2"),
 		},
-		// "dust not reinvested (no liquidity left after claim): single swap right -> left: 2 ticks, two shares, current tick in between lower and upper tick": {
-		// 	initialLiquidity: sdk.ZeroDec(),
-
-		// 	lowerTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(0))),
-		// 	upperTickFeeGrowthOutside: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("3.3"))),
-
-		// 	globalFeeGrowth: sdk.NewDecCoins(sdk.NewDecCoin(ETH, sdk.NewInt(10))),
-
-		// 	lowerTick:           0,
-		// 	upperTick:           2,
-		// 	positionIdToPrepare: DefaultPositionId,
-
-		// 	currentTick: 1,
-
-		// 	// expected = global - below lower - above upper = 10 - 0 3.3 = 6.7
-		// 	expectedInitAccumValue: sdk.NewDecCoins(sdk.NewDecCoinFromDec(ETH, sdk.MustNewDecFromStr("6.7"))),
-
-		// 	expectedReinvestedDustAmount: sdk.ZeroDec(),
-		// },
 		"swap occurs above the position, current tick > upper tick": {
 			initialLiquidity: sdk.OneDec(),
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Brought up by otter sec.

Reinvest dust fees into pool accumulator. Currently, we simply lose the truncation dust. However, a better way would be to put them back into the global pool accumulator.

## Testing and Verifying

Added test case

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A