### PR TITLE
fix: update pool uptime accum to now in query

### DIFF
--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -242,10 +242,6 @@ func CalcAccruedIncentivesForAccum(ctx sdk.Context, accumUptime time.Duration, q
 	return calcAccruedIncentivesForAccum(ctx, accumUptime, qualifyingLiquidity, timeElapsed, poolIncentiveRecords)
 }
 
-func (k Keeper) UpdateUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64) error {
-	return k.updatePoolUptimeAccumulatorsToNow(ctx, poolId)
-}
-
 func (k Keeper) UpdateGivenPoolUptimeAccumulatorsToNow(ctx sdk.Context, pool types.ConcentratedPoolExtension, uptimeAccums []accum.AccumulatorObject) error {
 	return k.updateGivenPoolUptimeAccumulatorsToNow(ctx, pool, uptimeAccums)
 }

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -317,7 +317,7 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 	return totalRewards, nil
 }
 
-// updatePoolUptimeAccumulatorsToNow syncs all uptime accumulators that are refetched from state for the given
+// UpdatePoolUptimeAccumulatorsToNow syncs all uptime accumulators that are refetched from state for the given
 // poold id to be up to date for the given pool. Updates the pool last liquidity update time with
 // the current block time and writes the updated pool to state.
 // Specifically, it gets the time elapsed since the last update and divides it
@@ -328,8 +328,8 @@ func (k Keeper) claimAndResetFullRangeBalancerPool(ctx sdk.Context, clPoolId uin
 // * this function fetches the uptime accumulators from state.
 // * this function fetches a pool from state by id.
 // updateGivenPoolUptimeAccumulatorsToNow is used in swaps for performance reasons to minimize state reads.
-// updatePoolUptimeAccumulatorsToNow is used in all other cases.
-func (k Keeper) updatePoolUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64) error {
+// UpdatePoolUptimeAccumulatorsToNow is used in all other cases.
+func (k Keeper) UpdatePoolUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64) error {
 	pool, err := k.getPoolById(ctx, poolId)
 	if err != nil {
 		return err
@@ -722,7 +722,7 @@ func (k Keeper) initOrUpdatePositionUptimeAccumulators(ctx sdk.Context, poolId u
 	// We update accumulators _prior_ to any position-related updates to ensure
 	// past rewards aren't distributed to new liquidity. We also update pool's
 	// LastLiquidityUpdate here.
-	err := k.updatePoolUptimeAccumulatorsToNow(ctx, poolId)
+	err := k.UpdatePoolUptimeAccumulatorsToNow(ctx, poolId)
 	if err != nil {
 		return err
 	}
@@ -874,7 +874,7 @@ func (k Keeper) prepareClaimAllIncentivesForPosition(ctx sdk.Context, positionId
 		return sdk.Coins{}, sdk.Coins{}, err
 	}
 
-	err = k.updatePoolUptimeAccumulatorsToNow(ctx, position.PoolId)
+	err = k.UpdatePoolUptimeAccumulatorsToNow(ctx, position.PoolId)
 	if err != nil {
 		return sdk.Coins{}, sdk.Coins{}, err
 	}
@@ -1062,7 +1062,7 @@ func (k Keeper) CreateIncentive(ctx sdk.Context, poolId uint64, sender sdk.AccAd
 	}
 
 	// Sync global uptime accumulators to current blocktime to ensure consistency in reward emissions
-	err = k.updatePoolUptimeAccumulatorsToNow(ctx, poolId)
+	err = k.UpdatePoolUptimeAccumulatorsToNow(ctx, poolId)
 	if err != nil {
 		return types.IncentiveRecord{}, err
 	}

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1075,7 +1075,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 				// Use cache context to avoid persisting updates for the next function
 				// that relies on the same test cases and setup.
 				cacheCtx, _ := s.Ctx.CacheContext()
-				err = clKeeper.UpdateUptimeAccumulatorsToNow(cacheCtx, tc.poolId)
+				err = clKeeper.UpdatePoolUptimeAccumulatorsToNow(cacheCtx, tc.poolId)
 
 				validateResult(cacheCtx, err, tc, balancerPoolId, clPool.GetId(), initUptimeAccumValues, qualifyingBalancerLiquidity, qualifyingLiquidity)
 
@@ -3152,7 +3152,7 @@ func (s *KeeperTestSuite) TestPrepareClaimAllIncentivesForPosition() {
 
 			// Update the uptime accumulators to the current block time.
 			// This is done to determine the exact amount of incentives we expect to be forfeited, if any.
-			err = s.clk.UpdateUptimeAccumulatorsToNow(s.Ctx, pool.GetId())
+			err = s.clk.UpdatePoolUptimeAccumulatorsToNow(s.Ctx, pool.GetId())
 			s.Require().NoError(err)
 
 			// Retrieve the uptime accumulators for the pool.

--- a/x/concentrated-liquidity/position.go
+++ b/x/concentrated-liquidity/position.go
@@ -566,7 +566,7 @@ func (k Keeper) fungifyChargedPosition(ctx sdk.Context, owner sdk.AccAddress, po
 	newPositionId := k.getNextPositionIdAndIncrement(ctx)
 
 	// Update pool uptime accumulators to now.
-	if err := k.updatePoolUptimeAccumulatorsToNow(ctx, poolId); err != nil {
+	if err := k.UpdatePoolUptimeAccumulatorsToNow(ctx, poolId); err != nil {
 		return 0, err
 	}
 

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -1081,7 +1081,7 @@ func (s *KeeperTestSuite) TestValidateAndFungifyChargedPositions() {
 			}
 
 			// Update the accumulators for defaultPoolId to the current time
-			err = s.clk.UpdateUptimeAccumulatorsToNow(s.Ctx, defaultPoolId)
+			err = s.clk.UpdatePoolUptimeAccumulatorsToNow(s.Ctx, defaultPoolId)
 			s.Require().NoError(err)
 
 			// Get the unclaimed rewards for all the positions that are being migrated
@@ -1337,7 +1337,7 @@ func (s *KeeperTestSuite) TestFungifyChargedPositions_ClaimIncentives() {
 	// prior to running fungify. However, we do not want the mutations made in test setup to have
 	// impact on the system under test because it (fungify) must update the uptime accumulators itself.
 	cacheCtx, _ := s.Ctx.CacheContext()
-	err := s.clk.UpdateUptimeAccumulatorsToNow(cacheCtx, pool.GetId())
+	err := s.clk.UpdatePoolUptimeAccumulatorsToNow(cacheCtx, pool.GetId())
 	s.Require().NoError(err)
 
 	claimableIncentives := sdk.NewCoins()

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -130,7 +130,7 @@ func (k Keeper) GetTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) (ti
 		}
 
 		// Sync global uptime accumulators to ensure the uptime tracker init values are up to date.
-		if err := k.updatePoolUptimeAccumulatorsToNow(ctx, poolId); err != nil {
+		if err := k.UpdatePoolUptimeAccumulatorsToNow(ctx, poolId); err != nil {
 			return tickStruct, err
 		}
 

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -877,7 +877,7 @@ type OverChargeSwapOutGivenInError struct {
 func (e OverChargeSwapOutGivenInError) Error() string {
 	return fmt.Sprintf("over charge problem swap out given in by (%s)", e.AmountSpecifiedRemaining)
 }
-  
+
 type ComputedSqrtPriceInequalityError struct {
 	IsZeroForOne                 bool
 	NextInitializedTickSqrtPrice osmomath.BigDec


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Pool incentives query was not updating uptime accumulators to now while the tick query was. This resulted in the global accum being smaller than the tick accum, which should not be possible.

This would not take place in state, but the query being this way lead to unnecessary debugging.