### PR TITLE
chore: v16 e2e init image updates

### DIFF
--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -96,8 +96,9 @@ var (
 	StakeAmountIntB  = sdk.NewInt(StakeAmountB)
 	StakeAmountCoinB = sdk.NewCoin(OsmoDenom, StakeAmountIntB)
 
-	// Can be removed after v17 upgrade.
+	// START: CAN REMOVE POST v17 UPGRADE
 	BaseDenomBalances = strAllUpgradeBaseDenoms()
+	// END: CAN REMOVE POST v17 UPGRADE
 
 	InitBalanceStrA = fmt.Sprintf("%d%s,%d%s,%d%s,%d%s,%d%s", OsmoBalanceA, OsmoDenom, StakeBalanceA, StakeDenom, IonBalanceA, IonDenom, UstBalanceA, UstIBCDenom, LuncBalanceA, LuncIBCDenom)
 	InitBalanceStrB = fmt.Sprintf("%d%s,%d%s,%d%s", OsmoBalanceB, OsmoDenom, StakeBalanceB, StakeDenom, IonBalanceB, IonDenom)
@@ -108,7 +109,7 @@ var (
 	WalletFeeTokens = sdk.NewCoin(E2EFeeToken, sdk.NewInt(WalletFeeBalance))
 )
 
-// Can be removed after v17 upgrade.
+// START: CAN REMOVE POST v17 UPGRADE
 func strAllUpgradeBaseDenoms() string {
 	upgradeBaseDenoms := fmt.Sprintf("%s%s,", DaiBalanceA, DaiDenom)
 	n := len(AssetPairs)
@@ -123,6 +124,8 @@ func strAllUpgradeBaseDenoms() string {
 	}
 	return upgradeBaseDenoms
 }
+
+// END: CAN REMOVE POST v17 UPGRADE
 
 func addAccount(path, moniker, amountStr string, accAddr sdk.AccAddress, forkHeight int) error {
 	serverCtx := server.NewDefaultContext()
@@ -350,13 +353,14 @@ func updateBankGenesis(appGenState map[string]json.RawMessage) func(s *banktypes
 			setDenomMetadata(bankGenState, denom)
 		}
 
-		// Can be removed after v17 upgrade.
+		// START: CAN REMOVE POST v17 UPGRADE
 		for _, assetPair := range AssetPairs {
 			if assetPair.BaseAsset == "uion" {
 				continue
 			}
 			setDenomMetadata(bankGenState, assetPair.BaseAsset)
 		}
+		// END: CAN REMOVE POST v17 UPGRADE
 
 		// Update pool balances with initial liquidity.
 		gammGenState := &gammtypes.GenesisState{}
@@ -403,6 +407,8 @@ func updatePoolIncentiveGenesis(pooliGenState *poolitypes.GenesisState) {
 	pooliGenState.Params = poolitypes.Params{
 		MintedDenom: OsmoDenom,
 	}
+
+	// START: CAN REMOVE POST v17 UPGRADE
 	poolToGauges := poolitypes.PoolToGauges{}
 	currentGaugeId := uint64(1)
 	for _, assetPair := range AssetPairs {
@@ -417,6 +423,7 @@ func updatePoolIncentiveGenesis(pooliGenState *poolitypes.GenesisState) {
 		}
 	}
 	pooliGenState.PoolToGauges = &poolToGauges
+	// END: CAN REMOVE POST v17 UPGRADE
 }
 
 func updateIncentivesGenesis(incentivesGenState *incentivestypes.GenesisState) {
@@ -429,7 +436,7 @@ func updateIncentivesGenesis(incentivesGenState *incentivestypes.GenesisState) {
 		DistrEpochIdentifier: "day",
 	}
 
-	// Add gauge here
+	// START: CAN REMOVE POST v17 UPGRADE
 	gauges := []incentivestypes.Gauge{}
 	currentGaugeId := uint64(1)
 	for _, assetPair := range AssetPairs {
@@ -457,6 +464,7 @@ func updateIncentivesGenesis(incentivesGenState *incentivestypes.GenesisState) {
 
 	incentivesGenState.Gauges = gauges
 	incentivesGenState.LastGaugeId = currentGaugeId
+	// END: CAN REMOVE POST v17 UPGRADE
 }
 
 func updateMintGenesis(mintGenState *minttypes.GenesisState) {
@@ -471,7 +479,7 @@ func updateTxfeesGenesis(txfeesGenState *txfeestypes.GenesisState) {
 	}
 }
 
-// Can be removed after v17 upgrade.
+// START: CAN REMOVE POST v17 UPGRADE
 type ByLinkedClassicPool []AssetPair
 
 func (a ByLinkedClassicPool) Len() int      { return len(a) }
@@ -479,6 +487,8 @@ func (a ByLinkedClassicPool) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a ByLinkedClassicPool) Less(i, j int) bool {
 	return a[i].LinkedClassicPool < a[j].LinkedClassicPool
 }
+
+// END: CAN REMOVE POST v17 UPGRADE
 
 func updateGammGenesis(gammGenState *gammtypes.GenesisState) {
 	gammGenState.Params.PoolCreationFee = tenOsmo
@@ -489,7 +499,7 @@ func updateGammGenesis(gammGenState *gammtypes.GenesisState) {
 
 	lastPoolID := uint64(1) // To keep track of the last assigned pool ID
 
-	// Can be removed after v17 upgrade.
+	// START: CAN REMOVE POST v17 UPGRADE
 
 	// Sort AssetPairs based on LinkedClassicPool values.
 	sort.Sort(ByLinkedClassicPool(AssetPairs))
@@ -511,6 +521,7 @@ func updateGammGenesis(gammGenState *gammtypes.GenesisState) {
 		// Update the lastPoolID to the current pool ID.
 		lastPoolID = poolID
 	}
+	// END: CAN REMOVE POST v17 UPGRADE
 
 	// Note that we set the next pool number as 1 greater than the latest created pool.
 	// This is to ensure that migrations are performed correctly.

--- a/tests/e2e/initialization/v17.go
+++ b/tests/e2e/initialization/v17.go
@@ -1,0 +1,206 @@
+package initialization
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	QuoteAsset  = "uosmo"
+	TickSpacing = 100
+)
+
+var (
+	ION            = "uion"
+	ISTIBCDenom    = "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
+	CMSTIBCDenom   = "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E"
+	WBTCIBCDenom   = "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
+	DOTIBCDenom    = "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7"
+	CROIBCDenom    = "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+	AKTIBCDenom    = "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4"
+	AXLIBCDenom    = "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E"
+	SCRTIBCDenom   = "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A"
+	STARSIBCDenom  = "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+	JUNOIBCDenom   = "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+	STRDIBCDenom   = "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4"
+	MARSIBCDenom   = "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580"
+	XPRTIBCDenom   = "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+	MEDIBCDenom    = "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB"
+	SOMMIBCDenom   = "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
+	BLDIBCDenom    = "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604"
+	KAVAIBCDenom   = "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205"
+	IRISIBCDenom   = "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+	stIBCXDenom    = "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx"
+	DVPNIBCDenom   = "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+	BTSGIBCDenom   = "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+	UMEEIBCDenom   = "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
+	HUAHUAIBCDenom = "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+	NCTIBCDenom    = "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68"
+	GRAVIBCDenom   = "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44"
+)
+
+type AssetPair struct {
+	BaseAsset         string
+	SpreadFactor      sdk.Dec
+	LinkedClassicPool uint64
+	Superfluid        bool
+}
+
+// AssetPairs contract: all AssetPairs being initialized in this upgrade handler all have the same quote asset (OSMO).
+var AssetPairs = []AssetPair{
+	{
+		BaseAsset:         ISTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 837,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         CMSTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.0001"), // Normally 0.0002, but is not authorized
+		LinkedClassicPool: 857,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         WBTCIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 712,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         DOTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 773,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         CROIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 9,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         AKTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 3,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         AXLIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 812,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         SCRTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 584,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         STARSIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.003"),
+		LinkedClassicPool: 604,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         JUNOIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.003"),
+		LinkedClassicPool: 497,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         STRDIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 806,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         MARSIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 907,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         ION,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.005"),
+		LinkedClassicPool: 1013,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         XPRTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 15,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         MEDIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 586,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         SOMMIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 627,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         BLDIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 795,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         KAVAIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 730,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         IRISIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 7,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         stIBCXDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.003"),
+		LinkedClassicPool: 1039,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         DVPNIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 5,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         BTSGIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 573,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         UMEEIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 641,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         HUAHUAIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 605,
+		Superfluid:        true,
+	},
+	{
+		BaseAsset:         NCTIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 971,
+		Superfluid:        false,
+	},
+	{
+		BaseAsset:         GRAVIBCDenom,
+		SpreadFactor:      sdk.MustNewDecFromStr("0.002"),
+		LinkedClassicPool: 625,
+		Superfluid:        false,
+	},
+}

--- a/tests/e2e/initialization/v17.go
+++ b/tests/e2e/initialization/v17.go
@@ -55,7 +55,7 @@ var AssetPairs = []AssetPair{
 	},
 	{
 		BaseAsset:         CMSTIBCDenom,
-		SpreadFactor:      sdk.MustNewDecFromStr("0.0001"), // Normally 0.0002, but is not authorized
+		SpreadFactor:      sdk.MustNewDecFromStr("0.0005"), // Normally 0.0002, but is not authorized so we round up.
 		LinkedClassicPool: 857,
 		Superfluid:        false,
 	},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We are creating canonical CL pools for a list of gamm pools in the v17 upgrade handler. In order to test if these pools properly get created / linked / SFS, we must modify the v16 init image to create the pools (similar to how we have done it in the past for the stride pool and the v16 CL pool)

## Testing and Verifying

Tested against the following PR 

https://github.com/osmosis-labs/osmosis/pull/5895

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A