### PR TITLE
fix: ignore panic on cosmwasm pools

### DIFF
--- a/x/pool-incentives/keeper/genesis.go
+++ b/x/pool-incentives/keeper/genesis.go
@@ -57,7 +57,11 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 			for _, duration := range lockableDurations {
 				gaugeID, err := k.GetPoolGaugeId(ctx, uint64(poolId), duration)
 				if err != nil {
-					panic(err)
+					// TODO: This error happens on pool export for CosmWasm
+					// assocated pools, to fix this we need to assign
+					// a gauge to cosmwasm pools on creation
+					ctx.Logger().Error(err.Error())
+					continue
 				}
 				var poolToGauge types.PoolToGauge
 				poolToGauge.Duration = duration


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- To ignore panic on cosmwasm pool export

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A