### PR TITLE
fix: fix the account number of `x/tokenfactory` module account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#5532](https://github.com/osmosis-labs/osmosis/pull/5532) fix: Fix x/tokenfactory genesis import denoms reset x/bank existing denom metadata
 
+### Misc Improvements
+
+* [#5534](https://github.com/osmosis-labs/osmosis/pull/5534) fix: fix the account number of x/tokenfactory module account
+
 ## v16.0.0
 Osmosis Labs is excited to announce the release of v16.0.0, a major upgrade that includes a number of new features and improvements like introduction of new modules, updates existing APIs, and dependency updates. This upgrade aims to enhance capital efficiency by introducing SuperCharged Liquidity, introduce custom liquidity pools backed by CosmWasm smart contracts, and improve overall functionality.
 

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v16/x/tokenfactory/types"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
@@ -83,6 +82,5 @@ func (k *Keeper) SetContractKeeper(contractKeeper types.ContractKeeper) {
 // it purely mints and burns them on behalf of the admin of respective denoms,
 // and sends to the relevant address.
 func (k Keeper) CreateModuleAccount(ctx sdk.Context) {
-	moduleAcc := authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter, authtypes.Burner)
-	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
+	k.accountKeeper.GetModuleAccount(ctx, types.ModuleName)
 }

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -73,6 +73,9 @@ func (s *KeeperTestSuite) CreateDefaultDenom() {
 func (s *KeeperTestSuite) TestCreateModuleAccount() {
 	app := s.App
 
+	// setup new next account number
+	nextAccountNumber := app.AccountKeeper.GetNextAccountNumber(s.Ctx)
+
 	// remove module account
 	tokenfactoryModuleAccount := app.AccountKeeper.GetAccount(s.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
 	app.AccountKeeper.RemoveAccount(s.Ctx, tokenfactoryModuleAccount)
@@ -88,4 +91,7 @@ func (s *KeeperTestSuite) TestCreateModuleAccount() {
 	// check that the module account is now initialized
 	tokenfactoryModuleAccount = app.AccountKeeper.GetAccount(s.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
 	s.Require().NotNil(tokenfactoryModuleAccount)
+
+	// check that the account number of the module account is now initialized correctly
+	s.Require().Equal(nextAccountNumber+1, tokenfactoryModuleAccount.GetAccountNumber())
 }

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -24,7 +24,7 @@ type BankKeeper interface {
 
 type AccountKeeper interface {
 	GetAccount(sdk.Context, sdk.AccAddress) authtypes.AccountI
-	SetModuleAccount(ctx sdk.Context, macc authtypes.ModuleAccountI)
+	GetModuleAccount(ctx sdk.Context, moduleName string) authtypes.ModuleAccountI
 }
 
 // BankHooks event hooks


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This pull request fixes the account number of `x/tokenfactory` is wrongly set by genesis since `CreateModuleAccount` only stores the module account with default account number 0, and it it also missing an update to `global_account_number` inside `x/auth`. 

To solve it, `CreateModuleAccount` should call `AccountKeeper.GetModuleAccount` instead of `AccountKeeper.SetModuleAccount`, or it lost to set account number properly, see:
https://github.com/cosmos/cosmos-sdk/blob/main/x/auth/keeper/keeper.go#L252

## Testing and Verifying

This change added tests and can be verified as follows:

- Added unit test that validates the account number of `x/tokenfactory` module account is correctly set


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A