### PR TITLE
refactor: emitLiquidityChangeEvent To Use Struct Params

### DIFF
--- a/x/concentrated-liquidity/event.go
+++ b/x/concentrated-liquidity/event.go
@@ -1,0 +1,59 @@
+package concentrated_liquidity
+
+import (
+	"strconv"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
+)
+
+//event is the interface all event types should be implementing
+type event interface {
+	emit(ctx sdk.Context)
+}
+
+// guarantee that liquidityChangeEvent type implements the event interface
+var _ event = &liquidityChangeEvent{}
+
+// liquidityChangeEvent represent the fields used for event emition 
+// and uniquely identifying a position such as: 
+// - position id
+// - sender
+// - pool id
+// - join time
+// - lower tick
+// - upper tick
+// It also hols additional attributes for the liquidity added or removed and the actual amounts of asset0 and asset1 it translates to.
+type liquidityChangeEvent struct {
+	eventType string
+	positionId uint64
+	sender sdk.AccAddress
+	poolId uint64
+	lowerTick int64
+	upperTick int64
+	joinTime time.Time
+	liquidityDelta sdk.Dec
+	actualAmount0 sdk.Int
+	actualAmount1 sdk.Int
+}
+
+//emit emits an event for a liquidity change when creating or withdrawing a position based its field.
+func (l *liquidityChangeEvent) emit(ctx sdk.Context) {
+	if l != nil {
+		ctx.EventManager().EmitEvent(sdk.NewEvent(
+			l.eventType,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(types.AttributeKeyPositionId, strconv.FormatUint(l.positionId, 10)),
+			sdk.NewAttribute(sdk.AttributeKeySender, l.sender.String()),
+			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(l.poolId, 10)),
+			sdk.NewAttribute(types.AttributeLowerTick, strconv.FormatInt(l.lowerTick, 10)),
+			sdk.NewAttribute(types.AttributeUpperTick, strconv.FormatInt(l.upperTick, 10)),
+			sdk.NewAttribute(types.AttributeJoinTime, l.joinTime.String()),
+			sdk.NewAttribute(types.AttributeLiquidity, l.liquidityDelta.String()),
+			sdk.NewAttribute(types.AttributeAmount0, l.actualAmount0.String()),
+			sdk.NewAttribute(types.AttributeAmount1, l.actualAmount1.String()),
+		))
+	}
+}

--- a/x/concentrated-liquidity/event.go
+++ b/x/concentrated-liquidity/event.go
@@ -9,7 +9,7 @@ import (
 	types "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 )
 
-//event is the interface all event types should be implementing
+// event is the interface all event types should be implementing
 type event interface {
 	emit(ctx sdk.Context)
 }
@@ -17,8 +17,8 @@ type event interface {
 // guarantee that liquidityChangeEvent type implements the event interface
 var _ event = &liquidityChangeEvent{}
 
-// liquidityChangeEvent represent the fields used for event emition 
-// and uniquely identifying a position such as: 
+// liquidityChangeEvent represent the fields used for event emission
+// and uniquely identifying a position such as:
 // - position id
 // - sender
 // - pool id
@@ -27,19 +27,19 @@ var _ event = &liquidityChangeEvent{}
 // - upper tick
 // It also hols additional attributes for the liquidity added or removed and the actual amounts of asset0 and asset1 it translates to.
 type liquidityChangeEvent struct {
-	eventType string
-	positionId uint64
-	sender sdk.AccAddress
-	poolId uint64
-	lowerTick int64
-	upperTick int64
-	joinTime time.Time
+	eventType      string
+	positionId     uint64
+	sender         sdk.AccAddress
+	poolId         uint64
+	lowerTick      int64
+	upperTick      int64
+	joinTime       time.Time
 	liquidityDelta sdk.Dec
-	actualAmount0 sdk.Int
-	actualAmount1 sdk.Int
+	actualAmount0  sdk.Int
+	actualAmount1  sdk.Int
 }
 
-//emit emits an event for a liquidity change when creating or withdrawing a position based its field.
+// emit emits an event for a liquidity change when creating or withdrawing a position based its field.
 func (l *liquidityChangeEvent) emit(ctx sdk.Context) {
 	if l != nil {
 		ctx.EventManager().EmitEvent(sdk.NewEvent(

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -262,7 +262,7 @@ func (k Keeper) WithdrawPosition(ctx sdk.Context, owner sdk.AccAddress, position
 		}
 	}
 	event := &liquidityChangeEvent{
-		eventType:      types.TypeEvtCreatePosition,
+		eventType:      types.TypeEvtWithdrawPosition,
 		positionId:     positionId,
 		sender:         owner,
 		poolId:         position.PoolId,

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -119,7 +119,19 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		return 0, sdk.Int{}, sdk.Int{}, sdk.Dec{}, time.Time{}, 0, 0, err
 	}
 
-	emitLiquidityChangeEvent(ctx, types.TypeEvtCreatePosition, positionId, owner, poolId, lowerTick, upperTick, joinTime, liquidityDelta, actualAmount0, actualAmount1)
+	event := &liquidityChangeEvent{
+		eventType: types.TypeEvtCreatePosition,
+		positionId: positionId,
+		sender: owner,
+		poolId: poolId,
+		lowerTick: lowerTick,
+		upperTick: upperTick,
+		joinTime: joinTime,
+		liquidityDelta: liquidityDelta,
+		actualAmount0: actualAmount0,
+		actualAmount1: actualAmount1,
+	}
+	event.emit(ctx)
 
 	if !hasPositions {
 		// N.B. calling this listener propagates to x/twap for twap record creation.
@@ -249,8 +261,19 @@ func (k Keeper) WithdrawPosition(ctx sdk.Context, owner sdk.AccAddress, position
 			k.listeners.AfterLastPoolPositionRemoved(ctx, owner, pool.GetId())
 		}
 	}
-
-	emitLiquidityChangeEvent(ctx, types.TypeEvtWithdrawPosition, positionId, owner, position.PoolId, position.LowerTick, position.UpperTick, position.JoinTime, liquidityDelta, actualAmount0, actualAmount1)
+	event := &liquidityChangeEvent{
+		eventType: types.TypeEvtCreatePosition,
+		positionId: positionId,
+		sender: owner,
+		poolId: position.PoolId,
+		lowerTick: position.LowerTick,
+		upperTick: position.UpperTick,
+		joinTime: position.JoinTime,
+		liquidityDelta: liquidityDelta,
+		actualAmount0: actualAmount0,
+		actualAmount1: actualAmount1,
+	}
+	event.emit(ctx)
 
 	return actualAmount0.Neg(), actualAmount1.Neg(), nil
 }
@@ -500,31 +523,6 @@ func (k Keeper) uninitializePool(ctx sdk.Context, poolId uint64) error {
 	}
 
 	return nil
-}
-
-// emitLiquidityChangeEvent emits an event for a liquidity change when creating or withdrawing a position.
-// It emits all of the fields uniquely identifying a position such as:
-// - position id
-// - sender
-// - pool id
-// - join time
-// - lower tick
-// - upper tick
-// It also emits additional attributes for the liquidity added or removed and the actual amounts of asset0 and asset1 it translates to.
-func emitLiquidityChangeEvent(ctx sdk.Context, eventType string, positionId uint64, sender sdk.AccAddress, poolId uint64, lowerTick, upperTick int64, joinTime time.Time, liquidityDelta sdk.Dec, actualAmount0, actualAmount1 sdk.Int) {
-	ctx.EventManager().EmitEvent(sdk.NewEvent(
-		eventType,
-		sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-		sdk.NewAttribute(types.AttributeKeyPositionId, strconv.FormatUint(positionId, 10)),
-		sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
-		sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
-		sdk.NewAttribute(types.AttributeLowerTick, strconv.FormatInt(lowerTick, 10)),
-		sdk.NewAttribute(types.AttributeUpperTick, strconv.FormatInt(upperTick, 10)),
-		sdk.NewAttribute(types.AttributeJoinTime, joinTime.String()),
-		sdk.NewAttribute(types.AttributeLiquidity, liquidityDelta.String()),
-		sdk.NewAttribute(types.AttributeAmount0, actualAmount0.String()),
-		sdk.NewAttribute(types.AttributeAmount1, actualAmount1.String()),
-	))
 }
 
 // isLockMature checks if the underlying lock has expired.

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -120,16 +120,16 @@ func (k Keeper) createPosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	}
 
 	event := &liquidityChangeEvent{
-		eventType: types.TypeEvtCreatePosition,
-		positionId: positionId,
-		sender: owner,
-		poolId: poolId,
-		lowerTick: lowerTick,
-		upperTick: upperTick,
-		joinTime: joinTime,
+		eventType:      types.TypeEvtCreatePosition,
+		positionId:     positionId,
+		sender:         owner,
+		poolId:         poolId,
+		lowerTick:      lowerTick,
+		upperTick:      upperTick,
+		joinTime:       joinTime,
 		liquidityDelta: liquidityDelta,
-		actualAmount0: actualAmount0,
-		actualAmount1: actualAmount1,
+		actualAmount0:  actualAmount0,
+		actualAmount1:  actualAmount1,
 	}
 	event.emit(ctx)
 
@@ -262,16 +262,16 @@ func (k Keeper) WithdrawPosition(ctx sdk.Context, owner sdk.AccAddress, position
 		}
 	}
 	event := &liquidityChangeEvent{
-		eventType: types.TypeEvtCreatePosition,
-		positionId: positionId,
-		sender: owner,
-		poolId: position.PoolId,
-		lowerTick: position.LowerTick,
-		upperTick: position.UpperTick,
-		joinTime: position.JoinTime,
+		eventType:      types.TypeEvtCreatePosition,
+		positionId:     positionId,
+		sender:         owner,
+		poolId:         position.PoolId,
+		lowerTick:      position.LowerTick,
+		upperTick:      position.UpperTick,
+		joinTime:       position.JoinTime,
 		liquidityDelta: liquidityDelta,
-		actualAmount0: actualAmount0,
-		actualAmount1: actualAmount1,
+		actualAmount0:  actualAmount0,
+		actualAmount1:  actualAmount1,
 	}
 	event.emit(ctx)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR refactors the emitLiquidityChangeEvent to use struct params to follow golang best practices

This is linked to https://github.com/osmosis-labs/osmosis/issues/5485#issuecomment-1584878204 and is a refactor proposal that could serve as a base for future refactoring. 

## Testing and Verifying

This change is already covered by existing tests in `lp_test.go`.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [x] N/A: this a refactoring that only aims to cleanup code base
