### PR TITLE
fix: e2e short

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -37,6 +37,11 @@ import (
 
 // TODO: Find more scalable way to do this
 func (s *IntegrationTestSuite) TestAllE2E() {
+	// If we skip the upgrade, we need to give our nodes time for their RPCs to come online, otherwise we get errors.
+	if s.skipUpgrade {
+		time.Sleep(3 * time.Second)
+	}
+
 	// Zero Dependent Tests
 	s.T().Run("CreateConcentratedLiquidityPoolVoting_And_TWAP", func(t *testing.T) {
 		t.Parallel()
@@ -1193,11 +1198,11 @@ func (s *IntegrationTestSuite) IBCTokenTransferRateLimiting() {
 }
 
 func (s *IntegrationTestSuite) LargeWasmUpload() {
-	chainB := s.configurer.GetChainConfig(1)
-	chainBNode, err := chainB.GetDefaultNode()
+	chainA := s.configurer.GetChainConfig(0)
+	chainANode, err := chainA.GetDefaultNode()
 	s.Require().NoError(err)
-	validatorAddr := chainBNode.GetWallet(initialization.ValidatorWalletName)
-	chainBNode.StoreWasmCode("bytecode/large.wasm", validatorAddr)
+	validatorAddr := chainANode.GetWallet(initialization.ValidatorWalletName)
+	chainANode.StoreWasmCode("bytecode/large.wasm", validatorAddr)
 }
 
 func (s *IntegrationTestSuite) IBCWasmHooks() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -37,10 +37,8 @@ import (
 
 // TODO: Find more scalable way to do this
 func (s *IntegrationTestSuite) TestAllE2E() {
-	// If we skip the upgrade, we need to give our nodes time for their RPCs to come online, otherwise we get errors.
-	if s.skipUpgrade {
-		time.Sleep(3 * time.Second)
-	}
+	// There appears to be an E2E quirk that requires a sleep here
+	time.Sleep(3 * time.Second)
 
 	// Zero Dependent Tests
 	s.T().Run("CreateConcentratedLiquidityPoolVoting_And_TWAP", func(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When setting up the e2e parallel tests, I did not check the `e2e-short` command. The only two issues were:
- E2E short was starting so fast that it didn't give the nodes time to spin up before starting the first test, causing an error
- One of the E2E short tests were changed to use chainB, when chainB does not exist for E2E short tests, so this was changed back to chainA

It also appears that sometimes, the E2E long would also error running the first test without the sleep, so for now I am adding it there and will further diagnose the issue post CL
