### PR TITLE
chore: add CLI autocomplete to makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,17 +77,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5534](https://github.com/osmosis-labs/osmosis/pull/5534) fix: fix the account number of x/tokenfactory module account
 * [#5750](https://github.com/osmosis-labs/osmosis/pull/5750) feat: add cli commmand for converting proto structs to proto marshalled bytes
 * [#5889](https://github.com/osmosis-labs/osmosis/pull/5889) provides an API for protorev to determine max amountIn that can be swapped based on max ticks willing to be traversed
-* [#5849] (https://github.com/osmosis-labs/osmosis/pull/5849) CL: Lower gas for leaving a position and withdrawing rewards
+* [#5849](https://github.com/osmosis-labs/osmosis/pull/5849) CL: Lower gas for leaving a position and withdrawing rewards
 * [#5855](https://github.com/osmosis-labs/osmosis/pull/5855) feat(x/cosmwasmpool): Sending token_in_max_amount to the contract before running contract msg
-* [#5893] (https://github.com/osmosis-labs/osmosis/pull/5893) Export createPosition method in CL so other modules can use it in testing
-* [#5870] (https://github.com/osmosis-labs/osmosis/pull/5870) Remove v14/ separator in protorev rest endpoints
-* [#5923] (https://github.com/osmosis-labs/osmosis/pull/5923) CL: Lower gas for initializing ticks
-* [#5927] (https://github.com/osmosis-labs/osmosis/pull/5927) Add gas metering to x/tokenfactory trackBeforeSend hook
+* [#5893](https://github.com/osmosis-labs/osmosis/pull/5893) Export createPosition method in CL so other modules can use it in testing
+* [#5870](https://github.com/osmosis-labs/osmosis/pull/5870) Remove v14/ separator in protorev rest endpoints
+* [#5923](https://github.com/osmosis-labs/osmosis/pull/5923) CL: Lower gas for initializing ticks
+* [#5927](https://github.com/osmosis-labs/osmosis/pull/5927) Add gas metering to x/tokenfactory trackBeforeSend hook
 * [#5890](https://github.com/osmosis-labs/osmosis/pull/5890) feat: CreateCLPool & LinkCFMMtoCL pool into one gov-prop
 * [#5959](https://github.com/osmosis-labs/osmosis/pull/5959) allow testing with different chain-id's in E2E testing
 * [#5964](https://github.com/osmosis-labs/osmosis/pull/5964) fix e2e test concurrency bugs
-* [#5948] (https://github.com/osmosis-labs/osmosis/pull/5948) Parameterizing Pool Type Information in Protorev
+* [#5948](https://github.com/osmosis-labs/osmosis/pull/5948) Parameterizing Pool Type Information in Protorev
 * [#6001](https://github.com/osmosis-labs/osmosis/pull/6001) feat: improve set-env CLI cmd
+* [#6012](https://github.com/osmosis-labs/osmosis/pull/6012) chore: add CLI autocomplete to makefile
 
 ### Minor improvements & Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#5964](https://github.com/osmosis-labs/osmosis/pull/5964) fix e2e test concurrency bugs
 * [#5948](https://github.com/osmosis-labs/osmosis/pull/5948) Parameterizing Pool Type Information in Protorev
 * [#6001](https://github.com/osmosis-labs/osmosis/pull/6001) feat: improve set-env CLI cmd
-* [#6012](https://github.com/osmosis-labs/osmosis/pull/6012) chore: add CLI autocomplete to makefile
+* [#6012](https://github.com/osmosis-labs/osmosis/pull/6012) chore: add autocomplete to makefile
 
 ### Minor improvements & Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 BUILDDIR ?= $(CURDIR)/build
 DOCKER := $(shell which docker)
 E2E_UPGRADE_VERSION := "v17"
+SHELL := /bin/bash
 
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
 GO_MODULE := $(shell cat go.mod | grep "module " | cut -d ' ' -f 2)
@@ -134,6 +135,7 @@ install-with-autocomplete: check_version go.sum
 		if ! grep -q -e "\. <(osmosisd enable-cli-autocomplete bash)" -e '\[\[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" \]\] && \. "/opt/homebrew/etc/profile.d/bash_completion.sh"' ~/.bashrc; then \
 			echo '[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bashrc; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
+			source ~/.bashrc; \
 			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
 		else \
 			echo "Autocomplete already enabled in ~/.bashrc"; \
@@ -143,6 +145,7 @@ install-with-autocomplete: check_version go.sum
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete bash)" ~/.bashrc; then \
 			echo '[[ -r "/etc/bash_completion" ]] && . "/etc/bash_completion"' >> ~/.bashrc; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
+			source ~/.bashrc; \
 			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
 		else \
 			echo "Autocomplete already enabled in ~/.bashrc"; \

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ install: check_version go.sum
 
 install-with-autocomplete: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
-	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p) && echo "Parent shell is: $$PARENT_SHELL" ;\
+	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p) ;\
 	if [[ "$$PARENT_SHELL" == *zsh* ]]; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete zsh)" ~/.zshrc; then \
 			echo ". <(osmosisd enable-cli-autocomplete zsh)" >> ~/.zshrc; \

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ install: check_version go.sum
 
 install-with-autocomplete: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
-	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p) ;\
+	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p); \
 	if [[ "$$PARENT_SHELL" == *zsh* ]]; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete zsh)" ~/.zshrc; then \
 			echo ". <(osmosisd enable-cli-autocomplete zsh)" >> ~/.zshrc; \

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,8 @@ install-with-autocomplete: check_version go.sum
 			brew install bash-completion; \
 			echo '[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bashrc; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
-			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation.";
+			echo; \
+			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
 		else \
 			echo "Autocomplete already enabled in ~/.bashrc"; \
 		fi \
@@ -144,7 +145,8 @@ install-with-autocomplete: check_version go.sum
 			sudo apt-get install -y bash-completion; \
 			echo '[[ -r "/etc/bash_completion" ]] && . "/etc/bash_completion"' >> ~/.bashrc; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
-			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation.";
+			echo; \
+			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
 		else \
 			echo "Autocomplete already enabled in ~/.bashrc"; \
 		fi \

--- a/Makefile
+++ b/Makefile
@@ -131,22 +131,20 @@ install-with-autocomplete: check_version go.sum
 			echo "Autocomplete already enabled in ~/.zshrc"; \
 		fi \
 	elif [[ "$$PARENT_SHELL" == *bash* && "$$(uname)" == "Darwin" ]]; then \
-		brew install bash-completion; \
 		if ! grep -q -e "\. <(osmosisd enable-cli-autocomplete bash)" -e '\[\[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" \]\] && \. "/opt/homebrew/etc/profile.d/bash_completion.sh"' ~/.bashrc; then \
+			brew install bash-completion; \
 			echo '[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bashrc; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
-			source ~/.bashrc; \
-			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
+			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation.";
 		else \
 			echo "Autocomplete already enabled in ~/.bashrc"; \
 		fi \
 	elif [[ "$$PARENT_SHELL" == *bash* && "$$(uname)" == "Linux" ]]; then \
-		sudo apt-get install -y bash-completion; \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete bash)" ~/.bashrc; then \
+			sudo apt-get install -y bash-completion; \
 			echo '[[ -r "/etc/bash_completion" ]] && . "/etc/bash_completion"' >> ~/.bashrc; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
-			source ~/.bashrc; \
-			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
+			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation.";
 		else \
 			echo "Autocomplete already enabled in ~/.bashrc"; \
 		fi \


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR adds a `install-with-autocomplete` Makefile command, which adds the autocomplete to your profile. If using bash, a separate package must be installed in order to get it to work, which this does as well. 

I considered just adding this to the `install` command, but I don't think we should be adding things to people's profiles as the default method. Although I do think the majority of people will want to use this method in place of the usual install.

## Testing and Verifying

This has been tested on:
1. Mac using zsh
2. Mac using bash
3. Linux using bash

And all have worked!

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A