### PR TITLE
Fix app wiring for packet foward keeper for v15.x

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -146,13 +146,11 @@ type AppKeepers struct {
 	// IBC modules
 	// transfer module
 	RawIcs20TransferAppModule transfer.AppModule
-	PacketFowardModule        packetforward.AppModule
-
-	RateLimitingICS4Wrapper *ibcratelimit.ICS4Wrapper
-	TransferStack           *ibchooks.IBCMiddleware
-	Ics20WasmHooks          *ibchooks.WasmHooks
-	HooksICS4Wrapper        ibchooks.ICS4Middleware
-	PacketForwardKeeper     *packetforwardkeeper.Keeper
+	RateLimitingICS4Wrapper   *ibcratelimit.ICS4Wrapper
+	TransferStack             *ibchooks.IBCMiddleware
+	Ics20WasmHooks            *ibchooks.WasmHooks
+	HooksICS4Wrapper          ibchooks.ICS4Middleware
+	PacketForwardKeeper       *packetforwardkeeper.Keeper
 
 	// keys to access the substores
 	keys    map[string]*sdk.KVStoreKey
@@ -258,9 +256,6 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	appKeepers.ICAHostKeeper = &icaHostKeeper
 
 	icaHostIBCModule := icahost.NewIBCModule(*appKeepers.ICAHostKeeper)
-
-	appKeepers.PacketFowardModule = packetforward.NewAppModule(appKeepers.PacketForwardKeeper)
-
 	// Create static IBC router, add transfer route, then set and seal it
 	ibcRouter := porttypes.NewRouter()
 	ibcRouter.AddRoute(icahosttypes.SubModuleName, icaHostIBCModule).

--- a/app/modules.go
+++ b/app/modules.go
@@ -11,6 +11,8 @@ import (
 	ibc "github.com/cosmos/ibc-go/v4/modules/core"
 	ibchost "github.com/cosmos/ibc-go/v4/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v4/modules/core/keeper"
+	router "github.com/strangelove-ventures/packet-forward-middleware/v4/router"
+	routertypes "github.com/strangelove-ventures/packet-forward-middleware/v4/router/types"
 
 	ibchookstypes "github.com/osmosis-labs/osmosis/x/ibc-hooks/types"
 
@@ -170,6 +172,7 @@ func appModules(
 		tokenfactory.NewAppModule(*app.TokenFactoryKeeper, app.AccountKeeper, app.BankKeeper),
 		valsetprefmodule.NewAppModule(appCodec, *app.ValidatorSetPreferenceKeeper),
 		ibcratelimitmodule.NewAppModule(*app.RateLimitingICS4Wrapper),
+		router.NewAppModule(app.PacketForwardKeeper),
 		ibc_hooks.NewAppModule(app.AccountKeeper),
 		icq.NewAppModule(*app.AppKeepers.ICQKeeper),
 	}
@@ -238,6 +241,7 @@ func OrderInitGenesis(allModuleNames []string) []string {
 		txfeestypes.ModuleName,
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
+		routertypes.ModuleName,
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 		vestingtypes.ModuleName,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Any querying for packet foward middle ware right now returns an error of 500. (Confirmed via cli that this is an error resulting from GRPC itself, not GRPC Gateway).  

Confirmed locally that this fix applies correct fix
```
matt@MacBook-Pro build % ./osmosisd q ibc-transfer params 
receive_enabled: true
send_enabled: true

```


## Testing and Verifying
Tested in local environment

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A