### PR TITLE
v19 superfluid fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### State Breaking
+
+### Bug Fixes
+* [#6190](https://github.com/osmosis-labs/osmosis/pull/6190) v19 upgrade handler superfluid fix
+
+### Misc Improvements
+
+### Minor improvements & Bug Fixes
+
+### Security
+
 ## v18.0.0
 
 ### Misc Improvements

--- a/app/upgrades/v19/constants.go
+++ b/app/upgrades/v19/constants.go
@@ -1,4 +1,4 @@
-package v18
+package v19
 
 import (
 	"github.com/osmosis-labs/osmosis/v19/app/upgrades"
@@ -7,7 +7,7 @@ import (
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v18 upgrade.
-const UpgradeName = "v18"
+const UpgradeName = "v19"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -37,5 +37,5 @@ func CreateUpgradeHandler(
 
 func resetSuperfluidSumtree(keepers *keepers.AppKeepers, ctx sdk.Context, id uint64) {
 	denom := gammtypes.GetPoolShareDenom(id)
-	keepers.LockupKeeper.RebuildAccumulationStoreForDenom(ctx, denom)
+	keepers.LockupKeeper.RebuildSuperfluidAccumulationStoresForDenom(ctx, denom)
 }

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -1,9 +1,11 @@
-package v18
+package v19
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	gammtypes "github.com/osmosis-labs/osmosis/v19/x/gamm/types"
 
 	"github.com/osmosis-labs/osmosis/v19/app/keepers"
 	"github.com/osmosis-labs/osmosis/v19/app/upgrades"
@@ -34,6 +36,6 @@ func CreateUpgradeHandler(
 }
 
 func resetSuperfluidSumtree(keepers *keepers.AppKeepers, ctx sdk.Context, id uint64) {
-	// denom := gammtypes.GetPoolShareDenom(id)
-	// keepers.LockupKeeper.RebuildAccumulationStoreForDenom(ctx, denom)
+	denom := gammtypes.GetPoolShareDenom(id)
+	keepers.LockupKeeper.RebuildAccumulationStoreForDenom(ctx, denom)
 }

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -312,7 +312,35 @@ func (k Keeper) RebuildAccumulationStoreForDenom(ctx sdk.Context, denom string) 
 }
 
 func (k Keeper) RebuildSuperfluidAccumulationStoresForDenom(ctx sdk.Context, denom string) {
-	k.RebuildAccumulationStoreForDenom(ctx, denom)
+	superfluidPrefix := denom + "/super"
+	superfluidStorePrefix := accumulationStorePrefix(superfluidPrefix)
+	k.clearKeysByPrefix(ctx, superfluidStorePrefix)
+
+	accumulationStoreEntries := make(map[string]map[time.Duration]sdk.Int)
+	locks := k.GetLocksDenom(ctx, denom)
+	for _, lock := range locks {
+		synthLock, found, err := k.GetSyntheticLockupByUnderlyingLockId(ctx, lock.ID)
+		if err != nil || !found {
+			continue
+		}
+
+		var curDurationMap map[time.Duration]sdk.Int
+		if durationMap, ok := accumulationStoreEntries[synthLock.SynthDenom]; ok {
+			curDurationMap = durationMap
+		} else {
+			curDurationMap = make(map[time.Duration]sdk.Int)
+		}
+		newAmt := lock.Coins.AmountOf(denom)
+		if curAmt, ok := curDurationMap[synthLock.Duration]; ok {
+			newAmt = newAmt.Add(curAmt)
+		}
+		curDurationMap[synthLock.Duration] = newAmt
+		accumulationStoreEntries[synthLock.SynthDenom] = curDurationMap
+	}
+
+	for synthDenom, durationMap := range accumulationStoreEntries {
+		k.writeDurationValuesToAccumTree(ctx, synthDenom, durationMap)
+	}
 }
 
 func (k Keeper) ClearAccumulationStores(ctx sdk.Context) {

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -311,6 +311,10 @@ func (k Keeper) RebuildAccumulationStoreForDenom(ctx sdk.Context, denom string) 
 	k.writeDurationValuesToAccumTree(ctx, denom, mapDurationToAmount)
 }
 
+func (k Keeper) RebuildSuperfluidAccumulationStoresForDenom(ctx sdk.Context, denom string) {
+	k.RebuildAccumulationStoreForDenom(ctx, denom)
+}
+
 func (k Keeper) ClearAccumulationStores(ctx sdk.Context) {
 	k.clearKeysByPrefix(ctx, types.KeyPrefixLockAccumulation)
 }


### PR DESCRIPTION
Repairs the superfluid synth denom stores. We set them here: https://github.com/osmosis-labs/osmosis/blob/dev/fix_v19/x/lockup/keeper/synthetic_lock.go#L161