### PR TITLE
feat[CLI]: transform normal denom to base denom and modify value

### DIFF
--- a/cmd/osmosisd/cmd/config.go
+++ b/cmd/osmosisd/cmd/config.go
@@ -171,19 +171,31 @@ const defaultConfigTemplate = `# This is a TOML config file.
 
 # The network chain ID
 chain-id = "{{ .ChainID }}"
+
 # The keyring's backend, where the keys are stored (os|file|kwallet|pass|test|memory)
 keyring-backend = "{{ .KeyringBackend }}"
+
 # CLI output format (text|json)
 output = "{{ .Output }}"
+
 # <host>:<port> to Tendermint RPC interface for this chain
 node = "{{ .Node }}"
+
 # Transaction broadcasting mode (sync|async)
 broadcast-mode = "{{ .BroadcastMode }}"
-# Human-readable denoms
-# If enabled, when using CLI, user can input base denoms (baseatom, basescrt, baseweth, basewbtc, basewbtc.grv etc.) instead of their ibc equivalents.
+
+# Human-readable denoms: Input
+# If enabled, when using CLI, user can input 0 exponent denoms (atom, scrt, avax, wbtc, etc.) instead of their ibc equivalents.
+# Note, this will also change the coin's value to it's base value if the input or flag is a coin.
+# Example:
+#  		* 10.45atom input will automatically change to 10450000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2
+#  		* uakt will change to ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4
+#		* 12000000uscrt will change to 12000000ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A
 # This feature isn't stable yet, and outputs will change in subsequent releases
 human-readable-denoms-input = {{ .HumanReadableDenomsInput }}
-# If enabled, CLI response return base denoms (baseatom, basescrt, baseweth, basewbtc, basewbtc.grv etc.) instead of their ibc equivalents.
+
+# Human-readable denoms: Output
+# If enabled, CLI response return base denoms (uatom, uscrt, wavax-wei, wbtc-satoshi, etc.) instead of their ibc equivalents.
 # This feature isn't stable yet, and outputs will change in subsequent releases
 human-readable-denoms-output = {{ .HumanReadableDenomsOutput }}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This update parses inputs and flags for regular denoms as well as mutates the coin value to its base exponent

![Screenshot 2023-08-01 at 3 40 11 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/49d87556-7448-46c7-9c9e-bbfe3639cf44)

Example:
 * `10.45atom` input will automatically change to `10450000ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2`
 * `uakt` will change to `ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4`
 * `12000000uscrt` will change to `12000000ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A`

## Testing and Verifying

Tested locally, but more testing would be appreciated to see if there are any further edge cases. Remember, the following values in the client.toml must be changed to "true" to get this feature:

```
human-readable-denoms-input = true
human-readable-denoms-output = true
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A