### PR TITLE
perf: remove repeated pool exists check

### DIFF
--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -41,7 +41,7 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 	b.StopTimer()
 
 	const (
-		numberOfPositions              = 100000
+		numberOfPositions              = 10000
 		maxAmountDeposited             = int64(1_000_000_000_000)
 		amountIn                       = "9999999999999999999"
 		shouldCreateFullRangePositions = true

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -200,12 +200,8 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 
 		swapAmountIn := sdk.MustNewDecFromStr(amountIn).TruncateInt()
 		largeSwapInCoin := sdk.NewCoin(denomIn, swapAmountIn)
-		s.Commit()
-
 		// Commit so that the changes are propagated to IAVL.
-		s.App.Commit()
-		// Reload latest store version
-		err = s.App.LoadLatestVersion()
+		s.Commit()
 		noError(b, err)
 
 		testFunc(b, &s, pool, largeSwapInCoin, currentTick)

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -41,7 +41,7 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 	b.StopTimer()
 
 	const (
-		numberOfPositions              = 10000
+		numberOfPositions              = 100000
 		maxAmountDeposited             = int64(1_000_000_000_000)
 		amountIn                       = "9999999999999999999"
 		shouldCreateFullRangePositions = true
@@ -59,6 +59,8 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 	)
 
 	rand.Seed(seed)
+
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		s := BenchTestSuite{}

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -201,6 +201,12 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 		swapAmountIn := sdk.MustNewDecFromStr(amountIn).TruncateInt()
 		largeSwapInCoin := sdk.NewCoin(denomIn, swapAmountIn)
 
+		// Commit so that the changes are propagated to IAVL.
+		s.App.Commit()
+		// Reload latest store version
+		err = s.App.LoadLatestVersion()
+		noError(b, err)
+
 		testFunc(b, &s, pool, largeSwapInCoin, currentTick)
 
 	}

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -202,7 +202,6 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 		largeSwapInCoin := sdk.NewCoin(denomIn, swapAmountIn)
 		// Commit so that the changes are propagated to IAVL.
 		s.Commit()
-		noError(b, err)
 
 		testFunc(b, &s, pool, largeSwapInCoin, currentTick)
 		cleanup()

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -109,10 +109,6 @@ func (k Keeper) GetNextPositionIdAndIncrement(ctx sdk.Context) uint64 {
 	return k.getNextPositionIdAndIncrement(ctx)
 }
 
-func (k Keeper) PoolExists(ctx sdk.Context, poolId uint64) bool {
-	return k.poolExists(ctx, poolId)
-}
-
 func (k Keeper) InitializeInitialPositionForPool(ctx sdk.Context, pool types.ConcentratedPoolExtension, amount0Desired, amount1Desired sdk.Int) error {
 	return k.initializeInitialPositionForPool(ctx, pool, amount0Desired, amount1Desired)
 }

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -111,18 +111,6 @@ func (k Keeper) GetPools(ctx sdk.Context) ([]poolmanagertypes.PoolI, error) {
 	)
 }
 
-// poolExists returns true if a pool with the given id exists. False otherwise.
-func (k Keeper) poolExists(ctx sdk.Context, poolId uint64) bool {
-	store := ctx.KVStore(k.storeKey)
-	pool := model.Pool{}
-	key := types.KeyPool(poolId)
-	found, err := osmoutils.Get(store, key, &pool)
-	if err != nil {
-		panic(err)
-	}
-	return found
-}
-
 // setPool stores a ConcentratedPoolExtension in the Keeper's KVStore.
 // It returns an error if the provided pool is not of type *model.Pool.
 func (k Keeper) setPool(ctx sdk.Context, pool types.ConcentratedPoolExtension) error {

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -177,23 +177,6 @@ func (s *KeeperTestSuite) TestGetPoolById() {
 	}
 }
 
-func (s *KeeperTestSuite) TestPoolExists() {
-	s.SetupTest()
-
-	// Create default CL pool
-	pool := s.PrepareConcentratedPool()
-
-	// Check that the pool exists
-	poolExists := s.App.ConcentratedLiquidityKeeper.PoolExists(s.Ctx, pool.GetId())
-	s.Require().True(poolExists)
-
-	// try checking for a non-existent pool
-	poolExists = s.App.ConcentratedLiquidityKeeper.PoolExists(s.Ctx, 2)
-
-	// ensure that this returns false
-	s.Require().False(poolExists)
-}
-
 func (s *KeeperTestSuite) TestConvertConcentratedToPoolInterface() {
 	s.SetupTest()
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -114,9 +114,6 @@ func (k Keeper) GetTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (ti
 	store := ctx.KVStore(k.storeKey)
 	tickStruct := model.TickInfo{}
 	key := types.KeyTick(poolId, tickIndex)
-	if !k.poolExists(ctx, poolId) {
-		return model.TickInfo{}, types.PoolNotFoundError{PoolId: poolId}
-	}
 
 	found, err := osmoutils.Get(store, key, &tickStruct)
 	// return 0 values if key has not been initialized

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -109,6 +109,7 @@ func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, swapS
 
 // GetTickInfo gets the tickInfo given a poolId and tickIndex. If the tick has not been initialized, it will initialize it.
 // If the tick has been initialized, it will return the tickInfo. If the pool does not exist, it will return an error.
+// CONTRACT: The caller must check that the pool with given id exists.
 // WARNING: this method may mutate the pool, make sure to refetch the pool after calling this method.
 func (k Keeper) GetTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (tickInfo model.TickInfo, err error) {
 	store := ctx.KVStore(k.storeKey)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Removing repeated defense-in-depth sanity check. We should be checking pool existence much earlier in the execution flow.

Old:

![image](https://github.com/osmosis-labs/osmosis/assets/34196718/b5fe192a-620e-4eb0-89fc-b4b168bf1ff2)


New:

![image](https://github.com/osmosis-labs/osmosis/assets/34196718/ea1e8340-9ac6-44e7-8ba1-13cd6271eda3)

With 100k positions and 180k ticks traversed:
```
go test -bench . -run BenchmarkSwapExactAmountIn -timeout=30m -v -count=3
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkSwapExactAmountIn
BenchmarkSwapExactAmountIn-4                           1        2412393389 ns/op
BenchmarkSwapExactAmountIn-4                           1        2406438654 ns/op
BenchmarkSwapExactAmountIn-4                           1        2307147354 ns/op
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A