### PR TITLE
fix: don't force makefile to use bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,27 +123,27 @@ install: check_version go.sum
 install-with-autocomplete: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p); \
-	if [[ "$$PARENT_SHELL" == *zsh* ]]; then \
+	if echo "$$PARENT_SHELL" | grep -q "zsh"; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete zsh)" ~/.zshrc; then \
 			echo ". <(osmosisd enable-cli-autocomplete zsh)" >> ~/.zshrc; \
 			source ~/.zshrc; \
 		else \
 			echo "Autocomplete already enabled in ~/.zshrc"; \
 		fi \
-	elif [[ "$$PARENT_SHELL" == *bash* && "$$(uname)" == "Darwin" ]]; then \
+	elif echo "$$PARENT_SHELL" | grep -q "bash" -a "$$(uname)" = "Darwin"; then \
 		if ! grep -q -e "\. <(osmosisd enable-cli-autocomplete bash)" -e '\[\[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" \]\] && \. "/opt/homebrew/etc/profile.d/bash_completion.sh"' ~/.bash_profile; then \
 			brew install bash-completion; \
-			echo '[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile; \
+			echo '[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bash_profile; \
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
-	elif [[ "$$PARENT_SHELL" == *bash* && "$$(uname)" == "Linux" ]]; then \
+	elif echo "$$PARENT_SHELL" | grep -q "bash" -a "$$(uname)" = "Linux"; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete bash)" ~/.bash_profile; then \
 			sudo apt-get install -y bash-completion; \
-			echo '[[ -r "/etc/bash_completion" ]] && . "/etc/bash_completion"' >> ~/.bash_profile; \
+			echo '[ -r "/etc/bash_completion" ] && . "/etc/bash_completion"' >> ~/.bash_profile; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bash_profile; \
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,6 @@ install: check_version go.sum
 install-with-autocomplete: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p); \
-	echo "Detected parent shell: $$PARENT_SHELL"; \
-	echo "Installing "$$(uname)"..."; \
 	if echo "$$PARENT_SHELL" | grep -q "zsh"; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete zsh)" ~/.zshrc; then \
 			echo ". <(osmosisd enable-cli-autocomplete zsh)" >> ~/.zshrc; \
@@ -140,6 +138,7 @@ install-with-autocomplete: check_version go.sum
 			echo '[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile; \
 			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bash_profile; \
 			echo; \
+			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
@@ -152,6 +151,7 @@ install-with-autocomplete: check_version go.sum
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
+			echo; \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,10 @@ install-with-autocomplete: check_version go.sum
 	if echo "$$PARENT_SHELL" | grep -q "zsh"; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete zsh)" ~/.zshrc; then \
 			echo ". <(osmosisd enable-cli-autocomplete zsh)" >> ~/.zshrc; \
-			source ~/.zshrc; \
+			echo; \
+			echo "Autocomplete enabled. Run 'source ~/.zshrc' to complete installation."; \
 		else \
+			echo; \
 			echo "Autocomplete already enabled in ~/.zshrc"; \
 		fi \
 	elif echo "$$PARENT_SHELL" | grep -q "bash" -a "$$(uname)" = "Darwin"; then \
@@ -138,6 +140,7 @@ install-with-autocomplete: check_version go.sum
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
+			echo; \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
 	elif echo "$$PARENT_SHELL" | grep -q "bash" -a "$$(uname)" = "Linux"; then \
@@ -148,6 +151,7 @@ install-with-autocomplete: check_version go.sum
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
+			echo; \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 BUILDDIR ?= $(CURDIR)/build
 DOCKER := $(shell which docker)
 E2E_UPGRADE_VERSION := "v17"
-SHELL := /bin/bash
+#SHELL := /bin/bash
 
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
 GO_MODULE := $(shell cat go.mod | grep "module " | cut -d ' ' -f 2)
@@ -131,24 +131,24 @@ install-with-autocomplete: check_version go.sum
 			echo "Autocomplete already enabled in ~/.zshrc"; \
 		fi \
 	elif [[ "$$PARENT_SHELL" == *bash* && "$$(uname)" == "Darwin" ]]; then \
-		if ! grep -q -e "\. <(osmosisd enable-cli-autocomplete bash)" -e '\[\[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" \]\] && \. "/opt/homebrew/etc/profile.d/bash_completion.sh"' ~/.bashrc; then \
+		if ! grep -q -e "\. <(osmosisd enable-cli-autocomplete bash)" -e '\[\[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" \]\] && \. "/opt/homebrew/etc/profile.d/bash_completion.sh"' ~/.bash_profile; then \
 			brew install bash-completion; \
-			echo '[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bashrc; \
-			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
+			echo '[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile; \
+			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bash_profile; \
 			echo; \
-			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
+			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
-			echo "Autocomplete already enabled in ~/.bashrc"; \
+			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
 	elif [[ "$$PARENT_SHELL" == *bash* && "$$(uname)" == "Linux" ]]; then \
-		if ! grep -q ". <(osmosisd enable-cli-autocomplete bash)" ~/.bashrc; then \
+		if ! grep -q ". <(osmosisd enable-cli-autocomplete bash)" ~/.bash_profile; then \
 			sudo apt-get install -y bash-completion; \
-			echo '[[ -r "/etc/bash_completion" ]] && . "/etc/bash_completion"' >> ~/.bashrc; \
-			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bashrc; \
+			echo '[[ -r "/etc/bash_completion" ]] && . "/etc/bash_completion"' >> ~/.bash_profile; \
+			echo ". <(osmosisd enable-cli-autocomplete bash)" >> ~/.bash_profile; \
 			echo; \
-			echo "Autocomplete enabled. Run 'source ~/.bashrc' to complete installation."; \
+			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
-			echo "Autocomplete already enabled in ~/.bashrc"; \
+			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
 	else \
 		echo "Shell or OS not recognized. Skipping autocomplete setup."; \

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,8 @@ install: check_version go.sum
 install-with-autocomplete: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p); \
+	echo "Detected parent shell: $$PARENT_SHELL"; \
+	echo "Installing "$$(uname)"..."; \
 	if echo "$$PARENT_SHELL" | grep -q "zsh"; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete zsh)" ~/.zshrc; then \
 			echo ". <(osmosisd enable-cli-autocomplete zsh)" >> ~/.zshrc; \
@@ -132,7 +134,7 @@ install-with-autocomplete: check_version go.sum
 			echo; \
 			echo "Autocomplete already enabled in ~/.zshrc"; \
 		fi \
-	elif echo "$$PARENT_SHELL" | grep -q "bash" -a "$$(uname)" = "Darwin"; then \
+	elif echo "$$PARENT_SHELL" | grep -q "bash" && [ "$$(uname)" = "Darwin" ]; then \
 		if ! grep -q -e "\. <(osmosisd enable-cli-autocomplete bash)" -e '\[\[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" \]\] && \. "/opt/homebrew/etc/profile.d/bash_completion.sh"' ~/.bash_profile; then \
 			brew install bash-completion; \
 			echo '[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile; \
@@ -140,10 +142,9 @@ install-with-autocomplete: check_version go.sum
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
-			echo; \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
-	elif echo "$$PARENT_SHELL" | grep -q "bash" -a "$$(uname)" = "Linux"; then \
+	elif echo "$$PARENT_SHELL" | grep -q "bash" && [ "$$(uname)" = "Linux" ]; then \
 		if ! grep -q ". <(osmosisd enable-cli-autocomplete bash)" ~/.bash_profile; then \
 			sudo apt-get install -y bash-completion; \
 			echo '[ -r "/etc/bash_completion" ] && . "/etc/bash_completion"' >> ~/.bash_profile; \
@@ -151,7 +152,6 @@ install-with-autocomplete: check_version go.sum
 			echo; \
 			echo "Autocomplete enabled. Run 'source ~/.bash_profile' to complete installation."; \
 		else \
-			echo; \
 			echo "Autocomplete already enabled in ~/.bash_profile"; \
 		fi \
 	else \

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -687,8 +687,8 @@ func genAutoCompleteCmd(rootCmd *cobra.Command) {
 		Long: `To configure your shell to load completions for each session, add to your profile:
 
 # bash example
-echo '. <(osmosisd enable-cli-autocomplete bash)' >> ~/.profile
-source ~/.profile
+echo '. <(osmosisd enable-cli-autocomplete bash)' >> ~/.bash_profile
+source ~/.bash_profile
 
 # zsh example
 echo '. <(osmosisd enable-cli-autocomplete zsh)' >> ~/.zshrc


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Forcing the Makefile to use bash instead of sh broke a CI step. This changes it back to how it was, and modifies the autocomplete step to be compatible with sh.

## Testing and Verifying

Tested on mac with zsh and bash, and on linux with bash

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A