### PR TITLE
Fix generate docs CI

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,54 +1,47 @@
-name: Generate Docs
+name: Update Docs
 
-on: 
+on:
   workflow_dispatch:
 
 jobs:
-  generate-docs:
+  update-docs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
+    - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Setup Go
-      uses: actions/setup-go@v4
+    - name: Set up Go
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.20
+        go-version: 1.18 
 
-    - name: Install yq
+    - name: Install Protoc
       run: |
-        sudo wget https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64 -O /usr/bin/yq
-        sudo chmod +x /usr/bin/yq
-
-    - name: Install protobuf compiler
-      run: |
+        sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '14'
-
-    - name: Run the script
-      run: bash ./scripts/generate-docs.sh
-
-    - name: Commit files
+    - name: Install Protoc-gen-swagger
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add -A
-        git commit -m "Add changes" || exit 0  
+        go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@latest
 
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Statik
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y golang-statik
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run make docs
+      run: |
+        make docs
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        title: "Generated docs updates"
-        body: "Updates to generated docs"
-        branch: "generate-docs-updates"
+        commit-message: Update docs
+        title: 'Update docs'
+        body: 'Update docs'
+        branch: 'docs-update-branch'

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18 
+        go-version: 1.20
 
     - name: Install Protoc
       run: |
@@ -38,7 +38,7 @@ jobs:
         make docs
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update docs

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.20
+        go-version: 1.18 
 
     - name: Install Protoc
       run: |
@@ -38,7 +38,7 @@ jobs:
         make docs
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update docs

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -38,7 +38,7 @@ jobs:
         make docs
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update docs


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
In https://github.com/osmosis-labs/osmosis/pull/5627 we have added CI run for generating docs, with an attachment of a succesful workflow. (https://github.com/mattverse/osmosis/actions/runs/5374789925 and https://github.com/mattverse/osmosis/pull/15).

However, I have noticed that I have created a PR off of the incorrect version, thus creating this PR with the working version 
that matches https://github.com/mattverse/osmosis/pull/14

## Testing and Verifying
Correct code has been used
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A