### PR TITLE
[CL]: Remove double rounding in `CalcAmount1Delta`

### DIFF
--- a/x/concentrated-liquidity/math/math.go
+++ b/x/concentrated-liquidity/math/math.go
@@ -112,7 +112,7 @@ func CalcAmount1Delta(liq, sqrtPriceA, sqrtPriceB sdk.Dec, roundUp bool) sdk.Dec
 		// Examples include:
 		// - calculating amountIn during swap
 		// - adding liquidity (request user to provide more tokens in in favor of the pool)
-		return liq.MulRoundUp(diff).Ceil()
+		return liq.Mul(diff).Ceil()
 	}
 	// This is truncated at precision end to round in favor of the pool when:
 	// - calculating amount out during swap


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5073

## What is the purpose of the change

This PR removes the unnecessary additional roundup in `CalcAmount1Delta`. The effective impact is minimal (as `MulRoundup` only rounds the last digit while `Ceil` rounds up to the next int), but still an appropriate change to make. 

## Testing and Verifying

This change does not affect rounding behavior enough to warrant a boundary test as the additional roundup was extraneous – all rounding-related test cases continue to pass.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A