### PR TITLE
test: proof non-monotonicity with low precision

### DIFF
--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -891,3 +891,40 @@ func TestSqrtPriceToTickRoundDownSpacing(t *testing.T) {
 		})
 	}
 }
+
+func TestMonotnicityAtPriceBounds(t *testing.T) {
+	// Note: this starting value was manually adjusted until it was on the boundary of where the
+	// ticks started becoming monotonic
+	x := int64(-108000002)
+	lastValueMonotonic := true
+	highestMonotonicTick := types.MinInitializedTick
+
+	// Find the highest tick where the sqrt price is monotonic. If nothing is found in 50,000 ticks,
+	// lastValueMonotonic is false and starting value should be adjusted.
+	for i := 0; i < 50000; i++ {
+		_, xSqrtPrice, err := math.TickToSqrtPrice(x)
+		require.NoError(t, err)
+		_, xSqrtPriceNext, err := math.TickToSqrtPrice(x + 1)
+		require.NoError(t, err)
+		if xSqrtPrice.GTE(xSqrtPriceNext) {
+			fmt.Printf("Non-monotonic behavior detected at x = %d\n", x)
+			lastValueMonotonic = false
+		} else if !lastValueMonotonic {
+			highestMonotonicTick = x
+			lastValueMonotonic = true
+		} else {
+			lastValueMonotonic = true
+		}
+		x++
+	}
+	fmt.Println("Last value was monotonic: ", lastValueMonotonic)
+
+	// highestMonotonicTick lands on tick -108000000
+	fmt.Println("Highest monotonic tick: ", highestMonotonicTick)
+
+	// smallestSupportedPrice = 10^-12
+	smallestSupportedPrice, smallestSqrtPrice, err := math.TickToSqrtPrice(highestMonotonicTick)
+	require.NoError(t, err)
+	fmt.Println("smallestSupportedPrice: ", smallestSupportedPrice)
+	fmt.Println("smallestSqrtPrice: ", smallestSqrtPrice)
+}

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Precomputed values for min and max tick
-	MinInitializedTick, MaxTick int64 = -108000000, 342000000
+	MinInitializedTick, MaxTick int64 = -162000000, 342000000
 	// If we consume all liquidity and cross the min initialized tick,
 	// our current tick will equal to MinInitializedTick - 1 with zero liquidity.
 	// However, note that this tick cannot be crossed. If current tick
@@ -28,7 +28,7 @@ const (
 
 var (
 	MaxSpotPrice       = sdk.MustNewDecFromStr("100000000000000000000000000000000000000")
-	MinSpotPrice       = sdk.MustNewDecFromStr("0.000000000001") // 10^-12
+	MinSpotPrice       = sdk.MustNewDecFromStr("0.000000000000000001") // 10^-12
 	MaxSqrtPrice       = osmomath.MustMonotonicSqrt(MaxSpotPrice)
 	MinSqrtPrice       = osmomath.MustMonotonicSqrt(MinSpotPrice)
 	MaxSqrtPriceBigDec = osmomath.BigDecFromSDKDec(MaxSqrtPrice)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Proving that with `sdk.Dec` in tick conversion we still have non-monotonicity today

```
go test -timeout 10s -run TestMonotnicityAtPriceBounds github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/math -count=1 -v
Non-monotonic behavior detected at x = -108000002
Non-monotonic behavior detected at x = -108000001
Last value was monotonic:  true
Highest monotonic tick:  -108000000
smallestSupportedPrice:  0.000000000001000000
smallestSqrtPrice:  0.000001000000000000
--- PASS: TestMonotnicityAtPriceBounds (0.28s)
PASS
ok      github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/math       0.340s
```

## References
- https://github.com/osmosis-labs/osmosis/issues/5550
- https://github.com/osmosis-labs/osmosis/pull/5525
- https://github.com/osmosis-labs/osmosis/pull/5551

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A