### PR TITLE
Update proto/query gen error message to include new querygen command

### DIFF
--- a/scripts/ci/check-generated.sh
+++ b/scripts/ci/check-generated.sh
@@ -10,7 +10,7 @@ if ! git diff --stat --exit-code . ':(exclude)*.mod' ':(exclude)*.sum'; then
     echo ">> ERROR:"
     echo ">>"
     echo ">> Protobuf generated code requires update (either tools or .proto files may have changed)."
-    echo ">> Ensure your tools are up-to-date, re-run 'make proto-all' and update this PR."
+    echo ">> Ensure your tools are up-to-date, re-run 'make proto-all' and  'make run-querygen' and update this PR."
     echo ">>"
     exit 1
 fi


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR adds an additional call to action to the proto gen error message now that we also use querygen (spent a lot of time debugging this)

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A