### PR TITLE
[fix] Reduce tokenfactory gas fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ and control over token transfers.
   * [#4801](https://github.com/osmosis-labs/osmosis/pull/4801) refactor: remove GetTotalShares, GetTotalLiquidity and GetExitFee from PoolI
   * [#4951](https://github.com/osmosis-labs/osmosis/pull/4951) feat: implement pool liquidity query in pool manager, deprecate the one in gamm
   * [#5000](https://github.com/osmosis-labs/osmosis/pull/5000) osmomath.Power panics for base < 1 to temporarily restrict broken logic for such base.
-  * [#5468](https://github.com/osmosis-labs/osmosis/pull/5468) fix: Reduce tokenfactory gas fee
+  * [#5468](https://github.com/osmosis-labs/osmosis/pull/5468) fix: Reduce tokenfactory denom creation gas fee to 1_000_000
 
 ## Dependencies
   * [#4783](https://github.com/osmosis-labs/osmosis/pull/4783) Update wasmd to 0.31 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and control over token transfers.
   * [#4801](https://github.com/osmosis-labs/osmosis/pull/4801) refactor: remove GetTotalShares, GetTotalLiquidity and GetExitFee from PoolI
   * [#4951](https://github.com/osmosis-labs/osmosis/pull/4951) feat: implement pool liquidity query in pool manager, deprecate the one in gamm
   * [#5000](https://github.com/osmosis-labs/osmosis/pull/5000) osmomath.Power panics for base < 1 to temporarily restrict broken logic for such base.
+  * [#5468](https://github.com/osmosis-labs/osmosis/pull/5468) fix: Reduce tokenfactory gas fee
 
 ## Dependencies
   * [#4783](https://github.com/osmosis-labs/osmosis/pull/4783) Update wasmd to 0.31 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -43,6 +43,7 @@ import (
 	"github.com/joho/godotenv"
 
 	"github.com/cosmos/cosmos-sdk/client/config"
+
 	osmosis "github.com/osmosis-labs/osmosis/v16/app"
 )
 

--- a/x/tokenfactory/types/params.go
+++ b/x/tokenfactory/types/params.go
@@ -12,7 +12,6 @@ var (
 	KeyDenomCreationFee        = []byte("DenomCreationFee")
 	KeyDenomCreationGasConsume = []byte("DenomCreationGasConsume")
 
-	// For choice, see: https://github.com/osmosis-labs/osmosis/pull/4983
 	// chosen as an arbitrary large number, less than the max_gas_wanted_per_tx in config.
 	DefaultCreationGasFee = 1_000_000
 )

--- a/x/tokenfactory/types/params.go
+++ b/x/tokenfactory/types/params.go
@@ -13,7 +13,7 @@ var (
 	KeyDenomCreationGasConsume = []byte("DenomCreationGasConsume")
 
 	// For choice, see: https://github.com/osmosis-labs/osmosis/pull/4983
-	// Set to 1_000_000 so that the gas limit doesnot go over 25M limit that is set in our config file.
+	// chosen as an arbitrary large number, less than the max_gas_wanted_per_tx in config.
 	DefaultCreationGasFee = 1_000_000
 )
 

--- a/x/tokenfactory/types/params.go
+++ b/x/tokenfactory/types/params.go
@@ -13,7 +13,8 @@ var (
 	KeyDenomCreationGasConsume = []byte("DenomCreationGasConsume")
 
 	// For choice, see: https://github.com/osmosis-labs/osmosis/pull/4983
-	DefaultCreationGasFee = 40_000_000
+	// Set to 1_000_000 so that the gas limit doesnot go over 25M limit that is set in our config file.
+	DefaultCreationGasFee = 1_000_000
 )
 
 // ParamTable for gamm module.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#5440](https://github.com/osmosis-labs/osmosis/issues/5440)

## What is the purpose of the change

The current default mempool max gas per tx value is the old 25M value:

[osmosis/cmd/osmosisd/cmd/root.go](https://github.com/osmosis-labs/osmosis/blob/c6697a5e4b2ccdf216f213a33db7e97b0dd46399/cmd/osmosisd/cmd/root.go#L151)

Line 151 in [c6697a5](https://github.com/osmosis-labs/osmosis/commit/c6697a5e4b2ccdf216f213a33db7e97b0dd46399)

 max-gas-wanted-per-tx = "25000000" 
Along with localosmosis instances, this apparently impacts edgenet? So transactions that exceed the 25M limit fail:

[osmosis/x/tokenfactory/types/params.go](https://github.com/osmosis-labs/osmosis/blob/c6697a5e4b2ccdf216f213a33db7e97b0dd46399/x/tokenfactory/types/params.go#L16)

Line 16 in [c6697a5](https://github.com/osmosis-labs/osmosis/commit/c6697a5e4b2ccdf216f213a33db7e97b0dd46399)

 DefaultCreationGasFee = 40_000_000

## Testing and Verifying
- need to verify that mempool is working correctly with fee reduction 

## Documentation and Release Note
n/a

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A