### PR TITLE
CL: Initialize tick minor gas optimization & cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5855](https://github.com/osmosis-labs/osmosis/pull/5855) feat(x/cosmwasmpool): Sending token_in_max_amount to the contract before running contract msg
 * [#5893] (https://github.com/osmosis-labs/osmosis/pull/5893) Export createPosition method in CL so other modules can use it in testing
 * [#5870] (https://github.com/osmosis-labs/osmosis/pull/5870) Remove v14/ separator in protorev rest endpoints
+* [#5923] (https://github.com/osmosis-labs/osmosis/pull/5923) CL: Lower gas for initializing ticks
 
 ### Minor improvements & Bug Fixes
 

--- a/x/concentrated-liquidity/export_test.go
+++ b/x/concentrated-liquidity/export_test.go
@@ -191,8 +191,8 @@ func CalculateSpreadRewardGrowth(targetTick int64, spreadRewardGrowthOutside sdk
 	return calculateSpreadRewardGrowth(targetTick, spreadRewardGrowthOutside, currentTick, spreadRewardsGrowthGlobal, isUpperTick)
 }
 
-func (k Keeper) GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
-	return k.getInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx, poolId, tick)
+func (k Keeper) GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, pool types.ConcentratedPoolExtension, tick int64) (sdk.DecCoins, error) {
+	return k.getInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx, pool, tick)
 }
 
 func ValidateTickRangeIsValid(tickSpacing uint64, lowerTick int64, upperTick int64) error {
@@ -254,8 +254,8 @@ func (k Keeper) SetMultipleIncentiveRecords(ctx sdk.Context, incentiveRecords []
 	return k.setMultipleIncentiveRecords(ctx, incentiveRecords)
 }
 
-func (k Keeper) GetInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, poolId uint64, tick int64) ([]sdk.DecCoins, error) {
-	return k.getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ctx, poolId, tick)
+func (k Keeper) GetInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, pool types.ConcentratedPoolExtension, tick int64) ([]sdk.DecCoins, error) {
+	return k.getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ctx, pool, tick)
 }
 
 func (k Keeper) InitOrUpdatePositionUptimeAccumulators(ctx sdk.Context, poolId uint64, position sdk.Dec, lowerTick, upperTick int64, liquidityDelta sdk.Dec, positionId uint64) error {

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -40,7 +40,7 @@ type positionAndLiquidity struct {
 }
 
 func TestFuzz_Many(t *testing.T) {
-	fuzz(t, defaultNumSwaps, defaultNumPositions, 100)
+	fuzz(t, defaultNumSwaps, defaultNumPositions, 10)
 }
 
 func (s *KeeperTestSuite) TestFuzz_GivenSeed() {

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -84,15 +84,10 @@ func (k Keeper) GetUptimeAccumulatorValues(ctx sdk.Context, poolId uint64) ([]sd
 // Similar to spread factors, by convention the value is chosen as if all of the uptime (seconds per liquidity) to date has
 // occurred below the tick.
 // Returns error if the pool with the given id does not exist or if fails to get any of the uptime accumulators.
-func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, poolId uint64, tick int64) ([]sdk.DecCoins, error) {
-	pool, err := k.getPoolById(ctx, poolId)
-	if err != nil {
-		return []sdk.DecCoins{}, err
-	}
-
+func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, pool types.ConcentratedPoolExtension, tick int64) ([]sdk.DecCoins, error) {
 	currentTick := pool.GetCurrentTick()
 	if currentTick >= tick {
-		uptimeAccumulatorValues, err := k.GetUptimeAccumulatorValues(ctx, poolId)
+		uptimeAccumulatorValues, err := k.GetUptimeAccumulatorValues(ctx, pool.GetId())
 		if err != nil {
 			return []sdk.DecCoins{}, err
 		}
@@ -335,7 +330,11 @@ func (k Keeper) UpdatePoolUptimeAccumulatorsToNow(ctx sdk.Context, poolId uint64
 		return err
 	}
 
-	uptimeAccums, err := k.GetUptimeAccumulators(ctx, poolId)
+	return k.updatePoolUptimeAccumulatorsToNowWithPool(ctx, pool)
+}
+
+func (k Keeper) updatePoolUptimeAccumulatorsToNowWithPool(ctx sdk.Context, pool types.ConcentratedPoolExtension) error {
+	uptimeAccums, err := k.GetUptimeAccumulators(ctx, pool.GetId())
 	if err != nil {
 		return err
 	}

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1179,18 +1179,15 @@ func (s *KeeperTestSuite) TestGetInitialUptimeGrowthOppositeDirectionOfLastTrave
 	expectedUptimes := getExpectedUptimes()
 
 	type getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick struct {
-		poolId                          uint64
 		tick                            int64
 		expectedUptimeAccumulatorValues []sdk.DecCoins
 	}
 	tests := map[string]getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick{
 		"uptime growth for tick <= currentTick": {
-			poolId:                          1,
 			tick:                            -2,
 			expectedUptimeAccumulatorValues: expectedUptimes.hundredTokensMultiDenom,
 		},
 		"uptime growth for tick > currentTick": {
-			poolId:                          2,
 			tick:                            1,
 			expectedUptimeAccumulatorValues: expectedUptimes.emptyExpectedAccumValues,
 		},
@@ -1204,21 +1201,19 @@ func (s *KeeperTestSuite) TestGetInitialUptimeGrowthOppositeDirectionOfLastTrave
 				s.SetupTest()
 				clKeeper := s.App.ConcentratedLiquidityKeeper
 
-				// create 2 pools
-				s.PrepareConcentratedPool()
-				s.PrepareConcentratedPool()
+				pool := s.PrepareConcentratedPool()
 
-				poolUptimeAccumulators, err := clKeeper.GetUptimeAccumulators(s.Ctx, tc.poolId)
+				poolUptimeAccumulators, err := clKeeper.GetUptimeAccumulators(s.Ctx, pool.GetId())
 				s.Require().NoError(err)
 
 				for uptimeId, uptimeAccum := range poolUptimeAccumulators {
 					uptimeAccum.AddToAccumulator(expectedUptimes.hundredTokensMultiDenom[uptimeId])
 				}
 
-				_, err = clKeeper.GetUptimeAccumulators(s.Ctx, tc.poolId)
+				_, err = clKeeper.GetUptimeAccumulators(s.Ctx, pool.GetId())
 				s.Require().NoError(err)
 
-				val, err := clKeeper.GetInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, tc.poolId, tc.tick)
+				val, err := clKeeper.GetInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, pool, tc.tick)
 				s.Require().NoError(err)
 				s.Require().Equal(val, tc.expectedUptimeAccumulatorValues)
 			})

--- a/x/concentrated-liquidity/spread_rewards.go
+++ b/x/concentrated-liquidity/spread_rewards.go
@@ -136,15 +136,10 @@ func (k Keeper) getSpreadRewardGrowthOutside(ctx sdk.Context, poolId uint64, low
 //
 // The value is chosen as if all of the spread rewards earned to date had occurred below the tick.
 // Returns error if the pool with the given id does exist or if fails to get the spread reward accumulator.
-func (k Keeper) getInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, poolId uint64, tick int64) (sdk.DecCoins, error) {
-	pool, err := k.getPoolById(ctx, poolId)
-	if err != nil {
-		return sdk.DecCoins{}, err
-	}
-
+func (k Keeper) getInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx sdk.Context, pool types.ConcentratedPoolExtension, tick int64) (sdk.DecCoins, error) {
 	currentTick := pool.GetCurrentTick()
 	if currentTick >= tick {
-		spreadRewardAccumulator, err := k.GetSpreadRewardAccumulator(ctx, poolId)
+		spreadRewardAccumulator, err := k.GetSpreadRewardAccumulator(ctx, pool.GetId())
 		if err != nil {
 			return sdk.DecCoins{}, err
 		}

--- a/x/concentrated-liquidity/spread_rewards_test.go
+++ b/x/concentrated-liquidity/spread_rewards_test.go
@@ -484,43 +484,48 @@ func (s *KeeperTestSuite) TestCalculateSpreadRewardGrowth() {
 	}
 }
 
+// Test what happens if somehow the accumulator didn't exist.
+// TODO: Does this test even matter? We should never be in a situation where the accumulator doesn't exist
+func (s *KeeperTestSuite) TestGetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTickAccumDoesntExist() {
+	pool, err := clmodel.NewConcentratedLiquidityPool(validPoolId, ETH, USDC, DefaultTickSpacing, DefaultZeroSpreadFactor)
+	s.Require().NoError(err)
+
+	// N.B.: we set the listener mock because we would like to avoid
+	// utilizing the production listeners, because we are testing a case that should be impossible
+	s.setListenerMockOnConcentratedLiquidityKeeper()
+
+	err = s.clk.SetPool(s.Ctx, &pool)
+	s.Require().NoError(err)
+
+	// System under test.
+	_, err = s.clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, &pool, 0)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, accum.AccumDoesNotExistError{AccumName: types.KeySpreadRewardPoolAccumulator(validPoolId)})
+}
+
 func (s *KeeperTestSuite) TestGetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick() {
 	sqrtPrice := osmomath.MustMonotonicSqrt(DefaultAmt1.ToDec().Quo(DefaultAmt0.ToDec()))
 	initialPoolTick, err := clmath.SqrtPriceToTickRoundDownSpacing(sqrtPrice, DefaultTickSpacing)
 	s.Require().NoError(err)
+	initialGlobalSpreadRewardGrowth := oneEth
 
 	tests := map[string]struct {
 		tick                            int64
 		initialGlobalSpreadRewardGrowth sdk.DecCoin
-		shouldAvoidCreatingAccum        bool
 
 		expectedInitialSpreadRewardGrowthOppositeDirectionOfLastTraversal sdk.DecCoins
-		expectError                                                       error
 	}{
 		"current tick > tick -> spread reward growth global": {
-			tick:                            initialPoolTick - 1,
-			initialGlobalSpreadRewardGrowth: oneEth,
-
+			tick: initialPoolTick - 1,
 			expectedInitialSpreadRewardGrowthOppositeDirectionOfLastTraversal: sdk.NewDecCoins(oneEth),
 		},
 		"current tick == tick -> spread reward growth global": {
-			tick:                            initialPoolTick,
-			initialGlobalSpreadRewardGrowth: oneEth,
-
+			tick: initialPoolTick,
 			expectedInitialSpreadRewardGrowthOppositeDirectionOfLastTraversal: sdk.NewDecCoins(oneEth),
 		},
 		"current tick < tick -> empty coins": {
-			tick:                            initialPoolTick + 1,
-			initialGlobalSpreadRewardGrowth: oneEth,
-
+			tick: initialPoolTick + 1,
 			expectedInitialSpreadRewardGrowthOppositeDirectionOfLastTraversal: cl.EmptyCoins,
-		},
-		"accumulator does not exist": {
-			tick:                            0,
-			initialGlobalSpreadRewardGrowth: oneEth,
-			shouldAvoidCreatingAccum:        true,
-
-			expectError: accum.AccumDoesNotExistError{AccumName: types.KeySpreadRewardPoolAccumulator(validPoolId)},
 		},
 	}
 
@@ -528,45 +533,12 @@ func (s *KeeperTestSuite) TestGetInitialSpreadRewardGrowthOppositeDirectionOfLas
 		tc := tc
 		s.Run(name, func() {
 			s.SetupTest()
-			ctx := s.Ctx
+			pool := s.preparePoolAndDefaultPosition()
+			s.AddToSpreadRewardAccumulator(pool.GetId(), initialGlobalSpreadRewardGrowth)
 
-			pool, err := clmodel.NewConcentratedLiquidityPool(validPoolId, ETH, USDC, DefaultTickSpacing, DefaultZeroSpreadFactor)
+			clpool, err := s.clk.GetPoolById(s.Ctx, pool.GetId())
 			s.Require().NoError(err)
-
-			// N.B.: we set the listener mock because we would like to avoid
-			// utilizing the production listeners. The production listeners
-			// are irrelevant in the context of the system under test. However,
-			// setting them up would require compromising being able to set up other
-			// edge case tests. For example, the test case where spread reward accumulator
-			// is not initialized.
-			s.setListenerMockOnConcentratedLiquidityKeeper()
-
-			err = s.clk.SetPool(ctx, &pool)
-			s.Require().NoError(err)
-
-			if !tc.shouldAvoidCreatingAccum {
-				err = s.clk.CreateSpreadRewardAccumulator(ctx, pool.GetId())
-				s.Require().NoError(err)
-
-				// Setup test position to make sure that tick is initialized
-				// We also set up uptime accums to ensure position creation works as intended
-				err = s.clk.CreateUptimeAccumulators(ctx, pool.GetId())
-				s.Require().NoError(err)
-				s.SetupDefaultPosition(pool.GetId())
-
-				s.AddToSpreadRewardAccumulator(pool.GetId(), tc.initialGlobalSpreadRewardGrowth)
-			}
-
-			// System under test.
-			clpool, err := s.clk.GetPoolById(ctx, pool.GetId())
-			s.Require().NoError(err)
-			initialSpreadRewardGrowthOppositeDirectionOfLastTraversal, err := s.clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(ctx, clpool, tc.tick)
-
-			if tc.expectError != nil {
-				s.Require().Error(err)
-				s.Require().ErrorIs(err, tc.expectError)
-				return
-			}
+			initialSpreadRewardGrowthOppositeDirectionOfLastTraversal, err := s.clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, clpool, tc.tick)
 			s.Require().NoError(err)
 			s.Require().Equal(tc.expectedInitialSpreadRewardGrowthOppositeDirectionOfLastTraversal, initialSpreadRewardGrowthOppositeDirectionOfLastTraversal)
 		})


### PR DESCRIPTION
This PR is simplifying the `GetTickInfo` code, by moving the initialization logic to its own function. Furthermore, we only get the pool once, removing repeated gets in every function this would otherwise call. (Saving a net of 2 GetPool operations). This has an added benefit of removing messiness from the test code, where it attempted to generate test cases with invalid pool ID's.

The remainder of this PR is cleaning up tests.
The "TestGetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick" was extremely messy, so just re-wrote the edge case that idt even makes sense to test into its own function, and made the main test use standard helpers.