### PR TITLE
Make go tests only run if relevant

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,27 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+      - name: Get git diff
+        uses: technote-space/get-diff-action@v6.1.2
+        with:
+          PATTERNS: |
+            **/**.wasm
+            **/**.go
+            **/**.mod
+            **/**.sum
+            Makefile
+            Dockerfile
+            .github/workflows/test.yml
       - name: 🐿 Setup Golang
         uses: actions/setup-go@v4
+        if: env.GIT_DIFF
         with:
           go-version: "^1.20"
       - name: Display go version
+        if: env.GIT_DIFF
         run: go version
       - name: Get data from build cache
+        if: env.GIT_DIFF
         uses: actions/cache@v3
         with:
           # In order:
@@ -40,6 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
       - name: Run unit tests
+        if: env.GIT_DIFF
         run: make test-unit
 
   e2e:


### PR DESCRIPTION
Make golang tests only run if theres a state machine affecting change. This should help CI bottlenecks for docs-only PR's