### PR TITLE
panic catch superfluid errors

### DIFF
--- a/x/superfluid/abci.go
+++ b/x/superfluid/abci.go
@@ -1,6 +1,7 @@
 package superfluid
 
 import (
+	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v17/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v17/x/superfluid/types"
 
@@ -14,6 +15,11 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper, ek types.EpochKeeper) {
 		panic(err)
 	}
 	if numBlocksSinceEpochStart == 0 {
-		k.AfterEpochStartBeginBlock(ctx)
+		// catch any panics/errors in superfluid, and revert begin block logic if it occurs.
+		//nolint:errcheck
+		osmoutils.ApplyFuncIfNoError(ctx, func(ctx2 sdk.Context) error {
+			k.AfterEpochStartBeginBlock(ctx2)
+			return nil
+		})
 	}
 }

--- a/x/superfluid/abci.go
+++ b/x/superfluid/abci.go
@@ -1,7 +1,6 @@
 package superfluid
 
 import (
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v17/x/superfluid/keeper"
 	"github.com/osmosis-labs/osmosis/v17/x/superfluid/types"
 
@@ -15,11 +14,6 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper, ek types.EpochKeeper) {
 		panic(err)
 	}
 	if numBlocksSinceEpochStart == 0 {
-		// catch any panics/errors in superfluid, and revert begin block logic if it occurs.
-		//nolint:errcheck
-		osmoutils.ApplyFuncIfNoError(ctx, func(ctx2 sdk.Context) error {
-			k.AfterEpochStartBeginBlock(ctx2)
-			return nil
-		})
+		k.AfterEpochStartBeginBlock(ctx)
 	}
 }

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -32,7 +32,11 @@ func (k Keeper) AfterEpochStartBeginBlock(ctx sdk.Context) {
 	k.MoveSuperfluidDelegationRewardToGauges(ctx)
 
 	ctx.Logger().Info("Distribute Superfluid gauges")
-	k.distributeSuperfluidGauges(ctx)
+	//nolint:errcheck
+	osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
+		k.distributeSuperfluidGauges(cacheCtx)
+		return nil
+	})
 
 	// Update all LP tokens multipliers for the upcoming epoch.
 	// This affects staking reward distribution until the next epochs rewards.


### PR DESCRIPTION
Catch panics if they occur during superfluid distributions, so we would not risk a chain halt.