### PR TITLE
refactor: new position id in events for add to position

### DIFF
--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -341,6 +341,7 @@ func (k Keeper) addToPosition(ctx sdk.Context, owner sdk.AccAddress, positionId 
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, owner.String()),
 			sdk.NewAttribute(types.AttributeKeyPositionId, strconv.FormatUint(positionId, 10)),
+			sdk.NewAttribute(types.AttributeKeyNewPositionId, strconv.FormatUint(newPositionId, 10)),
 			sdk.NewAttribute(types.AttributeAmount0, actualAmount0.String()),
 			sdk.NewAttribute(types.AttributeAmount1, actualAmount1.String()),
 		),

--- a/x/concentrated-liquidity/types/events.go
+++ b/x/concentrated-liquidity/types/events.go
@@ -14,6 +14,7 @@ const (
 
 	AttributeValueCategory         = ModuleName
 	AttributeKeyPositionId         = "position_id"
+	AttributeKeyNewPositionId      = "new_position_id"
 	AttributeKeyPoolId             = "pool_id"
 	AttributeAmount0               = "amount0"
 	AttributeAmount1               = "amount1"

--- a/x/superfluid/keeper/concentrated_liquidity.go
+++ b/x/superfluid/keeper/concentrated_liquidity.go
@@ -129,7 +129,8 @@ func (k Keeper) addToConcentratedLiquiditySuperfluidPosition(ctx sdk.Context, se
 		sdk.NewEvent(
 			types.TypeEvtAddToConcentratedLiquiditySuperfluidPosition,
 			sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
-			sdk.NewAttribute(types.AttributePositionId, strconv.FormatUint(newPositionId, 10)),
+			sdk.NewAttribute(types.AttributePositionId, strconv.FormatUint(positionId, 10)),
+			sdk.NewAttribute(types.AttributeNewPositionId, strconv.FormatUint(newPositionId, 10)),
 			sdk.NewAttribute(types.AttributeAmount0, actualNewAmount0.String()),
 			sdk.NewAttribute(types.AttributeAmount1, actualNewAmount1.String()),
 			sdk.NewAttribute(types.AttributeConcentratedLockId, strconv.FormatUint(newLockId, 10)),

--- a/x/superfluid/types/events.go
+++ b/x/superfluid/types/events.go
@@ -22,6 +22,7 @@ const (
 	AttributeConcentratedLockId                 = "concentrated_lock_id"
 	AttributeKeyPoolId                          = "pool_id"
 	AttributePositionId                         = "position_id"
+	AttributeNewPositionId                      = "new_position_id"
 	AttributeAmount0                            = "amount0"
 	AttributeAmount1                            = "amount1"
 	AttributeLiquidity                          = "liquidity"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Made to make sure that FE and data have all the info needed. This is likely not be needed since newPositionId is returned from the message. However, we decided to include this in advance in case we later find out that this is useful in events.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A