### PR TITLE
Move more logic into swap state

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -227,7 +227,7 @@ func (ss *SwapState) SetLiquidity(liquidity sdk.Dec) {
 	ss.liquidity = liquidity
 }
 
-// TODO: Refactor tests to ge this deleted?
+// TODO: Refactor tests to get this deleted?
 func (ss *SwapState) SetGlobalSpreadRewardGrowthPerUnitLiquidity(spreadRewardGrowthGlobal sdk.Dec) {
 	ss.globalSpreadRewardGrowthPerUnitLiquidity = spreadRewardGrowthGlobal
 }

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -227,12 +227,17 @@ func (ss *SwapState) SetLiquidity(liquidity sdk.Dec) {
 	ss.liquidity = liquidity
 }
 
-func (ss *SwapState) SetSpreadRewardGrowthGlobal(spreadRewardGrowthGlobal sdk.Dec) {
-	ss.spreadRewardGrowthGlobal = spreadRewardGrowthGlobal
+// TODO: Refactor tests to ge this deleted?
+func (ss *SwapState) SetGlobalSpreadRewardGrowthPerUnitLiquidity(spreadRewardGrowthGlobal sdk.Dec) {
+	ss.globalSpreadRewardGrowthPerUnitLiquidity = spreadRewardGrowthGlobal
 }
 
-func (ss *SwapState) GetSpreadRewardGrowthGlobal() sdk.Dec {
-	return ss.spreadRewardGrowthGlobal
+func (ss *SwapState) SetGlobalSpreadRewardGrowth(spreadRewardGrowthGlobal sdk.Dec) {
+	ss.globalSpreadRewardGrowth = spreadRewardGrowthGlobal
+}
+
+func (ss *SwapState) GetGlobalSpreadRewardGrowthPerUnitLiquidity() sdk.Dec {
+	return ss.globalSpreadRewardGrowthPerUnitLiquidity
 }
 
 // incentive methods

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -374,7 +374,8 @@ func (k Keeper) computeOutAmtGivenIn(
 	}
 
 	// Add spread reward growth per share to the pool-global spread reward accumulator.
-	spreadRewardAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.globalSpreadRewardGrowthPerUnitLiquidity)))
+	spreadRewardGrowth := sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.globalSpreadRewardGrowthPerUnitLiquidity)
+	spreadRewardAccumulator.AddToAccumulator(sdk.NewDecCoins(spreadRewardGrowth))
 
 	// Coin amounts require int values
 	// Round amountIn up to avoid under charging

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -53,17 +53,23 @@ type SwapState struct {
 	// Global spread reward growth per-current swap.
 	// Initialized to zero.
 	// Updated after every swap step.
-	spreadRewardGrowthGlobal sdk.Dec
+	globalSpreadRewardGrowthPerUnitLiquidity sdk.Dec
+	// global spread reward growth
+	globalSpreadRewardGrowth sdk.Dec
+
+	swapStrategy swapstrategy.SwapStrategy
 }
 
 func newSwapState(specifiedAmount sdk.Int, p types.ConcentratedPoolExtension, strategy swapstrategy.SwapStrategy) SwapState {
 	return SwapState{
-		amountSpecifiedRemaining: specifiedAmount.ToDec(),
-		amountCalculated:         sdk.ZeroDec(),
-		sqrtPrice:                p.GetCurrentSqrtPrice(),
-		tick:                     strategy.InitializeTickValue(p.GetCurrentTick()),
-		liquidity:                p.GetLiquidity(),
-		spreadRewardGrowthGlobal: sdk.ZeroDec(),
+		amountSpecifiedRemaining:                 specifiedAmount.ToDec(),
+		amountCalculated:                         sdk.ZeroDec(),
+		sqrtPrice:                                p.GetCurrentSqrtPrice(),
+		tick:                                     strategy.InitializeTickValue(p.GetCurrentTick()),
+		liquidity:                                p.GetLiquidity(),
+		globalSpreadRewardGrowthPerUnitLiquidity: sdk.ZeroDec(),
+		globalSpreadRewardGrowth:                 sdk.ZeroDec(),
+		swapStrategy:                             strategy,
 	}
 }
 
@@ -79,11 +85,12 @@ var (
 // As a result, the range from the end of position one to the beginning of position
 // two has no liquidity and can be skipped.
 func (ss *SwapState) updateSpreadRewardGrowthGlobal(spreadRewardChargeTotal sdk.Dec) {
+	ss.globalSpreadRewardGrowth = ss.globalSpreadRewardGrowth.Add(spreadRewardChargeTotal)
 	if !ss.liquidity.IsZero() {
 		// We round down here since we want to avoid overdistributing (the "spread factor charge" refers to
 		// the total spread factors that will be accrued to the spread factor accumulator)
-		spreadFactorssAccruedPerUnitOfLiquidity := spreadRewardChargeTotal.QuoTruncate(ss.liquidity)
-		ss.spreadRewardGrowthGlobal.AddMut(spreadFactorssAccruedPerUnitOfLiquidity)
+		spreadFactorsAccruedPerUnitOfLiquidity := spreadRewardChargeTotal.QuoTruncate(ss.liquidity)
+		ss.globalSpreadRewardGrowthPerUnitLiquidity.AddMut(spreadFactorsAccruedPerUnitOfLiquidity)
 		return
 	}
 }
@@ -294,7 +301,6 @@ func (k Keeper) computeOutAmtGivenIn(
 	nextTickIter := swapStrategy.InitializeNextTickIterator(ctx, poolId, swapState.tick)
 	defer nextTickIter.Close()
 
-	totalSpreadFactors = sdk.ZeroDec()
 	// Iterate and update swapState until we swap all tokenIn or we reach the specific sqrtPriceLimit
 	// TODO: for now, we check if amountSpecifiedRemaining is GT 0.0000001. This is because there are times when the remaining
 	// amount may be extremely small, and that small amount cannot generate and amountIn/amountOut and we are therefore left
@@ -339,12 +345,7 @@ func (k Keeper) computeOutAmtGivenIn(
 		swapState.updateSpreadRewardGrowthGlobal(spreadRewardCharge)
 
 		ctx.Logger().Debug("cl calc out given in")
-		ctx.Logger().Debug("start sqrt price", swapState.sqrtPrice)
-		ctx.Logger().Debug("reached sqrt price", sqrtPrice)
-		ctx.Logger().Debug("liquidity", swapState.liquidity)
-		ctx.Logger().Debug("amountIn", amountIn)
-		ctx.Logger().Debug("amountOut", amountOut)
-		ctx.Logger().Debug("spreadRewardCharge", spreadRewardCharge)
+		emitSwapDebugLogs(ctx, swapState, sqrtPrice, amountIn, amountOut, spreadRewardCharge)
 
 		// Update the swapState with the new sqrtPrice from the above swap
 		swapState.sqrtPrice = sqrtPrice
@@ -352,12 +353,11 @@ func (k Keeper) computeOutAmtGivenIn(
 		swapState.amountSpecifiedRemaining.SubMut(amountIn.Add(spreadRewardCharge))
 		// We add the amount of tokens we received (amountOut) from the computeSwapStep above to the amountCalculated accumulator
 		swapState.amountCalculated.AddMut(amountOut)
-		totalSpreadFactors = totalSpreadFactors.Add(spreadRewardCharge)
 
 		// If the computeSwapStep calculated a sqrtPrice that is equal to the nextSqrtPrice, this means all liquidity in the current
 		// tick has been consumed and we must move on to the next tick to complete the swap
 		if nextTickSqrtPrice.Equal(sqrtPrice) {
-			swapState, err = k.swapCrossTickLogic(ctx, swapState, swapStrategy,
+			swapState, err = k.swapCrossTickLogic(ctx, swapState,
 				nextTick, nextTickIter, p, spreadRewardAccumulator, uptimeAccums, tokenInMin.Denom)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
@@ -374,7 +374,7 @@ func (k Keeper) computeOutAmtGivenIn(
 	}
 
 	// Add spread reward growth per share to the pool-global spread reward accumulator.
-	spreadRewardAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.spreadRewardGrowthGlobal)))
+	spreadRewardAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInMin.Denom, swapState.globalSpreadRewardGrowthPerUnitLiquidity)))
 
 	// Coin amounts require int values
 	// Round amountIn up to avoid under charging
@@ -388,7 +388,7 @@ func (k Keeper) computeOutAmtGivenIn(
 	tokenIn = sdk.NewCoin(tokenInMin.Denom, amt0)
 	tokenOut = sdk.NewCoin(tokenOutDenom, amt1)
 
-	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, swapState.sqrtPrice, totalSpreadFactors, nil
+	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, swapState.sqrtPrice, swapState.globalSpreadRewardGrowth, nil
 }
 
 // computeInAmtGivenOut calculates tokens to be swapped in given the desired token out and spread factor deducted. It also returns
@@ -428,8 +428,6 @@ func (k Keeper) computeInAmtGivenOut(
 	if err != nil {
 		return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
 	}
-
-	totalSpreadFactors = sdk.ZeroDec()
 
 	// TODO: This should be GT 0 but some instances have very small remainder
 	// need to look into fixing this
@@ -471,23 +469,17 @@ func (k Keeper) computeInAmtGivenOut(
 		swapState.updateSpreadRewardGrowthGlobal(spreadRewardChargeTotal)
 
 		ctx.Logger().Debug("cl calc in given out")
-		ctx.Logger().Debug("start sqrt price", swapState.sqrtPrice)
-		ctx.Logger().Debug("reached sqrt price", sqrtPrice)
-		ctx.Logger().Debug("liquidity", swapState.liquidity)
-		ctx.Logger().Debug("amountIn", amountIn)
-		ctx.Logger().Debug("amountOut", amountOut)
-		ctx.Logger().Debug("spreadRewardChargeTotal", spreadRewardChargeTotal)
+		emitSwapDebugLogs(ctx, swapState, sqrtPrice, amountIn, amountOut, spreadRewardChargeTotal)
 
 		// update the swapState with the new sqrtPrice from the above swap
 		swapState.sqrtPrice = sqrtPrice
 		swapState.amountSpecifiedRemaining = swapState.amountSpecifiedRemaining.SubMut(amountOut)
 		swapState.amountCalculated = swapState.amountCalculated.AddMut(amountIn.Add(spreadRewardChargeTotal))
-		totalSpreadFactors = totalSpreadFactors.Add(spreadRewardChargeTotal)
 
 		// if the computeSwapStep calculated a sqrtPrice that is equal to the nextSqrtPrice, this means all liquidity in the current
 		// tick has been consumed and we must move on to the next tick to complete the swap
 		if sqrtPriceNextTick.Equal(sqrtPrice) {
-			swapState, err = k.swapCrossTickLogic(ctx, swapState, swapStrategy,
+			swapState, err = k.swapCrossTickLogic(ctx, swapState,
 				nextTick, nextTickIter, p, spreadRewardAccumulator, uptimeAccums, tokenInDenom)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, 0, sdk.Dec{}, sdk.Dec{}, sdk.Dec{}, err
@@ -504,7 +496,7 @@ func (k Keeper) computeInAmtGivenOut(
 	}
 
 	// Add spread reward growth per share to the pool-global spread reward accumulator.
-	spreadRewardAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInDenom, swapState.spreadRewardGrowthGlobal)))
+	spreadRewardAccumulator.AddToAccumulator(sdk.NewDecCoins(sdk.NewDecCoinFromDec(tokenInDenom, swapState.globalSpreadRewardGrowthPerUnitLiquidity)))
 
 	// coin amounts require int values
 	// Round amount in up to avoid under charging the user.
@@ -518,12 +510,21 @@ func (k Keeper) computeInAmtGivenOut(
 	tokenIn = sdk.NewCoin(tokenInDenom, amt0)
 	tokenOut = sdk.NewCoin(desiredTokenOut.Denom, amt1)
 
-	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, swapState.sqrtPrice, totalSpreadFactors, nil
+	return tokenIn, tokenOut, swapState.tick, swapState.liquidity, swapState.sqrtPrice, swapState.globalSpreadRewardGrowth, nil
+}
+
+func emitSwapDebugLogs(ctx sdk.Context, swapState SwapState, reachedPrice, amountIn, amountOut, spreadCharge sdk.Dec) {
+	ctx.Logger().Debug("start sqrt price", swapState.sqrtPrice)
+	ctx.Logger().Debug("reached sqrt price", reachedPrice)
+	ctx.Logger().Debug("liquidity", swapState.liquidity)
+	ctx.Logger().Debug("amountIn", amountIn)
+	ctx.Logger().Debug("amountOut", amountOut)
+	ctx.Logger().Debug("spreadRewardChargeTotal", spreadCharge)
 }
 
 // logic for crossing a tick during a swap
 func (k Keeper) swapCrossTickLogic(ctx sdk.Context,
-	swapState SwapState, swapStrategy swapstrategy.SwapStrategy,
+	swapState SwapState,
 	nextTick int64, nextTickIter db.Iterator,
 	p types.ConcentratedPoolExtension,
 	spreadRewardAccum accum.AccumulatorObject, uptimeAccums []accum.AccumulatorObject,
@@ -538,7 +539,7 @@ func (k Keeper) swapCrossTickLogic(ctx sdk.Context,
 	}
 
 	// Retrieve the liquidity held in the next closest initialized tick
-	liquidityNet, err := k.crossTick(ctx, p.GetId(), nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInDenom, swapState.spreadRewardGrowthGlobal), spreadRewardAccum.GetValue(), uptimeAccums)
+	liquidityNet, err := k.crossTick(ctx, p.GetId(), nextTick, &nextTickInfo, sdk.NewDecCoinFromDec(tokenInDenom, swapState.globalSpreadRewardGrowthPerUnitLiquidity), spreadRewardAccum.GetValue(), uptimeAccums)
 	if err != nil {
 		return swapState, err
 	}
@@ -546,7 +547,7 @@ func (k Keeper) swapCrossTickLogic(ctx sdk.Context,
 	// Move next tick iterator to the next tick as the tick is crossed.
 	nextTickIter.Next()
 
-	liquidityNet = swapStrategy.SetLiquidityDeltaSign(liquidityNet)
+	liquidityNet = swapState.swapStrategy.SetLiquidityDeltaSign(liquidityNet)
 	// Update the swapState's liquidity with the new tick's liquidity
 	newLiquidity := swapState.liquidity.AddMut(liquidityNet)
 	swapState.liquidity = newLiquidity

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -2391,13 +2391,14 @@ func (s *KeeperTestSuite) TestUpdateSpreadRewardGrowthGlobal() {
 			// Setup.
 			swapState := cl.SwapState{}
 			swapState.SetLiquidity(tc.liquidity)
-			swapState.SetSpreadRewardGrowthGlobal(sdk.ZeroDec())
+			swapState.SetGlobalSpreadRewardGrowthPerUnitLiquidity(sdk.ZeroDec())
+			swapState.SetGlobalSpreadRewardGrowth(sdk.ZeroDec())
 
 			// System under test.
 			swapState.UpdateSpreadRewardGrowthGlobal(tc.spreadRewardChargeTotal)
 
 			// Assertion.
-			s.Require().Equal(tc.expectedSpreadRewardGrowthGlobal, swapState.GetSpreadRewardGrowthGlobal())
+			s.Require().Equal(tc.expectedSpreadRewardGrowthGlobal, swapState.GetGlobalSpreadRewardGrowthPerUnitLiquidity())
 		})
 	}
 }


### PR DESCRIPTION
This PR:
- renames `ss.spreadRewardGrowthGlobal` to `ss.globalSpreadRewardGrowthPerUnitLiquidity`
- Adds `globalSpreadRewardGrowth` into swapState, rather than tracking it in the core swap loop
- Adds swaps strategy into swapstate, lowering # of arguments needed for code de-duplication across swap types
- Combines debug log emission

This is all generally in the theme of trying to make it easier to get attention on the part of this code that matters.