### PR TITLE
CL: add function to generate random `Positions` instances

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,6 +14,7 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
 	"github.com/osmosis-labs/osmosis/osmoutils"
 
 	"github.com/CosmWasm/wasmd/x/wasm"

--- a/go.sum
+++ b/go.sum
@@ -948,10 +948,8 @@ github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:Ylmch
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230621002052-afb82fbaa312 h1:7Y/948riUlpIfFSAUIx0rmRy3B+Mdk6alHwOa8lTNXY=
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230621002052-afb82fbaa312/go.mod h1:JTym95/bqrSnG5MPcXr1YDhv43JdCeo3p+iDbazoX68=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230622012610-25ef7aa8f2a5 h1:MTIKbW26Ire7kKL/JOPsXaVpbgTxfHdL8ySXHRcF3SM=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230622012610-25ef7aa8f2a5/go.mod h1:FqFOfj9+e5S1I7hR3baGUHrqje3g32EOHAXoOf7R00M=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343 h1:7V2b3+mSnLnK0Px+Dl3vnxAQgk4SV8e9ohfJ/tKsq0M=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343/go.mod h1:FqFOfj9+e5S1I7hR3baGUHrqje3g32EOHAXoOf7R00M=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230621031726-b8c2cf1a7257 h1:AoWnzqEsyBkbAUP8O/eWrkz+MiTT4KjqG5idLAkpJMA=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230621031726-b8c2cf1a7257/go.mod h1:FqFOfj9+e5S1I7hR3baGUHrqje3g32EOHAXoOf7R00M=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304 h1:RIrWLzIiZN5Xd2JOfSOtGZaf6V3qEQYg6EaDTAkMnCo=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304/go.mod h1:yPWoJTj5RKrXKUChAicp+G/4Ni/uVEpp27mi/FF/L9c=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230602130523-f9a94d8bbd10 h1:XrES5AHZMZ/Y78boW35PTignkhN9h8VvJ1sP8EJDIu8=

--- a/osmoutils/cosmwasm/helpers.go
+++ b/osmoutils/cosmwasm/helpers.go
@@ -2,6 +2,7 @@ package cosmwasm
 
 import (
 	"encoding/json"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/concentrated-liquidity/spread_rewards_test.go
+++ b/x/concentrated-liquidity/spread_rewards_test.go
@@ -1359,11 +1359,16 @@ func (s *KeeperTestSuite) TestUpdatePosValueToInitValuePlusGrowthOutside() {
 	}
 }
 
-func NewRandomizedPositions() Positions {
-	rand.Seed(time.Now().UnixNano())
+// NewRandomizedPositions creates a randomized Positions struct for randomization in tests.
+// Constraint: numAccounts >= (numFullRange or numNarrowRange or numConsecutive or numOverlapping)
+// Reason: you need to have at least X accounts to create X positions
+// Parameter cap is used to set maximum possible value of any field of returning struct
+func NewRandomizedPositions(cap int) Positions {
+	// Preset seed to ensure deterministic test runs.
+	rand.Seed(2)
 
-	numSwaps := 2 + rand.Intn(99) // Random number between 2 and 100
-	numAccounts := 2 + rand.Intn(99)
+	numSwaps := 2 + rand.Intn(cap) // Random number between 2 and 100, modulo cap to cap the max possible value
+	numAccounts := 2 + rand.Intn(cap)
 
 	numFullRange := rand.Intn(numAccounts + 1) // Random number between 0 and numAccounts inclusive
 	numNarrowRange := rand.Intn(numAccounts + 1)
@@ -1390,14 +1395,7 @@ type Positions struct {
 }
 
 func (s *KeeperTestSuite) TestFunctional_SpreadRewards_Swaps() {
-	positions := Positions{
-		numSwaps:       7,
-		numAccounts:    5,
-		numFullRange:   4,
-		numNarrowRange: 3,
-		numConsecutive: 2,
-		numOverlapping: 1,
-	}
+	positions := NewRandomizedPositions(10)
 	// Init suite.
 	s.SetupTest()
 

--- a/x/concentrated-liquidity/spread_rewards_test.go
+++ b/x/concentrated-liquidity/spread_rewards_test.go
@@ -2,6 +2,7 @@ package concentrated_liquidity_test
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -1355,6 +1356,27 @@ func (s *KeeperTestSuite) TestUpdatePosValueToInitValuePlusGrowthOutside() {
 			positionAccumDelta := positionPost.AccumValuePerShare.Sub(positionPre.AccumValuePerShare)
 			s.Require().Equal(tc.spreadRewardGrowthOutside, positionAccumDelta)
 		})
+	}
+}
+
+func NewRandomizedPositions() Positions {
+	rand.Seed(time.Now().UnixNano())
+
+	numSwaps := 2 + rand.Intn(99) // Random number between 2 and 100
+	numAccounts := 2 + rand.Intn(99)
+
+	numFullRange := rand.Intn(numAccounts + 1) // Random number between 0 and numAccounts inclusive
+	numNarrowRange := rand.Intn(numAccounts + 1)
+	numConsecutive := rand.Intn(numAccounts + 1)
+	numOverlapping := rand.Intn(numAccounts + 1)
+
+	return Positions{
+		numSwaps:       numSwaps,
+		numAccounts:    numAccounts,
+		numFullRange:   numFullRange,
+		numNarrowRange: numNarrowRange,
+		numConsecutive: numConsecutive,
+		numOverlapping: numOverlapping,
 	}
 }
 

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2897,6 +2897,14 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 		s.Require().NoError(err)
 	}
 
+	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	liq = clPool.GetLiquidity()
+	sqrtPriceCurr = clPool.GetCurrentSqrtPrice()
+	tokenInAmt = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps))).ToDec()
+	spreadFactor = clPool.GetSpreadFactor(s.Ctx)
+	tokenInAfterSpreadFactors = tokenInAmt.Mul(sdk.OneDec().Sub(spreadFactor))
+	fmt.Println(tokenInAmt, spreadFactor, tokenInAfterSpreadFactors, liq)
+
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
 	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
 	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
@@ -2937,10 +2945,10 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	// print(token_out)    # 5052068983.121266708067570832
 
 	// Get expected values from the calculations above
-	expectedSqrtPrice = osmomath.MustNewDecFromStr("70.64112736841825140176332377")
+	expectedSqrtPrice = osmomath.BigDecFromSDKDec(sqrtPriceCurr.Add(tokenInAfterSpreadFactors.Quo(liq)))
 	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut = sdk.NewInt(5052068983)
+	expectedTokenOut = liq.Mul(expectedSqrtPrice.SDKDec().Sub(sqrtPriceCurr)).Quo(sqrtPriceCurr.Mul(expectedSqrtPrice.SDKDec())).TruncateInt()
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
@@ -2956,6 +2964,13 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 		_, _, err = s.App.ConcentratedLiquidityKeeper.WithdrawPosition(s.Ctx, owner, positionId, position.Liquidity)
 		s.Require().NoError(err)
 	}
+
+	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	liq = clPool.GetLiquidity()
+	sqrtPriceCurr = clPool.GetCurrentSqrtPrice()
+	tokenInAmt = swapCoin1.Amount.Mul(sdk.NewInt(int64(positions.numSwaps))).ToDec()
+	spreadFactor = clPool.GetSpreadFactor(s.Ctx)
+	tokenInAfterSpreadFactors = tokenInAmt.Mul(sdk.OneDec().Sub(spreadFactor))
 
 	// Swap multiple times USDC for ETH, therefore increasing the spot price
 	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, types.MaxSpotPrice, positions.numSwaps)
@@ -2997,10 +3012,10 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	// print(token_out)    # 882804.6589413517320313885494
 
 	// Get expected values from the calculations above
-	expectedSqrtPrice = osmomath.MustNewDecFromStr("76.22545423006231767390422658")
+	expectedSqrtPrice = osmomath.BigDecFromSDKDec(sqrtPriceCurr.Add(tokenInAfterSpreadFactors.Quo(liq)))
 	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn = swapCoin1.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut = sdk.NewInt(882804)
+	expectedTokenOut = liq.Mul(expectedSqrtPrice.SDKDec().Sub(sqrtPriceCurr)).Quo(sqrtPriceCurr.Mul(expectedSqrtPrice.SDKDec())).TruncateInt()
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))
@@ -3016,6 +3031,13 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 		_, _, err = s.App.ConcentratedLiquidityKeeper.WithdrawPosition(s.Ctx, owner, positionId, position.Liquidity)
 		s.Require().NoError(err)
 	}
+
+	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
+	liq = clPool.GetLiquidity()
+	sqrtPriceCurr = clPool.GetCurrentSqrtPrice()
+	tokenInAmt = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps))).ToDec()
+	spreadFactor = clPool.GetSpreadFactor(s.Ctx)
+	tokenInAfterSpreadFactors = tokenInAmt.Mul(sdk.OneDec().Sub(spreadFactor))
 
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
 	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
@@ -3043,10 +3065,10 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	// print(token_out)  # 4509814620.762503497903902725
 
 	// Get expected values from the calculations above
-	expectedSqrtPrice = osmomath.MustNewDecFromStr("63.97671895942244949922335999")
+	expectedSqrtPrice = osmomath.BigDecFromSDKDec(sqrtPriceCurr.Add(tokenInAfterSpreadFactors.Quo(liq)))
 	actualSqrtPrice = osmomath.BigDecFromSDKDec(clPool.GetCurrentSqrtPrice())
 	expectedTokenIn = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps)))
-	expectedTokenOut = sdk.NewInt(4509814620)
+	expectedTokenOut = liq.Mul(expectedSqrtPrice.SDKDec().Sub(sqrtPriceCurr)).Quo(sqrtPriceCurr.Mul(expectedSqrtPrice.SDKDec())).TruncateInt()
 
 	// Compare the expected and actual values with a multiplicative tolerance of 0.0001%
 	s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(expectedSqrtPrice, actualSqrtPrice))

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2791,14 +2791,8 @@ func (s *KeeperTestSuite) validateAmountsWithTolerance(amountA sdk.Int, amountB 
 }
 
 func (s *KeeperTestSuite) TestFunctionalSwaps() {
-	positions := Positions{
-		numSwaps:       5,
-		numAccounts:    5,
-		numFullRange:   4,
-		numNarrowRange: 3,
-		numConsecutive: 2,
-		numOverlapping: 1,
-	}
+	positions := NewRandomizedPositions(10)
+
 	// Init s.
 	s.SetupTest()
 

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2999,7 +2999,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin1, ETH, types.MaxSpotPrice, positions.numSwaps)
 	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())
 	s.Require().NoError(err)
-
+	fmt.Println(clPool.GetCurrentTick())
 	// Range 2
 	liq_2 = clPool.GetLiquidity()
 	sqrtNext2 = sqrt5500.Add(tokenIn.Quo(liq_2))
@@ -3066,7 +3066,7 @@ func (s *KeeperTestSuite) TestFunctionalSwaps() {
 	tokenInAmt = swapCoin0.Amount.Mul(sdk.NewInt(int64(positions.numSwaps))).ToDec()
 	spreadFactor = clPool.GetSpreadFactor(s.Ctx)
 	tokenInAfterSpreadFactors = tokenInAmt.Mul(sdk.OneDec().Sub(spreadFactor))
-
+	fmt.Println(liq) // 0
 	// Swap multiple times ETH for USDC, therefore decreasing the spot price
 	_, _, totalTokenIn, totalTokenOut = s.swapAndTrackXTimesInARow(clPool.GetId(), swapCoin0, USDC, types.MinSpotPrice, positions.numSwaps)
 	clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPool.GetId())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4361

This function is used to generate an instance of the Positions struct with randomized field values.

The function populates `numSwaps` and `numAccounts` fields with a random number in the range of [2, 100]. For the remaining fields: `numFullRange`, `numNarrowRange`, `numConsecutive`, and `numOverlapping`, it generates a random number in the range of [0, numAccounts].

# Documentation

Minor