### PR TITLE
update e2e genesis config for protorev module

### DIFF
--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -24,6 +24,7 @@ import (
 	minttypes "github.com/osmosis-labs/osmosis/v15/x/mint/types"
 	poolitypes "github.com/osmosis-labs/osmosis/v15/x/pool-incentives/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v15/x/poolmanager/types"
+	protorevtypes "github.com/osmosis-labs/osmosis/v15/x/protorev/types"
 	twaptypes "github.com/osmosis-labs/osmosis/v15/x/twap/types"
 	txfeestypes "github.com/osmosis-labs/osmosis/v15/x/txfees/types"
 	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
@@ -296,6 +297,11 @@ func initGenesis(chain *internalChain, votingPeriod, expeditedVotingPeriod time.
 		return err
 	}
 
+	err = updateModuleGenesis(appGenState, protorevtypes.ModuleName, &protorevtypes.GenesisState{}, updateProtorevGenesis)
+	if err != nil {
+		return err
+	}
+
 	bz, err := json.MarshalIndent(appGenState, "", "  ")
 	if err != nil {
 		return err
@@ -535,6 +541,10 @@ func updateGenUtilGenesis(c *internalChain) func(*genutiltypes.GenesisState) {
 		}
 		genUtilGenState.GenTxs = genTxs
 	}
+}
+
+func updateProtorevGenesis(protorevGenState *protorevtypes.GenesisState) {
+	protorevGenState.DeveloperAddress = "osmo1qs9akhf0s05hqskmu9gdnzz3e6u4xc7aaya0u0"
 }
 
 func setDenomMetadata(genState *banktypes.GenesisState, denom string) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- v16 upgrade changes protorev to pay dev account after every trade, instead of tracking it in a kvstore and paying out on a weekly basis
- This PR adds a dev account to the ProtoRev module in e2e test to properly test that the v16 upgrade sends left over dev funds tracked in the kvstore to the dev account during the upgrade.

## Testing and Verifying

- Testing will happen in a future PR that implements protorev's v16 upgrade.

## Documentation and Release Note

- No new documentation added