### PR TITLE
Note accum key factor potential bugs/pit falls

### DIFF
--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -3,6 +3,7 @@ package accum
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -28,7 +29,11 @@ type AccumulatorObject struct {
 
 // Makes a new accumulator at store/accum/{accumName}
 // Returns error if already exists / theres some overlapping keys
+// @Dev: accumName must not contain "/"
 func MakeAccumulator(accumStore store.KVStore, accumName string) error {
+	if strings.Contains(accumName, "/") {
+		return fmt.Errorf("Accumulator name cannot contain '/'")
+	}
 	if accumStore.Has(formatAccumPrefixKey(accumName)) {
 		return errors.New("Accumulator with given name already exists in store")
 	}

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -28,12 +28,11 @@ type AccumulatorObject struct {
 }
 
 // Makes a new accumulator at store/accum/{accumName}
-// Returns error if already exists / theres some overlapping keys
-// @Dev: accumName must not contain "/"
+// Returns error if:
+// * accumName already exists
+// * theres some overlapping keys
+// * Accumulator name contains "||"
 func MakeAccumulator(accumStore store.KVStore, accumName string) error {
-	if strings.Contains(accumName, "/") {
-		return fmt.Errorf("Accumulator name cannot contain '/'") // alt we need to make a new key separator within accum
-	}
 	if accumStore.Has(formatAccumPrefixKey(accumName)) {
 		return errors.New("Accumulator with given name already exists in store")
 	}
@@ -50,7 +49,10 @@ func MakeAccumulator(accumStore store.KVStore, accumName string) error {
 }
 
 // Makes a new accumulator at store/accum/{accumName}
-// Returns error if already exists / theres some overlapping keys
+// Returns error if:
+// * accumName already exists
+// * theres some overlapping keys
+// * Accumulator name contains "||"
 func MakeAccumulatorWithValueAndShare(accumStore store.KVStore, accumName string, accumValue sdk.DecCoins, totalShares sdk.Dec) error {
 	if accumStore.Has(formatAccumPrefixKey(accumName)) {
 		return errors.New("Accumulator with given name already exists in store")
@@ -100,8 +102,8 @@ func (accum AccumulatorObject) GetPosition(name string) (Record, error) {
 }
 
 func setAccumulator(accum *AccumulatorObject, value sdk.DecCoins, shares sdk.Dec) error {
-	if strings.Contains(accum.name, keySeparator) {
-		return fmt.Errorf("Accumulator name cannot contain '%s', provided name %s", keySeparator, accum.name)
+	if strings.Contains(accum.name, KeySeparator) {
+		return fmt.Errorf("Accumulator name cannot contain '%s', provided name %s", KeySeparator, accum.name)
 	}
 	newAccum := AccumulatorContent{value, shares}
 	osmoutils.MustSet(accum.store, formatAccumPrefixKey(accum.name), &newAccum)

--- a/osmoutils/accum/prefix.go
+++ b/osmoutils/accum/prefix.go
@@ -6,18 +6,24 @@ const (
 	modulePrefix      = "accum"
 	accumulatorPrefix = "acc"
 	positionPrefix    = "pos"
+	keySeparator      = "||" // needs to be different from other modules.
+
+	accumPrefixKey    = modulePrefix + keySeparator + accumulatorPrefix + keySeparator
+	positionPrefixKey = modulePrefix + keySeparator + positionPrefix + keySeparator
 )
 
 // formatAccumPrefix returns the key prefix used
 // specifically for accumulator values in the KVStore.
-// Returns "accum/acc/{accumName}" as bytes.
+// Returns "accum||acc||{accumName}" as bytes.
 func formatAccumPrefixKey(accumName string) []byte {
-	return []byte(fmt.Sprintf(modulePrefix+"/"+accumulatorPrefix+"/%s", accumName))
+	return []byte(fmt.Sprintf(accumPrefixKey+"%s", accumName))
 }
 
 // FormatPositionPrefixKey returns the key prefix used
 // specifically for position values in the KVStore.
-// Returns "accum/pos/{accumName}/{name}" as bytes.
+// Returns "accum||pos||{accumName}||{name}" as bytes.
+// We use a different key separator, namely `||`, to separate the accumulator name and the position name.
+// This is because we require that accumName does not contain this as a substring.
 func FormatPositionPrefixKey(accumName, name string) []byte {
-	return []byte(fmt.Sprintf(modulePrefix+"/"+positionPrefix+"/%s/%s", accumName, name))
+	return []byte(fmt.Sprintf(positionPrefixKey+"%s"+keySeparator+"%s", accumName, name))
 }

--- a/osmoutils/accum/prefix.go
+++ b/osmoutils/accum/prefix.go
@@ -6,10 +6,10 @@ const (
 	modulePrefix      = "accum"
 	accumulatorPrefix = "acc"
 	positionPrefix    = "pos"
-	keySeparator      = "||" // needs to be different from other modules.
+	KeySeparator      = "||" // needs to be different from other modules.
 
-	accumPrefixKey    = modulePrefix + keySeparator + accumulatorPrefix + keySeparator
-	positionPrefixKey = modulePrefix + keySeparator + positionPrefix + keySeparator
+	accumPrefixKey    = modulePrefix + KeySeparator + accumulatorPrefix + KeySeparator
+	positionPrefixKey = modulePrefix + KeySeparator + positionPrefix + KeySeparator
 )
 
 // formatAccumPrefix returns the key prefix used
@@ -25,5 +25,5 @@ func formatAccumPrefixKey(accumName string) []byte {
 // We use a different key separator, namely `||`, to separate the accumulator name and the position name.
 // This is because we require that accumName does not contain this as a substring.
 func FormatPositionPrefixKey(accumName, name string) []byte {
-	return []byte(fmt.Sprintf(positionPrefixKey+"%s"+keySeparator+"%s", accumName, name))
+	return []byte(fmt.Sprintf(positionPrefixKey+"%s"+KeySeparator+"%s", accumName, name))
 }

--- a/osmoutils/accum/prefix.go
+++ b/osmoutils/accum/prefix.go
@@ -10,14 +10,14 @@ const (
 
 // formatAccumPrefix returns the key prefix used
 // specifically for accumulator values in the KVStore.
-// Returns "accum/acc/{name}" as bytes.
-func formatAccumPrefixKey(name string) []byte {
-	return []byte(fmt.Sprintf(modulePrefix+"/"+accumulatorPrefix+"/%s", name))
+// Returns "accum/acc/{accumName}" as bytes.
+func formatAccumPrefixKey(accumName string) []byte {
+	return []byte(fmt.Sprintf(modulePrefix+"/"+accumulatorPrefix+"/%s", accumName))
 }
 
 // FormatPositionPrefixKey returns the key prefix used
 // specifically for position values in the KVStore.
-// Returns "accum/acc/pos/{accumName}/{name}" as bytes.
+// Returns "accum/pos/{accumName}/{name}" as bytes.
 func FormatPositionPrefixKey(accumName, name string) []byte {
-	return []byte(fmt.Sprintf(modulePrefix+"/"+accumulatorPrefix+"/"+positionPrefix+"/%s/%s", accumName, name))
+	return []byte(fmt.Sprintf(modulePrefix+"/"+positionPrefix+"/%s/%s", accumName, name))
 }

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -604,14 +604,14 @@ func (k Keeper) GetIncentiveRecordSerialized(ctx sdk.Context, poolId uint64, pag
 	pageRes, err := query.Paginate(incentivesRecordStore, pagination, func(key, value []byte) error {
 		parts := bytes.Split(key, []byte(types.KeySeparator))
 
-		minUptimeIndex, err := strconv.ParseUint(string(parts[1]), 10, 64)
+		minUptimeIndex, err := strconv.ParseUint(string(parts[0]), 10, 64)
 		if err != nil {
 			return err
 		}
 
-		denom := string(parts[2])
+		denom := string(parts[1])
 
-		incentiveCreator, err := sdk.AccAddressFromBech32(string(parts[3]))
+		incentiveCreator, err := sdk.AccAddressFromBech32(string(parts[2]))
 		if err != nil {
 			return err
 		}

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -79,7 +79,7 @@ func (k Keeper) GetUptimeAccumulatorValues(ctx sdk.Context, poolId uint64) ([]sd
 // This value depends on the provided tick's location relative to the current tick. If the provided tick
 // is greater than the current tick, then the value is zero. Otherwise, the value is the value of the
 // current global spread reward growth.
-// TODO: EXPLAIN THAT CORRECTNESS HERE REQUIRES A NUANCED ARGUMENT
+// TODO: Explain that this is true iff this is being called for consecutive ticks, not if we were jump around.
 //
 // Similar to spread factors, by convention the value is chosen as if all of the uptime (seconds per liquidity) to date has
 // occurred below the tick.
@@ -849,7 +849,6 @@ func moveRewardsToNewPositionAndDeleteOldAcc(ctx sdk.Context, accum accum.Accumu
 		return types.ModifySamePositionAccumulatorError{PositionAccName: oldPositionName}
 	}
 
-	// @Dev: should this be GetPosition?
 	hasPosition, err := accum.HasPosition(oldPositionName)
 	if err != nil {
 		return err
@@ -902,8 +901,7 @@ func (k Keeper) claimAllIncentivesForPosition(ctx sdk.Context, positionId uint64
 
 	// Compute the age of the position.
 	positionAge := ctx.BlockTime().Sub(position.JoinTime)
-	// @Dev: This check seems concerning if its ever hit? Like panic worthy, how would you get a position in state from the future
-	// Do we actually need to be checking this?
+	// should never happen, defense in depth
 	if positionAge < 0 {
 		return sdk.Coins{}, sdk.Coins{}, types.NegativeDurationError{Duration: positionAge}
 	}
@@ -932,7 +930,7 @@ func (k Keeper) claimAllIncentivesForPosition(ctx sdk.Context, positionId uint64
 	// Loop through each uptime accumulator for the pool.
 	for uptimeIndex, uptimeAccum := range uptimeAccumulators {
 		// Check if the accumulator contains the position.
-		// @Dev: There should never be a case where you can have a position for 1 accumulator, and not the rest right?
+		// There should never be a case where you can have a position for 1 accumulator, and not the rest.
 		hasPosition, err := uptimeAccum.HasPosition(positionName)
 		if err != nil {
 			return sdk.Coins{}, sdk.Coins{}, err

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -1021,7 +1021,8 @@ func (k Keeper) collectIncentives(ctx sdk.Context, sender sdk.AccAddress, positi
 	}
 
 	// If no incentives were collected, return an empty coin set.
-	// @Dev: Does collectedIncentivesForPosition = 0 => forfeitedIncentivesForPosition = 0?
+	// TODO: Does collectedIncentivesForPosition = 0 => forfeitedIncentivesForPosition = 0?
+	// TODO: Do we need to get event emitted here still?
 	if collectedIncentivesForPosition.IsZero() {
 		return collectedIncentivesForPosition, forfeitedIncentivesForPosition, nil
 	}

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -219,10 +219,10 @@ func (k Keeper) GetUserPositionsSerialized(ctx sdk.Context, addr sdk.AccAddress,
 	var prefix []byte
 	var expectedKeyPartCount int
 	if poolId == 0 {
-		expectedKeyPartCount = 3
+		expectedKeyPartCount = 2
 		prefix = types.KeyUserPositions(addr)
 	} else {
-		expectedKeyPartCount = 2
+		expectedKeyPartCount = 1
 		prefix = types.KeyAddressAndPoolId(addr, poolId)
 	}
 

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -16,7 +16,7 @@ const (
 	KeySeparator = "|"
 
 	uint64ByteSize = 8
-	uintBase       = 10
+	base10         = 10
 
 	ConcentratedLiquidityTokenPrefix = "cl/pool"
 )
@@ -229,16 +229,17 @@ func KeySpreadRewardPositionAccumulator(positionId uint64) string {
 	return strings.Join([]string{string(SpreadRewardPositionAccumulatorPrefix), strconv.FormatUint(positionId, 10)}, KeySeparator)
 }
 
+// This is guaranteed to not contain "||" so it can be used as an accumulator name.
 func KeySpreadRewardPoolAccumulator(poolId uint64) string {
-	poolIdStr := strconv.FormatUint(poolId, uintBase)
+	poolIdStr := strconv.FormatUint(poolId, base10)
 	return strings.Join([]string{string(KeySpreadRewardPoolAccumulatorPrefix), poolIdStr}, "/")
 }
 
 // Uptme Accumulator Prefix Keys
-
+// This is guaranteed to not contain "||" so it can be used as an accumulator name.
 func KeyUptimeAccumulator(poolId uint64, uptimeIndex uint64) string {
-	poolIdStr := strconv.FormatUint(poolId, uintBase)
-	uptimeIndexStr := strconv.FormatUint(uptimeIndex, uintBase)
+	poolIdStr := strconv.FormatUint(poolId, base10)
+	uptimeIndexStr := strconv.FormatUint(uptimeIndex, base10)
 	return strings.Join([]string{string(UptimeAccumulatorPrefix), poolIdStr, uptimeIndexStr}, "/")
 }
 

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -227,13 +227,13 @@ func KeyIncentiveRecord(poolId uint64, minUptimeIndex int, denom string, addr sd
 // KeyUptimeIncentiveRecords returns the prefix key for incentives records using the combination of pool id + min uptime index.
 // This can be used to iterate over incentive records for the pool id + min upttime index combination.
 func KeyUptimeIncentiveRecords(poolId uint64, minUptimeIndex int) []byte {
-	return []byte(fmt.Sprintf("%s%s%d%s%d", IncentivePrefix, KeySeparator, poolId, KeySeparator, minUptimeIndex))
+	return []byte(fmt.Sprintf("%s%s%d%s%d%s", IncentivePrefix, KeySeparator, poolId, KeySeparator, minUptimeIndex, KeySeparator))
 }
 
 // KeyPoolIncentiveRecords returns the prefix key for incentives records using given pool id.
 // This can be used to iterate over all incentive records for the pool.
 func KeyPoolIncentiveRecords(poolId uint64) []byte {
-	return []byte(fmt.Sprintf("%s%s%d", IncentivePrefix, KeySeparator, poolId))
+	return []byte(fmt.Sprintf("%s%s%d%s", IncentivePrefix, KeySeparator, poolId, KeySeparator))
 }
 
 // Spread Reward Accumulator Prefix Keys

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -61,6 +61,7 @@ var (
 // However they are not in order relative to positive integers (as 2's complement flips the leading bit)
 // Hence we use the leading sign byte to ensure that negative tick indexes
 // are in order relative to positive tick indexes.
+// TODO: Test key iteration property
 func TickIndexToBytes(tickIndex int64) []byte {
 	key := make([]byte, 9)
 	if tickIndex < 0 {

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -185,7 +185,7 @@ func KeyAddressAndPoolId(addr sdk.AccAddress, poolId uint64) []byte {
 // KeyUserPositions returns the prefix key used to create KeyAddressPoolIdPositionId, which only includes the addr.
 // This key can be used to iterate over all positions that a specific address has.
 func KeyUserPositions(addr sdk.AccAddress) []byte {
-	return []byte(fmt.Sprintf("%s%s%x", PositionPrefix, KeySeparator, addr.Bytes()))
+	return []byte(fmt.Sprintf("%s%s%x%s", PositionPrefix, KeySeparator, addr.Bytes(), KeySeparator))
 }
 
 // Pool Position Prefix Keys

--- a/x/concentrated-liquidity/types/keys.go
+++ b/x/concentrated-liquidity/types/keys.go
@@ -56,7 +56,8 @@ var (
 // - Positive tick indexes are prefixed with a byte `b + 1`.
 // - Then we encode sign || BigEndian(uint64(tickIndex))
 //
-// @Dev: We should explain this better. (The uint64 cast is superflous) This is moreso about 2's complement.
+// @Dev: We should explain this better. (The uint64 cast is superflous)
+// This is really about 2's complement.
 // We do this because big endian byte encoding does not give us in
 // order iteration in state due to the tick index values being signed integers, thus
 // iterating starting from positive then to negative.

--- a/x/concentrated-liquidity/types/keys_test.go
+++ b/x/concentrated-liquidity/types/keys_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osmosis-labs/osmosis/osmoutils/accum"
@@ -65,4 +66,12 @@ func TestAccumulatorNameKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+// sanity test to show that addresses are hex encoded.
+func TestAddrKeyEncoding(t *testing.T) {
+	addr := "bytes_underlying_address"
+	accAddr := sdk.AccAddress(addr)
+	bz := types.KeyUserPositions(accAddr)
+	require.Equal(t, "\x02|62797465735f756e6465726c79696e675f61646472657373|", string(bz))
 }

--- a/x/concentrated-liquidity/types/keys_test.go
+++ b/x/concentrated-liquidity/types/keys_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/osmosis-labs/osmosis/osmoutils/accum"
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 )
 
@@ -40,6 +41,28 @@ func TestReverseRelationTickIndexToBytes(t *testing.T) {
 			tickIndexConverted, err := types.TickIndexFromBytes(tickIndexBytes)
 			require.NoError(t, err)
 			require.Equal(t, tc.tickIndex, tickIndexConverted)
+		})
+	}
+}
+
+// This is just to sanity check that keys used as accumulator names don't contain `||`
+func TestAccumulatorNameKeys(t *testing.T) {
+	tests := map[string]struct {
+		poolId uint64
+	}{
+		"basic": {1},
+		"zero":  {0},
+		"pipe":  {124},
+		"pipe2": {124*256 + 124},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			name1 := types.KeySpreadRewardPoolAccumulator(tc.poolId)
+			require.NotContains(t, string(name1), accum.KeySeparator)
+			for i := 0; i < 125; i++ {
+				name2 := types.KeyUptimeAccumulator(tc.poolId, uint64(i))
+				require.NotContains(t, string(name2), accum.KeySeparator)
+			}
 		})
 	}
 }

--- a/x/concentrated-liquidity/types/keyspace.md
+++ b/x/concentrated-liquidity/types/keyspace.md
@@ -7,7 +7,7 @@ If || is seen outside of a `backtick` quotation, it means raw appending.
 
 We use `string encoding` of an integer to mean the variable length, base10 encoding of an integer into a string.
 
-Also all of this really shows we vastly overpay for complexity in the statemachine, and that collections work in the SDK can really simplify this code.
+Also all of this really shows we vastly overpay for complexity in the state machine, and that collections work in the SDK can really simplify this code.
 
 We break this up into parts, the multi-component keys, and the single component keys that don't really have concern.
 

--- a/x/concentrated-liquidity/types/keyspace.md
+++ b/x/concentrated-liquidity/types/keyspace.md
@@ -12,6 +12,7 @@ Also all of this really shows we vastly overpay for complexity in the statemachi
 We break this up into parts, the multi-component keys, and the single component keys that don't really have concern.
 
 TODO: How do we train AI tools to do more of this for us, instead if it being manual
+- Maybe not worth doing since collections / ORM should delete this code for us.
 
 ## multi-component keys
 

--- a/x/concentrated-liquidity/types/keyspace.md
+++ b/x/concentrated-liquidity/types/keyspace.md
@@ -1,0 +1,46 @@
+# CL keyspace
+
+This document defines the key space format used in CL, and guarantees that are expected to hold.
+It was created to more easily reason about key space bugs that we were facing.
+
+If || is seen outside of a `backtick` quotation, it means raw appending.
+
+Also all of this really shows we vastly overpay for complexity in the statemachine, and that collections work in the SDK can really simplify this code.
+
+## 0x01 - Pool Tick storage
+
+If a key exists in state, that begins with `0x01`, it is expected that it is of the form:
+`0x01` || `8 byte big endian encoding of pool ID` || `9 byte signed tick encoding`
+
+We are expected to be able to iterate over all ticks in a pool, from most negative to most positive.
+
+## 0x02 - Indexed position ID storage
+
+If a key exists in state, that begins with `0x02`, it is expected that it is of the form:
+`0x02/` || `Hexadecimal encoding of an address` || `/` || `string encoding of pool ID` || `/` || `string encoding of position ID`
+
+- We are expected to be able to safely iterate over all positions for an address
+- We are expected to be able to safely iterate over all positions for an address, pool_ID pairs.
+
+
+## 0x08 - Position ID storage
+
+If a key exists in state, that begins with `0x08`, it is expected that it is of the form:
+`0x08` || `var-length, base10 string encoding of position ID`
+
+
+## 0x0D - Position to Lock map
+
+If a key exists in state, that begins with `0x0D`, it is expected that it is of the form:
+`0x0D` || `var-length, base10 string encoding of position ID`
+
+## 0x0E - Full range liquidity of every pool
+
+If a key exists in state, that begins with `0x0E`, it is expected that it is of the form:
+`0x0E` || `var-length, base10 string encoding of pool ID`
+
+
+## 0x10 - Lock to Position map
+
+If a key exists in state, that begins with `0x10`, it is expected that it is of the form:
+`0x10` || `var-length, base10 string encoding of lock ID`

--- a/x/concentrated-liquidity/types/keyspace.md
+++ b/x/concentrated-liquidity/types/keyspace.md
@@ -35,9 +35,7 @@ If a key exists in state, that begins with `0x02`, it is expected that it is of 
 
 Since we encode the address in hexadecimal, and hexadecimal doesn't contain `/`, there is no malleability on the encoding.
 
-However, we are likely better off encoding this address with bech32, which also doesn't contain `/`, but has the benefit of being:
-- A more user friendly representation
-- Marginally more space inefficient. ("43" bytes vs "40" bytes)
+However, we are likely better off encoding this address with bech32, which also doesn't contain `/`, but has the benefit of being a more user friendly representation. This is at the expense of being marginally more space inefficient. ("43" bytes vs "40" bytes)
 
 ## 0x04 - Incentive records
 
@@ -46,7 +44,11 @@ If a key exists in state, that begins with `0x04`, it is expected that it is of 
 `0x04|` || `string encoding of pool ID` || `|` || `string encoding of min uptime index` || `|` || `denom` || `|` || `bech32 addr`
 
 - This encoding is safe, because denom cannot contain a `|`, it is restricted to alpha-numeric and `/`.
-- We are expected to be able to iterate over every (pool id, uptime index) combination.
+
+- We are expected to be able to safely iterate over all positions for a pool ID
+    - Iterate over `0x04|` || `string encoding of pool ID` || `|` 
+- We are expected to be able to safely iterate over all positions for a pool_ID, uptime index.
+    - Iterate over `0x04|` || `string encoding of pool ID` || `|` || `string encoding of min uptime index` || `|` 
 
 ## 0x09 - Pool Position ID storage
 

--- a/x/concentrated-liquidity/types/keyspace.md
+++ b/x/concentrated-liquidity/types/keyspace.md
@@ -5,7 +5,15 @@ It was created to more easily reason about key space bugs that we were facing.
 
 If || is seen outside of a `backtick` quotation, it means raw appending.
 
+We use `string encoding` of an integer to mean the variable length, base10 encoding of an integer into a string.
+
 Also all of this really shows we vastly overpay for complexity in the statemachine, and that collections work in the SDK can really simplify this code.
+
+We break this up into parts, the multi-component keys, and the single component keys that don't really have concern.
+
+TODO: How do we train AI tools to do more of this for us, instead if it being manual
+
+## multi-component keys
 
 ## 0x01 - Pool Tick storage
 
@@ -20,14 +28,67 @@ If a key exists in state, that begins with `0x02`, it is expected that it is of 
 `0x02/` || `Hexadecimal encoding of an address` || `/` || `string encoding of pool ID` || `/` || `string encoding of position ID`
 
 - We are expected to be able to safely iterate over all positions for an address
+    - Iterate over `0x02/` || `Hexadecimal encoding of an address` || `/` 
 - We are expected to be able to safely iterate over all positions for an address, pool_ID pairs.
+    - Iterate over `0x02/` || `Hexadecimal encoding of an address` || `/` || `string encoding of pool ID` || `/` 
 
+Since we encode the address in hexadecimal, and hexadecimal doesn't contain `/`, there is no malleability on the encoding.
+
+However, we are likely better off encoding this address with bech32, which also doesn't contain `/`, but has the benefit of being:
+- A more user friendly representation
+- Marginally more space inefficient. ("43" bytes vs "40" bytes)
+
+## 0x04 - Incentive records
+
+If a key exists in state, that begins with `0x04`, it is expected that it is of the form:
+
+`0x04|` || `string encoding of pool ID` || `|` || `string encoding of min uptime index` || `|` || `denom` || `|` || `bech32 addr`
+
+- This encoding is safe, because denom cannot contain a `|`, it is restricted to alpha-numeric and `/`.
+- We are expected to be able to iterate over every (pool id, uptime index) combination.
+
+## 0x09 - Pool Position ID storage
+
+If a key exists in state, that begins with `0x09`, it is expected that it is of the form:
+`0x09` || `big endian encoding of pool ID` || `/` || `big endian encoding of position ID`
+
+It is expected that you can iterate over all position ID's for a given pool.
+
+## 0x0F - Balancer full range map
+
+If a key exists in state, that begins with `0x0F`, it is expected that it is of the form:
+`0x0F|` || `str encode cl pool ID` || `|` || `str encode balancer pool ID` || `|` || `str encode uptime index`
+
+
+## single component keys
+
+## 0x03 - Pool storage
+
+Just stores the pool structs.
+
+`0x03` || `var-length, base10 string encoding of pool ID`
 
 ## 0x08 - Position ID storage
 
 If a key exists in state, that begins with `0x08`, it is expected that it is of the form:
 `0x08` || `var-length, base10 string encoding of position ID`
 
+## accum - Accumulator storage
+
+This one is a bit complicated. Any key that begins with `accum` belongs to accumulator storage. The accumulator package writes state at the following two key formats:
+
+* `accum/acc/{accumName}`
+* `accum/pos/{accumName}||{positionName}`
+
+We really should be prefix separating this state into its own sub-area (or potentially even a different store entirely -- I think its worth doing this prelaunch)
+
+accumName and positionName's are confined to one of the following two:
+- Spread rewards
+    - accumName = `0x0B/` || `str encode pool ID`
+    - positionName = `0x0A/` || `str encode position ID`
+- incentive rewards
+    - accumName = `0x0C/` || `str encode pool ID` || `/` || `str encode uptime index ID`
+    - positionName = `0x08` || `var-length, base10 string encoding of position ID`
 
 ## 0x0D - Position to Lock map
 
@@ -38,7 +99,6 @@ If a key exists in state, that begins with `0x0D`, it is expected that it is of 
 
 If a key exists in state, that begins with `0x0E`, it is expected that it is of the form:
 `0x0E` || `var-length, base10 string encoding of pool ID`
-
 
 ## 0x10 - Lock to Position map
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

We have key malleability concerns with the accumulator key choices, if the accumulator name contains a `/` (which we do). Requires nuanced arguments that can easily be invalidated in the future to argue no bug. Hence we make this less brittle, by changing the appending to `||`. 

Furthermore fixes a bug if the accumulator name ever began with `pos/`. 

Fixes bugs for the iterators on User Positions

Also contains some other notes of mine, that seem time inefficient to branch out.

## Testing and Verifying

<TODO>

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A