### PR TITLE
add poolmanager swap messages to arb tx checker

### DIFF
--- a/x/poolmanager/types/msg_swap.go
+++ b/x/poolmanager/types/msg_swap.go
@@ -1,0 +1,48 @@
+package types
+
+// SwapMsg defines a simple interface for getting the token denoms on a swap message route.
+type SwapMsgRoute interface {
+	TokenInDenom() string
+	TokenOutDenom() string
+	TokenDenomsOnPath() []string
+}
+
+var (
+	_ SwapMsgRoute = MsgSwapExactAmountOut{}
+	_ SwapMsgRoute = MsgSwapExactAmountIn{}
+)
+
+func (msg MsgSwapExactAmountOut) TokenInDenom() string {
+	return msg.Routes[0].GetTokenInDenom()
+}
+
+func (msg MsgSwapExactAmountOut) TokenOutDenom() string {
+	return msg.TokenOut.Denom
+}
+
+func (msg MsgSwapExactAmountOut) TokenDenomsOnPath() []string {
+	denoms := make([]string, 0, len(msg.Routes)+1)
+	for i := 0; i < len(msg.Routes); i++ {
+		denoms = append(denoms, msg.Routes[i].TokenInDenom)
+	}
+	denoms = append(denoms, msg.TokenOutDenom())
+	return denoms
+}
+
+func (msg MsgSwapExactAmountIn) TokenInDenom() string {
+	return msg.TokenIn.Denom
+}
+
+func (msg MsgSwapExactAmountIn) TokenOutDenom() string {
+	lastRouteIndex := len(msg.Routes) - 1
+	return msg.Routes[lastRouteIndex].GetTokenOutDenom()
+}
+
+func (msg MsgSwapExactAmountIn) TokenDenomsOnPath() []string {
+	denoms := make([]string, 0, len(msg.Routes)+1)
+	denoms = append(denoms, msg.TokenInDenom())
+	for i := 0; i < len(msg.Routes); i++ {
+		denoms = append(denoms, msg.Routes[i].TokenOutDenom)
+	}
+	return denoms
+}

--- a/x/txfees/keeper/txfee_filters/arb_tx.go
+++ b/x/txfees/keeper/txfee_filters/arb_tx.go
@@ -2,6 +2,7 @@ package txfee_filters
 
 import (
 	gammtypes "github.com/osmosis-labs/osmosis/v19/x/gamm/types"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -35,7 +36,10 @@ func IsArbTxLoose(tx sdk.Tx) bool {
 
 		swapMsg, isSwapMsg := m.(gammtypes.SwapMsgRoute)
 		if !isSwapMsg {
-			continue
+			swapMsg, isSwapMsg = m.(poolmanagertypes.SwapMsgRoute)
+			if !isSwapMsg {
+				continue
+			}
 		}
 
 		// (1) Check that swap denom in != swap denom out


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

the arb transaction mempool filter does not currently account for poolmanager swap messages, thus it can be bypassed by simply changing the swap message type from gamm to poolmanager. this pr allows the filter to check for poolmanager messages as well.

note: it seems that even with these changes the filter can still be bypassed by further substituting the split route messages with a "non split" route instead. it will take more work to check for these messages as they cannot implement the `SwapMsgRoute` interface as-is

## Testing and Verifying

tested on localnet by verifying gamm and poolmanager swap messages have same gas requirement

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A