### PR TITLE
[ci] Paralleze go tests github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  go:
+  get_diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository code
         uses: actions/checkout@v3
-      - name: Get git diff
+      -
+        name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -28,110 +30,161 @@ jobs:
             Makefile
             Dockerfile
             .github/workflows/test.yml
-      - name: 🐿 Setup Golang
+    outputs:
+      git_diff: ${{ env.GIT_DIFF }}
+
+  go-split-test-files:
+    needs: get_diff
+    if: needs.get_diff.outputs.git_diff
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out repository code
+        uses: actions/checkout@v3
+      -
+        name: 🐿 Setup Golang
         uses: actions/setup-go@v4
-        if: env.GIT_DIFF
         with:
           go-version: "^1.20"
-      - name: Display go version
-        if: env.GIT_DIFF
+      -
+        name: Create a file with all core Cosmos SDK pkgs
+        run: go list ./... ./osmomath/... ./osmoutils/... ./x/ibc-hooks/... ./x/epochs | grep -E -v 'tests/simulator|e2e' > pkgs.txt
+      -
+        name: Split pkgs into 4 files
+        run: split -d -n l/4 pkgs.txt pkgs.txt.part.
+      -
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-00"
+          path: ./pkgs.txt.part.00
+      -
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-01"
+          path: ./pkgs.txt.part.01
+      -
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-02"
+          path: ./pkgs.txt.part.02
+      -
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-03"
+          path: ./pkgs.txt.part.03
+
+  go:
+    needs: [go-split-test-files, get_diff]
+    if: needs.get_diff.outputs.git_diff
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        part: ["00", "01", "02", "03"]
+    steps:
+      -
+        name: Check out repository code
+        uses: actions/checkout@v3
+      -
+        name: 🐿 Setup Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "^1.20"
+      -
+        name: Display go version
         run: go version
-      - name: Get data from build cache
-        if: env.GIT_DIFF
+      -
+        name: Get data from build cache
         uses: actions/cache@v3
         with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          # * Build cache (Windows)
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}-
-      - name: Run unit tests
-        if: env.GIT_DIFF
-        run: make test-unit
+            ${{ runner.os }}-go-
+      -
+        uses: actions/download-artifact@v3
+        with:
+          name: "${{ github.sha }}-${{ matrix.part }}"
+      -
+        name: Test & coverage report creation
+        run: |
+          VERSION=$(echo $(git describe --tags) | sed 's/^v//') || VERSION=${GITHUB_SHA}
+          TESTS=$(cat pkgs.txt.part.${{ matrix.part }})
+
+          VERSION=$VERSION SKIP_WASM_WSL_TESTS="false" go test -mod=readonly -tags='ledger test_ledger_mock norace' $TESTS
 
   e2e:
+    needs: get_diff
+    if: needs.get_diff.outputs.git_diff
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: 🐿 Setup Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: "^1.20"
-      - name: Check out repository code
+      -
+        name: Check out repository code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Get git diff
-        uses: technote-space/get-diff-action@v6.1.2
+      -
+        name: 🐿 Setup Golang
+        uses: actions/setup-go@v4
         with:
-          PATTERNS: |
-            **/**.wasm
-            **/**!(test).go
-            tests/**/**.go
-            go.mod
-            go.sum
-            Makefile
-            Dockerfile
-      - name: Get data from build cache
+          go-version: "^1.20"
+      -
+        name: Get data from build cache
         uses: actions/cache@v3
         with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          # * Build cache (Windows)
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~\AppData\Local\go-build
-          key: ${{ runner.os }}-go-docker-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-docker-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-docker-${{ matrix.go-version }}-
-        if: env.GIT_DIFF
-      - name: Set up QEMU
+            ${{ runner.os }}-go-docker-
+      -
+        name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        if: env.GIT_DIFF
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: env.GIT_DIFF
-      - name: Build e2e image
+      -
+        name: Build e2e image
         uses: docker/build-push-action@v4
         with:
           load: true
           context: .
           tags: osmosis:debug
-          # Use experimental Cache backend API: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
+          # Use experimental Cache backend API: 
+          # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
-        if: env.GIT_DIFF
-      - name: Test e2e and Upgrade
+      -
+        name: Test e2e and Upgrade
         run: make test-e2e-ci
-        if: env.GIT_DIFF
-      - name: Dump docker logs on failure
+      -
+        name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
           dest: "./logs"
-      - name: Tar logs
+      -
+        name: Tar logs
         if: failure()
         run: tar cvzf ./logs.tgz ./logs
-      - name: Upload logs to GitHub
+      -
+        name: Upload logs to GitHub
         uses: actions/upload-artifact@v3
         with:
           name: logs.tgz
           path: ./logs.tgz
         if: failure()
-      - name: 🧹 Clean up Osmosis Home
+      -
+        name: 🧹 Clean up Osmosis Home
         if: always()
         run: rm -rf $HOME/.osmosisd/ || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
       git_diff: ${{ env.GIT_DIFF }}
 
   go-split-test-files:
+    needs: get_diff
+    if: needs.get_diff.outputs.git_diff
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,6 @@ jobs:
       git_diff: ${{ env.GIT_DIFF }}
 
   go-split-test-files:
-    needs: get_diff
-    if: needs.get_diff.outputs.git_diff
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves the `go tests` GitHub Actions workflow.

Key changes:

1. Refactored the 'get-diff' action to execute only once, reducing redundant operations.
2. Moved the conditional checks for `GIT_DIFF` to the job level
3. Changed cache key as `{{matrix.go_version}}` is not defined
4. Parallelize tests as in https://github.com/cosmos/cosmos-sdk/blob/main/.github/workflows/test.yml

## Testing and Verifying

Run the workflow in my fork: https://github.com/niccoloraspa/osmosis/actions/runs/5345580730

Times might be different due to:
- not using cache
- different GitHub plan 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A