### PR TITLE
fix: fix `x/tokenfactory` genesis import denoms reset `x/bank` existing denom metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### State Breaking
+
+* [#5532](https://github.com/osmosis-labs/osmosis/pull/5532) fix: Fix x/tokenfactory genesis import denoms reset x/bank existing denom metadata
+
 ## v16.0.0
 Osmosis Labs is excited to announce the release of v16.0.0, a major upgrade that includes a number of new features and improvements like introduction of new modules, updates existing APIs, and dependency updates. This upgrade aims to enhance capital efficiency by introducing SuperCharged Liquidity, introduce custom liquidity pools backed by CosmWasm smart contracts, and improve overall functionality.
 

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -28,15 +28,18 @@ func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string
 // Runs CreateDenom logic after the charge and all denom validation has been handled.
 // Made into a second function for genesis initialization.
 func (k Keeper) createDenomAfterValidation(ctx sdk.Context, creatorAddr string, denom string) (err error) {
-	denomMetaData := banktypes.Metadata{
-		DenomUnits: []*banktypes.DenomUnit{{
-			Denom:    denom,
-			Exponent: 0,
-		}},
-		Base: denom,
-	}
+	_, exists := k.bankKeeper.GetDenomMetaData(ctx, denom)
+	if !exists {
+		denomMetaData := banktypes.Metadata{
+			DenomUnits: []*banktypes.DenomUnit{{
+				Denom:    denom,
+				Exponent: 0,
+			}},
+			Base: denom,
+		}
 
-	k.bankKeeper.SetDenomMetaData(ctx, denomMetaData)
+		k.bankKeeper.SetDenomMetaData(ctx, denomMetaData)
+	}
 
 	authorityMetadata := types.DenomAuthorityMetadata{
 		Admin: creatorAddr,

--- a/x/tokenfactory/keeper/createdenom_test.go
+++ b/x/tokenfactory/keeper/createdenom_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/osmosis-labs/osmosis/v16/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v16/x/tokenfactory/types"
@@ -164,6 +165,17 @@ func (s *KeeperTestSuite) TestCreateDenom() {
 
 				s.Require().NoError(err)
 				s.Require().Equal(s.TestAccs[0].String(), queryRes.AuthorityMetadata.Admin)
+
+				// Make sure that the denom metadata is initialized correctly
+				metadata, found := bankKeeper.GetDenomMetaData(s.Ctx, res.GetNewTokenDenom())
+				s.Require().True(found)
+				s.Require().Equal(banktypes.Metadata{
+					DenomUnits: []*banktypes.DenomUnit{{
+						Denom:    res.GetNewTokenDenom(),
+						Exponent: 0,
+					}},
+					Base: res.GetNewTokenDenom(),
+				}, metadata)
 			} else {
 				s.Require().Error(err)
 				// Ensure we don't charge if we expect an error

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -38,7 +38,7 @@ func (s *KeeperTestSuite) TestGenesis() {
 	for i, denom := range genesisState.FactoryDenoms {
 		// hacky, sets bank metadata to exist if i != 0, to cover both cases.
 		if i != 0 {
-			app.BankKeeper.SetDenomMetaData(s.Ctx, banktypes.Metadata{Base: denom.GetDenom()})
+			app.BankKeeper.SetDenomMetaData(s.Ctx, banktypes.Metadata{Base: denom.GetDenom(), Display: "test"})
 		}
 	}
 
@@ -56,4 +56,15 @@ func (s *KeeperTestSuite) TestGenesis() {
 	exportedGenesis := app.TokenFactoryKeeper.ExportGenesis(s.Ctx)
 	s.Require().NotNil(exportedGenesis)
 	s.Require().Equal(genesisState, *exportedGenesis)
+
+	app.BankKeeper.SetParams(s.Ctx, banktypes.DefaultParams())
+	app.BankKeeper.InitGenesis(s.Ctx, app.BankKeeper.ExportGenesis(s.Ctx))
+	for i, denom := range genesisState.FactoryDenoms {
+		// hacky, check whether bank metadata is not replaced if i != 0, to cover both cases.
+		if i != 0 {
+			metadata, found := app.BankKeeper.GetDenomMetaData(s.Ctx, denom.GetDenom())
+			s.Require().True(found)
+			s.Require().Equal(metadata, banktypes.Metadata{Base: denom.GetDenom(), Display: "test"})
+		}
+	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This pull request fixes the `x/tokenfactory` genesis import reset `x/bank` existing denom metadata, say, `x/bank` genesis has the metadata of **facotory/osmos1.../testtoken** with `{Display: test}`, `x/tokenfactory` init genesis phase will replace it with the empty disply, more details as follows:

Before `x/tokenfactory` init genesis, the `x/bank` set metadata as:
```
{
  Name:        "Mint Token",
  Symbol:      "MTK",
  Description: "The custom token of the test subspace.",
  DenomUnits: []*banktypes.DenomUnit{
	{Denom: "factory/cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47/uminttoken", Exponent: uint32(0), Aliases: nil},
	{Denom: "minttoken", Exponent: uint32(6), Aliases: []string{"minttoken"}},
  },
  Base:    "factory/cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47/uminttoken",
  Display: "minttoken",
}
```

After `x/tokenfactory` init genesis, the metadata is replaced into:
```
{
  DenomUnits: []*banktypes.DenomUnit{
	{Denom: "factory/cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47/uminttoken", Exponent: uint32(0)},
  },
  Base:    "factory/cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47/uminttoken",
}
```

## Testing and Verifying

This change added tests and can be verified as follows:

* Added unit test that validates the `x/bank` imported metadata won't be reset by `x/tokenfactory`


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A