### PR TITLE
fix: prevent all args from being lowercase

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -322,12 +322,13 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			if humanReadableDenomsInput {
 				// Parse and replace denoms in args
 				for i, arg := range args {
-					lowerCaseArg := strings.ToLower(arg)
-					lowerCaseArgArray := strings.Split(lowerCaseArg, ",")
+					//lowerCaseArg := strings.ToLower(arg)
+					argArray := strings.Split(arg, ",")
 
 					re := regexp.MustCompile(`^([\d.]+)(\D+)$`)
 
-					for i, lowerCaseArg := range lowerCaseArgArray {
+					for i, singleArg := range argArray {
+						lowerCaseArg := strings.ToLower(singleArg)
 						match := re.FindStringSubmatch(lowerCaseArg)
 						if len(match) == 3 {
 							value, denom := match[1], match[2]
@@ -337,15 +338,15 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 							if err != nil {
 								continue
 							}
-							lowerCaseArgArray[i] = transformedCoin
+							argArray[i] = transformedCoin
 						} else {
 							if _, ok := assetMap[lowerCaseArg]; ok {
 								// In this case, we just need to replace the denom with the base denom
-								lowerCaseArgArray[i] = assetMap[lowerCaseArg].Base
+								argArray[i] = assetMap[lowerCaseArg].Base
 							}
 						}
 					}
-					args[i] = strings.Join(lowerCaseArgArray, ",")
+					args[i] = strings.Join(argArray, ",")
 				}
 
 				// Parse and replace denoms in flags


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The human readable denom feature in client.toml has been surprisingly non buggy, however came across one today when I was querying routes from protorev. I had the parse input enabled, but used an ibc denom as input since I had it readily available. I realized through the error message that we were making all inputs lower case. What should just be happening is we should just search for the arg as lowercase since that is what we write it to in the map as. If an arg is not replaced, it should stay in whatever case it was originally provided in.

## Testing and Verifying

Tested locally with CLI.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A