### PR TITLE
feat(ante): removing sigverify ante in favor of authenticator ante

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -16,6 +16,8 @@ import (
 
 	txfeeskeeper "github.com/osmosis-labs/osmosis/v17/x/txfees/keeper"
 	txfeestypes "github.com/osmosis-labs/osmosis/v17/x/txfees/types"
+
+	authante "github.com/osmosis-labs/osmosis/v17/x/authenticator/ante"
 )
 
 // Link to default ante handler used by cosmos sdk:
@@ -55,7 +57,8 @@ func NewAnteHandler(
 		ante.NewSetPubKeyDecorator(ak), // SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewValidateSigCountDecorator(ak),
 		ante.NewSigGasConsumeDecorator(ak, sigGasConsumer),
-		ante.NewSigVerificationDecorator(ak, signModeHandler),
+		//ante.NewSigVerificationDecorator(ak, signModeHandler),
+		authante.NewAuthenticatorDecorator(ak, signModeHandler),
 		ante.NewIncrementSequenceDecorator(ak),
 		ibcante.NewAnteDecorator(channelKeeper),
 	)

--- a/x/authenticator/ante/authenticator.go
+++ b/x/authenticator/ante/authenticator.go
@@ -1,0 +1,137 @@
+package ante
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+)
+
+// Verify all signatures for a tx and return an error if any are invalid. Note,
+// the AuthenticatorDecorator will not check signatures on ReCheck.
+//
+// CONTRACT: Pubkeys are set in context for all signers before this decorator runs
+// CONTRACT: Tx must implement SigVerifiableTx interface
+type AuthenticatorDecorator struct {
+	ak              authante.AccountKeeper
+	signModeHandler authsigning.SignModeHandler
+}
+
+func NewAuthenticatorDecorator(
+	ak authante.AccountKeeper,
+	signModeHandler authsigning.SignModeHandler,
+) AuthenticatorDecorator {
+	return AuthenticatorDecorator{
+		ak:              ak,
+		signModeHandler: signModeHandler,
+		//TODO: Add authenticator struct here for later user
+	}
+}
+
+// AnteHandle is the authenticator decorator ante handler
+// this is used to validate multiple signatures
+func (ad AuthenticatorDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (newCtx sdk.Context, err error) {
+	ad.ValidateSignature(ctx, tx, simulate)
+	if err != nil {
+		return ctx, err
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// ValidateSignature validates the txn signature using Secp256k1 keys
+func (ad AuthenticatorDecorator) ValidateSignature(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+) (newCtx sdk.Context, err error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+	}
+
+	// stdSigs contains the sequence number, account number, and signatures.
+	// When simulating, this would just be a 0-length slice.
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	signerAddrs := sigTx.GetSigners()
+
+	// check that signer length and signature length are the same
+	if len(sigs) != len(signerAddrs) {
+		return ctx, sdkerrors.Wrapf(
+			sdkerrors.ErrUnauthorized,
+			"invalid number of signer;  expected: %d, got %d",
+			len(signerAddrs),
+			len(sigs))
+	}
+
+	for i, sig := range sigs {
+		acc, err := authante.GetSignerAcc(ctx, ad.ak, signerAddrs[i])
+		if err != nil {
+			return ctx, err
+		}
+
+		// retrieve pubkey
+		pubKey := acc.GetPubKey()
+		if !simulate && pubKey == nil {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
+		}
+
+		// Check account sequence number.
+		if sig.Sequence != acc.GetSequence() {
+			return ctx, sdkerrors.Wrapf(
+				sdkerrors.ErrWrongSequence,
+				"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
+			)
+		}
+
+		// retrieve signer data
+		genesis := ctx.IsGenesis() || ctx.BlockHeight() == 0
+		chainID := ctx.ChainID()
+		var accNum uint64
+		if !genesis {
+			accNum = acc.GetAccountNumber()
+		}
+		signerData := authsigning.SignerData{
+			ChainID:       chainID,
+			AccountNumber: accNum,
+			Sequence:      acc.GetSequence(),
+		}
+
+		// no need to verify signatures on recheck tx
+		if !simulate && !ctx.IsReCheckTx() {
+			err := authsigning.VerifySignature(pubKey, signerData, sig.Data, ad.signModeHandler, tx)
+			if err != nil {
+				var errMsg string
+				if authante.OnlyLegacyAminoSigners(sig.Data) {
+					// If all signers are using SIGN_MODE_LEGACY_AMINO, we rely on VerifySignature to check account sequence number,
+					// and therefore communicate sequence number as a potential cause of error.
+					errMsg = fmt.Sprintf(
+						"signature verification failed; please verify account number (%d), sequence (%d) and chain-id (%s)",
+						accNum,
+						acc.GetSequence(),
+						chainID,
+					)
+				} else {
+					errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d) and chain-id (%s)",
+						accNum,
+						chainID,
+					)
+				}
+				return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, errMsg)
+
+			}
+		}
+	}
+	return ctx, nil
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6077 

## What is the purpose of the change

This pull request is the first step towards abstracting the signature verification for acoounts 

There are no tests as we expect this functionality to change drastically in soon

## Testing and Verifying

- generate a transaction e.g bank send e.g

```sh
user1=$(osmosisd keys show user1 -a --keyring-backend=test --home=$HOME/.osmosisd)
val=$(osmosisd keys show validator -a --keyring-backend=test --home=$HOME/.osmosisd)

osmosisd tx bank send $val $user1 1000valtoken --from validator --chain-id testing --keyring-backend test --fees 1000stake -b block -y --generate-only > bank-send.json

```

- replace the auth info and signatures info with this:

auth info
```
  "auth_info": {
    "signer_infos": [
      {
        "public_key": {
          "@type": "/cosmos.crypto.secp256k1.PubKey",
          "key": "ApNE+TkLxJVav083Ol4g3Q+kGFVOrUQj2ekZr2l9UYa6"
        },
        "mode_info": {
          "single": {
            "mode": "SIGN_MODE_DIRECT"
          }
        },
        "sequence": "0"
      }
    ],
```

signature:
```
  "signatures": [
    "xIQWZr2cafwS7HGX+hjPzjnMwgd7gAB+jrLY+mNnyTNA0rheHQCRYwio5SDm+/0w6ZtlWRSn6CoXYwUgB7CJLQ=="
  ]
```

Broadcast the txn:

```
osmosisd tx broadcast bank-send-signed.json -b block
```


### What the error should look like:
```
code: 8
codespace: sdk
data: ""
events: []
gas_used: "42021"
gas_wanted: "350000"
height: "0"
info: ""
logs: []
raw_log: 'pubKey does not match signer address osmo1crrqd94grr7wam0drefm9dcynrmpjdxzyg4zj3
  with signer index: 0: invalid pubkey'
timestamp: ""
tx: null
txhash: F23E6B9467545781E2ED9AE1731F2361B598054689B8E66BD80CA8070CEDE2F4
```