### PR TITLE
fix: add no-op upgrade handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 BUILDDIR ?= $(CURDIR)/build
 DOCKER := $(shell which docker)
-E2E_UPGRADE_VERSION := "v17"
+E2E_UPGRADE_VERSION := "v17b"
 #SHELL := /bin/bash
 
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)

--- a/app/app.go
+++ b/app/app.go
@@ -58,6 +58,7 @@ import (
 	v15 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v15"
 	v16 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v16"
 	v17 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v17"
+	v17b "github.com/osmosis-labs/osmosis/v17/app/upgrades/v17b"
 	v3 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v3"
 	v4 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v5"
@@ -103,7 +104,7 @@ var (
 
 	// _ sdksimapp.App = (*OsmosisApp)(nil)
 
-	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v15.Upgrade, v16.Upgrade, v17.Upgrade}
+	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v15.Upgrade, v16.Upgrade, v17.Upgrade, v17b.Upgrade}
 	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork, v10.Fork}
 )
 

--- a/app/upgrades/v17b/constants.go
+++ b/app/upgrades/v17b/constants.go
@@ -1,0 +1,19 @@
+package v17b
+
+import (
+	"github.com/osmosis-labs/osmosis/v17/app/upgrades"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v17 upgrade.
+const UpgradeName = "v17b"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}

--- a/app/upgrades/v17b/upgrades.go
+++ b/app/upgrades/v17b/upgrades.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v17/app/keepers"
 	"github.com/osmosis-labs/osmosis/v17/app/upgrades"
+	"github.com/osmosis-labs/osmosis/v17/x/protorev/types"
 )
 
 func CreateUpgradeHandler(
@@ -22,6 +23,9 @@ func CreateUpgradeHandler(
 		if err != nil {
 			return nil, err
 		}
+
+		// Reset the pool weights upon upgrade. This will add support for CW pools on ProtoRev.
+		keepers.ProtoRevKeeper.SetInfoByPoolType(ctx, types.DefaultPoolTypeInfo)
 
 		return migrations, nil
 	}

--- a/app/upgrades/v17b/upgrades.go
+++ b/app/upgrades/v17b/upgrades.go
@@ -5,6 +5,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	ibchookstypes "github.com/osmosis-labs/osmosis/x/ibc-hooks/types"
+
 	"github.com/osmosis-labs/osmosis/v17/app/keepers"
 	"github.com/osmosis-labs/osmosis/v17/app/upgrades"
 	"github.com/osmosis-labs/osmosis/v17/x/protorev/types"
@@ -23,6 +25,9 @@ func CreateUpgradeHandler(
 		if err != nil {
 			return nil, err
 		}
+
+		// Set ibc-hooks params
+		keepers.IBCHooksKeeper.SetParams(ctx, ibchookstypes.DefaultParams())
 
 		// Reset the pool weights upon upgrade. This will add support for CW pools on ProtoRev.
 		keepers.ProtoRevKeeper.SetInfoByPoolType(ctx, types.DefaultPoolTypeInfo)

--- a/app/upgrades/v17b/upgrades.go
+++ b/app/upgrades/v17b/upgrades.go
@@ -1,0 +1,28 @@
+package v17b
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v17/app/keepers"
+	"github.com/osmosis-labs/osmosis/v17/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bpm upgrades.BaseAppParamManager,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Run migrations before applying any other state changes.
+		// NOTE: DO NOT PUT ANY STATE CHANGES BEFORE RunMigrations().
+		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, err
+		}
+
+		return migrations, nil
+	}
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 	appparams "github.com/osmosis-labs/osmosis/v17/app/params"
-	v17 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v17"
 	"github.com/osmosis-labs/osmosis/v17/tests/e2e/configurer/chain"
 	"github.com/osmosis-labs/osmosis/v17/tests/e2e/configurer/config"
 	"github.com/osmosis-labs/osmosis/v17/tests/e2e/initialization"
@@ -128,15 +127,6 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 		s.T().Run("AddToExistingLockPostUpgrade", func(t *testing.T) {
 			t.Parallel()
 			s.AddToExistingLockPostUpgrade()
-		})
-	}
-
-	if s.skipUpgrade {
-		s.T().Skip("Skipping ConcentratedLiquidity_CanonicalPools test")
-	} else {
-		s.T().Run("ConcentratedLiquidity_CanonicalPools", func(t *testing.T) {
-			t.Parallel()
-			s.ConcentratedLiquidity_CanonicalPools()
 		})
 	}
 
@@ -1786,64 +1776,3 @@ func (s *IntegrationTestSuite) GeometricTWAP() {
 	// quote assset supply / base asset supply = 1_000_000 / 2_000_000 = 0.5
 	osmoassert.DecApproxEq(s.T(), sdk.NewDecWithPrec(5, 1), afterSwapTwapBOverA, sdk.NewDecWithPrec(1, 2))
 }
-
-// START: CAN REMOVE POST v17 UPGRADE
-
-// Tests that v17 upgrade correctly creates the canonical pools in the upgrade handler.
-func (s *IntegrationTestSuite) ConcentratedLiquidity_CanonicalPools() {
-	if s.skipUpgrade {
-		s.T().Skip("Skipping v17 canonical pools creation test because upgrade is not enabled")
-	}
-
-	_, chainABNode, err := s.getChainCfgs()
-	s.Require().NoError(err)
-
-	for _, assetPair := range v17.AssetPairsForTestsOnly {
-		expectedSpreadFactor := assetPair.SpreadFactor
-		concentratedPoolId := chainABNode.QueryConcentratedPooIdLinkFromCFMM(assetPair.LinkedClassicPool)
-		concentratedPool := s.updatedConcentratedPool(chainABNode, concentratedPoolId)
-
-		s.Require().Equal(poolmanagertypes.Concentrated, concentratedPool.GetType())
-		s.Require().Equal(assetPair.BaseAsset, concentratedPool.GetToken0())
-		s.Require().Equal(assetPair.QuoteAsset, concentratedPool.GetToken1())
-		s.Require().Equal(uint64(v17.TickSpacing), concentratedPool.GetTickSpacing())
-		s.Require().Equal(expectedSpreadFactor.String(), concentratedPool.GetSpreadFactor(sdk.Context{}).String())
-
-		superfluidAssets := chainABNode.QueryAllSuperfluidAssets()
-
-		found := false
-		for _, superfluidAsset := range superfluidAssets {
-			if superfluidAsset.Denom == cltypes.GetConcentratedLockupDenomFromPoolId(concentratedPoolId) {
-				found = true
-				break
-			}
-		}
-
-		if assetPair.Superfluid {
-			s.Require().True(found, "concentrated liquidity pool denom not found in superfluid assets")
-		} else {
-			s.Require().False(found, "concentrated liquidity pool denom found in superfluid assets")
-		}
-
-		// This spot price is taken from the balancer pool that was initiated pre upgrade.
-		balancerPool := s.updatedCFMMPool(chainABNode, assetPair.LinkedClassicPool)
-		expectedSpotPrice, err := balancerPool.SpotPrice(sdk.Context{}, assetPair.QuoteAsset, assetPair.BaseAsset)
-		s.Require().NoError(err)
-
-		// Margin of error should be slightly larger than the gamm pool's spread factor, as the gamm pool is used to
-		// swap through when creating the initial position. The below implies a 0.1% margin of error.
-		tollerance := expectedSpreadFactor.Add(sdk.MustNewDecFromStr("0.0001"))
-		multiplicativeTolerance := osmomath.ErrTolerance{
-			MultiplicativeTolerance: tollerance,
-		}
-
-		s.Require().Equal(0, multiplicativeTolerance.CompareBigDec(osmomath.BigDecFromSDKDec(expectedSpotPrice), concentratedPool.GetCurrentSqrtPrice().PowerInteger(2)))
-	}
-
-	// Check that the community pool module account possesses positions for all the canonical pools.
-	communityPoolAddress := chainABNode.QueryCommunityPoolModuleAccount()
-	positions := chainABNode.QueryConcentratedPositions(communityPoolAddress)
-	s.Require().Len(positions, len(v17.AssetPairsForTestsOnly))
-}
-
-// END: CAN REMOVE POST v17 UPGRADE


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

v17b is branched off v17x current state, but with a no-op upgrade handler under the tag v17b.

## Testing and Verifying

If e2e passes, this shows that v17b upgrade handler executed successfully. 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A