### PR TITLE
feat: add reward/incentive claiming to cl script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,16 @@ localnet-cl-external-incentive:
 localnet-cl-create-pool:
 	go run tests/cl-go-client/main.go --operation 4
 
+# claims spread rewards for a random account for a random
+# subset of positions.
+localnet-cl-claim-spread-rewards:
+	go run tests/cl-go-client/main.go --operation 5
+
+# claims incentives for a random account for a random
+# subset of positions.
+localnet-cl-claim-incentives:
+	go run tests/cl-go-client/main.go --operation 6
+
 # does both of localnet-cl-create-positions and localnet-cl-small-swap
 localnet-cl-positions-small-swaps: localnet-cl-create-positions localnet-cl-small-swap
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3
 	github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230629191111-f375469de8b6
-	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343
+	github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230707192814-b6283c63146e
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230602130523-f9a94d8bbd10
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -952,6 +952,8 @@ github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230629191111-f375469de8b
 github.com/osmosis-labs/osmosis/osmomath v0.0.3-dev.0.20230629191111-f375469de8b6/go.mod h1:JTym95/bqrSnG5MPcXr1YDhv43JdCeo3p+iDbazoX68=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343 h1:7V2b3+mSnLnK0Px+Dl3vnxAQgk4SV8e9ohfJ/tKsq0M=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230623115558-38aaab07d343/go.mod h1:FqFOfj9+e5S1I7hR3baGUHrqje3g32EOHAXoOf7R00M=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230707192814-b6283c63146e h1:ZUiM1+ZJ+zY6Br1vfiuSaL8EurM+j98zDPjmeDQQvXw=
+github.com/osmosis-labs/osmosis/osmoutils v0.0.0-20230707192814-b6283c63146e/go.mod h1:Pl8Nzx6O6ow/+aqfMoMSz4hX+zz6RrnDYsooptECGxM=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304 h1:RIrWLzIiZN5Xd2JOfSOtGZaf6V3qEQYg6EaDTAkMnCo=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.0-20230328024000-175ec88e4304/go.mod h1:yPWoJTj5RKrXKUChAicp+G/4Ni/uVEpp27mi/FF/L9c=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230602130523-f9a94d8bbd10 h1:XrES5AHZMZ/Y78boW35PTignkhN9h8VvJ1sP8EJDIu8=

--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -1,6 +1,7 @@
 package osmoutils
 
 import (
+	"math/rand"
 	"reflect"
 	"sort"
 
@@ -101,4 +102,18 @@ func Contains[T comparable](slice []T, item T) bool {
 		}
 	}
 	return false
+}
+
+// GetRandomSubset returns a random subset of the given slice
+func GetRandomSubset[T any](slice []T) []T {
+	if len(slice) == 0 {
+		return []T{}
+	}
+
+	rand.Shuffle(len(slice), func(i, j int) {
+		slice[i], slice[j] = slice[j], slice[i]
+	})
+
+	n := rand.Intn(len(slice))
+	return slice[:n]
 }

--- a/osmoutils/slice_helper_test.go
+++ b/osmoutils/slice_helper_test.go
@@ -1,8 +1,10 @@
 package osmoutils_test
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -122,4 +124,51 @@ func TestContains(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetRandomSubset(t *testing.T) {
+	tests := []struct {
+		name  string
+		slice []int
+	}{
+		{
+			name:  "Empty slice",
+			slice: []int{},
+		},
+		{
+			name:  "Slice of integers",
+			slice: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+	}
+
+	rand.Seed(time.Now().UnixNano())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := osmoutils.GetRandomSubset(tt.slice)
+
+			// Check if the length of the returned subset is less than or equal to the length of the original slice
+			if len(got) > len(tt.slice) {
+				t.Errorf("GetRandomSubset() returned subset length %d, expected less than or equal to %d", len(got), len(tt.slice))
+			}
+
+			// Check if the returned subset contains only elements from the original slice
+			for _, v := range got {
+				if !contains(tt.slice, v) {
+					t.Errorf("GetRandomSubset() returned element %v not found in the original slice", v)
+				}
+			}
+		})
+	}
+}
+
+// contains checks if a slice contains a specific element
+func contains(slice interface{}, element interface{}) bool {
+	s := reflect.ValueOf(slice)
+	for i := 0; i < s.Len(); i++ {
+		if reflect.DeepEqual(s.Index(i).Interface(), element) {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/cl-go-client/main.go
+++ b/tests/cl-go-client/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ignite/cli/ignite/pkg/cosmosaccount"
 	"github.com/ignite/cli/ignite/pkg/cosmosclient"
 
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	clqueryproto "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/client/queryproto"
 	"github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/model"
 	cltypes "github.com/osmosis-labs/osmosis/v16/x/concentrated-liquidity/types"
@@ -478,7 +479,7 @@ func claimSpreadRewardsOp(igniteClient cosmosclient.Client) {
 	}
 
 	// Set positionIds to a random subset of allUserPositionIds
-	positionIds := getRandomSubset(allUserPositionIds)
+	positionIds := osmoutils.GetRandomSubset(allUserPositionIds)
 
 	log.Println("position IDs chosen: ", positionIds)
 
@@ -528,7 +529,7 @@ func claimIncentivesOp(igniteClient cosmosclient.Client) {
 	}
 
 	// Set positionIds to a random subset of allUserPositionIds
-	positionIds := getRandomSubset(allUserPositionIds)
+	positionIds := osmoutils.GetRandomSubset(allUserPositionIds)
 
 	log.Println("position IDs chosen: ", positionIds)
 
@@ -607,14 +608,4 @@ func roundTickDown(tickIndex int64, tickSpacing int64) int64 {
 		tickIndex = tickIndex - tickIndexModulus
 	}
 	return tickIndex
-}
-
-// getRandomSubset returns a random subset of the given slice
-func getRandomSubset(slice []uint64) []uint64 {
-	rand.Shuffle(len(slice), func(i, j int) {
-		slice[i], slice[j] = slice[j], slice[i]
-	})
-
-	n := rand.Intn(len(slice))
-	return slice[:n]
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Adds both spread reward and incentive claiming to the cl script. For both rewards:
- Selects a single random account
- Retrieves all of that address's position IDs
- Selects a random subset of those position IDs
- Claims for all those position IDs