### PR TITLE
fix: use min_amount field in AddToPosition Msg  correspond to amount being added

### DIFF
--- a/proto/osmosis/concentrated-liquidity/tx.proto
+++ b/proto/osmosis/concentrated-liquidity/tx.proto
@@ -99,8 +99,8 @@ message MsgAddToPosition {
   ];
   // token_min_amount0 represents the minimum amount of token0 desired from the
   // new position being created. Note that this field indicates the min amount0
-  // corresponding to the total liquidity of the position, not just the
-  // liquidity that is being added.
+  // corresponding to the liquidity that is being added, not the  total
+  // liquidity of the position.
   string token_min_amount0 = 5 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.moretags) = "yaml:\"token_min_amount0\"",
@@ -108,8 +108,8 @@ message MsgAddToPosition {
   ];
   // token_min_amount1 represents the minimum amount of token1 desired from the
   // new position being created. Note that this field indicates the min amount1
-  // corresponding to the total liquidity of the position, not just the
-  // liquidity that is being added.
+  // corresponding to the liquidity that is being added, not the  total
+  // liquidity of the position.
   string token_min_amount1 = 6 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.moretags) = "yaml:\"token_min_amount1\"",

--- a/proto/osmosis/concentrated-liquidity/tx.proto
+++ b/proto/osmosis/concentrated-liquidity/tx.proto
@@ -99,7 +99,7 @@ message MsgAddToPosition {
   ];
   // token_min_amount0 represents the minimum amount of token0 desired from the
   // new position being created. Note that this field indicates the min amount0
-  // corresponding to the liquidity that is being added, not the  total
+  // corresponding to the liquidity that is being added, not the total
   // liquidity of the position.
   string token_min_amount0 = 5 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
@@ -108,7 +108,7 @@ message MsgAddToPosition {
   ];
   // token_min_amount1 represents the minimum amount of token1 desired from the
   // new position being created. Note that this field indicates the min amount1
-  // corresponding to the liquidity that is being added, not the  total
+  // corresponding to the liquidity that is being added, not the total
   // liquidity of the position.
   string token_min_amount1 = 6 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -252,7 +252,7 @@ func (k Keeper) WithdrawPosition(ctx sdk.Context, owner sdk.AccAddress, position
 // For the sake of backwards-compatibility with future implementations of charging, this function deletes the old position and creates
 // a new one with the resulting amount after addition. Note that due to truncation after `withdrawPosition`, there is some rounding error
 // that is upper bounded by 1 unit of the more valuable token.
-// Uses the amount0MinGiven,amount1MinGiven as the minimum token out for creating the new position.
+// Uses the amount0MinGiven + withdrawn amount0, amount1MinGiven + withdrawn amount1 as the minimum token out for creating the new position.
 // Note that these field indicates the min amount corresponding to the total liquidity of the position,
 // not only for the liquidity amount that is being added.
 // Uses amounts withdrawn from the original position if provided min amount is zero.
@@ -318,10 +318,10 @@ func (k Keeper) addToPosition(ctx sdk.Context, owner sdk.AccAddress, positionId 
 	minimumAmount1 := amount1Withdrawn
 
 	if !amount0MinGiven.IsZero() {
-		minimumAmount0 = amount0MinGiven
+		minimumAmount0 = amount0Withdrawn.Add(amount0MinGiven)
 	}
 	if !amount1MinGiven.IsZero() {
-		minimumAmount1 = amount1MinGiven
+		minimumAmount1 = amount1Withdrawn.Add(amount1MinGiven)
 	}
 	newPositionId, actualAmount0, actualAmount1, _, _, _, _, err := k.createPosition(ctx, position.PoolId, owner, tokensProvided, minimumAmount0, minimumAmount1, position.LowerTick, position.UpperTick)
 	if err != nil {

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -981,7 +981,7 @@ func (s *KeeperTestSuite) TestAddToPosition() {
 				amount0Minimum: sdk.NewInt(1997960),
 				expectedError: types.InsufficientLiquidityCreatedError{
 					Actual:      sdk.NewInt(1997954),
-					Minimum:     sdk.NewInt(1997960),
+					Minimum:     sdk.NewInt(2996936),
 					IsTokenZero: true,
 				},
 			},
@@ -998,7 +998,7 @@ func (s *KeeperTestSuite) TestAddToPosition() {
 				amount1Minimum: sdk.NewInt(9999998916),
 				expectedError: types.InsufficientLiquidityCreatedError{
 					Actual:      sdk.NewInt(9999998816),
-					Minimum:     sdk.NewInt(9999998916),
+					Minimum:     sdk.NewInt(14999998915),
 					IsTokenZero: false,
 				},
 			},

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -978,10 +978,11 @@ func (s *KeeperTestSuite) TestAddToPosition() {
 
 			// system under test parameters
 			sutConfigOverwrite: &lpTest{
-				amount0Minimum: sdk.NewInt(1997960),
+				amount0Minimum: sdk.NewInt(1000000),
 				expectedError: types.InsufficientLiquidityCreatedError{
-					Actual:      sdk.NewInt(1997954),
-					Minimum:     sdk.NewInt(2996936),
+					Actual: sdk.NewInt(1997954),
+		         minimum amount we have input becomes default amt 0 expected (from original position withdraw) + 1000000 (input)
+					Minimum:     DefaultAmt0Expected.Add(sdk.NewInt(1000000)),
 					IsTokenZero: true,
 				},
 			},
@@ -995,10 +996,11 @@ func (s *KeeperTestSuite) TestAddToPosition() {
 
 			// system under test parameters
 			sutConfigOverwrite: &lpTest{
-				amount1Minimum: sdk.NewInt(9999998916),
+				amount1Minimum: sdk.NewInt(10000000000),
 				expectedError: types.InsufficientLiquidityCreatedError{
-					Actual:      sdk.NewInt(9999998816),
-					Minimum:     sdk.NewInt(14999998915),
+					Actual: sdk.NewInt(9999998816),
+					// minimum amount we have input becomes default amt 1 expected (from original position withdraw) + 10000000000 (input)
+					Minimum:     DefaultAmt1Expected.Add(sdk.NewInt(10000000000)),
 					IsTokenZero: false,
 				},
 			},

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -981,7 +981,7 @@ func (s *KeeperTestSuite) TestAddToPosition() {
 				amount0Minimum: sdk.NewInt(1000000),
 				expectedError: types.InsufficientLiquidityCreatedError{
 					Actual: sdk.NewInt(1997954),
-		         minimum amount we have input becomes default amt 0 expected (from original position withdraw) + 1000000 (input)
+					//  minimum amount we have input becomes default amt 0 expected (from original position withdraw) + 1000000 (input)
 					Minimum:     DefaultAmt0Expected.Add(sdk.NewInt(1000000)),
 					IsTokenZero: true,
 				},

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -999,8 +999,8 @@ func (s *KeeperTestSuite) TestAddToPosition() {
 				amount1Minimum: sdk.NewInt(10000000000),
 				expectedError: types.InsufficientLiquidityCreatedError{
 					Actual: sdk.NewInt(9999998816),
-					// minimum amount we have input becomes default amt 1 expected (from original position withdraw) + 10000000000 (input)
-					Minimum:     DefaultAmt1Expected.Add(sdk.NewInt(10000000000)),
+					// minimum amount we have input becomes default amt 1 expected (from original position withdraw) + 10000000000 (input) - 1 (rounding)
+					Minimum:     DefaultAmt1Expected.Add(sdk.NewInt(10000000000)).Sub(sdk.OneInt()),
 					IsTokenZero: false,
 				},
 			},

--- a/x/concentrated-liquidity/types/tx.pb.go
+++ b/x/concentrated-liquidity/types/tx.pb.go
@@ -202,13 +202,13 @@ type MsgAddToPosition struct {
 	Amount1 github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,4,opt,name=amount1,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"amount1" yaml:"amount1"`
 	// token_min_amount0 represents the minimum amount of token0 desired from the
 	// new position being created. Note that this field indicates the min amount0
-	// corresponding to the total liquidity of the position, not just the
-	// liquidity that is being added.
+	// corresponding to the liquidity that is being added, not the  total
+	// liquidity of the position.
 	TokenMinAmount0 github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,5,opt,name=token_min_amount0,json=tokenMinAmount0,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"token_min_amount0" yaml:"token_min_amount0"`
 	// token_min_amount1 represents the minimum amount of token1 desired from the
 	// new position being created. Note that this field indicates the min amount1
-	// corresponding to the total liquidity of the position, not just the
-	// liquidity that is being added.
+	// corresponding to the liquidity that is being added, not the  total
+	// liquidity of the position.
 	TokenMinAmount1 github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,6,opt,name=token_min_amount1,json=tokenMinAmount1,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"token_min_amount1" yaml:"token_min_amount1"`
 }
 

--- a/x/concentrated-liquidity/types/tx.pb.go
+++ b/x/concentrated-liquidity/types/tx.pb.go
@@ -202,12 +202,12 @@ type MsgAddToPosition struct {
 	Amount1 github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,4,opt,name=amount1,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"amount1" yaml:"amount1"`
 	// token_min_amount0 represents the minimum amount of token0 desired from the
 	// new position being created. Note that this field indicates the min amount0
-	// corresponding to the liquidity that is being added, not the  total
+	// corresponding to the liquidity that is being added, not the total
 	// liquidity of the position.
 	TokenMinAmount0 github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,5,opt,name=token_min_amount0,json=tokenMinAmount0,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"token_min_amount0" yaml:"token_min_amount0"`
 	// token_min_amount1 represents the minimum amount of token1 desired from the
 	// new position being created. Note that this field indicates the min amount1
-	// corresponding to the liquidity that is being added, not the  total
+	// corresponding to the liquidity that is being added, not the total
 	// liquidity of the position.
 	TokenMinAmount1 github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,6,opt,name=token_min_amount1,json=tokenMinAmount1,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"token_min_amount1" yaml:"token_min_amount1"`
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/5238

## What is the purpose of the change

Previously, the min amount fields in AddToPosition were corresponding to the min amount of the total liquidity of the position. 
This PR implements the change to use min amount field instead to use min amount field for the amount that is being added. 

## Testing and Verifying

Made fix to according tests

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A