### PR TITLE
[CL]: Reproduce panic during position creation

### DIFF
--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2629,6 +2629,6 @@ func (s *KeeperTestSuite) TestPositionCreationPanic() {
 	// Create position 2 adjacent and below position 1
 	// This triggers a panic, likely due to incorrect spread factor tracking/initialization
 	s.FundAcc(testAddr[2], DefaultRangeTestParams.baseAssets)
-	_, _, _, _, _, _, err = s.clk.CreatePosition(s.Ctx, pool.GetId(), testAddr[2], DefaultRangeTestParams.baseAssets, sdk.ZeroInt(), sdk.ZeroInt(), -200, -101) // -100, 0)
+	_, _, _, _, _, _, err = s.clk.CreatePosition(s.Ctx, pool.GetId(), testAddr[2], DefaultRangeTestParams.baseAssets, sdk.ZeroInt(), sdk.ZeroInt(), -200, -100) // -100, 0)
 	s.Require().NoError(err)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR reproduces a panic during position creation. I was able to construct it after a few attempts once I realized we had some odd behavior around spread factor initialization/tracking on ticks.

## Testing and Verifying

N/A

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A