### PR TITLE
wait longer for balance checks

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -176,7 +176,7 @@ func (s *IntegrationTestSuite) CheckBalance(node *chain.NodeConfig, addr, denom 
 		}
 		return false
 	},
-		1*time.Minute,
+		2*time.Minute,
 		10*time.Millisecond,
 	)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

PacketForwarding tests are intermitently failing. Example: https://github.com/osmosis-labs/osmosis/actions/runs/5316311889/jobs/9625698638?pr=5579#step:9:794 

My first guess is that this is because hermes takes longer to relay the packets than the maximum of one minute. This PR raises it to 2 minutes. 

## Testing and Verifying

Will run E2E tests on this PR a few times before merging to see if the error pops up again. We should still keep an eye for it after this is merged. 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A