### PR TITLE
chore[e2e]: faster epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### BugFix
 
 ### Misc Improvements
+* [#5976](https://github.com/osmosis-labs/osmosis/pull/5976) chore[e2e]: faster epoch
 
 ### Minor improvements & Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### State Breaking
-
-### BugFix
-
-### Misc Improvements
-* [#5976](https://github.com/osmosis-labs/osmosis/pull/5976) chore[e2e]: faster epoch
-
-### Minor improvements & Bug Fixes
-
 ## v16.1.2
 
 ### Misc Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### State Breaking
+
+### Bug Fixes
+
+### Misc Improvements
+* [#5976](https://github.com/osmosis-labs/osmosis/pull/5976) chore[e2e]: faster epoch
+
+### Minor improvements & Bug Fixes
+
+### Security
+
 ## v16.1.2
 
 ### Misc Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### State Breaking
+
+### BugFix
+
+### Misc Improvements
+
+### Minor improvements & Bug Fixes
+
 ## v16.1.2
 
 ### Misc Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
 ### State Breaking
 
 ### BugFix

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -547,10 +547,10 @@ func updatePoolManagerGenesis(appGenState map[string]json.RawMessage) func(*pool
 
 func updateEpochGenesis(epochGenState *epochtypes.GenesisState) {
 	epochGenState.Epochs = []epochtypes.EpochInfo{
-		// override week epochs which are in default integrations, to be 2min
-		epochtypes.NewGenesisEpochInfo("week", time.Second*120),
-		// override day epochs which are in default integrations, to be 1min
-		epochtypes.NewGenesisEpochInfo("day", time.Second*60),
+		// override week epochs which are in default integrations, to be 60 seconds
+		epochtypes.NewGenesisEpochInfo("week", time.Second*60),
+		// override day epochs which are in default integrations, to be 5 seconds
+		epochtypes.NewGenesisEpochInfo("day", time.Second*5),
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Epoch is currently set to 1 minute. There are two tests that wait for an epoch to pass before continuing in the e2e test suite. This means we could potentially have to wait up to a minute to continue the test. There is no need for this, so we should just speed up the epoch duration more.

## Testing and Verifying

Built locally, and tested against the currently open e2e PR against main

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A