### PR TITLE
Further epoch speedup, by making spam gauges not increase linear-time compute

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -414,10 +414,7 @@ func (k Keeper) distributeInternal(
 		}
 	} else {
 		// This is a standard lock distribution flow that assumes that we have locks associated with the gauge.
-		denom := lockuptypes.NativeDenom(gauge.DistributeTo.Denom)
-		lockSum := lockuptypes.SumLocksByDenom(locks, denom)
-
-		if lockSum.IsZero() {
+		if len(locks) == 0 {
 			return nil, nil
 		}
 
@@ -435,6 +432,14 @@ func (k Keeper) distributeInternal(
 			ctx.Logger().Debug(fmt.Sprintf("gauge debug, this gauge is perceived spam, skipping %d", gauge.Id))
 			err := k.updateGaugePostDistribute(ctx, gauge, totalDistrCoins)
 			return totalDistrCoins, err
+		}
+
+		// This is a standard lock distribution flow that assumes that we have locks associated with the gauge.
+		denom := lockuptypes.NativeDenom(gauge.DistributeTo.Denom)
+		lockSum := lockuptypes.SumLocksByDenom(locks, denom)
+
+		if lockSum.IsZero() {
+			return nil, nil
 		}
 
 		for _, lock := range locks {


### PR DESCRIPTION
Skip the linear time lockSum compute for spam gauges.

I checked it was state compatible on v16.x. It speeds up another ~45 seconds off the compute time on my test machine. (compute time = 2.5 minutes, commit time = 2.5 minutes)
(This is a nice speedup on test machine. For nodes with more state, commit time increases a lot, unrelated to this PR. So this may be super low impact for them)