### PR TITLE
[v17.0.0] Update cosmovisor binaries.json + releases docs

### DIFF
--- a/networks/osmosis-1/README.md
+++ b/networks/osmosis-1/README.md
@@ -17,6 +17,7 @@ Each version is identified by a specific id, name, tag, block height and softwar
 | `v14` | Neon      | `v14.0.1` | 7937500        | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v14.0.1/) | [401](https://www.mintscan.io/osmosis/proposals/401) |
 | `v15` | Sodium    | `v15.2.0` | 8732500        | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v15.2.0/) | [458](https://www.mintscan.io/osmosis/proposals/458) |
 | `v16` | Magnesium | `v16.1.1` | 10517000       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v16.1.1/) | [556](https://www.mintscan.io/osmosis/proposals/556) |
+| `v16` | Aluminum  | `v17.0.0` | 11126100       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v17.0.0/) | [556](https://www.mintscan.io/osmosis/proposals/586) |
 
 ## Upgrade Binaries
 
@@ -145,6 +146,19 @@ Each version is identified by a specific id, name, tag, block height and softwar
 }
 ```
 
+### v17.0.0
+
+```json
+{
+  "binaries": {
+    "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-arm64?checksum=sha256:5ca1b120a62ba473e7772682d89db949ae67aa10dc9bf4629b0022a95e7ff1df",
+    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-amd64?checksum=sha256:b5e4deb0d659eeeaee791dab765433bdb8d6a7e37d909628e0f9becb7d1f154b",
+    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-arm64?checksum=sha256:d5eeab6a15e2acd7e24e7caf4fe3336c35367ff376da6299d404defd09ce52f9",
+    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:d7fe62ae33cf2f0b48a17eb8b02644dadd9924f15861ed622cd90cb1a038135b"
+  }
+}
+```
+
 ## Replay from Genesis using Cosmovisor
 
 Assuming that your osmosis home it's already initialized with the desired genesis and configuration,
@@ -187,6 +201,9 @@ Alternatively, you can download the appropriate binary for your platform from ou
        ├── v16
        │   └── bin
        │       └── osmosisd
+       ├── v17
+       │   └── bin
+       │       └── osmosisd
        ├── v4
        │   └── bin
        │       └── osmosisd
@@ -220,6 +237,7 @@ versions_info=(
     "v14:https://github.com/osmosis-labs/osmosis/releases/download/v14.0.1/osmosisd-14.0.1-linux-amd64?checksum=sha256:2cc4172bcf000f0f06b30b16864d875a8de2ee12df994a593dfd52a506851bce"
     "v15:https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-amd64?checksum=sha256:3aab2f2668cb5a713d5770e46a777ef01c433753378702d9ae941aa2d1ee5618"
     "v16:https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:f838618633c1d42f593dc33d26b25842f5900961e987fc08570bb81a062e311d"
+    "v17:https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:d7fe62ae33cf2f0b48a17eb8b02644dadd9924f15861ed622cd90cb1a038135b"
 )
 
 # Create the cosmovisor directory

--- a/networks/osmosis-1/upgrades/v17/v17_binaries.json
+++ b/networks/osmosis-1/upgrades/v17/v17_binaries.json
@@ -1,6 +1,8 @@
 {
     "binaries": {
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:fe6196919508af62b6ba574b3dc477b8118eb41eb98ee42d06da0f8d39a30ed7",
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-arm64?checksum=sha256:feb0a13522ae0bacf58fc26b73ae8e924fedba4ea14ff1c65f5176be37e18521"
+        "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-arm64?checksum=sha256:5ca1b120a62ba473e7772682d89db949ae67aa10dc9bf4629b0022a95e7ff1df",
+        "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-amd64?checksum=sha256:b5e4deb0d659eeeaee791dab765433bdb8d6a7e37d909628e0f9becb7d1f154b",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-arm64?checksum=sha256:d5eeab6a15e2acd7e24e7caf4fe3336c35367ff376da6299d404defd09ce52f9",
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:d7fe62ae33cf2f0b48a17eb8b02644dadd9924f15861ed622cd90cb1a038135b"
     }
 }

--- a/scripts/release/create_all_binaries_json.sh
+++ b/scripts/release/create_all_binaries_json.sh
@@ -12,6 +12,7 @@ tags=(
     "v14.0.1" 
     "v15.2.0" 
     "v16.1.1"
+    "v17.0.0"
 )
 
 echo "# Cosmovisor binaries"


### PR DESCRIPTION
## What is the purpose of the change

This workflow updates the cosmovisor `binaries.json` using the correct `osmosisd` binaries generated by `goreleaser` that:

- don't showa an empty version on `osmosisd version`
- have `darwin` support

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A