### PR TITLE
[fix] Fix no-lock gauge CLI 

### DIFF
--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -87,11 +88,22 @@ func NewCreateGaugeCmd() *cobra.Command {
 				return err
 			}
 
-			distributeTo := lockuptypes.QueryCondition{
-				LockQueryType: lockuptypes.ByDuration,
-				Denom:         denom,
-				Duration:      duration,
-				Timestamp:     time.Unix(0, 0), // XXX check
+			var distributeTo lockuptypes.QueryCondition
+			// if poolId is 0 it is a guranteed lock gauge
+			// if poolId is > 0 it is a guranteed no-lock gauge
+			if poolId == 0 {
+				distributeTo = lockuptypes.QueryCondition{
+					LockQueryType: lockuptypes.ByDuration,
+					Denom:         denom,
+					Duration:      duration,
+					Timestamp:     time.Unix(0, 0), // XXX check
+				}
+			} else if poolId > 0 {
+				distributeTo = lockuptypes.QueryCondition{
+					LockQueryType: lockuptypes.NoLock,
+				}
+			} else {
+				return fmt.Errorf("Invalid Pool Id")
 			}
 
 			msg := types.NewMsgCreateGauge(

--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -102,8 +102,6 @@ func NewCreateGaugeCmd() *cobra.Command {
 				distributeTo = lockuptypes.QueryCondition{
 					LockQueryType: lockuptypes.NoLock,
 				}
-			} else {
-				return fmt.Errorf("Invalid Pool Id")
 			}
 
 			msg := types.NewMsgCreateGauge(

--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"time"
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
issue: unable to create external no-lock gauge because the lockupType is hardcoded to "ByDuration"
https://github.com/osmosis-labs/osmosis/blob/main/x/incentives/client/cli/tx.go#L90

## Testing and Verifying
tested on localosmosis

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A