### PR TITLE
[CL][bugfix]: Fix SwapInGivenOut to track fees with the correct denom

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -626,7 +626,7 @@ func (k Keeper) computeInAmtGivenOut(
 			}
 
 			// retrieve the liquidity held in the next closest initialized tick
-			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(desiredTokenOut.Denom, swapState.spreadRewardGrowthGlobal), spreadRewardAccumulator.GetValue(), uptimeAccums)
+			liquidityNet, err := k.crossTick(ctx, poolId, nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInDenom, swapState.spreadRewardGrowthGlobal), spreadRewardAccumulator.GetValue(), uptimeAccums)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5379

## What is the purpose of the change

During functional fungification tests, it came up that SwapInGivenOut (surprisingly) tracks the wrong denom for fees, leading to a panic being triggered when rewards are claimed. This PR fixes this by changing fees to always track the input denom.

Thanks to @czarcas7ic for helping narrowing down the source of the bug and the needed fix.

## Testing and Verifying

Tests for this functionality are in a separate PR on functional tests, as the abstractions set up in that PR makes this significantly simpler to test. This change was confirmed to fix the core issue against those tests and is being pushed separately to get breaking changes as early as possible.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A