### PR TITLE
perf: remove repeated pool unmarshaling and uptime accum refetching overhead in swaps

### DIFF
--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -87,11 +87,6 @@ func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickI
 	// subtract tick's fee growth opposite direction of last traversal from current fee growth global, including the fee growth of the current swap.
 	tickInfo.FeeGrowthOppositeDirectionOfLastTraversal = feeAccum.GetValue().Add(swapStateFeeGrowth).Sub(tickInfo.FeeGrowthOppositeDirectionOfLastTraversal)
 
-	// Update global accums to now before uptime outside changes
-	if err := k.updatePoolUptimeAccumulatorsToNow(ctx, poolId); err != nil {
-		return sdk.Dec{}, err
-	}
-
 	uptimeAccums, err := k.GetUptimeAccumulators(ctx, poolId)
 	if err != nil {
 		return sdk.Dec{}, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is a second improvement identified in:
https://github.com/osmosis-labs/osmosis/pull/5287

It focuses around:
- removes repeated proto unmarshaling inside the loop as we cross ticks in `updateUptimeAccumulatorsToNow`
- repeated uptime accumulator fetching and unsmarsharling. Instead, we fetch them once at the top and operated on the accumulators passed into methods by pointer.

## Testing and Verifying

- Covered by existing tests
- Added new tests where applicable
- [ ] Add tests marked with TODO

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A