### PR TITLE
Docs: Fix Broken Links (Jul 15, 2023)

### DIFF
--- a/networks/osmosis-1/upgrades/v16/mainnet/guide.md
+++ b/networks/osmosis-1/upgrades/v16/mainnet/guide.md
@@ -43,7 +43,7 @@ pre-install new binaries, and cosmovisor will automatically update them
 based on on-chain SoftwareUpgrade proposals.
 
 You should review the docs for cosmovisor located here:
-<https://docs.cosmos.network/master/run-node/cosmovisor.html>
+<https://docs.cosmos.network/main/tooling/cosmovisor>
 
 If you choose to use cosmovisor, please continue with these
 instructions:

--- a/x/superfluid/README.md
+++ b/x/superfluid/README.md
@@ -223,16 +223,6 @@ osmo-basepair pool of an asset. The multiplier is set once per epoch, at
 the beginning of the epoch. In the future, we will switch this out to
 use a TWAP instead.
 
-### State changes
-
-The state of superfluid module state modifiers are classified into below
-categories.
-
-- [Proposals](07_proposals.md)
-- [Messages](03_messages.md)
-- [Epoch](04_epoch.md)
-- [Hooks](06_hooks.md)
-
 ### Messages
 
 ### Superfluid Delegate


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #5843

## What is the purpose of the change

- Fixed the broken links found by either updating them to valid sites, or removing references. 
- I removed the `State` links as per [this comment](https://github.com/osmosis-labs/osmosis/pull/5728#issuecomment-1617447863)

### Leading Question
Should we ignore the `CHANGELOG.md` file from being checked? 
It has "broken links", but I'm not sure if makes sense to try to update them. They are already in the public-facing changelogs so this wouldn't really help with anything.

If we ignore it, it should be as simple as adding `--exclude-path 'CHANGELOG.md'` to the lychee-action. I tested this locally and it ignored the CHANGELOG correctly. Not sure if we should be doing `./**/CHANGELOG.md` for CI runs though. But i believe it should work as-is since it would be in the root folder, and `./CHANGELOG.md == CHANGELOG.md`
>       --exclude-path <EXCLUDE_PATH>
>          Exclude file path from getting checked

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

I was able to `brew install lychee` and ran `lychee --exclude-loopback --verbose --no-progress './**/*.md' './**/*.html' --exclude-paths 'CHANGELOG.md'` to see that those broken links were no longer an issue.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A