### PR TITLE
Parallelize some E2E operations within CL E2E test

### DIFF
--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -43,7 +43,7 @@ const (
 	// It is used when we are indifferent about the node we are working with.
 	defaultNodeIndex = 0
 	// waitUntilRepeatPauseTime is the time to wait between each check of the node status.
-	waitUntilRepeatPauseTime = 2 * time.Second
+	waitUntilRepeatPauseTime = 1 * time.Second
 	// waitUntilrepeatMax is the maximum number of times to repeat the wait until condition.
 	waitUntilrepeatMax = 60
 

--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -59,7 +58,7 @@ func New(t *testing.T, containerManager *containers.Manager, id string, initVali
 		},
 		ValidatorInitConfigs:  initValidatorConfigs,
 		VotingPeriod:          config.PropDepositBlocks + numVal*config.PropVoteBlocks + config.PropBufferBlocks,
-		ExpeditedVotingPeriod: config.PropDepositBlocks + numVal*config.PropVoteBlocks + config.PropBufferBlocks - 2,
+		ExpeditedVotingPeriod: config.PropDepositBlocks + numVal*config.PropVoteBlocks + config.PropBufferBlocks - 3,
 		t:                     t,
 		containerManager:      containerManager,
 	}
@@ -263,21 +262,11 @@ func (c *Config) getNodeAtIndex(nodeIndex int) (*NodeConfig, error) {
 }
 
 func (c *Config) SubmitCreateConcentratedPoolProposal(chainANode *NodeConfig) (uint64, error) {
-	propNumber := chainANode.SubmitCreateConcentratedPoolProposal(sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.InitialMinDeposit)))
+	propNumber := chainANode.SubmitCreateConcentratedPoolProposal(sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.InitialMinDeposit)), true)
 
-	chainANode.DepositProposal(propNumber, false)
+	chainANode.DepositProposal(propNumber, true)
 
-	var wg sync.WaitGroup
-
-	for _, n := range c.NodeConfigs {
-		wg.Add(1)
-		go func(nodeConfig *NodeConfig) {
-			defer wg.Done()
-			nodeConfig.VoteYesProposal(initialization.ValidatorWalletName, propNumber)
-		}(n)
-	}
-
-	wg.Wait()
+	AllValsVoteOnProposal(c, propNumber)
 
 	require.Eventually(c.t, func() bool {
 		status, err := chainANode.QueryPropStatus(propNumber)

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -792,6 +792,19 @@ func (n *NodeConfig) ParamChangeProposal(subspace, key string, value []byte, cha
 
 	propNumber := n.SubmitParamChangeProposal(string(proposalJson), initialization.ValidatorWalletName)
 
+	AllValsVoteOnProposal(chain, propNumber)
+
+	require.Eventually(n.t, func() bool {
+		status, err := n.QueryPropStatus(propNumber)
+		if err != nil {
+			return false
+		}
+		return status == proposalStatusPassed
+	}, time.Minute, 10*time.Millisecond)
+	return nil
+}
+
+func AllValsVoteOnProposal(chain *Config, propNumber int) {
 	var wg sync.WaitGroup
 
 	for _, n := range chain.NodeConfigs {
@@ -803,15 +816,6 @@ func (n *NodeConfig) ParamChangeProposal(subspace, key string, value []byte, cha
 	}
 
 	wg.Wait()
-
-	require.Eventually(n.t, func() bool {
-		status, err := n.QueryPropStatus(propNumber)
-		if err != nil {
-			return false
-		}
-		return status == proposalStatusPassed
-	}, time.Minute, 10*time.Millisecond)
-	return nil
 }
 
 func extractProposalIdFromResponse(response string) (int, error) {

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -783,7 +783,7 @@ func (n *NodeConfig) ParamChangeProposal(subspace, key string, value []byte, cha
 			},
 		},
 		IsExpedited: true,
-		Deposit:     strconv.Itoa(int(config.InitialMinExpeditedDeposit)) + "," + appparams.BaseCoinUnit,
+		Deposit:     strconv.Itoa(int(config.InitialMinExpeditedDeposit)) + appparams.BaseCoinUnit,
 	}
 	proposalJson, err := json.Marshal(proposal)
 	if err != nil {

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -312,9 +312,12 @@ func (n *NodeConfig) SubmitSuperfluidProposal(asset string, initialDeposit sdk.C
 	return proposalID
 }
 
-func (n *NodeConfig) SubmitCreateConcentratedPoolProposal(initialDeposit sdk.Coin) int {
+func (n *NodeConfig) SubmitCreateConcentratedPoolProposal(initialDeposit sdk.Coin, isExpedited bool) int {
 	n.LogActionF("Creating concentrated liquidity pool")
 	cmd := []string{"osmosisd", "tx", "gov", "submit-proposal", "create-concentratedliquidity-pool-proposal", "--pool-records=stake,uosmo,100,0.001", "--title=\"create concentrated pool\"", "--description=\"create concentrated pool", "--from=val", fmt.Sprintf("--deposit=%s", initialDeposit)}
+	if isExpedited {
+		cmd = append(cmd, "--is-expedited=true")
+	}
 	resp, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
 

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -782,7 +782,8 @@ func (n *NodeConfig) ParamChangeProposal(subspace, key string, value []byte, cha
 				Value:    value,
 			},
 		},
-		Deposit: "625000000uosmo",
+		IsExpedited: true,
+		Deposit:     strconv.Itoa(int(config.InitialMinExpeditedDeposit)) + "," + appparams.BaseCoinUnit,
 	}
 	proposalJson, err := json.Marshal(proposal)
 	if err != nil {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -98,6 +98,11 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 		s.LargeWasmUpload()
 	})
 
+	s.T().Run("StableSwap", func(t *testing.T) {
+		t.Parallel()
+		s.StableSwap()
+	})
+
 	// Test currently disabled
 	// s.T().Run("ArithmeticTWAP", func(t *testing.T) {
 	// 	t.Parallel()
@@ -116,15 +121,6 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 	}
 
 	// Upgrade Dependent Tests
-
-	if s.skipUpgrade {
-		s.T().Skip("Skipping StableSwapPostUpgrade test")
-	} else {
-		s.T().Run("StableSwapPostUpgrade", func(t *testing.T) {
-			t.Parallel()
-			s.StableSwapPostUpgrade()
-		})
-	}
 
 	if s.skipUpgrade {
 		s.T().Skip("Skipping GeometricTwapMigration test")
@@ -153,29 +149,17 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 			t.Parallel()
 			s.IBCTokenTransferRateLimiting()
 		})
-	}
 
-	if s.skipIBC {
-		s.T().Skip("Skipping IBC tests")
-	} else {
 		s.T().Run("IBCTokenTransferAndCreatePool", func(t *testing.T) {
 			t.Parallel()
 			s.IBCTokenTransferAndCreatePool()
 		})
-	}
 
-	if s.skipIBC {
-		s.T().Skip("Skipping IBC tests")
-	} else {
 		s.T().Run("IBCWasmHooks", func(t *testing.T) {
 			t.Parallel()
 			s.IBCWasmHooks()
 		})
-	}
 
-	if s.skipIBC {
-		s.T().Skip("Skipping IBC tests")
-	} else {
 		s.T().Run("PacketForwarding", func(t *testing.T) {
 			t.Parallel()
 			s.PacketForwarding()
@@ -895,12 +879,12 @@ func (s *IntegrationTestSuite) TickSpacingUpdateProp() {
 		spreadFactor        = "0.001" // 0.1%
 	)
 
-	chainB, chainBNode, err := s.getChainBCfgs()
+	chainA, chainANode, err := s.getChainACfgs()
 	s.Require().NoError(err)
 
 	// Test tick spacing reduction proposal
-	poolID := chainBNode.CreateConcentratedPool(initialization.ValidatorWalletName, denom0, denom1, tickSpacing, spreadFactor)
-	concentratedPool := s.updatedConcentratedPool(chainBNode, poolID)
+	poolID := chainANode.CreateConcentratedPool(initialization.ValidatorWalletName, denom0, denom1, tickSpacing, spreadFactor)
+	concentratedPool := s.updatedConcentratedPool(chainANode, poolID)
 	// Get the current tick spacing
 	currentTickSpacing := concentratedPool.GetTickSpacing()
 
@@ -917,14 +901,14 @@ func (s *IntegrationTestSuite) TickSpacingUpdateProp() {
 	newTickSpacing := cltypes.AuthorizedTickSpacing[indexOfCurrentTickSpacing-1]
 
 	// Run the tick spacing reduction proposal
-	propNumber := chainBNode.SubmitTickSpacingReductionProposal(fmt.Sprintf("%d,%d", poolID, newTickSpacing), sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.InitialMinExpeditedDeposit)), true)
+	propNumber := chainANode.SubmitTickSpacingReductionProposal(fmt.Sprintf("%d,%d", poolID, newTickSpacing), sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.InitialMinExpeditedDeposit)), true)
 
-	chainBNode.DepositProposal(propNumber, true)
+	chainANode.DepositProposal(propNumber, true)
 	// TODO: are we just waiting for 1-2 minutes for no reason here?
 	totalTimeChan := make(chan time.Duration, 1)
-	go chainBNode.QueryPropStatusTimed(propNumber, "PROPOSAL_STATUS_PASSED", totalTimeChan)
+	go chainANode.QueryPropStatusTimed(propNumber, "PROPOSAL_STATUS_PASSED", totalTimeChan)
 
-	chain.AllValsVoteOnProposal(chainB, propNumber)
+	chain.AllValsVoteOnProposal(chainA, propNumber)
 
 	// if querying proposal takes longer than timeoutPeriod, stop the goroutine and error
 	timeoutPeriod := 2 * time.Minute
@@ -937,15 +921,11 @@ func (s *IntegrationTestSuite) TickSpacingUpdateProp() {
 	}
 
 	// Check that the tick spacing was reduced to the expected new tick spacing
-	concentratedPool = s.updatedConcentratedPool(chainBNode, poolID)
+	concentratedPool = s.updatedConcentratedPool(chainANode, poolID)
 	s.Require().Equal(newTickSpacing, concentratedPool.GetTickSpacing())
 }
 
-func (s *IntegrationTestSuite) StableSwapPostUpgrade() {
-	if s.skipUpgrade {
-		s.T().Skip("Skipping StableSwapPostUpgrade test")
-	}
-
+func (s *IntegrationTestSuite) StableSwap() {
 	chainAB, chainABNode, err := s.getChainCfgs()
 	s.Require().NoError(err)
 
@@ -963,8 +943,7 @@ func (s *IntegrationTestSuite) StableSwapPostUpgrade() {
 	coinAIn, coinBIn := fmt.Sprintf("20000%s", denomA), fmt.Sprintf("2%s", denomB)
 
 	chainABNode.BankSend(initialization.WalletFeeTokens.String(), sender, config.StableswapWallet[index])
-	chainABNode.BankSend(coinAIn, sender, config.StableswapWallet[index])
-	chainABNode.BankSend(coinBIn, sender, config.StableswapWallet[index])
+	chainABNode.BankSend(coinAIn+","+coinBIn, sender, config.StableswapWallet[index])
 
 	s.T().Log("performing swaps")
 	chainABNode.SwapExactAmountIn(coinAIn, minAmountOut, fmt.Sprintf("%d", config.PreUpgradeStableSwapPoolId[index]), denomB, config.StableswapWallet[index])
@@ -1054,17 +1033,7 @@ func (s *IntegrationTestSuite) SuperfluidVoting() {
 	propNumber := chainABNode.SubmitTextProposal("superfluid vote overwrite test", sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.InitialMinDeposit)), false)
 	chainABNode.DepositProposal(propNumber, false)
 
-	var wg sync.WaitGroup
-
-	for _, n := range chainAB.NodeConfigs {
-		wg.Add(1)
-		go func(nodeConfig *chain.NodeConfig) {
-			defer wg.Done()
-			nodeConfig.VoteYesProposal(initialization.ValidatorWalletName, propNumber)
-		}(n)
-	}
-
-	wg.Wait()
+	chain.AllValsVoteOnProposal(chainAB, propNumber)
 
 	// set delegator vote to no
 	chainABNode.VoteNoProposal(superfluidVotingWallet, propNumber)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -920,6 +920,10 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 	chainBNode.SetMaxPoolPointsPerTx(int(protorevtypes.DefaultMaxPoolPointsPerTx), adminWalletAddr)
 }
 
+// func (s *IntegrationTestSuite) TestTickSpacingUpdateProp() {
+
+// }
+
 func (s *IntegrationTestSuite) StableSwapPostUpgrade() {
 	if s.skipUpgrade {
 		s.T().Skip("Skipping StableSwapPostUpgrade test")
@@ -1477,9 +1481,8 @@ func (s *IntegrationTestSuite) ArithmeticTWAP() {
 	twapFromBeforeSwapToBeforeSwapOneCA, err := chainABNode.QueryArithmeticTwapToNow(poolId, denomC, denomA, timeBeforeSwap)
 	s.Require().NoError(err)
 
-	chainABNode.BankSend(coinAIn, sender, swapWalletAddr)
-	chainABNode.BankSend(coinBIn, sender, swapWalletAddr)
-	chainABNode.BankSend(coinCIn, sender, swapWalletAddr)
+	swapAmt := coinAIn + "," + coinBIn + "," + coinCIn
+	chainABNode.BankSend(swapAmt, sender, swapWalletAddr)
 
 	s.T().Log("querying for the second TWAP to now before swap, must equal to first")
 	twapFromBeforeSwapToBeforeSwapTwoAB, err := chainABNode.QueryArithmeticTwapToNow(poolId, denomA, denomB, timeBeforeSwap.Add(50*time.Millisecond))

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -844,7 +844,7 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 			chainBNode.WithdrawPosition(addr, defaultLiquidityRemoval, posSet[0].Position.PositionId)
 			// assert
 			createdPositions[i] = chainBNode.QueryConcentratedPositions(addr)
-			s.Require().Equal(posLiquidityBefore, posSet[0].Position.Liquidity.Add(osmomath.MustNewDecFromStr(defaultLiquidityRemoval)))
+			s.Require().Equal(posLiquidityBefore, createdPositions[i][0].Position.Liquidity.Add(osmomath.MustNewDecFromStr(defaultLiquidityRemoval)))
 		}(i)
 	}
 	clwg.Wait()

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -834,7 +834,7 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 	// Assert removing some liquidity
 	// remove default liquidity from the 0th position of every address
 	clwg = sync.WaitGroup{}
-	for i := range createdPositions {
+	for i := 0; i < len(createdPositions); i++ {
 		clwg.Add(1)
 		go func(i int) { // Launch a goroutine
 			defer clwg.Done()
@@ -843,7 +843,7 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 			posLiquidityBefore := posSet[0].Position.Liquidity
 			chainBNode.WithdrawPosition(addr, defaultLiquidityRemoval, posSet[0].Position.PositionId)
 			// assert
-			positionsAddress1 = chainBNode.QueryConcentratedPositions(addr)
+			createdPositions[i] = chainBNode.QueryConcentratedPositions(addr)
 			s.Require().Equal(posLiquidityBefore, posSet[0].Position.Liquidity.Add(osmomath.MustNewDecFromStr(defaultLiquidityRemoval)))
 		}(i)
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -872,6 +872,7 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 	chainBNode.SetMaxPoolPointsPerTx(int(protorevtypes.DefaultMaxPoolPointsPerTx), adminWalletAddr)
 }
 
+// This must be spawned from CL update test suite since it depends on permissionless pool creation
 func (s *IntegrationTestSuite) TickSpacingUpdateProp() {
 	var (
 		denom0              = "uion"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -849,6 +849,10 @@ func (s *IntegrationTestSuite) ConcentratedLiquidity() {
 	}
 	clwg.Wait()
 
+	positionsAddress1 = createdPositions[0]
+	positionsAddress2 = createdPositions[1]
+	positionsAddress3 = createdPositions[2]
+
 	// Assert removing all liquidity
 	// address2: no more positions left
 	allLiquidityAddress2Position1 := positionsAddress2[0].Position.Liquidity

--- a/tests/e2e/helpers_e2e_test.go
+++ b/tests/e2e/helpers_e2e_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -127,6 +128,13 @@ func (s *IntegrationTestSuite) updatedCFMMPool(node *chain.NodeConfig, poolId ui
 	cfmmPool, err := node.QueryCFMMPool(poolId)
 	s.Require().NoError(err)
 	return cfmmPool
+}
+
+func formatCLIInt(i int) string {
+	if i < 0 {
+		return fmt.Sprintf("[%d]", i)
+	}
+	return strconv.Itoa(i)
 }
 
 // Assert returned positions:


### PR DESCRIPTION
Helps remove some of the code repetition as well, we can probably get a lot of this moved to helpers.

* Parallelize some repetitive components within CL code
* Parallelize CL param change proposals
* Move TickSPacingProp to its own parallelizable test
* Lower polling wait time from 2s to 1s
* Lower expedited prop wait time by 1 block
* Make more propsals expedited
* Eliminate redundant skipIBC's
* Remove Stableswap test from depending on upgrade (it no longer does)
* Delete some replicated code for validator votes on a proposal.
* Combine some BankSends together