### PR TITLE
bump previousVersionInitTag, remove no longer used protorev upgrade test

### DIFF
--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -27,7 +27,7 @@ const (
 	previousVersionOsmoTag        = "v15.x-833705e4-1679340262"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "v15.x-manual-ibc-denom"
+	previousVersionInitTag        = "v15.x-63e3f053-1685053483"
 	// Hermes repo/version for relayer
 	relayerRepository = "osmolabs/hermes"
 	relayerTag        = "1.3.0"

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,7 +24,7 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis-dev"
-	previousVersionOsmoTag        = "v15.x-833705e4-1679340262"
+	previousVersionOsmoTag        = "v15.x-63e3f053-1685053483"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
 	previousVersionInitTag        = "v15.x-63e3f053-1685053483"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -101,11 +101,6 @@ func (s *IntegrationTestSuite) TestProtoRev() {
 	s.Require().Len(supportedBaseDenoms, 1)
 	s.Require().Equal(supportedBaseDenoms[0].Denom, "uosmo")
 
-	// The module should have no developer account by default.
-	_, err = chainANode.QueryProtoRevDeveloperAccount()
-	s.T().Logf("checking that the protorev module has no developer account on init: %s", err)
-	s.Require().Error(err)
-
 	// --------------- Set up for a calculated backrun ---------------- //
 	// Create all of the pools that will be used in the test.
 	chainANode.CreateBalancerPool(poolFile1, initialization.ValidatorWalletName)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- In a previous PR, we changed e2e genesis config for protorev v16 upgrade testing: https://github.com/osmosis-labs/osmosis/pull/5312
- This PR bumps the previousVersionOsmoTag and previousVersionInitTag to the docker container tag output by the backport merge

## Testing and Verifying
- Removes a no longer used test for protorev upgrade

## Documentation and Release Note
- N/A