### PR TITLE
Fix: Use original BankKeeper for TokenFactory

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -421,7 +421,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.keys[tokenfactorytypes.StoreKey],
 		appKeepers.GetSubspace(tokenfactorytypes.ModuleName),
 		appKeepers.AccountKeeper,
-		appKeepers.BankKeeper.WithMintCoinsRestriction(tokenfactorytypes.NewTokenFactoryDenomMintCoinsRestriction()),
+		appKeepers.BankKeeper,
 		appKeepers.DistrKeeper,
 	)
 	appKeepers.TokenFactoryKeeper = &tokenFactoryKeeper

--- a/x/tokenfactory/keeper/admins_test.go
+++ b/x/tokenfactory/keeper/admins_test.go
@@ -129,6 +129,15 @@ func (s *KeeperTestSuite) TestMintDenom() {
 			),
 			expectPass: true,
 		},
+		{
+			desc: "error: try minting non-tokenfactory denom",
+			mintMsg: *types.NewMsgMintTo(
+				s.TestAccs[0].String(),
+				sdk.NewInt64Coin("uosmo", 10),
+				s.TestAccs[1].String(),
+			),
+			expectPass: false,
+		},
 	} {
 		s.Run(fmt.Sprintf("Case %s", tc.desc), func() {
 			_, err := s.msgServer.Mint(sdk.WrapSDKContext(s.Ctx), &tc.mintMsg)
@@ -213,6 +222,15 @@ func (s *KeeperTestSuite) TestBurnDenom() {
 			burnMsg: *types.NewMsgBurnFrom(
 				s.TestAccs[0].String(),
 				sdk.NewInt64Coin(s.defaultDenom, 10),
+				moduleAdress.String(),
+			),
+			expectPass: false,
+		},
+		{
+			desc: "fail case - burn non-tokenfactory denom",
+			burnMsg: *types.NewMsgBurnFrom(
+				s.TestAccs[0].String(),
+				sdk.NewInt64Coin("uosmo", 10),
 				moduleAdress.String(),
 			),
 			expectPass: false,

--- a/x/tokenfactory/types/denoms.go
+++ b/x/tokenfactory/types/denoms.go
@@ -1,12 +1,10 @@
 package types
 
 import (
-	fmt "fmt"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 )
 
 const (
@@ -67,18 +65,4 @@ func DeconstructDenom(denom string) (creator string, subdenom string, err error)
 	subdenom = strings.Join(strParts[2:], "/")
 
 	return creatorAddr.String(), subdenom, nil
-}
-
-// NewTokenFactoryDenomMintCoinsRestriction creates and returns a BankMintingRestrictionFn that only allows minting of
-// valid tokenfactory denoms
-func NewTokenFactoryDenomMintCoinsRestriction() bankkeeper.BankMintingRestrictionFn {
-	return func(ctx sdk.Context, coinsToMint sdk.Coins) error {
-		for _, coin := range coinsToMint {
-			_, _, err := DeconstructDenom(coin.Denom)
-			if err != nil {
-				return fmt.Errorf("does not have permission to mint %s", coin.Denom)
-			}
-		}
-		return nil
-	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
While testing token factory with contracts, it has been confirmed that somehow bank hooks were not properly triggered for the Token Factory module, whilst other modules were successfully triggering the bank hook that has recently been added.

This was due to a bug in app wiring where `WithMintCoinsRestriction` option would not return a pointer of the original bank keeper, but a new instance of the bank keeper. This makes the Bank Keeper that is being used, a separate instance from the ones being set hook, thus not being able to properly triggger hooks

## Testing and Verifying
Tested with the no_100.wasm contract, and confirmed on a node / contract that token factory module properly triggers hooks. Logs are below
```
stargate_msg("/osmosis.lockup.MsgLockTokens", lock_msg, wallet1, osmo)::::::::::::
:
:<EOF>
Out[31]: 
{'tx_response': {'height': '434',
  'txhash': 'EBA046EE55CE819AB606C3E4891B1182FD922FFC1E6A69BE335F037B97B5074E',
  'codespace': 'sdk',
  'code': 18,
  'data': '',
  'raw_log': 'failed to execute message; message index: 0: failed to call before send hook for denom factory/osmo16kknw79vd8rws905phrq6t5ex8vzxdhvc0gsmp/zdc628e55: Custom Error val: "Invalid Send Amount": execute wasm contract failed: invalid request',
  'logs': [],
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A