### PR TITLE
[CI] Add concurrency options to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ on:
 env:
   GO_VERSION: '1.20.5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   get_diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - "v[0-9]**"
   workflow_dispatch:
 
+
 env:
   GO_VERSION: '1.20.5'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
       - "v[0-9]**"
   workflow_dispatch:
 
-
 env:
   GO_VERSION: '1.20.5'
 


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

This PR introduces concurrency control in our GitHub Actions to reduce CI time.

By grouping workflows via the `group` key and setting `cancel-in-progress` to true, we prevent redundancy in runs triggered by multiple commits to the same branch.

Docs on concurrency: https://docs.github.com/en/actions/using-jobs/using-concurrency

Explanation on the chosen group key `${{ github.workflow }}-${{ github.head_ref || github.run_id }}`:

- ${{ github.workflow }} avoid collision between future workflows in https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
- ${{ github.head_ref || github.run_id }} cancels in-progress jobs or runs on pull_request events only as in https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value.

## Testing and Verifying

To test this PR we should make multiple fake commits to this PR and check if the tests workflow gets cancelled in previous runs.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A