### PR TITLE
Finding E2E tests with reflection

### DIFF
--- a/tests/e2e/e2e_cl_test.go
+++ b/tests/e2e/e2e_cl_test.go
@@ -27,7 +27,7 @@ import (
 // Note: do not use chain B in this test as it has taker fee set.
 // This TWAP test depends on specific values that might be affected
 // by the taker fee.
-func (s *IntegrationTestSuite) CreateConcentratedLiquidityPoolVoting_And_TWAP() {
+func (s *IntegrationTestSuite) CreateConcentratedLiquidityPoolVoting_And_TWAPTest() {
 	chainA, chainANode := s.getChainACfgs()
 
 	poolId, err := chainA.SubmitCreateConcentratedPoolProposal(chainANode)
@@ -131,7 +131,7 @@ func (s *IntegrationTestSuite) CreateConcentratedLiquidityPoolVoting_And_TWAP() 
 // Note: this test depends on taker fee being set.
 // As a result, we use chain B. Chain A has zero taker fee.
 // TODO: Move this test and its components to its own file, Its way too big and needs to be split up significantly.
-func (s *IntegrationTestSuite) ConcentratedLiquidity() {
+func (s *IntegrationTestSuite) ConcentratedLiquidityTest() {
 	var (
 		denom0                 = "uion"
 		denom1                 = "uosmo"

--- a/tests/e2e/e2e_cl_test.go
+++ b/tests/e2e/e2e_cl_test.go
@@ -27,7 +27,7 @@ import (
 // Note: do not use chain B in this test as it has taker fee set.
 // This TWAP test depends on specific values that might be affected
 // by the taker fee.
-func (s *IntegrationTestSuite) CreateConcentratedLiquidityPoolVoting_And_TWAPTest() {
+func (s *IntegrationTestSuite) CreateConcentratedLiquidityPoolVoting_And_TWAP_Test() {
 	chainA, chainANode := s.getChainACfgs()
 
 	poolId, err := chainA.SubmitCreateConcentratedPoolProposal(chainANode)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -53,7 +53,11 @@ func Contains(slice []string, target string) bool {
 }
 
 func (s *IntegrationTestSuite) TestAllE2E() {
-	// Zero Dependent Tests
+	s.T().Run("SetDefaultTakerFeeChainB", func(t *testing.T) {
+		s.T().Log("resetting the default taker fee to 0.15% on chain B only")
+		s.SetDefaultTakerFeeChainB()
+	})
+
 	value := reflect.ValueOf(s)
 	typeOfS := value.Type()
 
@@ -910,7 +914,7 @@ func (s *IntegrationTestSuite) GeometricTWAPTest() {
 //
 // Similarly, CL tests depend on taker fee being set.
 // As a result, we deterministically configure chain B's taker fee prior to running CL tests.
-func (s *IntegrationTestSuite) SetDefaultTakerFeeChainBTest() {
+func (s *IntegrationTestSuite) SetDefaultTakerFeeChainB() {
 	s.T().Log("resetting the default taker fee to 0.15% on chain B only")
 	chainB, chainBNode := s.getChainBCfgs()
 	err := chainBNode.ParamChangeProposal("poolmanager", string(poolmanagertypes.KeyDefaultTakerFee), json.RawMessage(`"0.001500000000000000"`), chainB)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -89,7 +89,7 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 		}
 
 		s.T().Run(methodName, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			value.MethodByName(methodName).Call(nil)
 		})
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -85,7 +85,7 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 		}
 
 		s.T().Run(methodName, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			value.MethodByName(methodName).Call(nil)
 		})
 

--- a/tests/e2e/new_test.go
+++ b/tests/e2e/new_test.go
@@ -7,7 +7,7 @@ import (
 const (
 	IbcFlag       = "Ibc"
 	UpgradeFlag   = "Upgrade"
-	StateSyncFlag = "StateSync"
+	StateSyncFlag = "StateSyncTest"
 )
 
 type E2ETest struct {

--- a/tests/e2e/new_test.go
+++ b/tests/e2e/new_test.go
@@ -7,7 +7,7 @@ import (
 const (
 	IbcFlag       = "Ibc"
 	UpgradeFlag   = "Upgrade"
-	StateSyncFlag = "StateSyncTest"
+	StateSyncFlag = "StateSync"
 )
 
 type E2ETest struct {

--- a/tests/e2e/sync_test.go
+++ b/tests/e2e/sync_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TODO: Consider moving this to its own package and having separate test instantiation for it.
-func (s *IntegrationTestSuite) StateSync() {
+func (s *IntegrationTestSuite) StateSyncTest() {
 	if s.skipStateSync {
 		s.T().Skip()
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

This is an idea of how to avoid having to list all the tests in e2e. Any thoughts?

## Testing and Verifying

all tests should pass

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A