### PR TITLE
bench: GetTickLiquidityNetInDirection & GetTickLiquidityForFullRange

### DIFF
--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
+	cl "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity"
+	clmath "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	clmodel "github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
 )
@@ -30,209 +32,203 @@ func (s BenchTestSuite) createPosition(accountIndex int, poolId uint64, coin0, c
 	}
 }
 
-func BenchmarkSwapExactAmountIn(b *testing.B) {
+func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64)) {
 	// Notice we stop the timer to skip setup code.
 	b.StopTimer()
 
-	// We cannot use s.Require().NoError() becuase the suite context
+	// We cannot use s.Require().NoError() because the suite context
 	// is defined on the testing.T and not testing.B
 	noError := func(err error) {
 		require.NoError(b, err)
 	}
 
 	const (
-		numberOfPositions = 10000
-
-		// max amount of each token deposited per position.
-		maxAmountDeposited = int64(1_000_000_000_000)
-
-		// amount swapped in.
-		amountIn = "9999999999999999999"
-
-		// flag controlling whether to create additional numberOfPositions full
-		// range positions for deeper liquidity.
+		numberOfPositions              = 10000
+		maxAmountDeposited             = int64(1_000_000_000_000)
+		amountIn                       = "9999999999999999999"
 		shouldCreateFullRangePositions = true
-
-		// flag controlling whether to create positions concentrated around current tick to mimic
-		// realistic scenario and deeper liquidity.
-		// if true,
-		// creates numberOfPositions positions within 10 ticks of the current tick.
-		// creates numberOfPositions positions within 100 ticks of the current tick.
-		shouldConcentrate = true
-
-		// tickSpacing is the spacing between ticks.
-		tickSpacing = 1
+		shouldConcentrate              = true
+		tickSpacing                    = 1
 	)
 
 	var (
-		// denoms of the pool.
-		denom0 = DefaultCoin0.Denom
-		denom1 = DefaultCoin1.Denom
-
-		// denom of the token to swap in.
-		denomIn = denom0
-
+		denom0               = DefaultCoin0.Denom
+		denom1               = DefaultCoin1.Denom
+		denomIn              = denom0
 		numberOfPositionsInt = sdk.NewInt(numberOfPositions)
 		maxAmountOfEachToken = sdk.NewInt(maxAmountDeposited).Mul(numberOfPositionsInt)
-
-		// Seed controlling determinism of the randomized positions.
-		seed = int64(1)
+		seed                 = int64(1)
 	)
+
 	rand.Seed(seed)
 
 	for i := 0; i < b.N; i++ {
 		s := BenchTestSuite{}
 		s.Setup()
 
-		// Fund all accounts with max amounts they would need to consume.
 		for _, acc := range s.TestAccs {
-			simapp.FundAccount(s.App.BankKeeper, s.Ctx, acc, sdk.NewCoins(sdk.NewCoin(denom0, maxAmountOfEachToken), sdk.NewCoin(denom1, maxAmountOfEachToken), sdk.NewCoin("uosmo", maxAmountOfEachToken)))
+			simapp.FundAccount(s.App.BankKeeper, s.Ctx, acc, sdk.NewCoins(
+				sdk.NewCoin(denom0, maxAmountOfEachToken),
+				sdk.NewCoin(denom1, maxAmountOfEachToken),
+				sdk.NewCoin("uosmo", maxAmountOfEachToken),
+			))
 		}
 
-		// Create a pool
-		poolId, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(s.TestAccs[0], denom0, denom1, tickSpacing, sdk.MustNewDecFromStr("0.001")))
+		poolId, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(
+			s.TestAccs[0], denom0, denom1, tickSpacing, sdk.MustNewDecFromStr("0.001"),
+		))
 		noError(err)
 
 		clKeeper := s.App.ConcentratedLiquidityKeeper
 
-		// Create first position to set a price of 1 and tick of zero.
 		tokenDesired0 := sdk.NewCoin(denom0, sdk.NewInt(100))
 		tokenDesired1 := sdk.NewCoin(denom1, sdk.NewInt(100))
 		tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
 		_, _, _, _, _, _, _, err = clKeeper.CreatePosition(s.Ctx, poolId, s.TestAccs[0], tokensDesired, sdk.ZeroInt(), sdk.ZeroInt(), types.MinTick, types.MaxTick)
+		noError(err)
 
 		pool, err := clKeeper.GetPoolById(s.Ctx, poolId)
 		noError(err)
 
-		// Zero by default, can configure by setting a specific position.
 		currentTick := pool.GetCurrentTick()
 
-		// Setup numberOfPositions positions at random ranges
-		for i := 0; i < numberOfPositions; i++ {
+		setupPositions := func() {
+			for i := 0; i < numberOfPositions; i++ {
+				var (
+					lowerTick int64
+					upperTick int64
+				)
 
-			var (
-				lowerTick int64
-				upperTick int64
-			)
+				if denomIn == denom0 {
+					lowerTick = rand.Int63n(currentTick-types.MinTick+1) + types.MinTick
+					upperTick = currentTick - rand.Int63n(int64(math.Abs(float64(currentTick-lowerTick))))
+				} else {
+					lowerTick = rand.Int63n(types.MaxTick-currentTick+1) + currentTick
+					upperTick = types.MaxTick - rand.Int63n(int64(math.Abs(float64(types.MaxTick-lowerTick))))
+				}
 
-			if denomIn == denom0 {
-				// Decreasing price so want to be below current tick
+				lowerTick = lowerTick + (tickSpacing - lowerTick%tickSpacing)
+				upperTick = upperTick - upperTick%tickSpacing
 
-				// minTick <= lowerTick <= currentTick
-				lowerTick = rand.Int63n(currentTick-types.MinTick+1) + types.MinTick
-				// lowerTick <= upperTick <= currentTick
-				upperTick = currentTick - rand.Int63n(int64(math.Abs(float64(currentTick-lowerTick))))
-			} else {
-				// Increasing price so want to be above current tick
+				priceLowerTick, priceUpperTick, _, _, err := clmath.TicksToSqrtPrice(lowerTick, upperTick)
+				noError(err)
 
-				// currentTick <= lowerTick <= maxTick
-				lowerTick := rand.Int63n(types.MaxTick-currentTick+1) + currentTick
-				// lowerTick <= upperTick <= maxTick
-				upperTick = types.MaxTick - rand.Int63n(int64(math.Abs(float64(types.MaxTick-lowerTick))))
+				lowerTick, upperTick, err = cl.RoundTickToCanonicalPriceTick(
+					lowerTick, upperTick, priceLowerTick, priceUpperTick, tickSpacing,
+				)
+				if err != nil {
+					continue
+				}
+
+				tokenDesired0 := sdk.NewCoin(denom0, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
+				tokenDesired1 := sdk.NewCoin(denom1, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
+
+				accountIndex := rand.Intn(len(s.TestAccs))
+				s.createPosition(accountIndex, poolId, tokenDesired0, tokenDesired1, lowerTick, upperTick)
 			}
-			// Normalize lowerTick to be a multiple of tickSpacing
-			lowerTick = lowerTick + (tickSpacing - lowerTick%tickSpacing)
-			// Normalize upperTick to be a multiple of tickSpacing
-			upperTick = upperTick - upperTick%tickSpacing
-
-			tokenDesired0 := sdk.NewCoin(denom0, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
-			tokenDesired1 := sdk.NewCoin(denom1, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
-
-			accountIndex := rand.Intn(len(s.TestAccs))
-
-			s.createPosition(accountIndex, poolId, tokenDesired0, tokenDesired1, lowerTick, upperTick)
 		}
 
-		// Setup numberOfPositions full range positions for deeper liquidity.
-		if shouldCreateFullRangePositions {
+		setupFullRangePositions := func() {
 			for i := 0; i < numberOfPositions; i++ {
 				lowerTick := types.MinTick
 				upperTick := types.MaxTick
-
 				maxAmountDepositedFullRange := sdk.NewInt(maxAmountDeposited).MulRaw(5)
 				tokenDesired0 := sdk.NewCoin(denom0, maxAmountDepositedFullRange)
 				tokenDesired1 := sdk.NewCoin(denom1, maxAmountDepositedFullRange)
 				tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
-
 				accountIndex := rand.Intn(len(s.TestAccs))
-
 				account := s.TestAccs[accountIndex]
-
 				simapp.FundAccount(s.App.BankKeeper, s.Ctx, account, tokensDesired)
-
 				s.createPosition(accountIndex, poolId, tokenDesired0, tokenDesired1, lowerTick, upperTick)
 			}
 		}
 
-		// Setup numberOfPositions * 2 positions at random ranges around the current tick for deeper
-		// liquidity.
-		if shouldConcentrate {
-			// Within 10 ticks of the current
+		setupConcentratedPositions := func() {
 			if tickSpacing <= 10 {
 				for i := 0; i < numberOfPositions; i++ {
 					lowerTick := currentTick - 10
 					upperTick := currentTick + 10
-
 					tokenDesired0 := sdk.NewCoin(denom0, sdk.NewInt(maxAmountDeposited).MulRaw(5))
 					tokenDesired1 := sdk.NewCoin(denom1, sdk.NewInt(maxAmountDeposited).MulRaw(5))
 					tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
-
 					accountIndex := rand.Intn(len(s.TestAccs))
-
 					account := s.TestAccs[accountIndex]
-
 					simapp.FundAccount(s.App.BankKeeper, s.Ctx, account, tokensDesired)
-
 					s.createPosition(accountIndex, poolId, tokenDesired0, tokenDesired1, lowerTick, upperTick)
 				}
 			}
 
-			// Within 100 ticks of the current
 			for i := 0; i < numberOfPositions; i++ {
 				lowerTick := currentTick - 100
 				upperTick := currentTick + 100
-				// Normalize lowerTick to be a multiple of tickSpacing
 				lowerTick = lowerTick + (tickSpacing - lowerTick%tickSpacing)
-				// Normalize upperTick to be a multiple of tickSpacing
 				upperTick = upperTick - upperTick%tickSpacing
-
 				tokenDesired0 := sdk.NewCoin(denom0, sdk.NewInt(maxAmountDeposited).MulRaw(5))
 				tokenDesired1 := sdk.NewCoin(denom1, sdk.NewInt(maxAmountDeposited).MulRaw(5))
 				tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
-
 				accountIndex := rand.Intn(len(s.TestAccs))
-
 				account := s.TestAccs[accountIndex]
-
 				simapp.FundAccount(s.App.BankKeeper, s.Ctx, account, tokensDesired)
-
 				s.createPosition(accountIndex, poolId, tokenDesired0, tokenDesired1, lowerTick, upperTick)
 			}
+		}
+
+		setupPositions()
+		if shouldCreateFullRangePositions {
+			setupFullRangePositions()
+		}
+		if shouldConcentrate {
+			setupConcentratedPositions()
 		}
 
 		swapAmountIn := sdk.MustNewDecFromStr(amountIn).TruncateInt()
 		largeSwapInCoin := sdk.NewCoin(denomIn, swapAmountIn)
 
+		testFunc(b, &s, pool, largeSwapInCoin, currentTick)
+
+	}
+}
+
+func BenchmarkSwapExactAmountIn(b *testing.B) {
+	runBenchmark(b, func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64) {
+		clKeeper := s.App.ConcentratedLiquidityKeeper
+		noError := func(err error) {
+			require.NoError(b, err)
+		}
+
 		liquidityNet, err := clKeeper.GetTickLiquidityNetInDirection(s.Ctx, pool.GetId(), largeSwapInCoin.Denom, sdk.NewInt(currentTick), sdk.Int{})
 		noError(err)
-
-		fmt.Println("num_ticks_traversed", len(liquidityNet))
-		fmt.Println("current_tick", currentTick)
-
-		// Commit the block so that position updates are propagated to IAVL.
-		s.Commit()
-
-		// Fund swap amount.
 		simapp.FundAccount(s.App.BankKeeper, s.Ctx, s.TestAccs[0], sdk.NewCoins(largeSwapInCoin))
 
-		// Notice that we start the timer as this is the system under test
 		b.StartTimer()
 
 		// System under test
-		_, err = clKeeper.SwapExactAmountIn(s.Ctx, s.TestAccs[0], pool, largeSwapInCoin, denom1, sdk.NewInt(1), pool.GetSpreadFactor(s.Ctx))
+		_, err = clKeeper.SwapExactAmountIn(s.Ctx, s.TestAccs[0], pool, largeSwapInCoin, DefaultCoin1.Denom, sdk.NewInt(1), pool.GetSpreadFactor(s.Ctx))
 		noError(err)
 
-		// Notice that we stop the timer again in case there are multiple iterations.
 		b.StopTimer()
-	}
+
+		fmt.Println("current_tick", currentTick)
+		fmt.Println("num_ticks_traversed", len(liquidityNet))
+	})
+}
+
+func BenchmarkGetTickLiquidityNetInDirection(b *testing.B) {
+	runBenchmark(b, func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64) {
+		clKeeper := s.App.ConcentratedLiquidityKeeper
+		noError := func(err error) {
+			require.NoError(b, err)
+		}
+
+		b.StartTimer()
+
+		// System under test
+		liquidityNet, err := clKeeper.GetTickLiquidityNetInDirection(s.Ctx, pool.GetId(), largeSwapInCoin.Denom, sdk.NewInt(currentTick), sdk.Int{})
+		noError(err)
+
+		b.StopTimer()
+
+		fmt.Println("current_tick", currentTick)
+		fmt.Println("num_ticks_traversed", len(liquidityNet))
+	})
 }

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -232,3 +232,23 @@ func BenchmarkGetTickLiquidityNetInDirection(b *testing.B) {
 		fmt.Println("num_ticks_traversed", len(liquidityNet))
 	})
 }
+
+func BenchmarkGetTickLiquidityForFullRange(b *testing.B) {
+	runBenchmark(b, func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64) {
+		clKeeper := s.App.ConcentratedLiquidityKeeper
+		noError := func(err error) {
+			require.NoError(b, err)
+		}
+
+		b.StartTimer()
+
+		// System under test
+		liquidityNet, err := clKeeper.GetTickLiquidityForFullRange(s.Ctx, pool.GetId())
+		noError(err)
+
+		b.StopTimer()
+
+		fmt.Println("current_tick", currentTick)
+		fmt.Println("num_ticks_traversed", len(liquidityNet))
+	})
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4597 

## What is the purpose of the change

### GetTickLiquidityNetInDirection: 10,000 positions

Benchmark | Iterations | Time
-- | -- | --
BenchmarkGetTickLiquidityNetInDirection-10 | 43 | 27575030 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 45 | 27375894 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 43 | 26541238 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 46 | 27896807 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 44 | 27972892 ns/op

<br class="Apple-interchange-newline">

![Screenshot 2023-05-23 at 2 33 36 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/255b21b5-7843-461d-8baf-841a217c135d)

### GetTickLiquidityNetInDirection: 100,000 positions

Benchmark | Iterations | Time
-- | -- | --
BenchmarkGetTickLiquidityNetInDirection-10 | 4 | 285060562 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 4 | 259781604 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 4 | 273009479 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 4 | 259881292 ns/op
BenchmarkGetTickLiquidityNetInDirection-10 | 4 | 277734042 ns/op

<br class="Apple-interchange-newline">

![Screenshot 2023-05-23 at 4 27 39 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/2f5b9247-aee3-4ea6-ba0e-54c9fdf6ae29)

### GetTickLiquidityForFullRange: 10,000 positions

Benchmark | Iterations | Time
-- | -- | --
BenchmarkGetTickLiquidityForFullRange-10 | 42 | 29545340 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 38 | 31198707 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 37 | 30210620 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 42 | 30781328 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 40 | 30758037 ns/op

<br class="Apple-interchange-newline">

![Screenshot 2023-05-23 at 3 18 01 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/f578f025-878e-4fc6-a060-a26ec0a7ae31)

### GetTickLiquidityForFullRange: 100,000 positions

Benchmark | Iterations | Time
-- | -- | --
BenchmarkGetTickLiquidityForFullRange-10 | 4 | 305054396 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 4 | 305594322 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 4 | 319074635 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 3 | 429191125 ns/op
BenchmarkGetTickLiquidityForFullRange-10 | 4 | 284993771 ns/op

<br class="Apple-interchange-newline">

![Screenshot 2023-05-23 at 5 59 24 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/057df76e-f2ff-4f14-afe5-571a7ef6d9fa)


## Testing and Verifying

Bechmarks that were used to get the above data are added in this PR.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A