### PR TITLE
fix: prevent sim from starting with zero validators

### DIFF
--- a/tests/simulator/state.go
+++ b/tests/simulator/state.go
@@ -136,7 +136,8 @@ func AppStateRandomizedFn(
 	// generate a random amount of initial stake coins and a random initial
 	// number of bonded accounts
 	initialStake := r.Int63n(1e12)
-	numInitiallyBonded := int64(r.Intn(300))
+	// Don't allow 0 validators to start off with
+	numInitiallyBonded := int64(rand.Intn(299)) + 1
 
 	if numInitiallyBonded > numAccs {
 		numInitiallyBonded = numAccs


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Another random sim error we have been getting has been due to us allowing the simulator to start with zero validators. This fixes that.

## Testing and Verifying

Sim seed I noticed this on (3112372204317306856) now passes.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A