### PR TITLE
Restructure protorev hook updating to only process pools with coins

### DIFF
--- a/x/protorev/keeper/hooks_test.go
+++ b/x/protorev/keeper/hooks_test.go
@@ -275,7 +275,18 @@ func (s *KeeperTestSuite) TestPoolCreation() {
 			expectPass: true,
 		},
 		{
-			name: "Concentrated Liquidity - Create Pool",
+			name: "Concentrated Liquidity - Create Pool w/ No Liqudity",
+			param: param{
+				matchDenom: "hookCL",
+				executePoolCreation: func() uint64 {
+					clPool := s.PrepareConcentratedPool()
+					return clPool.GetId()
+				},
+			},
+			expectPass: false,
+		},
+		{
+			name: "Concentrated Liquidity - Create Pool w/ Liqudity",
 			param: param{
 				matchDenom: "hookCL",
 				executePoolCreation: func() uint64 {
@@ -291,8 +302,14 @@ func (s *KeeperTestSuite) TestPoolCreation() {
 		s.Run(tc.name, func() {
 			poolId := tc.param.executePoolCreation()
 			setPoolId, err := s.App.ProtoRevKeeper.GetPoolForDenomPair(s.Ctx, types.OsmosisDenomination, tc.param.matchDenom)
-			s.Require().NoError(err)
-			s.Require().Equal(poolId, setPoolId)
+
+			if tc.expectPass {
+				s.Require().NoError(err)
+				s.Require().Equal(poolId, setPoolId)
+			} else {
+				s.Require().Error(err)
+				s.Require().NotEqual(poolId, setPoolId)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Addresses: https://github.com/osmosis-labs/osmosis/pull/5045#issuecomment-1572773104

## What is the purpose of the change

- Previously, protorev was triggered by AfterConcentratedPoolCreated, but this had an issue where the pool is created without any liquidity, returning empty coins object when getting total liquidity
- Instead, this PR makes  AfterConcentratedPoolCreated a no-op and moves the core logic into AfterInitialPoolPositionCreated, so that we know we have coins
- This allows us to not handle this case in any custom manner and can expect there to be coins

## Testing and Verifying

- Added more test cases to ensure this works as expected