### PR TITLE
fix: add seed to failing tree test

### DIFF
--- a/osmoutils/sumtree/tree_test.go
+++ b/osmoutils/sumtree/tree_test.go
@@ -2,6 +2,7 @@ package sumtree_test
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"sort"
 	"testing"
@@ -74,12 +75,16 @@ func (suite *TreeTestSuite) TestTreeInvariants() {
 	pairs := pairs{pair{[]byte("hello"), 100}}
 	suite.tree.Set([]byte("hello"), sdk.NewIntFromUint64(100))
 
+	seed := rand.Int63()
+	fmt.Printf("running seed %d: \n", seed)
+	r := rand.New(rand.NewSource(seed))
+
 	// tested up to 2000
 	for i := 0; i < 500; i++ {
 		// add a single element
-		key := make([]byte, rand.Int()%20)
-		value := rand.Uint64() % 100
-		rand.Read(key)
+		key := make([]byte, r.Int()%20)
+		value := r.Uint64() % 100
+		r.Read(key)
 		idx := sort.Search(len(pairs), func(n int) bool { return bytes.Compare(pairs[n].key, key) >= 0 })
 		if idx < len(pairs) {
 			if bytes.Equal(pairs[idx].key, key) {
@@ -126,8 +131,8 @@ func (suite *TreeTestSuite) TestTreeInvariants() {
 			right -= exact
 		}
 
-		if rand.Int()%2 == 0 {
-			idx := rand.Int() % len(pairs)
+		if r.Int()%2 == 0 {
+			idx := r.Int() % len(pairs)
 			pair := pairs[idx]
 			pairs = append(pairs[:idx], pairs[idx+1:]...)
 			suite.tree.Remove(pair.key)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Our tree test has been having some random failures that go away with a re-run. The most latest example is https://github.com/osmosis-labs/osmosis/actions/runs/5719776897/job/15498413011?pr=5895

This has been hard to debug since we don't use a seed value to run this test so the random values used are unknown. This PR adds a seed value that gets printed, so the next time the test fails, we can utilize this seed to be able to further debug.

## Testing and Verifying

N/A

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A