### PR TITLE
Don't rebuild binaries for test-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.20.5'
+  GO_VERSION: "1.20.5"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -43,22 +43,20 @@ jobs:
             arch: arm64
 
     steps:
-      -
-        name: Check out repository code
+      - name: Check out repository code
         uses: actions/checkout@v3
-      -
-        name: Get git diff
+      - name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
             **/**.wasm
-            **/**.go
+            !tests/**
+            **/**.go !**/*_test.go
             go.mod
             go.sum
             Makefile
             .github/workflows/build.yml
-      -
-        name: 🐿 Setup Golang
+      - name: 🐿 Setup Golang
         uses: actions/setup-go@v4
         if: env.GIT_DIFF
         with:
@@ -66,17 +64,14 @@ jobs:
         env:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}
-      -
-        name: Download Dependencies
+      - name: Download Dependencies
         if: env.GIT_DIFF
         run: go mod download
-      -
-        name: Build osmosisd
+      - name: Build osmosisd
         if: env.GIT_DIFF
         run: |
           GOWRK=off go build cmd/osmosisd/main.go
-      -
-        name: Upload osmosisd artifact
+      - name: Upload osmosisd artifact
         if: env.GIT_DIFF
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Don't run rebuild CI jobs for test-only changes.

These jobs are testing prod binaries, which should not include test compilation.