### PR TITLE
[CL][bugfix] Fix discount rate bound check

### DIFF
--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -196,8 +196,9 @@ func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64,
 	qualifyingFullRangeSharesPreDiscount := math.GetLiquidityFromAmounts(clPool.GetCurrentSqrtPrice(), types.MinSqrtPrice, types.MaxSqrtPrice, asset0Amount, asset1Amount)
 
 	// Get discount ratio from governance-set discount rate. Note that the case we check for is technically impossible, but we include
-	// the check as a guardrail anyway. Specifically, we error if the discount ratio is not [0, 1]. Note that this is different from the
-	// discount _rate_, which is [0, 1].
+	// the check as a guardrail anyway. Specifically, we error if the discount ratio is not [0, 1].
+	// Note that discount rate is the amount that is being discounted by (e.g. 0.05 for a 5% discount), while discount ratio is what
+	// we multiply by to apply the discount (e.g. 0.95 for a 5% discount).
 	balancerSharesDiscountRatio := sdk.OneDec().Sub(k.GetParams(ctx).BalancerSharesRewardDiscount)
 	if !balancerSharesDiscountRatio.GTE(sdk.ZeroDec()) || !balancerSharesDiscountRatio.LTE(sdk.OneDec()) {
 		return 0, sdk.ZeroDec(), types.InvalidDiscountRateError{DiscountRate: k.GetParams(ctx).BalancerSharesRewardDiscount}

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -199,7 +199,7 @@ func (k Keeper) prepareBalancerPoolAsFullRange(ctx sdk.Context, clPoolId uint64,
 	// the check as a guardrail anyway. Specifically, we error if the discount ratio is not [0, 1]. Note that this is different from the
 	// discount _rate_, which is [0, 1].
 	balancerSharesDiscountRatio := sdk.OneDec().Sub(k.GetParams(ctx).BalancerSharesRewardDiscount)
-	if !balancerSharesDiscountRatio.GTE(sdk.ZeroDec()) && !balancerSharesDiscountRatio.LTE(sdk.OneDec()) {
+	if !balancerSharesDiscountRatio.GTE(sdk.ZeroDec()) || !balancerSharesDiscountRatio.LTE(sdk.OneDec()) {
 		return 0, sdk.ZeroDec(), types.InvalidDiscountRateError{DiscountRate: k.GetParams(ctx).BalancerSharesRewardDiscount}
 	}
 

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -3201,7 +3201,6 @@ func (s *KeeperTestSuite) TestPrepareBalancerPoolAsFullRange() {
 		invalidConcentratedPoolID    bool
 		invalidBalancerPoolID        bool
 		invalidBalancerPoolLiquidity bool
-		invalidDiscountRate          bool
 
 		expectedError error
 	}
@@ -3294,10 +3293,6 @@ func (s *KeeperTestSuite) TestPrepareBalancerPoolAsFullRange() {
 			invalidConcentratedPoolID: true,
 			expectedError:             types.PoolNotFoundError{PoolId: invalidPoolId + 1},
 		},
-		"invalid discount rate": {
-			invalidDiscountRate: true,
-			expectedError:       types.InvalidDiscountRateError{DiscountRate: sdk.NewDec(2)},
-		},
 	}
 	// create invalid denom test cases. Either denom1, denom2 or both are invalid
 	denomSelector := [][]string{{"foo", "invalid1"}, {"bar", "invalid2"}}
@@ -3361,7 +3356,7 @@ func (s *KeeperTestSuite) TestPrepareBalancerPoolAsFullRange() {
 			qualifyingShares := (sdk.OneDec().Sub(types.DefaultBalancerSharesDiscount)).Mul(qualifyingSharesPreDiscount)
 
 			// TODO: clean this check up (will likely require refactoring the whole test)
-			clearOutQualifyingShares := tc.noBalancerPoolWithID || tc.invalidBalancerPoolLiquidity || tc.invalidConcentratedPoolID || tc.invalidBalancerPoolID || tc.noCanonicalBalancerPool || tc.invalidDiscountRate
+			clearOutQualifyingShares := tc.noBalancerPoolWithID || tc.invalidBalancerPoolLiquidity || tc.invalidConcentratedPoolID || tc.invalidBalancerPoolID || tc.noCanonicalBalancerPool
 			if clearOutQualifyingShares {
 				qualifyingShares = sdk.NewDec(0)
 			}
@@ -3369,12 +3364,6 @@ func (s *KeeperTestSuite) TestPrepareBalancerPoolAsFullRange() {
 			concentratedPoolId := clPool.GetId()
 			if tc.invalidConcentratedPoolID {
 				concentratedPoolId = invalidPoolId + 1
-			}
-
-			if tc.invalidDiscountRate {
-				params := clk.GetParams(s.Ctx)
-				params.BalancerSharesRewardDiscount = sdk.NewDec(2)
-				clk.SetParams(s.Ctx, params)
 			}
 
 			// --- System under test ---

--- a/x/concentrated-liquidity/types/export_test.go
+++ b/x/concentrated-liquidity/types/export_test.go
@@ -3,3 +3,7 @@ package types
 func ValidateTicks(i interface{}) error {
 	return validateTicks(i)
 }
+
+func ValidateBalancerSharesDiscount(i interface{}) error {
+	return validateBalancerSharesDiscount(i)
+}

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -186,7 +186,7 @@ func validateBalancerSharesDiscount(i interface{}) error {
 	}
 
 	// Ensure that the passed in discount rate is between 0 and 1.
-	if balancerSharesRewardDiscount.LT(sdk.ZeroDec()) && balancerSharesRewardDiscount.GT(sdk.OneDec()) {
+	if balancerSharesRewardDiscount.LT(sdk.ZeroDec()) || balancerSharesRewardDiscount.GT(sdk.OneDec()) {
 		return InvalidDiscountRateError{DiscountRate: balancerSharesRewardDiscount}
 	}
 

--- a/x/concentrated-liquidity/types/params_test.go
+++ b/x/concentrated-liquidity/types/params_test.go
@@ -65,12 +65,23 @@ func TestValidateBalancerSharesDiscount(t *testing.T) {
 		"happy path": {
 			i: types.DefaultBalancerSharesDiscount,
 		},
+		"zero discount rate": {
+			i: sdk.NewDec(0),
+		},
 		"error: negative discount rate": {
 			i:           sdk.NewDec(-1),
 			expectError: true,
 		},
+		"error: negative discount rate on boundary": {
+			i:           sdk.NewDecWithPrec(-1, 18),
+			expectError: true,
+		},
 		"error: discount rate > 1": {
 			i:           sdk.NewDec(2),
+			expectError: true,
+		},
+		"error: discount rate > 1 on boundary": {
+			i:           sdk.NewDec(1).Add(sdk.NewDecWithPrec(1, 18)),
 			expectError: true,
 		},
 	}

--- a/x/concentrated-liquidity/types/params_test.go
+++ b/x/concentrated-liquidity/types/params_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osmosis-labs/osmosis/v15/x/concentrated-liquidity/types"
@@ -46,6 +47,38 @@ func TestValidateTicks(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			err := types.ValidateTicks(tc.i)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateBalancerSharesDiscount(t *testing.T) {
+	tests := map[string]struct {
+		i           interface{}
+		expectError bool
+	}{
+		"happy path": {
+			i: types.DefaultBalancerSharesDiscount,
+		},
+		"error: negative discount rate": {
+			i:           sdk.NewDec(-1),
+			expectError: true,
+		},
+		"error: discount rate > 1": {
+			i:           sdk.NewDec(2),
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			err := types.ValidateBalancerSharesDiscount(tc.i)
 
 			if tc.expectError {
 				require.Error(t, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR fixes the discount rate bound check that was supposed to ensure invalid discount rates could never be put into a proposal. It also fixes the lower level check that was meant to ensure that if an invalid discount rate does get through, it does not allow for draining of funds.

## Testing and Verifying

- Added test case & logic to `incentives_test.go`

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A