### PR TITLE
Improve our release process with goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,78 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+
+env:
+  - CGO_ENABLED=1
+  - TM_VERSION=1.2.3
+
+builds:
+  - id: darwin
+    main: ./cmd/osmosisd/main.go
+    binary: osmosisd
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CC=o64-clang
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w 
+      - -X main.commit={{.Commit}} 
+      - -X main.date={{ .CommitDate }} 
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis 
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd 
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} 
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }} 
+      - -X github.com/tendermint/tendermint/version.TMCoreSemVer={{ .Env.TM_VERSION }}
+      - -linkmode=external
+    tags:
+      - netgo
+      - ledger
+      - static_wasm
+    overrides:
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=oa64-clang
+
+universal_binaries:
+  - id: darwin
+
+  # - id: darwin-arm64
+  #   main: ./cmd/osmosisd/main.go
+  #   env:
+  #   - CC=oa64-clang
+  #   binary: osmosisd
+  #   goos:
+  #     - darwin
+  #   goarch:
+  #     - arm64
+  #   flags:
+  #     - -mod=readonly
+  #   ldflags:
+  #     - -s -w 
+  #     - -X main.commit={{.Commit}} 
+  #     - -X main.date={{ .CommitDate }} 
+  #     - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis 
+  #     - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd 
+  #     - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} 
+  #     - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }} 
+  #     - -X github.com/tendermint/tendermint/version.TMCoreSemVer={{ .Env.TM_VERSION }}
+  #     - -linkmode=external
+  #   tags:
+  #     - netgo
+  #     - ledger
+  #     - static_wasm
+
+# universal_binaries:
+#   - id: darwin
+#     ids:
+#       - darwin-amd64
+#       - darwin-arm64
+#     replace: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,78 +1,253 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
-before:
-  hooks:
-    - go mod tidy
+project_name: osmosisd
 
 env:
   - CGO_ENABLED=1
-  - TM_VERSION=1.2.3
+  - COSMWASM_VERSION=1.2.3
 
 builds:
-  - id: darwin
+  - id: osmosisd-darwin-amd64
     main: ./cmd/osmosisd/main.go
     binary: osmosisd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    env:
+      - CC=o64-clang
+      - CGO_LDFLAGS=-L/lib
     goos:
       - darwin
     goarch:
       - amd64
-      - arm64
-    env:
-      - CC=o64-clang
     flags:
       - -mod=readonly
+      - -trimpath
     ldflags:
-      - -s -w 
-      - -X main.commit={{.Commit}} 
-      - -X main.date={{ .CommitDate }} 
-      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis 
-      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd 
-      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} 
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }} 
-      - -X github.com/tendermint/tendermint/version.TMCoreSemVer={{ .Env.TM_VERSION }}
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+      - -w -s
       - -linkmode=external
     tags:
       - netgo
       - ledger
       - static_wasm
-    overrides:
-      - goos: darwin
-        goarch: arm64
-        env:
-          - CC=oa64-clang
+
+  - id: osmosisd-darwin-arm64
+    main: ./cmd/osmosisd/main.go
+    binary: osmosisd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    env:
+      - CC=oa64-clang
+      - CGO_LDFLAGS=-L/lib
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+      - -w -s
+      - -linkmode=external
+    tags:
+      - netgo
+      - ledger
+      - static_wasm
+
+  - id: osmosisd-linux-amd64
+    main: ./cmd/osmosisd
+    binary: osmosisd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CC=x86_64-linux-gnu-gcc
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc
+      - -w -s
+      - -linkmode=external
+      - -extldflags '-Wl,-z,muldefs -static -lm'
+    tags:
+      - netgo
+      - ledger
+      - muslc
+
+  - id: osmosisd-linux-arm64
+    main: ./cmd/osmosisd
+    binary: osmosisd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis 
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd 
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} 
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc
+      - -w -s
+      - -linkmode=external
+      - -extldflags '-Wl,-z,muldefs -static -lm'
+    tags:
+      - netgo
+      - ledger
+      - muslc
 
 universal_binaries:
-  - id: darwin
+  - id: osmosisd-darwin-universal
+    ids:
+      - osmosisd-darwin-amd64
+      - osmosisd-darwin-arm64
+    replace: true
+    name_template: "{{.ProjectName}}"
 
-  # - id: darwin-arm64
-  #   main: ./cmd/osmosisd/main.go
-  #   env:
-  #   - CC=oa64-clang
-  #   binary: osmosisd
-  #   goos:
-  #     - darwin
-  #   goarch:
-  #     - arm64
-  #   flags:
-  #     - -mod=readonly
-  #   ldflags:
-  #     - -s -w 
-  #     - -X main.commit={{.Commit}} 
-  #     - -X main.date={{ .CommitDate }} 
-  #     - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis 
-  #     - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd 
-  #     - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} 
-  #     - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }} 
-  #     - -X github.com/tendermint/tendermint/version.TMCoreSemVer={{ .Env.TM_VERSION }}
-  #     - -linkmode=external
-  #   tags:
-  #     - netgo
-  #     - ledger
-  #     - static_wasm
+archives:
+  - id: zipped
+    builds:
+      - osmosisd-darwin-universal
+      - osmosisd-linux-amd64
+      - osmosisd-linux-arm64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: zip
+    files:
+      - none*
+  - id: binaries
+    builds:
+      - osmosisd-darwin-universal
+      - osmosisd-linux-amd64
+      - osmosisd-linux-arm64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+    files:
+      - none*
 
-# universal_binaries:
-#   - id: darwin
-#     ids:
-#       - darwin-amd64
-#       - darwin-arm64
-#     replace: false
+checksum:
+  name_template: "{{.ProjectName}}-{{ .Version }}-checksums.txt"
+  algorithm: sha256
+
+# Docs: https://goreleaser.com/customization/homebrew/
+brews:
+  - name: osmosisd
+    folder: Formula
+    ids:
+    - binaries
+    homepage: "https://gihub.com/osmosis-labs/osmosis"
+    description: "osmosisd binary to interact with the Osmosis network"
+    conflicts:
+      - osmosisd
+    test: |
+      system "#{bin}/osmosisd version"
+    install: |
+      bin.install 'osmosisd'
+    skip_upload: true
+    # # Uncomment line below if you want to try to commit the updated formula
+    # skip_upload: false
+    # repository:
+    #   owner: osmosis-labs
+    #   name: homebrew-osmosis
+    #   branch: main
+    #   pull_request:
+    #     enabled: true
+    # commit_author:
+    #   name: osmo-bot
+    #   email: devops@osmosis.team
+    # commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+
+# Docs: https://goreleaser.com/customization/changelog/
+changelog:
+  skip: true
+
+# Docs: https://goreleaser.com/customization/release/
+release:
+  github:
+    owner: osmosis-labs
+    name: osmosis
+  replace_existing_draft: true
+  header: |
+    < DESCRIPTION OF RELEASE >
+
+    ## Changelog
+
+    See the full changelog [here](https://github.com/osmosis-labs/osmosis/blob/v{{ .Version }}/CHANGELOG.md)
+
+    ## ⚡️ Binaries
+
+    Binaries for Linux (amd64 and arm64) are available below.
+    Darwin users can use the same universal binary for both amd64 and arm64.
+
+    #### 🔨 Build from source
+
+    If you prefer to build from source, you can use the following commands:
+
+    ````bash
+    git clone https://github.com/osmosis-labs/osmosis
+    cd osmosis && git checkout v{{ .Version }}
+    make install
+    ````
+
+    ## 🐳 Docker
+
+    The following Docker images are available in our registry:
+
+    | Image                                        | Description                              |
+    |----------------------------------------------|------------------------------------------|
+    | `osmolabs/osmosis:{{ .Version }}`            | Default image based on Distroless        |
+    | `osmolabs/osmosis:{{ .Version }}-distroless` | Distroless image  (same as above)        |
+    | `osmolabs/osmosis:{{ .Version }}-nonroot`    | Distroless non-root image                |
+    | `osmolabs/osmosis:{{ .Version }}-alpine`     | Alpine image                             |
+
+    Example:
+
+    ```bash
+    docker run osmolabs/osmosis:{{ .Version }} version
+    # v{{ .Version }}
+    ````
+
+    All the images support `arm64` and `amd64` architectures.
+
+  name_template: "Osmosis v{{.Version}} 🧪"
+  mode: replace
+  draft: true
+
+# Docs: https://goreleaser.com/customization/announce/
+#
+# We could automatically announce the release in
+# - discord
+# - slack
+# - twitter
+# - webhooks
+# - telegram
+# - reddit
+#
+# announce:
+  # discord:
+  #   enabled: true
+  #   message_template: 'New {{.Tag}} is out!'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -136,7 +136,7 @@ archives:
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-    format: zip
+    format: tar.gz
     files:
       - none*
   - id: binaries

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,7 +135,7 @@ archives:
       - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{.ProjectName}}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     files:
       - none*
@@ -144,13 +144,13 @@ archives:
       - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{.ProjectName}}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:
       - none*
 
 checksum:
-  name_template: "{{.ProjectName}}-{{ .Version }}-checksums.txt"
+  name_template: "checksums.txt"
   algorithm: sha256
 
 # Docs: https://goreleaser.com/customization/homebrew/
@@ -213,18 +213,19 @@ release:
     make install
     ````
 
-    ## 🐳 Docker
+    ## 🐳 Run with Docker
 
+    As an alternative to installing and running osmosisd on your system, you may run osmosisd in a Docker container.
     The following Docker images are available in our registry:
 
-    | Image                                        | Description                              |
-    |----------------------------------------------|------------------------------------------|
-    | `osmolabs/osmosis:{{ .Version }}`            | Default image based on Distroless        |
-    | `osmolabs/osmosis:{{ .Version }}-distroless` | Distroless image  (same as above)        |
-    | `osmolabs/osmosis:{{ .Version }}-nonroot`    | Distroless non-root image                |
-    | `osmolabs/osmosis:{{ .Version }}-alpine`     | Alpine image                             |
+    | Image Name | Base | Description |
+    |------------|------|---------|
+    | `osmolabs/osmosis:{{ .Version }}`            | `distroless/static-debian11` | Default image based on Distroless        |
+    | `osmolabs/osmosis:{{ .Version }}-distroless` | `distroless/static-debian11` |  Distroless image (same as above)        |
+    | `osmolabs/osmosis:{{ .Version }}-nonroot`    | `distroless/static-debian11:nonroot` |  Distroless non-root image     |            |
+    | `osmolabs/osmosis:{{ .Version }}-alpine`     | `alpine` |  Alpine image                 |
 
-    Example:
+    Example run:
 
     ```bash
     docker run osmolabs/osmosis:{{ .Version }} version


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces the `.goreleaser.yaml` configuration file and sets up the release process for the project osmosisd. 

Goreleaser is a popular tool used in the Go ecosystem to automate the build and release workflow for Go projects. It simplifies the process of building binaries, creating archives, generating checksums, and publishing releases across multiple platforms and architectures.

The `goreleaser.yaml` file included in this PR defines the configuration for the release process of `osmosisd`. 
Let's summarize the key elements of the configuration:

1. **Project Information:**
   - `project_name`: Specifies the name of the project as `osmosisd`.

2. **Environment Variables:**
   - Specifies the needed environment variables

3. **Builds:**
   The configuration defines four build targets, each specifying different operating systems and architectures:
   - `osmosisd-darwin-amd64`: Builds the `osmosisd` binary for macOS (darwin) on AMD64 architecture.
   - `osmosisd-darwin-arm64`: Builds the `osmosisd` binary for macOS (darwin) on ARM64 architecture.
   - `osmosisd-linux-amd64`: Builds the `osmosisd` binary for Linux on AMD64 architecture.
   - `osmosisd-linux-arm64`: Builds the `osmosisd` binary for Linux on ARM64 architecture.

   For each build, the configuration specifies the necessary build commands, hooks, environment variables, Go compiler options, flags, and linker flags.

4. **Universal Binaries:**
   - `osmosisd-darwin-universal`: Creates a universal binary that includes both the macOS (darwin) AMD64 and ARM64 builds. 

5. **Archives:**
   The configuration defines an archive configuration named `zipped` that generates zip archives for the universal darwin binary and Linux AMD64/ARM64 binaries.

6. **Checksums:**
   - Generates a checksum file named `osmosisd-{{ .Version }}-checksums.txt` using the SHA256 algorithm.

7. **Brew Formula:**
   - Defines a brew formula for `osmosisd` called `osmosisd`. The formula installs the `osmosisd` binary and includes tests and installation instructions. This would allow user to install `osmosisd` with `brew install osmosisd`

8. **Release Configuration:**
   - Create a draft release following the template
   - Upload the necessary binaries

There a lot of options that we could customize in this file. 
For example we could automatically announce on Discord, Slack, Twitter, etc.. once the release is done: https://goreleaser.com/customization/announce/

## Testing and Verifying

I have used this `.goreleaser.yaml` to create the following release in my local fork: [Link to Release](https://github.com/niccoloraspa/osmosis/releases/tag/v16.0.0)

To replicate the release process, execute the following command:

1. Fork the osmosis repo with all the tags 

2.   Clone the repo and select the tag

```bash
git clone https://github.com/<YOUR_GITHUB_USER>/osmosis
git checkout v16.0.0
```

4. Copy this `.goreleaser.yaml`

5. Edit the `.goreleaser.yaml` to avoid creating a release in the real repository.

```
release:
  github:
    #owner: osmosis-labs  
    owner: <YOUR_GITHUB_USER>
    name: osmosis
```

6. Run `goreleaser-cross`:

```yaml
docker run -e GITHUB_TOKEN=<GITHUB_TOKEN_WITH_REPO_ACCESS> -v /var/run/docker.sock:/var/run/docker.sock -v pwd:/go/src/osmosisd -w /go/src/osmosisd ghcr.io/goreleaser/goreleaser-cross:v1.20.5 release --clean
```

Replace `<GITHUB_TOKEN_WITH_REPO_ACCESS>` with an actual GitHub token that has access to the repository.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? 

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A