### PR TITLE
fix: cl param name

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -307,17 +307,17 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 	)
 
 	// Get the permisionless pool creation parameter.
-	isPermisionlessCreationEnabledStr := chainANode.QueryParams(cltypes.ModuleName, string(cltypes.KeyIsPermisionlessPoolCreationEnabled))
+	isPermisionlessCreationEnabledStr := chainANode.QueryParams(cltypes.ModuleName, string(cltypes.KeyIsPermissionlessPoolCreationEnabled))
 	if !strings.EqualFold(isPermisionlessCreationEnabledStr, "false") {
 		s.T().Fatal("concentrated liquidity pool creation is enabled when should not have been")
 	}
 
 	// Change the parameter to enable permisionless pool creation.
-	err := chainANode.ParamChangeProposal("concentratedliquidity", string(cltypes.KeyIsPermisionlessPoolCreationEnabled), []byte("true"), chainA)
+	err := chainANode.ParamChangeProposal("concentratedliquidity", string(cltypes.KeyIsPermissionlessPoolCreationEnabled), []byte("true"), chainA)
 	s.Require().NoError(err)
 
 	// Confirm that the parameter has been changed.
-	isPermisionlessCreationEnabledStr = chainANode.QueryParams(cltypes.ModuleName, string(cltypes.KeyIsPermisionlessPoolCreationEnabled))
+	isPermisionlessCreationEnabledStr = chainANode.QueryParams(cltypes.ModuleName, string(cltypes.KeyIsPermissionlessPoolCreationEnabled))
 	if !strings.EqualFold(isPermisionlessCreationEnabledStr, "true") {
 		s.T().Fatal("concentrated liquidity pool creation is not enabled")
 	}

--- a/x/concentrated-liquidity/types/params.go
+++ b/x/concentrated-liquidity/types/params.go
@@ -10,12 +10,12 @@ import (
 
 // Parameter store keys.
 var (
-	KeyAuthorizedTickSpacing              = []byte("AuthorizedTickSpacing")
-	KeyAuthorizedSpreadFactors            = []byte("AuthorizedSpreadFactors")
-	KeyDiscountRate                       = []byte("DiscountRate")
-	KeyAuthorizedQuoteDenoms              = []byte("AuthorizedQuoteDenoms")
-	KeyAuthorizedUptimes                  = []byte("AuthorizedUptimes")
-	KeyIsPermisionlessPoolCreationEnabled = []byte("IsPermisionlessPoolCreationEnabled")
+	KeyAuthorizedTickSpacing               = []byte("AuthorizedTickSpacing")
+	KeyAuthorizedSpreadFactors             = []byte("AuthorizedSpreadFactors")
+	KeyDiscountRate                        = []byte("DiscountRate")
+	KeyAuthorizedQuoteDenoms               = []byte("AuthorizedQuoteDenoms")
+	KeyAuthorizedUptimes                   = []byte("AuthorizedUptimes")
+	KeyIsPermissionlessPoolCreationEnabled = []byte("IsPermissionlessPoolCreationEnabled")
 
 	_ paramtypes.ParamSet = &Params{}
 )
@@ -82,7 +82,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 		paramtypes.NewParamSetPair(KeyAuthorizedTickSpacing, &p.AuthorizedTickSpacing, validateTicks),
 		paramtypes.NewParamSetPair(KeyAuthorizedSpreadFactors, &p.AuthorizedSpreadFactors, validateSpreadFactors),
 		paramtypes.NewParamSetPair(KeyAuthorizedQuoteDenoms, &p.AuthorizedQuoteDenoms, validateAuthorizedQuoteDenoms),
-		paramtypes.NewParamSetPair(KeyIsPermisionlessPoolCreationEnabled, &p.IsPermissionlessPoolCreationEnabled, validateIsPermissionLessPoolCreationEnabled),
+		paramtypes.NewParamSetPair(KeyIsPermissionlessPoolCreationEnabled, &p.IsPermissionlessPoolCreationEnabled, validateIsPermissionLessPoolCreationEnabled),
 		paramtypes.NewParamSetPair(KeyDiscountRate, &p.BalancerSharesRewardDiscount, validateBalancerSharesDiscount),
 		paramtypes.NewParamSetPair(KeyAuthorizedUptimes, &p.AuthorizedUptimes, validateAuthorizedUptimes),
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The param name for permissionless pool creation is wrong, which caused param change proposal confusion