### PR TITLE
fix: cl sf positions per user per pool query

### DIFF
--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -12,8 +12,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
-	errorsmod "cosmossdk.io/errors"
-
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/osmoutils/accum"
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/model"
@@ -731,16 +729,6 @@ func (k Keeper) GetLockIdFromPositionId(ctx sdk.Context, positionId uint64) (uin
 	value := store.Get(positionIdLockKey)
 	if value == nil {
 		return 0, types.PositionIdToLockNotFoundError{PositionId: positionId}
-	}
-
-	// Check if lock ID still exists (i.e. has not matured). In this context, the KVStore value is the source of truth
-	// that the lockID existed. Therefore, if the lock ID does not exist, it means it did exist at one point but has now matured.
-	// If it has matured, return an error. (We do not want to mutate state here in the getter)
-	lock, err := k.lockupKeeper.GetLockByID(ctx, sdk.BigEndianToUint64(value))
-	if err == errorsmod.Wrap(lockuptypes.ErrLockupNotFound, fmt.Sprintf("lock with ID %d does not exist", lock.GetID())) {
-		return 0, fmt.Errorf("lock ID %d is mature", sdk.BigEndianToUint64(value))
-	} else if err != nil {
-		return 0, err
 	}
 
 	return sdk.BigEndianToUint64(value), nil

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
+	errorsmod "cosmossdk.io/errors"
+
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/osmoutils/accum"
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/model"
@@ -729,6 +731,16 @@ func (k Keeper) GetLockIdFromPositionId(ctx sdk.Context, positionId uint64) (uin
 	value := store.Get(positionIdLockKey)
 	if value == nil {
 		return 0, types.PositionIdToLockNotFoundError{PositionId: positionId}
+	}
+
+	// Check if lock ID still exists (i.e. has not matured). In this context, the KVStore value is the source of truth
+	//that the lockID existed. Therefore, if the lock ID does not exist, it means it did exist at one point but has now matured.
+	// If it has matured, return an error. (We do not want to mutate state here in the getter)
+	lock, err := k.lockupKeeper.GetLockByID(ctx, sdk.BigEndianToUint64(value))
+	if err == errorsmod.Wrap(lockuptypes.ErrLockupNotFound, fmt.Sprintf("lock with ID %d does not exist", lock.GetID())) {
+		return 0, fmt.Errorf("lock ID %d is mature", sdk.BigEndianToUint64(value))
+	} else if err != nil {
+		return 0, err
 	}
 
 	return sdk.BigEndianToUint64(value), nil

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -734,7 +734,7 @@ func (k Keeper) GetLockIdFromPositionId(ctx sdk.Context, positionId uint64) (uin
 	}
 
 	// Check if lock ID still exists (i.e. has not matured). In this context, the KVStore value is the source of truth
-	//that the lockID existed. Therefore, if the lock ID does not exist, it means it did exist at one point but has now matured.
+	// that the lockID existed. Therefore, if the lock ID does not exist, it means it did exist at one point but has now matured.
 	// If it has matured, return an error. (We do not want to mutate state here in the getter)
 	lock, err := k.lockupKeeper.GetLockByID(ctx, sdk.BigEndianToUint64(value))
 	if err == errorsmod.Wrap(lockuptypes.ErrLockupNotFound, fmt.Sprintf("lock with ID %d does not exist", lock.GetID())) {

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -295,17 +295,11 @@ func (q Querier) UserSuperfluidPositionsPerConcentratedPoolBreakdown(goCtx conte
 		return nil, err
 	}
 
-	fmt.Println("POSITIONS", positions)
-
 	// Query each position ID and determine if it has a lock ID associated with it, which implies the position is superfluid staked.
 	// Construct a response with the position ID, lock ID, the amount of cl shares staked, and what those shares are worth in staked osmo tokens.
 	var clPoolUserPositionRecords []types.ConcentratedPoolUserPositionRecord
 	for _, pos := range positions {
-		fmt.Println("pos", pos)
-		// TODO: change query or hooks??
 		lockId, err := q.Keeper.clk.GetLockIdFromPositionId(ctx, pos.PositionId)
-		fmt.Println("lockId", lockId)
-		fmt.Println("err", err)
 		switch err.(type) {
 		case cltypes.PositionIdToLockNotFoundError:
 			continue

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -295,16 +295,25 @@ func (q Querier) UserSuperfluidPositionsPerConcentratedPoolBreakdown(goCtx conte
 		return nil, err
 	}
 
+	fmt.Println("POSITIONS", positions)
+
 	// Query each position ID and determine if it has a lock ID associated with it, which implies the position is superfluid staked.
 	// Construct a response with the position ID, lock ID, the amount of cl shares staked, and what those shares are worth in staked osmo tokens.
 	var clPoolUserPositionRecords []types.ConcentratedPoolUserPositionRecord
 	for _, pos := range positions {
+		fmt.Println("pos", pos)
+		// TODO: change query or hooks??
 		lockId, err := q.Keeper.clk.GetLockIdFromPositionId(ctx, pos.PositionId)
+		fmt.Println("lockId", lockId)
+		fmt.Println("err", err)
 		switch err.(type) {
 		case cltypes.PositionIdToLockNotFoundError:
 			continue
 		case nil:
 			lock, err := q.Keeper.lk.GetLockByID(ctx, lockId)
+			if err == fmt.Errorf("lock ID %d is mature", lockId) {
+				continue
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -304,8 +304,10 @@ func (q Querier) UserSuperfluidPositionsPerConcentratedPoolBreakdown(goCtx conte
 		case cltypes.PositionIdToLockNotFoundError:
 			continue
 		case nil:
+			// If we have hit this logic branch, it means that, at one point, the lockId provided existed. If we fetch it again
+			// and it doesn't exist, that means that the lock has matured.
 			lock, err := q.Keeper.lk.GetLockByID(ctx, lockId)
-			if err == fmt.Errorf("lock ID %d is mature", lockId) {
+			if err == errorsmod.Wrap(lockuptypes.ErrLockupNotFound, fmt.Sprintf("lock with ID %d does not exist", lock.GetID())) {
 				continue
 			}
 			if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The state entry for lock to position ID is not updated at the exact moment the lock matures. Because of this, when we query a users sf position by checking the lock ID associated with it in store, we need to also check if the respective lock ID still exists. If it doesn't that means it used to exist but no longer does, and we can assume the lock is now mature.
