### PR TITLE
fix: zero for one tick crossing bug for swap in given out

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -369,13 +369,11 @@ func (k Keeper) computeOutAmtGivenIn(
 		// If ComputeSwapWithinBucketOutGivenIn(...) calculated a computedSqrtPrice that is equal to the nextInitializedTickSqrtPrice, this means all liquidity in the current
 		// bucket has been consumed and we must move on to the next bucket to complete the swap
 		if nextInitializedTickSqrtPrice.Equal(computedSqrtPrice) {
-			swapState, err = k.swapCrossTickLogic(ctx, swapState,
+			swapState, err = k.swapCrossTickLogic(ctx, swapState, swapStrategy,
 				nextInitializedTick, nextInitTickIter, p, spreadRewardAccumulator, uptimeAccums, tokenInMin.Denom)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, PoolUpdates{}, sdk.Dec{}, err
 			}
-			// Update the swapState's tick with the tick we retrieved liquidity from
-			swapState.tick = swapStrategy.UpdateTickAfterCrossing(nextInitializedTick)
 		} else if !sqrtPriceStart.Equal(computedSqrtPrice) {
 			// Otherwise if the sqrtPrice calculated from ComputeSwapWithinBucketOutGivenIn(...) does not equal the sqrtPriceStart we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the computedSqrtPrice calculated from ComputeSwapWithinBucketOutGivenIn(...)
@@ -509,13 +507,11 @@ func (k Keeper) computeInAmtGivenOut(
 		// If the ComputeSwapWithinBucketInGivenOut(...) calculated a computedSqrtPrice that is equal to the nextInitializedTickSqrtPrice, this means all liquidity in the current
 		// bucket has been consumed and we must move on to the next bucket by crossing a tick to complete the swap
 		if nextInitializedTickSqrtPrice.Equal(computedSqrtPrice) {
-			swapState, err = k.swapCrossTickLogic(ctx, swapState,
+			swapState, err = k.swapCrossTickLogic(ctx, swapState, swapStrategy,
 				nextInitializedTick, nextInitTickIter, p, spreadRewardAccumulator, uptimeAccums, tokenInDenom)
 			if err != nil {
 				return sdk.Coin{}, sdk.Coin{}, PoolUpdates{}, sdk.Dec{}, err
 			}
-			// Update the swapState's tick with the tick we retrieved liquidity from
-			swapState.tick = swapStrategy.UpdateTickAfterCrossing(nextInitializedTick)
 		} else if !sqrtPriceStart.Equal(computedSqrtPrice) {
 			// Otherwise, if the computedSqrtPrice calculated from ComputeSwapWithinBucketInGivenOut(...) does not equal the sqrtPriceStart we started with at the
 			// beginning of this iteration, we set the swapState tick to the corresponding tick of the computedSqrtPrice calculated from ComputeSwapWithinBucketInGivenOut(...)
@@ -555,7 +551,7 @@ func emitSwapDebugLogs(ctx sdk.Context, swapState SwapState, reachedPrice, amoun
 
 // logic for crossing a tick during a swap
 func (k Keeper) swapCrossTickLogic(ctx sdk.Context,
-	swapState SwapState,
+	swapState SwapState, strategy swapstrategy.SwapStrategy,
 	nextInitializedTick int64, nextTickIter db.Iterator,
 	p types.ConcentratedPoolExtension,
 	spreadRewardAccum accum.AccumulatorObject, uptimeAccums []accum.AccumulatorObject,
@@ -581,6 +577,9 @@ func (k Keeper) swapCrossTickLogic(ctx sdk.Context,
 	liquidityNet = swapState.swapStrategy.SetLiquidityDeltaSign(liquidityNet)
 	// Update the swapState's liquidity with the new tick's liquidity
 	swapState.liquidity.AddMut(liquidityNet)
+
+	// Update the swapState's tick with the tick we retrieved liquidity from
+	swapState.tick = strategy.UpdateTickAfterCrossing(nextInitializedTick)
 
 	return swapState, nil
 }

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -659,7 +659,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:  sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 			expectedTokenIn:   sdk.NewCoin(ETH, sdk.NewInt(8404)),
-			expectedTick:      30996000,
+			expectedTick:      30996087,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.683007989825007162"),
 		},
 		"single position within one tick: usdc (in) -> eth (out) ofz": {
@@ -678,7 +678,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(13370)),
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(66891663)),
-			expectedTick:      31006200,
+			expectedTick:      31006234,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.754747188468900467"),
 		},
 		//  Two equal price ranges
@@ -704,7 +704,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(66829187)),
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(13370)),
-			expectedTick:      30996800,
+			expectedTick:      30996887,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.688664163727643650"),
 			// two positions with same liquidity entered
 			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
@@ -728,7 +728,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:  sdk.NewCoin("eth", sdk.NewInt(8398)),
 			expectedTokenIn:   sdk.NewCoin("usdc", sdk.NewInt(41998216)),
-			expectedTick:      31001900,
+			expectedTick:      31001956,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.724512595179305566"),
 			// two positions with same liquidity entered
 			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
@@ -771,7 +771,7 @@ var (
 			// print(token_in)
 			expectedTokenOut: sdk.NewCoin("usdc", sdk.NewInt(9103422788)),
 			expectedTokenIn:  sdk.NewCoin("eth", sdk.NewInt(2000000)),
-			expectedTick:     30095100,
+			expectedTick:     30095166,
 
 			expectedSqrtPrice:                         sdk.MustNewDecFromStr("63.993489023888951975"),
 			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(sdk.NewDec(2)),
@@ -820,7 +820,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(9999999570)),
-			expectedTick:      32105400,
+			expectedTick:      32105414,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315000, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
@@ -875,7 +875,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(2000000)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:      30129000,
+			expectedTick:      30129083,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("64.257943796086567725"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
@@ -931,7 +931,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin(ETH, sdk.NewInt(1800000)),
 			expectedTokenOut:  sdk.NewCoin(USDC, sdk.NewInt(8479320318)),
-			expectedTick:      30292000,
+			expectedTick:      30292059,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("65.513815286452064191"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
@@ -990,7 +990,7 @@ var (
 			// print(token_in)
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(9999994688)),
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(1864161)),
-			expectedTick:      32055900,
+			expectedTick:      32055918,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("77.819781711876553576"),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
@@ -1041,7 +1041,7 @@ var (
 			expectedTokenOut: sdk.NewCoin(ETH, sdk.NewInt(1609138)),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedTick:      31712600,
+			expectedTick:      31712695,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("75.582372355128594340"),
 			newLowerPrice:     sdk.NewDec(5001),
 			newUpperPrice:     sdk.NewDec(6250),
@@ -1086,7 +1086,7 @@ var (
 			// print(token_in)
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(9999994756)),
-			expectedTick:      32105500,
+			expectedTick:      32105554,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315010, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
@@ -1145,7 +1145,7 @@ var (
 			// print(spread_rewards_growth)
 			expectedTokenOut:  sdk.NewCoin(USDC, sdk.NewInt(42000000)),
 			expectedTokenIn:   sdk.NewCoin(ETH, sdk.NewInt(8489)),
-			expectedTick:      30996000,
+			expectedTick:      30996087,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.683007989825007162"),
 			expectedSpreadRewardGrowthAccumulatorValue: sdk.MustNewDecFromStr("0.000000055925868851"),
 		},
@@ -1175,7 +1175,7 @@ var (
 			// print(spread_rewards_growth)
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(8398)),
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(43297130)),
-			expectedTick:      31001900,
+			expectedTick:      31001956,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("70.724512595179305566"),
 			// two positions with same liquidity entered
 			poolLiqAmount0: sdk.NewInt(1000000).MulRaw(2),
@@ -1220,7 +1220,7 @@ var (
 			// print(spread_rewards_growth)
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(1820630)),
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(10010009580)),
-			expectedTick:      32105400,
+			expectedTick:      32105414,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("78.137148837036751553"),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315000, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
@@ -1276,7 +1276,7 @@ var (
 			// print(spread_rewards_growth)
 			expectedTokenIn:   sdk.NewCoin("eth", sdk.NewInt(2222223)),
 			expectedTokenOut:  sdk.NewCoin("usdc", sdk.NewInt(9321276930)),
-			expectedTick:      30129000,
+			expectedTick:      30129083,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("64.257943796086567725"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
@@ -1338,7 +1338,7 @@ var (
 			expectedTokenOut: sdk.NewCoin(ETH, sdk.NewInt(1609138)),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedTick:      31712600,
+			expectedTick:      31712695,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("75.582372355128594340"),
 			newLowerPrice:     sdk.NewDec(5001),
 			newUpperPrice:     sdk.NewDec(6250),
@@ -1381,7 +1381,7 @@ var (
 			// print(spread_rewards_growth)
 			expectedTokenOut:  sdk.NewCoin(ETH, sdk.NewInt(1820545)),
 			expectedTokenIn:   sdk.NewCoin(USDC, sdk.NewInt(10002995655)),
-			expectedTick:      32105500,
+			expectedTick:      32105554,
 			expectedSqrtPrice: sdk.MustNewDecFromStr("78.138050797173647031"),
 			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315010, expectedSpreadRewardGrowth: cl.EmptyCoins},
 			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: #5573

## What is the purpose of the change

Applying the same fix for swap in given out as was done in #5526

## Testing and Verifying

The cross tick test suite is to be expanded to cover swap in given out in a future PR

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A