### PR TITLE
 Add goreleaser commands to Makefile and create a Github Action to run goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ name: release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
 
 jobs:
   release:
@@ -13,6 +16,9 @@ jobs:
       -
         name: Check out repository code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.release_tag }}
       - 
         name: Make release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,17 @@
-# This workflow creates a release using 'make release' command.
+# This workflow creates a release using goreleaser
+# via the 'make release' command.
 
-name: release
+name: Create release
 
 on:
   workflow_dispatch:
     inputs:
       release_tag:
+        description: 'The desired tag for the release (e.g. v0.1.0).'
         required: true
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -22,6 +27,7 @@ jobs:
       - 
         name: Make release
         run: |
+          sudo rm -rf dist
           make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+# This workflow creates a release using 'make release' command.
+
+name: release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Create release
+    runs-on: self-hosted
+    steps:
+      -
+        name: Check out repository code
+        uses: actions/checkout@v3
+      - 
+        name: Make release
+        run: |
+          make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,6 @@ blocks.db
 # Ignore binary created from localosmosis scripts
 tests/cl-genesis-positions/script
 tests/cl-genesis-positions/*.json
+
+# Release folder
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ builds:
     binary: osmosisd
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     env:
       - CC=o64-clang
       - CGO_LDFLAGS=-L/lib
@@ -38,7 +38,7 @@ builds:
     binary: osmosisd
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     env:
       - CC=oa64-clang
       - CGO_LDFLAGS=-L/lib
@@ -67,7 +67,7 @@ builds:
     binary: osmosisd
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
     goos:
       - linux
     goarch:
@@ -96,7 +96,7 @@ builds:
     binary: osmosisd
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
     goos:
       - linux
     goarch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,6 @@ project_name: osmosisd
 
 env:
   - CGO_ENABLED=1
-  - COSMWASM_VERSION=1.2.3
 
 builds:
   - id: osmosisd-darwin-amd64
@@ -126,8 +125,7 @@ universal_binaries:
     ids:
       - osmosisd-darwin-amd64
       - osmosisd-darwin-arm64
-    replace: true
-    name_template: "{{.ProjectName}}"
+    replace: false
 
 archives:
   - id: zipped
@@ -135,7 +133,9 @@ archives:
       - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-    name_template: "{{.ProjectName}}-{{ .Os }}-{{ .Arch }}"
+      - osmosisd-darwin-amd64
+      - osmosisd-darwin-arm64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     files:
       - none*
@@ -143,43 +143,17 @@ archives:
     builds:
       - osmosisd-darwin-universal
       - osmosisd-linux-amd64
-      - osmosisd-linux-arm64
-    name_template: "{{.ProjectName}}-{{ .Os }}-{{ .Arch }}"
+      - osmosisd-linux-amd64
+      - osmosisd-darwin-amd64
+      - osmosisd-darwin-arm64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:
       - none*
 
 checksum:
-  name_template: "checksums.txt"
+  name_template: "sha256sum.txt"
   algorithm: sha256
-
-# Docs: https://goreleaser.com/customization/homebrew/
-brews:
-  - name: osmosisd
-    folder: Formula
-    ids:
-    - binaries
-    homepage: "https://gihub.com/osmosis-labs/osmosis"
-    description: "osmosisd binary to interact with the Osmosis network"
-    conflicts:
-      - osmosisd
-    test: |
-      system "#{bin}/osmosisd version"
-    install: |
-      bin.install 'osmosisd'
-    skip_upload: true
-    # # Uncomment line below if you want to try to commit the updated formula
-    # skip_upload: false
-    # repository:
-    #   owner: osmosis-labs
-    #   name: homebrew-osmosis
-    #   branch: main
-    #   pull_request:
-    #     enabled: true
-    # commit_author:
-    #   name: osmo-bot
-    #   email: devops@osmosis.team
-    # commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
 
 # Docs: https://goreleaser.com/customization/changelog/
 changelog:
@@ -188,7 +162,8 @@ changelog:
 # Docs: https://goreleaser.com/customization/release/
 release:
   github:
-    owner: osmosis-labs
+    owner: niccoloraspa
+    # owner: osmosis-labs
     name: osmosis
   replace_existing_draft: true
   header: |
@@ -200,8 +175,8 @@ release:
 
     ## ⚡️ Binaries
 
-    Binaries for Linux (amd64 and arm64) are available below.
-    Darwin users can use the same universal binary for both amd64 and arm64.
+    Binaries for Linux and Darwin (amd64 and arm64) are available below.
+    Darwin users can also use the same universal binary `osmosisd-{{ .Version }}-darwin-all` for both amd64 and arm64.
 
     #### 🔨 Build from source
 
@@ -218,12 +193,12 @@ release:
     As an alternative to installing and running osmosisd on your system, you may run osmosisd in a Docker container.
     The following Docker images are available in our registry:
 
-    | Image Name | Base | Description |
-    |------------|------|---------|
-    | `osmolabs/osmosis:{{ .Version }}`            | `distroless/static-debian11` | Default image based on Distroless        |
-    | `osmolabs/osmosis:{{ .Version }}-distroless` | `distroless/static-debian11` |  Distroless image (same as above)        |
-    | `osmolabs/osmosis:{{ .Version }}-nonroot`    | `distroless/static-debian11:nonroot` |  Distroless non-root image     |            |
-    | `osmolabs/osmosis:{{ .Version }}-alpine`     | `alpine` |  Alpine image                 |
+    | Image Name                                   | Base                                 | Description                       |
+    |----------------------------------------------|--------------------------------------|-----------------------------------|
+    | `osmolabs/osmosis:{{ .Version }}`            | `distroless/static-debian11`         | Default image based on Distroless |
+    | `osmolabs/osmosis:{{ .Version }}-distroless` | `distroless/static-debian11`         | Distroless image (same as above)  |
+    | `osmolabs/osmosis:{{ .Version }}-nonroot`    | `distroless/static-debian11:nonroot` | Distroless non-root image         |
+    | `osmolabs/osmosis:{{ .Version }}-alpine`     | `alpine`                             | Alpine image                      |
 
     Example run:
 
@@ -239,7 +214,6 @@ release:
   draft: true
 
 # Docs: https://goreleaser.com/customization/announce/
-#
 # We could automatically announce the release in
 # - discord
 # - slack

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -162,8 +162,7 @@ changelog:
 # Docs: https://goreleaser.com/customization/release/
 release:
   github:
-    owner: niccoloraspa
-    # owner: osmosis-labs
+    owner: osmosis-labs
     name: osmosis
   replace_existing_draft: true
   header: |

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@
 
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
+
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
-GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
-GO_MODULE := $(shell cat go.mod | grep "module " | cut -d ' ' -f 2)
 BUILDDIR ?= $(CURDIR)/build
 DOCKER := $(shell which docker)
 E2E_UPGRADE_VERSION := "v17"
 
-
+GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+GO_MODULE := $(shell cat go.mod | grep "module " | cut -d ' ' -f 2)
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 
@@ -551,6 +551,54 @@ go-mock-update:
 	mockgen -source=x/gamm/types/pool.go -destination=tests/mocks/cfmm_pool.go -package=mocks
 	mockgen -source=x/concentrated-liquidity/types/cl_pool_extensionI.go -destination=tests/mocks/cl_pool.go -package=mocks
 
+###############################################################################
+###                                Release                                  ###
+###############################################################################
+
+GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
+COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm | sed 's/.* //')
+
+ifdef GITHUB_TOKEN
+release:
+	docker run \
+		--rm \
+		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/osmosisd \
+		-w /go/src/osmosisd \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean
+else
+release:
+	@echo "Error: GITHUB_TOKEN is not defined. Please define it before running 'make release'."
+endif
+
+release-dry-run:
+	docker run \
+		--rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/osmosisd \
+		-w /go/src/osmosisd \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean \
+		--skip-publish
+
+release-snapshot:
+	docker run \
+		--rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/osmosisd \
+		-w /go/src/osmosisd \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean \
+		--snapshot \
+		--skip-validate \
+		--skip-publish
+
 .PHONY: all build-linux install format lint \
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \
-	test test-all test-build test-cover test-unit test-race benchmark
+	test test-all test-build test-cover test-unit test-race benchmark \
+	release release-dry-run release-snapshot

--- a/Makefile
+++ b/Makefile
@@ -563,6 +563,7 @@ release:
 	docker run \
 		--rm \
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/osmosisd \
 		-w /go/src/osmosisd \
@@ -577,6 +578,7 @@ endif
 release-dry-run:
 	docker run \
 		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/osmosisd \
 		-w /go/src/osmosisd \
@@ -588,6 +590,7 @@ release-dry-run:
 release-snapshot:
 	docker run \
 		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/osmosisd \
 		-w /go/src/osmosisd \


### PR DESCRIPTION
Tracked in: https://github.com/osmosis-labs/osmosis/issues/5904 

## What is the purpose of the change

This PR focuses on improving the release process through Goreleaser.

Main changes:

1. Updated .goreleaser.yml to match the previous release structure.
2. Added release targets to the Makefile:
   - `release`: This target performs a release using Goreleaser. It expects the `GITHUB_TOKEN` as an environment variable. It should never be run manually but always via the GitHub Action.
   - `release-dry-run`: This target simulates a release without publishing the artifacts. It allows testing the release process without actually creating a new release.
   - `release-snapshot`: This target creates a snapshot release without validation or publishing. It can be useful for quickly generating snapshots for testing purposes.
3. Added a release workflow to create a release by running the `make release` command.
  
3. Add a release workflow to create a release running the `make release` command.

## Testing and Verifying

I have used [the GitHub action](https://github.com/niccoloraspa/osmosis/actions/runs/5693172707) to create a [test release](https://github.com/niccoloraspa/osmosis/releases/tag/v22.22.22) in my fork.

You can run:

```
make release-dry-run
```

(requires clean git state)

and 

```
make release-snapshot
```

to test the process.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A