### PR TITLE
[Superfluid] Delete wrong check in `ValidateBasic` of `MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * [#4827] (https://github.com/osmosis-labs/osmosis/pull/4827) Protorev: Change highest liquidity pool updating from weekly to daily and change dev fee payout from weekly to after every trade.
 
 ### Misc Improvements
-  * [#5393](https://github.com/osmosis-labs/osmosis/pull/5393) Delete wrong check in ValidateBasic of MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition
+ 
   * [#5356](https://github.com/osmosis-labs/osmosis/pull/5356) Fix wrong restHandler for ReplaceMigrationRecordsProposal
   * [#5020](https://github.com/osmosis-labs/osmosis/pull/5020) Add gas config to the client.toml
   * [#5105](https://github.com/osmosis-labs/osmosis/pull/5105) Lint stableswap in the same manner as all of Osmosis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * [#4827] (https://github.com/osmosis-labs/osmosis/pull/4827) Protorev: Change highest liquidity pool updating from weekly to daily and change dev fee payout from weekly to after every trade.
 
 ### Misc Improvements
-  
+  * [#5393](https://github.com/osmosis-labs/osmosis/pull/5393) Delete wrong check in ValidateBasic of MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition
   * [#5356](https://github.com/osmosis-labs/osmosis/pull/5356) Fix wrong restHandler for ReplaceMigrationRecordsProposal
   * [#5020](https://github.com/osmosis-labs/osmosis/pull/5020) Add gas config to the client.toml
   * [#5105](https://github.com/osmosis-labs/osmosis/pull/5105) Lint stableswap in the same manner as all of Osmosis

--- a/x/superfluid/types/msgs.go
+++ b/x/superfluid/types/msgs.go
@@ -286,9 +286,6 @@ func (msg MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition) ValidateBasi
 	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
 	}
-	if msg.LockId <= 0 {
-		return fmt.Errorf("Invalid lock ID (%d)", msg.LockId)
-	}
 	if msg.SharesToMigrate.IsNegative() {
 		return fmt.Errorf("Invalid shares to migrate (%s)", msg.SharesToMigrate)
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Delete the wrong check in `ValidateBasic` of  `MsgUnlockAndMigrateSharesToFullRangeConcentratedPosition`
## Testing and Verifying

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A