### PR TITLE
add testcase to show panic when out below pool reserves

### DIFF
--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -2,6 +2,7 @@ package stableswap
 
 import (
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -138,13 +139,18 @@ func solveCFMMBinarySearchMulti(xReserve, yReserve, wSumSquares, yIn osmomath.Bi
 	roundingDirection := osmomath.RoundUp
 	errTolerance.RoundingDir = roundingDirection
 
+	fmt.Println("xReserve", xReserve)
+
 	xEst, err := osmomath.BinarySearchBigDec(iterKCalc, xLowEst, xHighEst, targetK, errTolerance, maxIterations)
 	if err != nil {
 		panic(err)
 	}
+	fmt.Println("xEst", xEst)
 
 	xOut := xReserve.Sub(xEst)
 	// fmt.Printf("xOut %v\n", xOut)
+
+	fmt.Println("xOut", xOut)
 
 	// We check the absolute value of the output against the xReserve amount to ensure that:
 	// 1. Swaps cannot more than double the input token's pool supply

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -1292,6 +1292,27 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 			expectPass: false,
 			poolType:   types.Stableswap,
 		},
+		{
+			name: "Asserts panic catching in MultihopEstimateInGivenExactAmountOut for stableswap: tokenOut below actual pool reserves",
+			param: param{
+				routes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       2,
+						TokenInDenom: bar,
+					},
+				},
+				estimateRoutes: []types.SwapAmountOutRoute{
+					{
+						PoolId:       4,
+						TokenInDenom: bar,
+					},
+				},
+				tokenInMaxAmount: sdk.NewInt(5_000_000),
+				tokenOut:         sdk.NewCoin(baz, sdk.NewInt(7_500_000)),
+			},
+			expectPass: false,
+			poolType:   types.Stableswap,
+		},
 	}
 
 	for _, test := range tests {
@@ -1299,6 +1320,7 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 		s.SetupTest()
 
 		s.Run(test.name, func() {
+			fmt.Println(test.name)
 			poolmanagerKeeper := s.App.PoolManagerKeeper
 
 			firstEstimatePoolId, secondEstimatePoolId := s.setupPools(test.poolType, defaultPoolSpreadFactor)
@@ -1314,11 +1336,14 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 				test.param.routes,
 				test.param.tokenInMaxAmount,
 				test.param.tokenOut)
+			fmt.Println(multihopTokenInAmount, errMultihop)
 
 			estimateMultihopTokenInAmount, errEstimate := poolmanagerKeeper.MultihopEstimateInGivenExactAmountOut(
 				s.Ctx,
 				test.param.estimateRoutes,
 				test.param.tokenOut)
+
+			fmt.Println(estimateMultihopTokenInAmount, errEstimate)
 
 			if test.expectPass {
 				s.Require().NoError(errMultihop, "test: %v", test.name)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
- To show a panic in stableswap pool exactOut estimation even when the Out wanted is less than the actual pool reserves
- The stableswap pools are initialized with 10mil liquidity, when trying to get the In needed to get out 7.5mil liquidity of an asset, a panic occurs
![Screen Shot 2023-08-07 at 1 56 32 PM](https://github.com/osmosis-labs/osmosis/assets/31809888/6943cda2-7470-4f1e-8bae-5ef34e3e8a5c)
