### PR TITLE
handle a TODO in synth lock

### DIFF
--- a/x/lockup/keeper/synthetic_lock.go
+++ b/x/lockup/keeper/synthetic_lock.go
@@ -113,12 +113,11 @@ func (k Keeper) CreateSyntheticLockup(ctx sdk.Context, lockID uint64, synthDenom
 	// There is no relationship between unbonding and bonding synthetic lockup, it's managed separately
 	// A separate accumulation store is incremented with the synth denom.
 
-	// TODO: Next state break change !synthlock.IsNil -> found
-	synthLock, _, err := k.GetSyntheticLockupByUnderlyingLockId(ctx, lockID)
+	_, found, err := k.GetSyntheticLockupByUnderlyingLockId(ctx, lockID)
 	if err != nil {
 		return err
 	}
-	if !synthLock.IsNil() {
+	if found {
 		return types.ErrSyntheticLockupAlreadyExists
 	}
 
@@ -136,7 +135,7 @@ func (k Keeper) CreateSyntheticLockup(ctx sdk.Context, lockID uint64, synthDenom
 	}
 
 	// set synthetic lockup object
-	synthLock = types.SyntheticLock{
+	synthLock := types.SyntheticLock{
 		UnderlyingLockId: lockID,
 		SynthDenom:       synthDenom,
 		EndTime:          endTime,


### PR DESCRIPTION
Fix a TODO inside of synthetic lock. Check out this PR when we introduced this new API: https://github.com/osmosis-labs/osmosis/pull/5833