### PR TITLE
feat: improve set-env CLI cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5890](https://github.com/osmosis-labs/osmosis/pull/5890) feat: CreateCLPool & LinkCFMMtoCL pool into one gov-prop
 * [#5964](https://github.com/osmosis-labs/osmosis/pull/5964) fix e2e test concurrency bugs
 * [#5948] (https://github.com/osmosis-labs/osmosis/pull/5948) Parameterizing Pool Type Information in Protorev
+* [#6001](https://github.com/osmosis-labs/osmosis/pull/6001) feat: improve set-env CLI cmd
 
 ### Minor improvements & Bug Fixes
 

--- a/cmd/osmosisd/cmd/change_environment.go
+++ b/cmd/osmosisd/cmd/change_environment.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 
@@ -14,7 +16,8 @@ import (
 const (
 	EnvVariable = "OSMOSISD_ENVIRONMENT"
 	EnvMainnet  = "mainnet"
-	EnvLocalnet = "localosmosis"
+	EnvTestnet  = "testnet"
+	EnvLocalnet = "localnet"
 )
 
 // ExportAirdropSnapshotCmd generates a snapshot.json from a provided exported genesis.json.
@@ -25,29 +28,18 @@ func ChangeEnvironmentCmd() *cobra.Command {
 		Long: `Set home environment variables for commands
 Example:
 	osmosisd set-env mainnet
-	osmosisd set-env localosmosis
+	osmosisd set-env testnet
+	osmosisd set-env localnet
 	osmosisd set-env $HOME/.custom-dir
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Note: If we are calling this method, the environment file has already been set in
+			// NewRootCmd() when creating the rootCmd. We do this because order of operations
+			// dictates this as a requirement. If we changed the env file here, the osmosis
+			// daemon would not initialize the folder we are intending to set to.
 			newEnv := args[0]
-
-			currentEnvironment := getHomeEnvironment()
-			fmt.Println("Current environment: ", currentEnvironment)
-
-			if _, err := environmentNameToPath(newEnv); err != nil {
-				return err
-			}
-
-			fmt.Println("New environment: ", newEnv)
-
-			envMap := make(map[string]string)
-			envMap[EnvVariable] = newEnv
-			err := godotenv.Write(envMap, filepath.Join(app.DefaultNodeHome, ".env"))
-			if err != nil {
-				return err
-			}
-			return nil
+			return clientSettingsFromEnv(cmd, newEnv)
 		},
 	}
 	return cmd
@@ -64,8 +56,8 @@ Example:
 
 	Returns one of:
 	- mainnet implying $HOME/.osmosisd
+	- testnet implying $HOME/.osmosisd-test
 	- localosmosis implying $HOME/.osmosisd-local
-	- localosmosis
 	- custom path`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			environment := getHomeEnvironment()
@@ -91,17 +83,122 @@ func environmentNameToPath(environmentName string) (string, error) {
 	switch environmentName {
 	case EnvMainnet:
 		return app.DefaultNodeHome, nil
+	case EnvTestnet:
+		return filepath.Join(userHomeDir, ".osmosisd-test/"), nil
 	case EnvLocalnet:
 		return filepath.Join(userHomeDir, ".osmosisd-local/"), nil
 	default:
-		osmosisdPath := filepath.Join(userHomeDir, environmentName)
-		_, err := os.Stat(osmosisdPath)
+		_, err := os.Stat(environmentName)
 		if os.IsNotExist(err) {
 			// Creating new environment directory
-			if err := os.Mkdir(osmosisdPath, os.ModePerm); err != nil {
+			if err := os.Mkdir(environmentName, os.ModePerm); err != nil {
 				return "", err
 			}
 		}
-		return osmosisdPath, nil
+		return environmentName, nil
 	}
+}
+
+// clientSettingsFromEnv takes the env name (mainnet, testnet, localnet, etc) and sets the
+// client.toml settings to commonly used values for that environment.
+func clientSettingsFromEnv(cmd *cobra.Command, environmentName string) error {
+	envConfigs := map[string]map[string]string{
+		EnvMainnet: {
+			flags.FlagChainID:       "osmosis-1",
+			flags.FlagNode:          "https://rpc.osmosis.zone:443",
+			flags.FlagBroadcastMode: "block",
+		},
+		EnvTestnet: {
+			flags.FlagChainID:       "osmo-test-5",
+			flags.FlagNode:          "https://rpc.testnet.osmosis.zone:443",
+			flags.FlagBroadcastMode: "block",
+		},
+		EnvLocalnet: {
+			flags.FlagChainID:       "localosmosis",
+			flags.FlagBroadcastMode: "block",
+		},
+	}
+
+	configs, ok := envConfigs[environmentName]
+	if !ok {
+		return nil
+	}
+
+	for flag, value := range configs {
+		if err := runConfigCmd(cmd, []string{flag, value}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// changeEnvironment takes the given environment name and changes the .env file to reflect it.
+func changeEnvironment(args []string) error {
+	newEnv := args[0]
+
+	currentEnvironment := getHomeEnvironment()
+	fmt.Println("Current environment: ", currentEnvironment)
+
+	if _, err := environmentNameToPath(newEnv); err != nil {
+		return err
+	}
+
+	fmt.Println("New environment: ", newEnv)
+
+	envMap := make(map[string]string)
+	envMap[EnvVariable] = newEnv
+	err := godotenv.Write(envMap, filepath.Join(app.DefaultNodeHome, ".env"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createHomeDirIfNotExist creates the home directory if it does not exist and writes a blank
+// .env file. This is used for the first time setup of the osmosisd home directory.
+func createHomeDirIfNotExist(homeDir string) error {
+	if _, err := os.Stat(homeDir); os.IsNotExist(err) {
+		err := os.MkdirAll(homeDir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	envFilePath := filepath.Join(homeDir, ".env")
+	if _, err := os.Stat(envFilePath); os.IsNotExist(err) {
+		file, err := os.Create(envFilePath)
+		if err != nil {
+			return err
+		}
+		file.Close()
+	}
+
+	return nil
+}
+
+// changeEnvPriorToSetup changes the env file to reflect the desired environment the user wants to change to.
+// If this is not called in NewRootCmd(), the environment change will happen **after** all relevant setup actions
+// happen (e.g., the .env will be read in as the previous value in the setup and not the new value).
+func changeEnvPriorToSetup(cmd *cobra.Command, initClientCtx *client.Context, args []string, homeDir string) error {
+	if cmd.Name() == "set-env" && len(args) == 1 {
+		err := createHomeDirIfNotExist(homeDir)
+		if err != nil {
+			return err
+		}
+
+		err = changeEnvironment(args)
+		if err != nil {
+			return err
+		}
+
+		homeEnvironment := getHomeEnvironment()
+		homeDir, err := environmentNameToPath(homeEnvironment)
+		if err != nil {
+			// Failed to convert home environment to home path, using default home
+			homeDir = app.DefaultNodeHome
+		}
+		*initClientCtx = initClientCtx.WithHomeDir(homeDir)
+	}
+	return nil
 }

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -287,6 +287,12 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		Use:   "osmosisd",
 		Short: "Start osmosis app",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// If not calling the set-env command, this is a no-op.
+			err := changeEnvPriorToSetup(cmd, &initClientCtx, args, homeDir)
+			if err != nil {
+				return err
+			}
+
 			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
 			if err != nil {
 				return err
@@ -391,8 +397,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 func getHomeEnvironment() string {
 	envPath := filepath.Join(osmosis.DefaultNodeHome, ".env")
 
-	// Use default node home if can't get environment
-	err := godotenv.Load(envPath)
+	// Use default node home if can't get environment.
+	// Overload must be used here in the event that the .env gets updated.
+	err := godotenv.Overload(envPath)
 	if err != nil {
 		// Failed to load, using default home directory
 		return EnvMainnet

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/types/address"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/types/address"
 
 	transfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
 	"github.com/iancoleman/orderedmap"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

https://github.com/osmosis-labs/osmosis/assets/40078083/265cf085-7861-4bd9-a1dc-246cfc33e55e

Getting started with osmosis is not very user friendly. The set-env command was a step in the right direction, but it still doesn't feel useable out of the box.

With this PR, a user can go from having no .osmosisd folder to querying the chain with a single command. 

Additionally, it fills out the chain-id in the client.toml, so the only flag a user should have to pass in is gas flags (you could 100 percent add this as well, but I wasn't quite sure what default gas values should be used).

Edit: last minute addition, allows you to add a chain ID to the set-env for localnet. If no chainID for localnet is provided, it default to localosmosis chain ID.

## Testing and Verifying

Tested against mainnet, testnet, and local env.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A