### PR TITLE
chore: auto complete cli

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -47,6 +47,38 @@ import (
 	osmosis "github.com/osmosis-labs/osmosis/v17/app"
 )
 
+func genAutoCompleteCmd(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "enable-cli-autocomplete [bash|zsh|fish|powershell]",
+		Short: "Generates cli completion scripts",
+		Long: `To configure your shell to load completions for each session, add to your profile:
+
+# bash example
+echo '. <(osmosisd enable-cli-autocomplete bash)' >> ~/.profile
+source ~/.profile
+
+# zsh example
+echo '. <(osmosisd enable-cli-autocomplete zsh)' >> ~/.zshrc
+source ~/.zshrc
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				_ = cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				_ = cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+		},
+	})
+}
+
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
 func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
@@ -94,6 +126,8 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		},
 		SilenceUsage: true,
 	}
+
+	genAutoCompleteCmd(rootCmd)
 
 	initRootCmd(rootCmd, encodingConfig)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

https://github.com/osmosis-labs/osmosis/assets/40078083/071ccd6c-2df2-4ac9-8207-57cd7738e77c


No more typing every. single. cli. cmd.

For bash:
```
echo '. <(osmosisd enable-cli-autocomplete bash)' >> ~/.profile
source ~/.profile
```
For zsh:

```
echo '. <(osmosisd enable-cli-autocomplete zsh)' >> ~/.zshrc
source ~/.zshrc
```

## Testing and Verifying

Tested locally for zsh, would be nice if someone could test for bash.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A