### PR TITLE
perf: remove repeated fee accumulator unmarshaling in swaps

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -43,8 +43,8 @@ func (k Keeper) GetPoolById(ctx sdk.Context, poolId uint64) (types.ConcentratedP
 	return k.getPoolById(ctx, poolId)
 }
 
-func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, nextTickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
-	return k.crossTick(ctx, poolId, tickIndex, nextTickInfo, swapStateFeeGrowth, uptimeAccums)
+func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, nextTickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, feeAccumValue sdk.DecCoins, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
+	return k.crossTick(ctx, poolId, tickIndex, nextTickInfo, swapStateFeeGrowth, feeAccumValue, uptimeAccums)
 }
 
 func (k Keeper) SendCoinsBetweenPoolAndUser(ctx sdk.Context, denom0, denom1 string, amount0, amount1 sdk.Int, sender, receiver sdk.AccAddress) error {
@@ -192,10 +192,6 @@ func CalculateFeeGrowth(targetTick int64, feeGrowthOutside sdk.DecCoins, current
 
 func (k Keeper) GetInitialFeeGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
 	return k.getInitialFeeGrowthOppositeDirectionOfLastTraversalForTick(ctx, poolId, tick)
-}
-
-func (k Keeper) ChargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
-	return k.chargeFee(ctx, poolId, feeUpdate)
 }
 
 func ValidateTickRangeIsValid(tickSpacing uint64, lowerTick int64, upperTick int64) error {

--- a/x/concentrated-liquidity/fees.go
+++ b/x/concentrated-liquidity/fees.go
@@ -32,20 +32,6 @@ func (k Keeper) GetFeeAccumulator(ctx sdk.Context, poolId uint64) (accum.Accumul
 	return acc, nil
 }
 
-// chargeFee charges the given fee on the pool with the given id by updating
-// the internal per-pool accumulator that tracks fee growth per one unit of
-// liquidity. Returns error if fails to get accumulator.
-func (k Keeper) chargeFee(ctx sdk.Context, poolId uint64, feeUpdate sdk.DecCoin) error {
-	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
-	if err != nil {
-		return err
-	}
-
-	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(feeUpdate))
-
-	return nil
-}
-
 // initOrUpdatePositionFeeAccumulator mutates the fee accumulator position by either creating or updating it
 // for the given pool id in the range specified by the given lower and upper ticks, position id and liquidityDelta.
 // If liquidityDelta is positive, it adds liquidity. If liquidityDelta is negative, it removes liquidity.

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -327,11 +327,22 @@ func (s *KeeperTestSuite) crossTickAndChargeFee(poolId uint64, tickIndexToCross 
 	uptimeAccums, err := s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, poolId)
 	s.Require().NoError(err)
 
+	feeAccum, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, poolId)
+	s.Require().NoError(err)
+
 	// Cross the tick to update it.
-	_, err = s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, poolId, tickIndexToCross, &nextTickInfo, DefaultFeeAccumCoins[0], uptimeAccums)
+	_, err = s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, poolId, tickIndexToCross, &nextTickInfo, DefaultFeeAccumCoins[0], feeAccum.GetValue(), uptimeAccums)
 	s.Require().NoError(err)
-	err = s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, poolId, DefaultFeeAccumCoins[0])
+	s.AddToFeeAccumulator(poolId, DefaultFeeAccumCoins[0])
+}
+
+// AddToFeeAccumulator adds the given fee to pool by updating
+// the internal per-pool accumulator that tracks fee growth per one unit of
+// liquidity.
+func (s *KeeperTestSuite) AddToFeeAccumulator(poolId uint64, feeUpdate sdk.DecCoin) {
+	feeAccumulator, err := s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, poolId)
 	s.Require().NoError(err)
+	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(feeUpdate))
 }
 
 func (s *KeeperTestSuite) validatePositionFeeGrowth(poolId uint64, positionId uint64, expectedUnclaimedRewards sdk.DecCoins) {

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -284,8 +284,7 @@ func (s *KeeperTestSuite) TestCreatePosition() {
 
 			// Pre-set fee growth accumulator
 			if !tc.preSetChargeFee.IsZero() {
-				err = clKeeper.ChargeFee(s.Ctx, 1, tc.preSetChargeFee)
-				s.Require().NoError(err)
+				s.AddToFeeAccumulator(poolID, tc.preSetChargeFee)
 			}
 
 			expectedNumCreatePositionEvents := 1
@@ -565,8 +564,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 
 			// Set global fee growth to 1 ETH and charge the fee to the pool.
 			globalFeeGrowth := sdk.NewDecCoin(ETH, sdk.NewInt(1))
-			err = concentratedLiquidityKeeper.ChargeFee(s.Ctx, pool.GetId(), globalFeeGrowth)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(pool.GetId(), globalFeeGrowth)
 
 			// Add global uptime growth
 			err = addToUptimeAccums(s.Ctx, pool.GetId(), concentratedLiquidityKeeper, defaultUptimeGrowth)
@@ -1653,8 +1651,7 @@ func (s *KeeperTestSuite) TestInverseRelation_CreatePosition_WithdrawPosition() 
 
 			// Pre-set fee growth accumulator
 			if !tc.preSetChargeFee.IsZero() {
-				err = clKeeper.ChargeFee(s.Ctx, 1, tc.preSetChargeFee)
-				s.Require().NoError(err)
+				s.AddToFeeAccumulator(1, tc.preSetChargeFee)
 			}
 
 			// If we want to test a non-first position, we create a first position with a separate account

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -323,6 +323,11 @@ func (k Keeper) computeOutAmtGivenIn(
 		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 	}
 
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
+	if err != nil {
+		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
+	}
+
 	// initialize swap state with the following parameters:
 	// as we iterate through the following for loop, this swap state will get updated after each required iteration
 	swapState := SwapState{
@@ -414,7 +419,7 @@ func (k Keeper) computeOutAmtGivenIn(
 			}
 
 			// Retrieve the liquidity held in the next closest initialized tick
-			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal), uptimeAccums)
+			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal), feeAccumulator.GetValue(), uptimeAccums)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -440,9 +445,8 @@ func (k Keeper) computeOutAmtGivenIn(
 		}
 	}
 
-	if err := k.chargeFee(ctx, poolId, sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal)); err != nil {
-		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
-	}
+	// Add fee growth per share to the pool-global fee accumulator.
+	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.feeGrowthGlobal)))
 
 	// Coin amounts require int values
 	// Round amountIn up to avoid under charging
@@ -551,6 +555,11 @@ func (k Keeper) computeInAmtGivenOut(
 		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 	}
 
+	feeAccumulator, err := k.GetFeeAccumulator(ctx, poolId)
+	if err != nil {
+		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
+	}
+
 	// TODO: This should be GT 0 but some instances have very small remainder
 	// need to look into fixing this
 	for swapState.amountSpecifiedRemaining.GT(smallestDec) && !swapState.sqrtPrice.Equal(sqrtPriceLimit) {
@@ -617,7 +626,7 @@ func (k Keeper) computeInAmtGivenOut(
 			}
 
 			// retrieve the liquidity held in the next closest initialized tick
-			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(desiredTokenOut.Denom, swapState.feeGrowthGlobal), uptimeAccums)
+			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(desiredTokenOut.Denom, swapState.feeGrowthGlobal), feeAccumulator.GetValue(), uptimeAccums)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}
@@ -642,9 +651,8 @@ func (k Keeper) computeInAmtGivenOut(
 		}
 	}
 
-	if err := k.chargeFee(ctx, poolId, sdk.NewDecCoinFromDec(tokenInDenom, swapState.feeGrowthGlobal)); err != nil {
-		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
-	}
+	// Add fee growth per share to the pool-global fee accumulator.
+	feeAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInDenom, swapState.feeGrowthGlobal)))
 
 	// coin amounts require int values
 	// Round amount in up to avoid under charging the user.

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -78,18 +78,13 @@ func (k Keeper) initOrUpdateTick(ctx sdk.Context, poolId uint64, currentTick int
 // CONTRACT: the caller validates that the pool with the given id exists.
 // CONTRACT: caller is responsible for the uptimeAccums to be up-to-date.
 // CONTRACT: uptimeAccums are associated with the given pool id.
-func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
+func (k Keeper) crossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo, swapStateFeeGrowth sdk.DecCoin, feeAccumValue sdk.DecCoins, uptimeAccums []accum.AccumulatorObject) (liquidityDelta sdk.Dec, err error) {
 	if tickInfo == nil {
 		return sdk.Dec{}, types.ErrNextTickInfoNil
 	}
 
-	feeAccum, err := k.GetFeeAccumulator(ctx, poolId)
-	if err != nil {
-		return sdk.Dec{}, err
-	}
-
 	// subtract tick's fee growth opposite direction of last traversal from current fee growth global, including the fee growth of the current swap.
-	tickInfo.FeeGrowthOppositeDirectionOfLastTraversal = feeAccum.GetValue().Add(swapStateFeeGrowth).Sub(tickInfo.FeeGrowthOppositeDirectionOfLastTraversal)
+	tickInfo.FeeGrowthOppositeDirectionOfLastTraversal = feeAccumValue.Add(swapStateFeeGrowth).Sub(tickInfo.FeeGrowthOppositeDirectionOfLastTraversal)
 
 	// For each supported uptime, subtract tick's uptime growth outside from the respective uptime accumulator
 	// This is functionally equivalent to "flipping" the trackers once the tick is crossed

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -428,8 +428,7 @@ func (s *KeeperTestSuite) TestGetTickInfo() {
 			if test.poolToGet == validPoolId {
 				s.SetupDefaultPosition(test.poolToGet)
 			}
-			err = clKeeper.ChargeFee(s.Ctx, validPoolId, oneEth)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(validPoolId, oneEth)
 
 			// System under test
 			tickInfo, err := clKeeper.GetTickInfo(s.Ctx, test.poolToGet, test.tickToGet)
@@ -554,14 +553,6 @@ func (s *KeeperTestSuite) TestCrossTick() {
 			expectedTickFeeGrowthOppositeDirectionOfLastTraversal: DefaultFeeAccumCoins.Add(defaultAdditiveFee.Add(defaultAdditiveFee)),
 		},
 		{
-			name:                    "error: Try invalid tick",
-			poolToGet:               2,
-			preInitializedTickIndex: preInitializedTickIndex,
-			tickToGet:               preInitializedTickIndex,
-			additiveFee:             defaultAdditiveFee,
-			expectedErr:             accum.AccumDoesNotExistError{},
-		},
-		{
 			name:                    "error: Nil tick",
 			poolToGet:               validPoolId,
 			preInitializedTickIndex: preInitializedTickIndex,
@@ -589,17 +580,16 @@ func (s *KeeperTestSuite) TestCrossTick() {
 			// Charge fee to make sure that the global fee accumulator is always updated.
 			// This is to test that the per-tick fee growth accumulator gets initialized.
 			defaultAccumCoins := sdk.NewDecCoin("foo", sdk.NewInt(50))
-			err := s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, validPoolId, defaultAccumCoins)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(validPoolId, defaultAccumCoins)
 
 			// Initialize global uptime accums
 			if test.initGlobalUptimeAccumValues != nil {
-				err = addToUptimeAccums(s.Ctx, clPool.GetId(), s.App.ConcentratedLiquidityKeeper, test.initGlobalUptimeAccumValues)
+				err := addToUptimeAccums(s.Ctx, clPool.GetId(), s.App.ConcentratedLiquidityKeeper, test.initGlobalUptimeAccumValues)
 				s.Require().NoError(err)
 			}
 
 			// Set up an initialized tick
-			err = s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(s.Ctx, validPoolId, DefaultCurrTick, test.preInitializedTickIndex, DefaultLiquidityAmt, true)
+			err := s.App.ConcentratedLiquidityKeeper.InitOrUpdateTick(s.Ctx, validPoolId, DefaultCurrTick, test.preInitializedTickIndex, DefaultLiquidityAmt, true)
 			s.Require().NoError(err)
 
 			// Update global uptime accums for edge case testing
@@ -610,8 +600,7 @@ func (s *KeeperTestSuite) TestCrossTick() {
 
 			// update the fee accumulator so that we have accum value > tick fee growth value
 			// now we have 100 foo coins inside the pool accumulator
-			err = s.App.ConcentratedLiquidityKeeper.ChargeFee(s.Ctx, validPoolId, defaultAccumCoins)
-			s.Require().NoError(err)
+			s.AddToFeeAccumulator(validPoolId, defaultAccumCoins)
 
 			var nextTickInfo *model.TickInfo
 
@@ -630,13 +619,17 @@ func (s *KeeperTestSuite) TestCrossTick() {
 			}
 
 			var uptimeAccums []accum.AccumulatorObject
+			var feeAccum accum.AccumulatorObject
 			if test.poolToGet == validPoolId {
 				uptimeAccums, err = s.App.ConcentratedLiquidityKeeper.GetUptimeAccumulators(s.Ctx, test.poolToGet)
+				s.Require().NoError(err)
+
+				feeAccum, err = s.App.ConcentratedLiquidityKeeper.GetFeeAccumulator(s.Ctx, test.poolToGet)
 				s.Require().NoError(err)
 			}
 
 			// System under test
-			liquidityDelta, err := s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, test.poolToGet, test.tickToGet, nextTickInfo, test.additiveFee, uptimeAccums)
+			liquidityDelta, err := s.App.ConcentratedLiquidityKeeper.CrossTick(s.Ctx, test.poolToGet, test.tickToGet, nextTickInfo, test.additiveFee, feeAccum.GetValue(), uptimeAccums)
 			if test.expectedErr != nil {
 				s.Require().Error(err)
 				s.Require().ErrorAs(err, &test.expectedErr)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is a third improvement identified in:
https://github.com/osmosis-labs/osmosis/pull/5287

Thi improvement focuses on removing the need for refetching and reunmarshaking fee accumulator on every swap step.

We only need to fetch it once, get its value every time a tick is crossed and update at the very end of the swap.

Drive-by changes:
- remove awkward abstraction called `ChargeFee`. I think it is clearer to add to the accumulator directly
- replace `ChargeFee` with `AddToFeeAccumulator` helper in tests

Since this is the last improvement identified, this is the flame graph as of [this commit]([116170d](https://github.com/osmosis-labs/osmosis/pull/5298/commits/116170d047f825c6ba7dedf6a827eeb587d39ae8))

![image](https://github.com/osmosis-labs/osmosis/assets/34196718/7599f059-dd92-4375-b573-1e1605e42866)

Comparison to commit from yesterday: https://github.com/osmosis-labs/osmosis/commit/8b523efcb4db53e4a74756405e6e5253d657089c

```
root@roman:~/osmosis/x/concentrated-liquidity# benchstat current.bench latest.bench
current.bench:5: missing iteration count
latest.bench:5: missing iteration count
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
                    │ current.bench │            latest.bench            │
                    │    sec/op     │   sec/op     vs base               │
SwapExactAmountIn-4    341.1m ± 14%   173.9m ± 8%  -49.02% (p=0.002 n=6)
```


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A