### PR TITLE
[ci] Add concurrency options to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ on:
 env:
   GO_VERSION: '1.20.5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: osmosisd-${{ matrix.targetos }}-${{ matrix.arch }}

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -4,6 +4,7 @@
 # changed, because generated code can change in response to toolchain updates
 # even if no files in the repository are modified.
 name: Check generated code
+
 on:
   workflow_dispatch:
   pull_request:
@@ -12,6 +13,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check-proto:

--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -42,6 +42,10 @@ env:
   LCD_ENDPOINT: https://lcd.osmosis.zone
   DELTA_HALT_HEIGHT: 50
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   compare_versions:
     # Compare current mainnet osmosis major version with the major version of github branch

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,4 +1,5 @@
 name: Cosmwasm Contracts
+
 on:
   pull_request:
     branches:
@@ -9,6 +10,9 @@ on:
       - "v[0-9]**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -21,7 +21,7 @@ on:
     branches:
     - main
     - v[0-9]+.x
-  
+
 env:
   RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
   OSMOSIS_DEV_IMAGE_REPOSITORY: osmolabs/osmosis-dev


### PR DESCRIPTION
## What is the purpose of the change

This PR extends the changes made in https://github.com/osmosis-labs/osmosis/pull/5955 
to all others GitHub actions that are triggered by pushed to a development branch.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A