### PR TITLE
Change token factory wasm keeper from hook to keeper

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -464,13 +464,15 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	)
 	appKeepers.WasmKeeper = &wasmKeeper
 	appKeepers.CosmwasmPoolKeeper.SetWasmKeeper(appKeepers.WasmKeeper)
-	appKeepers.TokenFactoryKeeper.SetWasmKeeper(appKeepers.WasmKeeper)
 
 	// Pass the contract keeper to all the structs (generally ICS4Wrappers for ibc middlewares) that need it
 	appKeepers.ContractKeeper = wasmkeeper.NewDefaultPermissionKeeper(appKeepers.WasmKeeper)
 	appKeepers.RateLimitingICS4Wrapper.ContractKeeper = appKeepers.ContractKeeper
 	appKeepers.Ics20WasmHooks.ContractKeeper = appKeepers.ContractKeeper
 	appKeepers.CosmwasmPoolKeeper.SetContractKeeper(appKeepers.ContractKeeper)
+
+	// set token factory contract keeper
+	appKeepers.TokenFactoryKeeper.SetContractKeeper(appKeepers.ContractKeeper)
 
 	// wire up x/wasm to IBC
 	ibcRouter.AddRoute(wasm.ModuleName, wasm.NewIBCHandler(appKeepers.WasmKeeper, appKeepers.IBCKeeper.ChannelKeeper, appKeepers.IBCKeeper.ChannelKeeper))

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -464,6 +464,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	)
 	appKeepers.WasmKeeper = &wasmKeeper
 	appKeepers.CosmwasmPoolKeeper.SetWasmKeeper(appKeepers.WasmKeeper)
+	appKeepers.TokenFactoryKeeper.SetWasmKeeper(appKeepers.WasmKeeper)
 
 	// Pass the contract keeper to all the structs (generally ICS4Wrappers for ibc middlewares) that need it
 	appKeepers.ContractKeeper = wasmkeeper.NewDefaultPermissionKeeper(appKeepers.WasmKeeper)
@@ -674,7 +675,7 @@ func (appKeepers *AppKeepers) SetupHooks() {
 	// Recall that SetHooks is a mutative call.
 	appKeepers.BankKeeper.SetHooks(
 		banktypes.NewMultiBankHooks(
-			appKeepers.TokenFactoryKeeper.Hooks(*appKeepers.WasmKeeper),
+			appKeepers.TokenFactoryKeeper.Hooks(),
 		),
 	)
 

--- a/x/tokenfactory/keeper/before_send.go
+++ b/x/tokenfactory/keeper/before_send.go
@@ -8,7 +8,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v16/x/tokenfactory/types"
 
 	errorsmod "cosmossdk.io/errors"
-	wasmKeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 )
 
@@ -65,30 +64,29 @@ func CWCoinFromSDKCoin(in sdk.Coin) wasmvmtypes.Coin {
 
 // Hooks wrapper struct for bank keeper
 type Hooks struct {
-	k          Keeper
-	wasmkeeper wasmKeeper.Keeper
+	k Keeper
 }
 
 var _ types.BankHooks = Hooks{}
 
 // Return the wrapper struct
-func (k Keeper) Hooks(wasmkeeper wasmKeeper.Keeper) Hooks {
-	return Hooks{k, wasmkeeper}
+func (k Keeper) Hooks() Hooks {
+	return Hooks{k}
 }
 
 // TrackBeforeSend calls the before send listener contract surpresses any errors
 func (h Hooks) TrackBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) {
-	_ = h.k.callBeforeSendListener(ctx, h.wasmkeeper, from, to, amount, false)
+	_ = h.k.callBeforeSendListener(ctx, from, to, amount, false)
 }
 
 // TrackBeforeSend calls the before send listener contract returns any errors
 func (h Hooks) BlockBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
-	return h.k.callBeforeSendListener(ctx, h.wasmkeeper, from, to, amount, true)
+	return h.k.callBeforeSendListener(ctx, from, to, amount, true)
 }
 
 // callBeforeSendListener iterates over each coin and sends corresponding sudo msg to the contract address stored in state.
 // If blockBeforeSend is true, sudoMsg wraps BlockBeforeSendMsg, otherwise sudoMsg wraps TrackBeforeSendMsg.
-func (k Keeper) callBeforeSendListener(ctx sdk.Context, wasmKeeper wasmKeeper.Keeper, from, to sdk.AccAddress, amount sdk.Coins, blockBeforeSend bool) error {
+func (k Keeper) callBeforeSendListener(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins, blockBeforeSend bool) error {
 	for _, coin := range amount {
 		cosmwasmAddress := k.GetBeforeSendHook(ctx, coin.Denom)
 		if cosmwasmAddress != "" {
@@ -125,7 +123,7 @@ func (k Keeper) callBeforeSendListener(ctx sdk.Context, wasmKeeper wasmKeeper.Ke
 
 			em := sdk.NewEventManager()
 
-			_, err = wasmKeeper.Sudo(ctx.WithEventManager(em), cwAddr, msgBz)
+			_, err = k.wasmKeeper.Sudo(ctx.WithEventManager(em), cwAddr, msgBz)
 			if err != nil {
 				return errorsmod.Wrapf(err, "failed to call before send hook for denom %s", coin.Denom)
 			}

--- a/x/tokenfactory/keeper/before_send.go
+++ b/x/tokenfactory/keeper/before_send.go
@@ -123,7 +123,7 @@ func (k Keeper) callBeforeSendListener(ctx sdk.Context, from, to sdk.AccAddress,
 
 			em := sdk.NewEventManager()
 
-			_, err = k.wasmKeeper.Sudo(ctx.WithEventManager(em), cwAddr, msgBz)
+			_, err = k.contractKeeper.Sudo(ctx.WithEventManager(em), cwAddr, msgBz)
 			if err != nil {
 				return errorsmod.Wrapf(err, "failed to call before send hook for denom %s", coin.Denom)
 			}

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -20,9 +20,9 @@ type (
 
 		paramSpace paramtypes.Subspace
 
-		accountKeeper types.AccountKeeper
-		bankKeeper    types.BankKeeper
-		wasmKeeper    types.WasmKeeper
+		accountKeeper  types.AccountKeeper
+		bankKeeper     types.BankKeeper
+		contractKeeper types.ContractKeeper
 
 		communityPoolKeeper types.CommunityPoolKeeper
 	}
@@ -74,8 +74,8 @@ func (k Keeper) GetCreatorsPrefixStore(ctx sdk.Context) sdk.KVStore {
 }
 
 // Set the wasm keeper.
-func (k *Keeper) SetWasmKeeper(wasmKeeper types.WasmKeeper) {
-	k.wasmKeeper = wasmKeeper
+func (k *Keeper) SetContractKeeper(contractKeeper types.ContractKeeper) {
+	k.contractKeeper = contractKeeper
 }
 
 // CreateModuleAccount creates a module account with minting and burning capabilities

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -20,8 +20,10 @@ type (
 
 		paramSpace paramtypes.Subspace
 
-		accountKeeper       types.AccountKeeper
-		bankKeeper          types.BankKeeper
+		accountKeeper types.AccountKeeper
+		bankKeeper    types.BankKeeper
+		wasmKeeper    types.WasmKeeper
+
 		communityPoolKeeper types.CommunityPoolKeeper
 	}
 )
@@ -69,6 +71,11 @@ func (k Keeper) GetCreatorPrefixStore(ctx sdk.Context, creator string) sdk.KVSto
 func (k Keeper) GetCreatorsPrefixStore(ctx sdk.Context) sdk.KVStore {
 	store := ctx.KVStore(k.storeKey)
 	return prefix.NewStore(store, types.GetCreatorsPrefix())
+}
+
+// Set the wasm keeper.
+func (k *Keeper) SetWasmKeeper(wasmKeeper types.WasmKeeper) {
+	k.wasmKeeper = wasmKeeper
 }
 
 // CreateModuleAccount creates a module account with minting and burning capabilities

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -37,3 +37,7 @@ type BankHooks interface {
 type CommunityPoolKeeper interface {
 	FundCommunityPool(ctx sdk.Context, amount sdk.Coins, sender sdk.AccAddress) error
 }
+
+type WasmKeeper interface {
+	Sudo(ctx sdk.Context, contractAddress sdk.AccAddress, msg []byte) ([]byte, error)
+}

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -38,6 +38,6 @@ type CommunityPoolKeeper interface {
 	FundCommunityPool(ctx sdk.Context, amount sdk.Coins, sender sdk.AccAddress) error
 }
 
-type WasmKeeper interface {
+type ContractKeeper interface {
 	Sudo(ctx sdk.Context, contractAddress sdk.AccAddress, msg []byte) ([]byte, error)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
Previously we had the design in token factory where we would be injecting wasm keeper to the hook interface, while as this PR changes the wasmKeeper to nest within the TokenFactory keeper.

## Testing and Verifying
Existing tests passes

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A