### PR TITLE
fix: sf unbonding migration patch

### DIFF
--- a/x/superfluid/keeper/migrate.go
+++ b/x/superfluid/keeper/migrate.go
@@ -166,8 +166,8 @@ func (k Keeper) migrateSuperfluidUnbondingBalancerToConcentrated(ctx sdk.Context
 		return 0, sdk.Int{}, sdk.Int{}, sdk.Dec{}, time.Time{}, 0, 0, 0, err
 	}
 
-	// Create a new synthetic lockup for the new intermediary account in an unlocking status
-	err = k.createSyntheticLockup(ctx, concentratedLockId, clIntermediateAccount, unlockingStatus)
+	// Create a new synthetic lockup for the new intermediary account in an unlocking status for the remaining duration.
+	err = k.createSyntheticLockupWithDuration(ctx, concentratedLockId, clIntermediateAccount, remainingLockTime, unlockingStatus)
 	if err != nil {
 		return 0, sdk.Int{}, sdk.Int{}, sdk.Dec{}, time.Time{}, 0, 0, 0, err
 	}

--- a/x/superfluid/keeper/synthetic_lock_wrapper.go
+++ b/x/superfluid/keeper/synthetic_lock_wrapper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/osmosis-labs/osmosis/v16/x/superfluid/types"
 
@@ -43,13 +44,19 @@ func (k Keeper) createSyntheticLockup(ctx sdk.Context,
 	underlyingLockId uint64, intermediateAcc types.SuperfluidIntermediaryAccount, lockingStat lockingStatus,
 ) error {
 	unbondingDuration := k.sk.GetParams(ctx).UnbondingTime
+	return k.createSyntheticLockupWithDuration(ctx, underlyingLockId, intermediateAcc, unbondingDuration, lockingStat)
+}
+
+func (k Keeper) createSyntheticLockupWithDuration(ctx sdk.Context,
+	underlyingLockId uint64, intermediateAcc types.SuperfluidIntermediaryAccount, unlockingDuration time.Duration, lockingStat lockingStatus,
+) error {
 	if lockingStat == unlockingStatus {
 		isUnlocking := true
 		synthdenom := unstakingSyntheticDenom(intermediateAcc.Denom, intermediateAcc.ValAddr)
-		return k.lk.CreateSyntheticLockup(ctx, underlyingLockId, synthdenom, unbondingDuration, isUnlocking)
+		return k.lk.CreateSyntheticLockup(ctx, underlyingLockId, synthdenom, unlockingDuration, isUnlocking)
 	} else {
 		notUnlocking := false
 		synthdenom := stakingSyntheticDenom(intermediateAcc.Denom, intermediateAcc.ValAddr)
-		return k.lk.CreateSyntheticLockup(ctx, underlyingLockId, synthdenom, unbondingDuration, notUnlocking)
+		return k.lk.CreateSyntheticLockup(ctx, underlyingLockId, synthdenom, unlockingDuration, notUnlocking)
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

While creating E2E tests for CL, @ThanhNhann from Notional discovered the following bug:

In the `migrateSuperfluidUnbondingBalancerToConcentrated` method, we call createSyntheticLockup https://github.com/osmosis-labs/osmosis/blob/41af9f9708ad25053b9a4a5660affd0ff1bae7b0/x/superfluid/keeper/migrate.go#L169-L173 at the very end in an unlocking status. This is so that if, after their migration their validator gets slashed, they will also still get slashed approppriatly.

The bug is, in `createSyntheticLockup` https://github.com/osmosis-labs/osmosis/blob/41af9f9708ad25053b9a4a5660affd0ff1bae7b0/x/superfluid/keeper/synthetic_lock_wrapper.go#L42-L55 we use the unbondingTime parameter as the unbonding duration for the synth lock. So even if the user had 4 mins left, their synth lock would persist for the UnbondingTime parameter.

The fix is simple, adding a `createSytheticLockupWithDuration` method that takes in a duration rather than using the parameter directly

## Testing and Verifying

`TestMigrateNonSuperfluidLockBalancerToConcentrated` adds an hour wait block time increase to better simulate an unblonding / unlocking lock that would be calling this method. This test case properly fails with the old code, confirming the bug was valid.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A