### PR TITLE
[Account Abstraction ] Feat/authenticator module wire

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -71,6 +71,8 @@ import (
 
 	_ "github.com/osmosis-labs/osmosis/v17/client/docs/statik"
 	owasm "github.com/osmosis-labs/osmosis/v17/wasmbinding"
+	authenticatorkeeper "github.com/osmosis-labs/osmosis/v17/x/authenticator/keeper"
+	authenticatortypes "github.com/osmosis-labs/osmosis/v17/x/authenticator/types"
 	concentratedliquidity "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity"
 	concentratedliquiditytypes "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/types"
 	gammkeeper "github.com/osmosis-labs/osmosis/v17/x/gamm/keeper"
@@ -149,6 +151,7 @@ type AppKeepers struct {
 	ValidatorSetPreferenceKeeper *valsetpref.Keeper
 	ConcentratedLiquidityKeeper  *concentratedliquidity.Keeper
 	CosmwasmPoolKeeper           *cosmwasmpool.Keeper
+	AuthenticatorKeeper          *authenticatorkeeper.Keeper
 
 	// IBC modules
 	// transfer module
@@ -444,6 +447,13 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.LockupKeeper,
 	)
 
+	authenticatorKeeper := authenticatorkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[authenticatortypes.StoreKey],
+		appKeepers.GetSubspace(authenticatortypes.ModuleName),
+	)
+	appKeepers.AuthenticatorKeeper = &authenticatorKeeper
+
 	appKeepers.ValidatorSetPreferenceKeeper = &validatorSetPreferenceKeeper
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
@@ -676,6 +686,7 @@ func (appKeepers *AppKeepers) initParamsKeeper(appCodec codec.BinaryCodec, legac
 	paramsKeeper.Subspace(packetforwardtypes.ModuleName).WithKeyTable(packetforwardtypes.ParamKeyTable())
 	paramsKeeper.Subspace(cosmwasmpooltypes.ModuleName)
 	paramsKeeper.Subspace(ibchookstypes.ModuleName)
+	paramsKeeper.Subspace(authenticatortypes.ModuleName)
 
 	return paramsKeeper
 }
@@ -794,5 +805,6 @@ func KVStoreKeys() []string {
 		icqtypes.StoreKey,
 		packetforwardtypes.StoreKey,
 		cosmwasmpooltypes.StoreKey,
+		authenticatortypes.StoreKey,
 	}
 }

--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -30,6 +30,7 @@ import (
 	ica "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts"
 
 	_ "github.com/osmosis-labs/osmosis/v17/client/docs/statik"
+	authenticator "github.com/osmosis-labs/osmosis/v17/x/authenticator"
 	clclient "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/client"
 	concentratedliquidity "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/clmodule"
 	cwpoolclient "github.com/osmosis-labs/osmosis/v17/x/cosmwasmpool/client"
@@ -120,4 +121,5 @@ var AppModuleBasics = []module.AppModuleBasic{
 	ibcratelimitmodule.AppModuleBasic{},
 	router.AppModuleBasic{},
 	cosmwasmpoolmodule.AppModuleBasic{},
+	authenticator.AppModuleBasic{},
 }

--- a/app/modules.go
+++ b/app/modules.go
@@ -61,6 +61,8 @@ import (
 	appparams "github.com/osmosis-labs/osmosis/v17/app/params"
 	_ "github.com/osmosis-labs/osmosis/v17/client/docs/statik"
 	"github.com/osmosis-labs/osmosis/v17/simulation/simtypes"
+	authenticator "github.com/osmosis-labs/osmosis/v17/x/authenticator"
+	authenticatortypes "github.com/osmosis-labs/osmosis/v17/x/authenticator/types"
 	concentratedliquidity "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/clmodule"
 	concentratedliquiditytypes "github.com/osmosis-labs/osmosis/v17/x/concentrated-liquidity/types"
 	cwpoolmodule "github.com/osmosis-labs/osmosis/v17/x/cosmwasmpool/module"
@@ -122,6 +124,7 @@ var moduleAccountPermissions = map[string][]string{
 	valsetpreftypes.ModuleName:               {authtypes.Staking},
 	poolmanagertypes.ModuleName:              nil,
 	cosmwasmpooltypes.ModuleName:             nil,
+	authenticatortypes.ModuleName:            nil,
 }
 
 // appModules return modules to initialize module manager.
@@ -185,6 +188,8 @@ func appModules(
 		icq.NewAppModule(*app.AppKeepers.ICQKeeper),
 		packetforward.NewAppModule(app.PacketForwardKeeper),
 		cwpoolmodule.NewAppModule(appCodec, *app.CosmwasmPoolKeeper),
+		cwpoolmodule.NewAppModule(appCodec, *app.CosmwasmPoolKeeper),
+		authenticator.NewAppModule(appCodec, *app.AuthenticatorKeeper),
 	}
 }
 
@@ -272,6 +277,7 @@ func OrderInitGenesis(allModuleNames []string) []string {
 		icqtypes.ModuleName,
 		packetforwardtypes.ModuleName,
 		cosmwasmpooltypes.ModuleName,
+		authenticatortypes.ModuleName,
 	}
 }
 

--- a/x/authenticator/keeper/keeper_test.go
+++ b/x/authenticator/keeper/keeper_test.go
@@ -1,12 +1,13 @@
 package keeper_test
 
 import (
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/v17/app/apptesting"
 	"github.com/osmosis-labs/osmosis/v17/x/authenticator/keeper"
 	"github.com/osmosis-labs/osmosis/v17/x/authenticator/types"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type KeeperTestSuite struct {
@@ -21,7 +22,8 @@ func TestKeeperTestSuite(t *testing.T) {
 func (s *KeeperTestSuite) SetupTest() {
 	s.Reset()
 	// ToDo: when wired up, modify for s.App.AuthenticatorKeeper. Tests will fail for now because the store key doesn't exist
-	s.Keeper = keeper.NewKeeper(s.App.AppCodec(), s.App.GetKey(types.StoreKey), s.App.ParamsKeeper.Subspace(types.ModuleName))
+	ss, _ := s.App.ParamsKeeper.GetSubspace(types.ModuleName)
+	s.Keeper = keeper.NewKeeper(s.App.AppCodec(), s.App.GetKey(types.StoreKey), ss)
 
 	// Register the SigVerificationAuthenticator
 	types.InitializeAuthenticators([]types.Authenticator{types.SigVerificationAuthenticator{}})
@@ -30,8 +32,6 @@ func (s *KeeperTestSuite) SetupTest() {
 // ToDo: more and better tests
 
 func (s *KeeperTestSuite) TestMsgServer_AddAuthenticator() {
-	s.T().Skip("skipping until this is wired up") // TODO: remove this line when this test is wired up
-
 	msgServer := keeper.NewMsgServerImpl(s.Keeper)
 	ctx := s.Ctx
 
@@ -50,7 +50,6 @@ func (s *KeeperTestSuite) TestMsgServer_AddAuthenticator() {
 }
 
 func (s *KeeperTestSuite) TestMsgServer_RemoveAuthenticator() {
-	s.T().Skip("skipping until this is wired up") // TODO: remove this line when this test is wired up
 	msgServer := keeper.NewMsgServerImpl(s.Keeper)
 	ctx := s.Ctx
 

--- a/x/authenticator/types/keys.go
+++ b/x/authenticator/types/keys.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"fmt"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6126

## What is the purpose of the change

Wiring authenticator module into node

## Testing and Verifying

Run:

- `make install`
- `osmosisd tx authenticator`

Expected output
```bash
authenticator transactions subcommands

Usage:
  osmosisd tx authenticator [flags]

Flags:
  -h, --help   help for authenticator

Global Flags:
      --chain-id string     The network chain ID
      --home string         directory for config and data (default "/home/ghost/.osmosisd")
      --log_format string   The logging format (json|plain) (default "plain")
      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --trace               print out full stack trace on errors
```