### PR TITLE
fix(ProtoRev): Updating Binary Search Range with CL Pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5831](https://github.com/osmosis-labs/osmosis/pull/5831) Fix superfluid_delegations query
 * [#5835](https://github.com/osmosis-labs/osmosis/pull/5835) Fix println's for "amountZeroInRemainingBigDec before fee" making it into production
 * [#5841] (https://github.com/osmosis-labs/osmosis/pull/5841) Fix protorev's out of gas erroring of the user's transcation.
-* [#5930] (https://github.com/osmosis-labs/osmosis/pull/5930) Updating Binary Search Range with CL Pools
+* [#5930] (https://github.com/osmosis-labs/osmosis/pull/5930) Updating Protorev Binary Search Range Logic with CL Pools
 
 ### Misc Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5831](https://github.com/osmosis-labs/osmosis/pull/5831) Fix superfluid_delegations query
 * [#5835](https://github.com/osmosis-labs/osmosis/pull/5835) Fix println's for "amountZeroInRemainingBigDec before fee" making it into production
 * [#5841] (https://github.com/osmosis-labs/osmosis/pull/5841) Fix protorev's out of gas erroring of the user's transcation.
+* [#5930] (https://github.com/osmosis-labs/osmosis/pull/5930) Updating Binary Search Range with CL Pools
 
 ### Misc Improvements
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -357,7 +357,13 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	protorevKeeper := protorevkeeper.NewKeeper(
 		appCodec, appKeepers.keys[protorevtypes.StoreKey],
 		appKeepers.GetSubspace(protorevtypes.ModuleName),
-		appKeepers.AccountKeeper, appKeepers.BankKeeper, appKeepers.GAMMKeeper, appKeepers.EpochsKeeper, appKeepers.PoolManagerKeeper)
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.GAMMKeeper,
+		appKeepers.EpochsKeeper,
+		appKeepers.PoolManagerKeeper,
+		appKeepers.ConcentratedLiquidityKeeper,
+	)
 	appKeepers.ProtoRevKeeper = &protorevKeeper
 
 	txFeesKeeper := txfeeskeeper.NewKeeper(

--- a/x/protorev/keeper/epoch_hook_test.go
+++ b/x/protorev/keeper/epoch_hook_test.go
@@ -152,8 +152,8 @@ func (s *KeeperTestSuite) TestUpdateHighestLiquidityPools() {
 			// There are 2 pools with epochTwo and uosmo as denoms,
 			// One in the GAMM module and one in the Concentrated Liquidity module.
 			// pool with ID 48 has a liquidity value of 1,000,000
-			// pool with ID 49 has a liquidity value of 2,000,000
-			// pool with ID 49 should be returned as the highest liquidity pool
+			// pool with ID 50 has a liquidity value of 2,000,000
+			// pool with ID 50 should be returned as the highest liquidity pool
 			// We provide epochTwo as the input base denom, to test the method chooses the correct pool
 			// across the GAMM and Concentrated Liquidity modules
 			name: "Get highest liquidity pools for one GAMM pool and one Concentrated Liquidity pool",
@@ -162,7 +162,7 @@ func (s *KeeperTestSuite) TestUpdateHighestLiquidityPools() {
 			},
 			expectedBaseDenomPools: map[string]map[string]keeper.LiquidityPoolStruct{
 				"epochTwo": {
-					"uosmo": {Liquidity: sdk.Int(sdk.NewUintFromString("999999000000000001000000000000000000")), PoolId: 49},
+					"uosmo": {Liquidity: sdk.Int(sdk.NewUintFromString("999999000000000001000000000000000000")), PoolId: 50},
 				},
 			},
 		},

--- a/x/protorev/keeper/hooks_test.go
+++ b/x/protorev/keeper/hooks_test.go
@@ -108,14 +108,14 @@ func (s *KeeperTestSuite) TestSwapping() {
 			param: param{
 				expectedTrades: []types.Trade{
 					{
-						Pool:     49,
+						Pool:     50,
 						TokenIn:  "uosmo",
 						TokenOut: "epochTwo",
 					},
 				},
 				executeSwap: func() {
 
-					route := []poolmanagertypes.SwapAmountInRoute{{PoolId: 49, TokenOutDenom: "epochTwo"}}
+					route := []poolmanagertypes.SwapAmountInRoute{{PoolId: 50, TokenOutDenom: "epochTwo"}}
 
 					_, err := s.App.PoolManagerKeeper.RouteExactAmountIn(s.Ctx, s.TestAccs[0], route, sdk.NewCoin("uosmo", sdk.NewInt(10)), sdk.NewInt(1))
 					s.Require().NoError(err)
@@ -606,7 +606,7 @@ func (s *KeeperTestSuite) TestStoreJoinExitPoolSwaps() {
 		{
 			name: "Non-Gamm Pool, Return Early Do Not Store Any Swaps",
 			param: param{
-				poolId:       49,
+				poolId:       50,
 				denom:        "uosmo",
 				isJoin:       true,
 				expectedSwap: types.Trade{},

--- a/x/protorev/keeper/keeper.go
+++ b/x/protorev/keeper/keeper.go
@@ -19,11 +19,12 @@ type (
 		storeKey   storetypes.StoreKey
 		paramstore paramtypes.Subspace
 
-		accountKeeper     types.AccountKeeper
-		bankKeeper        types.BankKeeper
-		gammKeeper        types.GAMMKeeper
-		epochKeeper       types.EpochKeeper
-		poolmanagerKeeper types.PoolManagerKeeper
+		accountKeeper               types.AccountKeeper
+		bankKeeper                  types.BankKeeper
+		gammKeeper                  types.GAMMKeeper
+		epochKeeper                 types.EpochKeeper
+		poolmanagerKeeper           types.PoolManagerKeeper
+		concentratedLiquidityKeeper types.ConcentratedLiquidityKeeper
 	}
 )
 
@@ -36,6 +37,7 @@ func NewKeeper(
 	gammKeeper types.GAMMKeeper,
 	epochKeeper types.EpochKeeper,
 	poolmanagerKeeper types.PoolManagerKeeper,
+	concentratedLiquidityKeeper types.ConcentratedLiquidityKeeper,
 ) Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -43,14 +45,15 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:               cdc,
-		storeKey:          storeKey,
-		paramstore:        ps,
-		accountKeeper:     accountKeeper,
-		bankKeeper:        bankKeeper,
-		gammKeeper:        gammKeeper,
-		epochKeeper:       epochKeeper,
-		poolmanagerKeeper: poolmanagerKeeper,
+		cdc:                         cdc,
+		storeKey:                    storeKey,
+		paramstore:                  ps,
+		accountKeeper:               accountKeeper,
+		bankKeeper:                  bankKeeper,
+		gammKeeper:                  gammKeeper,
+		epochKeeper:                 epochKeeper,
+		poolmanagerKeeper:           poolmanagerKeeper,
+		concentratedLiquidityKeeper: concentratedLiquidityKeeper,
 	}
 }
 

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -916,21 +916,18 @@ func (s *KeeperTestSuite) setUpPools() {
 	// Create a concentrated liquidity pool for range testing
 	// Pool 52
 	// Create the CL pool
-	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[2], "epochTwo", "uosmo", 100, sdk.NewDecWithPrec(2, 3))
-	fundCoins := sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(1000000000000000000)), sdk.NewCoin("epochTwo", sdk.NewInt(1000000000000000000)))
-	s.FundAcc(s.TestAccs[2], fundCoins)
+	clPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], "epochTwo", "uosmo", apptesting.DefaultTickSpacing, sdk.ZeroDec())
+	fundCoins := sdk.NewCoins(sdk.NewCoin("epochTwo", sdk.NewInt(10_000_000_000_000)), sdk.NewCoin("uosmo", sdk.NewInt(10_000_000_000_000)))
+	s.FundAcc(s.TestAccs[0], fundCoins)
+	s.CreateFullRangePosition(clPool, fundCoins)
 
-	// Create 100 ticks in the CL pool, 50 on each side
-	tokensProvided := sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(10000000)), sdk.NewCoin("epochTwo", sdk.NewInt(10000000)))
-	amount0Min := sdk.NewInt(0)
-	amount1Min := sdk.NewInt(0)
-	lowerTick := int64(0)
-	upperTick := int64(100)
-
-	for i := int64(0); i < 50; i++ {
-		s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, clPool.GetId(), s.TestAccs[2], tokensProvided, amount0Min, amount1Min, lowerTick-(100*i), upperTick-(100*i))
-		s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, clPool.GetId(), s.TestAccs[2], tokensProvided, amount0Min, amount1Min, lowerTick+(100*i), upperTick+(100*i))
-	}
+	// Create a concentrated liquidity pool for range testing
+	// Pool 52
+	// Create the CL pool
+	clPool = s.PrepareCustomConcentratedPool(s.TestAccs[0], "epochTwo", "uosmo", apptesting.DefaultTickSpacing, sdk.ZeroDec())
+	fundCoins = sdk.NewCoins(sdk.NewCoin("epochTwo", sdk.NewInt(2_000_000_000)), sdk.NewCoin("uosmo", sdk.NewInt(1_000_000_000)))
+	s.FundAcc(s.TestAccs[0], fundCoins)
+	s.CreateFullRangePosition(clPool, fundCoins)
 
 	// Set all of the pool info into the stores
 	err := s.App.ProtoRevKeeper.UpdatePools(s.Ctx)

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -922,7 +922,7 @@ func (s *KeeperTestSuite) setUpPools() {
 	s.CreateFullRangePosition(clPool, fundCoins)
 
 	// Create a concentrated liquidity pool for range testing
-	// Pool 52
+	// Pool 53
 	// Create the CL pool
 	clPool = s.PrepareCustomConcentratedPool(s.TestAccs[0], "epochTwo", "uosmo", apptesting.DefaultTickSpacing, sdk.ZeroDec())
 	fundCoins = sdk.NewCoins(sdk.NewCoin("epochTwo", sdk.NewInt(2_000_000_000)), sdk.NewCoin("uosmo", sdk.NewInt(1_000_000_000)))

--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -340,12 +340,12 @@ func (s *KeeperTestSuite) TestAnteHandle() {
 			params: param{
 				trades: []types.Trade{
 					{
-						Pool:     53,
+						Pool:     54,
 						TokenOut: "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
 						TokenIn:  "uosmo",
 					},
 				},
-				expectedNumOfTrades: sdk.NewInt(5),
+				expectedNumOfTrades: sdk.NewInt(6),
 				expectedProfits: []sdk.Coin{
 					{
 						Denom:  "Atom",
@@ -357,7 +357,7 @@ func (s *KeeperTestSuite) TestAnteHandle() {
 					},
 					{
 						Denom:  types.OsmosisDenomination,
-						Amount: sdk.NewInt(56_609_900),
+						Amount: sdk.NewInt(56_653_504),
 					},
 				},
 				expectedPoolPoints: 37,

--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -335,35 +335,6 @@ func (s *KeeperTestSuite) TestAnteHandle() {
 			},
 			expectPass: true,
 		},
-		{
-			name: "Concentrated Liquidity - Many Ticks Run Out of Gas While Rebalacing, Ensure Doesn't Fail User Tx",
-			params: param{
-				trades: []types.Trade{
-					{
-						Pool:     54,
-						TokenOut: "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-						TokenIn:  "uosmo",
-					},
-				},
-				expectedNumOfTrades: sdk.NewInt(6),
-				expectedProfits: []sdk.Coin{
-					{
-						Denom:  "Atom",
-						Amount: sdk.NewInt(15_767_231),
-					},
-					{
-						Denom:  "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-						Amount: sdk.NewInt(218_149_058),
-					},
-					{
-						Denom:  types.OsmosisDenomination,
-						Amount: sdk.NewInt(56_653_504),
-					},
-				},
-				expectedPoolPoints: 37,
-			},
-			expectPass: true,
-		},
 	}
 
 	// Ensure that the max points per tx is enough for the test suite

--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -340,7 +340,7 @@ func (s *KeeperTestSuite) TestAnteHandle() {
 			params: param{
 				trades: []types.Trade{
 					{
-						Pool:     51,
+						Pool:     53,
 						TokenOut: "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
 						TokenIn:  "uosmo",
 					},

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -275,7 +275,7 @@ func (k Keeper) ExtendSearchRangeIfNeeded(
 	// If the profit for the maximum amount in is still increasing, then we can increase the range of the binary search
 	if maxInProfit.GTE(sdk.ZeroInt()) {
 		maxInPlusOne := curRight.Add(sdk.OneInt()).Mul(route.StepSize)
-		if updatedMax.LT(maxInPlusOne) {
+		if updatedMax.Mul(route.StepSize).LT(maxInPlusOne) {
 			return curLeft, curRight, nil
 		}
 

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -214,9 +214,9 @@ func (k Keeper) CalculateUpperBoundForSearch(
 			return sdk.ZeroInt(), err
 		}
 
-		tokenOut := inputDenom
+		tokenInDenom := inputDenom
 		if index > 0 {
-			tokenOut = route.Route[index-1].TokenOutDenom
+			tokenInDenom = route.Route[index-1].TokenOutDenom
 		}
 
 		switch {
@@ -224,36 +224,35 @@ func (k Keeper) CalculateUpperBoundForSearch(
 			// If the pool is a concentrated liquidity pool, then check the maximum amount in that can be used
 			// and determine what this amount is as an input at the previous pool (working all the way up to the
 			// beginning of the route).
-			maxTokenIn, _, err := k.concentratedLiquidityKeeper.ComputeMaxInAmtGivenMaxTicksCrossed(
+			maxTokenIn, maxTokenOut, err := k.concentratedLiquidityKeeper.ComputeMaxInAmtGivenMaxTicksCrossed(
 				ctx,
 				pool.GetId(),
-				tokenOut,
+				tokenInDenom,
 				types.MaxTicksCrossed,
 			)
 			if err != nil {
 				return sdk.ZeroInt(), err
 			}
 
-			// if there have been no other CL pools in the route, then we can set the intermediate coin to the max input amount
-			if intermidiateCoin.IsNil() {
+			// if there have been no other CL pools in the route, then we can set the intermediate coin to the max input amount.
+			// Additionally, if the amount of the previous token is greater than the possible amount from this pool, then we
+			// can set the intermediate coin to the max input amount (from the current pool). Otherwise we have to do a
+			// safe swap given the previous max amount.
+			if intermidiateCoin.IsNil() || maxTokenOut.Amount.LT(intermidiateCoin.Amount) {
 				intermidiateCoin = maxTokenIn
 				continue
 			}
 
 			// In the scenario where there are multiple CL pools in a route, we select the one that inputs
 			// the smaller amount to ensure we do not overstep the max ticks moved.
-			intermidiateCoin, err = k.executeSafeSwap(ctx, pool.GetId(), intermidiateCoin, tokenOut, route.StepSize)
+			intermidiateCoin, err = k.executeSafeSwap(ctx, pool.GetId(), intermidiateCoin, tokenInDenom, route.StepSize)
 			if err != nil {
 				return sdk.ZeroInt(), err
-			}
-
-			if intermidiateCoin.Amount.GT(maxTokenIn.Amount) {
-				intermidiateCoin = maxTokenIn
 			}
 		case !intermidiateCoin.IsNil():
 			// If we have already seen a CL pool in the route, then simply propagate the intermediate coin up
 			// the route.
-			intermidiateCoin, err = k.executeSafeSwap(ctx, pool.GetId(), intermidiateCoin, tokenOut, route.StepSize)
+			intermidiateCoin, err = k.executeSafeSwap(ctx, pool.GetId(), intermidiateCoin, tokenInDenom, route.StepSize)
 			if err != nil {
 				return sdk.ZeroInt(), err
 			}
@@ -279,35 +278,35 @@ func (k Keeper) CalculateUpperBoundForSearch(
 func (k Keeper) executeSafeSwap(
 	ctx sdk.Context,
 	poolID uint64,
-	inputCoin sdk.Coin,
-	tokenOutDenom string,
+	outputCoin sdk.Coin,
+	tokenInDenom string,
 	stepSize sdk.Int,
 ) (sdk.Coin, error) {
 	liquidity, err := k.poolmanagerKeeper.GetTotalPoolLiquidity(ctx, poolID)
 	if err != nil {
-		return sdk.NewCoin(tokenOutDenom, sdk.ZeroInt()), err
+		return sdk.NewCoin(tokenInDenom, sdk.ZeroInt()), err
 	}
 
-	liquidTokenAmt := liquidity.AmountOf(inputCoin.Denom)
-	if liquidTokenAmt.LT(inputCoin.Amount) {
-		inputCoin.Amount = liquidTokenAmt.Sub(sdk.OneInt().Mul(stepSize))
+	liquidTokenAmt := liquidity.AmountOf(outputCoin.Denom)
+	if liquidTokenAmt.LT(outputCoin.Amount) {
+		outputCoin.Amount = liquidTokenAmt.Quo(sdk.NewInt(2))
 	}
 
-	amt, err := k.poolmanagerKeeper.MultihopEstimateOutGivenExactAmountIn(
+	amt, err := k.poolmanagerKeeper.MultihopEstimateInGivenExactAmountOut(
 		ctx,
-		poolmanagertypes.SwapAmountInRoutes{
+		poolmanagertypes.SwapAmountOutRoutes{
 			{
-				PoolId:        poolID,
-				TokenOutDenom: tokenOutDenom,
+				PoolId:       poolID,
+				TokenInDenom: tokenInDenom,
 			},
 		},
-		inputCoin,
+		outputCoin,
 	)
 	if err != nil {
-		return sdk.NewCoin(tokenOutDenom, amt), err
+		return sdk.NewCoin(tokenInDenom, sdk.ZeroInt()), err
 	}
 
-	return sdk.NewCoin(tokenOutDenom, amt), nil
+	return sdk.NewCoin(tokenInDenom, amt), nil
 }
 
 // Determine if the binary search range needs to be extended

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -224,11 +224,11 @@ func (k Keeper) CalculateUpperBoundForSearch(
 			// If the pool is a concentrated liquidity pool, then check the maximum amount in that can be used
 			// and determine what this amount is as an input at the previous pool (working all the way up to the
 			// beginning of the route).
-			_, maxTokenOut, err := k.concentratedLiquidityKeeper.ComputeMaxInAmtGivenMaxTicksCrossed(
+			maxTokenIn, _, err := k.concentratedLiquidityKeeper.ComputeMaxInAmtGivenMaxTicksCrossed(
 				ctx,
 				pool.GetId(),
-				hop.TokenOutDenom,
-				types.MaxTicksMoved,
+				tokenOut,
+				types.MaxTicksCrossed,
 			)
 			if err != nil {
 				return sdk.ZeroInt(), err
@@ -236,7 +236,7 @@ func (k Keeper) CalculateUpperBoundForSearch(
 
 			// if there have been no other CL pools in the route, then we can set the intermediate coin to the max input amount
 			if intermidiateCoin.IsNil() {
-				intermidiateCoin = maxTokenOut
+				intermidiateCoin = maxTokenIn
 				continue
 			}
 
@@ -247,8 +247,8 @@ func (k Keeper) CalculateUpperBoundForSearch(
 				return sdk.ZeroInt(), err
 			}
 
-			if intermidiateCoin.Amount.GT(maxTokenOut.Amount) {
-				intermidiateCoin = maxTokenOut
+			if intermidiateCoin.Amount.GT(maxTokenIn.Amount) {
+				intermidiateCoin = maxTokenIn
 			}
 		case !intermidiateCoin.IsNil():
 			// If we have already seen a CL pool in the route, then simply propagate the intermediate coin up

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -287,9 +287,10 @@ func (k Keeper) executeSafeSwap(
 		return sdk.NewCoin(tokenInDenom, sdk.ZeroInt()), err
 	}
 
-	liquidTokenAmt := liquidity.AmountOf(outputCoin.Denom)
+	// At most we can swap half of the liquidity in the pool
+	liquidTokenAmt := liquidity.AmountOf(outputCoin.Denom).Quo(sdk.NewInt(2))
 	if liquidTokenAmt.LT(outputCoin.Amount) {
-		outputCoin.Amount = liquidTokenAmt.Quo(sdk.NewInt(2))
+		outputCoin.Amount = liquidTokenAmt
 	}
 
 	amt, err := k.poolmanagerKeeper.MultihopEstimateInGivenExactAmountOut(

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -326,8 +326,7 @@ func (k Keeper) ExtendSearchRangeIfNeeded(
 	// If the profit for the maximum amount in is still increasing, then we can increase the range of the binary search
 	if maxInProfit.GTE(sdk.ZeroInt()) {
 		// Get the profit for the maximum amount in + 1
-		maxInPlusOne := curRight.Add(sdk.OneInt().Mul(route.StepSize))
-		_, maxInProfitPlusOne, err := k.EstimateMultihopProfit(ctx, inputDenom, maxInPlusOne.Mul(route.StepSize), route.Route)
+		_, maxInProfitPlusOne, err := k.EstimateMultihopProfit(ctx, inputDenom, curRight.Add(sdk.OneInt()).Mul(route.StepSize), route.Route)
 		if err != nil {
 			return sdk.ZeroInt(), sdk.ZeroInt(), err
 		}

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -290,7 +290,7 @@ func (k Keeper) executeSafeSwap(
 	}
 
 	// At most we can swap half of the liquidity in the pool
-	liquidTokenAmt := liquidity.AmountOf(outputCoin.Denom).Quo(sdk.NewInt(2))
+	liquidTokenAmt := liquidity.AmountOf(outputCoin.Denom).Quo(sdk.NewInt(4))
 	if liquidTokenAmt.LT(outputCoin.Amount) {
 		outputCoin.Amount = liquidTokenAmt
 	}

--- a/x/protorev/keeper/rebalance.go
+++ b/x/protorev/keeper/rebalance.go
@@ -49,6 +49,8 @@ func (k Keeper) IterateRoutes(ctx sdk.Context, routes []RouteMetaData, remaining
 }
 
 // ConvertProfits converts the profit denom to uosmo to allow for a fair comparison of profits
+//
+// NOTE: This does not check the underlying pool before swapping so this may go over the MaxTicksCrossed.
 func (k Keeper) ConvertProfits(ctx sdk.Context, inputCoin sdk.Coin, profit sdk.Int) (sdk.Int, error) {
 	if inputCoin.Denom == types.OsmosisDenomination {
 		return profit, nil

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -166,7 +166,7 @@ var extendedRangeRoute = poolmanagertypes.SwapAmountInRoutes{
 }
 
 // Tests the binary search range for CL pools
-var clPoolRoute = poolmanagertypes.SwapAmountInRoutes{
+var clPoolRouteExtended = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        49,
 		TokenOutDenom: "uosmo",
@@ -177,8 +177,20 @@ var clPoolRoute = poolmanagertypes.SwapAmountInRoutes{
 	},
 }
 
+// Tests multiple CL pools in the same route
+var clPoolRouteMulti = poolmanagertypes.SwapAmountInRoutes{
+	poolmanagertypes.SwapAmountInRoute{
+		PoolId:        52,
+		TokenOutDenom: "uosmo",
+	},
+	poolmanagertypes.SwapAmountInRoute{
+		PoolId:        53,
+		TokenOutDenom: "epochTwo",
+	},
+}
+
 // Tests reducing the binary search range
-var reducedRangeRoute = poolmanagertypes.SwapAmountInRoutes{
+var clPoolRoute = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
 		PoolId:        49,
 		TokenOutDenom: "uosmo",
@@ -315,9 +327,9 @@ func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
 			expectPass: false,
 		},
 		{
-			name: "CL Route",
+			name: "CL Route (extended range)",
 			param: param{
-				route:           clPoolRoute,
+				route:           clPoolRouteExtended,
 				expectedAmtIn:   sdk.NewInt(131_072_000_000),
 				expectedProfit:  sdk.NewInt(295_125_808),
 				routePoolPoints: 7,
@@ -325,12 +337,22 @@ func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
 			expectPass: true,
 		},
 		{
-			name: "Reduced Range Route", // This will search up to 60_000_000uosmo
+			name: "CL Route", // This will search up to 131072 * stepsize
 			param: param{
-				route:           reducedRangeRoute,
-				expectedAmtIn:   sdk.NewInt(60_000_000),
-				expectedProfit:  sdk.NewInt(31_474),
+				route:           clPoolRoute,
+				expectedAmtIn:   sdk.NewInt(13_159_000_000),
+				expectedProfit:  sdk.NewInt(18_055_586),
 				routePoolPoints: 7,
+			},
+			expectPass: true,
+		},
+		{
+			name: "CL Route Multi",
+			param: param{
+				route:           clPoolRouteMulti, // this will search up to 999 * stepsize
+				expectedAmtIn:   sdk.NewInt(414_000_000),
+				expectedProfit:  sdk.NewInt(171_555_698),
+				routePoolPoints: 12,
 			},
 			expectPass: true,
 		},

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -835,6 +835,6 @@ func (s *KeeperTestSuite) TestUpdateSearchRangeIfNeeded() {
 		)
 		s.Require().NoError(err)
 		s.Require().Equal(sdk.OneInt(), curLeft)
-		s.Require().Equal(sdk.NewInt(11247), curRight)
+		s.Require().Equal(sdk.NewInt(5141), curRight)
 	})
 }

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -165,6 +165,30 @@ var extendedRangeRoute = poolmanagertypes.SwapAmountInRoutes{
 	},
 }
 
+// Tests the binary search range for CL pools
+var clPoolRoute = poolmanagertypes.SwapAmountInRoutes{
+	poolmanagertypes.SwapAmountInRoute{
+		PoolId:        49,
+		TokenOutDenom: "uosmo",
+	},
+	poolmanagertypes.SwapAmountInRoute{
+		PoolId:        50,
+		TokenOutDenom: "epochTwo",
+	},
+}
+
+// Tests reducing the binary search range
+var reducedRangeRoute = poolmanagertypes.SwapAmountInRoutes{
+	poolmanagertypes.SwapAmountInRoute{
+		PoolId:        49,
+		TokenOutDenom: "uosmo",
+	},
+	poolmanagertypes.SwapAmountInRoute{
+		PoolId:        52,
+		TokenOutDenom: "epochTwo",
+	},
+}
+
 // EstimateMultiHopSwap Panic catching test
 var panicRoute = poolmanagertypes.SwapAmountInRoutes{
 	poolmanagertypes.SwapAmountInRoute{
@@ -289,6 +313,26 @@ func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
 				routePoolPoints: 0,
 			},
 			expectPass: false,
+		},
+		{
+			name: "CL Route",
+			param: param{
+				route:           clPoolRoute,
+				expectedAmtIn:   sdk.NewInt(131_072_000_000),
+				expectedProfit:  sdk.NewInt(295_125_808),
+				routePoolPoints: 7,
+			},
+			expectPass: true,
+		},
+		{
+			name: "Reduced Range Route", // This will search up to 60_000_000uosmo
+			param: param{
+				route:           reducedRangeRoute,
+				expectedAmtIn:   sdk.NewInt(60_000_000),
+				expectedProfit:  sdk.NewInt(31_474),
+				routePoolPoints: 7,
+			},
+			expectPass: true,
 		},
 	}
 

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -327,7 +327,7 @@ func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
 			expectPass: false,
 		},
 		{
-			name: "CL Route (extended range)",
+			name: "CL Route (extended range)", // This will search up to 131072 * stepsize
 			param: param{
 				route:           clPoolRouteExtended,
 				expectedAmtIn:   sdk.NewInt(131_072_000_000),
@@ -347,7 +347,7 @@ func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
 			expectPass: true,
 		},
 		{
-			name: "CL Route Multi",
+			name: "CL Route Reduced Range",
 			param: param{
 				route:           clPoolRouteMulti, // this will search up to 999 * stepsize
 				expectedAmtIn:   sdk.NewInt(414_000_000),

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -349,13 +349,13 @@ func (s *KeeperTestSuite) TestCalculateRoutePoolPoints() {
 		},
 		{
 			description:             "Valid route with a cosmwasm pool",
-			route:                   []poolmanagertypes.SwapAmountInRoute{{PoolId: 1, TokenOutDenom: ""}, {PoolId: 50, TokenOutDenom: ""}, {PoolId: 2, TokenOutDenom: ""}},
+			route:                   []poolmanagertypes.SwapAmountInRoute{{PoolId: 1, TokenOutDenom: ""}, {PoolId: 51, TokenOutDenom: ""}, {PoolId: 2, TokenOutDenom: ""}},
 			expectedRoutePoolPoints: 8,
 			expectedPass:            true,
 		},
 		{
 			description:             "Valid route with cw pool, balancer, stable swap and cl pool",
-			route:                   []poolmanagertypes.SwapAmountInRoute{{PoolId: 1, TokenOutDenom: ""}, {PoolId: 50, TokenOutDenom: ""}, {PoolId: 40, TokenOutDenom: ""}, {PoolId: 49, TokenOutDenom: ""}},
+			route:                   []poolmanagertypes.SwapAmountInRoute{{PoolId: 1, TokenOutDenom: ""}, {PoolId: 51, TokenOutDenom: ""}, {PoolId: 40, TokenOutDenom: ""}, {PoolId: 50, TokenOutDenom: ""}},
 			expectedRoutePoolPoints: 10,
 			expectedPass:            true,
 		},

--- a/x/protorev/protorev.md
+++ b/x/protorev/protorev.md
@@ -314,7 +314,7 @@ IterateRoutes iterates through a list of routes, determining the route and input
 
 ### FindMaxProfitForRoute
 
-This will take in a route and determine the optimal amount to swap in to maximize profits, given the reserves of all of the pools that are swapped against in the route.
+This will take in a route and determine the optimal amount to swap in to maximize profits, given the reserves of all of the pools that are swapped against in the route. The bounds of the binary search are dynamic and update per route (see `UpdateSearchRangeIfNeeded`) based on how computationally expensive (in terms of gas) swapping can be on that route. For instance, moving across several ticks on a concentrated pool is relatively expensive, so the bounds of the binary search with a route that includes that pool type may be smaller than a route that does not include that pool type.
 
 ### ExecuteTrade
 

--- a/x/protorev/types/constants.go
+++ b/x/protorev/types/constants.go
@@ -27,6 +27,10 @@ const MaxPoolPointsPerTx uint64 = 50
 // to the maximum execution time (in ms) of protorev per block
 const MaxPoolPointsPerBlock uint64 = 200
 
+// Max number of ticks we can move in a concentrated pool swap. This will be parameterized in a
+// follow up PR.
+const MaxTicksMoved uint64 = 5
+
 // ---------------- Module Profit Splitting Constants ---------------- //
 
 // Year 1 (20% of total profit)

--- a/x/protorev/types/constants.go
+++ b/x/protorev/types/constants.go
@@ -29,7 +29,7 @@ const MaxPoolPointsPerBlock uint64 = 200
 
 // Max number of ticks we can move in a concentrated pool swap. This will be parameterized in a
 // follow up PR.
-const MaxTicksMoved uint64 = 5
+const MaxTicksCrossed uint64 = 5
 
 // ---------------- Module Profit Splitting Constants ---------------- //
 

--- a/x/protorev/types/expected_keepers.go
+++ b/x/protorev/types/expected_keepers.go
@@ -61,3 +61,14 @@ type PoolManagerKeeper interface {
 type EpochKeeper interface {
 	GetEpochInfo(ctx sdk.Context, identifier string) epochtypes.EpochInfo
 }
+
+// ConcentratedLiquidityKeeper defines the ConcentratedLiquidity contract that must be fulfilled when
+// creating a x/protorev keeper.
+type ConcentratedLiquidityKeeper interface {
+	ComputeMaxInAmtGivenMaxTicksCrossed(
+		ctx sdk.Context,
+		poolId uint64,
+		tokenInDenom string,
+		maxTicksCrossed uint64,
+	) (maxTokenIn, resultingTokenOut sdk.Coin, err error)
+}

--- a/x/protorev/types/expected_keepers.go
+++ b/x/protorev/types/expected_keepers.go
@@ -44,6 +44,11 @@ type PoolManagerKeeper interface {
 		tokenIn sdk.Coin,
 	) (tokenOutAmount sdk.Int, err error)
 
+	MultihopEstimateInGivenExactAmountOut(
+		ctx sdk.Context,
+		routes []poolmanagertypes.SwapAmountOutRoute,
+		tokenOut sdk.Coin) (tokenInAmount sdk.Int, err error)
+
 	AllPools(
 		ctx sdk.Context,
 	) ([]poolmanagertypes.PoolI, error)


### PR DESCRIPTION
## What is the purpose of the change
This PR introduces a fix to `protorev` to update the binary search range in the case where it is too gas intensive to search over the hard-coded range. This is particularly useful for Concentrated Liquidity pools where moving across several ticks is very expensive. By determining if a route has an CL pools in it, we can bound the upper input amount by figuring out the maximum input amount respecting a maximum number of ticks. We do so across all CL pools and use this as our maximum input amount on the entire route.

Note, `MaxTicksMoved` is currently hard coded, but we plan to update that in a follow up PR. This will be configurable by the `DeveloperAccount`.

## Testing and Verifying

This change added tests and can be verified as follows:
  - *Added unit tests for `TestFindMaxProfitRoute` that test liquid and illiquid CL pools*
     - One of the test cases reduces the search range respecting the number of ticks that can be moved.

## Documentation and Release Note
This PR is related to these open issues (https://github.com/osmosis-labs/osmosis/issues/5858) and (https://github.com/osmosis-labs/osmosis/issues/5884)