### PR TITLE
refactor/fix: external vs internal pool id and gauge id links for "NoLock" gauge

### DIFF
--- a/x/incentives/keeper/distribute_test.go
+++ b/x/incentives/keeper/distribute_test.go
@@ -491,7 +491,7 @@ func (s *KeeperTestSuite) TestDistribute_ExternalIncentives_NoLock() {
 
 			// Force gauge's pool id to balancer to trigger error
 			if tc.poolId == defaultBalancerPool {
-				s.App.PoolIncentivesKeeper.SetPoolGaugeIdByDuration(s.Ctx, defaultBalancerPool, tc.distrTo.Duration, externalGaugeid)
+				s.App.PoolIncentivesKeeper.SetPoolGaugeIdInternalIncentive(s.Ctx, defaultBalancerPool, tc.distrTo.Duration, externalGaugeid)
 			}
 
 			// Activate the gauge.
@@ -865,7 +865,7 @@ func (s *KeeperTestSuite) TestGetPoolFromGaugeId() {
 			}
 
 			if tc.shouldSetPoolGaugeId {
-				s.App.PoolIncentivesKeeper.SetPoolGaugeIdByDuration(s.Ctx, validPoolId, duration, poolIdOne)
+				s.App.PoolIncentivesKeeper.SetPoolGaugeIdInternalIncentive(s.Ctx, validPoolId, duration, poolIdOne)
 			}
 
 			pool, err := s.App.IncentivesKeeper.GetPoolFromGaugeId(s.Ctx, tc.gaugeId, duration)

--- a/x/incentives/keeper/distribute_test.go
+++ b/x/incentives/keeper/distribute_test.go
@@ -491,7 +491,7 @@ func (s *KeeperTestSuite) TestDistribute_ExternalIncentives_NoLock() {
 
 			// Force gauge's pool id to balancer to trigger error
 			if tc.poolId == defaultBalancerPool {
-				s.App.PoolIncentivesKeeper.SetPoolGaugeId(s.Ctx, defaultBalancerPool, tc.distrTo.Duration, externalGaugeid)
+				s.App.PoolIncentivesKeeper.SetPoolGaugeIdByDuration(s.Ctx, defaultBalancerPool, tc.distrTo.Duration, externalGaugeid)
 			}
 
 			// Activate the gauge.
@@ -865,7 +865,7 @@ func (s *KeeperTestSuite) TestGetPoolFromGaugeId() {
 			}
 
 			if tc.shouldSetPoolGaugeId {
-				s.App.PoolIncentivesKeeper.SetPoolGaugeId(s.Ctx, validPoolId, duration, poolIdOne)
+				s.App.PoolIncentivesKeeper.SetPoolGaugeIdByDuration(s.Ctx, validPoolId, duration, poolIdOne)
 			}
 
 			pool, err := s.App.IncentivesKeeper.GetPoolFromGaugeId(s.Ctx, tc.gaugeId, duration)

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -152,9 +152,12 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 			return 0, fmt.Errorf("no lock gauges must be created for concentrated pools only")
 		}
 
-		// We assume that external gauges are created with 0 duration,
-		// while internal gauges are created with an incentive epoch duration.
-		k.pik.SetPoolGaugeId(ctx, poolId, distrTo.Duration, nextGaugeId)
+		//Note that this is a general linking between the gauge and the pool
+		// for "NoLock" gauges. It occurs for both external and internal gauges.
+		// That being said, internal gauges have an additional linking
+		// by duration where duration is the incentives epoch duration.
+		// The internal incentive linking is set in x/pool-incentives CreateConcentratedLiquidityPoolGauge.
+		k.pik.SetPoolGaugeIdNoLock(ctx, poolId, nextGaugeId)
 	} else {
 		// For all other gauges, pool id must be 0.
 		if poolId != 0 {

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -152,7 +152,7 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 			return 0, fmt.Errorf("no lock gauges must be created for concentrated pools only")
 		}
 
-		//Note that this is a general linking between the gauge and the pool
+		// Note that this is a general linking between the gauge and the pool
 		// for "NoLock" gauges. It occurs for both external and internal gauges.
 		// That being said, internal gauges have an additional linking
 		// by duration where duration is the incentives epoch duration.

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -555,9 +555,16 @@ func (s *KeeperTestSuite) TestCreateGauge_NoLockGauges() {
 
 				s.Require().Equal(tc.expectedGaugeId, gaugeId)
 
-				// Assert that pool id and gauge id links are created
-				gaugeId, err := s.App.PoolIncentivesKeeper.GetPoolGaugeId(s.Ctx, tc.poolId, tc.distrTo.Duration)
+				// Assert that pool id and gauge id link meant for internally incentivized gauges is unset.
+				_, err := s.App.PoolIncentivesKeeper.GetPoolGaugeId(s.Ctx, tc.poolId, tc.distrTo.Duration)
+				s.Require().Error(err)
+
+				// Confirm that the general pool id to gauge id link is set.
+				gaugeIds, err := s.App.PoolIncentivesKeeper.GetNoLockGaugeIdsFromPool(s.Ctx, tc.poolId)
 				s.Require().NoError(err)
+				// One must have been created at pool creation time for internal incentives.
+				s.Require().Len(gaugeIds, 2)
+				gaugeId := gaugeIds[1]
 
 				s.Require().Equal(tc.expectedGaugeId, gaugeId)
 

--- a/x/incentives/types/expected_keepers.go
+++ b/x/incentives/types/expected_keepers.go
@@ -57,7 +57,7 @@ type AccountKeeper interface {
 
 type PoolIncentiveKeeper interface {
 	GetPoolIdFromGaugeId(ctx sdk.Context, gaugeId uint64, lockableDuration time.Duration) (uint64, error)
-	SetPoolGaugeId(ctx sdk.Context, poolId uint64, lockableDuration time.Duration, gaugeId uint64)
+	SetPoolGaugeIdNoLock(ctx sdk.Context, poolId uint64, gaugeId uint64)
 }
 
 type GAMMKeeper interface {

--- a/x/incentives/types/keys.go
+++ b/x/incentives/types/keys.go
@@ -47,6 +47,9 @@ var (
 
 	// LockableDurationsKey defines key for storing valid durations for giving incentives.
 	LockableDurationsKey = []byte("lockable_durations")
+
+	NoLockInternalPrefix = "no-lock/i/"
+	NoLockExternalPrefix = "no-lock/e/"
 )
 
 func KeyPrefix(p string) []byte {
@@ -55,10 +58,10 @@ func KeyPrefix(p string) []byte {
 
 // NoLockExternalGaugeDenom returns the gauge denom for the no-lock external gauge for the given pool ID.
 func NoLockExternalGaugeDenom(poolId uint64) string {
-	return fmt.Sprintf("no-lock/e/%d", poolId)
+	return fmt.Sprintf("%s%d", NoLockExternalPrefix, poolId)
 }
 
 // NoLockInternalGaugeDenom returns the gauge denom for the no-lock internal gauge for the given pool ID.
 func NoLockInternalGaugeDenom(poolId uint64) string {
-	return fmt.Sprintf("no-lock/i/%d", poolId)
+	return fmt.Sprintf("%s%d", NoLockInternalPrefix, poolId)
 }

--- a/x/pool-incentives/keeper/genesis.go
+++ b/x/pool-incentives/keeper/genesis.go
@@ -23,7 +23,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 			if record.Duration == 0 {
 				k.SetPoolGaugeIdNoLock(ctx, record.PoolId, record.GaugeId)
 			} else {
-				k.SetPoolGaugeIdByDuration(ctx, record.PoolId, record.Duration, record.GaugeId)
+				k.SetPoolGaugeIdInternalIncentive(ctx, record.PoolId, record.Duration, record.GaugeId)
 			}
 		}
 	}

--- a/x/pool-incentives/keeper/genesis.go
+++ b/x/pool-incentives/keeper/genesis.go
@@ -20,7 +20,11 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	}
 	if genState.PoolToGauges != nil {
 		for _, record := range genState.PoolToGauges.PoolToGauge {
-			k.SetPoolGaugeId(ctx, record.PoolId, record.Duration, record.GaugeId)
+			if record.Duration == 0 {
+				k.SetPoolGaugeIdNoLock(ctx, record.PoolId, record.GaugeId)
+			} else {
+				k.SetPoolGaugeIdByDuration(ctx, record.PoolId, record.Duration, record.GaugeId)
+			}
 		}
 	}
 }

--- a/x/pool-incentives/keeper/genesis_test.go
+++ b/x/pool-incentives/keeper/genesis_test.go
@@ -48,6 +48,19 @@ var (
 					GaugeId:  2,
 					Duration: time.Second,
 				},
+				// This duplication with zero duration
+				// can happen with "NoLock" gauges
+				// where the link containing the duration
+				// is used to signify that the gauge is internal
+				// while the link without the duration is used
+				// for general purpose. This redundancy is
+				// made for convinience of plugging in the
+				// later added "NoLock" gauge into the existing
+				// logic without having to change majority of the queries.
+				{
+					PoolId:  2,
+					GaugeId: 2,
+				},
 			},
 		},
 	}

--- a/x/pool-incentives/keeper/grpc_query_test.go
+++ b/x/pool-incentives/keeper/grpc_query_test.go
@@ -424,6 +424,132 @@ func (s *KeeperTestSuite) TestExternalIncentiveGauges() {
 	}
 }
 
+// TestExternalIncentiveGauges_NoLock tests the ExternalIncentiveGauges
+// around gauges of type NoLock.
+// For every test case, this test sets up a balancer pool and a concentrated pool.
+// Balancer pool creates 3 internal gauges with ids 1, 2, 3
+// Concentrated pool creates 1 internal gauge with id 4
+// Next, each test case creates external gauges with different distributeTo conditions
+// based on the test case parameters.
+// Finally, the test calls ExternalIncentiveGauges and ensures that the correct
+// gauges are returned.
+func (s *KeeperTestSuite) TestExternalIncentiveGauges_NoLock() {
+	type gaugeConfig struct {
+		distributeTo lockuptypes.QueryCondition
+		poolId       uint64
+	}
+
+	const (
+		defaultIsPerpetual       = true
+		defaultNumEpochsPaidOver = 1
+
+		balancerPoolId     = 1
+		concentratedPoolId = 2
+
+		// Balancer pool creates 3 internal gauges with ids 1, 2, 3
+		// Concentrated pool creates 1 internal gauge with id 4
+		firstExpectedExternalGaugeId = 5
+
+		defaultDenom = "stake"
+	)
+
+	var (
+		defaultCoins = sdk.NewCoins(sdk.NewCoin(defaultDenom, sdk.NewInt(10000000000)))
+
+		defaultLockableDuration = s.App.IncentivesKeeper.GetLockableDurations(s.Ctx)[0]
+
+		defaultNoLockGaugeConfig = gaugeConfig{
+			distributeTo: lockuptypes.QueryCondition{
+				LockQueryType: lockuptypes.NoLock,
+			},
+			poolId: concentratedPoolId,
+		}
+
+		defaultByDurationGaugeConfig = gaugeConfig{
+			distributeTo: lockuptypes.QueryCondition{
+				LockQueryType: lockuptypes.ByDuration,
+				Duration:      defaultLockableDuration,
+				Denom:         defaultDenom,
+			},
+		}
+	)
+
+	tests := map[string]struct {
+		gaugesToCreate []gaugeConfig
+
+		expectedGaugeIds []uint64
+
+		expectError bool
+	}{
+		"1 no lock external gauge": {
+			gaugesToCreate: []gaugeConfig{
+				defaultNoLockGaugeConfig,
+			},
+			expectedGaugeIds: []uint64{firstExpectedExternalGaugeId},
+		},
+		"1 by duration external gauge": {
+			gaugesToCreate: []gaugeConfig{
+				defaultByDurationGaugeConfig,
+			},
+			expectedGaugeIds: []uint64{firstExpectedExternalGaugeId},
+		},
+		"5 gauges no lock and by duration mixed": {
+			gaugesToCreate: []gaugeConfig{
+				defaultByDurationGaugeConfig,
+				defaultNoLockGaugeConfig,
+				defaultByDurationGaugeConfig,
+				defaultNoLockGaugeConfig,
+				defaultByDurationGaugeConfig,
+			},
+			expectedGaugeIds: []uint64{
+				firstExpectedExternalGaugeId,
+				firstExpectedExternalGaugeId + 1,
+				firstExpectedExternalGaugeId + 2,
+				firstExpectedExternalGaugeId + 3,
+				firstExpectedExternalGaugeId + 4,
+			},
+		},
+	}
+	for name, tc := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+
+			defaultStartTime := s.Ctx.BlockTime()
+
+			queryClient := s.queryClient
+
+			// Prepare a balancer and a CL pool
+			// Creates 3 NoLock internal gauges with ids 1, 2, 3
+			s.PrepareBalancerPool()
+			// Creates 1 NoLock internal gauge with id 4
+			s.PrepareConcentratedPool()
+
+			// Pre-create external gauges
+			for _, gauge := range tc.gaugesToCreate {
+
+				// Fund creator
+				s.FundAcc(s.TestAccs[0], defaultCoins)
+
+				// Note that some parameters are defaults as they are not relevant to this test
+				_, err := s.App.IncentivesKeeper.CreateGauge(s.Ctx, defaultIsPerpetual, s.TestAccs[0], defaultCoins, gauge.distributeTo, defaultStartTime, defaultNumEpochsPaidOver, gauge.poolId)
+				s.Require().NoError(err)
+			}
+
+			res, err := queryClient.ExternalIncentiveGauges(context.Background(), &types.QueryExternalIncentiveGaugesRequest{})
+
+			if tc.expectError {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().Equal(len(tc.expectedGaugeIds), len(res.Data))
+				for i, gaugeId := range tc.expectedGaugeIds {
+					s.Require().Equal(gaugeId, res.Data[i].Id)
+				}
+			}
+		})
+	}
+}
+
 func (s *KeeperTestSuite) TestGaugeIncentivePercentage() {
 	s.SetupTest()
 

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -120,7 +120,7 @@ func (k Keeper) CreateConcentratedLiquidityPoolGauge(ctx sdk.Context, poolId uin
 		return err
 	}
 
-	// Although the pool id <> gauge "NoLock" link is creted in CreateGauge,
+	// Although the pool id <> gauge "NoLock" link is created in CreateGauge,
 	// we create an additional "ByDuration" link here for tracking
 	// internal incentive "NoLock" gauges
 	incentivesEpochDuration := k.incentivesKeeper.GetEpochInfo(ctx).Duration

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -175,7 +175,7 @@ func (k Keeper) GetPoolGaugeId(ctx sdk.Context, poolId uint64, lockableDuration 
 // - general
 // - by duration (for internal incentives)
 //
-// Any "NoLock" gauge has the first link. Only the internal incentives "NoLock" gauges
+// Every "NoLock" gauge has the first link. Only the internal incentives "NoLock" gauges
 // have the second link.
 func (k Keeper) GetNoLockGaugeIdsFromPool(ctx sdk.Context, poolId uint64) ([]uint64, error) {
 	store := ctx.KVStore(k.storeKey)

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -169,7 +169,7 @@ func (k Keeper) GetPoolGaugeId(ctx sdk.Context, poolId uint64, lockableDuration 
 	return sdk.BigEndianToUint64(bz), nil
 }
 
-// GetNoLockGaugeIdsFromPool returns all the gauge ids associated with the pool id.
+// GetNoLockGaugeIdsFromPool returns all the NoLock gauge ids associated with the pool id.
 // This can only be used for the "NoLock" gauges. For "NoLock" gauges there are 2 kinds
 // of links created:
 // - general

--- a/x/pool-incentives/keeper/keeper_test.go
+++ b/x/pool-incentives/keeper/keeper_test.go
@@ -92,7 +92,7 @@ func (s *KeeperTestSuite) TestCreateConcentratePoolGauges() {
 		gaugeId, err := keeper.GetPoolGaugeId(s.Ctx, clPool.GetId(), currEpoch.Duration)
 		s.NoError(err)
 
-		// Same amount of gauges as lockableDurations must be created for every pool created.
+		// Same amount of NoLock gauges as lockableDurations must be created for every pool created.
 		gaugeIds, err := keeper.GetNoLockGaugeIdsFromPool(s.Ctx, clPool.GetId())
 		s.NoError(err)
 

--- a/x/pool-incentives/keeper/keeper_test.go
+++ b/x/pool-incentives/keeper/keeper_test.go
@@ -91,6 +91,15 @@ func (s *KeeperTestSuite) TestCreateConcentratePoolGauges() {
 		// Same amount of gauges as lockableDurations must be created for every pool created.
 		gaugeId, err := keeper.GetPoolGaugeId(s.Ctx, clPool.GetId(), currEpoch.Duration)
 		s.NoError(err)
+
+		// Same amount of gauges as lockableDurations must be created for every pool created.
+		gaugeIds, err := keeper.GetNoLockGaugeIdsFromPool(s.Ctx, clPool.GetId())
+		s.NoError(err)
+
+		s.Equal(1, len(gaugeIds))
+
+		s.Equal(gaugeId, gaugeIds[0])
+
 		gauge, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, gaugeId)
 		s.NoError(err)
 		s.Equal(0, len(gauge.Coins))

--- a/x/pool-incentives/types/key.go
+++ b/x/pool-incentives/types/key.go
@@ -20,8 +20,9 @@ var (
 	DistrInfoKey         = []byte("distr_info")
 )
 
-// GetPoolGaugeIdStoreKey returns a StoreKey with pool ID and its duration as inputs
-func GetPoolGaugeIdStoreKey(poolId uint64, duration time.Duration) []byte {
+// GetPoolGaugeIdInternalStoreKey returns a StoreKey with pool ID and its duration as inputs
+// This is used for linking pool id, duration and gauge id for internal incentives.
+func GetPoolGaugeIdInternalStoreKey(poolId uint64, duration time.Duration) []byte {
 	return []byte(fmt.Sprintf("pool-incentives/%d/%s", poolId, duration.String()))
 }
 

--- a/x/pool-incentives/types/key.go
+++ b/x/pool-incentives/types/key.go
@@ -29,3 +29,16 @@ func GetPoolGaugeIdStoreKey(poolId uint64, duration time.Duration) []byte {
 func GetPoolIdFromGaugeIdStoreKey(gaugeId uint64, duration time.Duration) []byte {
 	return []byte(fmt.Sprintf("pool-incentives-pool-id/%d/%s", gaugeId, duration.String()))
 }
+
+// GetPoolNoLockGaugeIdStoreKey returns a StoreKey with pool ID and gauge id as input
+// assumming that the pool has no lockable duration.
+func GetPoolNoLockGaugeIdStoreKey(poolId uint64, gaugeId uint64) []byte {
+	return []byte(fmt.Sprintf("no-lock-pool-incentives/%d/%d", poolId, gaugeId))
+}
+
+// GetPoolNoLockGaugeIdIterationStoreKey returns a StoreKey with pool ID as input
+// assumming that the pool has no lockable duration. It is used for collecting
+// values by iterating over this prefix.
+func GetPoolNoLockGaugeIdIterationStoreKey(poolId uint64) []byte {
+	return []byte(fmt.Sprintf("no-lock-pool-incentives/%d/", poolId))
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This problem was called out during the review in:
https://github.com/osmosis-labs/osmosis/pull/5459#discussion_r1223386216

### Summary of the problem being fixed:

For the new "NoLock" type gauge we would create a pool id <> gauge it link in the `x/pool-incentives` module.
However, that link is currently used for determining which gauge is internally incentivized.

For example, in balancer, if there is a pool id <> gauge id link present, some queries assume that the gauge id is meand for internal incentives.

By utilizing the same store index with the new "NoLock" gauge, the external incentives query ended up being broken.

### Solution

To fix this, a completely new store index was introduced for the "NoLock` gauge. This store index is used for both external and internal "NoLock" gauges.

However, for internal "NoLock" gauges we still utilize the original pool id <> gauge id link. As a result, most of the queries end up functioning as expected.


### Drive-by changes

- `GaugeIds` query was completely broken. Fixed it.

## Testing and Verifying

- Added a new test `TestExternalIncentiveGauges_NoLock`
- Updated some existing tests where coverage did not seem sufficient

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A