### PR TITLE
Revert "feat: do not require changelog and state machine labels for m…

### DIFF
--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -4,8 +4,6 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
 jobs:
   build:
     name: Check Actions

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
       - 'main'
-    paths-ignore:
-      - '**/*.md'
 jobs:
   state_compatability_labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…arkdown only changes (#5297)"

This reverts commit c0cc5c969548b0b70d99f9637960be652d41aeb0.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR: https://github.com/osmosis-labs/osmosis/pull/5297 seems to have broken the changelog check.

Another PR with purely changelog updates: https://github.com/osmosis-labs/osmosis/pull/5309 does not have the `state_compatability_labels` check activated to matter what I do.

I suspect is because it is being skipped while remaining to be required. As a result, the PR ends up being blocked.

I'm reverting the change until a working solution is found and tested on fork

