### PR TITLE
fix[e2e]: e2e failure fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5923] (https://github.com/osmosis-labs/osmosis/pull/5923) CL: Lower gas for initializing ticks
 * [#5927] (https://github.com/osmosis-labs/osmosis/pull/5927) Add gas metering to x/tokenfactory trackBeforeSend hook
 * [#5890](https://github.com/osmosis-labs/osmosis/pull/5890) feat: CreateCLPool & LinkCFMMtoCL pool into one gov-prop
+* [#5964](https://github.com/osmosis-labs/osmosis/pull/5964) fix e2e test concurrency bugs
 
 ### Minor improvements & Bug Fixes
 

--- a/tests/e2e/configurer/base.go
+++ b/tests/e2e/configurer/base.go
@@ -79,18 +79,14 @@ func (bc *baseConfigurer) runValidators(chainConfig *chain.Config) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(chainConfig.NodeConfigs)) // Buffer the channel to avoid blocking
 
-	var mu sync.Mutex
-
 	// Increment the WaitGroup counter for each node
 	wg.Add(len(chainConfig.NodeConfigs))
 
 	// Iterate over each node
 	for _, node := range chainConfig.NodeConfigs {
 		go func(n *chain.NodeConfig) {
-			defer wg.Done() // Decrement the WaitGroup counter when the goroutine is done
-			mu.Lock()
+			defer wg.Done()  // Decrement the WaitGroup counter when the goroutine is done
 			errCh <- n.Run() // Run the node and send any error to the channel
-			mu.Unlock()
 		}(node)
 	}
 

--- a/tests/e2e/configurer/base.go
+++ b/tests/e2e/configurer/base.go
@@ -79,14 +79,18 @@ func (bc *baseConfigurer) runValidators(chainConfig *chain.Config) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(chainConfig.NodeConfigs)) // Buffer the channel to avoid blocking
 
+	var mu sync.Mutex
+
 	// Increment the WaitGroup counter for each node
 	wg.Add(len(chainConfig.NodeConfigs))
 
 	// Iterate over each node
 	for _, node := range chainConfig.NodeConfigs {
 		go func(n *chain.NodeConfig) {
-			defer wg.Done()  // Decrement the WaitGroup counter when the goroutine is done
+			defer wg.Done() // Decrement the WaitGroup counter when the goroutine is done
+			mu.Lock()
 			errCh <- n.Run() // Run the node and send any error to the channel
+			mu.Unlock()
 		}(node)
 	}
 

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -47,35 +47,57 @@ func NewNodeConfig(t *testing.T, initNode *initialization.Node, initConfig *init
 // The node configuration must be already added to the chain config prior to calling this
 // method.
 func (n *NodeConfig) Run() error {
-	n.t.Logf("starting node container: %s", n.Name)
-	resource, err := n.containerManager.RunNodeResource(n.chainId, n.Name, n.ConfigDir)
-	if err != nil {
-		return err
-	}
+	maxRetries := 2
+	currentRetry := 0
 
-	hostPort := resource.GetHostPort("26657/tcp")
-	rpcClient, err := rpchttp.New("tcp://"+hostPort, "/websocket")
-	if err != nil {
-		return err
-	}
+	for currentRetry < maxRetries {
+		n.t.Logf("starting node container: %s", n.Name)
+		resource, err := n.containerManager.RunNodeResource(n.chainId, n.Name, n.ConfigDir)
+		if err != nil {
+			return err
+		}
 
-	n.rpcClient = rpcClient
+		hostPort := resource.GetHostPort("26657/tcp")
+		rpcClient, err := rpchttp.New("tcp://"+hostPort, "/websocket")
+		if err != nil {
+			return err
+		}
 
-	require.Eventually(
-		n.t,
-		func() bool {
-			// This fails if unsuccessful.
-			_, err := n.QueryCurrentHeight()
-			if err != nil {
-				return false
+		n.rpcClient = rpcClient
+
+		successChan := make(chan bool)
+
+		go func() {
+			ticker := time.NewTicker(10 * time.Millisecond)
+			defer ticker.Stop()
+
+			for range ticker.C {
+				_, err := n.QueryCurrentHeight()
+				if err == nil {
+					n.t.Logf("started node container: %s", n.Name)
+					successChan <- true
+					return
+				}
 			}
-			n.t.Logf("started node container: %s", n.Name)
-			return true
-		},
-		time.Minute,
-		10*time.Millisecond,
-		"Osmosis node failed to produce blocks",
-	)
+		}()
+		defer close(successChan)
+
+		select {
+		case <-successChan:
+			break
+		case <-time.After(time.Second * 20):
+			n.t.Logf("failed to start node container, retrying... (%d/%d)", currentRetry+1, maxRetries)
+			err := n.containerManager.RemoveNodeResource(n.Name)
+			if err != nil {
+				return err
+			}
+			currentRetry++
+		}
+	}
+
+	if currentRetry >= maxRetries {
+		return fmt.Errorf("failed to start node container after %d retries", maxRetries)
+	}
 
 	if err := n.extractOperatorAddressIfValidator(); err != nil {
 		return err

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,6 +50,7 @@ type Manager struct {
 	pool              *dockertest.Pool
 	network           *dockertest.Network
 	resources         map[string]*dockertest.Resource
+	resourcesMutex    sync.RWMutex
 	isDebugLogEnabled bool
 }
 
@@ -297,7 +299,9 @@ func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir st
 		return nil, err
 	}
 
+	m.resourcesMutex.Lock()
 	m.resources[containerName] = resource
+	m.resourcesMutex.Unlock()
 
 	return resource, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Med/High confidence fix for concurrent map write

An example of the concurrent map write error https://github.com/osmosis-labs/osmosis/actions/runs/5754011094/job/15607044536

Adds a mutex to prevent this from happening

## Low/Med confidence fix for nodes not starting

There are random times (rare, maybe 1 in 100, both locally and in CI) when a docker container just wont start. While this isn't the best fix, this deletes the faulty container and attempt to recreate it instead of just failing on the spot.

An example of this happening https://github.com/osmosis-labs/osmosis/actions/runs/5719951506/job/15498941705