### PR TITLE
Remove proto deserialization from HasPosition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3
 	github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230621002052-afb82fbaa312
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230622012610-25ef7aa8f2a5
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230602130523-f9a94d8bbd10
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -950,6 +950,8 @@ github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230621002052-afb82fbaa31
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230621002052-afb82fbaa312/go.mod h1:JTym95/bqrSnG5MPcXr1YDhv43JdCeo3p+iDbazoX68=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230622012610-25ef7aa8f2a5 h1:MTIKbW26Ire7kKL/JOPsXaVpbgTxfHdL8ySXHRcF3SM=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230622012610-25ef7aa8f2a5/go.mod h1:FqFOfj9+e5S1I7hR3baGUHrqje3g32EOHAXoOf7R00M=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343 h1:7V2b3+mSnLnK0Px+Dl3vnxAQgk4SV8e9ohfJ/tKsq0M=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343/go.mod h1:FqFOfj9+e5S1I7hR3baGUHrqje3g32EOHAXoOf7R00M=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304 h1:RIrWLzIiZN5Xd2JOfSOtGZaf6V3qEQYg6EaDTAkMnCo=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304/go.mod h1:yPWoJTj5RKrXKUChAicp+G/4Ni/uVEpp27mi/FF/L9c=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230602130523-f9a94d8bbd10 h1:XrES5AHZMZ/Y78boW35PTignkhN9h8VvJ1sP8EJDIu8=

--- a/osmoutils/accum/accum.go
+++ b/osmoutils/accum/accum.go
@@ -376,19 +376,10 @@ func (accum AccumulatorObject) GetPositionSize(name string) (sdk.Dec, error) {
 }
 
 // HasPosition returns true if a position with the given name exists,
-// false otherwise. Returns error if internal database error occurs.
-func (accum AccumulatorObject) HasPosition(name string) (bool, error) {
-	_, err := GetPosition(accum, name)
-
-	if err != nil {
-		isNoPositionError := errors.Is(err, NoPositionError{Name: name})
-		if isNoPositionError {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
+// false otherwise.
+func (accum AccumulatorObject) HasPosition(name string) bool {
+	containsKey := accum.store.Has(FormatPositionPrefixKey(accum.name, name))
+	return containsKey
 }
 
 // GetValue returns the current value of the accumulator.

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1478,9 +1478,7 @@ func (suite *AccumTestSuite) TestHasPosition() {
 				suite.Require().NoError(err)
 			}
 
-			hasPosition, err := accObject.HasPosition(defaultPositionName)
-			suite.NoError(err)
-
+			hasPosition := accObject.HasPosition(defaultPositionName)
 			suite.Equal(tc.preCreatePosition, hasPosition)
 		})
 	}
@@ -1599,8 +1597,7 @@ func (suite *AccumTestSuite) TestGetTotalShares() {
 		baseAmt := sdk.NewDec(int64(i)).Mul(sdk.NewDec(10))
 
 		// If addr doesn't have a position yet, we make one
-		positionExists, err := curAccum.HasPosition(curAddr)
-		suite.Require().NoError(err)
+		positionExists := curAccum.HasPosition(curAddr)
 		if !positionExists {
 			err = curAccum.NewPosition(curAddr, baseAmt, nil)
 			suite.Require().NoError(err)
@@ -1770,8 +1767,7 @@ func (suite *AccumTestSuite) TestDeletePosition() {
 			}
 			suite.Require().NoError(err)
 
-			hasPosition, err := accObject.HasPosition(tc.positionName)
-			suite.Require().NoError(err)
+			hasPosition := accObject.HasPosition(tc.positionName)
 			suite.Require().False(hasPosition)
 
 			// Check rewards.

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -197,7 +197,8 @@ func GetDec(store store.KVStore, key []byte) (sdk.Dec, error) {
 }
 
 // Get returns a value at key by mutating the result parameter. Returns true if the value was found and the
-// result mutated correctly. If the value is not in the store, returns false. Returns error only when database or serialization errors occur. (And when an error occurs, returns false)
+// result mutated correctly. If the value is not in the store, returns false.
+// Returns error only when database or serialization errors occur. (And when an error occurs, returns false)
 func Get(store store.KVStore, key []byte, result proto.Message) (found bool, err error) {
 	b := store.Get(key)
 	if b == nil {

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -273,10 +273,7 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 		// Ensure that the given balancer pool has a record on the given uptime accumulator.
 		// We expect this to have been set in a prior call to `prepareBalancerAsFullRange`, which
 		// should precede all calls of `claimAndResetFullRangeBalancerPool`
-		recordExists, err := uptimeAccums[uptimeIndex].HasPosition(balancerPositionName)
-		if err != nil {
-			return sdk.Coins{}, err
-		}
+		recordExists := uptimeAccums[uptimeIndex].HasPosition(balancerPositionName)
 		if !recordExists {
 			return sdk.Coins{}, types.BalancerRecordNotFoundError{ClPoolId: clPoolId, BalancerPoolId: balPoolId, UptimeIndex: uint64(uptimeIndex)}
 		}
@@ -301,10 +298,7 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 		totalRewards = totalRewards.Add(claimedRewards...)
 
 		// Ensure record was deleted
-		recordExists, err = uptimeAccums[uptimeIndex].HasPosition(balancerPositionName)
-		if err != nil {
-			return sdk.Coins{}, err
-		}
+		recordExists = uptimeAccums[uptimeIndex].HasPosition(balancerPositionName)
 		if recordExists {
 			return sdk.Coins{}, types.BalancerRecordNotClearedError{ClPoolId: clPoolId, BalancerPoolId: balPoolId, UptimeIndex: uint64(uptimeIndex)}
 		}
@@ -752,10 +746,7 @@ func (k Keeper) initOrUpdatePositionUptimeAccumulators(ctx sdk.Context, poolId u
 	for uptimeIndex, curUptimeAccum := range uptimeAccumulators {
 		// If a record does not exist for this uptime accumulator, create a new position.
 		// Otherwise, add to existing record.
-		recordExists, err := curUptimeAccum.HasPosition(positionName)
-		if err != nil {
-			return err
-		}
+		recordExists := curUptimeAccum.HasPosition(positionName)
 
 		if !recordExists {
 			// Liquidity cannot be negative for a new position
@@ -812,10 +803,7 @@ func updateAccumAndClaimRewards(accum accum.AccumulatorObject, positionKey strin
 	}
 
 	// Check if position record was deleted after claiming rewards.
-	hasPosition, err := accum.HasPosition(positionKey)
-	if err != nil {
-		return sdk.Coins{}, sdk.DecCoins{}, err
-	}
+	hasPosition := accum.HasPosition(positionKey)
 
 	// If position still exists, we update the position's accumulator value to be the current accumulator value minus the growth outside.
 	if hasPosition {
@@ -845,10 +833,7 @@ func moveRewardsToNewPositionAndDeleteOldAcc(accum accum.AccumulatorObject, oldP
 		return types.ModifySamePositionAccumulatorError{PositionAccName: oldPositionName}
 	}
 
-	hasPosition, err := accum.HasPosition(oldPositionName)
-	if err != nil {
-		return err
-	}
+	hasPosition := accum.HasPosition(oldPositionName)
 	if !hasPosition {
 		return fmt.Errorf("position %s does not exist", oldPositionName)
 	}
@@ -927,10 +912,7 @@ func (k Keeper) prepareClaimAllIncentivesForPosition(ctx sdk.Context, positionId
 	for uptimeIndex, uptimeAccum := range uptimeAccumulators {
 		// Check if the accumulator contains the position.
 		// There should never be a case where you can have a position for 1 accumulator, and not the rest.
-		hasPosition, err := uptimeAccum.HasPosition(positionName)
-		if err != nil {
-			return sdk.Coins{}, sdk.Coins{}, err
-		}
+		hasPosition := uptimeAccum.HasPosition(positionName)
 
 		// If the accumulator contains the position, claim the position's incentives.
 		if hasPosition {

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1840,9 +1840,7 @@ func (s *KeeperTestSuite) TestInitOrUpdatePositionUptimeAccumulators() {
 
 				// Ensure records are properly updated for each supported uptime
 				for uptimeIndex := range types.SupportedUptimes {
-					recordExists, err := uptimeAccums[uptimeIndex].HasPosition(positionName)
-					s.Require().NoError(err)
-
+					recordExists := uptimeAccums[uptimeIndex].HasPosition(positionName)
 					s.Require().True(recordExists)
 
 					// Ensure position's record has correct values
@@ -3169,9 +3167,7 @@ func (s *KeeperTestSuite) TestPrepareClaimAllIncentivesForPosition() {
 				for _, uptimeAccum := range uptimeAccumulatorsPreClaim {
 					newPositionName := string(types.KeyPositionId(positionIdOne))
 					// Check if the accumulator contains the position.
-					hasPosition, err := uptimeAccum.HasPosition(newPositionName)
-					s.Require().NoError(err)
-
+					hasPosition := uptimeAccum.HasPosition(newPositionName)
 					if hasPosition {
 						position, err := accum.GetPosition(uptimeAccum, newPositionName)
 						s.Require().NoError(err)
@@ -4141,8 +4137,7 @@ func (s *KeeperTestSuite) TestMoveRewardsToNewPositionAndDeleteOldAcc() {
 				s.Require().NoError(err)
 
 				// Check the old accumulator is now deleted.
-				hasPosition, err := testAccumulator.HasPosition(oldPos)
-				s.Require().NoError(err)
+				hasPosition := testAccumulator.HasPosition(oldPos)
 				s.Require().False(hasPosition)
 
 				// Check that the new accumulator has the correct amount of rewards in unclaimed rewards.

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -35,8 +35,7 @@ func (s *KeeperTestSuite) AssertPositionsDoNotExist(positionIds []uint64) {
 		oldPositionName := string(types.KeyPositionId(positionId))
 		for _, uptimeAccum := range uptimeAccumulators {
 			// Check if the accumulator contains the position.
-			hasPosition, err := uptimeAccum.HasPosition(oldPositionName)
-			s.Require().NoError(err)
+			hasPosition := uptimeAccum.HasPosition(oldPositionName)
 			s.Require().False(hasPosition)
 		}
 
@@ -57,9 +56,7 @@ func (s *KeeperTestSuite) GetTotalAccruedRewardsByAccumulator(positionId uint64,
 	for i, uptimeAccum := range uptimeAccumulators {
 		newPositionName := string(types.KeyPositionId(positionId))
 		// Check if the accumulator contains the position.
-		hasPosition, err := uptimeAccum.HasPosition(newPositionName)
-		s.Require().NoError(err)
-
+		hasPosition := uptimeAccum.HasPosition(newPositionName)
 		if requireHasPosition {
 			s.Require().True(hasPosition)
 		}
@@ -296,8 +293,7 @@ func (s *KeeperTestSuite) TestInitOrUpdatePosition() {
 			for uptimeIndex, uptime := range supportedUptimes {
 				// Position-related checks
 
-				recordExists, err := newUptimeAccums[uptimeIndex].HasPosition(positionName)
-				s.Require().NoError(err)
+				recordExists := newUptimeAccums[uptimeIndex].HasPosition(positionName)
 				s.Require().True(recordExists)
 
 				// Ensure position's record has correct values
@@ -1300,8 +1296,7 @@ func (s *KeeperTestSuite) TestFungifyChargedPositions_SwapAndClaimSpreadRewards(
 		hasPosition := s.clk.HasPosition(s.Ctx, oldPositionId)
 		s.Require().False(hasPosition)
 
-		hasSpreadRewardPositionTracker, err := spreadRewardAccum.HasPosition(types.KeySpreadRewardPositionAccumulator(oldPositionId))
-		s.Require().NoError(err)
+		hasSpreadRewardPositionTracker := spreadRewardAccum.HasPosition(types.KeySpreadRewardPositionAccumulator(oldPositionId))
 		s.Require().False(hasSpreadRewardPositionTracker)
 	}
 }

--- a/x/concentrated-liquidity/spread_rewards.go
+++ b/x/concentrated-liquidity/spread_rewards.go
@@ -58,10 +58,7 @@ func (k Keeper) initOrUpdatePositionSpreadRewardAccumulator(ctx sdk.Context, poo
 	// Get the key for the position's accumulator in the spread reward accumulator.
 	positionKey := types.KeySpreadRewardPositionAccumulator(positionId)
 
-	hasPosition, err := spreadRewardAccumulator.HasPosition(positionKey)
-	if err != nil {
-		return err
-	}
+	hasPosition := spreadRewardAccumulator.HasPosition(positionKey)
 
 	spreadRewardGrowthOutside, err := k.getSpreadRewardGrowthOutside(ctx, poolId, lowerTick, upperTick)
 	if err != nil {
@@ -247,10 +244,7 @@ func (k Keeper) prepareClaimableSpreadRewards(ctx sdk.Context, positionId uint64
 	positionKey := types.KeySpreadRewardPositionAccumulator(positionId)
 
 	// Check if the position exists in the spread reward accumulator.
-	hasPosition, err := spreadRewardAccumulator.HasPosition(positionKey)
-	if err != nil {
-		return nil, err
-	}
+	hasPosition := spreadRewardAccumulator.HasPosition(positionKey)
 	if !hasPosition {
 		return nil, types.SpreadRewardPositionNotFoundError{PositionId: positionId}
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR removes proto deserialization from `accum.HasPosition` calls. This is technically a performance improvement, but its pretty negligible (.5% speedup in our CL tests)

The computation for proto serialization doesn't cost gas, hence this is state compatible.

Whats nice is it removes the error from this code, which has essentially been a dead code branch throughout our codebase. (Every test required NoError for this, and the only way to get an error was to write something of the wrong protobuf type, which we should be guaranteed by key structuring doesn't apply)

## Testing and Verifying

This is covered by the existing tests. 

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes? No
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? No
