### PR TITLE
fixed mint and burn message examples to include the to and from addresses

### DIFF
--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -35,14 +35,14 @@ func NewCreateDenomCmd() *cobra.Command {
 
 func NewMintCmd() *cobra.Command {
 	return osmocli.BuildTxCli[*types.MsgMint](&osmocli.TxCliDesc{
-		Use:   "mint [amount] [flags]",
+		Use:   "mint [amount] [mint-to-address] [flags]",
 		Short: "Mint a denom to an address. Must have admin authority to do so.",
 	})
 }
 
 func NewBurnCmd() *cobra.Command {
 	return osmocli.BuildTxCli[*types.MsgBurn](&osmocli.TxCliDesc{
-		Use:   "burn [amount] [flags]",
+		Use:   "burn [amount] [burn-from-address] [flags]",
 		Short: "Burn tokens from an address. Must have admin authority to do so.",
 	})
 }


### PR DESCRIPTION
## What is the purpose of the change

> Add a description of the overall background and high level changes that this PR introduces

Simply to add the `mint-to-address` and `burn-from-address` into the examples of the CLI for mint and burn tokenfactory messages.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A