### PR TITLE
Add a file ignore for check generated running

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -23,11 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - 
-        name: 🐿 Setup Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
-      - 
         uses: actions/checkout@v3
         with:
           fetch-depth: 1  # we need a .git directory to run git diff
@@ -43,6 +38,11 @@ jobs:
             Makefile
             Dockerfile
             .github/workflows/check-generated.yml
+      - 
+        name: 🐿 Setup Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20'
       -
         name: "Check protobuf generated code"
         run: scripts/ci/check-generated.sh

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -32,5 +32,17 @@ jobs:
         with:
           fetch-depth: 1  # we need a .git directory to run git diff
       -
+        name: Get git diff
+        uses: technote-space/get-diff-action@v6.1.2
+        with:
+          PATTERNS: |
+            proto/**
+            **/**.pb.go
+            **/client/**.go
+            scripts/ci/**
+            Makefile
+            Dockerfile
+            .github/workflows/check-generated.yml
+      -
         name: "Check protobuf generated code"
         run: scripts/ci/check-generated.sh


### PR DESCRIPTION
In our check-generated CI job, make it not run if not needed.
(It just runs make proto-gen && make run-querygen)

Also only setuip go after we pass git diff.