### PR TITLE
Backport: Emited IBC errors should also be logged

### DIFF
--- a/osmoutils/ibc.go
+++ b/osmoutils/ibc.go
@@ -9,11 +9,12 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v4/modules/core/exported"
 )
 
+const IbcAcknowledgementErrorType = "ibc-acknowledgement-error"
+
 // NewEmitErrorAcknowledgement creates a new error acknowledgement after having emitted an event with the
 // details of the error.
 func NewEmitErrorAcknowledgement(ctx sdk.Context, err error, errorContexts ...string) channeltypes.Acknowledgement {
-	errorType := "ibc-acknowledgement-error"
-	logger := ctx.Logger().With("module", errorType)
+	logger := ctx.Logger().With("module", IbcAcknowledgementErrorType)
 
 	attributes := make([]sdk.Attribute, len(errorContexts)+1)
 	attributes[0] = sdk.NewAttribute("error", err.Error())
@@ -24,7 +25,7 @@ func NewEmitErrorAcknowledgement(ctx sdk.Context, err error, errorContexts ...st
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			errorType,
+			IbcAcknowledgementErrorType,
 			attributes...,
 		),
 	})

--- a/osmoutils/ibc.go
+++ b/osmoutils/ibc.go
@@ -2,6 +2,7 @@ package osmoutils
 
 import (
 	"encoding/json"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	transfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
@@ -11,15 +12,19 @@ import (
 // NewEmitErrorAcknowledgement creates a new error acknowledgement after having emitted an event with the
 // details of the error.
 func NewEmitErrorAcknowledgement(ctx sdk.Context, err error, errorContexts ...string) channeltypes.Acknowledgement {
+	errorType := "ibc-acknowledgement-error"
+	logger := ctx.Logger().With("module", errorType)
+
 	attributes := make([]sdk.Attribute, len(errorContexts)+1)
 	attributes[0] = sdk.NewAttribute("error", err.Error())
 	for i, s := range errorContexts {
 		attributes[i+1] = sdk.NewAttribute("error-context", s)
+		logger.Error(fmt.Sprintf("error-context: %v", s))
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			"ibc-acknowledgement-error",
+			errorType,
 			attributes...,
 		),
 	})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

After huckleberry, IBC redacts emitted events if the ack is a failure. This means that the user cannot see those. To get around that, we can add the error context to the logs as well.

Eventually we can fix this properly with error-events in the sdk

## Testing and Verifying
all tests pass

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A