### PR TITLE
feat: do not require changelog and state machine labels for markdown only changes

### DIFF
--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -4,6 +4,8 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
 jobs:
   build:
     name: Check Actions

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
       - 'main'
+    paths-ignore:
+      - '**/*.md'
 jobs:
   state_compatability_labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5270 
## What is the purpose of the change

> Add a description of the overall background and high level changes that this PR introduces

- Update the .github/workflows/changelog-entry-reminder.yml and .github/workflows/required_labels.yml to not require changelog and state machine labels for markdown
- Using https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

## Testing and Verifying

*(Please pick one of the following options)*

This change was tested on my forked repository and be verified as follows:
 - To be updated

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A