### PR TITLE
[CL][tests]: Add all remaining intended test vectors from original tracking issue

### DIFF
--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -482,7 +482,7 @@ func (s *KeeperTestSuite) runMultiplePositionRanges(ranges [][]int64, rangeTestP
 	rand.Seed(2)
 
 	// TODO: add pool-related fuzz params (spread factor & number of pools)
-	pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, DefaultSpreadFactor)
+	pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, rangeTestParams.tickSpacing, rangeTestParams.spreadFactor)
 
 	// Run full state determined by params while asserting invariants at each intermediate step
 	s.setupRangesAndAssertInvariants(pool, ranges, rangeTestParams)

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2448,7 +2448,7 @@ func (s *KeeperTestSuite) TestMultipleRanges() {
 			tickRanges: [][]int64{
 				{0, 100},
 			},
-			rangeTestParams: withTickSpacing(DefaultRangeTestParams, uint64(100)),
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
 		},
 		"two adjacent ranges": {
 			tickRanges: [][]int64{
@@ -2510,7 +2510,7 @@ func (s *KeeperTestSuite) TestMultipleRanges() {
 			tickRanges: [][]int64{
 				{207000000, 207000000 + 100},
 			},
-			rangeTestParams: withTickSpacing(DefaultRangeTestParams, uint64(100)),
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
 		},
 		"one position adjacent to left of current tick (no swaps)": {
 			tickRanges: [][]int64{
@@ -2583,7 +2583,7 @@ func (s *KeeperTestSuite) TestMultipleRanges() {
 			tickRanges: [][]int64{
 				{types.MaxTick - 100, types.MaxTick},
 			},
-			rangeTestParams: withTickSpacing(DefaultRangeTestParams, uint64(100)),
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
 		},
 		"initial current tick equal to max tick": {
 			tickRanges: [][]int64{

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2448,7 +2448,7 @@ func (s *KeeperTestSuite) TestMultipleRanges() {
 			tickRanges: [][]int64{
 				{0, 100},
 			},
-			rangeTestParams: DefaultRangeTestParams,
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, uint64(100)),
 		},
 		"two adjacent ranges": {
 			tickRanges: [][]int64{
@@ -2457,16 +2457,141 @@ func (s *KeeperTestSuite) TestMultipleRanges() {
 			},
 			rangeTestParams: DefaultRangeTestParams,
 		},
+		"two adjacent ranges with current tick smaller than both": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -20000),
+		},
+		"two adjacent ranges with current tick larger than both": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 30000),
+		},
+		"two adjacent ranges with current tick exactly on lower bound": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -10000),
+		},
+		"two adjacent ranges with current tick exactly between both": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 10000),
+		},
+		"two adjacent ranges with current tick exactly on upper bound": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 20000),
+		},
+		"two non-adjacent ranges": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{20000, 30000},
+			},
+			rangeTestParams: DefaultRangeTestParams,
+		},
+		"two ranges with one tick gap in between, which is equal to current tick": {
+			tickRanges: [][]int64{
+				{799221, 799997},
+				{799997 + 2, 812343},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 799997+1),
+		},
 		"one range on large tick": {
 			tickRanges: [][]int64{
 				{207000000, 207000000 + 100},
 			},
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, uint64(100)),
+		},
+		"one position adjacent to left of current tick (no swaps)": {
+			tickRanges: [][]int64{
+				{-1, 0},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one position on left of current tick with gap (no swaps)": {
+			tickRanges: [][]int64{
+				{-2, -1},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one position adjacent to right of current tick (no swaps)": {
+			tickRanges: [][]int64{
+				{0, 1},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one position on right of current tick with gap (no swaps)": {
+			tickRanges: [][]int64{
+				{1, 2},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
 		},
 		"one range on small tick": {
 			tickRanges: [][]int64{
 				{-107000000, -107000000 + 100},
 			},
+			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
 		},
+		"one range on min tick": {
+			tickRanges: [][]int64{
+				{types.MinInitializedTick, types.MinInitializedTick + 100},
+			},
+			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
+		},
+		"initial current tick equal to min initialized tick": {
+			tickRanges: [][]int64{
+				{0, 1},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, types.MinInitializedTick),
+		},
+		"three overlapping ranges with no swaps, current tick in one": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{0, 20000},
+				{-7300, 12345},
+			},
+			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -9000)),
+		},
+		"three overlapping ranges with no swaps, current tick in two of three": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{0, 20000},
+				{-7300, 12345},
+			},
+			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -7231)),
+		},
+		"three overlapping ranges with no swaps, current tick in all three": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{0, 20000},
+				{-7300, 12345},
+			},
+			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, 109)),
+		},
+		/* TODO: uncomment when infinite loop bug is fixed
+		"one range on max tick": {
+			tickRanges: [][]int64{
+				{types.MaxTick - 100, types.MaxTick},
+			},
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, uint64(100)),
+		},
+		"initial current tick equal to max tick": {
+			tickRanges: [][]int64{
+				{0, 1},
+			},
+			rangeTestParams: withCurrentTick(withTickSpacing(DefaultRangeTestParams, uint64(1)), types.MaxTick),
+		},
+		*/
 	}
 
 	for name, tc := range tests {

--- a/x/concentrated-liquidity/range_test.go
+++ b/x/concentrated-liquidity/range_test.go
@@ -412,11 +412,11 @@ func (s *KeeperTestSuite) trackEmittedIncentives(cumulativeTrackedIncentives sdk
 		if recordStartTime.Before(lastTrackerUpdateTime) {
 			// If the record started emitting prior to the last incentiveCreationTime (the last time we checkpointed),
 			// then we assume it has been emitting for the whole period since then.
-			secondsEmitted = sdk.NewDec(int64(s.Ctx.BlockTime().Sub(lastTrackerUpdateTime))).Quo(sdk.MustNewDecFromStr("1000000000"))
+			secondsEmitted = sdk.NewDec(int64(s.Ctx.BlockTime().Sub(lastTrackerUpdateTime))).QuoInt64(int64(time.Second))
 		} else if recordStartTime.Before(s.Ctx.BlockTime()) {
 			// If the record started emitting between the last incentiveCreationTime and now, then we only track the
 			// emissions between when it started and now.
-			secondsEmitted = sdk.NewDec(int64(s.Ctx.BlockTime().Sub(recordStartTime))).Quo(sdk.MustNewDecFromStr("1000000000"))
+			secondsEmitted = sdk.NewDec(int64(s.Ctx.BlockTime().Sub(recordStartTime))).QuoInt64(int64(time.Second))
 		}
 
 		emissionRate := incentiveRecord.IncentiveRecordBody.EmissionRate

--- a/x/concentrated-liquidity/range_test.go
+++ b/x/concentrated-liquidity/range_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v16/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
 )
 
@@ -31,6 +32,11 @@ type RangeTestParams struct {
 	// List of addresses to swap from (randomly selected for each swap)
 	numSwapAddresses int
 
+	// -- Pool params --
+
+	spreadFactor sdk.Dec
+	tickSpacing  uint64
+
 	// -- Fuzz params --
 
 	fuzzAssets           bool
@@ -47,6 +53,13 @@ type RangeTestParams struct {
 	newActiveIncentivesBetweenJoins bool
 	// Create new inactive incentive records between each join
 	newInactiveIncentivesBetweenJoins bool
+	// Fund each position address with double the expected amount of assets.
+	// Should only be used for cases where join amount gets pushed up due to
+	// precision near min tick.
+	doubleFundPositionAddr bool
+	// Adjust input amounts for first position to set the starting current tick
+	// to the given value.
+	startingCurrentTick int64
 }
 
 var (
@@ -61,13 +74,70 @@ var (
 		baseEmissionRate:     sdk.NewDec(1),
 		baseIncentiveDenom:   "incentiveDenom",
 
+		// Pool params
+		spreadFactor: DefaultSpreadFactor,
+		tickSpacing:  uint64(1),
+
 		// Fuzz params
 		fuzzNumPositions:     true,
 		fuzzAssets:           true,
 		fuzzSwapAmounts:      true,
 		fuzzTimeBetweenJoins: true,
 	}
+	RangeTestParamsLargeSwap = RangeTestParams{
+		// Base amounts
+		baseNumPositions:     10,
+		baseAssets:           sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(5000000000)), sdk.NewCoin(USDC, sdk.NewInt(5000000000))),
+		baseTimeBetweenJoins: time.Hour,
+		baseSwapAmount:       sdk.Int(sdk.MustNewDecFromStr("100000000000000000000000000000000000000")),
+		numSwapAddresses:     10,
+		baseIncentiveAmount:  sdk.NewInt(1000000000000000000),
+		baseEmissionRate:     sdk.NewDec(1),
+		baseIncentiveDenom:   "incentiveDenom",
+
+		// Pool params
+		spreadFactor: DefaultSpreadFactor,
+		tickSpacing:  uint64(100),
+
+		// Fuzz params
+		fuzzNumPositions:     true,
+		fuzzAssets:           true,
+		fuzzTimeBetweenJoins: true,
+	}
+	RangeTestParamsNoFuzzNoSwap = RangeTestParams{
+		// Base amounts
+		baseNumPositions:     1,
+		baseAssets:           sdk.NewCoins(sdk.NewCoin(ETH, sdk.NewInt(5000000000)), sdk.NewCoin(USDC, sdk.NewInt(5000000000))),
+		baseTimeBetweenJoins: time.Hour,
+		baseIncentiveAmount:  sdk.NewInt(1000000000000000000),
+		baseEmissionRate:     sdk.NewDec(1),
+		baseIncentiveDenom:   "incentiveDenom",
+
+		// Pool params
+		spreadFactor: DefaultSpreadFactor,
+		tickSpacing:  uint64(1),
+	}
 )
+
+func withDoubleFundedLP(params RangeTestParams) RangeTestParams {
+	params.doubleFundPositionAddr = true
+	return params
+}
+
+func withCurrentTick(params RangeTestParams, tick int64) RangeTestParams {
+	params.startingCurrentTick = tick
+	return params
+}
+
+func withTickSpacing(params RangeTestParams, tickSpacing uint64) RangeTestParams {
+	params.tickSpacing = tickSpacing
+	return params
+}
+
+func withNoSwap(params RangeTestParams) RangeTestParams {
+	params.baseSwapAmount = sdk.Int{}
+	return params
+}
 
 // setupRangesAndAssertInvariants sets up the state specified by `testParams` on the given set of ranges.
 // It also asserts global invariants at each intermediate step.
@@ -125,8 +195,19 @@ func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.Concentrated
 
 			// Set up assets for new position
 			curAssets := getRandomizedAssets(testParams.baseAssets, testParams.fuzzAssets)
+
+			// If a desired current tick was specified, retrieve special asset amounts for the first position
+			if testParams.startingCurrentTick != 0 && curNumPositions == 0 {
+				curAssets = s.getInitialPositionAssets(pool, testParams.startingCurrentTick)
+			}
+
 			roundingError := sdk.NewCoins(sdk.NewCoin(pool.GetToken0(), sdk.OneInt()), sdk.NewCoin(pool.GetToken1(), sdk.OneInt()))
 			s.FundAcc(curAddr, curAssets.Add(roundingError...))
+
+			// Double fund LP address if applicable
+			if testParams.doubleFundPositionAddr {
+				s.FundAcc(curAddr, curAssets.Add(roundingError...))
+			}
 
 			// TODO: implement intermediate record creation with fuzzing
 
@@ -151,7 +232,10 @@ func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.Concentrated
 
 			// Track changes to state
 			actualAddedCoins := sdk.NewCoins(sdk.NewCoin(pool.GetToken0(), actualAmt0), sdk.NewCoin(pool.GetToken1(), actualAmt1))
-			totalAssets = totalAssets.Add(actualAddedCoins...).Add(swappedIn).Sub(sdk.NewCoins(swappedOut))
+			totalAssets = totalAssets.Add(actualAddedCoins...)
+			if testParams.baseSwapAmount != (sdk.Int{}) {
+				totalAssets = totalAssets.Add(swappedIn).Sub(sdk.NewCoins(swappedOut))
+			}
 			totalLiquidity = totalLiquidity.Add(curLiquidity)
 			totalTimeElapsed = totalTimeElapsed + timeElapsed
 			allPositionIds = append(allPositionIds, curPositionId)
@@ -174,7 +258,6 @@ func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.Concentrated
 	// We rebuild coins to handle nil cases cleanly
 	s.Require().Equal(sdk.NewCoins(totalAssets...), sdk.NewCoins(poolAssets.Add(poolSpreadRewards...)...))
 
-	fmt.Println("cumulative emitted incentives: ", cumulativeEmittedIncentives)
 	// Do a final checkpoint for incentives and then run assertions on expected global claimable value
 	cumulativeEmittedIncentives, lastIncentiveTrackerUpdate = s.trackEmittedIncentives(cumulativeEmittedIncentives, lastIncentiveTrackerUpdate)
 	truncatedEmissions, _ := cumulativeEmittedIncentives.TruncateDecimal()
@@ -266,6 +349,19 @@ func (s *KeeperTestSuite) executeRandomizedSwap(pool types.ConcentratedPoolExten
 
 	swapOutCoin := sdk.NewCoin(swapOutDenom, baseSwapOutAmount)
 
+	// If the swap we're about to execute will not generate enough input, we skip the swap.
+	if swapOutDenom == pool.GetToken1() {
+		pool, err := s.clk.GetPoolById(s.Ctx, pool.GetId())
+		s.Require().NoError(err)
+
+		poolSpotPrice := pool.GetCurrentSqrtPrice().Power(2)
+		minSwapOutAmount := poolSpotPrice.Mul(sdk.SmallestDec()).TruncateInt()
+		poolBalances := s.App.BankKeeper.GetAllBalances(s.Ctx, pool.GetAddress())
+		if poolBalances.AmountOf(swapOutDenom).LTE(minSwapOutAmount) {
+			return sdk.Coin{}, sdk.Coin{}
+		}
+	}
+
 	// Note that we set the price limit to zero to ensure that the swap can execute in either direction (gets automatically set to correct limit)
 	swappedIn, swappedOut, _, err := s.clk.SwapInAmtGivenOut(s.Ctx, swapAddress, pool, swapOutCoin, swapInDenom, pool.GetSpreadFactor(s.Ctx), sdk.ZeroDec())
 	s.Require().NoError(err)
@@ -312,27 +408,44 @@ func (s *KeeperTestSuite) trackEmittedIncentives(cumulativeTrackedIncentives sdk
 			continue
 		}
 
-		secondsEmitted := int64(0)
+		secondsEmitted := sdk.ZeroDec()
 		if recordStartTime.Before(lastTrackerUpdateTime) {
 			// If the record started emitting prior to the last incentiveCreationTime (the last time we checkpointed),
 			// then we assume it has been emitting for the whole period since then.
-			secondsEmitted = int64(s.Ctx.BlockTime().Sub(lastTrackerUpdateTime).Seconds())
+			secondsEmitted = sdk.NewDec(int64(s.Ctx.BlockTime().Sub(lastTrackerUpdateTime))).Quo(sdk.MustNewDecFromStr("1000000000"))
 		} else if recordStartTime.Before(s.Ctx.BlockTime()) {
 			// If the record started emitting between the last incentiveCreationTime and now, then we only track the
 			// emissions between when it started and now.
-			secondsEmitted = int64(s.Ctx.BlockTime().Sub(recordStartTime).Seconds())
+			secondsEmitted = sdk.NewDec(int64(s.Ctx.BlockTime().Sub(recordStartTime))).Quo(sdk.MustNewDecFromStr("1000000000"))
 		}
 
 		emissionRate := incentiveRecord.IncentiveRecordBody.EmissionRate
 		incentiveDenom := incentiveRecord.IncentiveRecordBody.RemainingCoin.Denom
 
 		// Track emissions for the current record
-		emittedAmount := emissionRate.MulInt64(secondsEmitted)
+		emittedAmount := emissionRate.Mul(secondsEmitted)
 		emittedDecCoin := sdk.NewDecCoinFromDec(incentiveDenom, emittedAmount)
 		updatedTrackedIncentives = updatedTrackedIncentives.Add(emittedDecCoin)
 	}
 
 	return updatedTrackedIncentives, s.Ctx.BlockTime()
+}
+
+// getInitialPositionAssets returns the assets required for the first position in a pool to set the initial current tick to the given value.
+func (s *KeeperTestSuite) getInitialPositionAssets(pool types.ConcentratedPoolExtension, initialCurrentTick int64) sdk.Coins {
+	requiredPrice, err := math.TickToPrice(initialCurrentTick)
+	s.Require().NoError(err)
+
+	// Calculate asset amounts that would be required to get the required spot price (rounding up on asset1 to ensure we stay in the intended tick)
+	asset0Amount := sdk.NewInt(100000000000000)
+	asset1Amount := sdk.NewDecFromInt(asset0Amount).Mul(requiredPrice).Ceil().TruncateInt()
+
+	assetCoins := sdk.NewCoins(
+		sdk.NewCoin(pool.GetToken0(), asset0Amount),
+		sdk.NewCoin(pool.GetToken1(), asset1Amount),
+	)
+
+	return assetCoins
 }
 
 // getFuzzedAssets returns the base asset amount, fuzzing each asset if applicable


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5428

## What is the purpose of the change

This PR adds the remaining test vectors from #5428. No new issues were encountered while implementing these, but the existing infinite loop bug was hit by two test vectors that are left commented out in this PR.

## Testing and Verifying

- Added test cases can be found in `position_test.go`
- A few minor fixes were made to testing logic in `range_test.go`

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A