### PR TITLE
test: parallel fuzz swap test suite

### DIFF
--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -1,0 +1,312 @@
+package concentrated_liquidity_test
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
+)
+
+const (
+	fuzzPoolId         = uint64(1)
+	maxAmountDeposited = 999_999_999_999_999_999
+
+	initialNumPositions = 30
+)
+
+func (s *KeeperTestSuite) TestFuzz() {
+	s.FuzzTest(100, 10)
+}
+
+// pre-condition: poolId exists, and has at least one position
+func (s *KeeperTestSuite) FuzzTest(numSwaps int, numPositions int) {
+	seed := time.Now().Unix()
+
+	r := rand.New(rand.NewSource(seed))
+
+	spreadFactor := sdk.NewDecWithPrec(1, 3)
+	pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, spreadFactor)
+
+	initialAmt0 := randomIntAmount(r)
+	initialAmt1 := randomIntAmount(r)
+
+	defaultCoins := sdk.NewCoins(sdk.NewCoin(ETH, initialAmt0), sdk.NewCoin(USDC, initialAmt1))
+	s.CreateFullRangePosition(pool, defaultCoins)
+
+	// Refetch pool
+	pool, err := s.clk.GetPoolById(s.Ctx, pool.GetId())
+	s.Require().NoError(err)
+
+	fmt.Printf("BEGIN FUZZ TEST. seed %d, initialAmt0 %s initialAmt1 %s \n", seed, initialAmt0, initialAmt1)
+
+	s.fuzzTestWithSeed(r, pool.GetId(), numSwaps, numPositions)
+}
+
+type fuzzState struct {
+	r      *rand.Rand
+	poolId int
+}
+
+func (s *KeeperTestSuite) fuzzTestWithSeed(r *rand.Rand, poolId uint64, numSwaps int, numPositions int) {
+	// Add 1000 random positions
+	for i := 0; i < initialNumPositions; i++ {
+		s.addRandomPositonMinMaxOneSpacing(r)
+	}
+	s.assertWithdrawAllInvariant()
+
+	fmt.Printf("\n\n\n--------------------Positions Pre-Created Beginning Fuzz--------------------\n\n\n")
+
+	// Fuzz by swapping and adding/removing liquidity in-between
+
+	completedSwaps := 0
+	completedPositions := 0
+	targetActions := numSwaps + numPositions
+	for i := 0; i < targetActions; i++ {
+		fmt.Printf("\n\n\n>>>>>>>>>>>>>> Begin Action\n")
+
+		doSwap := s.selectAction(r, numSwaps, numPositions, completedSwaps, completedPositions)
+		if doSwap {
+			// s.swap(r)
+			s.randomSwap(r, poolId)
+			completedSwaps++
+		} else {
+			s.addOrRemoveLiquidity(r)
+			completedPositions++
+		}
+
+		s.assertWithdrawAllInvariant()
+	}
+}
+
+func (s *KeeperTestSuite) randomSwap(r *rand.Rand, poolId uint64) {
+
+	for didSwap := false; !didSwap; {
+
+		pool, err := s.clk.GetPoolById(s.Ctx, poolId)
+		s.Require().NoError(err)
+
+		zfo := s.chooseSwapDirection(r, pool)
+
+		// High level decision, decide which swap strategy to do.
+		// 1. Swap a random amount
+		// 2. Swap near next tick boundary
+		// 3. Swap to later tick boundary (TODO)
+		swapStrategy := r.Intn(2)
+		if swapStrategy == 0 {
+			didSwap = s.swapRandomAmount(r, pool, zfo)
+		} else {
+			didSwap = s.swapNearNextTickBoundary(r, pool, zfo)
+		}
+
+		if !didSwap {
+			fmt.Printf("swap failed for acceptable reasons, retrying \n\n")
+		}
+	}
+}
+
+func (s *KeeperTestSuite) swapRandomAmount(r *rand.Rand, pool types.ConcentratedPoolExtension, zfo bool) (didSwap bool) {
+	fmt.Println("swap type: random amount")
+	swapInDenom, swapOutDenom := zfoToDenoms(zfo, pool)
+	swapAmt := randomIntAmount(r)
+	swapInCoin := sdk.NewCoin(swapInDenom, swapAmt)
+	return s.swap(pool, swapInCoin, swapOutDenom)
+}
+
+func (s *KeeperTestSuite) swapNearNextTickBoundary(r *rand.Rand, pool types.ConcentratedPoolExtension, zfo bool) (didSwap bool) {
+	fmt.Println("swap type: near next tick boundary")
+	targetTick := pool.GetCurrentTick()
+	if zfo {
+		targetTick -= 1
+	} else {
+		targetTick += 1
+	}
+	return s.swapNearTickBoundary(r, pool, targetTick, zfo)
+}
+
+func (s *KeeperTestSuite) swapNearTickBoundary(r *rand.Rand, pool types.ConcentratedPoolExtension, targetTick int64, zfo bool) (didSwap bool) {
+	swapInDenom, swapOutDenom := zfoToDenoms(zfo, pool)
+	// TODO: Confirm accuracy of this method.
+	amountInRequired, curLiquidity, _ := s.computeSwapAmounts(pool.GetId(), pool.GetCurrentSqrtPrice(), targetTick, zfo, false)
+
+	// Decide if below, exactly, or above target tick
+
+	poolSpotPrice := pool.GetCurrentSqrtPrice().Power(osmomath.NewBigDec(2))
+	fmt.Printf("pool: tick %d, spot price: %s, liq %s \n", pool.GetCurrentTick(), poolSpotPrice, curLiquidity)
+
+	amountInRequired = tickAmtChange(r, amountInRequired)
+
+	swapInCoin := sdk.NewCoin(swapInDenom, amountInRequired.TruncateInt())
+	return s.swap(pool, swapInCoin, swapOutDenom)
+}
+
+// change tick amount to be at, above or below the target amount
+func tickAmtChange(r *rand.Rand, targetAmount sdk.Dec) sdk.Dec {
+	changeType := r.Intn(3)
+
+	// Generate a random percentage under 0.1%
+	randChangePercent := sdk.NewDec(rand.Int63n(1)).QuoInt64(1000)
+	change := targetAmount.Mul(randChangePercent)
+
+	change = sdk.MaxDec(sdk.NewDec(1), randChangePercent)
+
+	switch changeType {
+	case 0:
+		fmt.Printf("tick amt change type: no change, orig: %s \n", targetAmount)
+		// do nothing
+		return targetAmount
+	case 1:
+		// above tick
+		change = change.Ceil()
+		fmt.Printf("tick amt change type: beyond tick, orig: %s  change added %s\n", targetAmount, change)
+		return targetAmount.Add(change.TruncateDec())
+	}
+
+	if targetAmount.LTE(sdk.OneDec()) {
+		fmt.Printf("tick amt change type: no change, orig: %s \n", targetAmount)
+		return targetAmount
+	}
+
+	// below tick
+	change = change.TruncateDec()
+	fmt.Printf("tick amt change type: not reaching tick, orig: %s change subtracted: %s\n", targetAmount, change)
+	return targetAmount.Sub(change.TruncateDec())
+}
+
+func (s *KeeperTestSuite) swap(pool types.ConcentratedPoolExtension, swapInFunded sdk.Coin, swapOutDenom string) (didSwap bool) {
+	s.FundAcc(s.TestAccs[0], sdk.NewCoins(swapInFunded))
+	// // Execute swap
+	fmt.Printf("swap in: %s\n", swapInFunded)
+	cacheCtx, write := s.Ctx.CacheContext()
+	_, _, _, err := s.clk.SwapOutAmtGivenIn(cacheCtx, s.TestAccs[0], pool, swapInFunded, swapOutDenom, pool.GetSpreadFactor(s.Ctx), sdk.ZeroDec())
+	if errors.As(err, &types.InvalidAmountCalculatedError{}) {
+		// If the swap we're about to execute will not generate enough output, we skip the swap.
+		// it would error for a real user though. This is good though, since that user would just be burning funds.
+		if err.(types.InvalidAmountCalculatedError).Amount.IsZero() {
+			return false
+		}
+	}
+	s.Require().NoError(err)
+
+	// Write only if no error
+	write()
+
+	return true
+}
+
+func (s *KeeperTestSuite) chooseSwapDirection(r *rand.Rand, pool types.ConcentratedPoolExtension) (zfo bool) {
+	poolLiquidity := s.App.BankKeeper.GetAllBalances(s.Ctx, pool.GetAddress())
+	s.Require().True(len(poolLiquidity) == 1 || len(poolLiquidity) == 2, "Pool liquidity should be in one or two tokens")
+
+	if len(poolLiquidity) == 1 {
+		// If all pool liquidity is in one token, swap in the other token
+		swapOutDenom := poolLiquidity[0].Denom
+		if swapOutDenom == pool.GetToken0() {
+			return false
+		} else {
+			return true
+		}
+	}
+	return r.Int()%2 == 0
+}
+
+func zfoToDenoms(zfo bool, pool types.ConcentratedPoolExtension) (swapInDenom, swapOutDenom string) {
+	if zfo {
+		return pool.GetToken0(), pool.GetToken1()
+	} else {
+		return pool.GetToken1(), pool.GetToken0()
+	}
+}
+
+// if true swap, if false, LP
+func (s *KeeperTestSuite) selectAction(r *rand.Rand, numSwaps, numPositions, completedSwaps, completedPositions int) bool {
+	if completedSwaps == numSwaps {
+		return false
+	}
+	if completedPositions == numPositions {
+		return true
+	}
+
+	if numPositions == 0 {
+		return false
+	}
+
+	return r.Intn(2) == 0
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Add or remove liquidity
+
+func (s *KeeperTestSuite) addOrRemoveLiquidity(r *rand.Rand) {
+
+	// shouldAddPosition := s.selectAddOrRemove(r)
+
+	if true {
+		s.addRandomPositonMinMaxOneSpacing(r)
+	} else {
+		fmt.Println("removing position")
+		// s.removeLiquidity(r, randomizedAssets)
+	}
+
+}
+
+// if true add position, if false remove position
+func (s *KeeperTestSuite) selectAddOrRemove(r *rand.Rand) bool {
+	if len(s.positionIds) == 0 {
+		return true
+	}
+	return r.Intn(2) == 0
+}
+
+func (s *KeeperTestSuite) addRandomPositonMinMaxOneSpacing(r *rand.Rand) {
+	s.addRandomPositon(r, types.MinInitializedTick, types.MaxTick, 1)
+}
+
+func (s *KeeperTestSuite) addRandomPositon(r *rand.Rand, minTick, maxTick int64, tickSpacing int64) {
+	tokenDesired0 := sdk.NewCoin(ETH, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
+	tokenDesired1 := sdk.NewCoin(USDC, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
+	tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
+
+	s.FundAcc(s.TestAccs[0], tokensDesired)
+
+	lowerTick := roundTickDownSpacing(rand.Int63n(maxTick-minTick+1)+minTick, tickSpacing)
+	// lowerTick <= upperTick <= maxTick
+	upperTick := roundTickDownSpacing(maxTick-rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))), tickSpacing)
+
+	fmt.Println("creating position: ", "accountName", "lowerTick", lowerTick, "upperTick", upperTick, "token0Desired", tokenDesired0, "tokenDesired1", tokenDesired1)
+
+	positionId, amt0, amt1, _, _, _, err := s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, fuzzPoolId, s.TestAccs[0], tokensDesired, sdk.ZeroInt(), sdk.ZeroInt(), types.MinInitializedTick, types.MaxTick)
+	s.Require().NoError(err)
+	fmt.Printf("actually created: %s%s %s%s \n", amt0, ETH, amt1, USDC)
+
+	s.positionIds = append(s.positionIds, positionId)
+}
+
+func roundTickDownSpacing(tickIndex int64, tickSpacing int64) int64 {
+	// Round the tick index down to the nearest tick spacing if the tickIndex is in between authorized tick values
+	// Note that this is Euclidean modulus.
+	// The difference from default Go modulus is that Go default results
+	// in a negative remainder when the dividend is negative.
+	// Consider example tickIndex = -17, tickSpacing = 10
+	// tickIndexModulus = tickIndex % tickSpacing = -7
+	// tickIndexModulus = -7 + 10 = 3
+	// tickIndex = -17 - 3 = -20
+	tickIndexModulus := tickIndex % tickSpacing
+	if tickIndexModulus < 0 {
+		tickIndexModulus += tickSpacing
+	}
+
+	if tickIndexModulus != 0 {
+		tickIndex = tickIndex - tickIndexModulus
+	}
+	return tickIndex
+}
+
+func randomIntAmount(r *rand.Rand) sdk.Int {
+	return sdk.NewInt(rand.Int63n(maxAmountDeposited))
+}

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sync"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -36,11 +35,8 @@ func (s *KeeperTestSuite) TestFuzz_GivenSeed() {
 func (s *KeeperTestSuite) FuzzTest(numSwaps int, numPositions int, numFuzzes int) {
 	seed := time.Now().Unix()
 
-	wg := &sync.WaitGroup{}
-
 	for i := 0; i < numFuzzes; i++ {
 		i := i
-		wg.Add(1)
 
 		currentSeed := seed + int64(i)
 		r := rand.New(rand.NewSource(currentSeed))
@@ -50,14 +46,13 @@ func (s *KeeperTestSuite) FuzzTest(numSwaps int, numPositions int, numFuzzes int
 		currentSuite.SetT(s.T())
 
 		currentSuite.Run(fmt.Sprintf("Fuzz %d, seed: %d", i, currentSeed), func() {
+
+			// Run in parallel.
 			currentSuite.T().Parallel()
 
 			currentSuite.individualFuzz(r, i, numSwaps, numPositions)
-			wg.Done()
 		})
 	}
-
-	// wg.Wait()
 }
 
 func (s *KeeperTestSuite) individualFuzz(r *rand.Rand, fuzzNum int, numSwaps int, numPositions int) {

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -85,7 +85,8 @@ func TestConstants(t *testing.T) {
 }
 
 type FuzzTestSuite struct {
-	positionIds []uint64
+	positionIds     []uint64
+	collectedErrors []error
 }
 
 type KeeperTestSuite struct {

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -2,7 +2,6 @@ package concentrated_liquidity_test
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -85,8 +84,13 @@ func TestConstants(t *testing.T) {
 	require.Equal(t, DefaultLiquidityAmt, liq)
 }
 
+type FuzzTestSuite struct {
+	positionIds []uint64
+}
+
 type KeeperTestSuite struct {
 	apptesting.KeeperTestHelper
+	FuzzTestSuite
 	clk               *concentrated_liquidity.Keeper
 	authorizedUptimes []time.Duration
 }
@@ -478,19 +482,4 @@ func (s *KeeperTestSuite) runMultipleAuthorizedUptimes(tests func()) {
 		s.authorizedUptimes = curAuthorizedUptimes
 		tests()
 	}
-}
-
-// runMultiplePositionRanges runs various test constructions and invariants on the given position ranges.
-func (s *KeeperTestSuite) runMultiplePositionRanges(ranges [][]int64, rangeTestParams RangeTestParams) {
-	// Preset seed to ensure deterministic test runs.
-	rand.Seed(2)
-
-	// TODO: add pool-related fuzz params (spread factor & number of pools)
-	pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, rangeTestParams.tickSpacing, rangeTestParams.spreadFactor)
-
-	// Run full state determined by params while asserting invariants at each intermediate step
-	s.setupRangesAndAssertInvariants(pool, ranges, rangeTestParams)
-
-	// Assert global invariants on final state
-	s.assertGlobalInvariants(ExpectedGlobalRewardValues{})
 }

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -87,6 +87,8 @@ func TestConstants(t *testing.T) {
 
 type FuzzTestSuite struct {
 	positionIds     []uint64
+	iteration       int
+	seed            int64
 	collectedErrors []error
 }
 

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	DefaultMinTick, DefaultMaxTick       = types.MinInitializedTick, types.MaxTick
+	DefaultMinCurrentTick                = types.MinCurrentTick
 	DefaultLowerPrice                    = sdk.NewDec(4545)
 	DefaultLowerTick                     = int64(30545000)
 	DefaultUpperPrice                    = sdk.NewDec(5500)

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -2,6 +2,7 @@ package concentrated_liquidity_test
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -483,4 +484,19 @@ func (s *KeeperTestSuite) runMultipleAuthorizedUptimes(tests func()) {
 		s.authorizedUptimes = curAuthorizedUptimes
 		tests()
 	}
+}
+
+// runMultiplePositionRanges runs various test constructions and invariants on the given position ranges.
+func (s *KeeperTestSuite) runMultiplePositionRanges(ranges [][]int64, rangeTestParams RangeTestParams) {
+	// Preset seed to ensure deterministic test runs.
+	rand.Seed(2)
+
+	// TODO: add pool-related fuzz params (spread factor & number of pools)
+	pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, rangeTestParams.tickSpacing, rangeTestParams.spreadFactor)
+
+	// Run full state determined by params while asserting invariants at each intermediate step
+	s.setupRangesAndAssertInvariants(pool, ranges, rangeTestParams)
+
+	// Assert global invariants on final state
+	s.assertGlobalInvariants(ExpectedGlobalRewardValues{})
 }

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -74,7 +74,7 @@ func TickToPrice(tickIndex int64) (price sdk.Dec, err error) {
 	geometricExponentIncrementDistanceInTicks := sdkNineDec.Mul(PowTenInternal(-exponentAtPriceOne)).TruncateInt64()
 
 	// Check that the tick index is between min and max value
-	if tickIndex < types.MinInitializedTick {
+	if tickIndex < types.MinCurrentTick {
 		return sdk.Dec{}, types.TickIndexMinimumError{MinTick: types.MinInitializedTick}
 	}
 	if tickIndex > types.MaxTick {

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -75,7 +75,7 @@ func TickToPrice(tickIndex int64) (price sdk.Dec, err error) {
 
 	// Check that the tick index is between min and max value
 	if tickIndex < types.MinCurrentTick {
-		return sdk.Dec{}, types.TickIndexMinimumError{MinTick: types.MinInitializedTick}
+		return sdk.Dec{}, types.TickIndexMinimumError{MinTick: types.MinCurrentTick}
 	}
 	if tickIndex > types.MaxTick {
 		return sdk.Dec{}, types.TickIndexMaximumError{MaxTick: types.MaxTick}

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -271,7 +271,7 @@ func CalculateSqrtPriceToTick(sqrtPrice osmomath.BigDec) (tickIndex int64, err e
 	// already shifted and making it exclusive would make min/max tick impossible to reach by construction.
 	// We do this primary for code simplicity, as alternatives would require more branching and special cases.
 	if (!outOfBounds && sqrtPrice.GTE(sqrtPriceTplus2)) || (outOfBounds && sqrtPrice.GT(sqrtPriceTplus2)) || sqrtPrice.LT(sqrtPriceTmin1) {
-		return 0, fmt.Errorf("sqrt price to tick could not find a satisfying tick index. Hit bounds: %v", outOfBounds)
+		return 0, types.SqrtPriceToTickError{OutOfBounds: outOfBounds}
 	}
 
 	// We expect this case to only be hit when the original provided sqrt price is exactly equal to the max sqrt price.

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -134,12 +134,12 @@ func TestTickToSqrtPrice(t *testing.T) {
 			expectedPrice: types.MinSpotPrice,
 		},
 		"error: tickIndex less than minimum": {
-			tickIndex:     types.MinInitializedTick - 1,
-			expectedError: types.TickIndexMinimumError{MinTick: types.MinInitializedTick},
+			tickIndex:     types.MinCurrentTick - 1,
+			expectedError: types.TickIndexMinimumError{MinTick: types.MinCurrentTick},
 		},
 		"error: tickIndex greater than maximum": {
-			tickIndex:     342000000 + 1,
-			expectedError: types.TickIndexMaximumError{MaxTick: 342000000},
+			tickIndex:     types.MaxTick + 1,
+			expectedError: types.TickIndexMaximumError{MaxTick: types.MaxTick},
 		},
 		"Gyen <> USD, tick -20594000 -> price 0.0074060": {
 			tickIndex:     -20594000,
@@ -264,9 +264,9 @@ func TestTicksToSqrtPrice(t *testing.T) {
 			expectedLowerPrice: types.MinSpotPrice,
 		},
 		"error: lowerTickIndex less than minimum": {
-			lowerTickIndex: sdk.NewInt(types.MinInitializedTick - 1),
+			lowerTickIndex: sdk.NewInt(types.MinCurrentTick - 1),
 			upperTickIndex: sdk.NewInt(36073300),
-			expectedError:  types.TickIndexMinimumError{MinTick: types.MinInitializedTick},
+			expectedError:  types.TickIndexMinimumError{MinTick: types.MinCurrentTick},
 		},
 		"error: upperTickIndex greater than maximum": {
 			lowerTickIndex: sdk.NewInt(types.MinInitializedTick),
@@ -660,7 +660,7 @@ func TestTickToPrice_ErrorCases(t *testing.T) {
 			tickIndex: types.MaxTick + 1,
 		},
 		"tick index is less than min tick": {
-			tickIndex: types.MinInitializedTick - 1,
+			tickIndex: types.MinCurrentTick - 1,
 		},
 	}
 	for name, tc := range testCases {

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2436,171 +2436,171 @@ func (s *KeeperTestSuite) TestTickRoundingEdgeCase() {
 	s.Require().NoError(err)
 }
 
-func (s *KeeperTestSuite) TestMultipleRanges() {
-	tests := map[string]struct {
-		tickRanges      [][]int64
-		rangeTestParams RangeTestParams
-	}{
-		"one range, default params": {
-			tickRanges: [][]int64{
-				{0, 10000},
-			},
-			rangeTestParams: DefaultRangeTestParams,
-		},
-		"one min width range": {
-			tickRanges: [][]int64{
-				{0, 100},
-			},
-			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
-		},
-		"two adjacent ranges": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{10000, 20000},
-			},
-			rangeTestParams: DefaultRangeTestParams,
-		},
-		"two adjacent ranges with current tick smaller than both": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{10000, 20000},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -20000),
-		},
-		"two adjacent ranges with current tick larger than both": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{10000, 20000},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 30000),
-		},
-		"two adjacent ranges with current tick exactly on lower bound": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{10000, 20000},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -10000),
-		},
-		"two adjacent ranges with current tick exactly between both": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{10000, 20000},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 10000),
-		},
-		"two adjacent ranges with current tick exactly on upper bound": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{10000, 20000},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 20000),
-		},
-		"two non-adjacent ranges": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{20000, 30000},
-			},
-			rangeTestParams: DefaultRangeTestParams,
-		},
-		"two ranges with one tick gap in between, which is equal to current tick": {
-			tickRanges: [][]int64{
-				{799221, 799997},
-				{799997 + 2, 812343},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 799997+1),
-		},
-		"one range on large tick": {
-			tickRanges: [][]int64{
-				{207000000, 207000000 + 100},
-			},
-			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
-		},
-		"one position adjacent to left of current tick (no swaps)": {
-			tickRanges: [][]int64{
-				{-1, 0},
-			},
-			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-		},
-		"one position on left of current tick with gap (no swaps)": {
-			tickRanges: [][]int64{
-				{-2, -1},
-			},
-			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-		},
-		"one position adjacent to right of current tick (no swaps)": {
-			tickRanges: [][]int64{
-				{0, 1},
-			},
-			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-		},
-		"one position on right of current tick with gap (no swaps)": {
-			tickRanges: [][]int64{
-				{1, 2},
-			},
-			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-		},
-		"one range on small tick": {
-			tickRanges: [][]int64{
-				{-107000000, -107000000 + 100},
-			},
-			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
-		},
-		"one range on min tick": {
-			tickRanges: [][]int64{
-				{types.MinInitializedTick, types.MinInitializedTick + 100},
-			},
-			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
-		},
-		"initial current tick equal to min initialized tick": {
-			tickRanges: [][]int64{
-				{0, 1},
-			},
-			rangeTestParams: withCurrentTick(DefaultRangeTestParams, types.MinInitializedTick),
-		},
-		"three overlapping ranges with no swaps, current tick in one": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{0, 20000},
-				{-7300, 12345},
-			},
-			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -9000)),
-		},
-		"three overlapping ranges with no swaps, current tick in two of three": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{0, 20000},
-				{-7300, 12345},
-			},
-			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -7231)),
-		},
-		"three overlapping ranges with no swaps, current tick in all three": {
-			tickRanges: [][]int64{
-				{-10000, 10000},
-				{0, 20000},
-				{-7300, 12345},
-			},
-			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, 109)),
-		},
-		/* TODO: uncomment when infinite loop bug is fixed
-		"one range on max tick": {
-			tickRanges: [][]int64{
-				{types.MaxTick - 100, types.MaxTick},
-			},
-			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
-		},
-		"initial current tick equal to max tick": {
-			tickRanges: [][]int64{
-				{0, 1},
-			},
-			rangeTestParams: withCurrentTick(withTickSpacing(DefaultRangeTestParams, uint64(1)), types.MaxTick),
-		},
-		*/
-	}
+// func (s *KeeperTestSuite) TestMultipleRanges() {
+// 	tests := map[string]struct {
+// 		tickRanges      [][]int64
+// 		rangeTestParams RangeTestParams
+// 	}{
+// 		"one range, default params": {
+// 			tickRanges: [][]int64{
+// 				{0, 10000},
+// 			},
+// 			rangeTestParams: DefaultRangeTestParams,
+// 		},
+// 		"one min width range": {
+// 			tickRanges: [][]int64{
+// 				{0, 100},
+// 			},
+// 			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
+// 		},
+// 		"two adjacent ranges": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{10000, 20000},
+// 			},
+// 			rangeTestParams: DefaultRangeTestParams,
+// 		},
+// 		"two adjacent ranges with current tick smaller than both": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{10000, 20000},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -20000),
+// 		},
+// 		"two adjacent ranges with current tick larger than both": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{10000, 20000},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 30000),
+// 		},
+// 		"two adjacent ranges with current tick exactly on lower bound": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{10000, 20000},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -10000),
+// 		},
+// 		"two adjacent ranges with current tick exactly between both": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{10000, 20000},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 10000),
+// 		},
+// 		"two adjacent ranges with current tick exactly on upper bound": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{10000, 20000},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 20000),
+// 		},
+// 		"two non-adjacent ranges": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{20000, 30000},
+// 			},
+// 			rangeTestParams: DefaultRangeTestParams,
+// 		},
+// 		"two ranges with one tick gap in between, which is equal to current tick": {
+// 			tickRanges: [][]int64{
+// 				{799221, 799997},
+// 				{799997 + 2, 812343},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 799997+1),
+// 		},
+// 		"one range on large tick": {
+// 			tickRanges: [][]int64{
+// 				{207000000, 207000000 + 100},
+// 			},
+// 			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
+// 		},
+// 		"one position adjacent to left of current tick (no swaps)": {
+// 			tickRanges: [][]int64{
+// 				{-1, 0},
+// 			},
+// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+// 		},
+// 		"one position on left of current tick with gap (no swaps)": {
+// 			tickRanges: [][]int64{
+// 				{-2, -1},
+// 			},
+// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+// 		},
+// 		"one position adjacent to right of current tick (no swaps)": {
+// 			tickRanges: [][]int64{
+// 				{0, 1},
+// 			},
+// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+// 		},
+// 		"one position on right of current tick with gap (no swaps)": {
+// 			tickRanges: [][]int64{
+// 				{1, 2},
+// 			},
+// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+// 		},
+// 		"one range on small tick": {
+// 			tickRanges: [][]int64{
+// 				{-107000000, -107000000 + 100},
+// 			},
+// 			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
+// 		},
+// 		"one range on min tick": {
+// 			tickRanges: [][]int64{
+// 				{types.MinInitializedTick, types.MinInitializedTick + 100},
+// 			},
+// 			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
+// 		},
+// 		"initial current tick equal to min initialized tick": {
+// 			tickRanges: [][]int64{
+// 				{0, 1},
+// 			},
+// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, types.MinInitializedTick),
+// 		},
+// 		"three overlapping ranges with no swaps, current tick in one": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{0, 20000},
+// 				{-7300, 12345},
+// 			},
+// 			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -9000)),
+// 		},
+// 		"three overlapping ranges with no swaps, current tick in two of three": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{0, 20000},
+// 				{-7300, 12345},
+// 			},
+// 			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -7231)),
+// 		},
+// 		"three overlapping ranges with no swaps, current tick in all three": {
+// 			tickRanges: [][]int64{
+// 				{-10000, 10000},
+// 				{0, 20000},
+// 				{-7300, 12345},
+// 			},
+// 			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, 109)),
+// 		},
+// 		/* TODO: uncomment when infinite loop bug is fixed
+// 		"one range on max tick": {
+// 			tickRanges: [][]int64{
+// 				{types.MaxTick - 100, types.MaxTick},
+// 			},
+// 			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
+// 		},
+// 		"initial current tick equal to max tick": {
+// 			tickRanges: [][]int64{
+// 				{0, 1},
+// 			},
+// 			rangeTestParams: withCurrentTick(withTickSpacing(DefaultRangeTestParams, uint64(1)), types.MaxTick),
+// 		},
+// 		*/
+// 	}
 
-	for name, tc := range tests {
-		s.Run(name, func() {
-			s.SetupTest()
-			s.runMultiplePositionRanges(tc.tickRanges, tc.rangeTestParams)
-		})
-	}
-}
+// 	// for name, tc := range tests {
+// 	// 	s.Run(name, func() {
+// 	// 		s.SetupTest()
+// 	// 		// s.runMultiplePositionRanges(tc.tickRanges, tc.rangeTestParams)
+// 	// 	})
+// 	// }
+// }

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2436,171 +2436,171 @@ func (s *KeeperTestSuite) TestTickRoundingEdgeCase() {
 	s.Require().NoError(err)
 }
 
-// func (s *KeeperTestSuite) TestMultipleRanges() {
-// 	tests := map[string]struct {
-// 		tickRanges      [][]int64
-// 		rangeTestParams RangeTestParams
-// 	}{
-// 		"one range, default params": {
-// 			tickRanges: [][]int64{
-// 				{0, 10000},
-// 			},
-// 			rangeTestParams: DefaultRangeTestParams,
-// 		},
-// 		"one min width range": {
-// 			tickRanges: [][]int64{
-// 				{0, 100},
-// 			},
-// 			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
-// 		},
-// 		"two adjacent ranges": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{10000, 20000},
-// 			},
-// 			rangeTestParams: DefaultRangeTestParams,
-// 		},
-// 		"two adjacent ranges with current tick smaller than both": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{10000, 20000},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -20000),
-// 		},
-// 		"two adjacent ranges with current tick larger than both": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{10000, 20000},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 30000),
-// 		},
-// 		"two adjacent ranges with current tick exactly on lower bound": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{10000, 20000},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -10000),
-// 		},
-// 		"two adjacent ranges with current tick exactly between both": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{10000, 20000},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 10000),
-// 		},
-// 		"two adjacent ranges with current tick exactly on upper bound": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{10000, 20000},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 20000),
-// 		},
-// 		"two non-adjacent ranges": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{20000, 30000},
-// 			},
-// 			rangeTestParams: DefaultRangeTestParams,
-// 		},
-// 		"two ranges with one tick gap in between, which is equal to current tick": {
-// 			tickRanges: [][]int64{
-// 				{799221, 799997},
-// 				{799997 + 2, 812343},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 799997+1),
-// 		},
-// 		"one range on large tick": {
-// 			tickRanges: [][]int64{
-// 				{207000000, 207000000 + 100},
-// 			},
-// 			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
-// 		},
-// 		"one position adjacent to left of current tick (no swaps)": {
-// 			tickRanges: [][]int64{
-// 				{-1, 0},
-// 			},
-// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-// 		},
-// 		"one position on left of current tick with gap (no swaps)": {
-// 			tickRanges: [][]int64{
-// 				{-2, -1},
-// 			},
-// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-// 		},
-// 		"one position adjacent to right of current tick (no swaps)": {
-// 			tickRanges: [][]int64{
-// 				{0, 1},
-// 			},
-// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-// 		},
-// 		"one position on right of current tick with gap (no swaps)": {
-// 			tickRanges: [][]int64{
-// 				{1, 2},
-// 			},
-// 			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
-// 		},
-// 		"one range on small tick": {
-// 			tickRanges: [][]int64{
-// 				{-107000000, -107000000 + 100},
-// 			},
-// 			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
-// 		},
-// 		"one range on min tick": {
-// 			tickRanges: [][]int64{
-// 				{types.MinInitializedTick, types.MinInitializedTick + 100},
-// 			},
-// 			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
-// 		},
-// 		"initial current tick equal to min initialized tick": {
-// 			tickRanges: [][]int64{
-// 				{0, 1},
-// 			},
-// 			rangeTestParams: withCurrentTick(DefaultRangeTestParams, types.MinInitializedTick),
-// 		},
-// 		"three overlapping ranges with no swaps, current tick in one": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{0, 20000},
-// 				{-7300, 12345},
-// 			},
-// 			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -9000)),
-// 		},
-// 		"three overlapping ranges with no swaps, current tick in two of three": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{0, 20000},
-// 				{-7300, 12345},
-// 			},
-// 			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -7231)),
-// 		},
-// 		"three overlapping ranges with no swaps, current tick in all three": {
-// 			tickRanges: [][]int64{
-// 				{-10000, 10000},
-// 				{0, 20000},
-// 				{-7300, 12345},
-// 			},
-// 			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, 109)),
-// 		},
-// 		/* TODO: uncomment when infinite loop bug is fixed
-// 		"one range on max tick": {
-// 			tickRanges: [][]int64{
-// 				{types.MaxTick - 100, types.MaxTick},
-// 			},
-// 			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
-// 		},
-// 		"initial current tick equal to max tick": {
-// 			tickRanges: [][]int64{
-// 				{0, 1},
-// 			},
-// 			rangeTestParams: withCurrentTick(withTickSpacing(DefaultRangeTestParams, uint64(1)), types.MaxTick),
-// 		},
-// 		*/
-// 	}
+func (s *KeeperTestSuite) TestMultipleRanges() {
+	tests := map[string]struct {
+		tickRanges      [][]int64
+		rangeTestParams RangeTestParams
+	}{
+		"one range, default params": {
+			tickRanges: [][]int64{
+				{0, 10000},
+			},
+			rangeTestParams: DefaultRangeTestParams,
+		},
+		"one min width range": {
+			tickRanges: [][]int64{
+				{0, 100},
+			},
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
+		},
+		"two adjacent ranges": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: DefaultRangeTestParams,
+		},
+		"two adjacent ranges with current tick smaller than both": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -20000),
+		},
+		"two adjacent ranges with current tick larger than both": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 30000),
+		},
+		"two adjacent ranges with current tick exactly on lower bound": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, -10000),
+		},
+		"two adjacent ranges with current tick exactly between both": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 10000),
+		},
+		"two adjacent ranges with current tick exactly on upper bound": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{10000, 20000},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 20000),
+		},
+		"two non-adjacent ranges": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{20000, 30000},
+			},
+			rangeTestParams: DefaultRangeTestParams,
+		},
+		"two ranges with one tick gap in between, which is equal to current tick": {
+			tickRanges: [][]int64{
+				{799221, 799997},
+				{799997 + 2, 812343},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, 799997+1),
+		},
+		"one range on large tick": {
+			tickRanges: [][]int64{
+				{207000000, 207000000 + 100},
+			},
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
+		},
+		"one position adjacent to left of current tick (no swaps)": {
+			tickRanges: [][]int64{
+				{-1, 0},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one position on left of current tick with gap (no swaps)": {
+			tickRanges: [][]int64{
+				{-2, -1},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one position adjacent to right of current tick (no swaps)": {
+			tickRanges: [][]int64{
+				{0, 1},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one position on right of current tick with gap (no swaps)": {
+			tickRanges: [][]int64{
+				{1, 2},
+			},
+			rangeTestParams: RangeTestParamsNoFuzzNoSwap,
+		},
+		"one range on small tick": {
+			tickRanges: [][]int64{
+				{-107000000, -107000000 + 100},
+			},
+			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
+		},
+		"one range on min tick": {
+			tickRanges: [][]int64{
+				{types.MinInitializedTick, types.MinInitializedTick + 100},
+			},
+			rangeTestParams: withDoubleFundedLP(DefaultRangeTestParams),
+		},
+		"initial current tick equal to min initialized tick": {
+			tickRanges: [][]int64{
+				{0, 1},
+			},
+			rangeTestParams: withCurrentTick(DefaultRangeTestParams, types.MinInitializedTick),
+		},
+		"three overlapping ranges with no swaps, current tick in one": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{0, 20000},
+				{-7300, 12345},
+			},
+			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -9000)),
+		},
+		"three overlapping ranges with no swaps, current tick in two of three": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{0, 20000},
+				{-7300, 12345},
+			},
+			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, -7231)),
+		},
+		"three overlapping ranges with no swaps, current tick in all three": {
+			tickRanges: [][]int64{
+				{-10000, 10000},
+				{0, 20000},
+				{-7300, 12345},
+			},
+			rangeTestParams: withNoSwap(withCurrentTick(DefaultRangeTestParams, 109)),
+		},
+		/* TODO: uncomment when infinite loop bug is fixed
+		"one range on max tick": {
+			tickRanges: [][]int64{
+				{types.MaxTick - 100, types.MaxTick},
+			},
+			rangeTestParams: withTickSpacing(DefaultRangeTestParams, DefaultTickSpacing),
+		},
+		"initial current tick equal to max tick": {
+			tickRanges: [][]int64{
+				{0, 1},
+			},
+			rangeTestParams: withCurrentTick(withTickSpacing(DefaultRangeTestParams, uint64(1)), types.MaxTick),
+		},
+		*/
+	}
 
-// 	// for name, tc := range tests {
-// 	// 	s.Run(name, func() {
-// 	// 		s.SetupTest()
-// 	// 		// s.runMultiplePositionRanges(tc.tickRanges, tc.rangeTestParams)
-// 	// 	})
-// 	// }
-// }
+	for name, tc := range tests {
+		s.Run(name, func() {
+			s.SetupTest()
+			s.runMultiplePositionRanges(tc.tickRanges, tc.rangeTestParams)
+		})
+	}
+}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -416,7 +416,7 @@ func (k Keeper) computeOutAmtGivenIn(
 
 	// Note, this should be impossible to reach but we leave it as a defense-in-depth measure.
 	if swapState.amountSpecifiedRemaining.IsNegative() {
-		return sdk.Coin{}, sdk.Coin{}, PoolUpdates{}, sdk.Dec{}, fmt.Errorf("over charge problem swap out given in by (%s)", swapState.amountSpecifiedRemaining)
+		return sdk.Coin{}, sdk.Coin{}, PoolUpdates{}, sdk.Dec{}, types.OverChargeSwapOutGivenInError{AmountSpecifiedRemaining: swapState.amountSpecifiedRemaining}
 	}
 
 	// Add spread reward growth per share to the pool-global spread reward accumulator.

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -1199,7 +1199,7 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 
 			poolId:        defaultPoolId,
 			tokenIn:       ETH,
-			boundTick:     sdk.NewInt(DefaultMinTick - 1),
+			boundTick:     sdk.NewInt(DefaultMinCurrentTick - 1),
 			expectedError: true,
 		},
 		{

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -861,3 +861,19 @@ type SwapNoProgressWithConsumptionError struct {
 func (e SwapNoProgressWithConsumptionError) Error() string {
 	return fmt.Sprintf("did not advance sqrt price after swap step %s, with amounts in (%s), out (%s)", e.ComputedSqrtPrice, e.AmountIn, e.AmountOut)
 }
+
+type SqrtPriceToTickError struct {
+	OutOfBounds bool
+}
+
+func (e SqrtPriceToTickError) Error() string {
+	return fmt.Sprintf("sqrt price to tick could not find a satisfying tick index. Hit bounds: %v", e.OutOfBounds)
+}
+
+type OverChargeSwapOutGivenInError struct {
+	AmountSpecifiedRemaining sdk.Dec
+}
+
+func (e OverChargeSwapOutGivenInError) Error() string {
+	return fmt.Sprintf("over charge problem swap out given in by (%s)", e.AmountSpecifiedRemaining)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Parallelized fuzz test suite that supports swapping around ticks

## Testing and Verifying

Run parallel randomized fuzz suite
```bash
go test -timeout 30m -run TestFuzz_Many github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity -v -count=1
```

Run specific seed
```bash
go test -timeout 30m -run TestFuzz_GivenSeed github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity -v -count=1
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A