### PR TITLE
chore: reduce e2e vote time

### DIFF
--- a/tests/e2e/configurer/config/constants.go
+++ b/tests/e2e/configurer/config/constants.go
@@ -6,9 +6,9 @@ const (
 	// if not skipping upgrade, how many blocks we allow for fork to run pre upgrade state creation
 	ForkHeightPreUpgradeOffset int64 = 60
 	// estimated number of blocks it takes to submit for a proposal
-	PropSubmitBlocks float32 = 10
+	PropSubmitBlocks float32 = 1
 	// estimated number of blocks it takes to deposit for a proposal
-	PropDepositBlocks float32 = 10
+	PropDepositBlocks float32 = 1
 	// number of blocks it takes to vote for a single validator to vote for a proposal
 	PropVoteBlocks float32 = 1.2
 	// number of blocks used as a calculation buffer


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We are using a custom docker tag right now for the e2e parallel speedup. Now that it is merged into main, we can modify the actual v15.x branch so we can use the next docker image auto generated from this branch