### PR TITLE
fix(e2e): remove taker fee non-determinism affecting geo twap in e2e

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -301,6 +301,8 @@ func (s *IntegrationTestSuite) ProtoRev() {
 	s.Require().Equal(profits, routeStats[0].Profits)
 }
 
+// Note: this test depends on taker fee being set.
+// As a result, we use chain B. Chain A has zero taker fee.
 func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 	var (
 		denom0                 = "uion"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #https://github.com/osmosis-labs/osmosis/issues/6259

## What is the purpose of the change

See investigation analysis in: https://github.com/osmosis-labs/osmosis/issues/6259

Summary of the problem:

The taker fee e2e tests asynchronously set taker fee for both chains A and B.

Due to asynchrony, twap tests sometimes ran before and other times after taker fee being set.

However, geometric twap depends on specific swap amounts to function without jitter.

To work around the issue, taker fee is now set deterministically on chain B while chain A has zero taker fee.

As a result, concentrated liquidity tests that depend on non-zero taker fee now use chain b and geometric twap tests that depend on taker fee not being set use chain A.

## Testing and Verifying

Tested by running e2e in CI muliple times. Also, tested by completely removing the taker fee e2e test in a separate PR and rerunning CI multiple times: https://github.com/osmosis-labs/osmosis/pull/6272

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A