### PR TITLE
[CL] Demo non-monotinicity of approx root using hand picked values

### DIFF
--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -1436,3 +1436,18 @@ func (s *decimalTestSuite) TestPower() {
 		})
 	}
 }
+
+func (s *decimalTestSuite) TestApproxRootMonotinicity() {
+	// Set hand-picked values to demonstrate lack of monotonicity
+	decOne := sdk.MustNewDecFromStr("120.120060020005000000")
+	decTwo := sdk.MustNewDecFromStr("120.120060020005000001")
+
+	// Take square root of both using `ApproxRoot`
+	sqrtDecOne, err := decOne.ApproxRoot(2)
+	s.Require().NoError(err)
+	sqrtDecTwo, err := decTwo.ApproxRoot(2)
+	s.Require().NoError(err)
+
+	// We expect this to be true for all `decTwo` > `decOne`, but it fails for these specific values
+	s.Require().True(sqrtDecOne.LT(sqrtDecTwo), "sqrtDecOne: %s, sqrtDecTwo: %s", sqrtDecOne, sqrtDecTwo)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Ref: #5517

## What is the purpose of the change

This branch demonstrates that our `ApproxRoot` function is non-monotonic using hand picked inputs.

## Testing and Verifying

N/A

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A