### PR TITLE
Use more precomputation for price to tick

### DIFF
--- a/x/concentrated-liquidity/math/precompute.go
+++ b/x/concentrated-liquidity/math/precompute.go
@@ -40,8 +40,10 @@ type tickExpIndexData struct {
 	// if price >= maxPrice, we are not in this exponent range.
 	maxPrice sdk.Dec
 	// TODO: Change to normal Dec, if min spot price increases.
+	// additive increment per tick here.
 	additiveIncrementPerTick osmomath.BigDec
-	initialTick              int64
+	// the tick that corresponds to initial price
+	initialTick int64
 }
 
 var tickExpCache map[int64]*tickExpIndexData = make(map[int64]*tickExpIndexData)
@@ -52,6 +54,7 @@ func buildTickExpCache() {
 	curExpIndex := int64(0)
 	for maxPrice.LT(types.MaxSpotPrice) {
 		tickExpCache[curExpIndex] = &tickExpIndexData{
+			// price range 10^curExpIndex to 10^(curExpIndex + 1). (10, 100)
 			initialPrice:             sdkOneDec.Mul(sdkTenDec.Power(uint64(curExpIndex))),
 			maxPrice:                 sdkOneDec.Mul(sdkTenDec.Power(uint64(curExpIndex + 1))),
 			additiveIncrementPerTick: powTenBigDec(types.ExponentAtPriceOne + curExpIndex),
@@ -62,10 +65,10 @@ func buildTickExpCache() {
 	}
 
 	minPrice := sdkOneDec
-	// minSpotPrice := osmomath.BigDecFromSDKDec(types.MinSpotPrice)
 	curExpIndex = -1
 	for minPrice.GT(types.MinSpotPrice) {
 		tickExpCache[curExpIndex] = &tickExpIndexData{
+			// price range 10^curExpIndex to 10^(curExpIndex + 1). (0.001, 0.01)
 			initialPrice:             powTenBigDec(curExpIndex).SDKDec(),
 			maxPrice:                 powTenBigDec(curExpIndex + 1).SDKDec(),
 			additiveIncrementPerTick: powTenBigDec(types.ExponentAtPriceOne + curExpIndex),

--- a/x/concentrated-liquidity/math/precompute.go
+++ b/x/concentrated-liquidity/math/precompute.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 )
 
 var (
@@ -17,6 +18,10 @@ var (
 	osmomathBigTenDec = osmomath.NewBigDec(10)
 	bigPowersOfTen    []osmomath.BigDec
 	bigNegPowersOfTen []osmomath.BigDec
+
+	// 9 * 10^(-types.ExponentAtPriceOne), where types.ExponentAtPriceOne is non-positive and is s.t.
+	// this answer fits well within an int64.
+	geometricExponentIncrementDistanceInTicks = 9 * sdk.NewDec(10).PowerMut(uint64(-types.ExponentAtPriceOne)).TruncateInt64()
 )
 
 // Set precision multipliers

--- a/x/concentrated-liquidity/math/precompute.go
+++ b/x/concentrated-liquidity/math/precompute.go
@@ -44,14 +44,14 @@ type tickExpIndexData struct {
 	initialTick              int64
 }
 
-var tickExpCache map[int64]tickExpIndexData = make(map[int64]tickExpIndexData)
+var tickExpCache map[int64]*tickExpIndexData = make(map[int64]*tickExpIndexData)
 
 func buildTickExpCache() {
 	// build positive indices first
 	maxPrice := sdkOneDec
 	curExpIndex := int64(0)
 	for maxPrice.LT(types.MaxSpotPrice) {
-		tickExpCache[curExpIndex] = tickExpIndexData{
+		tickExpCache[curExpIndex] = &tickExpIndexData{
 			initialPrice:             sdkOneDec.Mul(sdkTenDec.Power(uint64(curExpIndex))),
 			maxPrice:                 sdkOneDec.Mul(sdkTenDec.Power(uint64(curExpIndex + 1))),
 			additiveIncrementPerTick: powTenBigDec(types.ExponentAtPriceOne + curExpIndex),
@@ -65,7 +65,7 @@ func buildTickExpCache() {
 	// minSpotPrice := osmomath.BigDecFromSDKDec(types.MinSpotPrice)
 	curExpIndex = -1
 	for minPrice.GT(types.MinSpotPrice) {
-		tickExpCache[curExpIndex] = tickExpIndexData{
+		tickExpCache[curExpIndex] = &tickExpIndexData{
 			initialPrice:             powTenBigDec(curExpIndex).SDKDec(),
 			maxPrice:                 powTenBigDec(curExpIndex + 1).SDKDec(),
 			additiveIncrementPerTick: powTenBigDec(types.ExponentAtPriceOne + curExpIndex),

--- a/x/concentrated-liquidity/math/precompute.go
+++ b/x/concentrated-liquidity/math/precompute.go
@@ -47,7 +47,7 @@ type tickExpIndexData struct {
 var tickExpCache map[int64]tickExpIndexData = make(map[int64]tickExpIndexData)
 
 func buildTickExpCache() {
-	// build positive numbers first
+	// build positive indices first
 	maxPrice := sdkOneDec
 	curExpIndex := int64(0)
 	for maxPrice.LT(types.MaxSpotPrice) {
@@ -59,6 +59,20 @@ func buildTickExpCache() {
 		}
 		maxPrice = tickExpCache[curExpIndex].maxPrice
 		curExpIndex += 1
+	}
+
+	minPrice := sdkOneDec
+	// minSpotPrice := osmomath.BigDecFromSDKDec(types.MinSpotPrice)
+	curExpIndex = -1
+	for minPrice.GT(types.MinSpotPrice) {
+		tickExpCache[curExpIndex] = tickExpIndexData{
+			initialPrice:             powTenBigDec(curExpIndex).SDKDec(),
+			maxPrice:                 powTenBigDec(curExpIndex + 1).SDKDec(),
+			additiveIncrementPerTick: powTenBigDec(types.ExponentAtPriceOne + curExpIndex),
+			initialTick:              geometricExponentIncrementDistanceInTicks * curExpIndex,
+		}
+		minPrice = tickExpCache[curExpIndex].initialPrice
+		curExpIndex -= 1
 	}
 }
 

--- a/x/concentrated-liquidity/math/precompute.go
+++ b/x/concentrated-liquidity/math/precompute.go
@@ -55,8 +55,8 @@ func buildTickExpCache() {
 	for maxPrice.LT(types.MaxSpotPrice) {
 		tickExpCache[curExpIndex] = &tickExpIndexData{
 			// price range 10^curExpIndex to 10^(curExpIndex + 1). (10, 100)
-			initialPrice:             sdkOneDec.Mul(sdkTenDec.Power(uint64(curExpIndex))),
-			maxPrice:                 sdkOneDec.Mul(sdkTenDec.Power(uint64(curExpIndex + 1))),
+			initialPrice:             sdkTenDec.Power(uint64(curExpIndex)),
+			maxPrice:                 sdkTenDec.Power(uint64(curExpIndex + 1)),
 			additiveIncrementPerTick: powTenBigDec(types.ExponentAtPriceOne + curExpIndex),
 			initialTick:              geometricExponentIncrementDistanceInTicks * curExpIndex,
 		}

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -206,7 +206,7 @@ func CalculatePriceToTick(price sdk.Dec) (tickIndex int64) {
 	// * taking the bucket index of the smallest price in this tick
 	// * adding to it the number of ticks "completely" filled by the current spacing
 	// the latter is the truncation of the division above
-	// TODO: This should be rounding down???
+	// TODO: This should be rounding down?
 	tickIndex = geoSpacing.initialTick + ticksFilledByCurrentSpacing.SDKDec().RoundInt64()
 	return tickIndex
 }

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -170,9 +170,11 @@ func powTenBigDec(exponent int64) osmomath.BigDec {
 // This function does not take into consideration tick spacing.
 func CalculatePriceToTick(price sdk.Dec) (tickIndex int64) {
 	// The formula is as follows: geometricExponentIncrementDistanceInTicks = 9 * 10**(-exponentAtPriceOne)
-	// Due to sdk.Power restrictions, if the resulting power is negative, we take 9 * (1/10**exponentAtPriceOne)
+	// NOTE: exponent at price one is constrained to be non-positive.
+	// It semantically means, at price one, the first tick has a price increase of 10**(-exponentAtPriceOne).
 	exponentAtPriceOne := types.ExponentAtPriceOne
-	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(exponentAtPriceOne * -1)).TruncateInt64()
+	// pulled from constant
+	geometricExponentIncrementDistanceInTicks := geometricExponentIncrementDistanceInTicks
 
 	// Initialize the current price to 1, the current precision to exponentAtPriceOne, and the number of ticks passed to 0
 	currentPrice := sdkOneDec
@@ -180,29 +182,35 @@ func CalculatePriceToTick(price sdk.Dec) (tickIndex int64) {
 
 	exponentAtCurrentTick := exponentAtPriceOne
 
-	// Set the currentAdditiveIncrementInTicks to the exponentAtPriceOne
-	currentAdditiveIncrementInTicks := powTenBigDec(exponentAtPriceOne)
+	// Set the currentAdditiveIncrementInTicks to the 10^{exponentAtPriceOne}
+	// this will be a value like 10^-6. It will increase/decrease by powers of 10.
+	currentAdditiveIncrementInTicks := PowTenInternal(exponentAtPriceOne)
+	// TODO: If we raise min spot price, we can compute in sdk.Dec the whole way through
+	var currentAdditiveIncrementInTicksBigDec osmomath.BigDec
 
 	// Now, we loop through the exponentAtCurrentTicks until we have passed the price
 	// Once we pass the price, we can determine what which geometric exponents we have filled in their entirety,
 	// as well as how many ticks that corresponds to
 	// In the opposite direction (price < 1), we do the same thing (just decrement the geometric exponent instead of incrementing).
 	// The only difference is we must reduce the increment distance by a factor of 10.
+	// TODO: Precompute the entire loop structure and cache it
 	if price.GT(sdkOneDec) {
 		for currentPrice.LT(price) {
-			currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurrentTick)
-			maxPriceForCurrentAdditiveIncrementInTicks := osmomath.NewBigDec(geometricExponentIncrementDistanceInTicks).Mul(currentAdditiveIncrementInTicks)
-			currentPrice = currentPrice.Add(maxPriceForCurrentAdditiveIncrementInTicks.SDKDec())
+			currentAdditiveIncrementInTicks = PowTenInternal(exponentAtCurrentTick)
+			maxPriceForCurrentAdditiveIncrementInTicks := currentAdditiveIncrementInTicks.MulInt64(geometricExponentIncrementDistanceInTicks)
+			currentPrice = currentPrice.Add(maxPriceForCurrentAdditiveIncrementInTicks)
 			exponentAtCurrentTick = exponentAtCurrentTick + 1
 			ticksPassed = ticksPassed + geometricExponentIncrementDistanceInTicks
 		}
+		currentAdditiveIncrementInTicksBigDec = osmomath.BigDecFromSDKDec(currentAdditiveIncrementInTicks)
 	} else {
 		// We must decrement the exponentAtCurrentTick by one when traversing negative ticks in order to constantly step up in precision when going further down in ticks
 		// Otherwise, from tick 0 to tick -(geometricExponentIncrementDistanceInTicks), we would use the same exponent as the exponentAtPriceOne
 		exponentAtCurrentTick := exponentAtPriceOne - 1
+		currentAdditiveIncrementInTicksBigDec = osmomath.BigDecFromSDKDec(currentAdditiveIncrementInTicks)
 		for currentPrice.GT(price) {
-			currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurrentTick)
-			maxPriceForCurrentAdditiveIncrementInTicks := osmomath.NewBigDec(geometricExponentIncrementDistanceInTicks).Mul(currentAdditiveIncrementInTicks)
+			currentAdditiveIncrementInTicksBigDec = powTenBigDec(exponentAtCurrentTick)
+			maxPriceForCurrentAdditiveIncrementInTicks := currentAdditiveIncrementInTicksBigDec.MulInt64(geometricExponentIncrementDistanceInTicks)
 			currentPrice = currentPrice.Sub(maxPriceForCurrentAdditiveIncrementInTicks.SDKDec())
 			exponentAtCurrentTick = exponentAtCurrentTick - 1
 			ticksPassed = ticksPassed - geometricExponentIncrementDistanceInTicks
@@ -210,7 +218,7 @@ func CalculatePriceToTick(price sdk.Dec) (tickIndex int64) {
 	}
 
 	// Determine how many ticks we have passed in the exponentAtCurrentTick (in other words, the incomplete geometricExponent above)
-	ticksToBeFulfilledByExponentAtCurrentTick := osmomath.BigDecFromSDKDec(price.Sub(currentPrice)).Quo(currentAdditiveIncrementInTicks)
+	ticksToBeFulfilledByExponentAtCurrentTick := osmomath.BigDecFromSDKDec(price.Sub(currentPrice)).Quo(currentAdditiveIncrementInTicksBigDec)
 
 	// Finally, add the ticks we have passed from the completed geometricExponent values, as well as the ticks we have passed in the current geometricExponent value
 	tickIndex = ticksPassed + ticksToBeFulfilledByExponentAtCurrentTick.SDKDec().RoundInt64()

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -8,20 +8,22 @@ import (
 
 const (
 	// Precomputed values for min and max tick
-	MinTick, MaxTick int64 = -162000000, 342000000
+	MinTick, MaxTick              int64 = -162000000, 342000000
+	ExponentAtPriceOne            int64 = -6
+	ConcentratedGasFeeForSwap           = 10_000
+	BaseGasFeeForNewIncentive           = 10_000
+	BaseGasFeeForInitializingTick       = 10_000
 )
 
 var (
-	ConcentratedGasFeeForSwap = 10_000
-	MaxSpotPrice              = sdk.MustNewDecFromStr("100000000000000000000000000000000000000")
-	MinSpotPrice              = sdk.MustNewDecFromStr("0.000000000000000001")
-	MaxSqrtPrice, _           = MaxSpotPrice.ApproxRoot(2)
-	MinSqrtPrice, _           = MinSpotPrice.ApproxRoot(2)
+	MaxSpotPrice    = sdk.MustNewDecFromStr("100000000000000000000000000000000000000")
+	MinSpotPrice    = sdk.MustNewDecFromStr("0.000000000000000001") // 10^-18
+	MaxSqrtPrice, _ = MaxSpotPrice.ApproxRoot(2)
+	MinSqrtPrice, _ = MinSpotPrice.ApproxRoot(2)
 	// Supported uptimes preset to 1 ns, 1 min, 1 hr, 1D, 1W, 2W
-	SupportedUptimes              = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24, time.Hour * 24 * 7, time.Hour * 24 * 7 * 2}
-	ExponentAtPriceOne      int64 = -6
-	AuthorizedTickSpacing         = []uint64{1, 10, 100, 1000}
-	AuthorizedSpreadFactors       = []sdk.Dec{
+	SupportedUptimes        = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24, time.Hour * 24 * 7, time.Hour * 24 * 7 * 2}
+	AuthorizedTickSpacing   = []uint64{1, 10, 100, 1000}
+	AuthorizedSpreadFactors = []sdk.Dec{
 		sdk.ZeroDec(),
 		sdk.MustNewDecFromStr("0.0001"), // 0.01%
 		sdk.MustNewDecFromStr("0.0005"), // 0.05%
@@ -30,9 +32,7 @@ var (
 		sdk.MustNewDecFromStr("0.003"),  // 0.3%
 		sdk.MustNewDecFromStr("0.005"),  // 0.5%
 	}
-	BaseGasFeeForNewIncentive     = 10_000
 	DefaultBalancerSharesDiscount = sdk.MustNewDecFromStr("0.05")
 	// By default, we only authorize one nanosecond (one block) uptime as an option
-	DefaultAuthorizedUptimes      = []time.Duration{time.Nanosecond}
-	BaseGasFeeForInitializingTick = 10_000
+	DefaultAuthorizedUptimes = []time.Duration{time.Nanosecond}
 )


### PR DESCRIPTION
This PR uses pre-computation for price to tick, and (at least to me) feels like it simplifies the code.

This also surfaces questions for the bucket index definition that I think we should be handling in a follow-up PR