### PR TITLE
fix/test: swap over contiguously initialized ticks with spacing of one

### DIFF
--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -143,7 +143,7 @@ func main() {
 }
 
 func createManyRandomPositions(igniteClient cosmosclient.Client, poolId uint64, numPositions int) {
-	minTick, maxTick := cltypes.MinTick, cltypes.MaxTick
+	minTick, maxTick := cltypes.MinInitializedTick, cltypes.MaxTick
 	log.Println(minTick, " ", maxTick)
 	for i := 0; i < numPositions; i++ {
 		var (

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -245,7 +245,7 @@ func (s *IntegrationTestSuite) TestConcentratedLiquidity() {
 
 	// Create 2 positions for address3: overlap together, overlap with 2 address1 positions, one position starts from minimum
 	chainANode.CreateConcentratedPosition(address3, "[-160000]", "[-20000]", fmt.Sprintf("10000000%s,10000000%s", denom0, denom1), 0, 0, poolID)
-	chainANode.CreateConcentratedPosition(address3, fmt.Sprintf("[%d]", cltypes.MinTick), "140000", fmt.Sprintf("10000000%s,10000000%s", denom0, denom1), 0, 0, poolID)
+	chainANode.CreateConcentratedPosition(address3, fmt.Sprintf("[%d]", cltypes.MinInitializedTick), "140000", fmt.Sprintf("10000000%s,10000000%s", denom0, denom1), 0, 0, poolID)
 
 	// Get newly created positions
 	positionsAddress1 := chainANode.QueryConcentratedPositions(address1)
@@ -278,7 +278,7 @@ func (s *IntegrationTestSuite) TestConcentratedLiquidity() {
 	// First position third address
 	s.validateCLPosition(addr3position1, poolID, -160000, -20000)
 	// Second position third address
-	s.validateCLPosition(addr3position2, poolID, cltypes.MinTick, 140000)
+	s.validateCLPosition(addr3position2, poolID, cltypes.MinInitializedTick, 140000)
 
 	// Collect SpreadRewards
 

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -113,7 +113,7 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 		tokenDesired0 := sdk.NewCoin(denom0, sdk.NewInt(100))
 		tokenDesired1 := sdk.NewCoin(denom1, sdk.NewInt(100))
 		tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
-		_, _, _, _, _, _, err = clKeeper.CreatePosition(s.Ctx, clPoolId, s.TestAccs[0], tokensDesired, sdk.ZeroInt(), sdk.ZeroInt(), types.MinTick, types.MaxTick)
+		_, _, _, _, _, _, err = clKeeper.CreatePosition(s.Ctx, clPoolId, s.TestAccs[0], tokensDesired, sdk.ZeroInt(), sdk.ZeroInt(), types.MinInitializedTick, types.MaxTick)
 		noError(b, err)
 
 		pool, err := clKeeper.GetPoolById(s.Ctx, clPoolId)
@@ -133,7 +133,7 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 				if denomIn == denom0 {
 					// Decreasing price so want to be below current tick
 					// minTick <= lowerTick <= currentTick
-					lowerTick = rand.Int63n(currentTick-types.MinTick+1) + types.MinTick
+					lowerTick = rand.Int63n(currentTick-types.MinInitializedTick+1) + types.MinInitializedTick
 					// lowerTick <= upperTick <= currentTick
 					upperTick = currentTick - rand.Int63n(int64(math.Abs(float64(currentTick-lowerTick))))
 				} else {
@@ -180,7 +180,7 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 		// Setup numberOfPositions full range positions for deeper liquidity.
 		setupFullRangePositions := func() {
 			for i := 0; i < numberOfPositions; i++ {
-				lowerTick := types.MinTick
+				lowerTick := types.MinInitializedTick
 				upperTick := types.MaxTick
 				createPosition(lowerTick, upperTick)
 			}

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -349,7 +349,7 @@ func (k Keeper) GetLargestSupportedUptimeDuration(ctx sdk.Context) time.Duration
 func (k Keeper) SetupSwapStrategy(ctx sdk.Context, p types.ConcentratedPoolExtension,
 	spreadFactor sdk.Dec, tokenInDenom string,
 	priceLimit sdk.Dec) (strategy swapstrategy.SwapStrategy, sqrtPriceLimit sdk.Dec, err error) {
-	return k.setupSwapStrategy(ctx, p, spreadFactor, tokenInDenom, priceLimit)
+	return k.setupSwapStrategy(p, spreadFactor, tokenInDenom, priceLimit)
 }
 
 func MoveRewardsToNewPositionAndDeleteOldAcc(ctx sdk.Context, accum accum.AccumulatorObject, oldPositionName, newPositionName string, growthOutside sdk.DecCoins) error {

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1058,7 +1058,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 						qualifyingBalancerLiquidity = (sdk.OneDec().Sub(types.DefaultBalancerSharesDiscount)).Mul(qualifyingBalancerLiquidityPreDiscount)
 						qualifyingLiquidity = qualifyingLiquidity.Add(qualifyingBalancerLiquidity)
 
-						actualLiquidityAdded0, actualLiquidityAdded1, err := clPool.CalcActualAmounts(s.Ctx, types.MinTick, types.MaxTick, qualifyingBalancerLiquidity)
+						actualLiquidityAdded0, actualLiquidityAdded1, err := clPool.CalcActualAmounts(s.Ctx, types.MinInitializedTick, types.MaxTick, qualifyingBalancerLiquidity)
 						s.Require().NoError(err)
 						s.FundAcc(clPool.GetIncentivesAddress(), sdk.NewCoins(sdk.NewCoin(clPool.GetToken0(), actualLiquidityAdded0.TruncateInt()), sdk.NewCoin(clPool.GetToken1(), actualLiquidityAdded1.TruncateInt())))
 					}

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	DefaultMinTick, DefaultMaxTick                       = types.MinTick, types.MaxTick
+	DefaultMinTick, DefaultMaxTick                       = types.MinInitializedTick, types.MaxTick
 	DefaultLowerPrice                                    = sdk.NewDec(4545)
 	DefaultLowerTick                                     = int64(30545000)
 	DefaultUpperPrice                                    = sdk.NewDec(5500)

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -58,8 +58,8 @@ func TickToPrice(tickIndex int64) (price sdk.Dec, err error) {
 	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(-exponentAtPriceOne)).TruncateInt64()
 
 	// Check that the tick index is between min and max value
-	if tickIndex < types.MinTick {
-		return sdk.Dec{}, types.TickIndexMinimumError{MinTick: types.MinTick}
+	if tickIndex < types.MinInitializedTick {
+		return sdk.Dec{}, types.TickIndexMinimumError{MinTick: types.MinInitializedTick}
 	}
 	if tickIndex > types.MaxTick {
 		return sdk.Dec{}, types.TickIndexMaximumError{MaxTick: types.MaxTick}
@@ -114,8 +114,8 @@ func RoundDownTickToSpacing(tickIndex int64, tickSpacing int64) (int64, error) {
 
 	// Defense-in-depth check to ensure that the tick index is within the authorized range
 	// Should never get here.
-	if tickIndex > types.MaxTick || tickIndex < types.MinTick {
-		return 0, types.TickIndexNotWithinBoundariesError{ActualTick: tickIndex, MinTick: types.MinTick, MaxTick: types.MaxTick}
+	if tickIndex > types.MaxTick || tickIndex < types.MinInitializedTick {
+		return 0, types.TickIndexNotWithinBoundariesError{ActualTick: tickIndex, MinTick: types.MinInitializedTick, MaxTick: types.MaxTick}
 	}
 
 	return tickIndex, nil
@@ -218,8 +218,8 @@ func CalculateSqrtPriceToTick(sqrtPrice sdk.Dec) (tickIndex int64, err error) {
 	// We check this at max tick - 1 instead of max tick, since we expect the output to
 	// have some error that can push us over the tick boundary.
 	outOfBounds := false
-	if truncatedTick <= types.MinTick {
-		truncatedTick = types.MinTick + 1
+	if truncatedTick <= types.MinInitializedTick {
+		truncatedTick = types.MinInitializedTick + 1
 		outOfBounds = true
 	} else if truncatedTick >= types.MaxTick-1 {
 		truncatedTick = types.MaxTick - 2

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -18,7 +18,7 @@ var (
 	// Note we get spot price exponent by counting the number of digits in the max spot price and subtracting 1.
 	closestPriceBelowMaxPriceDefaultTickSpacing = types.MaxSpotPrice.Sub(sdk.NewDec(10).PowerMut(uint64(len(types.MaxSpotPrice.TruncateInt().String()) - 1 - int(-types.ExponentAtPriceOne) - 1)))
 	// min tick + 10 ^ -expoentAtPriceOne
-	closestTickAboveMinPriceDefaultTickSpacing = sdk.NewInt(types.MinTick).Add(sdk.NewInt(10).ToDec().Power(uint64(types.ExponentAtPriceOne * -1)).TruncateInt())
+	closestTickAboveMinPriceDefaultTickSpacing = sdk.NewInt(types.MinInitializedTick).Add(sdk.NewInt(10).ToDec().Power(uint64(types.ExponentAtPriceOne * -1)).TruncateInt())
 )
 
 // use following equations to test testing vectors using sage
@@ -421,7 +421,7 @@ func (suite *ConcentratedMathTestSuite) TestPriceToTickRoundDown() {
 		"tick spacing 100, MinSpotPrice, MinTick": {
 			price:        types.MinSpotPrice,
 			tickSpacing:  defaultTickSpacing,
-			tickExpected: types.MinTick,
+			tickExpected: types.MinInitializedTick,
 		},
 		"tick spacing 100, Spot price one tick above min, one tick above min -> MinTick": {
 			price:        types.MinSpotPrice.Add(sdk.SmallestDec()),
@@ -664,7 +664,7 @@ func (suite *ConcentratedMathTestSuite) TestTickToPrice_ErrorCases() {
 			tickIndex: types.MaxTick + 1,
 		},
 		"tick index is less than min tick": {
-			tickIndex: types.MinTick - 1,
+			tickIndex: types.MinInitializedTick - 1,
 		},
 	}
 	for name, tc := range testCases {
@@ -799,7 +799,7 @@ func (s *ConcentratedMathTestSuite) TestSqrtPriceToTickRoundDownSpacing() {
 		"sqrt price exactly equal to min sqrt price": {
 			sqrtPrice:    types.MinSqrtPrice,
 			tickSpacing:  defaultTickSpacing,
-			tickExpected: types.MinTick,
+			tickExpected: types.MinInitializedTick,
 		},
 		"sqrt price equal to max sqrt price minus one ULP": {
 			sqrtPrice:    types.MaxSqrtPrice.Sub(sdk.SmallestDec()),

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -287,7 +287,7 @@ func (p *Pool) ApplySwap(newLiquidity sdk.Dec, newCurrentTick int64, newCurrentS
 	}
 
 	// Check if the new tick provided is within boundaries of the pool's precision factor.
-	if newCurrentTick < types.MinTick || newCurrentTick > types.MaxTick {
+	if newCurrentTick < types.MinTick-1 || newCurrentTick > types.MaxTick {
 		return types.TickIndexNotWithinBoundariesError{
 			MaxTick:    types.MaxTick,
 			MinTick:    types.MinTick,

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -287,10 +287,10 @@ func (p *Pool) ApplySwap(newLiquidity sdk.Dec, newCurrentTick int64, newCurrentS
 	}
 
 	// Check if the new tick provided is within boundaries of the pool's precision factor.
-	if newCurrentTick < types.MinTick-1 || newCurrentTick > types.MaxTick {
+	if newCurrentTick < types.MinInitializedTick-1 || newCurrentTick > types.MaxTick {
 		return types.TickIndexNotWithinBoundariesError{
 			MaxTick:    types.MaxTick,
-			MinTick:    types.MinTick,
+			MinTick:    types.MinInitializedTick,
 			ActualTick: newCurrentTick,
 		}
 	}

--- a/x/concentrated-liquidity/model/pool_test.go
+++ b/x/concentrated-liquidity/model/pool_test.go
@@ -372,7 +372,7 @@ func (s *ConcentratedPoolTestSuite) TestApplySwap() {
 			currentTick:      DefaultCurrTick,
 			currentSqrtPrice: DefaultCurrSqrtPrice,
 			newLiquidity:     DefaultLiquidityAmt,
-			newTick:          types.MinTick,
+			newTick:          types.MinInitializedTick,
 			newSqrtPrice:     DefaultCurrSqrtPrice,
 			expectErr:        nil,
 		},
@@ -386,7 +386,7 @@ func (s *ConcentratedPoolTestSuite) TestApplySwap() {
 			newSqrtPrice:     DefaultCurrSqrtPrice,
 			expectErr: types.TickIndexNotWithinBoundariesError{
 				MaxTick:    types.MaxTick,
-				MinTick:    types.MinTick,
+				MinTick:    types.MinInitializedTick,
 				ActualTick: math.MaxInt64,
 			},
 		},
@@ -400,7 +400,7 @@ func (s *ConcentratedPoolTestSuite) TestApplySwap() {
 			newSqrtPrice:     DefaultCurrSqrtPrice,
 			expectErr: types.TickIndexNotWithinBoundariesError{
 				MaxTick:    types.MaxTick,
-				MinTick:    types.MinTick,
+				MinTick:    types.MinInitializedTick,
 				ActualTick: math.MinInt64,
 			},
 		},

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -345,7 +345,7 @@ func (k Keeper) SetPosition(ctx sdk.Context,
 	}
 
 	// If position is full range, update the pool ID to total full range liquidity mapping.
-	if lowerTick == types.MinTick && upperTick == types.MaxTick {
+	if lowerTick == types.MinInitializedTick && upperTick == types.MaxTick {
 		err := k.updateFullRangeLiquidityInPool(ctx, poolId, liquidity)
 		if err != nil {
 			return err
@@ -429,7 +429,7 @@ func (k Keeper) CreateFullRangePosition(ctx sdk.Context, poolId uint64, owner sd
 	}
 
 	// Create a full range (min to max tick) concentrated liquidity position.
-	positionId, amount0, amount1, liquidity, _, _, err = k.createPosition(ctx, concentratedPool.GetId(), owner, coins, sdk.ZeroInt(), sdk.ZeroInt(), types.MinTick, types.MaxTick)
+	positionId, amount0, amount1, liquidity, _, _, err = k.createPosition(ctx, concentratedPool.GetId(), owner, coins, sdk.ZeroInt(), sdk.ZeroInt(), types.MinInitializedTick, types.MaxTick)
 	if err != nil {
 		return 0, sdk.Int{}, sdk.Int{}, sdk.Dec{}, err
 	}
@@ -493,7 +493,7 @@ func (k Keeper) mintSharesAndLock(ctx sdk.Context, concentratedPoolId, positionI
 	if err != nil {
 		return 0, sdk.Coins{}, err
 	}
-	if position.LowerTick != types.MinTick || position.UpperTick != types.MaxTick {
+	if position.LowerTick != types.MinInitializedTick || position.UpperTick != types.MaxTick {
 		return 0, sdk.Coins{}, types.PositionNotFullRangeError{PositionId: positionId, LowerTick: position.LowerTick, UpperTick: position.UpperTick}
 	}
 

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2525,7 +2525,7 @@ func (s *KeeperTestSuite) TestTickRoundingEdgeCase() {
 	swapAddr := testAccs[2]
 	desiredTokenOut := sdk.NewCoin(USDC, sdk.NewInt(10000))
 	s.FundAcc(swapAddr, sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(1000000000000000000))))
-	_, _, _, _, _, err := s.clk.SwapInAmtGivenOut(s.Ctx, swapAddr, pool, desiredTokenOut, ETH, sdk.ZeroDec(), sdk.ZeroDec())
+	_, _, _, err := s.clk.SwapInAmtGivenOut(s.Ctx, swapAddr, pool, desiredTokenOut, ETH, sdk.ZeroDec(), sdk.ZeroDec())
 	s.Require().NoError(err)
 
 	// Both positions should be able to withdraw successfully

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -1069,9 +1069,9 @@ func (s *KeeperTestSuite) TestValidateAndFungifyChargedPositions() {
 		{
 			name: "Error: one of the full range positions is locked",
 			setupFullyChargedPositions: []position{
-				{1, defaultPoolId, defaultAddress, DefaultCoins, types.MinTick, types.MaxTick, unlocked},
-				{2, defaultPoolId, defaultAddress, DefaultCoins, types.MinTick, types.MaxTick, locked},
-				{3, defaultPoolId, defaultAddress, DefaultCoins, types.MinTick, types.MaxTick, unlocked},
+				{1, defaultPoolId, defaultAddress, DefaultCoins, types.MinInitializedTick, types.MaxTick, unlocked},
+				{2, defaultPoolId, defaultAddress, DefaultCoins, types.MinInitializedTick, types.MaxTick, locked},
+				{3, defaultPoolId, defaultAddress, DefaultCoins, types.MinInitializedTick, types.MaxTick, unlocked},
 			},
 			lockPositionIds:         []uint64{2},
 			positionIdsToMigrate:    []uint64{1, 2, 3},
@@ -1082,9 +1082,9 @@ func (s *KeeperTestSuite) TestValidateAndFungifyChargedPositions() {
 		{
 			name: "Pass: one of the full range positions was locked but got unlocked 1ms before fungification",
 			setupFullyChargedPositions: []position{
-				{1, defaultPoolId, defaultAddress, DefaultCoins, types.MinTick, types.MaxTick, unlocked},
-				{2, defaultPoolId, defaultAddress, DefaultCoins, types.MinTick, types.MaxTick, locked},
-				{3, defaultPoolId, defaultAddress, DefaultCoins, types.MinTick, types.MaxTick, unlocked},
+				{1, defaultPoolId, defaultAddress, DefaultCoins, types.MinInitializedTick, types.MaxTick, unlocked},
+				{2, defaultPoolId, defaultAddress, DefaultCoins, types.MinInitializedTick, types.MaxTick, locked},
+				{3, defaultPoolId, defaultAddress, DefaultCoins, types.MinInitializedTick, types.MaxTick, unlocked},
 			},
 
 			lockPositionIds:         []uint64{2},
@@ -1840,10 +1840,10 @@ func (s *KeeperTestSuite) TestMintSharesAndLock() {
 			name:                    "err: upper tick is not max tick",
 			owner:                   defaultAddress,
 			createFullRangePosition: false,
-			lowerTick:               types.MinTick,
+			lowerTick:               types.MinInitializedTick,
 			upperTick:               DefaultUpperTick,
 			remainingLockDuration:   24 * time.Hour,
-			expectedErr:             types.PositionNotFullRangeError{PositionId: 1, LowerTick: types.MinTick, UpperTick: DefaultUpperTick},
+			expectedErr:             types.PositionNotFullRangeError{PositionId: 1, LowerTick: types.MinInitializedTick, UpperTick: DefaultUpperTick},
 		},
 	}
 
@@ -2494,7 +2494,7 @@ func (s *KeeperTestSuite) TestCreateFullRangePositionLocked() {
 			s.Require().NoError(err)
 			s.Require().Equal(s.Ctx.BlockTime(), position.JoinTime)
 			s.Require().Equal(types.MaxTick, position.UpperTick)
-			s.Require().Equal(types.MinTick, position.LowerTick)
+			s.Require().Equal(types.MinInitializedTick, position.LowerTick)
 			s.Require().Equal(liquidity, position.Liquidity)
 
 			// Check locked

--- a/x/concentrated-liquidity/simulation/sim_msgs.go
+++ b/x/concentrated-liquidity/simulation/sim_msgs.go
@@ -371,7 +371,7 @@ func RandomPrepareCreatePositionFunc(sim *osmosimtypes.SimCtx, ctx sdk.Context, 
 	}
 
 	//  Retrieve minTick and maxTick from kprecision factor
-	minTick, maxTick := cltypes.MinTick, cltypes.MaxTick
+	minTick, maxTick := cltypes.MinInitializedTick, cltypes.MaxTick
 
 	// Randomize lowerTick and upperTick from max values to create position
 	lowerTick, upperTick, err := getRandomTickPositions(sim, minTick, maxTick, clPool.GetTickSpacing())

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -543,12 +543,14 @@ func (k Keeper) computeInAmtGivenOut(
 }
 
 func emitSwapDebugLogs(ctx sdk.Context, swapState SwapState, reachedPrice, amountIn, amountOut, spreadCharge sdk.Dec) {
-	ctx.Logger().Debug("start sqrt price", swapState.sqrtPrice)
-	ctx.Logger().Debug("reached sqrt price", reachedPrice)
-	ctx.Logger().Debug("liquidity", swapState.liquidity)
-	ctx.Logger().Debug("amountIn", amountIn)
-	ctx.Logger().Debug("amountOut", amountOut)
-	ctx.Logger().Debug("spreadRewardChargeTotal", spreadCharge)
+	fmt.Println("start sqrt price", swapState.sqrtPrice)
+	fmt.Println("reached sqrt price", reachedPrice)
+	fmt.Println("tick", swapState.tick)
+	fmt.Println("liquidity", swapState.liquidity)
+	fmt.Println("amountIn", amountIn)
+	fmt.Println("amountOut", amountOut)
+	fmt.Println("spreadRewardChargeTotal", spreadCharge)
+	fmt.Printf("\n\n")
 }
 
 // logic for crossing a tick during a swap

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -543,14 +543,12 @@ func (k Keeper) computeInAmtGivenOut(
 }
 
 func emitSwapDebugLogs(ctx sdk.Context, swapState SwapState, reachedPrice, amountIn, amountOut, spreadCharge sdk.Dec) {
-	fmt.Println("start sqrt price", swapState.sqrtPrice)
-	fmt.Println("reached sqrt price", reachedPrice)
-	fmt.Println("tick", swapState.tick)
-	fmt.Println("liquidity", swapState.liquidity)
-	fmt.Println("amountIn", amountIn)
-	fmt.Println("amountOut", amountOut)
-	fmt.Println("spreadRewardChargeTotal", spreadCharge)
-	fmt.Printf("\n\n")
+	ctx.Logger().Debug("start sqrt price", swapState.sqrtPrice)
+	ctx.Logger().Debug("reached sqrt price", reachedPrice)
+	ctx.Logger().Debug("liquidity", swapState.liquidity)
+	ctx.Logger().Debug("amountIn", amountIn)
+	ctx.Logger().Debug("amountOut", amountOut)
+	ctx.Logger().Debug("spreadRewardChargeTotal", spreadCharge)
 }
 
 // logic for crossing a tick during a swap

--- a/x/concentrated-liquidity/swaps_tick_cross_test.go
+++ b/x/concentrated-liquidity/swaps_tick_cross_test.go
@@ -262,18 +262,10 @@ func (s *SwapTickCrossTestSuite) computeSwapAmounts(poolId uint64, curSqrtPrice 
 
 		var isWithinDesiredBucketAfterSwap bool
 		if isZeroForOne {
-			fmt.Println("test swap step", originalCurrentTick)
-			fmt.Println("liq", currentLiquidity)
-			fmt.Println("curSqrtPrice", curSqrtPrice)
-			fmt.Println("nextInitTickSqrtPrice", nextInitTickSqrtPrice)
-			fmt.Println("current tick", currentTick)
 
 			curAmountIn := math.CalcAmount0Delta(currentLiquidity, curSqrtPrice, nextInitTickSqrtPrice, true)
 
 			amountIn = amountIn.Add(curAmountIn)
-
-			fmt.Println("curAmountIn", curAmountIn)
-			fmt.Printf("\n")
 
 			shouldCrossTick := currentTick > expectedTickToSwapTo && !shouldStayWithinTheSameBucket
 			if shouldCrossTick {
@@ -293,18 +285,8 @@ func (s *SwapTickCrossTestSuite) computeSwapAmounts(poolId uint64, curSqrtPrice 
 				amountIn = amountIn.Add(curAmountIn)
 			}
 		} else {
-
-			fmt.Println("test swap step", originalCurrentTick)
-			fmt.Println("liq", currentLiquidity)
-			fmt.Println("curSqrtPrice", curSqrtPrice)
-			fmt.Println("nextInitTickSqrtPrice", nextInitTickSqrtPrice)
-			fmt.Println("current tick", currentTick)
-
 			curAmountIn := math.CalcAmount1Delta(currentLiquidity, curSqrtPrice, nextInitTickSqrtPrice, true)
 			amountIn = amountIn.Add(curAmountIn)
-
-			fmt.Println("curAmountIn", curAmountIn)
-			fmt.Printf("\n")
 
 			shouldCrossTick := currentTick <= expectedTickToSwapTo && !shouldStayWithinTheSameBucket
 			if shouldCrossTick {
@@ -1029,8 +1011,6 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickS
 
 					// Discount the amount in by 50% if we are swapping within the same tick.
 					amountInRoundedUp := amountIn.Mul(withinTheSameTickDiscount).Ceil().TruncateInt()
-
-					fmt.Printf("\n\n\n\n")
 
 					// Perform the swap in the desired direction.
 					if isZeroForOne {

--- a/x/concentrated-liquidity/swaps_tick_cross_test.go
+++ b/x/concentrated-liquidity/swaps_tick_cross_test.go
@@ -46,10 +46,10 @@ const (
 // This configuratio is expected to generate the position layout below:
 //
 //	                                 original_cur_tick
-//		                                    ///
-//		                                /////////
-//		                            ////////////////
-//	                             //////////////////////
+//		                                    ///               (NR4)
+//		                                /////////             (NR3)
+//		                            ////////////////          (NR2)
+//	                             //////////////////////       (NR1)
 //
 // min tick                                                      max tick
 var (
@@ -872,11 +872,22 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Tick_Initialization_And_Cros
 }
 
 func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickSpacingOne() {
-
+	// defines an individual test case
 	type continugousTestCase struct {
+		// This defines how many ticks away from current the swap should reach
+		// negative values indicate ticks below current tick
+		// positive values indicate ticks above current tick
 		swapEndTicksAwayFromOriginalCurrent []int64
-		isOneForZeroWithinSameTick          bool
+		// This flag is used to control an edge case behavior in test setup
+		// when swapping right and then right again within the same tick.
+		// It is only used to signal the swap direction while estimating the expected results.
+		isOneForZeroWithinSameTick bool
 
+		// isPositionActiveFlag is used to control the expected state of position
+		// at the end of configured swaps of the test.
+		// See diagram above the definition of defaultTickSpacingsAway variable for layout.
+		// The first position is NR1, the second position is NR2 etc.
+		// That is, the wider range position is preceeds the narrower range position.
 		isPositionActiveFlag []bool
 	}
 

--- a/x/concentrated-liquidity/swaps_tick_cross_test.go
+++ b/x/concentrated-liquidity/swaps_tick_cross_test.go
@@ -871,6 +871,10 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Tick_Initialization_And_Cros
 	})
 }
 
+// TestSwapOutGivenIn_Contiguous_Initialized_TickSpacingOne tests swapping multiple times in various directions
+// when there are contiguous ticks initialized on a swap range in a pool with tick spacing of 1.
+// For position layout, see diagram above the definition of defaultTickSpacingsAway variable.
+// For specific test vectors, follow the table-driven names below.
 func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickSpacingOne() {
 	// defines an individual test case
 	type continugousTestCase struct {
@@ -918,6 +922,26 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickS
 		}
 
 		return expectedSwapEndTicks
+	}
+
+	// computeExpectedValuesForTestOneForZero returns the tick to swap to during estimate computation and amountIn multiplier.
+	// It most cases, the tick to swap to is the same as the expected tick to reach after the swap and the multiplier is 1.
+	// The only exception is when performing a second swap in the same direction within the same tick.
+	// In such a case, we need to run our estimate logic one tick further to ensure that our estimate is non-zero.
+	// However, we discount the amountIn by half to ensure that the tick is not crossed.
+	computeNextTickToReachAndMultiplier := func(isZeroForOne bool, expectedSwapEndTick int64, shouldStayWithinTheSameTickInCompute bool) (int64, sdk.Dec) {
+		if shouldStayWithinTheSameTickInCompute {
+			nextTickToReachInCompute := expectedSwapEndTick
+			if isZeroForOne {
+				nextTickToReachInCompute = nextTickToReachInCompute - 1
+			} else {
+				nextTickToReachInCompute = nextTickToReachInCompute + 1
+			}
+
+			return nextTickToReachInCompute, sdk.NewDecWithPrec(5, 1)
+		}
+
+		return expectedSwapEndTick, sdk.OneDec()
 	}
 
 	s.Run("tick spacing one, contiguosly initialized", func() {
@@ -973,36 +997,42 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickS
 				poolId, positionMeta := s.setupPoolAndPositions(tickSpacingOne, defaultTickSpacingsAway)
 				s.Require().Equal(len(tc.isPositionActiveFlag), len(positionMeta))
 
-				// Get pool
+				// Refetch pool.
 				pool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
 				s.Require().NoError(err)
 
+				// Compute expected ticks from test case configuration.
 				expectedSwapEndTicks := computeExpectedTicks(poolId, tc)
 
+				// Determine if swaps within the same tick are expected.
+				// This is so that we discount the last swap by 50% to make
+				// sure to remain within the same tick and never cross.
 				isWithinTheSameTick := osmoutils.ContainsDuplicate(expectedSwapEndTicks)
-				withinTheSameTickDiscount := sdk.OneDec()
 
 				// Perform the swaps
 				curSqrtPrice := sdk.Dec{}
 				curTick := pool.GetCurrentTick()
-
+				// For every expected, swap, estimate the amount in needed
+				// to reach it and run validations after the swap.
 				for i, expectedSwapEndTick := range expectedSwapEndTicks {
+					// Determine if we are swapping zero for one or one for zero.
 					isZeroForOne := expectedSwapEndTick <= curTick && !tc.isOneForZeroWithinSameTick
 
-					nextTickToReachInCompute := expectedSwapEndTick
+					// This is used to control the computations for the last swap when swapping
+					// See definition of computeNextTickToReachAndMultiplier for more details.
 					shouldStayWithinTheSameTickInCompute := isWithinTheSameTick && i == len(expectedSwapEndTicks)-1
-					if shouldStayWithinTheSameTickInCompute {
-						nextTickToReachInCompute = nextTickToReachInCompute - 1
-						withinTheSameTickDiscount = sdk.NewDecWithPrec(5, 1)
-					}
+					nextTickToReachInCompute, withinTheSameTickDiscount := computeNextTickToReachAndMultiplier(isZeroForOne, expectedSwapEndTick, shouldStayWithinTheSameTickInCompute)
 
+					// Estimate the amountIn necessary to reach the expected swap end tick, the expected liquidity and
+					// the "current sqrt price" for next swap.
 					amountIn, expectedLiquidity, nextSqrtPrice := s.computeSwapAmounts(poolId, curSqrtPrice, nextTickToReachInCompute, isZeroForOne, shouldStayWithinTheSameTickInCompute)
-					curSqrtPrice = nextSqrtPrice
 
+					// Discount the amount in by 50% if we are swapping within the same tick.
 					amountInRoundedUp := amountIn.Mul(withinTheSameTickDiscount).Ceil().TruncateInt()
 
 					fmt.Printf("\n\n\n\n")
 
+					// Perform the swap in the desired direction.
 					if isZeroForOne {
 						amountInCoin := sdk.NewCoin(pool.GetToken0(), amountInRoundedUp)
 						s.swapZeroForOneLeft(poolId, amountInCoin)
@@ -1011,9 +1041,12 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickS
 						s.swapOneForZeroRight(poolId, amountInCoin)
 					}
 
+					// Validate that current tick and current liquidity are as expected.
 					s.assertPoolTickEquals(poolId, expectedSwapEndTick)
 					s.assertPoolLiquidityEquals(poolId, expectedLiquidity)
 
+					// Update the current sqrt price and tick for next swap.
+					curSqrtPrice = nextSqrtPrice
 					curTick = expectedSwapEndTick
 				}
 
@@ -1022,6 +1055,7 @@ func (s *SwapTickCrossTestSuite) TestSwapOutGivenIn_Contiguous_Initialized_TickS
 				s.Require().NoError(err)
 
 				// Validate the positions
+				s.Require().NotEmpty(tc.isPositionActiveFlag)
 				for i, expectedActivePositionIndex := range tc.isPositionActiveFlag {
 
 					isInRange := pool.IsCurrentTickInRange(positionMeta[i].lowerTick, positionMeta[i].upperTick)

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -385,6 +385,15 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 	store := ctx.KVStore(k.storeKey)
 	prefixBz := types.KeyTickPrefixByPoolId(poolId)
 	prefixStore := prefix.NewStore(store, prefixBz)
+
+	// If zero for one, we use reverse iterator. As a result, we need to increment the start tick by 1
+	// so that we include the start tick in the search.
+	//
+	// If one for zero, we use forward iterator. However, our definition of the active range is inclusive
+	// of the lower bound. As a result, current liquidity must already include the lower bound tick
+	// so we skip it.
+	startTick = startTick + 1
+
 	startTickKey := types.TickIndexToBytes(startTick)
 	boundTickKey := types.TickIndexToBytes(boundTick.Int64())
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -171,13 +171,13 @@ func validateTickRangeIsValid(tickSpacing uint64, lowerTick int64, upperTick int
 	}
 
 	// Check if the lower tick value is within the valid range of MinTick to MaxTick.
-	if lowerTick < types.MinTick || lowerTick >= types.MaxTick {
-		return types.InvalidTickError{Tick: lowerTick, IsLower: true, MinTick: types.MinTick, MaxTick: types.MaxTick}
+	if lowerTick < types.MinInitializedTick || lowerTick >= types.MaxTick {
+		return types.InvalidTickError{Tick: lowerTick, IsLower: true, MinTick: types.MinInitializedTick, MaxTick: types.MaxTick}
 	}
 
 	// Check if the upper tick value is within the valid range of MinTick to MaxTick.
-	if upperTick > types.MaxTick || upperTick <= types.MinTick {
-		return types.InvalidTickError{Tick: upperTick, IsLower: false, MinTick: types.MinTick, MaxTick: types.MaxTick}
+	if upperTick > types.MaxTick || upperTick <= types.MinInitializedTick {
+		return types.InvalidTickError{Tick: upperTick, IsLower: false, MinTick: types.MinInitializedTick, MaxTick: types.MaxTick}
 	}
 
 	// Check if the lower tick value is greater than or equal to the upper tick value.
@@ -223,7 +223,7 @@ func (k Keeper) GetTickLiquidityForFullRange(ctx sdk.Context, poolId uint64) ([]
 
 	// set current tick to min tick, and find the first initialized tick starting from min tick -1.
 	// we do -1 to make min tick inclusive.
-	currentTick := types.MinTick - 1
+	currentTick := types.MinInitializedTick - 1
 
 	nextTickIter := swapStrategy.InitializeNextTickIterator(ctx, poolId, currentTick)
 	defer nextTickIter.Close()
@@ -333,12 +333,12 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 
 	// use max or min tick if provided bound is nil
 
-	ctx.Logger().Debug(fmt.Sprintf("min_tick %d\n", types.MinTick))
+	ctx.Logger().Debug(fmt.Sprintf("min_tick %d\n", types.MinInitializedTick))
 	ctx.Logger().Debug(fmt.Sprintf("max_tick %d\n", types.MaxTick))
 
 	if boundTick.IsNil() {
 		if zeroForOne {
-			boundTick = sdk.NewInt(types.MinTick)
+			boundTick = sdk.NewInt(types.MinInitializedTick)
 		} else {
 			boundTick = sdk.NewInt(types.MaxTick)
 		}

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1373,14 +1373,14 @@ func (s *KeeperTestSuite) TestValidateTickRangeIsValid() {
 			lowerTick: types.MaxTick,
 			upperTick: types.MaxTick,
 
-			expectedError: types.InvalidTickError{Tick: types.MaxTick, IsLower: true, MinTick: types.MinTick, MaxTick: types.MaxTick},
+			expectedError: types.InvalidTickError{Tick: types.MaxTick, IsLower: true, MinTick: types.MinInitializedTick, MaxTick: types.MaxTick},
 		},
 		{
 			name:      "upper tick is equal to min tick.",
-			lowerTick: types.MinTick,
-			upperTick: types.MinTick,
+			lowerTick: types.MinInitializedTick,
+			upperTick: types.MinInitializedTick,
 
-			expectedError: types.InvalidTickError{Tick: types.MinTick, IsLower: false, MinTick: types.MinTick, MaxTick: types.MaxTick},
+			expectedError: types.InvalidTickError{Tick: types.MinInitializedTick, IsLower: false, MinTick: types.MinInitializedTick, MaxTick: types.MaxTick},
 		},
 	}
 

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1077,6 +1077,10 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			boundTick:       sdk.NewInt(-15),
 			expectedLiquidityDepths: []queryproto.TickLiquidityNet{
 				{
+					LiquidityNet: sdk.NewDec(-20),
+					TickIndex:    10,
+				},
+				{
 					LiquidityNet: sdk.NewDec(20),
 					TickIndex:    -10,
 				},
@@ -1096,13 +1100,19 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			boundTick:       sdk.NewInt(-15),
 			expectedLiquidityDepths: []queryproto.TickLiquidityNet{
 				{
+
+					LiquidityNet: sdk.NewDec(-20),
+					TickIndex:    10,
+				},
+				{
+
 					LiquidityNet: sdk.NewDec(20),
 					TickIndex:    -10,
 				},
 			},
 		},
 		{
-			name: "11: current pool tick == start tick, one for zero",
+			name: "current pool tick == start tick, one for zero",
 			presetTicks: []genesis.FullTick{
 				withLiquidityNetandTickIndex(defaultTick, -10, sdk.NewDec(20)),
 				withLiquidityNetandTickIndex(defaultTick, 10, sdk.NewDec(-20)),
@@ -1274,7 +1284,7 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			}
 
 			s.Require().NoError(err)
-			s.Require().Equal(liquidityForRange, test.expectedLiquidityDepths)
+			s.Require().Equal(test.expectedLiquidityDepths, liquidityForRange)
 		})
 	}
 }

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -8,7 +8,13 @@ import (
 
 const (
 	// Precomputed values for min and max tick
-	MinTick, MaxTick              int64 = -162000000, 342000000
+	MinInitializedTick, MaxTick int64 = -162000000, 342000000
+	// If we consume all liquidity and cross the min initialized tick,
+	// our current tick will equal to this value with zero liquidity.
+	// However, note that this tick cannot be crossed. If current tick
+	// equals to this tick, it is only possible to swap in the right (one for zero)
+	// direction.
+	MinCurrentTick                int64 = MinInitializedTick - 1
 	ExponentAtPriceOne            int64 = -6
 	ConcentratedGasFeeForSwap           = 10_000
 	BaseGasFeeForNewIncentive           = 10_000

--- a/x/concentrated-liquidity/types/keys_test.go
+++ b/x/concentrated-liquidity/types/keys_test.go
@@ -29,7 +29,7 @@ func TestReverseRelationTickIndexToBytes(t *testing.T) {
 			tickIndex: types.MaxTick,
 		},
 		"minimum tick index": {
-			tickIndex: types.MinTick,
+			tickIndex: types.MinInitializedTick,
 		},
 	}
 

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -110,16 +110,16 @@ func validateTicks(i interface{}) error {
 		if MaxTick%tickSpacingInt64 != 0 {
 			return fmt.Errorf("max tick (%d) is not a multiple of tick spacing (%d)", MaxTick, tickSpacing)
 		}
-		if MinTick%tickSpacingInt64 != 0 {
-			return fmt.Errorf("in tick (%d) is not a multiple of tick spacing (%d)", MinTick, tickSpacing)
+		if MinInitializedTick%tickSpacingInt64 != 0 {
+			return fmt.Errorf("in tick (%d) is not a multiple of tick spacing (%d)", MinInitializedTick, tickSpacing)
 		}
 
 		if tickSpacingInt64 > MaxTick {
 			return fmt.Errorf("tick spacing (%d) cannot be greater than max tick spacing (%d)", tickSpacing, MaxTick)
 		}
 
-		if tickSpacingInt64 < MinTick {
-			return fmt.Errorf("tick spacing (%d) cannot be less than min tick spacing (%d)", tickSpacing, MinTick)
+		if tickSpacingInt64 < MinInitializedTick {
+			return fmt.Errorf("tick spacing (%d) cannot be less than min tick spacing (%d)", tickSpacing, MinInitializedTick)
 		}
 	}
 

--- a/x/concentrated-liquidity/types/params_test.go
+++ b/x/concentrated-liquidity/types/params_test.go
@@ -30,7 +30,7 @@ func TestValidateTicks(t *testing.T) {
 			expectError: true,
 		},
 		"error: not a multiple of min tick": {
-			i:           []int64{types.MinTick + 1},
+			i:           []int64{types.MinInitializedTick + 1},
 			expectError: true,
 		},
 		"error: greater than max tick": {
@@ -42,11 +42,11 @@ func TestValidateTicks(t *testing.T) {
 			expectError: true,
 		},
 		"error: smaller than min tick": {
-			i:           []int64{types.MinTick * 2},
+			i:           []int64{types.MinInitializedTick * 2},
 			expectError: true,
 		},
 		"error: is min tick": {
-			i:           []int64{types.MinTick},
+			i:           []int64{types.MinInitializedTick},
 			expectError: true,
 		},
 	}

--- a/x/superfluid/keeper/concentrated_liquidity.go
+++ b/x/superfluid/keeper/concentrated_liquidity.go
@@ -49,7 +49,7 @@ func (k Keeper) addToConcentratedLiquiditySuperfluidPosition(ctx sdk.Context, se
 	}
 
 	// Defense in depth making sure that the position is full-range.
-	if position.LowerTick != cltypes.MinTick || position.UpperTick != cltypes.MaxTick {
+	if position.LowerTick != cltypes.MinInitializedTick || position.UpperTick != cltypes.MaxTick {
 		return 0, sdk.Int{}, sdk.Int{}, sdk.Dec{}, 0, types.ConcentratedTickRangeNotFullError{ActualLowerTick: position.LowerTick, ActualUpperTick: position.UpperTick}
 	}
 

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -153,7 +153,7 @@ func (k Keeper) UpdateOsmoEquivalentMultipliers(ctx sdk.Context, asset types.Sup
 		}
 
 		position := model.Position{
-			LowerTick: cltypes.MinTick,
+			LowerTick: cltypes.MinInitializedTick,
 			UpperTick: cltypes.MaxTick,
 			Liquidity: fullRangeLiquidity,
 		}

--- a/x/superfluid/types/errors.go
+++ b/x/superfluid/types/errors.go
@@ -87,7 +87,7 @@ type ConcentratedTickRangeNotFullError struct {
 }
 
 func (e ConcentratedTickRangeNotFullError) Error() string {
-	return fmt.Sprintf("position must be full range. Lower tick (%d) must be (%d). Upper tick (%d) must be (%d)", e.ActualLowerTick, e.ActualUpperTick, cltypes.MinTick, cltypes.MaxTick)
+	return fmt.Sprintf("position must be full range. Lower tick (%d) must be (%d). Upper tick (%d) must be (%d)", e.ActualLowerTick, e.ActualUpperTick, cltypes.MinInitializedTick, cltypes.MaxTick)
 }
 
 type NegativeDurationError struct {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5558

## What is the purpose of the change

Adding swap test vectors for out given in  where contiguous ticks are initialized with spacing of one. Both zero for one and one for zero are covered

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A