### PR TITLE
CLI fix: `create-gauge` exact args

### DIFF
--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -33,7 +33,7 @@ func NewCreateGaugeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-gauge [lockup_denom] [reward] [poolId] [flags]",
 		Short: "create a gauge to distribute rewards to users",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {

--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -32,7 +32,7 @@ func GetTxCmd() *cobra.Command {
 func NewCreateGaugeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-gauge [lockup_denom] [reward] [poolId] [flags]",
-		Short: "create a gauge to distribute rewards to users",
+		Short: "create a gauge to distribute rewards to users. For duration lock gauges set poolId = 0 and for all CL (no-lock) gauges set it to a CL poolId.",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fix create gauge CLI param count requirement.

Also, though, I was getting this error:
`Error: pool id should not be set for duration distr condition`

Perhaps the args should be a range of 2-3, then the pool ID value is set to 0 (as that error requires) if it is not set in CLI. Otherwise, omitting the pool ID as that message suggests causes an exception. IMO it would be more intuitive than knowing to set the ID to 0.

## Testing and Verifying

- Run make install, then ensure the CLI command works

Example:
`osmosisd tx incentives create-gauge gamm/pool/2 10000000uion 0 --from val --keyring-backend test --chain-id localosmosis --duration 168h  --epochs 12 --fees 100000uosmo`
