### PR TITLE
test(CL): add swaps in given out to fuzz suite and fix deterministic randomness

### DIFF
--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -298,7 +298,7 @@ func (s *KeeperTestSuite) swap(pool types.ConcentratedPoolExtension, swapInFunde
 		// 2% tolerance
 		MultiplicativeTolerance: sdk.NewDecWithPrec(2, 2),
 		// Expected amount in returned from swap "in given out" to be smaller
-		// that original amount in given to "out given in".
+		// than original amount in given to "out given in".
 		// Reason: rounding in pool's favor.
 		RoundingDir: osmomath.RoundDown,
 	}

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -28,6 +28,7 @@ func TestFuzz_Many(t *testing.T) {
 }
 
 func (s *KeeperTestSuite) TestFuzz_GivenSeed() {
+	// Seed 1688572291 - gives mismatch between tokenIn given to "out given in" and token in returned from "in given out"
 	r := rand.New(rand.NewSource(1688572291))
 	s.individualFuzz(r, 0, 30, 10)
 

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -28,7 +28,7 @@ func TestFuzz_Many(t *testing.T) {
 }
 
 func (s *KeeperTestSuite) TestFuzz_GivenSeed() {
-	r := rand.New(rand.NewSource(1688520583))
+	r := rand.New(rand.NewSource(1688572291))
 	s.individualFuzz(r, 0, 30, 10)
 
 	s.validateNoErrors(s.collectedErrors)
@@ -225,7 +225,7 @@ func tickAmtChange(r *rand.Rand, targetAmount sdk.Dec) sdk.Dec {
 	changeType := r.Intn(3)
 
 	// Generate a random percentage under 0.1%
-	randChangePercent := sdk.NewDec(rand.Int63n(1)).QuoInt64(1000)
+	randChangePercent := sdk.NewDec(r.Int63n(1)).QuoInt64(1000)
 	change := targetAmount.Mul(randChangePercent)
 
 	change = sdk.MaxDec(sdk.NewDec(1), randChangePercent)
@@ -257,8 +257,8 @@ func (s *KeeperTestSuite) swap(pool types.ConcentratedPoolExtension, swapInFunde
 	s.FundAcc(s.TestAccs[0], sdk.NewCoins(swapInFunded))
 	// // Execute swap
 	fmt.Printf("swap in: %s\n", swapInFunded)
-	cacheCtx, write := s.Ctx.CacheContext()
-	_, _, _, err := s.clk.SwapOutAmtGivenIn(cacheCtx, s.TestAccs[0], pool, swapInFunded, swapOutDenom, pool.GetSpreadFactor(s.Ctx), sdk.ZeroDec())
+	cacheCtx, writeOutGivenIn := s.Ctx.CacheContext()
+	_, tokenOut, _, err := s.clk.SwapOutAmtGivenIn(cacheCtx, s.TestAccs[0], pool, swapInFunded, swapOutDenom, pool.GetSpreadFactor(s.Ctx), sdk.ZeroDec())
 	if errors.As(err, &types.InvalidAmountCalculatedError{}) {
 		// If the swap we're about to execute will not generate enough output, we skip the swap.
 		// it would error for a real user though. This is good though, since that user would just be burning funds.
@@ -267,14 +267,82 @@ func (s *KeeperTestSuite) swap(pool types.ConcentratedPoolExtension, swapInFunde
 		}
 	}
 	if err != nil {
-		fmt.Printf("swap error: %s\n", err.Error())
+		fmt.Printf("swap error in out given in: %s\n", err.Error())
 		// Add error to list of errors. Will fail at the end of the fuzz run in high level test.
 		s.collectedErrors = append(s.collectedErrors, err)
 		return false, false
 	}
 
-	// Write only if no error
-	write()
+	// Now, swap in given out with the amount out given by previous swap
+	// We expect the returned amountIn to be roughly equal to the original swapInFunded.
+	cacheCtx, _ = s.Ctx.CacheContext()
+	amountInSwapResult, _, _, err := s.clk.SwapInAmtGivenOut(cacheCtx, s.TestAccs[0], pool, tokenOut, swapInFunded.Denom, pool.GetSpreadFactor(s.Ctx), sdk.ZeroDec())
+	if errors.As(err, &types.InvalidAmountCalculatedError{}) {
+		// If the swap we're about to execute will not generate enough output, we skip the swap.
+		// it would error for a real user though. This is good though, since that user would just be burning funds.
+		if err.(types.InvalidAmountCalculatedError).Amount.IsZero() {
+			return false, false
+		}
+	}
+
+	if err != nil {
+		fmt.Printf("swap error in in given out: %s\n", err.Error())
+		// Add error to list of errors. Will fail at the end of the fuzz run in high level test.
+		s.collectedErrors = append(s.collectedErrors, err)
+		return false, false
+	}
+
+	errTolerance := osmomath.ErrTolerance{
+		// 2% tolerance
+		MultiplicativeTolerance: sdk.NewDecWithPrec(2, 2),
+		RoundingDir:             osmomath.RoundDown,
+	}
+
+	result := errTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(swapInFunded.Amount.ToDec()), osmomath.BigDecFromSDKDec(amountInSwapResult.Amount.ToDec()))
+
+	if result != 0 {
+		// Note: did some investigations into why this happens.
+		// Seed: 1688572291
+		//
+		// Logs & Prints (only relevant parts for brevity):
+		//
+		//
+		// swap out given in
+		//
+		// swap in: 53154819938620036019618231426080065450usdc
+		// start sqrt price 1.925114640286395175000000000000000000
+		// reached sqrt price 9990000000000000000.001925114640286395490901354505635230
+		// liquidity 5315481993862003602.985114363264252712
+		// amountIn 53101665118681415983598613194653985385.000000000000000000
+		//
+		// swap in given out
+		// start sqrt price 1.925114640286395175000000000000000000
+		// reached sqrt price 5504536865264953043.262903126972924283156861610109232553
+		// liquidity 5315481993862003602.985114363264252712
+		// amountIn 29259266591865455675844375866509084121.000000000000000000
+		//
+		// Note that reached sqrt price is different in both cases leading to different amounts in.
+		// Traced the values with clmath.py.
+		// Conclusion: the small rounding difference uner 1 unit leads to such a large difference because
+		// the affected sqrt price range is long
+		//
+		// This is what we get in in given out calculation of sqrt price with non-rounded tokenOut:
+		// get_next_sqrt_price_from_amount0_out_round_up(liquidity, sqrtPriceCurrent, amountOutGiven)
+		// Decimal('9989999999999999983.247487166393337205203511259650091832')
+		//
+		// This is what we get in in given out calculation of sqrt price with rounded tokenOut:
+		// get_next_sqrt_price_from_amount0_out_round_up(liquidity, sqrtPriceCurrent, amountOutTests)
+		// Decimal('5504536865264953043.262903126972924283156861610109232553')
+		//
+		// This proves that this is a test setup error, not a swap logic error. We need smarter detection of when
+		// a small difference between non-rounded tokenOut in swap out given in and the returned tokenOut here leads
+		// to a large difference in sqrt price (TBD later).
+		s.collectedErrors = append(s.collectedErrors, fmt.Errorf("amounts in mismatch, original %s, swapped in given out: %s, difference of %s", swapInFunded, amountInSwapResult, swapInFunded.Amount.Sub(amountInSwapResult.Amount)))
+		return true, false
+	}
+
+	// Write out given in only if no error
+	writeOutGivenIn()
 
 	return true, false
 }
@@ -383,15 +451,15 @@ func (s *KeeperTestSuite) addRandomPositonMinMaxOneSpacing(r *rand.Rand, poolId 
 }
 
 func (s *KeeperTestSuite) addRandomPositon(r *rand.Rand, poolId uint64, minTick, maxTick int64, tickSpacing int64) {
-	tokenDesired0 := sdk.NewCoin(ETH, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
-	tokenDesired1 := sdk.NewCoin(USDC, sdk.NewInt(rand.Int63n(maxAmountDeposited)))
+	tokenDesired0 := sdk.NewCoin(ETH, sdk.NewInt(r.Int63n(maxAmountDeposited)))
+	tokenDesired1 := sdk.NewCoin(USDC, sdk.NewInt(r.Int63n(maxAmountDeposited)))
 	tokensDesired := sdk.NewCoins(tokenDesired0, tokenDesired1)
 
 	s.FundAcc(s.TestAccs[0], tokensDesired)
 
-	lowerTick := roundTickDownSpacing(rand.Int63n(maxTick-minTick+1)+minTick, tickSpacing)
+	lowerTick := roundTickDownSpacing(r.Int63n(maxTick-minTick+1)+minTick, tickSpacing)
 	// lowerTick <= upperTick <= maxTick
-	upperTick := roundTickDownSpacing(maxTick-rand.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))), tickSpacing)
+	upperTick := roundTickDownSpacing(maxTick-r.Int63n(int64(math.Abs(float64(maxTick-lowerTick)))), tickSpacing)
 
 	fmt.Println("creating position: ", "accountName", "lowerTick", lowerTick, "upperTick", upperTick, "token0Desired", tokenDesired0, "tokenDesired1", tokenDesired1)
 
@@ -423,5 +491,5 @@ func roundTickDownSpacing(tickIndex int64, tickSpacing int64) int64 {
 }
 
 func randomIntAmount(r *rand.Rand) sdk.Int {
-	return sdk.NewInt(rand.Int63n(maxAmountDeposited))
+	return sdk.NewInt(r.Int63n(maxAmountDeposited))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

**Main focus:** add swaps in given out to fuzz swap suite
- Try to integrate it as an inverse relationship swap
   * `tokenOut` returned from out given in is used as input to in given out
- Noticed some oddity where amountIn given as input to "out given in" and amount in returned from "out given in" do not match in some edge cases
  * Conclusion: seems like a test setup error that is acceptable. Explained further in comments

Secondary change:
- fixed using the correct source of randomness to be able to run the suite from a deterministic seed

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A