### PR TITLE
feat(secp256k1 auth): implementing secpk256k1 authenticator

### DIFF
--- a/x/authenticator/ante/authenticator.go
+++ b/x/authenticator/ante/authenticator.go
@@ -1,12 +1,11 @@
 package ante
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+
+	authenticatortypes "github.com/osmosis-labs/osmosis/v17/x/authenticator/types"
 )
 
 // Verify all signatures for a tx and return an error if any are invalid. Note,
@@ -26,7 +25,6 @@ func NewAuthenticatorDecorator(
 	return AuthenticatorDecorator{
 		ak:              ak,
 		signModeHandler: signModeHandler,
-		//TODO: Add authenticator struct here for later user
 	}
 }
 
@@ -38,100 +36,21 @@ func (ad AuthenticatorDecorator) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (newCtx sdk.Context, err error) {
-	ad.ValidateSignature(ctx, tx, simulate)
+
+	// Create the signature verification authenticator
+	sigVerificationAuthenticator := authenticatortypes.NewSigVerificationAuthenticator(ad.ak, ad.signModeHandler)
+
+	// Get the signer data from the tx
+	authData, err := sigVerificationAuthenticator.GetAuthenticationData(tx)
+	if err != nil {
+		return ctx, err
+	}
+
+	// Validate the signatures for each transaction in the array
+	err = sigVerificationAuthenticator.Authenticate(ctx, authData, simulate)
 	if err != nil {
 		return ctx, err
 	}
 
 	return next(ctx, tx, simulate)
-}
-
-// ValidateSignature validates the txn signature using Secp256k1 keys
-func (ad AuthenticatorDecorator) ValidateSignature(
-	ctx sdk.Context,
-	tx sdk.Tx,
-	simulate bool,
-) (newCtx sdk.Context, err error) {
-	sigTx, ok := tx.(authsigning.SigVerifiableTx)
-	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
-	}
-
-	// stdSigs contains the sequence number, account number, and signatures.
-	// When simulating, this would just be a 0-length slice.
-	sigs, err := sigTx.GetSignaturesV2()
-	if err != nil {
-		return ctx, err
-	}
-
-	signerAddrs := sigTx.GetSigners()
-
-	// check that signer length and signature length are the same
-	if len(sigs) != len(signerAddrs) {
-		return ctx, sdkerrors.Wrapf(
-			sdkerrors.ErrUnauthorized,
-			"invalid number of signer;  expected: %d, got %d",
-			len(signerAddrs),
-			len(sigs))
-	}
-
-	for i, sig := range sigs {
-		acc, err := authante.GetSignerAcc(ctx, ad.ak, signerAddrs[i])
-		if err != nil {
-			return ctx, err
-		}
-
-		// retrieve pubkey
-		pubKey := acc.GetPubKey()
-		if !simulate && pubKey == nil {
-			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
-		}
-
-		// Check account sequence number.
-		if sig.Sequence != acc.GetSequence() {
-			return ctx, sdkerrors.Wrapf(
-				sdkerrors.ErrWrongSequence,
-				"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
-			)
-		}
-
-		// retrieve signer data
-		genesis := ctx.IsGenesis() || ctx.BlockHeight() == 0
-		chainID := ctx.ChainID()
-		var accNum uint64
-		if !genesis {
-			accNum = acc.GetAccountNumber()
-		}
-		signerData := authsigning.SignerData{
-			ChainID:       chainID,
-			AccountNumber: accNum,
-			Sequence:      acc.GetSequence(),
-		}
-
-		// no need to verify signatures on recheck tx
-		if !simulate && !ctx.IsReCheckTx() {
-			err := authsigning.VerifySignature(pubKey, signerData, sig.Data, ad.signModeHandler, tx)
-			if err != nil {
-				var errMsg string
-				if authante.OnlyLegacyAminoSigners(sig.Data) {
-					// If all signers are using SIGN_MODE_LEGACY_AMINO, we rely on VerifySignature to check account sequence number,
-					// and therefore communicate sequence number as a potential cause of error.
-					errMsg = fmt.Sprintf(
-						"signature verification failed; please verify account number (%d), sequence (%d) and chain-id (%s)",
-						accNum,
-						acc.GetSequence(),
-						chainID,
-					)
-				} else {
-					errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d) and chain-id (%s)",
-						accNum,
-						chainID,
-					)
-				}
-				return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, errMsg)
-
-			}
-		}
-	}
-	return ctx, nil
 }

--- a/x/authenticator/ante/authenticator.go
+++ b/x/authenticator/ante/authenticator.go
@@ -41,13 +41,13 @@ func (ad AuthenticatorDecorator) AnteHandle(
 	sigVerificationAuthenticator := authenticatortypes.NewSigVerificationAuthenticator(ad.ak, ad.signModeHandler)
 
 	// Get the signer data from the tx
-	authData, err := sigVerificationAuthenticator.GetAuthenticationData(tx)
+	authData, err := sigVerificationAuthenticator.GetAuthenticationData(tx, simulate)
 	if err != nil {
 		return ctx, err
 	}
 
 	// Validate the signatures for each transaction in the array
-	err = sigVerificationAuthenticator.Authenticate(ctx, authData, simulate)
+	err = sigVerificationAuthenticator.Authenticate(ctx, authData)
 	if err != nil {
 		return ctx, err
 	}

--- a/x/authenticator/types/authenticators.go
+++ b/x/authenticator/types/authenticators.go
@@ -1,16 +1,22 @@
 package types
 
-// ToDo: consider moving to a different package
+// TODO: consider moving to a different package
 
 import (
+	fmt "fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
 
 type Authenticator[T any] interface {
-	GetAuthenticationData(tx sdk.Tx, messageIndex uint8) T
-	Authenticate(ctx sdk.Context, msg sdk.Msg, authenticationData T) bool
+	GetAuthenticationData(tx sdk.Tx) (T, error)
+	Authenticate(ctx sdk.Context, authenticationData T, simulate bool) (err error)
 	ConfirmExecution(ctx sdk.Context, msg sdk.Msg, authenticated bool, authenticationData T) bool
 
 	// Optional Hooks. ToDo: Revisit this when adding the authenticator storage and messages
@@ -18,62 +24,147 @@ type Authenticator[T any] interface {
 	//OnAuthenticatorRemoved(...) bool
 }
 
-type SigVerificationAuthenticator struct {
-	//accountKeeper   authsigning.AccountKeeper
-	//signModeHandler *txsigning.HandlerMap
-}
-
-// These keepers will probably be needed later to validate the signatures
-//func (c SigVerificationAuthenticator) SetAccountKeeper(ak authsigning.AccountKeeper) {
-//	c.accountKeeper = ak
-//}
-//
-//func (c SigVerificationAuthenticator) SetSignModeHandler(sm *txsigning.HandlerMap) {
-//	c.signModeHandler = sm
-//}
-
+// Compile time type assertion for the SigVerificationData using the
+// SigVerificationAuthenticator struct
 var _ Authenticator[SigVerificationData] = &SigVerificationAuthenticator{}
 
-type SigVerificationData struct {
-	Signer    []byte
-	Signature signing.SignatureV2
-	// ToDo: we will probably need to provide the whole Tx's data here as signatures are over the whole tx
+// Secp256k1 signature authenticator
+type SigVerificationAuthenticator struct {
+	ak      authante.AccountKeeper
+	Handler authsigning.SignModeHandler
 }
 
-func (c SigVerificationAuthenticator) GetAuthenticationData(tx sdk.Tx, msgIndex uint8) SigVerificationData {
+// NewSigVerificationAuthenticator creates a new SigVerificationAuthenticator
+func NewSigVerificationAuthenticator(
+	ak authante.AccountKeeper,
+	Handler authsigning.SignModeHandler,
+) SigVerificationAuthenticator {
+	return SigVerificationAuthenticator{
+		ak:      ak,
+		Handler: Handler,
+	}
+}
+
+// SetAccountKeeper sets the account keeper one the SigVerificationAuthenticator
+func (c SigVerificationAuthenticator) SetAccountKeeper(ak authante.AccountKeeper) {
+	c.ak = ak
+}
+
+// SetAccountKeeper sets the sign mode one the SigVerificationAuthenticator
+func (c SigVerificationAuthenticator) SetSignModeHandler(sm *authsigning.SignModeHandler) {
+	c.Handler = *sm
+}
+
+// NOTE: should have a SigVerification variable in the struct
+type SigVerificationData struct {
+	Signers    []sdk.AccAddress
+	Signatures []signing.SignatureV2
+	Tx         authsigning.Tx
+}
+
+// GetAuthenticationData parses the signers and signatures from a transactiom
+// then returns a indexed list of both signers and signatures
+// NOTE: position in the array is used to associate the signer and signature
+func (c SigVerificationAuthenticator) GetAuthenticationData(tx sdk.Tx) (SigVerificationData, error) {
 	sigTx, ok := tx.(authsigning.Tx)
 	if !ok {
-		return SigVerificationData{}
+		return SigVerificationData{},
+			sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
 	}
+
+	// Get all signers
+	signers := sigTx.GetSigners()
 
 	// stdSigs contains the sequence number, account number, and signatures.
 	// When simulating, this would just be a 0-length slice.
 	signatures, err := sigTx.GetSignaturesV2()
 	if err != nil {
-		return SigVerificationData{}
+		return SigVerificationData{}, err
 	}
-
-	signers := sigTx.GetSigners()
 
 	// check that signer length and signature length are the same
 	if len(signatures) != len(signers) {
-		return SigVerificationData{}
-	}
-
-	if msgIndex >= uint8(len(signatures)) {
-		return SigVerificationData{}
+		return SigVerificationData{},
+			sdkerrors.Wrapf(
+				sdkerrors.ErrUnauthorized,
+				"invalid number of signer;  expected: %d, got %d",
+				len(signers),
+				len(signatures))
 	}
 
 	// Get the signature for the message at msgIndex
 	return SigVerificationData{
-		Signer:    signers[msgIndex],
-		Signature: signatures[msgIndex], // ToDo: better marshaling
-	}
+		Signers:    signers,
+		Signatures: signatures,
+		Tx:         sigTx,
+	}, nil
 }
 
-func (c SigVerificationAuthenticator) Authenticate(ctx sdk.Context, msg sdk.Msg, authenticationData SigVerificationData) bool {
-	// TODO: Use signature verification abstraction here
-	return true
+func (c SigVerificationAuthenticator) Authenticate(
+	ctx sdk.Context,
+	verificationData SigVerificationData,
+	simulate bool,
+) (err error) {
+	for i, sig := range verificationData.Signatures {
+		acc, err := authante.GetSignerAcc(ctx, c.ak, verificationData.Signers[i])
+		if err != nil {
+			return err
+		}
+
+		// retrieve pubkey
+		pubKey := acc.GetPubKey()
+		if !simulate && pubKey == nil {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
+		}
+
+		// Check account sequence number.
+		if sig.Sequence != acc.GetSequence() {
+			return sdkerrors.Wrapf(
+				sdkerrors.ErrWrongSequence,
+				"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
+			)
+		}
+
+		// retrieve signer data
+		genesis := ctx.IsGenesis() || ctx.BlockHeight() == 0
+		chainID := ctx.ChainID()
+		var accNum uint64
+		if !genesis {
+			accNum = acc.GetAccountNumber()
+		}
+		signerData := authsigning.SignerData{
+			ChainID:       chainID,
+			AccountNumber: accNum,
+			Sequence:      acc.GetSequence(),
+		}
+
+		// no need to verify signatures on recheck tx
+		if !simulate && !ctx.IsReCheckTx() {
+			err := authsigning.VerifySignature(pubKey, signerData, sig.Data, c.Handler, verificationData.Tx)
+			if err != nil {
+				var errMsg string
+				if authante.OnlyLegacyAminoSigners(sig.Data) {
+					// If all signers are using SIGN_MODE_LEGACY_AMINO, we rely on VerifySignature to check account sequence number,
+					// and therefore communicate sequence number as a potential cause of error.
+					errMsg = fmt.Sprintf(
+						"signature verification failed; please verify account number (%d), sequence (%d) and chain-id (%s)",
+						accNum,
+						acc.GetSequence(),
+						chainID,
+					)
+				} else {
+					errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d) and chain-id (%s)",
+						accNum,
+						chainID,
+					)
+				}
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, errMsg)
+
+			}
+		}
+	}
+
+	return
 }
 
 func (c SigVerificationAuthenticator) ConfirmExecution(ctx sdk.Context, msg sdk.Msg, authenticated bool, authenticationData SigVerificationData) bool {

--- a/x/authenticator/types/authenticators.go
+++ b/x/authenticator/types/authenticators.go
@@ -55,7 +55,8 @@ func (c SigVerificationAuthenticator) SetSignModeHandler(sm *authsigning.SignMod
 	c.Handler = *sm
 }
 
-// NOTE: should have a SigVerification variable in the struct
+// SigVerificationData is used to package all the signature data and the tx
+// for use in the Authenticate function
 type SigVerificationData struct {
 	Signers    []sdk.AccAddress
 	Signatures []signing.SignatureV2
@@ -72,7 +73,7 @@ func (c SigVerificationAuthenticator) GetAuthenticationData(tx sdk.Tx) (SigVerif
 			sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
 	}
 
-	// Get all signers
+	// Get all signers for a transaction
 	signers := sigTx.GetSigners()
 
 	// stdSigs contains the sequence number, account number, and signatures.
@@ -100,6 +101,8 @@ func (c SigVerificationAuthenticator) GetAuthenticationData(tx sdk.Tx) (SigVerif
 	}, nil
 }
 
+// Authenticate takes a SignaturesVerificationData struct and validates
+// each signer and signature using Secp256k1 signature verification
 func (c SigVerificationAuthenticator) Authenticate(
 	ctx sdk.Context,
 	verificationData SigVerificationData,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6080

## What is the purpose of the change

This abstracts the signature verification into a struct that can be used to verify auth, this is the first authenticator and will be built upon to allow account abstraction

There are no tests as we expect this functionality to change soon.

## Testing and Verifying

- start a node with `user1` and `user2` in the genesis

- generate a transaction e.g bank send e.g

```sh
user1=$(osmosisd keys show user1 -a --keyring-backend=test --home=$HOME/.osmosisd)
val=$(osmosisd keys show validator -a --keyring-backend=test --home=$HOME/.osmosisd)

osmosisd tx bank send $val $user1 1000valtoken --from validator --chain-id testing --keyring-backend test --fees 1000stake -b block -y --generate-only > bank-send.json

```

- replace the auth info and signatures info with this:

auth info
```
  "auth_info": {
    "signer_infos": [
      {
        "public_key": {
          "@type": "/cosmos.crypto.secp256k1.PubKey",
          "key": "ApNE+TkLxJVav083Ol4g3Q+kGFVOrUQj2ekZr2l9UYa6"
        },
        "mode_info": {
          "single": {
            "mode": "SIGN_MODE_DIRECT"
          }
        },
        "sequence": "0"
      }
    ],
```

signature:
```
  "signatures": [
    "xIQWZr2cafwS7HGX+hjPzjnMwgd7gAB+jrLY+mNnyTNA0rheHQCRYwio5SDm+/0w6ZtlWRSn6CoXYwUgB7CJLQ=="
  ]
```

Broadcast the txn:

```
osmosisd tx broadcast bank-send-signed.json -b block
```


### What the error should look like:
```
code: 8
codespace: sdk
data: ""
events: []
gas_used: "42021"
gas_wanted: "350000"
height: "0"
info: ""
logs: []
raw_log: 'pubKey does not match signer address osmo1crrqd94grr7wam0drefm9dcynrmpjdxzyg4zj3
  with signer index: 0: invalid pubkey'
timestamp: ""
tx: null
txhash: F23E6B9467545781E2ED9AE1731F2361B598054689B8E66BD80CA8070CEDE2F4

