### PR TITLE
refactor: reduce the number of returns in superfluid migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### API breaks
 
+* [#6014](https://github.com/osmosis-labs/osmosis/pull/6014) refactor: reduce the number of returns in superfluid migration
 * [#5983](https://github.com/osmosis-labs/osmosis/pull/5983) refactor(CL): 6 return values in CL CreatePosition with a struct
 * [#6004](https://github.com/osmosis-labs/osmosis/pull/6004) reduce number of returns for creating full range position
 

--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v17/x/gamm/types"
 	gammmigration "github.com/osmosis-labs/osmosis/v17/x/gamm/types/migration"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v17/x/poolmanager/types"
+	superfluidtypes "github.com/osmosis-labs/osmosis/v17/x/superfluid/types"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,41 +21,44 @@ import (
 func (k Keeper) MigrateUnlockedPositionFromBalancerToConcentrated(ctx sdk.Context,
 	sender sdk.AccAddress, sharesToMigrate sdk.Coin,
 	tokenOutMins sdk.Coins,
-) (positionData cltypes.CreateFullRangePositionData, poolIdLeaving, poolIdEntering uint64, err error) {
+) (cltypes.CreateFullRangePositionData, superfluidtypes.MigrationPoolIDs, error) {
 	// Get the balancer poolId by parsing the gamm share denom.
-	poolIdLeaving, err = types.GetPoolIdFromShareDenom(sharesToMigrate.Denom)
+	poolIdLeaving, err := types.GetPoolIdFromShareDenom(sharesToMigrate.Denom)
 	if err != nil {
-		return cltypes.CreateFullRangePositionData{}, 0, 0, err
+		return cltypes.CreateFullRangePositionData{}, superfluidtypes.MigrationPoolIDs{}, err
 	}
 
 	// Find the governance sanctioned link between the balancer pool and a concentrated pool.
-	poolIdEntering, err = k.GetLinkedConcentratedPoolID(ctx, poolIdLeaving)
+	poolIdEntering, err := k.GetLinkedConcentratedPoolID(ctx, poolIdLeaving)
 	if err != nil {
-		return cltypes.CreateFullRangePositionData{}, 0, 0, err
+		return cltypes.CreateFullRangePositionData{}, superfluidtypes.MigrationPoolIDs{}, err
 	}
 
 	// Get the concentrated pool from the message and type cast it to ConcentratedPoolExtension.
 	concentratedPool, err := k.concentratedLiquidityKeeper.GetConcentratedPoolById(ctx, poolIdEntering)
 	if err != nil {
-		return cltypes.CreateFullRangePositionData{}, 0, 0, err
+		return cltypes.CreateFullRangePositionData{}, superfluidtypes.MigrationPoolIDs{}, err
 	}
 
 	// Exit the balancer pool position.
 	exitCoins, err := k.ExitPool(ctx, sender, poolIdLeaving, sharesToMigrate.Amount, tokenOutMins)
 	if err != nil {
-		return cltypes.CreateFullRangePositionData{}, 0, 0, err
+		return cltypes.CreateFullRangePositionData{}, superfluidtypes.MigrationPoolIDs{}, err
 	}
 	// Defense in depth, ensuring we are returning exactly two coins.
 	if len(exitCoins) != 2 {
-		return cltypes.CreateFullRangePositionData{}, 0, 0, fmt.Errorf("Balancer pool must have exactly two tokens")
+		return cltypes.CreateFullRangePositionData{}, superfluidtypes.MigrationPoolIDs{}, fmt.Errorf("Balancer pool must have exactly two tokens")
 	}
 
 	// Create a full range (min to max tick) concentrated liquidity position.
-	positionData, err = k.concentratedLiquidityKeeper.CreateFullRangePosition(ctx, concentratedPool.GetId(), sender, exitCoins)
+	positionData, err := k.concentratedLiquidityKeeper.CreateFullRangePosition(ctx, concentratedPool.GetId(), sender, exitCoins)
 	if err != nil {
-		return cltypes.CreateFullRangePositionData{}, 0, 0, err
+		return cltypes.CreateFullRangePositionData{}, superfluidtypes.MigrationPoolIDs{}, err
 	}
-	return positionData, poolIdLeaving, poolIdEntering, nil
+	return positionData, superfluidtypes.MigrationPoolIDs{
+		LeavingID:  poolIdLeaving,
+		EnteringID: poolIdEntering,
+	}, nil
 }
 
 // GetAllMigrationInfo gets all existing links between Balancer Pool and Concentrated Pool,

--- a/x/gamm/keeper/migrate_test.go
+++ b/x/gamm/keeper/migrate_test.go
@@ -229,15 +229,15 @@ func (s *KeeperTestSuite) TestMigrate() {
 
 		// Migrate the user's gamm shares to a full range concentrated liquidity position
 		userBalancesBeforeMigration := s.App.BankKeeper.GetAllBalances(s.Ctx, test.param.sender)
-		positionData, poolIdLeaving, poolIdEntering, err := keeper.MigrateUnlockedPositionFromBalancerToConcentrated(s.Ctx, test.param.sender, sharesToMigrate, test.tokenOutMins)
+		positionData, migratedPools, err := keeper.MigrateUnlockedPositionFromBalancerToConcentrated(s.Ctx, test.param.sender, sharesToMigrate, test.tokenOutMins)
 		userBalancesAfterMigration := s.App.BankKeeper.GetAllBalances(s.Ctx, test.param.sender)
 		if test.expectedErr != nil {
 			s.Require().Error(err)
 			s.Require().ErrorContains(err, test.expectedErr.Error())
 
 			// Expect zero values for both pool ids
-			s.Require().Zero(poolIdLeaving)
-			s.Require().Zero(poolIdEntering)
+			s.Require().Zero(migratedPools.LeavingID)
+			s.Require().Zero(migratedPools.EnteringID)
 
 			// Assure the user's gamm shares still exist
 			userGammBalanceAfterFailedMigration := s.App.BankKeeper.GetBalance(s.Ctx, test.param.sender, "gamm/pool/1")
@@ -259,8 +259,8 @@ func (s *KeeperTestSuite) TestMigrate() {
 
 		// Expect the poolIdLeaving to be the balancer pool id
 		// Expect the poolIdEntering to be the concentrated liquidity pool id
-		s.Require().Equal(balancerPoolId, poolIdLeaving)
-		s.Require().Equal(clPool.GetId(), poolIdEntering)
+		s.Require().Equal(balancerPoolId, migratedPools.LeavingID)
+		s.Require().Equal(clPool.GetId(), migratedPools.EnteringID)
 
 		// Determine how much of the user's balance was not used in the migration
 		// This amount should be returned to the user.

--- a/x/superfluid/keeper/export_test.go
+++ b/x/superfluid/keeper/export_test.go
@@ -7,6 +7,7 @@ import (
 
 	cltypes "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v17/x/lockup/types"
+	types "github.com/osmosis-labs/osmosis/v17/x/superfluid/types"
 )
 
 var (
@@ -22,15 +23,15 @@ func (k Keeper) PrepareConcentratedLockForSlash(ctx sdk.Context, lock *lockuptyp
 	return k.prepareConcentratedLockForSlash(ctx, lock, slashAmt)
 }
 
-func (k Keeper) MigrateSuperfluidBondedBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin, synthDenomBeforeMigration string, tokenOutMins sdk.Coins) (positionData cltypes.CreateFullRangePositionData, concentratedLockId, poolIdLeaving, poolIdEntering uint64, err error) {
+func (k Keeper) MigrateSuperfluidBondedBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin, synthDenomBeforeMigration string, tokenOutMins sdk.Coins) (cltypes.CreateFullRangePositionData, uint64, types.MigrationPoolIDs, error) {
 	return k.migrateSuperfluidBondedBalancerToConcentrated(ctx, sender, lockId, sharesToMigrate, synthDenomBeforeMigration, tokenOutMins)
 }
 
-func (k Keeper) MigrateSuperfluidUnbondingBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin, synthDenomBeforeMigration string, tokenOutMins sdk.Coins) (positionData cltypes.CreateFullRangePositionData, concentratedLockId, poolIdLeaving, poolIdEntering uint64, err error) {
+func (k Keeper) MigrateSuperfluidUnbondingBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin, synthDenomBeforeMigration string, tokenOutMins sdk.Coins) (cltypes.CreateFullRangePositionData, uint64, types.MigrationPoolIDs, error) {
 	return k.migrateSuperfluidUnbondingBalancerToConcentrated(ctx, sender, lockId, sharesToMigrate, synthDenomBeforeMigration, tokenOutMins)
 }
 
-func (k Keeper) MigrateNonSuperfluidLockBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin, tokenOutMins sdk.Coins) (positionData cltypes.CreateFullRangePositionData, concentratedLockId, poolIdLeaving, poolIdEntering uint64, err error) {
+func (k Keeper) MigrateNonSuperfluidLockBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin, tokenOutMins sdk.Coins) (cltypes.CreateFullRangePositionData, uint64, types.MigrationPoolIDs, error) {
 	return k.migrateNonSuperfluidLockBalancerToConcentrated(ctx, sender, lockId, sharesToMigrate, tokenOutMins)
 }
 
@@ -42,7 +43,7 @@ func (k Keeper) RouteMigration(ctx sdk.Context, sender sdk.AccAddress, lockId in
 	return k.routeMigration(ctx, sender, lockId, sharesToMigrate)
 }
 
-func (k Keeper) ValidateMigration(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin) (poolIdLeaving, poolIdEntering uint64, preMigrationLock *lockuptypes.PeriodLock, remainingLockTime time.Duration, err error) {
+func (k Keeper) ValidateMigration(ctx sdk.Context, sender sdk.AccAddress, lockId uint64, sharesToMigrate sdk.Coin) (types.MigrationPoolIDs, *lockuptypes.PeriodLock, time.Duration, error) {
 	return k.validateMigration(ctx, sender, lockId, sharesToMigrate)
 }
 

--- a/x/superfluid/keeper/msg_server.go
+++ b/x/superfluid/keeper/msg_server.go
@@ -205,7 +205,7 @@ func (server msgServer) UnlockAndMigrateSharesToFullRangeConcentratedPosition(go
 		return nil, err
 	}
 
-	positionData, poolIdLeaving, poolIdEntering, clLockId, err := server.keeper.RouteLockedBalancerToConcentratedMigration(ctx, sender, msg.LockId, msg.SharesToMigrate, msg.TokenOutMins)
+	positionData, migratedPoolIDs, clLockId, err := server.keeper.RouteLockedBalancerToConcentratedMigration(ctx, sender, msg.LockId, msg.SharesToMigrate, msg.TokenOutMins)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +213,8 @@ func (server msgServer) UnlockAndMigrateSharesToFullRangeConcentratedPosition(go
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeEvtUnlockAndMigrateShares,
-			sdk.NewAttribute(types.AttributeKeyPoolIdEntering, strconv.FormatUint(poolIdEntering, 10)),
-			sdk.NewAttribute(types.AttributeKeyPoolIdLeaving, strconv.FormatUint(poolIdLeaving, 10)),
+			sdk.NewAttribute(types.AttributeKeyPoolIdEntering, strconv.FormatUint(migratedPoolIDs.EnteringID, 10)),
+			sdk.NewAttribute(types.AttributeKeyPoolIdLeaving, strconv.FormatUint(migratedPoolIDs.LeavingID, 10)),
 			sdk.NewAttribute(types.AttributeConcentratedLockId, strconv.FormatUint(clLockId, 10)),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
 			sdk.NewAttribute(types.AttributePositionId, strconv.FormatUint(positionData.ID, 10)),

--- a/x/superfluid/types/expected_keepers.go
+++ b/x/superfluid/types/expected_keepers.go
@@ -56,7 +56,7 @@ type GammKeeper interface {
 	ExitPool(ctx sdk.Context, sender sdk.AccAddress, poolId uint64, shareInAmount sdk.Int, tokenOutMins sdk.Coins) (exitCoins sdk.Coins, err error)
 	GetAllMigrationInfo(ctx sdk.Context) (gammmigration.MigrationRecords, error)
 	GetLinkedConcentratedPoolID(ctx sdk.Context, poolIdLeaving uint64) (poolIdEntering uint64, err error)
-	MigrateUnlockedPositionFromBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, sharesToMigrate sdk.Coin, tokenOutMins sdk.Coins) (positionData cltypes.CreateFullRangePositionData, poolIdLeaving, poolIdEntering uint64, err error)
+	MigrateUnlockedPositionFromBalancerToConcentrated(ctx sdk.Context, sender sdk.AccAddress, sharesToMigrate sdk.Coin, tokenOutMins sdk.Coins) (positionData cltypes.CreateFullRangePositionData, migratedPoolIDs MigrationPoolIDs, err error)
 }
 
 type BankKeeper interface {

--- a/x/superfluid/types/migration.go
+++ b/x/superfluid/types/migration.go
@@ -1,0 +1,6 @@
+package types
+
+type MigrationPoolIDs struct {
+	LeavingID  uint64
+	EnteringID uint64
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: https://github.com/osmosis-labs/osmosis/issues/5984

## What is the purpose of the change

Reduces the number of returns in superfluid migration to eventually enable a linter, restricting it from happening.

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A