### PR TITLE
feat(taker fees): Implement taker fee collection and tracking tests (…

### DIFF
--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v19/app/keepers"
 	"github.com/osmosis-labs/osmosis/v19/app/upgrades"
-	v18 "github.com/osmosis-labs/osmosis/v19/app/upgrades/v18"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
+
+	v18 "github.com/osmosis-labs/osmosis/v19/app/upgrades/v18"
 )
 
 const lastPoolToCorrect = v18.FirstCLPoolId - 1
@@ -40,7 +41,6 @@ func CreateUpgradeHandler(
 		// TODO: In v20 upgrade handler, delete this param from the concentrated liquidity params.
 		currentConcentratedLiquidityParams := keepers.ConcentratedLiquidityKeeper.GetParams(ctx)
 		defaultPoolManagerParams := poolmanagertypes.DefaultParams()
-
 		defaultPoolManagerParams.AuthorizedQuoteDenoms = currentConcentratedLiquidityParams.AuthorizedQuoteDenoms
 		defaultPoolManagerParams.TakerFeeParams.DefaultTakerFee = sdk.ZeroDec()
 		keepers.PoolManagerKeeper.SetParams(ctx, defaultPoolManagerParams)

--- a/x/gamm/keeper/msg_server_test.go
+++ b/x/gamm/keeper/msg_server_test.go
@@ -77,7 +77,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn_Events() {
 			},
 			tokenIn:               sdk.NewCoin(doesNotExistDenom, sdk.NewInt(tokenIn)),
 			tokenOutMinAmount:     sdk.NewInt(tokenInMinAmount),
-			expectedMessageEvents: 1, // 1 event gets triggered prior to failure.
+			expectedMessageEvents: 2, // 2 event gets triggered prior to failure.
 			expectError:           true,
 		},
 	}

--- a/x/poolmanager/taker_fee.go
+++ b/x/poolmanager/taker_fee.go
@@ -174,11 +174,9 @@ func (k Keeper) calcTakerFeeExactIn(tokenIn sdk.Coin, takerFee sdk.Dec) (sdk.Coi
 	return tokenInAfterSubTakerFee, takerFeeCoin
 }
 
-// Returns takerFee adjusted required amountIn, and takerFeeCoins.
-// Computed as tokenIn / (1 - takerFee), tokenIn * (1 - / (1 - takerFee))
 func (k Keeper) calcTakerFeeExactOut(tokenIn sdk.Coin, takerFee sdk.Dec) (sdk.Coin, sdk.Coin) {
 	amountInAfterAddTakerFee := tokenIn.Amount.ToDec().Quo(sdk.OneDec().Sub(takerFee))
-	tokenInAfterAddTakerFee := sdk.NewCoin(tokenIn.Denom, amountInAfterAddTakerFee.RoundInt())
+	tokenInAfterAddTakerFee := sdk.NewCoin(tokenIn.Denom, amountInAfterAddTakerFee.Ceil().TruncateInt())
 	takerFeeCoin := sdk.NewCoin(tokenIn.Denom, tokenInAfterAddTakerFee.Amount.Sub(tokenIn.Amount))
 
 	return tokenInAfterAddTakerFee, takerFeeCoin

--- a/x/poolmanager/types/params.go
+++ b/x/poolmanager/types/params.go
@@ -48,7 +48,7 @@ func DefaultParams() Params {
 	return Params{
 		PoolCreationFee: sdk.Coins{sdk.NewInt64Coin(appparams.BaseCoinUnit, 1000_000_000)}, // 1000 OSMO
 		TakerFeeParams: TakerFeeParams{
-			DefaultTakerFee: sdk.MustNewDecFromStr("0.0015"), // 0.15%
+			DefaultTakerFee: sdk.ZeroDec(), // 0%
 			OsmoTakerFeeDistribution: TakerFeeDistributionPercentage{
 				StakingRewards: sdk.MustNewDecFromStr("1"), // 100%
 				CommunityPool:  sdk.MustNewDecFromStr("0"), // 0%

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -737,6 +737,7 @@ func (s *KeeperTestSuite) TestRemainingPoolPointsForTx() {
 }
 
 func (s *KeeperTestSuite) TestUpdateSearchRangeIfNeeded() {
+	s.SetupTest()
 	s.Run("Extended search on stable pools", func() {
 		route := keeper.RouteMetaData{
 			Route:    extendedRangeRoute,

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -1160,7 +1160,7 @@ func (s *KeeperTestSuite) TestConvertLockToStake() {
 		"error: min amount to stake greater than actual amount": {
 			useMinAmountToStake: true,
 			expectedError: types.TokenConvertedLessThenDesiredStakeError{
-				ActualTotalAmtToStake:   sdk.NewInt(8306),
+				ActualTotalAmtToStake:   sdk.NewInt(8309),
 				ExpectedTotalAmtToStake: sdk.NewInt(999999999),
 			},
 		},
@@ -1218,7 +1218,7 @@ func (s *KeeperTestSuite) TestConvertLockToStake() {
 				// err check for LockOwnerMismatchError needs further refactoring for all these test cases
 				// since lock owner is not know-able at the time of test creation
 				if !tc.senderIsNotOwnerOfLock {
-					s.Require().Equal(err.Error(), tc.expectedError.Error())
+					s.Require().Equal(tc.expectedError.Error(), err.Error())
 				}
 				return
 			}
@@ -1359,7 +1359,7 @@ func (s *KeeperTestSuite) TestConvertGammSharesToOsmoAndStake() {
 		},
 		"error: min amount to stake exceeds actual amount staking": {
 			useMinAmtToStake: true,
-			expectedError:    "actual amount converted to stake (8306) is less then minimum amount expected to be staked (999999999)",
+			expectedError:    "actual amount converted to stake (8309) is less then minimum amount expected to be staked (999999999)",
 		},
 	}
 

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -181,7 +181,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 
 	// checks to make sure a separate module account has been set to collect fees not in base token
 	if addrNonNativeFee := dfd.ak.GetModuleAddress(types.FeeCollectorForStakingRewardsName); addrNonNativeFee == nil {
-		return ctx, fmt.Errorf("non native fee collector module account (%s) has not been set", types.FeeCollectorForStakingRewardsName)
+		return ctx, fmt.Errorf("fee collector module account for staking rewards (%s) has not been set", types.FeeCollectorForStakingRewardsName)
 	}
 
 	// fee can be in any denom (checked for validity later)


### PR DESCRIPTION
…#6183)

* add taker fee determination and extraction

* remove osmo multi hop logic

* route to both community pool and staking rewards

* fix a handfull of tests

* assign taker fee to pool at time of creation

* pull taker fee direct from pool struct

* fix more tests

* fix tests, set back up osmo multi hop discount

* correct taker fee extraction

* regen mocks

* abstract taker fee to pool manager (highest lvl)

* fix extract cmd

* update changelog

* tidy

* remove param that no longer exists

* add extra params to genesis logic

* add back osmo multihop tests

* add comment

* fix e2e keeping prints

* fixes

* more test fixes

* remove prints

* more naive approach to determining taker fee

* fix e2e

* re-enable disabled test

* minor cleaning

* simplify params

* not nullable

* clean up

* add whitelist set message denom pair taker fees

* use real addresses

* add gov prop for denom pair taker fee update

* clean

* move logic to its own taker_fee.go file

* add CLI for gov prop for denomPairTakerFee

* add admin address denomPairTakerFee cli msg

* clean and simplifications

* use authorized quote denoms from poolmanger

* remove stableswap taker fee

* sim msg change

* add test for CLI

* msg server tests

* add route_test test

* add gov_test.go

* add msgs_test.go

* remove print line

* change from v18 to v19

* Update upgrades.go

* set default taker fee to zero in upgrade handler

* conflicts

* Update proto/osmosis/poolmanager/v1beta1/genesis.proto

* Update proto/osmosis/poolmanager/v1beta1/genesis.proto

* Update x/poolmanager/taker_fee.go

* Generated protofile changes

* rename extractTakerFeeAndDistribute to chargeTakerFee

* clean up

* comment

* rename

* godoc for NonNativeFeeCollectorForCommunityPoolName

* baseDenom to defaultFeesDenom name change

* fix upgrade handler

* fix AfterEpochEnd order of denoms when getting pools; reduce code dupl; tests

* add taker fee tests at poolmanager level and fix rounding

* fix track volume

* add key separator for pool manager

* add comment to denom pair route

* add basic lexicographical key test

* update chargeTakerFee godoc

* undo rounding change

* fix test case

* set the default taker fee back to non zero for e2e

* add split route and multihop tests with global taker fee

* change PoolMangerGetParams API to  GetAuthorizedQuoteDenoms (same for setters)

* add tests for varying taker fees along split/multihop routes

* fix rounding behavior and set default fee to zero

* update txfees & poolmanager READMEs with takerFee

* add granular taker fee balance checks covering rounding behavior, exact in

* undo taker fee charge on stake convert tests

* further cleanup

* clean up test comments

* dont use self hosted runners for e2e

* fix merge from main

* test fixes

---------

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

> Add a description of the overall background and high level changes that this PR introduces

*(E.g.: This pull request improves documentation of area A by adding ....*

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A