### PR TITLE
fix: change dai amount e2e

### DIFF
--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -71,6 +71,7 @@ const (
 	StakeAmountA  = 100000000000
 	UstBalanceA   = 500000000000000
 	LuncBalanceA  = 500000000000000
+	DaiBalanceA   = "100000000000000000000000"
 	// chainB
 	ChainBID          = "osmo-test-b"
 	OsmoBalanceB      = 500000000000
@@ -93,9 +94,7 @@ var (
 	StakeAmountIntB  = sdk.NewInt(StakeAmountB)
 	StakeAmountCoinB = sdk.NewCoin(OsmoDenom, StakeAmountIntB)
 
-	// Pool balances for testing Stride migration in v15.
-	// Can be removed after v15 upgrade.
-	DaiOsmoPoolBalances = fmt.Sprintf("%d%s", LuncBalanceA, DaiDenom)
+	DaiOsmoPoolBalances = fmt.Sprintf("%s%s", DaiBalanceA, DaiDenom)
 
 	InitBalanceStrA = fmt.Sprintf("%d%s,%d%s,%d%s,%d%s,%d%s", OsmoBalanceA, OsmoDenom, StakeBalanceA, StakeDenom, IonBalanceA, IonDenom, UstBalanceA, UstIBCDenom, LuncBalanceA, LuncIBCDenom)
 	InitBalanceStrB = fmt.Sprintf("%d%s,%d%s,%d%s", OsmoBalanceB, OsmoDenom, StakeBalanceB, StakeDenom, IonBalanceB, IonDenom)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We need our init image to fund the e2e accounts with enough DAI to create the DAI osmo pool for e2e. We were operating on incorrect assumptions for DAI precision previously. 

This was tested locally with v16 (using this as the init image) and passed the previously failing test.