### PR TITLE
Update chain-registry to v15.1.2

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -2,14 +2,15 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "codebase":{
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v15.1.0",
+    "recommended_version": "v15.1.2",
     "compatible_versions": [
+      "v15.0.0",
       "v15.1.0",
-      "v15.0.0"
+      "v15.1.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-amd64?checksum=sha256:f16f901dfd47426caced8436c507e2950a4e2452b6cc6efc7845ab3b43a5c5d5",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-arm64?checksum=sha256:08b20f0753b6b0bafa3a6ca7e4bb6807baf72754dfb69d6db7b1fb2b4b55ffc0"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.2/osmosisd-15.1.2-linux-amd64?checksum=sha256:c2fa311c5962eb0d5718d2640b8908804d3989665a6d13f82860904c390ad05f",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.2/osmosisd-15.1.2-linux-arm64?checksum=sha256:991e0db581cfb592339b117b3f253d044dfe8e5fc5ca062fda26e5ad92c32741"
     },
     "cosmos_sdk_version": "0.45",
     "consensus": {
@@ -83,28 +84,8 @@
       },
       {
         "name": "v15",
-        "tag" : "v15.1.0",
-        "height": 8732500,
-        "recommended_version": "v15.1.0",
-        "compatible_versions": [
-          "v15.1.0",
-          "v15.0.0"
-        ],
-        "cosmos_sdk_version": "0.45",
-        "consensus": {
-          "type": "tendermint",
-          "version": "0.34"
-        },
-        "cosmwasm_version": "0.30",
-        "cosmwasm_enabled": true,
-        "ibc_go_version": "4.3.0",
-        "ics_enabled": [
-          "ics20-1"
-        ],
-        "binaries": {
-          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-amd64?checksum=sha256:f16f901dfd47426caced8436c507e2950a4e2452b6cc6efc7845ab3b43a5c5d5",
-          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-arm64?checksum=sha256:08b20f0753b6b0bafa3a6ca7e4bb6807baf72754dfb69d6db7b1fb2b4b55ffc0"
-        }
+        "tag" : "v15.1.2",
+        "height": 8732500
       }
     ]
   }


### PR DESCRIPTION
## What is the purpose of the change

Update chain-registry to latest minor release `v15.1.2`

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.