### PR TITLE
Fix tokenfactory events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 * [#6190](https://github.com/osmosis-labs/osmosis/pull/6190) v19 upgrade handler superfluid fix
-
+* [#6195](https://github.com/osmosis-labs/osmosis/pull/6195) (x/tokenfactory) Fix events for `mintTo` and `burnFrom`
 ### Misc Improvements
 
 ### Minor improvements & Bug Fixes

--- a/proto/osmosis/tokenfactory/v1beta1/tx.proto
+++ b/proto/osmosis/tokenfactory/v1beta1/tx.proto
@@ -46,7 +46,9 @@ message MsgCreateDenomResponse {
 }
 
 // MsgMint is the sdk.Msg type for allowing an admin account to mint
-// more of a token.  For now, we only support minting to the sender account
+// more of a token.
+// Only the admin of the token factory denom has permission to mint unless
+// the denom does not have any admin.
 message MsgMint {
   option (amino.name) = "osmosis/tokenfactory/mint";
 
@@ -62,7 +64,9 @@ message MsgMint {
 message MsgMintResponse {}
 
 // MsgBurn is the sdk.Msg type for allowing an admin account to burn
-// a token.  For now, we only support burning from the sender account.
+// a token.
+// Only the admin of the token factory denom has permission to burn unless
+// the denom does not have any admin.
 message MsgBurn {
   option (amino.name) = "osmosis/tokenfactory/burn";
 

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -72,7 +72,7 @@ func (server msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeMsgMint,
-			sdk.NewAttribute(types.AttributeMintToAddress, msg.Sender),
+			sdk.NewAttribute(types.AttributeMintToAddress, msg.MintToAddress),
 			sdk.NewAttribute(types.AttributeAmount, msg.Amount.String()),
 		),
 	})
@@ -110,7 +110,7 @@ func (server msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.TypeMsgBurn,
-			sdk.NewAttribute(types.AttributeBurnFromAddress, msg.Sender),
+			sdk.NewAttribute(types.AttributeBurnFromAddress, msg.BurnFromAddress),
 			sdk.NewAttribute(types.AttributeAmount, msg.Amount.String()),
 		),
 	})

--- a/x/tokenfactory/types/tx.pb.go
+++ b/x/tokenfactory/types/tx.pb.go
@@ -140,7 +140,9 @@ func (m *MsgCreateDenomResponse) GetNewTokenDenom() string {
 }
 
 // MsgMint is the sdk.Msg type for allowing an admin account to mint
-// more of a token.  For now, we only support minting to the sender account
+// more of a token.
+// Only the admin of the token factory denom has permission to mint unless
+// the denom does not have any admin.
 type MsgMint struct {
 	Sender        string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
 	Amount        types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`
@@ -238,7 +240,9 @@ func (m *MsgMintResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgMintResponse proto.InternalMessageInfo
 
 // MsgBurn is the sdk.Msg type for allowing an admin account to burn
-// a token.  For now, we only support burning from the sender account.
+// a token.
+// Only the admin of the token factory denom has permission to burn unless
+// the denom does not have any admin.
 type MsgBurn struct {
 	Sender          string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty" yaml:"sender"`
 	Amount          types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount" yaml:"amount"`


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/6147
## What is the purpose of the change

Previously token factory events were emitting wrong attribute for mintTo and burnFrom, this PR fixes it 


## Testing and Verifying
This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A