### PR TITLE
[CL][tests]: Extract global invariant helpers from functional tests

### DIFF
--- a/osmomath/binary_search.go
+++ b/osmomath/binary_search.go
@@ -141,6 +141,23 @@ func (e ErrTolerance) CompareBigDec(expected BigDec, actual BigDec) int {
 	return 0
 }
 
+// EqualCoins returns true iff the two coins are equal within the ErrTolerance constraints and false otherwise.
+// TODO: move error tolerance functions to a separate file.
+func (e ErrTolerance) EqualCoins(expectedCoins sdk.Coins, actualCoins sdk.Coins) bool {
+	if len(expectedCoins) < len(actualCoins) {
+		return false
+	}
+
+	for _, expectedCoin := range expectedCoins {
+		curCoinEqual := e.Compare(expectedCoin.Amount, actualCoins.AmountOf(expectedCoin.Denom))
+		if curCoinEqual != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Binary search inputs between [lowerbound, upperbound] to a monotonic increasing function f.
 // We stop once f(found_input) meets the ErrTolerance constraints.
 // If we perform more than maxIterations (or equivalently lowerbound = upperbound), we return an error.

--- a/x/concentrated-liquidity/invariant_test.go
+++ b/x/concentrated-liquidity/invariant_test.go
@@ -18,9 +18,9 @@ import (
 func (s *KeeperTestSuite) getAllPositionsAndPoolBalances(ctx sdk.Context) ([]model.Position, sdk.Coins, sdk.Coins, sdk.Coins) {
 	// Get total spread rewards distributed to all pools
 	allPools, err := s.clk.GetPools(ctx)
-	totalPoolAssets := sdk.NewCoins()
-	totalSpreadRewards := sdk.NewCoins()
-	totalIncentives := sdk.NewCoins()
+	totalPoolAssets, totalSpreadRewards, totalIncentives := sdk.NewCoins(), sdk.NewCoins(), sdk.NewCoins()
+
+	// Sum up pool balances across all pools
 	for _, pool := range allPools {
 		clPool, ok := pool.(types.ConcentratedPoolExtension)
 		s.Require().True(ok)
@@ -49,10 +49,8 @@ func (s *KeeperTestSuite) assertTotalRewardsInvariant() {
 	cachedCtx, _ := s.Ctx.CacheContext()
 
 	// Collect spread rewards for all positions and track output
-	totalCollectedSpread := sdk.NewCoins()
-	totalCollectedIncentives := sdk.NewCoins()
+	totalCollectedSpread, totalCollectedIncentives := sdk.NewCoins(), sdk.NewCoins()
 	for _, position := range allPositions {
-		// Ensure position exists and get owner
 		owner, err := sdk.AccAddressFromBech32(position.Address)
 		s.Require().NoError(err)
 
@@ -89,10 +87,8 @@ func (s *KeeperTestSuite) assertTotalRewardsInvariant() {
 		RoundingDir:       osmomath.RoundDown,
 	}
 
-	// Assert total collected spread rewards equal to expected
+	// Assert total collected spread rewards and incentives equal to expected
 	s.Require().True(errTolerance.EqualCoins(expectedTotalSpreadRewards, totalCollectedSpread))
-
-	// Assert total collected incentives equal to expected
 	s.Require().True(errTolerance.EqualCoins(expectedTotalIncentives, totalCollectedIncentives))
 
 	// Refetch total pool balances across all pools
@@ -122,7 +118,6 @@ func (s *KeeperTestSuite) assertWithdrawAllInvariant() {
 	// Withdraw all assets for all positions and track output
 	totalWithdrawn := sdk.NewCoins()
 	for _, position := range allPositions {
-		// Ensure position exists and get owner
 		owner, err := sdk.AccAddressFromBech32(position.Address)
 		s.Require().NoError(err)
 

--- a/x/concentrated-liquidity/invariant_test.go
+++ b/x/concentrated-liquidity/invariant_test.go
@@ -1,0 +1,165 @@
+package concentrated_liquidity_test
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/model"
+	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
+)
+
+// getAllPositionsAndBalances returns all the positions in state alongside all the pool balances for all pools in state.
+//
+// Returns:
+// * All positions across all pools
+// * Total pool assets across all pools
+// * Total pool spread rewards across all pools
+// * Total pool incentives across all pools
+func (s *KeeperTestSuite) getAllPositionsAndPoolBalances(ctx sdk.Context) ([]model.Position, sdk.Coins, sdk.Coins, sdk.Coins) {
+	// Get total spread rewards distributed to all pools
+	allPools, err := s.clk.GetPools(ctx)
+	totalPoolAssets := sdk.NewCoins()
+	totalSpreadRewards := sdk.NewCoins()
+	totalIncentives := sdk.NewCoins()
+	for _, pool := range allPools {
+		clPool, ok := pool.(types.ConcentratedPoolExtension)
+		s.Require().True(ok)
+		totalPoolAssets = totalPoolAssets.Add(s.App.BankKeeper.GetAllBalances(ctx, clPool.GetAddress())...)
+		totalSpreadRewards = totalSpreadRewards.Add(s.App.BankKeeper.GetAllBalances(ctx, clPool.GetSpreadRewardsAddress())...)
+		totalIncentives = totalIncentives.Add(s.App.BankKeeper.GetAllBalances(ctx, clPool.GetIncentivesAddress())...)
+	}
+
+	// Get all positions in state
+	allPoolPositions, err := s.clk.GetAllPositions(ctx)
+	s.Require().NoError(err)
+
+	return allPoolPositions, totalPoolAssets, totalSpreadRewards, totalIncentives
+}
+
+// assertTotalRewardsInvariant asserts two invariants on the current context:
+// 1. Claiming spread rewards and incentives for all positions in state yields the amount stored in pool reward addresses minus rounding errors
+// 2. Claiming spread rewards and incentives for all positions in state empties all pool reward addresses except for rounding errors
+//
+// This function operates on cached context to avoid persisting any changes to state.
+func (s *KeeperTestSuite) assertTotalRewardsInvariant() {
+	// Get all positions and total pool balances across all CL pools in state
+	allPositions, initialTotalPoolLiquidity, expectedTotalSpreadRewards, expectedTotalIncentives := s.getAllPositionsAndPoolBalances(s.Ctx)
+
+	// Switch to cached context to avoid persisting any changes to state
+	cachedCtx, _ := s.Ctx.CacheContext()
+
+	// Collect spread rewards for all positions and track output
+	totalCollectedSpread := sdk.NewCoins()
+	totalCollectedIncentives := sdk.NewCoins()
+	for _, position := range allPositions {
+		// Ensure position exists and get owner
+		owner, err := sdk.AccAddressFromBech32(position.Address)
+		s.Require().NoError(err)
+
+		// Collect spread rewards.
+		collectedSpread, err := s.clk.CollectSpreadRewards(cachedCtx, owner, position.PositionId)
+		s.Require().NoError(err)
+
+		// Collect incentives.
+		//
+		// Since we expect forfeited coins to go to other positions who have not yet claimed, we
+		// do not include them in the sum.
+		//
+		// Balancer full range incentives are also not factored in because they are claimed and sent to
+		// gauge immediately upon distribution.
+		collectedIncentives, _, err := s.clk.CollectIncentives(cachedCtx, owner, position.PositionId)
+		s.Require().NoError(err)
+
+		fmt.Println("collected spread rewards for position with ID: ", position.PositionId, collectedSpread)
+
+		// Track total amounts
+		totalCollectedSpread = totalCollectedSpread.Add(collectedSpread...)
+		totalCollectedIncentives = totalCollectedIncentives.Add(collectedIncentives...)
+	}
+
+	// We allow for an additive tolerance of 1 per position in the pool, since this is the maximum that can be truncated
+	// when collecting spread rewards.
+	errTolerance := osmomath.ErrTolerance{
+		AdditiveTolerance: sdk.NewDec(int64(len(allPositions))),
+		RoundingDir:       osmomath.RoundDown,
+	}
+
+	// Assert total collected spread rewards equal to expected
+	s.Require().True(errTolerance.EqualCoins(expectedTotalSpreadRewards, totalCollectedSpread))
+
+	// Assert total collected incentives equal to expected
+	s.Require().True(errTolerance.EqualCoins(expectedTotalIncentives, totalCollectedIncentives))
+
+	// Refetch total pool balances across all pools
+	remainingPositions, finalTotalPoolLiquidity, remainingTotalSpreadRewards, remainingTotalIncentives := s.getAllPositionsAndPoolBalances(cachedCtx)
+
+	// Ensure pool liquidity remains unchanged
+	s.Require().Equal(initialTotalPoolLiquidity, finalTotalPoolLiquidity)
+
+	// Ensure total remaining spread rewards and incentives are exactly equal to loss due to rounding
+	roundingLossSpread := expectedTotalSpreadRewards.Sub(totalCollectedSpread)
+	s.Require().Equal(roundingLossSpread, remainingTotalSpreadRewards)
+	roundingLossIncentives := expectedTotalIncentives.Sub(totalCollectedIncentives)
+	s.Require().Equal(roundingLossIncentives, remainingTotalIncentives)
+
+	// Ensure no positions were deleted
+	s.Require().Equal(len(allPositions), len(remainingPositions))
+}
+
+// assertWithdrawAllInvariant withdraws all positions from all pools in state and asserts that all pool liquidity was removed from pool balances.
+func (s *KeeperTestSuite) assertWithdrawAllInvariant() {
+	// Get all positions and pool balances across all CL pools in state
+	allPositions, expectedTotalWithdrawn, _, _ := s.getAllPositionsAndPoolBalances(s.Ctx)
+
+	// Switch to cached context to avoid persisting any changes to state
+	cachedCtx, _ := s.Ctx.CacheContext()
+
+	// Withdraw all assets for all positions and track output
+	totalWithdrawn := sdk.NewCoins()
+	for _, position := range allPositions {
+		// Ensure position exists and get owner
+		owner, err := sdk.AccAddressFromBech32(position.Address)
+		s.Require().NoError(err)
+
+		// Withdraw all assets from position
+		amt0Withdrawn, amt1Withdrawn, err := s.clk.WithdrawPosition(cachedCtx, owner, position.PositionId, position.Liquidity)
+		s.Require().NoError(err)
+
+		// Convert withdrawn assets to coins
+		positionPool, err := s.clk.GetPoolById(cachedCtx, position.PoolId)
+		s.Require().NoError(err)
+		withdrawn := sdk.NewCoins(
+			sdk.NewCoin(positionPool.GetToken0(), amt0Withdrawn),
+			sdk.NewCoin(positionPool.GetToken1(), amt1Withdrawn),
+		)
+
+		// Track total withdrawn assets
+		totalWithdrawn = totalWithdrawn.Add(withdrawn...)
+	}
+
+	// We allow for an additive tolerance of 1 per position in the pool, since this is the maximum that can be truncated
+	// when collecting spread rewards.
+	errTolerance := osmomath.ErrTolerance{
+		AdditiveTolerance: sdk.NewDec(int64(len(allPositions))),
+		RoundingDir:       osmomath.RoundDown,
+	}
+
+	// Assert total withdrawn assets equal to expected
+	s.Require().True(errTolerance.EqualCoins(expectedTotalWithdrawn, totalWithdrawn))
+
+	// Refetch total pool balances across all pools
+	remainingPositions, finalTotalPoolAssets, remainingTotalSpreadRewards, remainingTotalIncentives := s.getAllPositionsAndPoolBalances(cachedCtx)
+
+	// Ensure no more positions exist in state
+	s.Require().Equal(0, len(remainingPositions))
+
+	// Ensure pool liquidity only has rounding error left in it
+	roundingLossAssets := expectedTotalWithdrawn.Sub(totalWithdrawn)
+	s.Require().Equal(roundingLossAssets, finalTotalPoolAssets)
+
+	// Ensure spread rewards and incentives are all claimed except for rounding error
+	s.Require().True(errTolerance.EqualCoins(remainingTotalSpreadRewards, sdk.NewCoins()))
+	s.Require().True(errTolerance.EqualCoins(remainingTotalIncentives, sdk.NewCoins()))
+}

--- a/x/concentrated-liquidity/invariant_test.go
+++ b/x/concentrated-liquidity/invariant_test.go
@@ -1,8 +1,6 @@
 package concentrated_liquidity_test
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -58,6 +56,9 @@ func (s *KeeperTestSuite) assertTotalRewardsInvariant() {
 		owner, err := sdk.AccAddressFromBech32(position.Address)
 		s.Require().NoError(err)
 
+		// Log initial position owner balance
+		initialBalance := s.App.BankKeeper.GetAllBalances(cachedCtx, owner)
+
 		// Collect spread rewards.
 		collectedSpread, err := s.clk.CollectSpreadRewards(cachedCtx, owner, position.PositionId)
 		s.Require().NoError(err)
@@ -72,7 +73,9 @@ func (s *KeeperTestSuite) assertTotalRewardsInvariant() {
 		collectedIncentives, _, err := s.clk.CollectIncentives(cachedCtx, owner, position.PositionId)
 		s.Require().NoError(err)
 
-		fmt.Println("collected spread rewards for position with ID: ", position.PositionId, collectedSpread)
+		// Ensure position owner's balance was updated correctly
+		finalBalance := s.App.BankKeeper.GetAllBalances(cachedCtx, owner)
+		s.Require().Equal(initialBalance.Add(collectedSpread...).Add(collectedIncentives...), finalBalance)
 
 		// Track total amounts
 		totalCollectedSpread = totalCollectedSpread.Add(collectedSpread...)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: #5428

## What is the purpose of the change

This PR implements the following two test helpers for tracking global CL invariants:
1. `assertTotalRewardsInvariant`: claims all spread rewards and incentives for all positions and ensures claim amounts are correct relative to pool balances
2. `assertWithdrawAllInvariant`: withdraws all positions from all pools and ensures state is updated correctly

Please note that the individual balances are not directly checked for `assertWithdrawAllInvariant` as it's difficult to track exactly how much was claimed due to fees vs. withdrawn amount. Regardless, as long as global invariants hold, we guarantee that the pool-side balance was updated correctly.

## Testing and Verifying

This change introduces test helpers.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A