### PR TITLE
Driveby apptesting changes I made, while looking at other testing things

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -86,24 +86,26 @@ func (s *KeeperTestHelper) PrepareBalancerPoolWithCoinsAndWeights(coins sdk.Coin
 	})
 }
 
+var zeroDec = sdk.ZeroDec()
+var oneThirdSpotPriceUnits = sdk.NewDec(1).Quo(sdk.NewDec(3)).
+	MulIntMut(gammtypes.SpotPriceSigFigs).RoundInt().ToDec().QuoInt(gammtypes.SpotPriceSigFigs)
+
 // PrepareBalancerPool returns a Balancer pool's pool-ID with pool params set in PrepareBalancerPoolWithPoolParams.
 func (s *KeeperTestHelper) PrepareBalancerPool() uint64 {
 	poolId := s.PrepareBalancerPoolWithPoolParams(balancer.PoolParams{
-		SwapFee: sdk.NewDec(0),
-		ExitFee: sdk.NewDec(0),
+		SwapFee: zeroDec,
+		ExitFee: zeroDec,
 	})
 
 	spotPrice, err := s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, FOO, BAR)
 	s.NoError(err)
-	s.Equal(sdk.NewDec(2).String(), spotPrice.String())
+	s.Equal(sdk.NewDec(2), spotPrice)
 	spotPrice, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, BAR, BAZ)
 	s.NoError(err)
-	s.Equal(sdk.NewDecWithPrec(15, 1).String(), spotPrice.String())
+	s.Equal(sdk.NewDecWithPrec(15, 1), spotPrice)
 	spotPrice, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, BAZ, FOO)
 	s.NoError(err)
-	oneThird := sdk.NewDec(1).Quo(sdk.NewDec(3))
-	sp := oneThird.MulInt(gammtypes.SpotPriceSigFigs).RoundInt().ToDec().QuoInt(gammtypes.SpotPriceSigFigs)
-	s.Equal(sp.String(), spotPrice.String())
+	s.Equal(oneThirdSpotPriceUnits, spotPrice)
 
 	return poolId
 }

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -198,7 +198,7 @@ func (s *KeeperTestHelper) SetupValidator(bondStatus stakingtypes.BondStatus) sd
 	s.FundAcc(sdk.AccAddress(valAddr), selfBond)
 
 	stakingHandler := staking.NewHandler(*s.App.StakingKeeper)
-	stakingCoin := sdk.Coin{Denom: bondDenom, Amount: selfBond[0].Amount}
+	stakingCoin := sdk.Coin{Denom: sdk.DefaultBondDenom, Amount: selfBond[0].Amount}
 	ZeroCommission := stakingtypes.NewCommissionRates(zeroDec, zeroDec, zeroDec)
 	msg, err := stakingtypes.NewMsgCreateValidator(valAddr, valPub, stakingCoin, stakingtypes.Description{}, ZeroCommission, sdk.OneInt())
 	s.Require().NoError(err)

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -22,6 +22,7 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -60,9 +61,15 @@ type KeeperTestHelper struct {
 }
 
 var (
-	SecondaryDenom  = "uion"
-	SecondaryAmount = sdk.NewInt(100000000)
+	SecondaryDenom       = "uion"
+	SecondaryAmount      = sdk.NewInt(100000000)
+	baseTestAccts        = []sdk.AccAddress{}
+	defaultTestStartTime = time.Now().UTC()
 )
+
+func init() {
+	baseTestAccts = CreateRandomAccounts(3)
+}
 
 // Setup sets up basic environment for suite (App, Ctx, and test accounts)
 // preserves the caching enabled/disabled state.
@@ -99,7 +106,7 @@ func (s *KeeperTestHelper) SetupWithLevelDb() func() {
 }
 
 func (s *KeeperTestHelper) setupGeneral() {
-	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "osmosis-1", Time: defaultTestStartTime})
 	if s.withCaching {
 		s.Ctx, _ = s.Ctx.CacheContext()
 	}
@@ -109,7 +116,8 @@ func (s *KeeperTestHelper) setupGeneral() {
 	}
 
 	s.SetEpochStartTime()
-	s.TestAccs = CreateRandomAccounts(3)
+	s.TestAccs = []sdk.AccAddress{}
+	s.TestAccs = append(s.TestAccs, baseTestAccts...)
 	s.SetupConcentratedLiquidityDenomsAndPoolCreation()
 	s.hasUsedAbci = false
 }
@@ -190,8 +198,8 @@ func (s *KeeperTestHelper) SetupValidator(bondStatus stakingtypes.BondStatus) sd
 	s.FundAcc(sdk.AccAddress(valAddr), selfBond)
 
 	stakingHandler := staking.NewHandler(*s.App.StakingKeeper)
-	stakingCoin := sdk.NewCoin(sdk.DefaultBondDenom, selfBond[0].Amount)
-	ZeroCommission := stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	stakingCoin := sdk.Coin{Denom: bondDenom, Amount: selfBond[0].Amount}
+	ZeroCommission := stakingtypes.NewCommissionRates(zeroDec, zeroDec, zeroDec)
 	msg, err := stakingtypes.NewMsgCreateValidator(valAddr, valPub, stakingCoin, stakingtypes.Description{}, ZeroCommission, sdk.OneInt())
 	s.Require().NoError(err)
 	res, err := stakingHandler(s.Ctx, msg)
@@ -491,29 +499,30 @@ func TestMessageAuthzSerialization(t *testing.T, msg sdk.Msg) {
 		mockMsgExec   authz.MsgExec
 	)
 
+	// mutates mockMsg
+	testSerDeser := func(msg proto.Message, mockMsg proto.Message) {
+		msgGrantBytes := json.RawMessage(sdk.MustSortJSON(authzcodec.ModuleCdc.MustMarshalJSON(msg)))
+		err := authzcodec.ModuleCdc.UnmarshalJSON(msgGrantBytes, mockMsg)
+		require.NoError(t, err)
+	}
+
 	// Authz: Grant Msg
 	typeURL := sdk.MsgTypeURL(msg)
 	grant, err := authz.NewGrant(someDate, authz.NewGenericAuthorization(typeURL), someDate.Add(time.Hour))
 	require.NoError(t, err)
 
 	msgGrant := authz.MsgGrant{Granter: mockGranter, Grantee: mockGrantee, Grant: grant}
-	msgGrantBytes := json.RawMessage(sdk.MustSortJSON(authzcodec.ModuleCdc.MustMarshalJSON(&msgGrant)))
-	err = authzcodec.ModuleCdc.UnmarshalJSON(msgGrantBytes, &mockMsgGrant)
-	require.NoError(t, err)
+	testSerDeser(&msgGrant, &mockMsgGrant)
 
 	// Authz: Revoke Msg
 	msgRevoke := authz.MsgRevoke{Granter: mockGranter, Grantee: mockGrantee, MsgTypeUrl: typeURL}
-	msgRevokeByte := json.RawMessage(sdk.MustSortJSON(authzcodec.ModuleCdc.MustMarshalJSON(&msgRevoke)))
-	err = authzcodec.ModuleCdc.UnmarshalJSON(msgRevokeByte, &mockMsgRevoke)
-	require.NoError(t, err)
+	testSerDeser(&msgRevoke, &mockMsgRevoke)
 
 	// Authz: Exec Msg
 	msgAny, err := cdctypes.NewAnyWithValue(msg)
 	require.NoError(t, err)
 	msgExec := authz.MsgExec{Grantee: mockGrantee, Msgs: []*cdctypes.Any{msgAny}}
-	execMsgByte := json.RawMessage(sdk.MustSortJSON(authzcodec.ModuleCdc.MustMarshalJSON(&msgExec)))
-	err = authzcodec.ModuleCdc.UnmarshalJSON(execMsgByte, &mockMsgExec)
-	require.NoError(t, err)
+	testSerDeser(&msgExec, &mockMsgExec)
 	require.Equal(t, msgExec.Msgs[0].Value, mockMsgExec.Msgs[0].Value)
 }
 

--- a/osmoutils/accum/accum_test.go
+++ b/osmoutils/accum/accum_test.go
@@ -1685,8 +1685,6 @@ func (suite *AccumTestSuite) TestAddToUnclaimedRewards() {
 
 	for name, tc := range tests {
 		suite.Run(name, func() {
-
-			// Setup
 			err := accObject.NewPositionIntervalAccumulation(validPositionName, sdk.OneDec(), initialCoinsDenomOne, nil)
 			suite.Require().NoError(err)
 
@@ -1746,7 +1744,6 @@ func (suite *AccumTestSuite) TestDeletePosition() {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		suite.Run(name, func() {
 			suite.SetupTest()
 

--- a/x/gamm/keeper/migrate_test.go
+++ b/x/gamm/keeper/migrate_test.go
@@ -8,13 +8,14 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v16/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v16/x/gamm/types"
 	gammmigration "github.com/osmosis-labs/osmosis/v16/x/gamm/types/migration"
 	poolincentivestypes "github.com/osmosis-labs/osmosis/v16/x/pool-incentives/types"
 )
 
 func (s *KeeperTestSuite) TestMigrate() {
-	defaultAccount := s.TestAccs[0]
+	defaultAccount := apptesting.CreateRandomAccounts(1)[0]
 	defaultGammShares := sdk.NewCoin("gamm/pool/1", sdk.MustNewDecFromStr("100000000000000000000").RoundInt())
 	invalidGammShares := sdk.NewCoin("gamm/pool/1", sdk.MustNewDecFromStr("190000000000000000001").RoundInt())
 	defaultAccountFunds := sdk.NewCoins(sdk.NewCoin("eth", sdk.NewInt(200000000000)), sdk.NewCoin("usdc", sdk.NewInt(200000000000)))

--- a/x/poolmanager/create_pool_test.go
+++ b/x/poolmanager/create_pool_test.go
@@ -221,8 +221,6 @@ func (s *KeeperTestSuite) TestCreatePool() {
 
 	for i, tc := range tests {
 		s.Run(tc.name, func() {
-			tc := tc
-
 			if tc.isPermissionlessPoolCreationDisabled {
 				params := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
 				params.IsPermissionlessPoolCreationEnabled = false
@@ -262,8 +260,6 @@ func (s *KeeperTestSuite) TestCreatePool() {
 
 // Tests that only poolmanager as a pool creator can create a pool via CreatePoolZeroLiquidityNoCreationFee
 func (s *KeeperTestSuite) TestCreatePoolZeroLiquidityNoCreationFee() {
-	s.SetupTest()
-
 	poolManagerModuleAcc := s.App.AccountKeeper.GetModuleAccount(s.Ctx, types.ModuleName)
 
 	withCreator := func(msg clmodel.MsgCreateConcentratedPool, address sdk.AccAddress) clmodel.MsgCreateConcentratedPool {
@@ -309,8 +305,6 @@ func (s *KeeperTestSuite) TestCreatePoolZeroLiquidityNoCreationFee() {
 
 	for i, tc := range tests {
 		s.Run(tc.name, func() {
-			tc := tc
-
 			poolmanagerKeeper := s.App.PoolManagerKeeper
 			ctx := s.Ctx
 
@@ -394,8 +388,6 @@ func (s *KeeperTestSuite) TestSetAndGetAllPoolRoutes() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			tc := tc
-
 			s.Setup()
 			poolManagerKeeper := s.App.PoolManagerKeeper
 
@@ -429,7 +421,6 @@ func (s *KeeperTestSuite) TestGetNextPoolIdAndIncrement() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			tc := tc
 			s.Setup()
 
 			s.App.PoolManagerKeeper.SetNextPoolId(s.Ctx, tc.expectedNextPoolId)
@@ -480,7 +471,6 @@ func (s *KeeperTestSuite) TestValidateCreatedPool() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			tc := tc
 			s.Setup()
 
 			// System under test.

--- a/x/poolmanager/keeper_test.go
+++ b/x/poolmanager/keeper_test.go
@@ -66,8 +66,6 @@ func (s *KeeperTestSuite) createBalancerPoolsFromCoins(poolCoins []sdk.Coins) {
 }
 
 func (s *KeeperTestSuite) TestInitGenesis() {
-	s.Setup()
-
 	s.App.PoolManagerKeeper.InitGenesis(s.Ctx, &types.GenesisState{
 		Params: types.Params{
 			PoolCreationFee: testPoolCreationFee,
@@ -82,8 +80,6 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 }
 
 func (s *KeeperTestSuite) TestExportGenesis() {
-	s.Setup()
-
 	s.App.PoolManagerKeeper.InitGenesis(s.Ctx, &types.GenesisState{
 		Params: types.Params{
 			PoolCreationFee: testPoolCreationFee,

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -143,7 +143,6 @@ func (s *KeeperTestSuite) TestGetPoolModule() {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		s.Run(name, func() {
 			s.SetupTest()
 			poolmanagerKeeper := s.App.PoolManagerKeeper
@@ -219,7 +218,6 @@ func (s *KeeperTestSuite) TestRouteGetPoolDenoms() {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		s.Run(name, func() {
 			s.SetupTest()
 			poolmanagerKeeper := s.App.PoolManagerKeeper

--- a/x/superfluid/keeper/concentrated_liquidity_test.go
+++ b/x/superfluid/keeper/concentrated_liquidity_test.go
@@ -8,6 +8,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v16/app/apptesting"
 	cltypes "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/osmosis/v16/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v16/x/superfluid/types"
@@ -15,8 +16,7 @@ import (
 
 func (s *KeeperTestSuite) TestAddToConcentratedLiquiditySuperfluidPosition() {
 	defaultJoinTime := s.Ctx.BlockTime()
-	owner := s.TestAccs[0]
-	nonOwner := s.TestAccs[1]
+	owner, nonOwner := apptesting.CreateRandomAccounts(1)[0], apptesting.CreateRandomAccounts(1)[0]
 	type sendTest struct {
 		superfluidDelegated    bool
 		superfluidUndelegating bool


### PR DESCRIPTION
Some small driveby apptesting changes, nothing in this PR really matters though.

Does mild speedups by:
- reusing decimals for preparing balancer pools
- no longer gets time.Now on every reset
- no longer generate new accounts on every reset call