### PR TITLE
Fix broken link issue closure step not closing older issues

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -15,11 +15,13 @@ jobs:
         uses: actions/stale@v8
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
+          # Broken link issues are automatically created with the "automated issue" and "Broken links" labels, so we only care about closing those.
           only-issue-labels: automated issue,Broken links
+          ignore-issue-updates: true
           # close-issue-message requires permission `issues: write`
-          close-issue-message: 'This issue is closed due to a new "Check Broken Links" run. If any links are still broken, they will be reported in a new issue: https://github.com/osmosis-labs/osmosis/issues?q=is%3Aissue+is%3Aopen+label%3A%22automated+issue%22+label%3A%22Broken+links%22'
-          days-before-stale: -1
-          days-before-close: 0
+          close-issue-message: 'This issue is `stale` and has been closed due to a new "Check Broken Links" run. If any links are still broken, they will be reported in a new issue: https://github.com/osmosis-labs/osmosis/issues?q=is%3Aissue+is%3Aopen+label%3A%22automated+issue%22+label%3A%22Broken+links%22'
+          days-before-issue-stale: 0
+          days-before-issue-close: 0
 
       - name: Link Checker
         id: lychee


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6274

## What is the purpose of the change

Previously, we added logic to automatically close older "broken link" issues when a new run happened, that is because the new run would contain any-and-all broken links and therefore the previously created issue should be closed.

After more investigation, I see that the `days-before(-issue)-close` description states:
> The idle number of days before closing the stale issues or the stale pull requests (due to the stale label).

So, while it was `0`, we did set `days-before(-issue)-stale: -1`, meaning the issue would never be marked as `Stale`. My **hypothesis** is that since is wasn't marked as stale, the closing didn't take effect. So by updating the action to mark the issue as `Stale` same-day, and closing same-day it will do what we expect.

The [action's run](https://github.com/osmosis-labs/osmosis/actions/runs/6048086017/job/16412796684#step:3:555) successfully found the issue, but did not close it.
```
[#6048] Issue #6048
  [#6048] Found this issue last updated at: 2023-08-15T10:03:25Z
  [#6048] The option only-labels (​[https://github.com/actions/stale#only-labels​)](https://github.com/actions/stale#only-labels%E2%80%8B)) was specified to only process issues and pull requests with all those labels (2)
  [#6048] ├── All the required labels are present on this issue
  [#6048] └── Continuing the process for this issue
  [#6048] Days before issue stale: -1
  [#6048] The issue is not closed nor locked. Trying to remove the close label...
  [#6048] ├── The close-issue-label (​[https://github.com/actions/stale#close-issue-label​)](https://github.com/actions/stale#close-issue-label%E2%80%8B)) option was not set
  [#6048] └── Skipping the removal of the close label
  [#6048] This issue does not include a stale label
  [#6048] The option any-of-labels (​[https://github.com/actions/stale#any-of-labels​)](https://github.com/actions/stale#any-of-labels%E2%80%8B)) was not specified
  [#6048] └── Continuing the process for this issue
  [#6048] This issue has no milestone
  [#6048] └── Skip the milestones checks
  [#6048] This issue has no assignee
  [#6048] └── Skip the assignees checks
  [#6048] This issue is not stale
  [#6048] The option ignore-updates (​[https://github.com/actions/stale#ignore-updates​)](https://github.com/actions/stale#ignore-updates%E2%80%8B)) is disabled. The stale counter will take into account updates and comments on this issue to avoid to stale when there is some update
  [#6048] This issue should be stale based on the last update date the 15-08-2023 (2023-08-15T10:03:25Z)
  [#6048] This issue should not be marked as stale based on the option days-before-stale (​[https://github.com/actions/stale#days-before-stale​)](https://github.com/actions/stale#days-before-stale%E2%80%8B)) (-1)
```

** Still needs to be manually verified.

## Testing and Verifying

**This change is a trivial rework / code cleanup without any test coverage.**

Will need to verify this closes older issues _and_ that it doesn't affect any already-closed issues.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A