### PR TITLE
fix: pass through non sf locks in query

### DIFF
--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -319,8 +319,10 @@ func (q Querier) UserSuperfluidPositionsPerConcentratedPoolBreakdown(goCtx conte
 				return nil, err
 			}
 
+			// Its possible for a non superfluid lock to be attached to a position. This can happen for users migrating non superfluid positions that
+			// they intend to let mature so they can eventually set non full range positions.
 			if syntheticLock.UnderlyingLockId == 0 {
-				return nil, fmt.Errorf("synthetic lockup with underlying lock ID %d not found", lockId)
+				continue
 			}
 
 			valAddr, err := ValidatorAddressFromSyntheticDenom(syntheticLock.SynthDenom)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Our SF per position per pool for CL query was too strict, in that if a lock was associated with a positions, it HAD to be superfluid. There are cases in which locks are associated with positions that are not superfluid staked. For instance, users migrating staked gamm shares that they intend to let mature so they can create non full range positions. 
