### PR TITLE
feat: token factory defer explict error handling

### DIFF
--- a/x/tokenfactory/keeper/before_send.go
+++ b/x/tokenfactory/keeper/before_send.go
@@ -91,7 +91,7 @@ func (h Hooks) BlockBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount 
 func (k Keeper) callBeforeSendListener(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins, blockBeforeSend bool) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = types.ErrTrackBeforeSendOutOfGas
+			err = errorsmod.Wrapf(types.ErrTrackBeforeSendOutOfGas, "%v", r)
 		}
 	}()
 


### PR DESCRIPTION
## What is the purpose of the change

Integrating token factory in different apps I have seen that the error handling for **callBeforeSendListener** is a little bit difficult to debug because any error it throws is overwritten by "gas meter hit maximum limit", I suggest to wrap the original error inside the ErrTrackBeforeSendOutOfGas. 