### PR TITLE
Use custom directories for each test instance

### DIFF
--- a/app/apptesting/cosmwasmpool.go
+++ b/app/apptesting/cosmwasmpool.go
@@ -26,13 +26,11 @@ const (
 
 // PrepareCosmWasmPool sets up a cosmwasm pool with the default parameters.
 func (s *KeeperTestHelper) PrepareCosmWasmPool() cosmwasmpooltypes.CosmWasmExtension {
-	s.T().Skip("CI was getting flaky: https://github.com/osmosis-labs/osmosis/issues/5477")
 	return s.PrepareCustomTransmuterPool(s.TestAccs[0], []string{DefaultTransmuterDenomA, DefaultTransmuterDenomB})
 }
 
 // PrepareCustomConcentratedPool sets up a concentrated liquidity pool with the custom parameters.
 func (s *KeeperTestHelper) PrepareCustomTransmuterPool(owner sdk.AccAddress, denoms []string) cosmwasmpooltypes.CosmWasmExtension {
-	s.T().Skip("CI was getting flaky: https://github.com/osmosis-labs/osmosis/issues/5477")
 	// Mint some assets to the account.
 	s.FundAcc(s.TestAccs[0], DefaultAcctFunds)
 

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -57,7 +57,12 @@ var (
 
 // Setup sets up basic environment for suite (App, Ctx, and test accounts)
 func (s *KeeperTestHelper) Setup() {
-	s.App = app.Setup(false)
+	dir, err := os.MkdirTemp("", "osmosisd-test-home")
+	if err != nil {
+		panic(fmt.Sprintf("failed creating temporary directory: %v", err))
+	}
+	s.T().Cleanup(func() { os.RemoveAll(dir) })
+	s.App = app.SetupWithCustomHome(false, dir)
 	s.setupGeneral()
 }
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -26,10 +26,10 @@ func getDefaultGenesisStateBytes() []byte {
 	return defaultGenesisBz
 }
 
-// Setup initializes a new OsmosisApp.
-func Setup(isCheckTx bool) *OsmosisApp {
+// SetupWithCustomHome initializes a new OsmosisApp with a custom home directory
+func SetupWithCustomHome(isCheckTx bool, dir string) *OsmosisApp {
 	db := dbm.NewMemDB()
-	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, simapp.EmptyAppOptions{}, EmptyWasmOpts)
+	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, dir, 0, simapp.EmptyAppOptions{}, EmptyWasmOpts)
 	if !isCheckTx {
 		stateBytes := getDefaultGenesisStateBytes()
 
@@ -43,6 +43,11 @@ func Setup(isCheckTx bool) *OsmosisApp {
 	}
 
 	return app
+}
+
+// Setup initializes a new OsmosisApp.
+func Setup(isCheckTx bool) *OsmosisApp {
+	return SetupWithCustomHome(isCheckTx, DefaultNodeHome)
 }
 
 // SetupTestingAppWithLevelDb initializes a new OsmosisApp intended for testing,

--- a/x/cosmwasmpool/cosmwasm/msg/transmuter/transmuter_test.go
+++ b/x/cosmwasmpool/cosmwasm/msg/transmuter/transmuter_test.go
@@ -34,7 +34,6 @@ var (
 )
 
 func TestTransmuterSuite(t *testing.T) {
-	t.Skip("CI was getting flaky: https://github.com/osmosis-labs/osmosis/issues/5477")
 	suite.Run(t, new(TransmuterSuite))
 }
 

--- a/x/cosmwasmpool/model/pool_test.go
+++ b/x/cosmwasmpool/model/pool_test.go
@@ -19,7 +19,6 @@ const (
 )
 
 func TestPoolModuleSuite(t *testing.T) {
-	t.Skip("CI was getting flaky: https://github.com/osmosis-labs/osmosis/issues/5477")
 	suite.Run(t, new(CosmWasmPoolSuite))
 }
 

--- a/x/cosmwasmpool/pool_module_test.go
+++ b/x/cosmwasmpool/pool_module_test.go
@@ -35,14 +35,11 @@ var (
 )
 
 func TestPoolModuleSuite(t *testing.T) {
-	t.Skip("CI was getting flaky: https://github.com/osmosis-labs/osmosis/issues/5477")
 	suite.Run(t, new(PoolModuleSuite))
 }
 
 func (s *PoolModuleSuite) TestInitializePool() {
-	var (
-		validInstantitateMsg = s.GetTransmuterInstantiateMsgBytes(defaultDenoms)
-	)
+	validInstantitateMsg := s.GetTransmuterInstantiateMsgBytes(defaultDenoms)
 
 	tests := map[string]struct {
 		codeid            uint64

--- a/x/cosmwasmpool/whitelist_test.go
+++ b/x/cosmwasmpool/whitelist_test.go
@@ -13,7 +13,6 @@ type WhitelistSuite struct {
 }
 
 func TestWhitelistSuite(t *testing.T) {
-	t.Skip("CI was getting flaky: https://github.com/osmosis-labs/osmosis/issues/5477")
 	suite.Run(t, new(WhitelistSuite))
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

CI tests are failing intermittently for cosmwasmpool tests. The working theory is that the issue is due to parallelism where different tests try to write the same contracts to cache, which means that the bytecode can be corrupted when some of the tests read during a partial write.

(Thanks to Simon Warta for helping figure this out)

This change ensures each instance of the app used in tests has its own custom (temp) directory 

## Testing and Verifying
Tests should consistently pass

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A