### PR TITLE
chore: lint concentrated liquidity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  tests: false
+  tests: true
   timeout: 5m
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  tests: true
+  tests: false
   timeout: 5m
 
 linters:
@@ -55,15 +55,15 @@ issues:
   exclude-rules:
     - linters:
         - staticcheck
-      text: "SA1024: cutset contains duplicate characters" # proved to not provide much value, only false positives.
+      text: 'SA1024: cutset contains duplicate characters' # proved to not provide much value, only false positives.
     - linters:
         - staticcheck
-      text: "SA9004: only the first constant in this group has an explicit type" # explicitly recommended in go syntax
+      text: 'SA9004: only the first constant in this group has an explicit type' # explicitly recommended in go syntax
     - linters:
         - stylecheck
-      text: "ST1003:" # requires identifiers with "id" to be "ID".
+      text: 'ST1003:' # requires identifiers with "id" to be "ID".
     - linters:
         - stylecheck
-      text: "ST1005:" # punctuation in error messages
+      text: 'ST1005:' # punctuation in error messages
   max-issues-per-linter: 10000
   max-same-issues: 10000

--- a/x/concentrated-liquidity/bench_test.go
+++ b/x/concentrated-liquidity/bench_test.go
@@ -36,10 +36,12 @@ func (s *BenchTestSuite) createPosition(accountIndex int, poolId uint64, coin0, 
 }
 
 func noError(b *testing.B, err error) {
+	b.Helper()
 	require.NoError(b, err)
 }
 
 func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64)) {
+	b.Helper()
 	// Notice we stop the timer to skip setup code.
 	b.StopTimer()
 
@@ -231,7 +233,9 @@ func runBenchmark(b *testing.B, testFunc func(b *testing.B, s *BenchTestSuite, p
 }
 
 func BenchmarkSwapExactAmountIn(b *testing.B) {
+	b.Helper()
 	runBenchmark(b, func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64) {
+		b.Helper()
 		clKeeper := s.App.ConcentratedLiquidityKeeper
 
 		liquidityNet, err := clKeeper.GetTickLiquidityNetInDirection(s.Ctx, pool.GetId(), largeSwapInCoin.Denom, osmomath.NewInt(currentTick), osmomath.Int{})
@@ -251,7 +255,9 @@ func BenchmarkSwapExactAmountIn(b *testing.B) {
 }
 
 func BenchmarkGetTickLiquidityNetInDirection(b *testing.B) {
+	b.Helper()
 	runBenchmark(b, func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64) {
+		b.Helper()
 		clKeeper := s.App.ConcentratedLiquidityKeeper
 
 		b.StartTimer()
@@ -267,7 +273,9 @@ func BenchmarkGetTickLiquidityNetInDirection(b *testing.B) {
 }
 
 func BenchmarkGetTickLiquidityForFullRange(b *testing.B) {
+	b.Helper()
 	runBenchmark(b, func(b *testing.B, s *BenchTestSuite, pool types.ConcentratedPoolExtension, largeSwapInCoin sdk.Coin, currentTick int64) {
+		b.Helper()
 		clKeeper := s.App.ConcentratedLiquidityKeeper
 
 		b.StartTimer()

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -40,6 +40,7 @@ type positionAndLiquidity struct {
 }
 
 func TestFuzz_Many(t *testing.T) {
+	t.Parallel()
 	fuzz(t, defaultNumSwaps, defaultNumPositions, 10)
 }
 
@@ -54,6 +55,7 @@ func (s *KeeperTestSuite) TestFuzz_GivenSeed() {
 
 // pre-condition: poolId exists, and has at least one position
 func fuzz(t *testing.T, numSwaps int, numPositions int, numIterations int) {
+	t.Helper()
 	seed := time.Now().Unix()
 
 	for i := 0; i < numIterations; i++ {
@@ -99,11 +101,6 @@ func (s *KeeperTestSuite) individualFuzz(r *rand.Rand, fuzzNum int, numSwaps int
 	s.fuzzTestWithSeed(r, pool.GetId(), numSwaps, numPositions)
 
 	s.validateNoErrors(s.collectedErrors)
-}
-
-type fuzzState struct {
-	r      *rand.Rand
-	poolId int
 }
 
 func (s *KeeperTestSuite) fuzzTestWithSeed(r *rand.Rand, poolId uint64, numSwaps int, numPositions int) {
@@ -159,7 +156,6 @@ func (s *KeeperTestSuite) randomSwap(r *rand.Rand, poolId uint64) (fatalErr bool
 	swapStrategy, zfo := updateStrategy()
 
 	for didSwap := false; !didSwap; {
-
 		if swapStrategy == 0 {
 			didSwap, fatalErr = s.swapRandomAmount(r, pool, zfo)
 		} else if swapStrategy == 1 {
@@ -243,9 +239,8 @@ func tickAmtChange(r *rand.Rand, targetAmount osmomath.Dec) osmomath.Dec {
 
 	// Generate a random percentage under 0.1%
 	randChangePercent := osmomath.NewDec(r.Int63n(1)).QuoInt64(1000)
-	change := targetAmount.Mul(randChangePercent)
 
-	change = sdk.MaxDec(osmomath.NewDec(1), randChangePercent)
+	change := sdk.MaxDec(osmomath.NewDec(1), randChangePercent)
 
 	switch changeType {
 	case 0:
@@ -400,7 +395,6 @@ func (s *KeeperTestSuite) validateNoErrors(possibleErrors []error) {
 	fullMsg := ""
 	shouldFail := false
 	for _, err := range possibleErrors {
-
 		// TODO: figure out if this is OK
 		// Answer: Ok for now, due to outofbounds=True restriction
 		// Should sanity check that our fuzzer isn't hitting this too often though, that could hit at
@@ -460,7 +454,6 @@ func (s *KeeperTestSuite) addOrRemoveLiquidity(r *rand.Rand, poolId uint64) {
 	} else {
 		s.removeRandomPosition(r)
 	}
-
 }
 
 // if true add position, if false remove position

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -13,7 +13,6 @@ import (
 	cl "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity"
 	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
-	"github.com/osmosis-labs/osmosis/v19/x/gamm/pool-models/balancer"
 )
 
 var (
@@ -102,8 +101,7 @@ var (
 
 	testQualifyingDepositsOne = osmomath.NewInt(50)
 
-	defaultBalancerPoolParams = balancer.PoolParams{SwapFee: osmomath.NewDec(0), ExitFee: osmomath.NewDec(0)}
-	invalidPoolId             = uint64(10)
+	invalidPoolId = uint64(10)
 )
 
 type ExpectedUptimes struct {
@@ -2219,7 +2217,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 
 					// Add to uptime growth outside range
 					if tc.addedUptimeGrowthOutside != nil {
-						s.addUptimeGrowthOutsideRange(s.Ctx, validPoolId, ownerWithValidPosition, tc.currentTick, tc.positionParams.lowerTick, tc.positionParams.upperTick, tc.addedUptimeGrowthOutside)
+						s.addUptimeGrowthOutsideRange(s.Ctx, validPoolId, tc.currentTick, tc.positionParams.lowerTick, tc.positionParams.upperTick, tc.addedUptimeGrowthOutside)
 					}
 				}
 
@@ -2806,7 +2804,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 
 				clPool.SetCurrentTick(DefaultCurrTick)
 				if tc.growthOutside != nil {
-					s.addUptimeGrowthOutsideRange(s.Ctx, validPoolId, defaultSender, DefaultCurrTick, DefaultLowerTick, DefaultUpperTick, tc.growthOutside)
+					s.addUptimeGrowthOutsideRange(s.Ctx, validPoolId, DefaultCurrTick, DefaultLowerTick, DefaultUpperTick, tc.growthOutside)
 				}
 
 				if tc.growthInside != nil {

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -736,7 +737,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 		expectedError            error
 	}
 
-	validateResult := func(ctx sdk.Context, err error, tc updateAccumToNow, poolId uint64, initUptimeAccumValues []sdk.DecCoins, qualifyingLiquidity sdk.Dec) []sdk.DecCoins {
+	validateResult := func(ctx sdk.Context, err error, tc updateAccumToNow, poolId uint64, initUptimeAccumValues []sdk.DecCoins, qualifyingLiquidity sdkmath.LegacyDec) []sdk.DecCoins {
 		if tc.expectedError != nil {
 			s.Require().ErrorContains(err, tc.expectedError.Error())
 
@@ -3240,7 +3241,7 @@ func (s *KeeperTestSuite) TestGetAllIncentiveRecordsForUptime() {
 					curUptimeRecords, err := clKeeper.GetAllIncentiveRecordsForUptime(s.Ctx, poolId, supportedUptime)
 					s.Require().NoError(err)
 
-					retrievedRecordsByUptime = append(retrievedRecordsByUptime, curUptimeRecords...)
+					retrievedRecordsByUptime = append(retrievedRecordsByUptime, curUptimeRecords...) //nolint:staticcheck,makezero // for testing, we want to append to the slice
 				}
 			})
 		}

--- a/x/concentrated-liquidity/invariant_test.go
+++ b/x/concentrated-liquidity/invariant_test.go
@@ -32,6 +32,7 @@ func (s *KeeperTestSuite) assertGlobalInvariants(expectedGlobalRewardValues Expe
 func (s *KeeperTestSuite) getAllPositionsAndPoolBalances(ctx sdk.Context) ([]model.Position, sdk.Coins, sdk.Coins, sdk.Coins) {
 	// Get total spread rewards distributed to all pools
 	allPools, err := s.clk.GetPools(ctx)
+	s.Require().NoError(err)
 	totalPoolAssets, totalSpreadRewards, totalIncentives := sdk.NewCoins(), sdk.NewCoins(), sdk.NewCoins()
 
 	// Sum up pool balances across all pools

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -2,7 +2,6 @@ package concentrated_liquidity_test
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -449,9 +448,6 @@ func (s *KeeperTestSuite) runMultipleAuthorizedUptimes(tests func()) {
 
 // runMultiplePositionRanges runs various test constructions and invariants on the given position ranges.
 func (s *KeeperTestSuite) runMultiplePositionRanges(ranges [][]int64, rangeTestParams RangeTestParams) {
-	// Preset seed to ensure deterministic test runs.
-	rand.Seed(2)
-
 	// TODO: add pool-related fuzz params (spread factor & number of pools)
 	pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, rangeTestParams.tickSpacing, rangeTestParams.spreadFactor)
 

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -292,7 +292,7 @@ func (s *KeeperTestSuite) addUptimeGrowthInsideRange(ctx sdk.Context, poolId uin
 //   - If lowerTick < upperTick <= currentTick, we add to both lowerTick and upperTick's uptime trackers,
 //     the former to put the growth below the tick range and the latter to keep both ticks consistent (since
 //     lowerTick's uptime trackers are a subset of upperTick's in this case).
-func (s *KeeperTestSuite) addUptimeGrowthOutsideRange(ctx sdk.Context, poolId uint64, owner sdk.AccAddress, currentTick, lowerTick, upperTick int64, uptimeGrowthToAdd []sdk.DecCoins) {
+func (s *KeeperTestSuite) addUptimeGrowthOutsideRange(ctx sdk.Context, poolId uint64, currentTick, lowerTick, upperTick int64, uptimeGrowthToAdd []sdk.DecCoins) {
 	s.Require().True(lowerTick <= upperTick)
 
 	// Note that we process adds to global accums at the end to ensure that they don't affect the behavior of uninitialized ticks.

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -1448,10 +1448,7 @@ func (s *KeeperTestSuite) TestSendCoinsBetweenPoolAndUser() {
 			// store pool interface
 			poolI, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, 1)
 			s.Require().NoError(err)
-			concentratedPool, ok := poolI.(types.ConcentratedPoolExtension)
-			if !ok {
-				s.FailNow("poolI is not a ConcentratedPoolExtension")
-			}
+			concentratedPool := poolI
 
 			// fund pool address and user address
 			s.FundAcc(poolI.GetAddress(), sdk.NewCoins(sdk.NewCoin("eth", osmomath.NewInt(10000000000000)), sdk.NewCoin("usdc", osmomath.NewInt(1000000000000))))
@@ -1688,10 +1685,8 @@ func (s *KeeperTestSuite) TestUpdatePosition() {
 				// validate if pool liquidity has been updated properly
 				poolI, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, tc.poolId)
 				s.Require().NoError(err)
-				concentratedPool, ok := poolI.(types.ConcentratedPoolExtension)
-				if !ok {
-					s.FailNow("poolI is not a ConcentratedPoolExtension")
-				}
+				concentratedPool := poolI
+
 				s.Require().Equal(tc.expectedPoolLiquidity, concentratedPool.GetLiquidity())
 
 				// Test that liquidity update time was successfully changed.

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -2187,7 +2187,8 @@ func (s *KeeperTestSuite) TestValidatePositionUpdateById() {
 				s.Require().NoError(err)
 				owner, err := sdk.AccAddressFromBech32(position.Address)
 				s.Require().NoError(err)
-				s.clk.SetPosition(s.Ctx, defaultPoolId, owner, position.LowerTick, position.UpperTick, position.JoinTime, osmomath.OneDec(), position.PositionId, 0)
+				err = s.clk.SetPosition(s.Ctx, defaultPoolId, owner, position.LowerTick, position.UpperTick, position.JoinTime, osmomath.OneDec(), position.PositionId, 0)
+				s.Require().NoError(err)
 			}
 
 			err := clKeeper.ValidatePositionUpdateById(s.Ctx, tc.positionId, updateInitiator, tc.lowerTickGiven, tc.upperTickGiven, tc.liquidityDeltaGiven, tc.joinTimeGiven, tc.poolIdGiven)

--- a/x/concentrated-liquidity/math/math_test.go
+++ b/x/concentrated-liquidity/math/math_test.go
@@ -380,10 +380,10 @@ type sqrtRoundingTestCase struct {
 
 func runSqrtRoundingTestCase(
 	t *testing.T,
-	name string,
 	fn func(osmomath.BigDec, osmomath.BigDec, osmomath.BigDec) osmomath.BigDec,
 	cases map[string]sqrtRoundingTestCase,
 ) {
+	t.Helper()
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
@@ -418,7 +418,7 @@ func TestGetNextSqrtPriceFromAmount0InRoundingUp(t *testing.T) {
 			expected: osmomath.MustNewBigDecFromStr("70.666663910857144331148691821263626767"),
 		},
 	}
-	runSqrtRoundingTestCase(t, "TestGetNextSqrtPriceFromAmount0InRoundingUp", math.GetNextSqrtPriceFromAmount0InRoundingUp, tests)
+	runSqrtRoundingTestCase(t, math.GetNextSqrtPriceFromAmount0InRoundingUp, tests)
 }
 
 // Estimates are computed with x/concentrated-liquidity/python/clmath.py
@@ -439,7 +439,7 @@ func TestGetNextSqrtPriceFromAmount0OutRoundingUp(t *testing.T) {
 			expected: osmomath.MustNewBigDecFromStr("2.5"),
 		},
 	}
-	runSqrtRoundingTestCase(t, "TestGetNextSqrtPriceFromAmount0OutRoundingUp", math.GetNextSqrtPriceFromAmount0OutRoundingUp, tests)
+	runSqrtRoundingTestCase(t, math.GetNextSqrtPriceFromAmount0OutRoundingUp, tests)
 }
 
 // Estimates are computed with x/concentrated-liquidity/python/clmath.py
@@ -468,7 +468,7 @@ func TestGetNextSqrtPriceFromAmount1InRoundingDown(t *testing.T) {
 			expected: osmomath.MustNewBigDecFromStr("70.738319930382329008049494613660784220"),
 		},
 	}
-	runSqrtRoundingTestCase(t, "TestGetNextSqrtPriceFromAmount1InRoundingDown", math.GetNextSqrtPriceFromAmount1InRoundingDown, tests)
+	runSqrtRoundingTestCase(t, math.GetNextSqrtPriceFromAmount1InRoundingDown, tests)
 }
 
 func TestGetNextSqrtPriceFromAmount1OutRoundingDown(t *testing.T) {
@@ -488,5 +488,5 @@ func TestGetNextSqrtPriceFromAmount1OutRoundingDown(t *testing.T) {
 			expected: osmomath.MustNewBigDecFromStr("2.5"),
 		},
 	}
-	runSqrtRoundingTestCase(t, "TestGetNextSqrtPriceFromAmount1OutRoundingDown", math.GetNextSqrtPriceFromAmount1OutRoundingDown, tests)
+	runSqrtRoundingTestCase(t, math.GetNextSqrtPriceFromAmount1OutRoundingDown, tests)
 }

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -19,11 +19,8 @@ var (
 	// spot price - (10^(spot price exponent - 6 - 1))
 	// Note we get spot price exponent by counting the number of digits in the max spot price and subtracting 1.
 	closestPriceBelowMaxPriceDefaultTickSpacing = types.MaxSpotPrice.Sub(osmomath.NewDec(10).PowerMut(uint64(len(types.MaxSpotPrice.TruncateInt().String()) - 1 - int(-types.ExponentAtPriceOne) - 1)))
-	// min tick + 10 ^ -expoentAtPriceOne
-	closestTickAboveMinPriceDefaultTickSpacing = osmomath.NewInt(types.MinInitializedTick).Add(osmomath.NewInt(10).ToLegacyDec().Power(uint64(types.ExponentAtPriceOne * -1)).TruncateInt())
 
 	smallestBigDec = osmomath.SmallestBigDec()
-	bigOneDec      = osmomath.OneDec()
 	bigTenDec      = osmomath.NewBigDec(10)
 )
 
@@ -394,7 +391,7 @@ func TestPriceToTick(t *testing.T) {
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {
-			// surpress error here, we only listen to errors from system under test.
+			// suppress error here, we only listen to errors from system under test.
 			tick, _ := math.CalculatePriceToTick(tc.price)
 
 			// With tick spacing of one, no rounding should occur.

--- a/x/concentrated-liquidity/model/pool_test.go
+++ b/x/concentrated-liquidity/model/pool_test.go
@@ -53,7 +53,6 @@ func TestConcentratedPoolTestSuite(t *testing.T) {
 
 // TestGetAddress tests the GetAddress method of pool
 func (s *ConcentratedPoolTestSuite) TestGetAddress() {
-
 	tests := []struct {
 		name          string
 		expectedPanic bool
@@ -94,7 +93,6 @@ func (s *ConcentratedPoolTestSuite) TestGetAddress() {
 
 // TestGetIncentivesAddress tests the GetIncentivesAddress method of pool
 func (s *ConcentratedPoolTestSuite) TestGetIncentivesAddress() {
-
 	tests := []struct {
 		name          string
 		expectedPanic bool
@@ -564,11 +562,11 @@ func (s *ConcentratedPoolTestSuite) TestNewConcentratedLiquidityPool() {
 	}
 }
 
-func (suite *ConcentratedPoolTestSuite) TestCalcActualAmounts() {
+func (s *ConcentratedPoolTestSuite) TestCalcActualAmounts() {
 	var (
 		tickToSqrtPrice = func(tick int64) osmomath.BigDec {
 			_, sqrtPrice, err := clmath.TickToSqrtPrice(tick)
-			suite.Require().NoError(err)
+			s.Require().NoError(err)
 			return sqrtPrice
 		}
 
@@ -689,8 +687,8 @@ func (suite *ConcentratedPoolTestSuite) TestCalcActualAmounts() {
 
 	for name, tc := range tests {
 		tc := tc
-		suite.Run(name, func() {
-			suite.Setup()
+		s.Run(name, func() {
+			s.Setup()
 
 			pool := model.Pool{
 				CurrentTick: tc.currentTick,
@@ -698,35 +696,35 @@ func (suite *ConcentratedPoolTestSuite) TestCalcActualAmounts() {
 			_, currenTicktSqrtPrice, _ := clmath.TickToSqrtPrice(pool.CurrentTick)
 			pool.CurrentSqrtPrice = currenTicktSqrtPrice
 
-			actualAmount0, actualAmount1, err := pool.CalcActualAmounts(suite.Ctx, tc.lowerTick, tc.upperTick, tc.liquidityDelta)
+			actualAmount0, actualAmount1, err := pool.CalcActualAmounts(s.Ctx, tc.lowerTick, tc.upperTick, tc.liquidityDelta)
 
 			if tc.expectError != nil {
-				suite.Require().Error(err)
-				suite.Require().ErrorIs(err, tc.expectError)
+				s.Require().Error(err)
+				s.Require().ErrorIs(err, tc.expectError)
 				return
 			}
-			suite.Require().NoError(err)
+			s.Require().NoError(err)
 
-			suite.Require().Equal(tc.expectedAmount0, actualAmount0)
-			suite.Require().Equal(tc.expectedAmount1, actualAmount1)
+			s.Require().Equal(tc.expectedAmount0, actualAmount0)
+			s.Require().Equal(tc.expectedAmount1, actualAmount1)
 
 			// Note: to test rounding invariants around positive and negative liquidity.
 			if tc.shouldTestRoundingInvariant {
-				actualAmount0Neg, actualAmount1Neg, err := pool.CalcActualAmounts(suite.Ctx, tc.lowerTick, tc.upperTick, tc.liquidityDelta.Neg())
-				suite.Require().NoError(err)
+				actualAmount0Neg, actualAmount1Neg, err := pool.CalcActualAmounts(s.Ctx, tc.lowerTick, tc.upperTick, tc.liquidityDelta.Neg())
+				s.Require().NoError(err)
 
 				amt0Diff := actualAmount0.Sub(actualAmount0Neg.Neg())
 				amt1Diff := actualAmount1.Sub(actualAmount1Neg.Neg())
 
 				// Difference is between 0 and 1 due to positive liquidity rounding up and negative liquidity performing math normally.
-				suite.Require().True(amt0Diff.IsPositive() && amt0Diff.LT(osmomath.OneDec()))
-				suite.Require().True(amt1Diff.IsPositive() && amt1Diff.LT(osmomath.OneDec()))
+				s.Require().True(amt0Diff.IsPositive() && amt0Diff.LT(osmomath.OneDec()))
+				s.Require().True(amt1Diff.IsPositive() && amt1Diff.LT(osmomath.OneDec()))
 			}
 		})
 	}
 }
 
-func (suite *ConcentratedPoolTestSuite) TestUpdateLiquidityIfActivePosition() {
+func (s *ConcentratedPoolTestSuite) TestUpdateLiquidityIfActivePosition() {
 	var (
 		defaultLiquidityDelta = osmomath.NewDec(1000)
 		defaultLiquidityAmt   = osmomath.NewDec(1000)
@@ -783,8 +781,8 @@ func (suite *ConcentratedPoolTestSuite) TestUpdateLiquidityIfActivePosition() {
 
 	for name, tc := range tests {
 		tc := tc
-		suite.Run(name, func() {
-			suite.Setup()
+		s.Run(name, func() {
+			s.Setup()
 
 			pool := model.Pool{
 				CurrentTick:          tc.currentTick,
@@ -793,20 +791,20 @@ func (suite *ConcentratedPoolTestSuite) TestUpdateLiquidityIfActivePosition() {
 			_, currenTicktSqrtPrice, _ := clmath.TickToSqrtPrice(pool.CurrentTick)
 			pool.CurrentSqrtPrice = currenTicktSqrtPrice
 
-			wasUpdated := pool.UpdateLiquidityIfActivePosition(suite.Ctx, tc.lowerTick, tc.upperTick, tc.liquidityDelta)
+			wasUpdated := pool.UpdateLiquidityIfActivePosition(s.Ctx, tc.lowerTick, tc.upperTick, tc.liquidityDelta)
 			if tc.lowerTick <= tc.currentTick && tc.currentTick <= tc.upperTick {
-				suite.Require().True(wasUpdated)
+				s.Require().True(wasUpdated)
 				expectedCurrentTickLiquidity := defaultLiquidityAmt.Add(tc.liquidityDelta)
-				suite.Require().Equal(expectedCurrentTickLiquidity, pool.CurrentTickLiquidity)
+				s.Require().Equal(expectedCurrentTickLiquidity, pool.CurrentTickLiquidity)
 			} else {
-				suite.Require().False(wasUpdated)
-				suite.Require().Equal(defaultLiquidityAmt, pool.CurrentTickLiquidity)
+				s.Require().False(wasUpdated)
+				s.Require().Equal(defaultLiquidityAmt, pool.CurrentTickLiquidity)
 			}
 		})
 	}
 }
 
-func (suite *ConcentratedPoolTestSuite) TestPoolSetMethods() {
+func (s *ConcentratedPoolTestSuite) TestPoolSetMethods() {
 	var (
 		newCurrentTick      = DefaultCurrTick
 		newCurrentSqrtPrice = DefaultCurrSqrtPrice
@@ -829,17 +827,17 @@ func (suite *ConcentratedPoolTestSuite) TestPoolSetMethods() {
 
 	for name, tc := range tests {
 		tc := tc
-		suite.Run(name, func() {
-			suite.Setup()
+		s.Run(name, func() {
+			s.Setup()
 
-			currentBlockTime := suite.Ctx.BlockTime()
+			currentBlockTime := s.Ctx.BlockTime()
 
 			// Create the pool and check that the initial values are not equal to the new values we will set.
-			clPool := suite.PrepareConcentratedPool()
-			suite.Require().NotEqual(tc.currentTick, clPool.GetCurrentTick())
-			suite.Require().NotEqual(tc.currentSqrtPrice, clPool.GetCurrentSqrtPrice())
-			suite.Require().NotEqual(tc.tickSpacing, clPool.GetTickSpacing())
-			suite.Require().NotEqual(currentBlockTime.Add(tc.lastLiquidityUpdateDelta), clPool.GetLastLiquidityUpdate())
+			clPool := s.PrepareConcentratedPool()
+			s.Require().NotEqual(tc.currentTick, clPool.GetCurrentTick())
+			s.Require().NotEqual(tc.currentSqrtPrice, clPool.GetCurrentSqrtPrice())
+			s.Require().NotEqual(tc.tickSpacing, clPool.GetTickSpacing())
+			s.Require().NotEqual(currentBlockTime.Add(tc.lastLiquidityUpdateDelta), clPool.GetLastLiquidityUpdate())
 
 			// Run the setters.
 			clPool.SetCurrentTick(tc.currentTick)
@@ -848,10 +846,10 @@ func (suite *ConcentratedPoolTestSuite) TestPoolSetMethods() {
 			clPool.SetLastLiquidityUpdate(currentBlockTime.Add(tc.lastLiquidityUpdateDelta))
 
 			// Check that the values are now equal to the new values.
-			suite.Require().Equal(tc.currentTick, clPool.GetCurrentTick())
-			suite.Require().Equal(tc.currentSqrtPrice, clPool.GetCurrentSqrtPrice())
-			suite.Require().Equal(tc.tickSpacing, clPool.GetTickSpacing())
-			suite.Require().Equal(currentBlockTime.Add(tc.lastLiquidityUpdateDelta), clPool.GetLastLiquidityUpdate())
+			s.Require().Equal(tc.currentTick, clPool.GetCurrentTick())
+			s.Require().Equal(tc.currentSqrtPrice, clPool.GetCurrentSqrtPrice())
+			s.Require().Equal(tc.tickSpacing, clPool.GetTickSpacing())
+			s.Require().Equal(currentBlockTime.Add(tc.lastLiquidityUpdateDelta), clPool.GetLastLiquidityUpdate())
 		})
 	}
 }

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -459,7 +459,6 @@ func (s *KeeperTestSuite) TestCollectIncentives_Events() {
 }
 
 func (s *KeeperTestSuite) TestFungify_Events() {
-
 	s.T().Skip("TODO: re-enable fungify test if message is restored")
 
 	testcases := map[string]struct {

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -619,19 +619,19 @@ func (s *KeeperTestSuite) TestValidateTickSpacingUpdate() {
 
 func (s *KeeperTestSuite) TestGetUserUnbondingPositions() {
 	var (
-		defaultFooAsset balancer.PoolAsset = balancer.PoolAsset{
+		defaultFooAsset = balancer.PoolAsset{
 			Weight: osmomath.NewInt(100),
 			Token:  sdk.NewCoin("foo", osmomath.NewInt(10000)),
 		}
-		defaultBondDenomAsset balancer.PoolAsset = balancer.PoolAsset{
+		defaultBondDenomAsset = balancer.PoolAsset{
 			Weight: osmomath.NewInt(100),
 			Token:  sdk.NewCoin(sdk.DefaultBondDenom, osmomath.NewInt(10000)),
 		}
-		defaultPoolAssets []balancer.PoolAsset = []balancer.PoolAsset{defaultFooAsset, defaultBondDenomAsset}
-		defaultAddress                         = s.TestAccs[0]
-		defaultFunds                           = sdk.NewCoins(defaultPoolAssets[0].Token, sdk.NewCoin("stake", osmomath.NewInt(5000000000)))
-		defaultBlockTime                       = time.Unix(1, 1).UTC()
-		defaultLockedAmt                       = sdk.NewCoins(sdk.NewCoin("cl/pool/1", osmomath.NewInt(10000)))
+		defaultPoolAssets = []balancer.PoolAsset{defaultFooAsset, defaultBondDenomAsset}
+		defaultAddress    = s.TestAccs[0]
+		defaultFunds      = sdk.NewCoins(defaultPoolAssets[0].Token, sdk.NewCoin("stake", osmomath.NewInt(5000000000)))
+		defaultBlockTime  = time.Unix(1, 1).UTC()
+		defaultLockedAmt  = sdk.NewCoins(sdk.NewCoin("cl/pool/1", osmomath.NewInt(10000)))
 	)
 
 	tests := []struct {

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
-	cltypes "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
 )
 
 const (
@@ -400,15 +399,6 @@ func (s *KeeperTestSuite) TestGetNextPositionAndIncrement() {
 	s.Require().Equal(positionId, uint64(3))
 }
 
-type positionOwnershipTest struct {
-	queryPositionOwner sdk.AccAddress
-	queryPositionId    uint64
-	expPass            bool
-
-	setupPositions []sdk.AccAddress
-	poolId         uint64
-}
-
 func (s *KeeperTestSuite) TestGetUserPositions() {
 	s.Setup()
 	defaultAddress := s.TestAccs[0]
@@ -568,7 +558,6 @@ func (s *KeeperTestSuite) TestGetUserPositionsSerialized() {
 
 	for _, test := range tests {
 		s.Run(test.name, func() {
-
 			s.SetupTest()
 			k := s.App.ConcentratedLiquidityKeeper
 
@@ -952,7 +941,7 @@ func (s *KeeperTestSuite) TestHasAnyPositionForPool() {
 
 func (s *KeeperTestSuite) TestCreateFullRangePosition() {
 	var (
-		positionData       cltypes.CreateFullRangePositionData
+		positionData       types.CreateFullRangePositionData
 		concentratedLockId uint64
 		err                error
 	)
@@ -1126,7 +1115,7 @@ func (s *KeeperTestSuite) TestMintSharesAndLock() {
 
 			// Create a position
 			positionId := uint64(0)
-			liquidity := osmomath.ZeroDec()
+			var liquidity osmomath.Dec
 			if test.createFullRangePosition {
 				var err error
 				positionData, err := s.App.ConcentratedLiquidityKeeper.CreateFullRangePosition(s.Ctx, clPool.GetId(), test.owner, DefaultCoins)
@@ -1635,7 +1624,7 @@ func (s *KeeperTestSuite) TestGetAndUpdateFullRangeLiquidity() {
 		s.Require().NoError(err)
 		actualFullRangeLiquidity = actualFullRangeLiquidity.Add(positionData.Liquidity)
 
-		clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPoolId)
+		_, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPoolId)
 		s.Require().NoError(err)
 
 		// Get the full range liquidity for the pool.
@@ -1648,7 +1637,7 @@ func (s *KeeperTestSuite) TestGetAndUpdateFullRangeLiquidity() {
 		_, err = s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, clPoolId, owner, DefaultCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), tc.lowerTick, tc.upperTick)
 		s.Require().NoError(err)
 
-		clPool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPoolId)
+		_, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, clPoolId)
 		s.Require().NoError(err)
 
 		// Test updating the full range liquidity.
@@ -2081,7 +2070,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor)
 
 	// Refetch pool
-	pool, err = s.clk.GetPoolById(s.Ctx, poolId)
+	_, err = s.clk.GetPoolById(s.Ctx, poolId)
 	s.Require().NoError(err)
 
 	// Swap to approximately DefaultCurrTick + 150
@@ -2126,6 +2115,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	})
 
 	s.RunTestCaseWithoutStateUpdates("assert rewards when current tick is below the position with negative accumulator", func(t *testing.T) {
+		t.Helper()
 		// Make closure-local copy of expectedTotalSpreadRewards
 		expectedTotalSpreadRewards := expectedTotalSpreadRewards
 		expectedTotalIncentiveRewards := expectedTotalIncentiveRewards
@@ -2155,6 +2145,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	})
 
 	s.RunTestCaseWithoutStateUpdates("assert rewards when current tick is inside the position with negative accumulator", func(t *testing.T) {
+		t.Helper()
 		// Make closure-local copy of expectedTotalSpreadRewards
 		expectedTotalSpreadRewards := expectedTotalSpreadRewards
 		expectedTotalIncentiveRewards := expectedTotalIncentiveRewards
@@ -2184,6 +2175,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	})
 
 	s.RunTestCaseWithoutStateUpdates("assert rewards when current tick is above the position with negative accumulator", func(t *testing.T) {
+		t.Helper()
 		// Make closure-local copy of expectedTotalSpreadRewards
 		expectedTotalSpreadRewards := expectedTotalSpreadRewards
 		expectedTotalIncentiveRewards := expectedTotalIncentiveRewards

--- a/x/concentrated-liquidity/query_test.go
+++ b/x/concentrated-liquidity/query_test.go
@@ -564,7 +564,7 @@ func (s *KeeperTestSuite) TestGetTickLiquidityNetInDirection() {
 			// with tick spacing > 1, requiring price to tick conversion with rounding.
 			curTick, err := math.CalculateSqrtPriceToTick(osmomath.BigDecFromDec(osmomath.MustMonotonicSqrt(curPrice)))
 			s.Require().NoError(err)
-			var curSqrtPrice osmomath.BigDec = osmomath.OneBigDec()
+			var curSqrtPrice = osmomath.OneBigDec()
 			if test.currentPoolTick > 0 {
 				_, sqrtPrice, err := math.TickToSqrtPrice(test.currentPoolTick)
 				s.Require().NoError(err)

--- a/x/concentrated-liquidity/range_test.go
+++ b/x/concentrated-liquidity/range_test.go
@@ -44,16 +44,12 @@ type RangeTestParams struct {
 	fuzzNumPositions     bool
 	fuzzSwapAmounts      bool
 	fuzzTimeBetweenJoins bool
-	fuzzIncentiveRecords bool
 
 	// -- Optional additional test dimensions --
 
 	// Have a single address for all positions in each range
 	singleAddrPerRange bool
-	// Create new active incentive records between each join
-	newActiveIncentivesBetweenJoins bool
-	// Create new inactive incentive records between each join
-	newInactiveIncentivesBetweenJoins bool
+
 	// Fund each position address with double the expected amount of assets.
 	// Should only be used for cases where join amount gets pushed up due to
 	// precision near min tick.
@@ -143,7 +139,6 @@ func withNoSwap(params RangeTestParams) RangeTestParams {
 // setupRangesAndAssertInvariants sets up the state specified by `testParams` on the given set of ranges.
 // It also asserts global invariants at each intermediate step.
 func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.ConcentratedPoolExtension, ranges [][]int64, testParams RangeTestParams) {
-
 	// --- Parse test params ---
 
 	// Prepare a slice tracking how many positions to create on each range.
@@ -260,7 +255,7 @@ func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.Concentrated
 	s.Require().Equal(sdk.NewCoins(totalAssets...), sdk.NewCoins(poolAssets.Add(poolSpreadRewards...)...))
 
 	// Do a final checkpoint for incentives and then run assertions on expected global claimable value
-	cumulativeEmittedIncentives, lastIncentiveTrackerUpdate = s.trackEmittedIncentives(cumulativeEmittedIncentives, lastIncentiveTrackerUpdate)
+	cumulativeEmittedIncentives, _ = s.trackEmittedIncentives(cumulativeEmittedIncentives, lastIncentiveTrackerUpdate)
 	truncatedEmissions, _ := cumulativeEmittedIncentives.TruncateDecimal()
 
 	// Run global assertions with an optional parameter specifying the expected incentive amount claimable by all positions.

--- a/x/concentrated-liquidity/spread_rewards_test.go
+++ b/x/concentrated-liquidity/spread_rewards_test.go
@@ -1432,7 +1432,7 @@ func (s *KeeperTestSuite) TestFunctional_SpreadRewards_LP() {
 	spreadRewardsCollected := s.collectSpreadRewardsAndCheckInvariance(ctx, 0, DefaultMinTick, DefaultMaxTick, positionDataOne.ID, sdk.NewCoins(), []string{USDC}, [][]int64{ticksActivatedAfterEachSwap})
 	expectedSpreadRewardsTruncated := totalSpreadRewardsExpected
 	for i, spreadRewardToken := range totalSpreadRewardsExpected {
-		// We run expected spread rewards through a cycle of divison and multiplication by liquidity to capture appropriate rounding behavior
+		// We run expected spread rewards through a cycle of division and multiplication by liquidity to capture appropriate rounding behavior
 		expectedSpreadRewardsTruncated[i] = sdk.NewCoin(spreadRewardToken.Denom, spreadRewardToken.Amount.ToLegacyDec().QuoTruncate(positionDataOne.Liquidity).MulTruncate(positionDataOne.Liquidity).TruncateInt())
 	}
 	s.Require().Equal(expectedSpreadRewardsTruncated, spreadRewardsCollected)

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v19/app/apptesting"
 	cl "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity"
-	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/math"
 	clmath "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
@@ -758,7 +757,7 @@ var (
 			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(12892)),
 			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
 			expectedTick: func() int64 {
-				tick, _ := math.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(sqrt4994), DefaultTickSpacing)
+				tick, _ := clmath.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(sqrt4994), DefaultTickSpacing)
 				return tick
 			}(),
 			// Since the next sqrt price is based on the price limit, we can calculate this directly.
@@ -896,7 +895,7 @@ var (
 			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
 			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000085792039652"),
 			expectedTick: func() int64 {
-				tick, _ := math.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(sqrt4994), DefaultTickSpacing)
+				tick, _ := clmath.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(sqrt4994), DefaultTickSpacing)
 				return tick
 			}(),
 			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.668238976219012614"),
@@ -2027,9 +2026,9 @@ func (s *KeeperTestSuite) getExpectedLiquidity(test SwapTest, pool types.Concent
 
 	newLowerTick, newUpperTick := s.lowerUpperPricesToTick(test.newLowerPrice, test.newUpperPrice, pool.GetTickSpacing())
 
-	_, lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
+	_, lowerSqrtPrice, err := clmath.TickToSqrtPrice(newLowerTick)
 	s.Require().NoError(err)
-	_, upperSqrtPrice, err := math.TickToSqrtPrice(newUpperTick)
+	_, upperSqrtPrice, err := clmath.TickToSqrtPrice(newUpperTick)
 	s.Require().NoError(err)
 
 	if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
@@ -2037,7 +2036,7 @@ func (s *KeeperTestSuite) getExpectedLiquidity(test SwapTest, pool types.Concent
 		test.poolLiqAmount1 = DefaultAmt1
 	}
 
-	expectedLiquidity := math.GetLiquidityFromAmounts(DefaultCurrSqrtPrice, lowerSqrtPrice, upperSqrtPrice, test.poolLiqAmount0, test.poolLiqAmount1)
+	expectedLiquidity := clmath.GetLiquidityFromAmounts(DefaultCurrSqrtPrice, lowerSqrtPrice, upperSqrtPrice, test.poolLiqAmount0, test.poolLiqAmount1)
 	return expectedLiquidity
 }
 

--- a/x/concentrated-liquidity/swaps_tick_cross_test.go
+++ b/x/concentrated-liquidity/swaps_tick_cross_test.go
@@ -208,7 +208,7 @@ func (s *KeeperTestSuite) setupPoolAndPositions(testTickSpacing uint64, position
 	s.Require().NoError(err)
 
 	// Refetch pool as the first position updated its state.
-	pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
+	_, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
 	s.Require().NoError(err)
 
 	// Create all narrow range positions per given tick spacings away from the current tick
@@ -403,7 +403,7 @@ func (s *KeeperTestSuite) computeSwapAmountsInGivenOut(poolId uint64, curSqrtPri
 			if amountOut.IsZero() && isWithinDesiredBucketAfterSwap {
 				nextInitTickSqrtPrice := s.tickToSqrtPrice(liquidityNetAmounts[i+1].TickIndex)
 
-				// We discound by two so that we do no cross any tick and remain in the same bucket.
+				// We discounted by two so that we do no cross any tick and remain in the same bucket.
 				curAmountIn := math.CalcAmount1Delta(currentLiquidity, curSqrtPrice, nextInitTickSqrtPrice, false).QuoInt64(2)
 				amountOut = amountOut.Add(curAmountIn.DecRoundUp())
 			}
@@ -512,7 +512,6 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_Tick_Initialization_And_Crossing() 
 
 	// testCase defines the test case configuration
 	type testCase struct {
-		name        string
 		tickSpacing uint64
 
 		swapTicksAway                  int64
@@ -634,8 +633,8 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_Tick_Initialization_And_Crossing() 
 		s.Require().True(isNarrowInRange)
 
 		var (
-			amountZeroIn   osmomath.Dec    = osmomath.ZeroDec()
-			sqrtPriceStart osmomath.BigDec = pool.GetCurrentSqrtPrice()
+			amountZeroIn   = osmomath.ZeroDec()
+			sqrtPriceStart = pool.GetCurrentSqrtPrice()
 
 			liquidity = pool.GetLiquidity()
 		)
@@ -726,9 +725,9 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_Tick_Initialization_And_Crossing() 
 		s.Require().NoError(err)
 
 		var (
-			amountOneIn    osmomath.Dec    = osmomath.ZeroDec()
-			sqrtPriceStart osmomath.BigDec = pool.GetCurrentSqrtPrice()
-			liquidity                      = pool.GetLiquidity()
+			amountOneIn    = osmomath.ZeroDec()
+			sqrtPriceStart = pool.GetCurrentSqrtPrice()
+			liquidity      = pool.GetLiquidity()
 		)
 
 		if tickToSwapTo >= nr1Position.upperTick {
@@ -953,7 +952,6 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_Tick_Initialization_And_Crossing() 
 		for name, tc := range testCases {
 			tc := tc
 			s.Run(name, func() {
-
 				////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 				// 1. Prepare pool and positions for test
 
@@ -1019,7 +1017,7 @@ func (s *KeeperTestSuite) TestSwaps_Contiguous_Initialized_TickSpacingOne() {
 		// at the end of configured swaps of the test.
 		// See diagram above the definition of defaultTickSpacingsAway variable for layout.
 		// The first position is NR1, the second position is NR2 etc.
-		// That is, the wider range position is preceeds the narrower range position.
+		// That is, the wider range position is precedes the narrower range position.
 		isPositionActiveFlag []bool
 	}
 
@@ -1080,7 +1078,6 @@ func (s *KeeperTestSuite) TestSwaps_Contiguous_Initialized_TickSpacingOne() {
 		// Validate the positions
 		s.Require().NotEmpty(expectedIsPositionActiveFlags)
 		for i, expectedActivePositionIndex := range expectedIsPositionActiveFlags {
-
 			isInRange := pool.IsCurrentTickInRange(positionMeta[i].lowerTick, positionMeta[i].upperTick)
 			s.Require().Equal(expectedActivePositionIndex, isInRange, fmt.Sprintf("position %d", i))
 		}
@@ -1329,7 +1326,7 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_SwapToAllowedBoundaries() {
 		poolId, _ := s.setupPoolAndPositions(tickSpacingOne, defaultTickSpacingsAway, DefaultCoins)
 
 		// Fetch pool
-		pool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
+		_, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
 		s.Require().NoError(err)
 
 		// Compute tokenIn amount necessary to reach the min tick.
@@ -1347,7 +1344,7 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_SwapToAllowedBoundaries() {
 		s.assertPositionOutOfRange(poolId, types.MinInitializedTick, types.MaxTick)
 
 		// Refetch pool
-		pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
+		pool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
 		s.Require().NoError(err)
 
 		// Validate cannot swap left again
@@ -1369,7 +1366,7 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_SwapToAllowedBoundaries() {
 		poolId, _ := s.setupPoolAndPositions(tickSpacingOne, defaultTickSpacingsAway, DefaultCoins)
 
 		// Fetch pool
-		pool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
+		_, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
 		s.Require().NoError(err)
 
 		// Compute tokenIn amount necessary to reach the max tick.
@@ -1390,7 +1387,7 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_SwapToAllowedBoundaries() {
 		s.assertPositionOutOfRange(poolId, types.MinInitializedTick, types.MaxTick)
 
 		// Refetch pool
-		pool, err = s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
+		pool, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, poolId)
 		s.Require().NoError(err)
 
 		// Validate cannot swap right again
@@ -1411,7 +1408,7 @@ func (s *KeeperTestSuite) TestSwapOutGivenIn_SwapToAllowedBoundaries() {
 // that liquidiy is calculated for that position as well as the adjacent position on the swap path.
 // It then repeats this for the other direction.
 func (s *KeeperTestSuite) TestSwapOutGivenIn_GetLiquidityFromAmountsPositionBounds() {
-	// See definiton of defaultTickSpacingsAway for position layout diagram.
+	// See definition of defaultTickSpacingsAway for position layout diagram.
 	poolId, positions := s.setupPoolAndPositions(tickSpacingOne, defaultTickSpacingsAway, DefaultCoins)
 	var (
 		// 3 tick spacings away [30999997, 31000003) (3TS) from the original current tick (31000000)

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy_test.go
@@ -49,7 +49,6 @@ var (
 	defaultAmountReserves   = osmomath.NewInt(1_000_000_000)
 	DefaultCoins            = sdk.NewCoins(sdk.NewCoin(ETH, defaultAmountReserves), sdk.NewCoin(USDC, defaultAmountReserves))
 	oneULPDec               = osmomath.SmallestDec()
-	oneULPBigDec            = osmomath.SmallestDec()
 )
 
 func TestStrategyTestSuite(t *testing.T) {
@@ -61,13 +60,11 @@ func (suite *StrategyTestSuite) SetupTest() {
 }
 
 type tickIteratorTest struct {
-	currentTick     int64
 	preSetPositions []position
 	tickSpacing     uint64
 
 	expectIsValid  bool
 	expectNextTick int64
-	expectError    error
 }
 
 func (suite *StrategyTestSuite) runTickIteratorTest(strategy swapstrategy.SwapStrategy, tc tickIteratorTest) {

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -366,7 +366,6 @@ func (s *KeeperTestSuite) TestInitOrUpdateTick() {
 			} else {
 				s.Require().True(gasConsumed < uint64(types.BaseGasFeeForInitializingTick))
 			}
-
 		})
 	}
 }
@@ -477,7 +476,7 @@ func (s *KeeperTestSuite) TestGetTickInfo() {
 				s.Require().Equal(model.TickInfo{}, tickInfo)
 			} else {
 				s.Require().NoError(err)
-				clPool, err = clKeeper.GetPoolById(s.Ctx, validPoolId)
+				_, err = clKeeper.GetPoolById(s.Ctx, validPoolId)
 				s.Require().NoError(err)
 				s.Require().Equal(test.expectedTickInfo, tickInfo)
 			}

--- a/x/concentrated-liquidity/types/genesis/genesis_test.go
+++ b/x/concentrated-liquidity/types/genesis/genesis_test.go
@@ -22,7 +22,7 @@ func TestValidateGenesis(t *testing.T) {
 		},
 		{
 			name: "invalid params",
-			genesis: *&genesis.GenesisState{
+			genesis: genesis.GenesisState{
 				Params:                types.Params{},
 				PoolData:              genesis.DefaultGenesis().PoolData,
 				NextPositionId:        genesis.DefaultGenesis().GetNextPositionId(),
@@ -32,7 +32,7 @@ func TestValidateGenesis(t *testing.T) {
 		},
 		{
 			name: "next position id is zero",
-			genesis: *&genesis.GenesisState{
+			genesis: genesis.GenesisState{
 				Params:                genesis.DefaultGenesis().GetParams(),
 				PoolData:              genesis.DefaultGenesis().PoolData,
 				NextPositionId:        0,
@@ -42,7 +42,7 @@ func TestValidateGenesis(t *testing.T) {
 		},
 		{
 			name: "next incentive record id is zero",
-			genesis: *&genesis.GenesisState{
+			genesis: genesis.GenesisState{
 				Params:                genesis.DefaultGenesis().GetParams(),
 				PoolData:              genesis.DefaultGenesis().PoolData,
 				NextPositionId:        genesis.DefaultGenesis().GetNextPositionId(),

--- a/x/concentrated-liquidity/types/keys_test.go
+++ b/x/concentrated-liquidity/types/keys_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestReverseRelationTickIndexToBytes tests if TickIndexToBytes and TickIndexFromBytes
-// succesfully converts back to the original value.
+// successfully converts back to the original value.
 func TestReverseRelationTickIndexToBytes(t *testing.T) {
 	tests := map[string]struct {
 		tickIndex int64
@@ -112,10 +112,10 @@ func TestAccumulatorNameKeys(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			name1 := types.KeySpreadRewardPoolAccumulator(tc.poolId)
-			require.NotContains(t, string(name1), accum.KeySeparator)
+			require.NotContains(t, name1, accum.KeySeparator)
 			for i := 0; i < 125; i++ {
 				name2 := types.KeyUptimeAccumulator(tc.poolId, uint64(i))
-				require.NotContains(t, string(name2), accum.KeySeparator)
+				require.NotContains(t, name2, accum.KeySeparator)
 			}
 		})
 	}

--- a/x/concentrated-liquidity/types/msgs_test.go
+++ b/x/concentrated-liquidity/types/msgs_test.go
@@ -32,6 +32,7 @@ func init() {
 }
 
 func runValidateBasicTest(t *testing.T, name string, msg extMsg, expectPass bool, expType string) {
+	t.Helper()
 	if expectPass {
 		require.NoError(t, msg.ValidateBasic(), "test: %v", name)
 		require.Equal(t, msg.Route(), types.RouterKey)


### PR DESCRIPTION
## What is the purpose of the change

This PR lints the concentrated liquidity module.  Observations are that there was a good deal of unused code here. 

## Testing and Verifying

This PR should pass all existing tests, and pass the linter, if it is configured like:

```yaml
run:
  tests: true
  timeout: 5m
```


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? no
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? no

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A
