### PR TITLE
perf: remove repeated pool unmarshaling and uptime accum refetching overhead in swaps

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -43,8 +43,8 @@ func (k Keeper) GetPoolById(ctx sdk.Context, poolId uint64) (types.ConcentratedP
 	return k.getPoolById(ctx, poolId)
 }
 
-func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, nextTickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin) (liquidityDelta sdk.Dec, err error) {
-	return k.crossTick(ctx, poolId, tickIndex, nextTickInfo, swapStateFeeGrowth)
+func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, nextTickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
+	return k.crossTick(ctx, poolId, tickIndex, nextTickInfo, swapStateFeeGrowth, uptimeAccums)
 }
 
 func (k Keeper) SendCoinsBetweenPoolAndUser(ctx sdk.Context, denom0, denom1 string, amount0, amount1 sdk.Int, sender, receiver sdk.AccAddress) error {
@@ -252,6 +252,10 @@ func (k Keeper) UpdateUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64) er
 	return k.updatePoolUptimeAccumulatorsToNow(ctx, poolId)
 }
 
+func (k Keeper) UpdatePoolGivenUptimeAccumulatorsToNow(ctx sdk.Context, pool types.ConcentratedPoolExtension, uptimeAccums []accum.AccumulatorObject) error {
+	return k.updatePoolGivenUptimeAccumulatorsToNow(ctx, pool, uptimeAccums)
+}
+
 func (k Keeper) SetIncentiveRecord(ctx sdk.Context, incentiveRecord types.IncentiveRecord) error {
 	return k.setIncentiveRecord(ctx, incentiveRecord)
 }
@@ -300,12 +304,12 @@ func (k Keeper) UpdatePoolForSwap(ctx sdk.Context, pool types.ConcentratedPoolEx
 	return k.updatePoolForSwap(ctx, pool, sender, tokenIn, tokenOut, newCurrentTick, newLiquidity, newSqrtPrice, totalFees)
 }
 
-func (k Keeper) PrepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64) (uint64, sdk.Dec, error) {
-	return k.prepareBalancerPoolAsFullRange(ctx, clPoolId)
+func (k Keeper) PrepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64, uptimeAccums []accum.AccumulatorObject) (uint64, sdk.Dec, error) {
+	return k.prepareBalancerPoolAsFullRange(ctx, clPoolId, uptimeAccums)
 }
 
-func (k Keeper) ClaimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uint64, balPoolId uint64) (sdk.Coins, error) {
-	return k.claimAndResetFullRangeBalancerPool(ctx, clPoolId, balPoolId)
+func (k Keeper) ClaimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uint64, balPoolId uint64, uptimeAccums []accum.AccumulatorObject) (sdk.Coins, error) {
+	return k.claimAndResetFullRangeBalancerPool(ctx, clPoolId, balPoolId, uptimeAccums)
 }
 
 func (k Keeper) UninitializePool(ctx sdk.Context, poolId uint64) error {

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -43,8 +43,8 @@ func (k Keeper) GetPoolById(ctx sdk.Context, poolId uint64) (types.ConcentratedP
 	return k.getPoolById(ctx, poolId)
 }
 
-func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, nextTickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
-	return k.crossTick(ctx, poolId, tickIndex, nextTickInfo, swapStateFeeGrowth, uptimeAccums)
+func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, nextTickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, feeAccumValue sdk.DecCoins, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
+	return k.crossTick(ctx, poolId, tickIndex, nextTickInfo, swapStateFeeGrowth, feeAccumValue, uptimeAccums)
 }
 
 func (k Keeper) SendCoinsBetweenPoolAndUser(ctx sdk.Context, denom0, denom1 string, amount0, amount1 sdk.Int, sender, receiver sdk.AccAddress) error {
@@ -192,10 +192,6 @@ func CalculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, current
 
 func (k Keeper) GetInitialFeeGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
 	return k.getInitialFeeGrowthOppositeDirectionOfLastTraversalForTick(ctx, poolId, tick)
-}
-
-func (k Keeper) ChargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
-	return k.chargeFee(ctx, poolId, feeUpdate)
 }
 
 func ValidateTickRangeIsValid(tickSpacing uint64, lowerTick int64, upperTick int64) error {

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -252,8 +252,8 @@ func (k Keeper) UpdateUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64) er
 	return k.updatePoolUptimeAccumulatorsToNow(ctx, poolId)
 }
 
-func (k Keeper) UpdatePoolGivenUptimeAccumulatorsToNow(ctx sdk.Context, pool types.ConcentratedPoolExtension, uptimeAccums []accum.AccumulatorObject) error {
-	return k.updatePoolGivenUptimeAccumulatorsToNow(ctx, pool, uptimeAccums)
+func (k Keeper) UpdateGivenPoolUptimeAccumulatorsToNow(ctx sdk.Context, pool types.ConcentratedPoolExtension, uptimeAccums []accum.AccumulatorObject) error {
+	return k.updateGivenPoolUptimeAccumulatorsToNow(ctx, pool, uptimeAccums)
 }
 
 func (k Keeper) SetIncentiveRecord(ctx sdk.Context, incentiveRecord types.IncentiveRecord) error {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -32,20 +32,6 @@ func (k Keeper) GetFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.Accumul
 	return acc, nil
 }
 
-// chargeFee charges the given fee on the pool with the given id by updating
-// the internal per-pool accumulator that tracks fee growth per one unit of
-// liquidity. Returns error if fails to get accumulator.
-func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
-	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
-	if err != nil {
-		return err
-	}
-
-	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(feeUpdate))
-
-	return nil
-}
-
 // initOrUpdatePositionFeeAccumulator mutates the fee accumulator position by either creating or updating it
 // for the given pool id in the range specified by the given lower and upper ticks, position id and liquidityDelta.
 // If liquidityDelta is positive, it adds liquidity. If liquidityDelta is negative, it removes liquidity.

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -251,8 +251,6 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 		return sdk.Coins{}, err
 	}
 
-	// Create a temporary position record on all uptime accumulators with this amount. We expect this to be cleared later
-	// with `claimAndResetFullRangeBalancerPool`
 	// Claim rewards on each uptime accumulator. Delete each record after claiming.
 	totalRewards := sdk.NewCoins()
 	for uptimeIndex := range uptimeAccums {

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -358,6 +358,10 @@ func (k Keeper) updatePoolUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64
 // * this function only attempts to fetch a pool after validating lastLiquidityUpdate time is not in the current block.
 // This is to avoid unnecessary state reads during swaps for performance reasons.
 func (k Keeper) updatePoolGivenUptimeAccumulatorsToNow(ctx sdk.Context, pool types.ConcentratedPoolExtension, uptimeAccums []accum.AccumulatorObject) error {
+	if pool == nil {
+		return types.ErrPoolNil
+	}
+
 	// Since our base unit of time is nanoseconds, we divide with truncation by 10^9 (10e8) to get
 	// time elapsed in seconds
 	timeElapsedNanoSec := sdk.NewDec(int64(ctx.BlockTime().Sub(pool.GetLastLiquidityUpdate())))

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -107,8 +107,7 @@ func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ct
 // if it exists, adds the number of full range shares it qualifies for to the CL pool uptime accumulators.
 // This is functionally equivalent to treating the Balancer pool shares as a single full range position on the CL pool,
 // but just for the purposes of incentives. The Balancer pool liquidity is not actually traded against in CL pool swaps.
-// The given uptime accumulators are mutated to reflect the added full range shares. The caller is responsible
-// for ensuring that uptimeAccums are up-to-date and refetched when needed.
+// The given uptime accumulators are mutated to reflect the added full range shares.
 //
 // If no canonical Balancer pool exists, this function is a no-op.
 //
@@ -116,7 +115,9 @@ func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ct
 // Returns error if a canonical pool ID exists but there is an issue when retrieving the pool assets for this pool.
 //
 // CONTRACT: canonical Balancer pool has the same denoms as the CL pool and is an even-weighted 2-asset pool.
-// CONTRACT: uptimeAccums are associated with the given CL pool id.
+// CONTRACT: the caller validates that the pool with the given id exists.
+// CONTRACT: caller is responsible for the uptimeAccums to be up-to-date.
+// CONTRACT: uptimeAccums are associated with the given pool id.
 func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64, uptimeAccums []accum.AccumulatorObject) (uint64, sdk.Dec, error) {
 	// Get CL pool from ID
 	clPool, err := k.getPoolById(ctx, clPoolId)
@@ -224,12 +225,13 @@ func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64,
 // claimAndResetFullRangeBalancerPool claims rewards for the "full range" shares corresponding to the given Balancer pool, and
 // then deletes the record from the uptime accumulators. It adds the claimed rewards to the gauge corresponding to the longest duration
 // lock on the Balancer pool. Importantly, this is a dynamic check such that if a longer duration lock is added in the future, it will
-// begin using that lock. The given uptime accumulators are mutated to reflect the claimed rewards. The caller is responsible
-// for ensuring that uptimeAccums are up-to-date and refetched when needed.
+// begin using that lock. The given uptime accumulators are mutated to reflect the claimed rewards.
 //
 // Returns the number of coins that were claimed and distrbuted.
 // Returns error if either reward claiming, record deletion or adding to the gauge fails.
-// CONTRACT: uptimeAccums are associated with the given CL pool id.
+// CONTRACT: the caller validates that the pool with the given id exists.
+// CONTRACT: caller is responsible for the uptimeAccums to be up-to-date.
+// CONTRACT: uptimeAccums are associated with the given pool id.
 func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uint64, balPoolId uint64, uptimeAccums []accum.AccumulatorObject) (sdk.Coins, error) {
 	// Get CL pool from ID. This also serves as an early pool existence check.
 	clPool, err := k.getPoolById(ctx, clPoolId)

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -107,6 +107,8 @@ func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ct
 // if it exists, adds the number of full range shares it qualifies for to the CL pool uptime accumulators.
 // This is functionally equivalent to treating the Balancer pool shares as a single full range position on the CL pool,
 // but just for the purposes of incentives. The Balancer pool liquidity is not actually traded against in CL pool swaps.
+// The given uptime accumulators are mutated to reflect the added full range shares. The caller is responsible
+// for ensuring that uptimeAccums are up-to-date and refetched when needed.
 //
 // If no canonical Balancer pool exists, this function is a no-op.
 //
@@ -114,7 +116,7 @@ func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ct
 // Returns error if a canonical pool ID exists but there is an issue when retrieving the pool assets for this pool.
 //
 // CONTRACT: canonical Balancer pool has the same denoms as the CL pool and is an even-weighted 2-asset pool.
-// TODO: add test that uptimeAccums are mutated.
+// CONTRACT: uptimeAccums are associated with the given CL pool id.
 func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64, uptimeAccums []accum.AccumulatorObject) (uint64, sdk.Dec, error) {
 	// Get CL pool from ID
 	clPool, err := k.getPoolById(ctx, clPoolId)

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -224,11 +224,12 @@ func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64,
 // claimAndResetFullRangeBalancerPool claims rewards for the "full range" shares corresponding to the given Balancer pool, and
 // then deletes the record from the uptime accumulators. It adds the claimed rewards to the gauge corresponding to the longest duration
 // lock on the Balancer pool. Importantly, this is a dynamic check such that if a longer duration lock is added in the future, it will
-// begin using that lock.
+// begin using that lock. The given uptime accumulators are mutated to reflect the claimed rewards. The caller is responsible
+// for ensuring that uptimeAccums are up-to-date and refetched when needed.
 //
 // Returns the number of coins that were claimed and distrbuted.
 // Returns error if either reward claiming, record deletion or adding to the gauge fails.
-// TODO: add test that uptimeAccums are mutated.
+// CONTRACT: uptimeAccums are associated with the given CL pool id.
 func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uint64, balPoolId uint64, uptimeAccums []accum.AccumulatorObject) (sdk.Coins, error) {
 	// Get CL pool from ID. This also serves as an early pool existence check.
 	clPool, err := k.getPoolById(ctx, clPoolId)

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1,6 +1,7 @@
 package concentrated_liquidity_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -740,6 +741,87 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 		expectedIncentiveRecords []types.IncentiveRecord
 		expectedError            error
 	}
+
+	validateResult := func(ctx sdk.Context, err error, tc updateAccumToNow, balancerPoolId, poolId uint64, initUptimeAccumValues []sdk.DecCoins, qualifyingBalancerLiquidity sdk.Dec, qualifyingLiquidity sdk.Dec) {
+		clKeeper := s.App.ConcentratedLiquidityKeeper
+
+		if tc.expectedError != nil {
+			s.Require().Error(err)
+			s.Require().ErrorContains(err, tc.expectedError.Error())
+
+			// Ensure accumulators remain unchanged
+			newUptimeAccumValues, err := clKeeper.GetUptimeAccumulatorValues(ctx, poolId)
+			s.Require().NoError(err)
+			s.Require().Equal(initUptimeAccumValues, newUptimeAccumValues)
+
+			// Ensure incentive records remain unchanged
+			updatedIncentiveRecords, err := clKeeper.GetAllIncentiveRecordsForPool(ctx, poolId)
+			s.Require().NoError(err)
+			s.Require().Equal(tc.poolIncentiveRecords, updatedIncentiveRecords)
+
+			return
+		}
+
+		s.Require().NoError(err)
+
+		// Get updated pool for testing purposes
+		clPool, err := clKeeper.GetPoolById(ctx, tc.poolId)
+		s.Require().NoError(err)
+
+		// Calculate expected uptime deltas using qualifying liquidity deltas.
+		// Recall that uptime accumulators track emitted incentives / qualifying liquidity.
+		expectedUptimeDeltas := []sdk.DecCoins{}
+		for _, curSupportedUptime := range types.SupportedUptimes {
+			// Calculate expected incentives for the current uptime by emitting incentives from
+			// all incentive records to their respective uptime accumulators in the pool.
+			// TODO: find a cleaner way to calculate this that does not involve iterating over all incentive records for each uptime accum.
+			curUptimeAccruedIncentives := cl.EmptyCoins
+			for _, poolRecord := range tc.poolIncentiveRecords {
+				if poolRecord.MinUptime == curSupportedUptime {
+					// We set the expected accrued incentives based on the total time that has elapsed since position creation
+					curUptimeAccruedIncentives = curUptimeAccruedIncentives.Add(sdk.NewDecCoins(expectedIncentivesFromRate(poolRecord.IncentiveDenom, poolRecord.IncentiveRecordBody.EmissionRate, defaultTestUptime+tc.timeElapsed, qualifyingLiquidity))...)
+				}
+			}
+			expectedUptimeDeltas = append(expectedUptimeDeltas, curUptimeAccruedIncentives)
+		}
+
+		// Get new uptime accum values for comparison
+		newUptimeAccumValues, err := clKeeper.GetUptimeAccumulatorValues(ctx, tc.poolId)
+		s.Require().NoError(err)
+
+		// Ensure that each accumulator value changes by the correct amount
+		totalUptimeDeltas := sdk.NewDecCoins()
+		for uptimeIndex := range newUptimeAccumValues {
+			uptimeDelta := newUptimeAccumValues[uptimeIndex].Sub(initUptimeAccumValues[uptimeIndex])
+			s.Require().Equal(expectedUptimeDeltas[uptimeIndex], uptimeDelta)
+
+			totalUptimeDeltas = totalUptimeDeltas.Add(uptimeDelta...)
+		}
+
+		// Ensure that LastLiquidityUpdate field is updated for pool
+		s.Require().Equal(ctx.BlockTime(), clPool.GetLastLiquidityUpdate())
+
+		// Ensure that pool's IncentiveRecords are updated to reflect emitted incentives
+		updatedIncentiveRecords, err := clKeeper.GetAllIncentiveRecordsForPool(ctx, tc.poolId)
+		s.Require().NoError(err)
+		s.Require().Equal(tc.expectedIncentiveRecords, updatedIncentiveRecords)
+
+		// If applicable, get gauge for canonical balancer pool and ensure it increased by the appropriate amount.
+		if tc.canonicalBalancerPoolAssets != nil {
+			gaugeId, err := s.App.PoolIncentivesKeeper.GetPoolGaugeId(ctx, balancerPoolId, longestLockableDuration)
+			s.Require().NoError(err)
+
+			gauge, err := s.App.IncentivesKeeper.GetGaugeByID(ctx, gaugeId)
+			s.Require().NoError(err)
+
+			// Since balancer shares are added prior to actual emissions to the pool, they are already factored into the
+			// accumulator values ("totalUptimeDeltas"). We leverage this to find the expected amount of incentives emitted
+			// to the gauge.
+			expectedGaugeShares := sdk.NewCoins(sdk.NormalizeCoins(totalUptimeDeltas.MulDec(qualifyingBalancerLiquidity))...)
+			s.Require().Equal(expectedGaugeShares, gauge.Coins)
+		}
+	}
+
 	tests := map[string]updateAccumToNow{
 		"one incentive record": {
 			poolId:               defaultPoolId,
@@ -969,84 +1051,28 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 			// Let `timeElapsed` time pass to test incentive distribution
 			s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(tc.timeElapsed))
 
-			// System under test
-			err = clKeeper.UpdateUptimeAccumulatorsToNow(s.Ctx, tc.poolId)
+			// System under test 1
+			// Use cache context to avoud persisting updates for the next function
+			// that relies on the same test cases and setup.
+			cacheCtx, _ := s.Ctx.CacheContext()
+			err = clKeeper.UpdateUptimeAccumulatorsToNow(cacheCtx, tc.poolId)
 
-			if tc.expectedError != nil {
-				s.Require().Error(err)
-				s.Require().ErrorContains(err, tc.expectedError.Error())
+			validateResult(cacheCtx, err, tc, balancerPoolId, clPool.GetId(), initUptimeAccumValues, qualifyingBalancerLiquidity, qualifyingLiquidity)
 
-				// Ensure accumulators remain unchanged
-				newUptimeAccumValues, err := clKeeper.GetUptimeAccumulatorValues(s.Ctx, clPool.GetId())
-				s.Require().NoError(err)
-				s.Require().Equal(initUptimeAccumValues, newUptimeAccumValues)
+			// System under test 2
 
-				// Ensure incentive records remain unchanged
-				updatedIncentiveRecords, err := clKeeper.GetAllIncentiveRecordsForPool(s.Ctx, clPool.GetId())
-				s.Require().NoError(err)
-				s.Require().Equal(tc.poolIncentiveRecords, updatedIncentiveRecords)
-
+			// Skip this test case as UpdatePoolGivenUptimeAccumulatorsToNow relies
+			// on this check to be done by the caller.
+			if errors.Is(tc.expectedError, types.PoolNotFoundError{PoolId: invalidPoolId}) {
 				return
 			}
 
+			uptimeAccs, err := clKeeper.GetUptimeAccumulators(s.Ctx, tc.poolId)
 			s.Require().NoError(err)
 
-			// Get updated pool for testing purposes
-			clPool, err = clKeeper.GetPoolById(s.Ctx, tc.poolId)
-			s.Require().NoError(err)
+			err = clKeeper.UpdatePoolGivenUptimeAccumulatorsToNow(s.Ctx, clPool, uptimeAccs)
 
-			// Calculate expected uptime deltas using qualifying liquidity deltas.
-			// Recall that uptime accumulators track emitted incentives / qualifying liquidity.
-			expectedUptimeDeltas := []sdk.DecCoins{}
-			for _, curSupportedUptime := range types.SupportedUptimes {
-				// Calculate expected incentives for the current uptime by emitting incentives from
-				// all incentive records to their respective uptime accumulators in the pool.
-				// TODO: find a cleaner way to calculate this that does not involve iterating over all incentive records for each uptime accum.
-				curUptimeAccruedIncentives := cl.EmptyCoins
-				for _, poolRecord := range tc.poolIncentiveRecords {
-					if poolRecord.MinUptime == curSupportedUptime {
-						// We set the expected accrued incentives based on the total time that has elapsed since position creation
-						curUptimeAccruedIncentives = curUptimeAccruedIncentives.Add(sdk.NewDecCoins(expectedIncentivesFromRate(poolRecord.IncentiveDenom, poolRecord.IncentiveRecordBody.EmissionRate, defaultTestUptime+tc.timeElapsed, qualifyingLiquidity))...)
-					}
-				}
-				expectedUptimeDeltas = append(expectedUptimeDeltas, curUptimeAccruedIncentives)
-			}
-
-			// Get new uptime accum values for comparison
-			newUptimeAccumValues, err := clKeeper.GetUptimeAccumulatorValues(s.Ctx, tc.poolId)
-			s.Require().NoError(err)
-
-			// Ensure that each accumulator value changes by the correct amount
-			totalUptimeDeltas := sdk.NewDecCoins()
-			for uptimeIndex := range newUptimeAccumValues {
-				uptimeDelta := newUptimeAccumValues[uptimeIndex].Sub(initUptimeAccumValues[uptimeIndex])
-				s.Require().Equal(expectedUptimeDeltas[uptimeIndex], uptimeDelta)
-
-				totalUptimeDeltas = totalUptimeDeltas.Add(uptimeDelta...)
-			}
-
-			// Ensure that LastLiquidityUpdate field is updated for pool
-			s.Require().Equal(s.Ctx.BlockTime(), clPool.GetLastLiquidityUpdate())
-
-			// Ensure that pool's IncentiveRecords are updated to reflect emitted incentives
-			updatedIncentiveRecords, err := clKeeper.GetAllIncentiveRecordsForPool(s.Ctx, tc.poolId)
-			s.Require().NoError(err)
-			s.Require().Equal(tc.expectedIncentiveRecords, updatedIncentiveRecords)
-
-			// If applicable, get gauge for canonical balancer pool and ensure it increased by the appropriate amount.
-			if tc.canonicalBalancerPoolAssets != nil {
-				gaugeId, err := s.App.PoolIncentivesKeeper.GetPoolGaugeId(s.Ctx, balancerPoolId, longestLockableDuration)
-				s.Require().NoError(err)
-
-				gauge, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, gaugeId)
-				s.Require().NoError(err)
-
-				// Since balancer shares are added prior to actual emissions to the pool, they are already factored into the
-				// accumulator values ("totalUptimeDeltas"). We leverage this to find the expected amount of incentives emitted
-				// to the gauge.
-				expectedGaugeShares := sdk.NewCoins(sdk.NormalizeCoins(totalUptimeDeltas.MulDec(qualifyingBalancerLiquidity))...)
-				s.Require().Equal(expectedGaugeShares, gauge.Coins)
-			}
+			validateResult(s.Ctx, err, tc, balancerPoolId, clPool.GetId(), initUptimeAccumValues, qualifyingBalancerLiquidity, qualifyingLiquidity)
 		})
 	}
 }
@@ -3327,7 +3353,11 @@ func (s *KeeperTestSuite) TestPrepareBalancerPoolAsFullRange() {
 
 			// --- System under test ---
 
-			retrievedBalancerPoolId, addedLiquidity, err := s.App.ConcentratedLiquidityKeeper.PrepareBalancerPoolAsFullRange(s.Ctx, concentratedPoolId)
+			// Get uptime accums for the cl pool.
+			uptimeAccums, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, clPool.GetId())
+			s.Require().NoError(err)
+
+			retrievedBalancerPoolId, addedLiquidity, err := s.App.ConcentratedLiquidityKeeper.PrepareBalancerPoolAsFullRange(s.Ctx, concentratedPoolId, uptimeAccums)
 
 			// --- Assertions ---
 
@@ -3525,7 +3555,11 @@ func (s *KeeperTestSuite) TestClaimAndResetFullRangeBalancerPool() {
 			// Add balancer shares to CL accumulatores
 			addedLiquidity := sdk.ZeroDec()
 			if !tc.balSharesNotAddedToAccums {
-				addedBalPool, qualifiedShares, err := s.App.ConcentratedLiquidityKeeper.PrepareBalancerPoolAsFullRange(s.Ctx, clPool.GetId())
+				// Get uptime accums for the cl pool.
+				uptimeAccums, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, clPool.GetId())
+				s.Require().NoError(err)
+
+				addedBalPool, qualifiedShares, err := s.App.ConcentratedLiquidityKeeper.PrepareBalancerPoolAsFullRange(s.Ctx, clPool.GetId(), uptimeAccums)
 				addedLiquidity = addedLiquidity.Add(qualifiedShares)
 
 				// If a valid link exists, ensure no error and sanity check the output pool ID
@@ -3549,7 +3583,11 @@ func (s *KeeperTestSuite) TestClaimAndResetFullRangeBalancerPool() {
 
 			// --- System under test ---
 
-			amountClaimed, err := s.App.ConcentratedLiquidityKeeper.ClaimAndResetFullRangeBalancerPool(s.Ctx, clPoolId, balancerPoolId)
+			// Get uptime accums for the cl pool.
+			uptimeAccums, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, clPool.GetId())
+			s.Require().NoError(err)
+
+			amountClaimed, err := s.App.ConcentratedLiquidityKeeper.ClaimAndResetFullRangeBalancerPool(s.Ctx, clPoolId, balancerPoolId, uptimeAccums)
 
 			// --- Assertions ---
 

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -3378,16 +3378,21 @@ func (s *KeeperTestSuite) TestPrepareBalancerPoolAsFullRange() {
 			updatedClPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 			s.Require().NoError(err)
 
-			clPoolUptimeAccumulators, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, clPool.GetId())
+			clPoolUptimeAccumulatorsFromState, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, clPool.GetId())
 			s.Require().NoError(err)
 
-			s.Require().True(len(clPoolUptimeAccumulators) > 0)
-			for _, uptimeAccum := range clPoolUptimeAccumulators {
+			s.Require().True(len(clPoolUptimeAccumulatorsFromState) > 0)
+			expectedShares := qualifyingShares.Add(initialLiquidity)
+			for uptimeIdx, uptimeAccum := range clPoolUptimeAccumulatorsFromState {
 				currAccumShares, err := uptimeAccum.GetTotalShares()
 				s.Require().NoError(err)
 
 				// Ensure each accum has the correct number of final shares
-				s.Require().Equal(qualifyingShares.Add(initialLiquidity), currAccumShares)
+				s.Require().Equal(expectedShares, currAccumShares)
+
+				// Also validate uptime accumulators passed in as parameter.
+				currAccumShares, err = uptimeAccums[uptimeIdx].GetTotalShares()
+				s.Require().Equal(expectedShares, currAccumShares)
 			}
 
 			// Ensure added liquidity is equal to the amount accum shares changed by

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1070,7 +1070,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 			uptimeAccs, err := clKeeper.GetUptimeAccumulators(s.Ctx, tc.poolId)
 			s.Require().NoError(err)
 
-			err = clKeeper.UpdatePoolGivenUptimeAccumulatorsToNow(s.Ctx, clPool, uptimeAccs)
+			err = clKeeper.UpdateGivenPoolUptimeAccumulatorsToNow(s.Ctx, clPool, uptimeAccs)
 
 			validateResult(s.Ctx, err, tc, balancerPoolId, clPool.GetId(), initUptimeAccumValues, qualifyingBalancerLiquidity, qualifyingLiquidity)
 		})

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1061,7 +1061,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 
 			validateResult(cacheCtx, err, tc, balancerPoolId, clPool.GetId(), initUptimeAccumValues, qualifyingBalancerLiquidity, qualifyingLiquidity)
 
-			// System under test 2
+			// Now test a similar method with different parameters
 
 			// Skip this test case as UpdatePoolGivenUptimeAccumulatorsToNow relies
 			// on this check to be done by the caller.
@@ -1072,6 +1072,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 			uptimeAccs, err := clKeeper.GetUptimeAccumulators(s.Ctx, tc.poolId)
 			s.Require().NoError(err)
 
+			// System under test 2
 			err = clKeeper.UpdateGivenPoolUptimeAccumulatorsToNow(s.Ctx, clPool, uptimeAccs)
 
 			expectedUptimeDeltas := validateResult(s.Ctx, err, tc, balancerPoolId, clPool.GetId(), initUptimeAccumValues, qualifyingBalancerLiquidity, qualifyingLiquidity)

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -324,8 +324,11 @@ func (s *KeeperTestSuite) crossTickAndChargeFee(poolId uint64, tickIndexToCross 
 	nextTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, poolId, tickIndexToCross)
 	s.Require().NoError(err)
 
+	uptimeAccums, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, poolId)
+	s.Require().NoError(err)
+
 	// Cross the tick to update it.
-	_, err = s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, poolId, tickIndexToCross, &nextTickInfo, DefaultFeeAccumCoins[0])
+	_, err = s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, poolId, tickIndexToCross, &nextTickInfo, DefaultFeeAccumCoins[0], uptimeAccums)
 	s.Require().NoError(err)
 	err = s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, poolId, DefaultFeeAccumCoins[0])
 	s.Require().NoError(err)

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -327,11 +327,22 @@ func (s *KeeperTestSuite) crossTickAndChargeFee(poolId uint64, tickIndexToCross 
 	uptimeAccums, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, poolId)
 	s.Require().NoError(err)
 
+	feeAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, poolId)
+	s.Require().NoError(err)
+
 	// Cross the tick to update it.
-	_, err = s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, poolId, tickIndexToCross, &nextTickInfo, DefaultFeeAccumCoins[0], uptimeAccums)
+	_, err = s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, poolId, tickIndexToCross, &nextTickInfo, DefaultFeeAccumCoins[0], feeAccum.GetValue(), uptimeAccums)
 	s.Require().NoError(err)
-	err = s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, poolId, DefaultFeeAccumCoins[0])
+	s.AddToFeeAccumulator(poolId, DefaultFeeAccumCoins[0])
+}
+
+// AddToFeeAccumulator adds the given fee to pool by updating
+// the internal per-pool accumulator that tracks fee growth per one unit of
+// liquidity.
+func (s *KeeperTestSuite) AddToFeeAccumulator(poolId uint64, feeUpdate sdk.DecCoin) {
+	feeAccumulator, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, poolId)
 	s.Require().NoError(err)
+	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(feeUpdate))
 }
 
 func (s *KeeperTestSuite) validatePositionFeeGrowth(poolId uint64, positionId uint64, expectedUnclaimedRewards sdk.DecCoins) {

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -284,8 +284,7 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 
 			// Pre-set fee growth accumulator
 			if !tc.preSetChargeFee.IsZero() {
-				err = clKeeper.ChargeFee(s.Ctx, 1, tc.preSetChargeFee)
-				s.Require().NoError(err)
+				s.AddToFeeAccumulator(poolID, tc.preSetChargeFee)
 			}
 
 			expectedNumCreatePositionEvents := 1
@@ -565,8 +564,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 
 			// Set global fee growth to 1 ETH and charge the fee to the pool.
 			globalFeeGrowth := sdk.NewDecCoin(ETH, sdk.NewInt(1))
-			err = concentratedLiquidityKeeper.ChargeFee(s.Ctx, pool.GetId(), globalFeeGrowth)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(pool.GetId(), globalFeeGrowth)
 
 			// Add global uptime growth
 			err = addToUptimeAccums(s.Ctx, pool.GetId(), concentratedLiquidityKeeper, defaultUptimeGrowth)
@@ -1653,8 +1651,7 @@ func (s *KeeperTestSuite) TestInverseRelation_CreatePosition_WithdrawPosition() 
 
 			// Pre-set fee growth accumulator
 			if !tc.preSetChargeFee.IsZero() {
-				err = clKeeper.ChargeFee(s.Ctx, 1, tc.preSetChargeFee)
-				s.Require().NoError(err)
+				s.AddToFeeAccumulator(1, tc.preSetChargeFee)
 			}
 
 			// If we want to test a non-first position, we create a first position with a separate account

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -323,6 +323,11 @@ func (k Keeper) computeOutAmtGivenIn(
 		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 	}
 
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
+	if err != nil {
+		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
+	}
+
 	// initialize swap state with the following parameters:
 	// as we iterate through the following for loop, this swap state will get updated after each required iteration
 	swapState := SwapState{
@@ -414,7 +419,7 @@ func (k Keeper) computeOutAmtGivenIn(
 			}
 
 			// Retrieve the liquidity held in the next closest initialized tick
-			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal), uptimeAccums)
+			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal), feeAccumulator.GetValue(), uptimeAccums)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -440,9 +445,8 @@ func (k Keeper) computeOutAmtGivenIn(
 		}
 	}
 
-	if err := k.chargeFee(ctx, poolId, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal)); err != nil {
-		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
-	}
+	// Add fee growth per share to the pool-global fee accumulator.
+	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal)))
 
 	// Coin amounts require int values
 	// Round amountIn up to avoid under charging
@@ -551,6 +555,11 @@ func (k Keeper) computeInAmtGivenOut(
 		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 	}
 
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
+	if err != nil {
+		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
+	}
+
 	// TODO: This should be GT 0 but some instances have very small remainder
 	// need to look into fixing this
 	for swapState.amountSpecifiedRemaining.GT(smallestDec) && !swapState.sqrtPrice.Equal(sqrtPriceLimit) {
@@ -617,7 +626,7 @@ func (k Keeper) computeInAmtGivenOut(
 			}
 
 			// retrieve the liquidity held in the next closest initialized tick
-			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(desiredTokenOut.Denom, swapState.feeGrowthGlobal), uptimeAccums)
+			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(desiredTokenOut.Denom, swapState.feeGrowthGlobal), feeAccumulator.GetValue(), uptimeAccums)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -642,9 +651,8 @@ func (k Keeper) computeInAmtGivenOut(
 		}
 	}
 
-	if err := k.chargeFee(ctx, poolId, sdk.NewDecCoinFromDec(tokenInDenom, swapState.feeGrowthGlobal)); err != nil {
-		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
-	}
+	// Add fee growth per share to the pool-global fee accumulator.
+	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInDenom, swapState.feeGrowthGlobal)))
 
 	// coin amounts require int values
 	// Round amount in up to avoid under charging the user.

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -258,7 +258,7 @@ func (k Keeper) computeOutAmtGivenIn(
 	spreadFactor sdk.Dec,
 	priceLimit sdk.Dec,
 ) (tokenIn, tokenOut sdk.Coin, updatedTick int64, updatedLiquidity, updatedSqrtPrice sdk.Dec, totalFees sdk.Dec, err error) {
-	// Get p and asset info
+	// Get pool and asset info
 	p, err := k.getPoolById(ctx, poolId)
 	if err != nil {
 		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
@@ -414,7 +414,7 @@ func (k Keeper) computeOutAmtGivenIn(
 			}
 
 			// Retrieve the liquidity held in the next closest initialized tick
-			liquidityNet, err := k.crossTick(ctx, p.GetId(), nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal), uptimeAccums)
+			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal), uptimeAccums)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -409,7 +409,7 @@ func (k Keeper) computeOutAmtGivenIn(
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
 
-			if err := k.updatePoolGivenUptimeAccumulatorsToNow(ctx, p, uptimeAccums); err != nil {
+			if err := k.updateGivenPoolUptimeAccumulatorsToNow(ctx, p, uptimeAccums); err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
 
@@ -612,7 +612,7 @@ func (k Keeper) computeInAmtGivenOut(
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
 
-			if err := k.updatePoolGivenUptimeAccumulatorsToNow(ctx, p, uptimeAccums); err != nil {
+			if err := k.updateGivenPoolUptimeAccumulatorsToNow(ctx, p, uptimeAccums); err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -72,7 +72,7 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 
 // crossTick crosses the given tick. The tick is specified by its index and tick info.
 // It updates the given tick's uptime and fee accumulators and writes it back to state.
-// Prior to updating the tick info and writing it to state, it updates the pool uptime accumulators until the current block time.
+// Prior to writing it to state, it updates the pool uptime accumulators until the current block time.
 // WARNING: this method may mutate the pool, make sure to refetch the pool after calling this method.
 func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -78,18 +78,13 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 // CONTRACT: the caller validates that the pool with the given id exists.
 // CONTRACT: caller is responsible for the uptimeAccums to be up-to-date.
 // CONTRACT: uptimeAccums are associated with the given pool id.
-func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
+func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, feeAccumValue sdk.DecCoins, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {
 		return sdk.Dec{}, types.ErrNextTickInfoNil
 	}
 
-	feeAccum, err := k.GetFeeAccumulator(ctx, poolId)
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-
 	// subtract tick's fee growth opposite direction of last traversal from current fee growth global, including the fee growth of the current swap.
-	tickInfo.FeeGrowthOppositeDirectionOfLastTraversal = feeAccum.GetValue().Add(swapStateFeeGrowth).Sub(tickInfo.FeeGrowthOppositeDirectionOfLastTraversal)
+	tickInfo.FeeGrowthOppositeDirectionOfLastTraversal = feeAccumValue.Add(swapStateFeeGrowth).Sub(tickInfo.FeeGrowthOppositeDirectionOfLastTraversal)
 
 	// For each supported uptime, subtract tick's uptime growth outside from the respective uptime accumulator
 	// This is functionally equivalent to "flipping" the trackers once the tick is crossed

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -75,7 +75,6 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 // It updates the given tick's uptime and fee accumulators and writes it back to state.
 // Prior to updating the tick info and writing it to state, it updates the pool uptime accumulators until the current block time.
 // WARNING: this method may mutate the pool, make sure to refetch the pool after calling this method.
-// TODO: add test that uptimeAccums are not mutated.
 func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {
 		return sdk.Dec{}, types.ErrNextTickInfoNil

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -10,6 +10,7 @@ import (
 	db "github.com/tendermint/tm-db"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
+	"github.com/osmosis-labs/osmosis/osmoutils/accum"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/client/queryproto"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/model"
@@ -74,7 +75,8 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 // It updates the given tick's uptime and fee accumulators and writes it back to state.
 // Prior to updating the tick info and writing it to state, it updates the pool uptime accumulators until the current block time.
 // WARNING: this method may mutate the pool, make sure to refetch the pool after calling this method.
-func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin) (liquidityDelta sdk.Dec, err error) {
+// TODO: add test that uptimeAccums are not mutated.
+func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {
 		return sdk.Dec{}, types.ErrNextTickInfoNil
 	}
@@ -87,21 +89,11 @@ func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickI
 	// subtract tick's fee growth opposite direction of last traversal from current fee growth global, including the fee growth of the current swap.
 	tickInfo.FeeGrowthOppositeDirectionOfLastTraversal = feeAccum.GetValue().Add(swapStateFeeGrowth).Sub(tickInfo.FeeGrowthOppositeDirectionOfLastTraversal)
 
-	// Update global accums to now before uptime outside changes
-	if err := k.updatePoolUptimeAccumulatorsToNow(ctx, poolId); err != nil {
-		return sdk.Dec{}, err
-	}
-
-	uptimeAccums, err := k.GetUptimeAccumulators(ctx, poolId)
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-
 	// For each supported uptime, subtract tick's uptime growth outside from the respective uptime accumulator
 	// This is functionally equivalent to "flipping" the trackers once the tick is crossed
 	updatedUptimeTrackers := tickInfo.UptimeTrackers
-	for uptimeId, uptimeAccum := range uptimeAccums {
-		updatedUptimeTrackers[uptimeId].UptimeGrowthOutside = uptimeAccum.GetValue().Sub(updatedUptimeTrackers[uptimeId].UptimeGrowthOutside)
+	for uptimeId := range uptimeAccums {
+		updatedUptimeTrackers[uptimeId].UptimeGrowthOutside = uptimeAccums[uptimeId].GetValue().Sub(updatedUptimeTrackers[uptimeId].UptimeGrowthOutside)
 	}
 
 	k.SetTickInfo(ctx, poolId, tickIndex, tickInfo)

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -72,7 +72,7 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 
 // crossTick crosses the given tick. The tick is specified by its index and tick info.
 // It updates the given tick's uptime and fee accumulators and writes it back to state.
-// Prior to writing it to state, it updates the pool uptime accumulators until the current block time.
+// Prior to updating the tick info and writing it to state, it updates the pool uptime accumulators until the current block time.
 // WARNING: this method may mutate the pool, make sure to refetch the pool after calling this method.
 func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -75,6 +75,9 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 // It updates the given tick's uptime and fee accumulators and writes it back to state.
 // Prior to updating the tick info and writing it to state, it updates the pool uptime accumulators until the current block time.
 // WARNING: this method may mutate the pool, make sure to refetch the pool after calling this method.
+// CONTRACT: the caller validates that the pool with the given id exists.
+// CONTRACT: caller is responsible for the uptimeAccums to be up-to-date.
+// CONTRACT: uptimeAccums are associated with the given pool id.
 func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {
 		return sdk.Dec{}, types.ErrNextTickInfoNil

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -629,8 +629,14 @@ func (s *KeeperTestSuite) TestCrossTick() {
 				nextTickInfo = &model.TickInfo{}
 			}
 
+			var uptimeAccums []accum.AccumulatorObject
+			if test.poolToGet == validPoolId {
+				uptimeAccums, err = s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, test.poolToGet)
+				s.Require().NoError(err)
+			}
+
 			// System under test
-			liquidityDelta, err := s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, test.poolToGet, test.tickToGet, nextTickInfo, test.additiveFee)
+			liquidityDelta, err := s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, test.poolToGet, test.tickToGet, nextTickInfo, test.additiveFee, uptimeAccums)
 			if test.expectedErr != nil {
 				s.Require().Error(err)
 				s.Require().ErrorAs(err, &test.expectedErr)

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -428,8 +428,7 @@ func (s *KeeperTestSuite) TestGetTickInfo() {
 			if test.poolToGet == validPoolId {
 				s.SetupDefaultPosition(test.poolToGet)
 			}
-			err = clKeeper.ChargeFee(s.Ctx, validPoolId, oneEth)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(validPoolId, oneEth)
 
 			// System under test
 			tickInfo, err := clKeeper.GetTickInfo(s.Ctx, test.poolToGet, test.tickToGet)
@@ -554,14 +553,6 @@ func (s *KeeperTestSuite) TestCrossTick() {
 			expectedTickFeeGrowthOppositeDirectionOfLastTraversal: DefaultFeeAccumCoins.Add(defaultAdditiveFee.Add(defaultAdditiveFee)),
 		},
 		{
-			name:                    "error: Try invalid tick",
-			poolToGet:               2,
-			preInitializedTickIndex: preInitializedTickIndex,
-			tickToGet:               preInitializedTickIndex,
-			additiveFee:             defaultAdditiveFee,
-			expectedErr:             accum.AccumDoesNotExistError{},
-		},
-		{
 			name:                    "error: Nil tick",
 			poolToGet:               validPoolId,
 			preInitializedTickIndex: preInitializedTickIndex,
@@ -589,17 +580,16 @@ func (s *KeeperTestSuite) TestCrossTick() {
 			// Charge fee to make sure that the global fee accumulator is always updated.
 			// This is to test that the per-tick fee growth accumulator gets initialized.
 			defaultAccumCoins := sdk.NewDecCoin("foo", sdk.NewInt(50))
-			err := s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, validPoolId, defaultAccumCoins)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(validPoolId, defaultAccumCoins)
 
 			// Initialize global uptime accums
 			if test.initGlobalUptimeAccumValues != nil {
-				err = addToUptimeAccums(s.Ctx, clPool.GetId(), s.App.ConcentratedLiquidityKeeper, test.initGlobalUptimeAccumValues)
+				err := addToUptimeAccums(s.Ctx, clPool.GetId(), s.App.ConcentratedLiquidityKeeper, test.initGlobalUptimeAccumValues)
 				s.Require().NoError(err)
 			}
 
 			// Set up an initialized tick
-			err = s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(s.Ctx, validPoolId, DefaultCurrTick, test.preInitializedTickIndex, DefaultLiquidityAmt, true)
+			err := s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(s.Ctx, validPoolId, DefaultCurrTick, test.preInitializedTickIndex, DefaultLiquidityAmt, true)
 			s.Require().NoError(err)
 
 			// Update global uptime accums for edge case testing
@@ -610,8 +600,7 @@ func (s *KeeperTestSuite) TestCrossTick() {
 
 			// update the fee accumulator so that we have accum value > tick fee growth value
 			// now we have 100 foo coins inside the pool accumulator
-			err = s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, validPoolId, defaultAccumCoins)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(validPoolId, defaultAccumCoins)
 
 			var nextTickInfo *model.TickInfo
 
@@ -630,13 +619,17 @@ func (s *KeeperTestSuite) TestCrossTick() {
 			}
 
 			var uptimeAccums []accum.AccumulatorObject
+			var feeAccum accum.AccumulatorObject
 			if test.poolToGet == validPoolId {
 				uptimeAccums, err = s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, test.poolToGet)
+				s.Require().NoError(err)
+
+				feeAccum, err = s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, test.poolToGet)
 				s.Require().NoError(err)
 			}
 
 			// System under test
-			liquidityDelta, err := s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, test.poolToGet, test.tickToGet, nextTickInfo, test.additiveFee, uptimeAccums)
+			liquidityDelta, err := s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, test.poolToGet, test.tickToGet, nextTickInfo, test.additiveFee, feeAccum.GetValue(), uptimeAccums)
 			if test.expectedErr != nil {
 				s.Require().Error(err)
 				s.Require().ErrorAs(err, &test.expectedErr)

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -16,6 +16,7 @@ var (
 	ErrPermissionlessPoolCreationDisabled = errors.New("permissionless pool creation is disabled for the concentrated liquidity module")
 	ErrZeroLiquidity                      = errors.New("liquidity cannot be 0")
 	ErrNextTickInfoNil                    = errors.New("next tick info cannot be nil")
+	ErrPoolNil                            = errors.New("pool cannot be nil")
 )
 
 // x/concentrated-liquidity module sentinel errors.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is a second improvement identified in:
https://github.com/osmosis-labs/osmosis/pull/5287

It focuses around:
- removes repeated proto unmarshaling inside the loop as we cross ticks in `updateUptimeAccumulatorsToNow`
- repeated uptime accumulator fetching and unsmarsharling. Instead, we fetch them once at the top and operated on the accumulators passed into methods as a slice. In Go, slice elements are mutated as long as they are edited directly via slice instead of copied to a local variable.

## Testing and Verifying

- Covered by existing tests
- Added new tests where applicable

Added strict tests to ensure that the parameter `uptimeAccums` are mutated in:

- [x] `updateGivenPoolUptimeAccumulatorsToNow`
- [x] `claimAndResetFullRangeBalancerPool`
- [x] `prepareBalancerPoolAsFullRange`  

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A