### PR TITLE
[CL]: Fix two critical tick iterator-related bugs

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -337,7 +337,6 @@ func (k Keeper) computeOutAmtGivenIn(
 		amountSpecifiedRemaining: tokenAmountInSpecified.Clone(), // tokenIn
 		amountCalculated:         sdk.ZeroDec(),                  // tokenOut
 		sqrtPrice:                curSqrtPrice,
-		// Pad (or don't pad) current tick based on swap direction to avoid off-by-one errors
 		tick:                     p.GetCurrentTick(),
 		liquidity:                p.GetLiquidity(),
 		spreadRewardGrowthGlobal: sdk.ZeroDec(),

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -296,7 +296,7 @@ func (k Keeper) computeOutAmtGivenIn(
 	}
 
 	// Set the swap strategy
-	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, spreadFactor, p.GetTickSpacing())
+	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, spreadFactor)
 
 	// Get current sqrt price from pool and run sanity check that current sqrt price is
 	// on the correct side of the price limit given swap direction.
@@ -511,7 +511,7 @@ func (k Keeper) computeInAmtGivenOut(
 	}
 
 	// set the swap strategy
-	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, spreadFactor, tickSpacing)
+	swapStrategy := swapstrategy.New(zeroForOne, sqrtPriceLimit, k.storeKey, spreadFactor)
 
 	// get current sqrt price from pool
 	curSqrtPrice := p.GetCurrentSqrtPrice()

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -338,7 +338,7 @@ func (k Keeper) computeOutAmtGivenIn(
 		amountCalculated:         sdk.ZeroDec(),                  // tokenOut
 		sqrtPrice:                curSqrtPrice,
 		// Pad (or don't pad) current tick based on swap direction to avoid off-by-one errors
-		tick:                     swapStrategy.InitializeTickValue(p.GetCurrentTick()),
+		tick:                     p.GetCurrentTick(),
 		liquidity:                p.GetLiquidity(),
 		spreadRewardGrowthGlobal: sdk.ZeroDec(),
 	}
@@ -540,7 +540,7 @@ func (k Keeper) computeInAmtGivenOut(
 		amountSpecifiedRemaining: tokenAmountOutSpecified, // tokenOut
 		amountCalculated:         sdk.ZeroDec(),           // tokenIn
 		sqrtPrice:                curSqrtPrice,
-		tick:                     swapStrategy.InitializeTickValue(p.GetCurrentTick()),
+		tick:                     p.GetCurrentTick(),
 		liquidity:                p.GetLiquidity(),
 		spreadRewardGrowthGlobal: sdk.ZeroDec(),
 	}

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero.go
@@ -21,7 +21,6 @@ type oneForZeroStrategy struct {
 	sqrtPriceLimit sdk.Dec
 	storeKey       sdk.StoreKey
 	spreadFactor   sdk.Dec
-	tickSpacing    uint64
 }
 
 var _ swapStrategy = (*oneForZeroStrategy)(nil)

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero.go
@@ -181,19 +181,6 @@ func (s oneForZeroStrategy) InitializeNextTickIterator(ctx sdk.Context, poolId u
 	return iter
 }
 
-// InitializeTickValue returns the initial tick value for computing swaps based
-// on the actual current tick.
-//
-// oneForZeroStrategy assumes moving to the right of the current square root price.
-// As a result, we use forward iterator in InitializeNextTickIterator to find the next
-// tick to the left of current. The end cursor for forward iteration is inclusive.
-// Therefore, this method is, essentially a no-op. The logic is reversed for
-// zeroForOneStrategy where we use reverse iterator and have to add one to
-// the input. Therefore, we define this method to account for different strategies.
-func (s oneForZeroStrategy) InitializeTickValue(currentTick int64) int64 {
-	return currentTick + 1
-}
-
 // SetLiquidityDeltaSign sets the liquidity delta sign for the given liquidity delta.
 // This is called when consuming all liquidity.
 // When a position is created, we add liquidity to lower tick

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -67,7 +67,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 		liquidity            sdk.Dec
 		amountOneInRemaining sdk.Dec
 		spreadFactor         sdk.Dec
-		tickSpacing          uint64
 
 		expectedSqrtPriceNext           sdk.Dec
 		expectedAmountInConsumed        sdk.Dec
@@ -97,7 +96,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			liquidity:            defaultLiquidity,
 			amountOneInRemaining: defaultAmountOne.Sub(sdk.NewDec(100)),
 			spreadFactor:         sdk.ZeroDec(),
-			tickSpacing:          defaultTickSpacing,
 
 			// sqrt_price_current + token_in / liquidity
 			expectedSqrtPriceNext:    sqrtPriceTargetNotReached,
@@ -112,7 +110,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			liquidity:            defaultLiquidity,
 			amountOneInRemaining: defaultAmountOne.Add(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultSpreadReward)),
 			spreadFactor:         defaultSpreadReward,
-			tickSpacing:          defaultTickSpacing,
 
 			expectedSqrtPriceNext:    sqrtPriceNext,
 			expectedAmountInConsumed: defaultAmountOne.Ceil(),
@@ -126,7 +123,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			liquidity:            defaultLiquidity,
 			amountOneInRemaining: defaultAmountOne.Sub(sdk.NewDec(100)).Quo(sdk.OneDec().Sub(defaultSpreadReward)),
 			spreadFactor:         defaultSpreadReward,
-			tickSpacing:          defaultTickSpacing,
 
 			expectedSqrtPriceNext:    sqrtPriceTargetNotReached,
 			expectedAmountInConsumed: defaultAmountOne.Sub(sdk.NewDec(100)).Ceil(),
@@ -143,7 +139,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 			// this value is exactly enough to reach the target
 			amountOneInRemaining: sdk.NewDec(1336900668450),
 			spreadFactor:         sdk.ZeroDec(),
-			tickSpacing:          defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrt(100_000_100),
 
@@ -157,7 +152,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, tc.tickSpacing)
+			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
 			sqrtPriceNext, amountInConsumed, amountZeroOut, spreadRewardChargeTotal := strategy.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountOneInRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
@@ -190,7 +185,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 	tests := map[string]struct {
 		amountZeroOutRemaining sdk.Dec
 		spreadFactor           sdk.Dec
-		tickSpacing            uint64
 
 		expectedSqrtPriceNext           sdk.Dec
 		expectedAmountZeroOutConsumed   sdk.Dec
@@ -203,7 +197,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 			// Add 100.
 			amountZeroOutRemaining: defaultAmountZero.Add(sdk.NewDec(100)),
 			spreadFactor:           sdk.ZeroDec(),
-			tickSpacing:            defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceNext,
 			// Reached target, so 100 is not consumed.
@@ -215,7 +208,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 		"2: no spread reward - do not reach target": {
 			amountZeroOutRemaining: defaultAmountZero.Sub(sdk.NewDec(1000)),
 			spreadFactor:           sdk.ZeroDec(),
-			tickSpacing:            defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
 
@@ -228,7 +220,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 		"3: 3% spread reward - reach target": {
 			amountZeroOutRemaining: defaultAmountZero.Quo(sdk.OneDec().Sub(defaultSpreadReward)),
 			spreadFactor:           defaultSpreadReward,
-			tickSpacing:            defaultTickSpacing,
 
 			expectedSqrtPriceNext:           sqrtPriceNext,
 			expectedAmountZeroOutConsumed:   defaultAmountZero.Sub(sdk.SmallestDec()), // subtracting smallest dec to account for truncations in favor of the pool.
@@ -238,7 +229,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 		"4: 3% spread reward - do not reach target": {
 			amountZeroOutRemaining: defaultAmountZero.Sub(sdk.NewDec(1000)),
 			spreadFactor:           defaultSpreadReward,
-			tickSpacing:            defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
 			// subtracting 3 * smallest dec to account for truncations in favor of the pool.
@@ -250,7 +240,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, tc.tickSpacing)
+			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
 			sqrtPriceNext, amountZeroOutConsumed, amountOneIn, spreadRewardChargeTotal := strategy.ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, defaultLiquidity, tc.amountZeroOutRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 )
 
-func (suite *StrategyTestSuite) setupNewOneForZeroSwapStrategy(sqrtPriceLimit sdk.Dec, spread sdk.Dec, tickSpacing uint64) swapstrategy.SwapStrategy {
+func (suite *StrategyTestSuite) setupNewOneForZeroSwapStrategy(sqrtPriceLimit sdk.Dec, spread sdk.Dec) swapstrategy.SwapStrategy {
 	suite.SetupTest()
-	return swapstrategy.New(false, sqrtPriceLimit, suite.App.GetKey(types.ModuleName), spread, tickSpacing)
+	return swapstrategy.New(false, sqrtPriceLimit, suite.App.GetKey(types.ModuleName), spread)
 }
 
 func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_OneForZero() {
@@ -38,7 +38,7 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_OneForZero() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewOneForZeroSwapStrategy(tc.sqrtPriceLimit, zero, defaultTickSpacing)
+			strategy := suite.setupNewOneForZeroSwapStrategy(tc.sqrtPriceLimit, zero)
 			actualSqrtTargetPrice := strategy.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 			suite.Require().Equal(tc.expectedResult, actualSqrtTargetPrice)
 		})
@@ -152,7 +152,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_OneForZero() {
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
+			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor)
 			sqrtPriceNext, amountInConsumed, amountZeroOut, spreadRewardChargeTotal := strategy.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountOneInRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
@@ -240,7 +240,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_OneForZero() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
+			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor)
 			sqrtPriceNext, amountZeroOutConsumed, amountOneIn, spreadRewardChargeTotal := strategy.ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, defaultLiquidity, tc.amountZeroOutRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
@@ -391,7 +391,7 @@ func (suite *StrategyTestSuite) TestInitializeNextTickIterator_OneForZero() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, zero, tc.tickSpacing)
+			strategy := suite.setupNewOneForZeroSwapStrategy(types.MaxSqrtPrice, zero)
 			suite.runTickIteratorTest(strategy, tc)
 		})
 	}

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -10,7 +10,7 @@ import (
 
 func (suite *StrategyTestSuite) setupNewOneForZeroSwapStrategy(sqrtPriceLimit sdk.Dec, spread sdk.Dec) swapstrategy.SwapStrategy {
 	suite.SetupTest()
-	return swapstrategy.New(false, sqrtPriceLimit, suite.App.GetKey(types.ModuleName), spread, defaultTickSpacing)
+	return swapstrategy.New(false, sqrtPriceLimit, suite.App.GetKey(types.ModuleName), spread, 1) // defaultTickSpacing)
 }
 
 func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_OneForZero() {
@@ -281,7 +281,7 @@ func (suite *StrategyTestSuite) TestInitializeNextTickIterator_OneForZero() {
 			preSetPositions: []position{
 				{
 					lowerTick: 0,
-					upperTick: 100,
+					upperTick: 1,
 				},
 			},
 			expectIsValid:  true,

--- a/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
+++ b/x/concentrated-liquidity/swapstrategy/one_for_zero_test.go
@@ -319,6 +319,84 @@ func (suite *StrategyTestSuite) TestInitializeNextTickIterator_OneForZero() {
 			tickSpacing:   defaultTickSpacing,
 			expectIsValid: false,
 		},
+
+		// Non-default tick spacing
+
+		"1 position, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -1,
+					upperTick: 1,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: 1,
+		},
+		"2 positions, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -4,
+					upperTick: 3,
+				},
+				{
+					lowerTick: -2,
+					upperTick: 2,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: 2,
+		},
+		"lower tick lands on current tick, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: 0,
+					upperTick: 1,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: 1,
+		},
+		"upper tick lands on current tick, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -1,
+					upperTick: 0,
+				},
+				{
+					lowerTick: 1,
+					upperTick: 2,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: 1,
+		},
+
+		"sanity check: 1 position, 10 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -10,
+					upperTick: 10,
+				},
+			},
+			tickSpacing:    10,
+			expectIsValid:  true,
+			expectNextTick: 10,
+		},
+		"sanity check: 1 position, 1000 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -1000,
+					upperTick: 1000,
+				},
+			},
+			tickSpacing:    1000,
+			expectIsValid:  true,
+			expectNextTick: 1000,
+		},
 	}
 
 	for name, tc := range tests {

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy.go
@@ -73,11 +73,11 @@ type swapStrategy interface {
 // New returns a swap strategy based on the provided zeroForOne parameter
 // with sqrtPriceLimit for the maximum square root price until which to perform
 // the swap and the stor key of the module that stores swap data.
-func New(zeroForOne bool, sqrtPriceLimit sdk.Dec, storeKey sdk.StoreKey, spreadFactor sdk.Dec, tickSpacing uint64) swapStrategy {
+func New(zeroForOne bool, sqrtPriceLimit sdk.Dec, storeKey sdk.StoreKey, spreadFactor sdk.Dec) swapStrategy {
 	if zeroForOne {
-		return &zeroForOneStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, spreadFactor: spreadFactor, tickSpacing: tickSpacing}
+		return &zeroForOneStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, spreadFactor: spreadFactor}
 	}
-	return &oneForZeroStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, spreadFactor: spreadFactor, tickSpacing: tickSpacing}
+	return &oneForZeroStrategy{sqrtPriceLimit: sqrtPriceLimit, storeKey: storeKey, spreadFactor: spreadFactor}
 }
 
 // GetPriceLimit returns the price limit based on which token is being swapped in.

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy.go
@@ -54,10 +54,6 @@ type swapStrategy interface {
 	// If nex tick relative to tickINdex does not exist in the store, it will return an invalid iterator.
 	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
 	InitializeNextTickIterator(ctx sdk.Context, poolId uint64, tickIndex int64) dbm.Iterator
-	// InitializeTickValue returns the initial tick value for computing swaps based
-	// on the actual current tick.
-	// See oneForZeroStrategy or zeroForOneStrategy for implementation details.
-	InitializeTickValue(currentTick int64) int64
 	// SetLiquidityDeltaSign sets the liquidity delta sign for the given liquidity delta.
 	// This is called when consuming all liquidity.
 	// When a position is created, we add liquidity to lower tick

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -211,7 +211,7 @@ func (suite *StrategyTestSuite) TestComputeSwapState_Inverse() {
 	for name, tc := range testCases {
 		tc := tc
 		suite.Run(name, func() {
-			sut := swapstrategy.New(tc.zeroForOne, sdk.ZeroDec(), suite.App.GetKey(types.ModuleName), sdk.ZeroDec(), defaultTickSpacing)
+			sut := swapstrategy.New(tc.zeroForOne, sdk.ZeroDec(), suite.App.GetKey(types.ModuleName), sdk.ZeroDec())
 			sqrtPriceNextOutGivenIn, amountInOutGivenIn, amountOutOutGivenIn, _ := sut.ComputeSwapStepOutGivenIn(tc.sqrtPriceCurrent, tc.sqrtPriceTarget, tc.liquidity, tc.amountIn)
 			suite.Require().Equal(tc.expectedSqrtPriceNextOutGivenIn.String(), sqrtPriceNextOutGivenIn.String())
 

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -60,6 +60,7 @@ func (suite *StrategyTestSuite) SetupTest() {
 type tickIteratorTest struct {
 	currentTick     int64
 	preSetPositions []position
+	tickSpacing     uint64
 
 	expectIsValid  bool
 	expectNextTick int64
@@ -67,7 +68,7 @@ type tickIteratorTest struct {
 }
 
 func (suite *StrategyTestSuite) runTickIteratorTest(strategy swapstrategy.SwapStrategy, tc tickIteratorTest) {
-	pool := suite.PrepareCustomConcentratedPool(suite.TestAccs[0], ETH, USDC, 1, sdk.ZeroDec()) // PrepareConcentratedPool()
+	pool := suite.PrepareCustomConcentratedPool(suite.TestAccs[0], ETH, USDC, tc.tickSpacing, sdk.ZeroDec())
 	suite.setupPresetPositions(pool.GetId(), tc.preSetPositions)
 
 	// refetch pool

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -78,9 +78,7 @@ func (suite *StrategyTestSuite) runTickIteratorTest(strategy swapstrategy.SwapSt
 	currentTick := pool.GetCurrentTick()
 	suite.Require().Equal(int64(0), currentTick)
 
-	tickIndex := strategy.InitializeTickValue(currentTick)
-
-	iter := strategy.InitializeNextTickIterator(suite.Ctx, defaultPoolId, tickIndex)
+	iter := strategy.InitializeNextTickIterator(suite.Ctx, defaultPoolId, currentTick)
 	defer iter.Close()
 
 	suite.Require().Equal(tc.expectIsValid, iter.Valid())

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -67,7 +67,7 @@ type tickIteratorTest struct {
 }
 
 func (suite *StrategyTestSuite) runTickIteratorTest(strategy swapstrategy.SwapStrategy, tc tickIteratorTest) {
-	pool := suite.PrepareConcentratedPool()
+	pool := suite.PrepareCustomConcentratedPool(suite.TestAccs[0], ETH, USDC, 1, sdk.ZeroDec()) // PrepareConcentratedPool()
 	suite.setupPresetPositions(pool.GetId(), tc.preSetPositions)
 
 	// refetch pool

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one.go
@@ -21,7 +21,6 @@ type zeroForOneStrategy struct {
 	sqrtPriceLimit sdk.Dec
 	storeKey       sdk.StoreKey
 	spreadFactor   sdk.Dec
-	tickSpacing    uint64
 }
 
 var _ swapStrategy = (*zeroForOneStrategy)(nil)

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one.go
@@ -148,10 +148,11 @@ func (s zeroForOneStrategy) ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPric
 // InitializeNextTickIterator returns iterator that seeks to the next tick from the given tickIndex.
 // If nex tick relative to tickINdex does not exist in the store, it will return an invalid iterator.
 //
-// oneForZeroStrategy assumes moving to the left of the current square root price.
+// zeroForOneStrategy assumes moving to the left of the current square root price.
 // As a result, we use a reverse iterator to seek to the next tick index relative to the currentTickIndexPlusOne.
-// Since end key of the reverse iterator is exclusive, we search from current + 1 tick index.
-// in decrasing lexicographic order until a tick one smaller than current is found.
+// Even though the end key of the reverse iterator is exclusive, we search from current tick index, as we do not
+// want the current tick to be included in our iterator anyway.
+// We iterate in decrasing lexicographic order until a tick one smaller than current is found.
 // Returns an invalid iterator if currentTickIndexPlusOne is not in the store.
 // Panics if fails to parse tick index from bytes.
 // The caller is responsible for closing the iterator on success.
@@ -176,17 +177,6 @@ func (s zeroForOneStrategy) InitializeNextTickIterator(ctx sdk.Context, poolId u
 		}
 	}
 	return iter
-}
-
-// InitializeTickValue returns the initial tick value for computing swaps based
-// on the actual current tick.
-//
-// zeroForOneStrategy assumes moving to the left of the current square root price.
-// As a result, we use reverse iterator in InitializeNextTickIterator to find the next
-// tick to the left of current. The end cursor for reverse iteration is non-inclusive
-// so must add one here to make sure that the current tick is included in the search.
-func (s zeroForOneStrategy) InitializeTickValue(currentTick int64) int64 {
-	return currentTick + 1
 }
 
 // SetLiquidityDeltaSign sets the liquidity delta sign for the given liquidity delta.

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one.go
@@ -149,18 +149,18 @@ func (s zeroForOneStrategy) ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPric
 // If nex tick relative to tickINdex does not exist in the store, it will return an invalid iterator.
 //
 // zeroForOneStrategy assumes moving to the left of the current square root price.
-// As a result, we use a reverse iterator to seek to the next tick index relative to the currentTickIndexPlusOne.
+// As a result, we use a reverse iterator to seek to the next tick index relative to the currentTickIndex.
 // Even though the end key of the reverse iterator is exclusive, we search from current tick index, as we do not
 // want the current tick to be included in our iterator anyway.
 // We iterate in decrasing lexicographic order until a tick one smaller than current is found.
-// Returns an invalid iterator if currentTickIndexPlusOne is not in the store.
+// Returns an invalid iterator if currentTickIndex is not in the store.
 // Panics if fails to parse tick index from bytes.
 // The caller is responsible for closing the iterator on success.
-func (s zeroForOneStrategy) InitializeNextTickIterator(ctx sdk.Context, poolId uint64, currentTickIndexPlusOne int64) dbm.Iterator {
+func (s zeroForOneStrategy) InitializeNextTickIterator(ctx sdk.Context, poolId uint64, currentTickIndex int64) dbm.Iterator {
 	store := ctx.KVStore(s.storeKey)
 	prefixBz := types.KeyTickPrefixByPoolId(poolId)
 	prefixStore := prefix.NewStore(store, prefixBz)
-	startKey := types.TickIndexToBytes(currentTickIndexPlusOne)
+	startKey := types.TickIndexToBytes(currentTickIndex)
 
 	iter := prefixStore.ReverseIterator(nil, startKey)
 
@@ -172,7 +172,7 @@ func (s zeroForOneStrategy) InitializeNextTickIterator(ctx sdk.Context, poolId u
 			iter.Close()
 			panic(fmt.Errorf("invalid tick index (%s): %v", string(iter.Key()), err))
 		}
-		if tick < currentTickIndexPlusOne {
+		if tick < currentTickIndex {
 			break
 		}
 	}

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 )
 
-func (suite *StrategyTestSuite) setupNewZeroForOneSwapStrategy(sqrtPriceLimit sdk.Dec, spread sdk.Dec, tickSpacing uint64) swapstrategy.SwapStrategy {
+func (suite *StrategyTestSuite) setupNewZeroForOneSwapStrategy(sqrtPriceLimit sdk.Dec, spread sdk.Dec) swapstrategy.SwapStrategy {
 	suite.SetupTest()
-	return swapstrategy.New(true, sqrtPriceLimit, suite.App.GetKey(types.ModuleName), spread, tickSpacing)
+	return swapstrategy.New(true, sqrtPriceLimit, suite.App.GetKey(types.ModuleName), spread)
 }
 
 func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_ZeroForOne() {
@@ -39,7 +39,7 @@ func (suite *StrategyTestSuite) TestGetSqrtTargetPrice_ZeroForOne() {
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-			sut := suite.setupNewZeroForOneSwapStrategy(tc.sqrtPriceLimit, zero, defaultTickSpacing)
+			sut := suite.setupNewZeroForOneSwapStrategy(tc.sqrtPriceLimit, zero)
 			actualSqrtTargetPrice := sut.GetSqrtTargetPrice(tc.nextTickSqrtPrice)
 			suite.Require().Equal(tc.expectedResult, actualSqrtTargetPrice)
 		})
@@ -118,7 +118,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
+			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor)
 			sqrtPriceNext, amountZeroIn, amountOneOut, spreadRewardChargeTotal := strategy.ComputeSwapStepOutGivenIn(sqrtPriceCurrent, sqrtPriceTarget, defaultLiquidity, tc.amountZeroInRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
@@ -206,7 +206,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
+			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor)
 			sqrtPriceNext, amountOneOut, amountZeroIn, spreadRewardChargeTotal := strategy.ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, defaultLiquidity, tc.amountOneOutRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
@@ -362,7 +362,7 @@ func (suite *StrategyTestSuite) TestInitializeNextTickIterator_ZeroForOne() {
 	for name, tc := range tests {
 		tc := tc
 		suite.Run(name, func() {
-			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, zero, tc.tickSpacing)
+			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, zero)
 			suite.runTickIteratorTest(strategy, tc)
 		})
 	}

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
@@ -62,7 +62,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 	tests := map[string]struct {
 		amountZeroInRemaining sdk.Dec
 		spreadFactor          sdk.Dec
-		tickSpacing           uint64
 
 		expectedSqrtPriceNext           sdk.Dec
 		amountZeroInConsumed            sdk.Dec
@@ -75,7 +74,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 			// add 100 more
 			amountZeroInRemaining: defaultAmountZero.Add(sdk.NewDec(100)),
 			spreadFactor:          sdk.ZeroDec(),
-			tickSpacing:           defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceNext,
 			// consumed without 100 since reached target.
@@ -87,7 +85,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 		"2: no spread reward - do not reach target": {
 			amountZeroInRemaining: defaultAmountZero.Sub(sdk.NewDec(100)),
 			spreadFactor:          sdk.ZeroDec(),
-			tickSpacing:           defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
 			amountZeroInConsumed:  defaultAmountZero.Sub(sdk.NewDec(100)).Ceil(),
@@ -99,7 +96,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 			// add 100 more
 			amountZeroInRemaining: defaultAmountZero.Add(sdk.NewDec(100)).Quo(one.Sub(defaultSpreadReward)),
 			spreadFactor:          defaultSpreadReward,
-			tickSpacing:           defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceNext,
 			// Consumes without 100 since reached target and spread reward is applied.
@@ -122,7 +118,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepOutGivenIn_ZeroForOne() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, tc.tickSpacing)
+			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
 			sqrtPriceNext, amountZeroIn, amountOneOut, spreadRewardChargeTotal := strategy.ComputeSwapStepOutGivenIn(sqrtPriceCurrent, sqrtPriceTarget, defaultLiquidity, tc.amountZeroInRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)
@@ -154,7 +150,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 	tests := map[string]struct {
 		amountOneOutRemaining sdk.Dec
 		spreadFactor          sdk.Dec
-		tickSpacing           uint64
 
 		expectedSqrtPriceNext           sdk.Dec
 		amountOneOutConsumed            sdk.Dec
@@ -167,7 +162,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 			// Add 100.
 			amountOneOutRemaining: defaultAmountOne.Add(sdk.NewDec(100)),
 			spreadFactor:          zero,
-			tickSpacing:           defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceNext,
 			// Consumes without 100 since reaches target.
@@ -178,7 +172,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 		"2: no spread reward - do not reach target": {
 			amountOneOutRemaining: defaultAmountOne.Sub(sdk.NewDec(10000)),
 			spreadFactor:          zero,
-			tickSpacing:           defaultTickSpacing,
 
 			// sqrt_cur - amt_one / liq quo round up
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
@@ -191,7 +184,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 			// Add 100.
 			amountOneOutRemaining: defaultAmountOne.Quo(one.Sub(defaultSpreadReward)),
 			spreadFactor:          defaultSpreadReward,
-			tickSpacing:           defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceNext,
 			// Consumes without 100 since reaches target.
@@ -203,7 +195,6 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 		"4: 3% spread reward - do not reach target": {
 			amountOneOutRemaining: defaultAmountOne.Sub(sdk.NewDec(10000)),
 			spreadFactor:          defaultSpreadReward,
-			tickSpacing:           defaultTickSpacing,
 
 			expectedSqrtPriceNext: sqrtPriceTargetNotReached,
 			// subtracting 1 * smallest dec to account for truncations in favor of the pool.
@@ -215,7 +206,7 @@ func (suite *StrategyTestSuite) TestComputeSwapStepInGivenOut_ZeroForOne() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, tc.tickSpacing)
+			strategy := suite.setupNewZeroForOneSwapStrategy(types.MaxSqrtPrice, tc.spreadFactor, defaultTickSpacing)
 			sqrtPriceNext, amountOneOut, amountZeroIn, spreadRewardChargeTotal := strategy.ComputeSwapStepInGivenOut(sqrtPriceCurrent, sqrtPriceTarget, defaultLiquidity, tc.amountOneOutRemaining)
 
 			suite.Require().Equal(tc.expectedSqrtPriceNext, sqrtPriceNext)

--- a/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
+++ b/x/concentrated-liquidity/swapstrategy/zero_for_one_test.go
@@ -257,13 +257,17 @@ func (suite *StrategyTestSuite) TestInitializeNextTickIterator_ZeroForOne() {
 		"lower tick lands on current tick, zero for one": {
 			preSetPositions: []position{
 				{
+					lowerTick: -200,
+					upperTick: -100,
+				},
+				{
 					lowerTick: 0,
 					upperTick: 100,
 				},
 			},
 			tickSpacing:    defaultTickSpacing,
 			expectIsValid:  true,
-			expectNextTick: 0,
+			expectNextTick: -100,
 		},
 		"upper tick lands on current tick, zero for one": {
 			preSetPositions: []position{
@@ -274,11 +278,93 @@ func (suite *StrategyTestSuite) TestInitializeNextTickIterator_ZeroForOne() {
 			},
 			tickSpacing:    defaultTickSpacing,
 			expectIsValid:  true,
-			expectNextTick: 0,
+			expectNextTick: -100,
 		},
 		"no ticks, zero for one": {
 			tickSpacing:   defaultTickSpacing,
 			expectIsValid: false,
+		},
+
+		// Non-default tick spacing
+
+		"1 position, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -1,
+					upperTick: 1,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: -1,
+		},
+		"2 positions, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -4,
+					upperTick: 3,
+				},
+				{
+					lowerTick: -2,
+					upperTick: 2,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: -2,
+		},
+		"lower tick lands on current tick, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -3,
+					upperTick: -2,
+				},
+				{
+					lowerTick: 0,
+					upperTick: 1,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: -2,
+		},
+		"upper tick lands on current tick, 1 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -1,
+					upperTick: 0,
+				},
+				{
+					lowerTick: 1,
+					upperTick: 2,
+				},
+			},
+			tickSpacing:    1,
+			expectIsValid:  true,
+			expectNextTick: -1,
+		},
+
+		"sanity check: 1 position, 10 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -10,
+					upperTick: 10,
+				},
+			},
+			tickSpacing:    10,
+			expectIsValid:  true,
+			expectNextTick: -10,
+		},
+		"sanity check: 1 position, 1000 tick spacing": {
+			preSetPositions: []position{
+				{
+					lowerTick: -1000,
+					upperTick: 1000,
+				},
+			},
+			tickSpacing:    1000,
+			expectIsValid:  true,
+			expectNextTick: -1000,
 		},
 	}
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -222,14 +222,9 @@ func roundTickToCanonicalPriceTick(lowerTick, upperTick int64, priceTickLower, p
 
 // GetTickLiquidityForFullRange returns an array of liquidity depth for all ticks existing from min tick ~ max tick.
 func (k Keeper) GetTickLiquidityForFullRange(ctx sdk.Context, poolId uint64) ([]queryproto.LiquidityDepthWithRange, error) {
-	pool, err := k.getPoolById(ctx, poolId)
-	if err != nil {
-		return []queryproto.LiquidityDepthWithRange{}, err
-	}
-
 	// use false for zeroForOne since we're going from lower tick -> upper tick
 	zeroForOne := false
-	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec(), pool.GetTickSpacing())
+	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec())
 
 	// set current tick to min tick, and find the first initialized tick starting from min tick -1.
 	// we do -1 to make min tick inclusive.
@@ -355,7 +350,7 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 	}
 
 	liquidityDepths := []queryproto.TickLiquidityNet{}
-	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec(), p.GetTickSpacing())
+	swapStrategy := swapstrategy.New(zeroForOne, sdk.ZeroDec(), k.storeKey, sdk.ZeroDec())
 
 	currentTick := p.GetCurrentTick()
 	_, currentTickSqrtPrice, err := math.TickToSqrtPrice(currentTick)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Tick iterator setup for both swap directions had an off by one error that made pools vulnerable to being forced into invalid tick iterator states. This PR patches both of these bugs, tests the changes, and cleans up the code (since implementing the fix rendered `InitializeTickValue` unnecessary).

## Testing and Verifying

All the new/amended tests can be found in the respective swap strategy test files (`zero_for_one_test.go` and `one_for_zero_test.go`).

I had a local repro hitting this specific case for the second bug at a higher level of abstraction with swaps but did not want to block this PR on manually calculating the test vectors. Will include this test in a future PR with functional tests.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A