### PR TITLE
feat: run mutation script on specific files

### DIFF
--- a/scripts/mutation-test.sh
+++ b/scripts/mutation-test.sh
@@ -1,39 +1,32 @@
 #!/usr/bin/env bash
 
 set -eo pipefail
-oIFS="$IFS"; IFS=, ; set -- $1 ; IFS="$oIFS"
+IFS=' '
+MODULE=$1
+SPECIFIC_FILES=$2
 
 DISABLED_MUTATORS='branch/*'
 
-# Only consider the following:
-# * go files in types, keeper, or module root directories
-# * ignore test and Protobuf files
-go_file_exclusions="-type f ! -path */client/* -name *.go -and -not -name *_test.go -and -not -name *pb* -and -not -name module.go"
-MUTATION_SOURCES=$(find ../x  $go_file_exclusions )
-MUTATION_SOURCES+=$(printf '\n'; find ../x -maxdepth 2 $go_file_exclusions )
-
-# Filter on a module-by-module basis as provided by input
-arg_len=$#
-
-if [ $arg_len -gt 0 ]; then
-  for i in "$@"; do
-    if [ $arg_len -gt 1 ]; then
-      MODULE_FORMAT+="./x/$i\|"
-      MODULE_NAMES+="${i} "
-      let "arg_len--"
-    else
-      MODULE_FORMAT+="./x/$i"
-      MODULE_NAMES+="${i}"
-    fi
-  done
-  MUTATION_SOURCES=$(echo "$MUTATION_SOURCES" | grep "$MODULE_FORMAT")
-  echo "running mutation tests for the following module(s): $MODULE_NAMES"
+# Check if specific files are provided
+if [ -n "$SPECIFIC_FILES" ]; then
+    IFS=','
+    read -ra FILE_ARRAY <<< "$SPECIFIC_FILES"
+    for file in "${FILE_ARRAY[@]}"; do
+        MUTATION_SOURCES+=$(find $file)
+    done
+    echo "Running mutation tests on the following file(s): $SPECIFIC_FILES"
 else
-  echo "No specific modules provided, running mutation tests for all modules."
+    # Only consider the following:
+    # * go files in types, keeper, or module root directories
+    # * ignore test and Protobuf files
+    go_file_exclusions="-type f ! -path */client/* -name *.go -and -not -name *_test.go -and -not -name *pb* -and -not -name module.go"
+    MUTATION_SOURCES=$(find ../x/$MODULE $go_file_exclusions)
+    MUTATION_SOURCES+=$(printf '\n'; find ../x/$MODULE -maxdepth 2 $go_file_exclusions)
+    echo "No specific files provided, running mutation tests on all Go files in the module: $MODULE"
 fi
 
 #Collect multiple lines into a single line to be fed into go-mutesting
-MUTATION_SOURCES=$(echo $MUTATION_SOURCES | tr '\n' ' ')
+MUTATION_SOURCES=$(echo $MUTATION_SOURCES | tr '\n' ' ' | sed 's/^ *//;s/ *$//')
 
 OUTPUT=$(go run github.com/osmosis-labs/go-mutesting/cmd/go-mutesting --disable=$DISABLED_MUTATORS $MUTATION_SOURCES)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The mutation script allows users to specify specific modules to run mutation tests on. These tests still take a really long time, and many times a user might just want to run on a specific file. This modification allows for this. For example:

```
./mutation-test.sh "concentrated-liquidity" "../x/concentrated-liquidity/incentives.go"
```

This runs mutation tests on just incentives.go file and nothing else.
