### PR TITLE
fix/test: GetTickLiquidityNetInDirection start tick and tests

### DIFF
--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -385,6 +385,15 @@ func (k Keeper) GetTickLiquidityNetInDirection(ctx sdk.Context, poolId uint64, t
 	store := ctx.KVStore(k.storeKey)
 	prefixBz := types.KeyTickPrefixByPoolId(poolId)
 	prefixStore := prefix.NewStore(store, prefixBz)
+
+	// If zero for one, we use reverse iterator. As a result, we need to increment the start tick by 1
+	// so that we include the start tick in the search.
+	//
+	// If one for zero, we use forward iterator. However, our definition of the active range is inclusive
+	// of the lower bound. As a result, current liquidity must already include the lower bound tick
+	// so we skip it.
+	startTick = startTick + 1
+
 	startTickKey := types.TickIndexToBytes(startTick)
 	boundTickKey := types.TickIndexToBytes(boundTick.Int64())
 

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1077,6 +1077,10 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			boundTick:       sdk.NewInt(-15),
 			expectedLiquidityDepths: []queryproto.TickLiquidityNet{
 				{
+					LiquidityNet: sdk.NewDec(-20),
+					TickIndex:    10,
+				},
+				{
 					LiquidityNet: sdk.NewDec(20),
 					TickIndex:    -10,
 				},
@@ -1096,13 +1100,19 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			boundTick:       sdk.NewInt(-15),
 			expectedLiquidityDepths: []queryproto.TickLiquidityNet{
 				{
+
+					LiquidityNet: sdk.NewDec(-20),
+					TickIndex:    10,
+				},
+				{
+
 					LiquidityNet: sdk.NewDec(20),
 					TickIndex:    -10,
 				},
 			},
 		},
 		{
-			name: "11: current pool tick == start tick, one for zero",
+			name: "current pool tick == start tick, one for zero",
 			presetTicks: []genesis.FullTick{
 				withLiquidityNetandTickIndex(defaultTick, -10, sdk.NewDec(20)),
 				withLiquidityNetandTickIndex(defaultTick, 10, sdk.NewDec(-20)),
@@ -1274,7 +1284,7 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			}
 
 			s.Require().NoError(err)
-			s.Require().Equal(liquidityForRange, test.expectedLiquidityDepths)
+			s.Require().Equal(test.expectedLiquidityDepths, liquidityForRange)
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Found a bug in the liquidity net in direction query. It was discovered while implementing token in quote estimation (similar to how we do it on frontend) for https://github.com/osmosis-labs/osmosis/pull/5567

The core of the bug is that when swapping zero for one, it would exclude the start tick due to reverse iterator's upper end being exclusive.

Additionally, in the zero for one direction, it would redundantly return the current tick's liquidity net value which is redundant. When swapping one for zero, current liquidity already includes liquidity net of the current tick. Therefore, we should avoid returning it.

This might be related to the fee issues @jonator is experiencing on the front end.

## Testing and Verifying

This change added tests


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A