### PR TITLE
[CL]: Fix incorrect bound check/chain halt vector

### DIFF
--- a/x/concentrated-liquidity/math/math.go
+++ b/x/concentrated-liquidity/math/math.go
@@ -181,7 +181,7 @@ func GetLiquidityFromAmounts(sqrtPrice, sqrtPriceA, sqrtPriceB sdk.Dec, amount0,
 	if sqrtPrice.LTE(sqrtPriceA) {
 		// If the current price is less than or equal to the lower tick, then we use the liquidity0 formula.
 		liquidity = Liquidity0(amount0, sqrtPriceA, sqrtPriceB)
-	} else if sqrtPrice.LTE(sqrtPriceB) {
+	} else if sqrtPrice.LT(sqrtPriceB) {
 		// If the current price is between the lower and upper ticks (non-inclusive of the lower tick but inclusive of the upper tick),
 		// then we use the minimum of the liquidity0 and liquidity1 formulas.
 		liquidity0 := Liquidity0(amount0, sqrtPrice, sqrtPriceB)

--- a/x/concentrated-liquidity/math/math_test.go
+++ b/x/concentrated-liquidity/math/math_test.go
@@ -413,6 +413,16 @@ func (suite *ConcentratedMathTestSuite) TestGetLiquidityFromAmounts() {
 			expectedLiquidity0: sdk.MustNewDecFromStr("7.706742302257039729"),
 			expectedLiquidity1: sdk.MustNewDecFromStr("4.828427124746190095"),
 		},
+		"current sqrt price on upper bound": {
+			currentSqrtP:   sqrt5500,
+			sqrtPHigh:      sqrt5500,
+			sqrtPLow:       sqrt4545,
+			amount0Desired: sdk.ZeroInt(),
+			amount1Desired: sdk.NewInt(1000000),
+			// Liquidity1 = amount1 / (sqrtPriceB - sqrtPriceA)
+			// https://www.wolframalpha.com/input?i=1000000%2F%2874.161984870956629487-67.416615162732695594%29
+			expectedLiquidity: "148249.842967213952971325",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5556

## What is the purpose of the change

This PR fixes a bound check mistake that could have been escalated to a chain halt (see issue).

## Testing and Verifying

- The panic trigger is reproduced in `math_test.go` and passes/behaves as expected after the fix.
- All existing tests pass after the change, demonstrating that this behavior was untested

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A