### PR TITLE
fix cl readme typo

### DIFF
--- a/x/concentrated-liquidity/README.md
+++ b/x/concentrated-liquidity/README.md
@@ -58,7 +58,7 @@ $$y = L \sqrt P$$
 Note the square root around price. By tracking it this way, we can utilize the
 following core property of the architecture:
 
-$$L = \Delta Y / \Delta \sqrt P$$
+$$L = \Delta y / \Delta \sqrt P$$
 
 Since only one of the following changes at a time:
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
This PR fixes a typo in the concentrated liquidity README, there was first a capital Y which should be a capital y

## Testing and Verifying

This change is a trivial rework without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
    no
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?
    no

Where is the change documented? 
  - [x] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A