### PR TITLE
fix: tick spacing with cl go client script for creating positions

### DIFF
--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -27,8 +27,9 @@ const (
 	addressPrefix                   = "osmo"
 	localosmosisFromHomePath        = "/.osmosisd-local"
 	consensusFee                    = "1500uosmo"
-	denom0                          = "uusdc"
-	denom1                          = "uosmo"
+	denom0                          = "uosmo"
+	denom1                          = "uusdc"
+	tickSpacing              int64  = 100
 	accountNamePrefix               = "lo-test"
 	numPositions                    = 1_000
 	minAmountDeposited              = int64(1_000_000)
@@ -102,9 +103,9 @@ func main() {
 			randAccountNum = rand.Intn(8) + 1
 			accountName    = fmt.Sprintf("%s%d", accountNamePrefix, randAccountNum)
 			// minTick <= lowerTick <= upperTick
-			lowerTick = rand.Int63n(maxTick-minTick+1) + minTick
+			lowerTick = roundTickDown(rand.Int63n(maxTick-minTick+1)+minTick, tickSpacing)
 			// lowerTick <= upperTick <= maxTick
-			upperTick = maxTick - rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick))))
+			upperTick = roundTickDown(maxTick-rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))), tickSpacing)
 
 			tokenDesired0 = sdk.NewCoin(denom0, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
 			tokenDesired1 = sdk.NewCoin(denom1, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
@@ -190,4 +191,24 @@ func getClientHomePath() string {
 	}
 
 	return currentUser.HomeDir + localosmosisFromHomePath
+}
+
+func roundTickDown(tickIndex int64, tickSpacing int64) int64 {
+	// Round the tick index down to the nearest tick spacing if the tickIndex is in between authorized tick values
+	// Note that this is Euclidean modulus.
+	// The difference from default Go modulus is that Go default results
+	// in a negative remainder when the dividend is negative.
+	// Consider example tickIndex = -17, tickSpacing = 10
+	// tickIndexModulus = tickIndex % tickSpacing = -7
+	// tickIndexModulus = -7 + 10 = 3
+	// tickIndex = -17 - 3 = -20
+	tickIndexModulus := tickIndex % tickSpacing
+	if tickIndexModulus < 0 {
+		tickIndexModulus += tickSpacing
+	}
+
+	if tickIndexModulus != 0 {
+		tickIndex = tickIndex - tickIndexModulus
+	}
+	return tickIndex
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

@jonator mentioned that script breaks due to not accounting for tick spacing. This fixes it

## Testing and Verifying

Tested locally and can create positions with no issues

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A