### PR TITLE
fix: modify v16 upgrade handler

### DIFF
--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -1,6 +1,7 @@
 package v16
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -134,24 +135,37 @@ func CreateUpgradeHandler(
 
 		// Get community pool and DAI/OSMO pool address.
 		communityPoolAddress := keepers.AccountKeeper.GetModuleAddress(distrtypes.ModuleName)
-		daiOsmoPool, err := keepers.PoolManagerKeeper.GetPool(ctx, DaiOsmoPoolId)
+
+		// Determine the amount of OSMO that can be bought with 1 DAI.
+		oneDai := sdk.NewCoin(DAIIBCDenom, sdk.NewInt(1000000000000000000))
+		daiOsmoGammPool, err := keepers.PoolManagerKeeper.GetPool(ctx, DaiOsmoPoolId)
 		if err != nil {
 			return nil, err
 		}
-
-		// Swap in a maximum of 10 OSMO for one DAI via the community pool.
-		oneDai := sdk.NewCoin(DAIIBCDenom, sdk.NewInt(1000000000000000000))
-		tokenInAmt, err := keepers.GAMMKeeper.SwapExactAmountOut(ctx, communityPoolAddress, daiOsmoPool, DesiredDenom0, sdk.NewInt(10000000), oneDai, sdk.ZeroDec())
+		respectiveOsmo, err := keepers.GAMMKeeper.CalcOutAmtGivenIn(ctx, daiOsmoGammPool, oneDai, DesiredDenom0, sdk.ZeroDec())
 		if err != nil {
 			return nil, err
 		}
 
 		// Create a full range position via the community pool with the funds that were swapped.
-		fullRangeOsmoDaiCoins := sdk.NewCoins(sdk.NewCoin(DesiredDenom0, tokenInAmt), oneDai)
+		fullRangeOsmoDaiCoins := sdk.NewCoins(respectiveOsmo, oneDai)
 		_, _, _, _, err = keepers.ConcentratedLiquidityKeeper.CreateFullRangePosition(ctx, clPoolId, communityPoolAddress, fullRangeOsmoDaiCoins)
 		if err != nil {
 			return nil, err
 		}
+
+		// Because we are doing a direct send from the community pool, we need to manually change the fee pool to reflect the change.
+
+		// Remove coins we used from the community pool to make the CL position
+		feePool := keepers.DistrKeeper.GetFeePool(ctx)
+		newPool, negative := feePool.CommunityPool.SafeSub(sdk.NewDecCoinsFromCoins(fullRangeOsmoDaiCoins...))
+		if negative {
+			return nil, fmt.Errorf("community pool cannot be negative: %s", newPool)
+		}
+
+		// Update and set the new fee pool
+		feePool.CommunityPool = newPool
+		keepers.DistrKeeper.SetFeePool(ctx, feePool)
 
 		// Add the cl pool's full range denom as an authorized superfluid asset.
 		superfluidAsset := superfluidtypes.SuperfluidAsset{

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -149,7 +149,7 @@ func CreateUpgradeHandler(
 
 		// Create a full range position via the community pool with the funds that were swapped.
 		fullRangeOsmoDaiCoins := sdk.NewCoins(respectiveOsmo, oneDai)
-		_, _, _, _, err = keepers.ConcentratedLiquidityKeeper.CreateFullRangePosition(ctx, clPoolId, communityPoolAddress, fullRangeOsmoDaiCoins)
+		_, actualOsmoAmtUsed, actualDaiAmtUsed, _, err := keepers.ConcentratedLiquidityKeeper.CreateFullRangePosition(ctx, clPoolId, communityPoolAddress, fullRangeOsmoDaiCoins)
 		if err != nil {
 			return nil, err
 		}
@@ -158,7 +158,8 @@ func CreateUpgradeHandler(
 
 		// Remove coins we used from the community pool to make the CL position
 		feePool := keepers.DistrKeeper.GetFeePool(ctx)
-		newPool, negative := feePool.CommunityPool.SafeSub(sdk.NewDecCoinsFromCoins(fullRangeOsmoDaiCoins...))
+		fulllRangeOsmoDaiCoinsUsed := sdk.NewCoins(sdk.NewCoin(DesiredDenom0, actualOsmoAmtUsed), sdk.NewCoin(DAIIBCDenom, actualDaiAmtUsed))
+		newPool, negative := feePool.CommunityPool.SafeSub(sdk.NewDecCoinsFromCoins(fulllRangeOsmoDaiCoinsUsed...))
 		if negative {
 			return nil, fmt.Errorf("community pool cannot be negative: %s", newPool)
 		}

--- a/app/upgrades/v16/upgrades_test.go
+++ b/app/upgrades/v16/upgrades_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -60,6 +61,11 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 		suite.Require().NoError(err)
 	}
 
+	// Allow 0.01% margin of error.
+	multiplicativeTolerance := osmomath.ErrTolerance{
+		MultiplicativeTolerance: sdk.MustNewDecFromStr("0.0001"),
+	}
+
 	testCases := []struct {
 		name         string
 		pre_upgrade  func()
@@ -78,23 +84,48 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 
 				// Create DAI / OSMO pool
 				suite.PrepareBalancerPoolWithCoins(daiCoin, desiredDenom0Coin)
+
 			},
 			func() {
 				stakingParams := suite.App.StakingKeeper.GetParams(suite.Ctx)
 				stakingParams.BondDenom = "uosmo"
 				suite.App.StakingKeeper.SetParams(suite.Ctx, stakingParams)
 
-				// Send one dai to the community pool (this is true in current mainnet)
 				oneDai := sdk.NewCoins(sdk.NewCoin(v16.DAIIBCDenom, sdk.NewInt(1000000000000000000)))
+
+				// Send one dai to the community pool (this is true in current mainnet)
 				suite.FundAcc(suite.TestAccs[0], oneDai)
 
 				err := suite.App.DistrKeeper.FundCommunityPool(suite.Ctx, oneDai, suite.TestAccs[0])
 				suite.Require().NoError(err)
 
+				// Determine approx how much OSMO will be used from community pool when 1 DAI used.
+				daiOsmoGammPool, err := suite.App.PoolManagerKeeper.GetPool(suite.Ctx, v16.DaiOsmoPoolId)
+				suite.Require().NoError(err)
+				respectiveOsmo, err := suite.App.GAMMKeeper.CalcOutAmtGivenIn(suite.Ctx, daiOsmoGammPool, oneDai[0], v16.DesiredDenom0, sdk.ZeroDec())
+				suite.Require().NoError(err)
+
+				// Retrieve the community pool balance before the upgrade
+				communityPoolAddress := suite.App.AccountKeeper.GetModuleAddress(distrtypes.ModuleName)
+				communityPoolBalancePre := suite.App.BankKeeper.GetAllBalances(suite.Ctx, communityPoolAddress)
+
 				dummyUpgrade(suite)
 				suite.Require().NotPanics(func() {
 					suite.App.BeginBlocker(suite.Ctx, abci.RequestBeginBlock{})
 				})
+
+				// Retrieve the community pool balance (and the feePool balance) after the upgrade
+				communityPoolBalancePost := suite.App.BankKeeper.GetAllBalances(suite.Ctx, communityPoolAddress)
+				feePoolCommunityPoolPost := suite.App.DistrKeeper.GetFeePool(suite.Ctx).CommunityPool
+
+				// Validate that the community pool balance has been reduced by the amount of OSMO that was used to create the pool
+				// Note we use all the osmo, but a small amount of DAI is left over due to rounding when creating the first position.
+				suite.Require().Equal(communityPoolBalancePre.AmountOf("uosmo").Sub(respectiveOsmo.Amount).String(), communityPoolBalancePost.AmountOf("uosmo").String())
+				suite.Require().Equal(0, multiplicativeTolerance.Compare(communityPoolBalancePre.AmountOf(v16.DAIIBCDenom), oneDai[0].Amount.Sub(communityPoolBalancePost.AmountOf(v16.DAIIBCDenom))))
+
+				// Validate that the fee pool community pool balance has been decreased by the amount of OSMO/DAI that was used to create the pool
+				suite.Require().Equal(communityPoolBalancePost.AmountOf("uosmo").String(), feePoolCommunityPoolPost.AmountOf("uosmo").TruncateInt().String())
+				suite.Require().Equal(communityPoolBalancePost.AmountOf(v16.DAIIBCDenom).String(), feePoolCommunityPoolPost.AmountOf(v16.DAIIBCDenom).TruncateInt().String())
 
 				// Get balancer pool's spot price.
 				balancerSpotPrice, err := suite.App.GAMMKeeper.CalculateSpotPrice(suite.Ctx, v16.DaiOsmoPoolId, v16.DAIIBCDenom, v16.DesiredDenom0)
@@ -110,11 +141,6 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 				suite.Require().True(ok)
 				suite.Require().Equal(v16.DesiredDenom0, concentratedTypePool.GetToken0())
 				suite.Require().Equal(v16.DAIIBCDenom, concentratedTypePool.GetToken1())
-
-				// Allow 0.01% margin of error.
-				multiplicativeTolerance := osmomath.ErrTolerance{
-					MultiplicativeTolerance: sdk.MustNewDecFromStr("0.0001"),
-				}
 
 				// Validate that the spot price of the CL pool is what we expect
 				suite.Require().Equal(0, multiplicativeTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(concentratedTypePool.GetCurrentSqrtPrice().Power(2)), osmomath.BigDecFromSDKDec(balancerSpotPrice)))

--- a/app/upgrades/v16/upgrades_test.go
+++ b/app/upgrades/v16/upgrades_test.go
@@ -83,6 +83,14 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 				stakingParams := suite.App.StakingKeeper.GetParams(suite.Ctx)
 				stakingParams.BondDenom = "uosmo"
 				suite.App.StakingKeeper.SetParams(suite.Ctx, stakingParams)
+
+				// Send one dai to the community pool (this is true in current mainnet)
+				oneDai := sdk.NewCoins(sdk.NewCoin(v16.DAIIBCDenom, sdk.NewInt(1000000000000000000)))
+				suite.FundAcc(suite.TestAccs[0], oneDai)
+
+				err := suite.App.DistrKeeper.FundCommunityPool(suite.Ctx, oneDai, suite.TestAccs[0])
+				suite.Require().NoError(err)
+
 				dummyUpgrade(suite)
 				suite.Require().NotPanics(func() {
 					suite.App.BeginBlocker(suite.Ctx, abci.RequestBeginBlock{})

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -391,6 +391,14 @@ func (n *NodeConfig) BankSend(amount string, sendAddress string, receiveAddress 
 	n.LogActionF("successfully sent bank sent %s from address %s to %s", amount, sendAddress, receiveAddress)
 }
 
+func (n *NodeConfig) FundCommunityPool(sendAddress string, funds string) {
+	n.LogActionF("funding community pool from address %s with %s", sendAddress, funds)
+	cmd := []string{"osmosisd", "tx", "distribution", "fund-community-pool", funds, fmt.Sprintf("--from=%s", sendAddress)}
+	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
+	require.NoError(n.t, err)
+	n.LogActionF("successfully funded community pool from address %s with %s", sendAddress, funds)
+}
+
 // This method also funds fee tokens from the `initialization.ValidatorWalletName` account.
 // TODO: Abstract this to be a fee token provider account.
 func (n *NodeConfig) CreateWallet(walletName string) string {

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	appparams "github.com/osmosis-labs/osmosis/v16/app/params"
+	v16 "github.com/osmosis-labs/osmosis/v16/app/upgrades/v16"
 	"github.com/osmosis-labs/osmosis/v16/tests/e2e/configurer/chain"
 	"github.com/osmosis-labs/osmosis/v16/tests/e2e/configurer/config"
 	"github.com/osmosis-labs/osmosis/v16/tests/e2e/containers"
@@ -168,6 +169,13 @@ func (uc *UpgradeConfigurer) CreatePreUpgradeState() error {
 
 	// test lock and add to existing lock for both regular and superfluid lockups (only chainA)
 	chainA.LockAndAddToExistingLock(sdk.NewInt(1000000000000000000), poolShareDenom, config.LockupWallet, config.LockupWalletSuperfluid)
+
+	// fund the community pool with one dai
+	oneDai := sdk.NewCoin(v16.DAIIBCDenom, sdk.NewInt(1000000000000000000))
+	communityPoolFunder := chainANode.CreateWalletAndFund("communityPoolFunder", []string{
+		oneDai.String(),
+	})
+	chainANode.FundCommunityPool(communityPoolFunder, oneDai.String())
 
 	return nil
 }

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -177,6 +177,11 @@ func (uc *UpgradeConfigurer) CreatePreUpgradeState() error {
 	})
 	chainANode.FundCommunityPool(communityPoolFunder, oneDai.String())
 
+	communityPoolFunder = chainBNode.CreateWalletAndFund("communityPoolFunder", []string{
+		oneDai.String(),
+	})
+	chainBNode.FundCommunityPool(communityPoolFunder, oneDai.String())
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The community pool now has the DAI it needs to create the first position, so the logic for swapping is now removed.

Additionally, since we send funds via the community pool, the community pool entry in feePool within the distribution module must also be manually set. This was discovered via state exported testnets.
