### PR TITLE
[CL]: Demo issue with truncation for ticks

### DIFF
--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -207,6 +207,6 @@ func CalculatePriceToTick(price sdk.Dec) (tickIndex int64) {
 	// * adding to it the number of ticks "completely" filled by the current spacing
 	// the latter is the truncation of the division above
 	// TODO: This should be rounding down?
-	tickIndex = geoSpacing.initialTick + ticksFilledByCurrentSpacing.SDKDec().RoundInt64()
+	tickIndex = geoSpacing.initialTick + ticksFilledByCurrentSpacing.SDKDec().TruncateInt64()
 	return tickIndex
 }

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -714,3 +714,19 @@ func (suite *ConcentratedMathTestSuite) TestCalculatePriceToTick() {
 		})
 	}
 }
+
+func (suite *ConcentratedMathTestSuite) TestSqrtTickPriceVector() {
+	// Tick 31003912 -> sqrtPrice 70.738334727359817881
+	// Tick 31003913 -> sqrtPrice 70.738341795662697029
+	// Implies that sqrtPrice equal to 70.738341795662697029 should be in tick 31003913
+	startingSqrtPrice := sdk.MustNewDecFromStr("70.738341795662697029")
+
+	// Incorrectly yields tick 31003912 if we truncate in `CalculatePriceToTick`
+	tickFromPrice, err := math.PriceToTickRoundDown(startingSqrtPrice.Power(2), uint64(1))
+	suite.Require().NoError(err)
+	fmt.Println("tick: ", tickFromPrice)
+
+	_, sqrtPriceFromTick, err := math.TickToSqrtPrice(tickFromPrice)
+	suite.Require().NoError(err)
+	fmt.Println("sqrtPriceFromTick: ", sqrtPriceFromTick)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR demonstrates why merely truncating the tick in price to tick conversion is not sufficient to cover all edge case behavior around bound checks (incorrectly puts us in wrong tick at boundary)

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A