### PR TITLE
Try abstracting workflow components

### DIFF
--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -12,21 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v36.0.14
-        with:
-          files_ignore: |
-            **/*.md
-            **/*_test.go
-            .github/workflows/*.yml
+      - name: Is there a Changelog requiring diff?
+        id: state_machine_diff
+        uses: ./.github/workflows/workflow_components.yml
 
       - name: Changelog check
-        # Skip this step and return success result for markdown only changes
         if: |
-          steps.changed-files.outputs.any_changed == 'true' ||
-          steps.changed-files.outputs.any_deleted == 'true' ||
-          steps.changed-files.outputs.any_modified == 'true'
+          env.CODE_DIFF == 'true'
         uses: Zomzog/changelog-checker@v1.3.0
         with:
           fileName: CHANGELOG.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-            .github/**
+            .github/workflows/lint.yml
             Makefile
       - name: Get data from build cache
         uses: actions/cache@v3

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -12,21 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v36.0.14
-        with:
-          files_ignore: |
-            **/*.md
-            **/*_test.go
-            .github/workflows/*.yml
+      - name: Is there a State machine affecting change?
+        id: state_machine_diff
+        uses: ./.github/workflows/workflow_components.yml
 
       - name: Check required labels
-        # Skip this step and return success result for markdown only changes
         if: |
-          steps.changed-files.outputs.any_changed == 'true' ||
-          steps.changed-files.outputs.any_deleted == 'true' ||
-          steps.changed-files.outputs.any_modified == 'true'
+          env.CODE_DIFF == 'true'
         uses: mheap/github-action-required-labels@v4
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/workflow_components.yml
+++ b/.github/workflows/workflow_components.yml
@@ -1,0 +1,26 @@
+name: Reusable steps
+
+on:
+  workflow_call:
+  
+jobs:
+  state_machine_diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v36.0.14
+        with:
+          files_ignore: |
+            **/*.md
+            **/*_test.go
+            tests/**
+            .github/workflows/*.yml
+
+      - name: Set change variable
+        id: set-state-machine-changed
+        run: echo "CODE_DIFF=true" >> $GITHUB_ENV
+        if: |
+          steps.changed-files.outputs.any_changed == 'true' ||
+          steps.changed-files.outputs.any_deleted == 'true' ||
+          steps.changed-files.outputs.any_modified == 'true'


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Our CI workflows are getting a bit unwieldy. This starts trying to get some re-usable components for git differences across our workflows. 

It also makes the changelog & state machine labels ignore the `tests/**` path.

## Testing and Verifying

Does this PR require a changelog label. (Should be no)