### PR TITLE
feat: do not require changelog and state machine labels for markdown only changes

### DIFF
--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -20,7 +20,7 @@ jobs:
             **/*.md
 
       - name: Changelog check
-        # Skip this step for markdown only changes
+        # Skip this step and return success result for markdown only changes
         if: |
           steps.changed-files.outputs.any_changed == 'true' ||
           steps.changed-files.outputs.any_deleted == 'true' ||

--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -4,13 +4,27 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+
 jobs:
   build:
     name: Check Actions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v36.0.9
+        with:
+          files_ignore: |
+            **/*.md
+
       - name: Changelog check
+        # Skip this step for markdown only changes
+        if: |
+          steps.changed-files.outputs.any_changed == 'true' ||
+          steps.changed-files.outputs.any_deleted == 'true' ||
+          steps.changed-files.outputs.any_modified == 'true'
         uses: Zomzog/changelog-checker@v1.3.0
         with:
           fileName: CHANGELOG.md

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -5,11 +5,27 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
       - 'main'
+
 jobs:
   state_compatability_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v4
+      - uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v36.0.9
+        with:
+          files_ignore: |
+            **/*.md
+
+      - name: Check required labels
+        # Skip this step for markdown only changes
+        if: |
+          steps.changed-files.outputs.any_changed == 'true' ||
+          steps.changed-files.outputs.any_deleted == 'true' ||
+          steps.changed-files.outputs.any_modified == 'true'
+        uses: mheap/github-action-required-labels@v4
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
         with: #Require one of the following labels

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -20,7 +20,7 @@ jobs:
             **/*.md
 
       - name: Check required labels
-        # Skip this step for markdown only changes
+        # Skip this step and return success result for markdown only changes
         if: |
           steps.changed-files.outputs.any_changed == 'true' ||
           steps.changed-files.outputs.any_deleted == 'true' ||


### PR DESCRIPTION
Closes: #5270 (Rework)
## What is the purpose of the change
Do not require changelog and state machine labels for markdown only changes by using following steps:
- Detect the changed files by using this workflow https://github.com/tj-actions/changed-files
- Skip the step to check changelog and return success results for `changelog` and `required label` checks incase only markdown changes. 
- If the PR contains file other than *.md, it will function as current behaviour

## Testing and Verifying
This change was tested on my forked repository and be verified as follows:
 - See: https://github.com/tungbq/osmosis/pull/4/checks
- Case 01: Only markdown changes: 
![image](https://github.com/osmosis-labs/osmosis/assets/85242618/ea1bcdeb-1efb-4a93-8986-3314b6263a2a)
![image](https://github.com/osmosis-labs/osmosis/assets/85242618/6f3d197a-bb22-4dba-afae-0a396e112e81)

- Case 02: Normal changes: 
![image](https://github.com/osmosis-labs/osmosis/assets/85242618/0b3aad97-6df1-49e3-b094-4be014ad4809)
![image](https://github.com/osmosis-labs/osmosis/assets/85242618/d2c2f2ed-49d2-4a84-af02-9a0d4727faab)

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A