### PR TITLE
Update fee in x/gamm/README.md

### DIFF
--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -274,8 +274,8 @@ The configuration json file contains the following parameters:
 {
  "weights": "5ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4,5uosmo",
  "initial-deposit": "499404ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4,500000uosmo",
- "swap-fee": "0.01",
- "exit-fee": "0.01",
+ "swap-fee": "0.003",
+ "exit-fee": "0.00",
  "future-governor": ""
 }
 ```


### PR DESCRIPTION
## What is the purpose of the change

Updates x/gamm/README.md, which is used as a reference by teams creating pools via CLI, many of which (maybe half) accidentally create them with 2% or 3% swap fee instead of 0.2% or 0.3%. Updating the swap fee from 0.01 to 0.003 could help avoid the mistake. Also sets exit fee to 0 since that is the preference and standard.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

Where is the change documented? 
  - [ ] N/A