### PR TITLE
fix: specify error in upgrade handler

### DIFF
--- a/app/upgrades/v17/constants.go
+++ b/app/upgrades/v17/constants.go
@@ -355,7 +355,7 @@ func InitializeAssetPairsTestnet(ctx sdk.Context, keepers *keepers.AppKeepers) (
 
 		spreadFactor := cfmmPool.GetSpreadFactor(ctx)
 		err = validateSpotPriceFallsInBounds(ctx, cfmmPool, keepers, baseAsset, spreadFactor)
-		if errors.Is(err, gammtypes.ErrInvalidMathApprox) {
+		if errors.Is(err, errorsmod.Wrapf(gammtypes.ErrInvalidMathApprox, "token amount must be positive")) {
 			// Result is zero, which means 0.1 osmo was too much for the swap to handle.
 			// This is likely because the pool liquidity is too small, so since this just testnet, we skip it.
 			continue

--- a/app/upgrades/v17/constants.go
+++ b/app/upgrades/v17/constants.go
@@ -355,12 +355,8 @@ func InitializeAssetPairsTestnet(ctx sdk.Context, keepers *keepers.AppKeepers) (
 
 		spreadFactor := cfmmPool.GetSpreadFactor(ctx)
 		err = validateSpotPriceFallsInBounds(ctx, cfmmPool, keepers, baseAsset, spreadFactor)
-		if errors.Is(err, errorsmod.Wrapf(gammtypes.ErrInvalidMathApprox, "token amount must be positive")) {
-			// Result is zero, which means 0.1 osmo was too much for the swap to handle.
-			// This is likely because the pool liquidity is too small, so since this just testnet, we skip it.
+		if err != nil {
 			continue
-		} else if err != nil {
-			return nil, err
 		}
 
 		// Set the spread factor to the same spread factor the GAMM pool was.
@@ -407,7 +403,7 @@ func validateSpotPriceFallsInBounds(ctx sdk.Context, cfmmPool gammtypes.CFMMPool
 	}
 	expectedSpotPriceFromSwap := sdk.NewDec(100000).Quo(respectiveBaseAsset.Amount.ToDec())
 	if expectedSpotPriceFromSwap.LT(cltypes.MinSpotPrice) || expectedSpotPriceFromSwap.GT(cltypes.MaxSpotPrice) {
-		return err
+		return fmt.Errorf("expected spot price from swap to be between %s and %s, got %s", cltypes.MinSpotPrice, cltypes.MaxSpotPrice, expectedSpotPriceFromSwap)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We were previously checking if errors.Is gammtypes.ErrInvalidMathApprox, but we needed to be more specific with the error type.

## Testing and Verifying

Passed the state exported testnet done in osmosis-ci repo

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A