### PR TITLE
fix: patch export genesis cosmwasm pool type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
 
           # Remove containers with names starting with "hermes-relayer"
           docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
+
+          # Prune docker networks
+          docker network prune
       - name: Check out repository code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,9 +110,6 @@ jobs:
 
           # Remove containers with names starting with "hermes-relayer"
           docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
-
-          # Prune docker networks
-          docker network prune
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
@@ -163,3 +160,6 @@ jobs:
 
           # Remove containers with names starting with "hermes-relayer"
           docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
+
+          # Prune docker networks
+          docker network prune

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
   e2e:
     needs: get_diff
     if: needs.get_diff.outputs.git_diff
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Clean up Pre-Existing E2E Docker containers
@@ -110,9 +110,6 @@ jobs:
 
           # Remove containers with names starting with "hermes-relayer"
           docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
-
-          # Prune docker networks
-          docker network prune
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
@@ -163,6 +160,3 @@ jobs:
 
           # Remove containers with names starting with "hermes-relayer"
           docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
-
-          # Prune docker networks
-          docker network prune

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
   e2e:
     needs: get_diff
     if: needs.get_diff.outputs.git_diff
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 25
     steps:
       - name: Clean up Pre-Existing E2E Docker containers
@@ -110,6 +110,9 @@ jobs:
 
           # Remove containers with names starting with "hermes-relayer"
           docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
+
+          # Prune docker network
+          docker network prune --force
       - name: Check out repository code
         uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#6121](https://github.com/osmosis-labs/osmosis/pull/6121) fix: patch export genesis cosmwasm pool type
+
 ### API breaks
 
 * [#6071](https://github.com/osmosis-labs/osmosis/pull/6071) reduce number of returns for UpdatePosition and TicksToSqrtPrice functions

--- a/x/cosmwasmpool/genesis.go
+++ b/x/cosmwasmpool/genesis.go
@@ -26,14 +26,17 @@ func (k *Keeper) InitGenesis(ctx sdk.Context, gen *types.GenesisState, unpacker 
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	params := k.GetParams(ctx)
 
-	pools, err := k.GetPools(ctx)
+	pools, err := k.GetPoolsWithWasmKeeper(ctx)
 	if err != nil {
 		panic(err)
 	}
 	poolAnys := []*codectypes.Any{}
 	for _, poolI := range pools {
-		poolI := poolI
-		any, err := codectypes.NewAnyWithValue(poolI)
+		cosmwasmPool, ok := poolI.(types.CosmWasmExtension)
+		if !ok {
+			panic("invalid pool type")
+		}
+		any, err := codectypes.NewAnyWithValue(cosmwasmPool)
 		if err != nil {
 			panic(err)
 		}

--- a/x/cosmwasmpool/genesis.go
+++ b/x/cosmwasmpool/genesis.go
@@ -32,11 +32,8 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	}
 	poolAnys := []*codectypes.Any{}
 	for _, poolI := range pools {
-		cosmwasmPool, ok := poolI.(types.CosmWasmExtension)
-		if !ok {
-			panic("invalid pool type")
-		}
-		any, err := codectypes.NewAnyWithValue(cosmwasmPool)
+		poolI := poolI
+		any, err := codectypes.NewAnyWithValue(poolI)
 		if err != nil {
 			panic(err)
 		}

--- a/x/cosmwasmpool/model/codec.go
+++ b/x/cosmwasmpool/model/codec.go
@@ -22,7 +22,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"osmosis.poolmanager.v1beta1.PoolI",
 		(*poolmanagertypes.PoolI)(nil),
-		&CosmWasmPool{},
+		&Pool{},
 	)
 	registry.RegisterInterface(
 		"osmosis.cosmwasmpool.v1beta1.CosmWasmExtension",

--- a/x/cosmwasmpool/model/codec.go
+++ b/x/cosmwasmpool/model/codec.go
@@ -23,10 +23,12 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		"osmosis.poolmanager.v1beta1.PoolI",
 		(*poolmanagertypes.PoolI)(nil),
 		&Pool{},
+		&CosmWasmPool{},
 	)
 	registry.RegisterInterface(
 		"osmosis.cosmwasmpool.v1beta1.CosmWasmExtension",
 		(*types.CosmWasmExtension)(nil),
+		&Pool{},
 		&CosmWasmPool{},
 	)
 

--- a/x/cosmwasmpool/pool_module.go
+++ b/x/cosmwasmpool/pool_module.go
@@ -2,6 +2,8 @@
 package cosmwasmpool
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
@@ -78,7 +80,23 @@ func (k Keeper) GetPool(ctx sdk.Context, poolId uint64) (poolmanagertypes.PoolI,
 	if err != nil {
 		return nil, err
 	}
-	return cwPool, nil
+
+	poolI, err := asPoolI(cwPool)
+	if err != nil {
+		return nil, err
+	}
+	return poolI, nil
+}
+
+func asPoolI(cwPool types.CosmWasmExtension) (poolmanagertypes.PoolI, error) {
+	// Attempt to convert the concentratedPool to a poolmanagertypes.PoolI
+	pool, ok := cwPool.(poolmanagertypes.PoolI)
+	if !ok {
+		// If the conversion fails, return an error
+		return nil, fmt.Errorf("given pool does not implement CosmWasmExtension, implements %T", pool)
+	}
+	// Return the converted value
+	return pool, nil
 }
 
 // GetPools retrieves all pool objects stored in the keeper.

--- a/x/pool-incentives/keeper/genesis.go
+++ b/x/pool-incentives/keeper/genesis.go
@@ -53,6 +53,10 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 			poolToGauge.GaugeId = gaugeID
 			poolToGauge.PoolId = uint64(poolId)
 			poolToGauges.PoolToGauge = append(poolToGauges.PoolToGauge, poolToGauge)
+		} else if pool.GetType() == poolmanagertypes.CosmWasm {
+			// Cosmwasm pools currently have no after pool created hook to make
+			// internal gauges, so we skip them for now when exporting gauges.
+			continue
 		} else {
 			for _, duration := range lockableDurations {
 				gaugeID, err := k.GetPoolGaugeId(ctx, uint64(poolId), duration)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

CW pools do not have an "afterPoolCreated" hook to create an internal gauge. Therefore, if a pool is created and we attempt to state export, we error on exporting gauges for the CW pool.

This is a temp patch. We will need to eventually create gauges for CW pools via a hook.

## Testing and Verifying

Currently testing with osmosis-ci.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A