### PR TITLE
fix: twap record upgrade handler

### DIFF
--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -126,6 +126,16 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 
+		clPoolTwapRecords, err := keepers.TwapKeeper.GetAllMostRecentRecordsForPool(ctx, clPoolId)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, twapRecord := range clPoolTwapRecords {
+			twapRecord.LastErrorTime = time.Time{}
+			keepers.TwapKeeper.StoreNewRecord(ctx, twapRecord)
+		}
+
 		updateTokenFactoryParams(ctx, keepers.TokenFactoryKeeper)
 
 		// Transfers out all the dev fees in kvstore to dev account during upgrade

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -16,16 +16,8 @@ type (
 	GeometricTwapStrategy  = geometric
 )
 
-func (k Keeper) StoreNewRecord(ctx sdk.Context, record types.TwapRecord) {
-	k.storeNewRecord(ctx, record)
-}
-
 func (k Keeper) GetMostRecentRecordStoreRepresentation(ctx sdk.Context, poolId uint64, asset0Denom string, asset1Denom string) (types.TwapRecord, error) {
 	return k.getMostRecentRecordStoreRepresentation(ctx, poolId, asset0Denom, asset1Denom)
-}
-
-func (k Keeper) GetAllMostRecentRecordsForPool(ctx sdk.Context, poolId uint64) ([]types.TwapRecord, error) {
-	return k.getAllMostRecentRecordsForPool(ctx, poolId)
 }
 
 func (k Keeper) GetRecordAtOrBeforeTime(ctx sdk.Context, poolId uint64, time time.Time, asset0Denom string, asset1Denom string) (types.TwapRecord, error) {

--- a/x/twap/keeper.go
+++ b/x/twap/keeper.go
@@ -65,7 +65,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	})
 
 	for _, twap := range genState.Twaps {
-		k.storeNewRecord(ctx, twap)
+		k.StoreNewRecord(ctx, twap)
 	}
 }
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -93,7 +93,7 @@ func (k Keeper) afterCreatePool(ctx sdk.Context, poolId uint64) error {
 		// that there is a swap against this pool in this same block.
 		// furthermore, this protects against an edge case where a pool is created
 		// during EndBlock, after twapkeeper's endblock.
-		k.storeNewRecord(ctx, record)
+		k.StoreNewRecord(ctx, record)
 	}
 	k.trackChangedPool(ctx, poolId)
 	return err
@@ -124,7 +124,7 @@ func (k Keeper) EndBlock(ctx sdk.Context) {
 //     number of denoms in the pool.
 func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 	// Will only err if pool doesn't have most recent entry set
-	records, err := k.getAllMostRecentRecordsForPool(ctx, poolId)
+	records, err := k.GetAllMostRecentRecordsForPool(ctx, poolId)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (k Keeper) updateRecords(ctx sdk.Context, poolId uint64) error {
 		if err != nil {
 			return err
 		}
-		k.storeNewRecord(ctx, newRecord)
+		k.StoreNewRecord(ctx, newRecord)
 	}
 	return nil
 }

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -144,9 +144,9 @@ func (k Keeper) getMostRecentRecordStoreRepresentation(ctx sdk.Context, poolId u
 	return twap, err
 }
 
-// getAllMostRecentRecordsForPool returns all most recent twap records
+// GetAllMostRecentRecordsForPool returns all most recent twap records
 // (in state representation) for the provided pool id.
-func (k Keeper) getAllMostRecentRecordsForPool(ctx sdk.Context, poolId uint64) ([]types.TwapRecord, error) {
+func (k Keeper) GetAllMostRecentRecordsForPool(ctx sdk.Context, poolId uint64) ([]types.TwapRecord, error) {
 	store := ctx.KVStore(k.storeKey)
 	return types.GetAllMostRecentTwapsForPool(store, poolId)
 }
@@ -162,8 +162,8 @@ func (k Keeper) getAllHistoricalPoolIndexedTWAPs(ctx sdk.Context) ([]types.TwapR
 	return osmoutils.GatherValuesFromStorePrefix(ctx.KVStore(k.storeKey), []byte(types.HistoricalTWAPPoolIndexPrefix), types.ParseTwapFromBz)
 }
 
-// storeNewRecord stores a record, in both the most recent record store and historical stores.
-func (k Keeper) storeNewRecord(ctx sdk.Context, twap types.TwapRecord) {
+// StoreNewRecord stores a record, in both the most recent record store and historical stores.
+func (k Keeper) StoreNewRecord(ctx sdk.Context, twap types.TwapRecord) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.FormatMostRecentTWAPKey(twap.PoolId, twap.Asset0Denom, twap.Asset1Denom)
 	osmoutils.MustSet(store, key, &twap)

--- a/x/twap/types/genesis.go
+++ b/x/twap/types/genesis.go
@@ -57,10 +57,10 @@ func (t TwapRecord) validate() error {
 	// if there was an error in this record, one of the spot prices should be 0.
 	// else, the spot prices must be positive for both spot prices.
 	if t.LastErrorTime.Equal(t.Time) {
-		isP0LastSpotPriseZero := t.P0LastSpotPrice.IsNil() || t.P0LastSpotPrice.IsZero()
-		isP1LastSpotPriseZero := t.P1LastSpotPrice.IsNil() || t.P1LastSpotPrice.IsZero()
+		isP0LastSpotPriceZero := t.P0LastSpotPrice.IsNil() || t.P0LastSpotPrice.IsZero()
+		isP1LastSpotPriceZero := t.P1LastSpotPrice.IsNil() || t.P1LastSpotPrice.IsZero()
 
-		if !isP0LastSpotPriseZero && !isP1LastSpotPriseZero {
+		if !isP0LastSpotPriceZero && !isP1LastSpotPriceZero {
 			return fmt.Errorf("one of twap record p0 and p1 last spot price must be zero due to having an error, was (%s, %s)", t.P0LastSpotPrice, t.P1LastSpotPrice)
 		}
 	} else {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5343 

## What is the purpose of the change

We currently create a CL pool and create a position all within the same block in the upgrade handler. This causes the last error time to get set to now (this is default behavior when we create a pool) AND the spot prices are set when we create a position. This causes a genesis check to pop. 

This PR nils out the last error time in the upgrade handler for the CL pool's twap record

## Testing and Verifying

Nicco tested out this branch with mainnet state and ran the upgrade handler and no longer receives the twap error.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A