### PR TITLE
fix: remove v17 from v17b

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -57,7 +57,6 @@ import (
 	v14 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v14"
 	v15 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v15"
 	v16 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v16"
-	v17 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v17"
 	v17b "github.com/osmosis-labs/osmosis/v17/app/upgrades/v17b"
 	v3 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v3"
 	v4 "github.com/osmosis-labs/osmosis/v17/app/upgrades/v4"
@@ -104,7 +103,7 @@ var (
 
 	// _ sdksimapp.App = (*OsmosisApp)(nil)
 
-	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v15.Upgrade, v16.Upgrade, v17.Upgrade, v17b.Upgrade}
+	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v15.Upgrade, v16.Upgrade, v17b.Upgrade}
 	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork, v10.Fork}
 )
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

There is potentially a bug with how sdk handles upgrades. It seems like even though v17b is specified in the prop, v17 is getting triggered. This completely unregisters the v17 upgrade to see if this fixes that issue.

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A