### PR TITLE
fix:  add pool manager spot price query to stargate whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and control over token transfers.
   * [#5138](https://github.com/osmosis-labs/osmosis/pull/5138) refactor: rename swap fee to spread factor
   * [#5020](https://github.com/osmosis-labs/osmosis/pull/5020) Add gas config to the client.toml
   * [#5459](https://github.com/osmosis-labs/osmosis/pull/5459) Create locktypes.LockQueryType.NoLock gauge. MsgCreateGauge takes pool id for new gauge type.
+  * [#5503](https://github.com/osmosis-labs/osmosis/pull/5503) Deprecate gamm spot price query and add pool manager spot price query to stargate query whitelist.
 
 ## State Breaking
   * [#5380](https://github.com/osmosis-labs/osmosis/pull/5380) feat: add ica authorized messages in upgrade handler

--- a/wasmbinding/query_plugin_test.go
+++ b/wasmbinding/query_plugin_test.go
@@ -71,7 +71,7 @@ func (suite *StargateTestSuite) TestStargateQuerier() {
 		},
 		{
 			name: "happy path gamm",
-			path: "/osmosis.gamm.v2.Query/SpotPrice",
+			path: "/osmosis.poolmanager.v1beta1.Query/SpotPrice",
 			testSetup: func() {
 				pk := ed25519.GenPrivKey().PubKey()
 				sender := sdk.AccAddress(pk.Address())

--- a/wasmbinding/query_plugin_test.go
+++ b/wasmbinding/query_plugin_test.go
@@ -70,7 +70,36 @@ func (suite *StargateTestSuite) TestStargateQuerier() {
 			responseProtoStruct: &epochtypes.QueryEpochsInfoResponse{},
 		},
 		{
-			name: "happy path gamm",
+			name: "happy path gamm spot price",
+			path: "/osmosis.gamm.v2.Query/SpotPrice",
+			testSetup: func() {
+				pk := ed25519.GenPrivKey().PubKey()
+				sender := sdk.AccAddress(pk.Address())
+				err := simapp.FundAccount(suite.app.BankKeeper, suite.ctx, sender, apptesting.DefaultAcctFunds)
+				suite.Require().NoError(err)
+				msg := balancer.NewMsgCreateBalancerPool(sender,
+					balancer.NewPoolParams(sdk.ZeroDec(), sdk.ZeroDec(), nil),
+					apptesting.DefaultPoolAssets, "")
+				_, err = suite.app.PoolManagerKeeper.CreatePool(suite.ctx, msg)
+				suite.NoError(err)
+			},
+			requestData: func() []byte {
+				queryrequest := gammv2types.QuerySpotPriceRequest{ //nolint:staticcheck // we're intentionally using this deprecated package for testing
+					PoolId:          1,
+					BaseAssetDenom:  "bar",
+					QuoteAssetDenom: "uosmo",
+				}
+				bz, err := proto.Marshal(&queryrequest)
+				suite.Require().NoError(err)
+				return bz
+			},
+			checkResponseStruct: true,
+			responseProtoStruct: &gammv2types.QuerySpotPriceResponse{ //nolint:staticcheck // we're intentionally using this deprecated package for testing
+				SpotPrice: sdk.NewDecWithPrec(5, 1).String(),
+			},
+		},
+		{
+			name: "happy path pool manager",
 			path: "/osmosis.poolmanager.v1beta1.Query/SpotPrice",
 			testSetup: func() {
 				pk := ed25519.GenPrivKey().PubKey()

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -17,7 +17,6 @@ import (
 	concentratedliquidityquery "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/client/queryproto"
 	downtimequerytypes "github.com/osmosis-labs/osmosis/v16/x/downtime-detector/client/queryproto"
 	gammtypes "github.com/osmosis-labs/osmosis/v16/x/gamm/types"
-	gammv2types "github.com/osmosis-labs/osmosis/v16/x/gamm/v2types"
 	incentivestypes "github.com/osmosis-labs/osmosis/v16/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v16/x/lockup/types"
 	minttypes "github.com/osmosis-labs/osmosis/v16/x/mint/types"
@@ -93,7 +92,6 @@ func init() {
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/CalcExitPoolCoinsFromShares", &gammtypes.QueryCalcExitPoolCoinsFromSharesResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/CalcJoinPoolNoSwapShares", &gammtypes.QueryCalcJoinPoolNoSwapSharesResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/PoolType", &gammtypes.QueryPoolTypeResponse{})
-	setWhitelistedQuery("/osmosis.gamm.v2.Query/SpotPrice", &gammv2types.QuerySpotPriceResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/EstimateSwapExactAmountIn", &gammtypes.QuerySwapExactAmountInResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/EstimateSwapExactAmountOut", &gammtypes.QuerySwapExactAmountOutResponse{})
 
@@ -131,6 +129,7 @@ func init() {
 	setWhitelistedQuery("/osmosis.poolmanager.v1beta1.Query/EstimateSinglePoolSwapExactAmountIn", &poolmanagerqueryproto.EstimateSwapExactAmountInResponse{})
 	setWhitelistedQuery("/osmosis.poolmanager.v1beta1.Query/EstimateSinglePoolSwapExactAmountOut", &poolmanagerqueryproto.EstimateSwapExactAmountOutResponse{})
 	setWhitelistedQuery("/osmosis.poolmanager.v1beta1.Query/Pool", &poolmanagerqueryproto.PoolResponse{})
+	setWhitelistedQuery("/osmosis.poolmanager.v1beta1.Query/SpotPrice", &poolmanagerqueryproto.SpotPriceResponse{})
 
 	// txfees
 	setWhitelistedQuery("/osmosis.txfees.v1beta1.Query/FeeTokens", &txfeestypes.QueryFeeTokensResponse{})

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -14,6 +14,8 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
 
+	gammv2types "github.com/osmosis-labs/osmosis/v16/x/gamm/v2types"
+
 	concentratedliquidityquery "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/client/queryproto"
 	downtimequerytypes "github.com/osmosis-labs/osmosis/v16/x/downtime-detector/client/queryproto"
 	gammtypes "github.com/osmosis-labs/osmosis/v16/x/gamm/types"
@@ -92,6 +94,7 @@ func init() {
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/CalcExitPoolCoinsFromShares", &gammtypes.QueryCalcExitPoolCoinsFromSharesResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/CalcJoinPoolNoSwapShares", &gammtypes.QueryCalcJoinPoolNoSwapSharesResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/PoolType", &gammtypes.QueryPoolTypeResponse{})
+	setWhitelistedQuery("/osmosis.gamm.v2.Query/SpotPrice", &gammv2types.QuerySpotPriceResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/EstimateSwapExactAmountIn", &gammtypes.QuerySwapExactAmountInResponse{})
 	setWhitelistedQuery("/osmosis.gamm.v1beta1.Query/EstimateSwapExactAmountOut", &gammtypes.QuerySwapExactAmountOutResponse{})
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Gamm v2 spot price qurey has been marked deprecated, whilst we have created a new query for spot price in the pool manager. 

We did not deprecate it in stargate whitelist though, having the old query still in stargate whitelist. 
This PR submits a change so that we use the new query for spot price in stargate whitelist. 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A