### PR TITLE
Internal Review][CL][deletePosition]: test edge cases where one of the indexes does not exist

### DIFF
--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -296,19 +296,19 @@ func (k Keeper) deletePosition(ctx sdk.Context,
 	}
 	store.Delete(positionIdKey)
 
-	// Remove the address-pool-position ID to position mapping.
-	addressPoolIdPositionIdKey := types.KeyAddressPoolIdPositionId(owner, poolId, positionId)
-	if !store.Has(addressPoolIdPositionIdKey) {
-		return types.AddressPoolPositionIdNotFoundError{Owner: owner.String(), PoolId: poolId, PositionId: positionId}
-	}
-	store.Delete(addressPoolIdPositionIdKey)
-
 	// Remove the pool-position ID mapping.
 	poolIdKey := types.KeyPoolPositionPositionId(poolId, positionId)
 	if !store.Has(poolIdKey) {
 		return types.PoolPositionIdNotFoundError{PoolId: poolId, PositionId: positionId}
 	}
 	store.Delete(poolIdKey)
+
+	// Remove the address-pool-position ID to position mapping.
+	addressPoolIdPositionIdKey := types.KeyAddressPoolIdPositionId(owner, poolId, positionId)
+	if !store.Has(addressPoolIdPositionIdKey) {
+		return types.AddressPoolPositionIdNotFoundError{Owner: owner.String(), PoolId: poolId, PositionId: positionId}
+	}
+	store.Delete(addressPoolIdPositionIdKey)
 
 	// Remove the position ID to underlying lock ID mapping (if it exists)
 	positionIdLockKey := types.KeyPositionIdForLock(positionId)

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -557,28 +557,46 @@ func (s *KeeperTestSuite) TestGetAllUserPositions() {
 func (s *KeeperTestSuite) TestDeletePosition() {
 	defaultPoolId := uint64(1)
 	DefaultJoinTime := s.Ctx.BlockTime()
+	defaultCreator := s.TestAccs[0]
+	secondaryAccount := s.TestAccs[1]
 
 	tests := []struct {
 		name             string
 		positionId       uint64
 		underlyingLockId uint64
+		creator          sdk.AccAddress
+		poolId           uint64
 		expectedErr      error
 	}{
 		{
-			name:             "Delete position info on existing pool and existing position (no underlying lock)",
+			name:             "Valid case: Delete position info on existing pool and existing position (no underlying lock)",
 			underlyingLockId: 0,
 			positionId:       DefaultPositionId,
 		},
 		{
-			name:             "Delete position info on existing pool and existing position (has underlying lock)",
+			name:             "Valid case: Delete position info on existing pool and existing position (has underlying lock)",
 			underlyingLockId: 1,
 			positionId:       DefaultPositionId,
 		},
 		{
-			name:             "Delete a non existing position",
+			name:             "InValid case: Delete a non existing position",
 			positionId:       DefaultPositionId + 1,
 			underlyingLockId: 0,
 			expectedErr:      types.PositionIdNotFoundError{PositionId: DefaultPositionId + 1},
+		},
+		{
+			name:             "InValid case: Delete the address-pool-position ID to position mapping",
+			positionId:       DefaultPositionId,
+			underlyingLockId: 0,
+			creator:          secondaryAccount,
+			expectedErr:      types.AddressPoolPositionIdNotFoundError{PoolId: DefaultPositionId, PositionId: DefaultPositionId, Owner: secondaryAccount.String()},
+		},
+		{
+			name:             "InValid case: Delete pool-position ID mapping",
+			poolId:           3,
+			positionId:       DefaultPositionId,
+			underlyingLockId: 0,
+			expectedErr:      types.PoolPositionIdNotFoundError{PoolId: 3, PositionId: DefaultPositionId},
 		},
 	}
 
@@ -593,11 +611,11 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 			s.PrepareConcentratedPool()
 
 			// Set up a default initialized position
-			err := s.App.ConcentratedLiquidityKeeper.InitOrUpdatePosition(s.Ctx, validPoolId, s.TestAccs[0], DefaultLowerTick, DefaultUpperTick, DefaultLiquidityAmt, DefaultJoinTime, DefaultPositionId)
+			err := s.App.ConcentratedLiquidityKeeper.InitOrUpdatePosition(s.Ctx, validPoolId, defaultCreator, DefaultLowerTick, DefaultUpperTick, DefaultLiquidityAmt, DefaultJoinTime, DefaultPositionId)
 			s.Require().NoError(err)
 
 			if test.underlyingLockId != 0 {
-				err = s.App.ConcentratedLiquidityKeeper.SetPosition(s.Ctx, validPoolId, s.TestAccs[0], DefaultLowerTick, DefaultUpperTick, DefaultJoinTime, DefaultLiquidityAmt, 1, test.underlyingLockId)
+				err = s.App.ConcentratedLiquidityKeeper.SetPosition(s.Ctx, validPoolId, defaultCreator, DefaultLowerTick, DefaultUpperTick, DefaultJoinTime, DefaultLiquidityAmt, 1, test.underlyingLockId)
 				s.Require().NoError(err)
 			}
 
@@ -608,14 +626,14 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 			osmoutils.MustGet(store, positionIdToPositionKey, &position)
 			s.Require().Equal(DefaultPositionId, position.PositionId)
 			s.Require().Equal(defaultPoolId, position.PoolId)
-			s.Require().Equal(s.TestAccs[0].String(), position.Address)
+			s.Require().Equal(defaultCreator.String(), position.Address)
 			s.Require().Equal(DefaultLowerTick, position.LowerTick)
 			s.Require().Equal(DefaultUpperTick, position.UpperTick)
 			s.Require().Equal(DefaultJoinTime, position.JoinTime)
 			s.Require().Equal(DefaultLiquidityAmt, position.Liquidity)
 
 			// Retrieve the position ID from the store via owner/poolId key and compare to expected value (true).
-			ownerPoolIdToPositionIdKey := types.KeyAddressPoolIdPositionId(s.TestAccs[0], defaultPoolId, DefaultPositionId)
+			ownerPoolIdToPositionIdKey := types.KeyAddressPoolIdPositionId(defaultCreator, defaultPoolId, DefaultPositionId)
 			valueBytes := store.Get(ownerPoolIdToPositionIdKey)
 			s.Require().Equal([]byte{1}, valueBytes)
 
@@ -642,7 +660,15 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 				s.Require().Nil(positionIdBytes)
 			}
 
-			err = s.App.ConcentratedLiquidityKeeper.DeletePosition(s.Ctx, test.positionId, s.TestAccs[0], defaultPoolId)
+			if test.creator != nil {
+				defaultCreator = secondaryAccount
+			}
+
+			if test.poolId != 0 && test.poolId != defaultPoolId {
+				defaultPoolId = test.poolId
+			}
+
+			err = s.App.ConcentratedLiquidityKeeper.DeletePosition(s.Ctx, test.positionId, defaultCreator, defaultPoolId)
 			if test.expectedErr != nil {
 				s.Require().Error(err)
 				s.Require().ErrorIs(err, test.expectedErr)
@@ -664,7 +690,7 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 				s.Require().Equal(model.Position{}, position)
 
 				// Retrieve the position ID from the store via owner/poolId key and compare to expected values.
-				ownerPoolIdToPositionIdKey = types.KeyAddressPoolIdPositionId(s.TestAccs[0], defaultPoolId, DefaultPositionId)
+				ownerPoolIdToPositionIdKey = types.KeyAddressPoolIdPositionId(defaultCreator, defaultPoolId, DefaultPositionId)
 				positionIdBytes := store.Get(ownerPoolIdToPositionIdKey)
 				s.Require().Nil(positionIdBytes)
 

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -581,7 +581,7 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 			positionId:       DefaultPositionId,
 		},
 		{
-			name:             "InValid case: Delete a non existing position",
+			name:             "Invalid case: Delete a non existing position",
 			positionId:       DefaultPositionId + 1,
 			underlyingLockId: 0,
 			poolId:           defaultPoolId,

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -571,28 +571,32 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 		{
 			name:             "Valid case: Delete position info on existing pool and existing position (no underlying lock)",
 			underlyingLockId: 0,
+			poolId:           defaultPoolId,
 			positionId:       DefaultPositionId,
 		},
 		{
 			name:             "Valid case: Delete position info on existing pool and existing position (has underlying lock)",
 			underlyingLockId: 1,
+			poolId:           defaultPoolId,
 			positionId:       DefaultPositionId,
 		},
 		{
 			name:             "InValid case: Delete a non existing position",
 			positionId:       DefaultPositionId + 1,
 			underlyingLockId: 0,
+			poolId:           defaultPoolId,
 			expectedErr:      types.PositionIdNotFoundError{PositionId: DefaultPositionId + 1},
 		},
 		{
-			name:             "InValid case: Delete the address-pool-position ID to position mapping",
+			name:             "Invalid case: non-existent the address-pool-position ID to position mapping",
 			positionId:       DefaultPositionId,
 			underlyingLockId: 0,
+			poolId:           defaultPoolId,
 			creator:          secondaryAccount,
 			expectedErr:      types.AddressPoolPositionIdNotFoundError{PoolId: DefaultPositionId, PositionId: DefaultPositionId, Owner: secondaryAccount.String()},
 		},
 		{
-			name:             "InValid case: Delete pool-position ID mapping",
+			name:             "Invalid case: non-existent pool-position ID mapping",
 			poolId:           3,
 			positionId:       DefaultPositionId,
 			underlyingLockId: 0,
@@ -664,7 +668,7 @@ func (s *KeeperTestSuite) TestDeletePosition() {
 				defaultCreator = secondaryAccount
 			}
 
-			if test.poolId != 0 && test.poolId != defaultPoolId {
+			if test.poolId != defaultPoolId {
 				defaultPoolId = test.poolId
 			}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#5052](https://github.com/osmosis-labs/osmosis/issues/5052)

## What is the purpose of the change

In deletePosition, we delete from multiple indexes. However, there is only one error case covered by tests - PositionIdNotFoundError

## Testing and Verifying
added test
