### PR TITLE
fix: sim val number being non deterministic

### DIFF
--- a/tests/simulator/state.go
+++ b/tests/simulator/state.go
@@ -137,7 +137,7 @@ func AppStateRandomizedFn(
 	// number of bonded accounts
 	initialStake := r.Int63n(1e12)
 	// Don't allow 0 validators to start off with
-	numInitiallyBonded := int64(rand.Intn(299)) + 1
+	numInitiallyBonded := int64(r.Intn(299)) + 1
 
 	if numInitiallyBonded > numAccs {
 		numInitiallyBonded = numAccs


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We were not using the seeded random value when determining number of validators. This makes each run have a different number of validators, sometimes failing the non determinism check. See:

https://github.com/osmosis-labs/osmosis/actions/runs/5798085879/job/15715067009
https://github.com/osmosis-labs/osmosis/actions/runs/5799915139/job/15720939362?pr=5949

## Testing and Verifying

Run a single seed, see that it no longer has differing values for the number of validators for the run

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A