### PR TITLE
e2e remove setup go step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,10 +114,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: 🐿 Setup Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{env.GO_VERSION}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
Maybe im misunderstanding, but I don't think this does anything. Its installing golang outside of docker. (And costs 3 minutes!)