### PR TITLE
e2e: fast blocks

### DIFF
--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -23,11 +23,11 @@ const (
 	// Pre-upgrade osmosis repo/tag to pull.
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
-	previousVersionOsmoRepository = "osmolabs/osmosis-dev"
-	previousVersionOsmoTag        = "17.0-alpine"
+	previousVersionOsmoRepository = "osmolabs/osmosis"
+	previousVersionOsmoTag        = "18.0.0-alpine"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "17.0.0-rc0"
+	previousVersionInitTag        = "v18-faster-blocks"
 	// Hermes repo/version for relayer
 	relayerRepository = "informalsystems/hermes"
 	relayerTag        = "1.5.1"

--- a/tests/e2e/initialization/node.go
+++ b/tests/e2e/initialization/node.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	sdkcrypto "github.com/cosmos/cosmos-sdk/crypto"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -312,6 +313,14 @@ func (n *internalNode) initNodeConfigs(persistentPeers []string) error {
 	valConfig.LogLevel = "info"
 	valConfig.P2P.PersistentPeers = strings.Join(persistentPeers, ",")
 	valConfig.Storage.DiscardABCIResponses = true
+
+	valConfig.Consensus.TimeoutPropose = time.Millisecond * 300
+	valConfig.Consensus.TimeoutProposeDelta = 0
+	valConfig.Consensus.TimeoutPrevote = 0
+	valConfig.Consensus.TimeoutPrevoteDelta = 0
+	valConfig.Consensus.TimeoutPrecommit = 0
+	valConfig.Consensus.TimeoutPrecommitDelta = 0
+	valConfig.Consensus.TimeoutCommit = 0
 
 	tmconfig.WriteConfigFile(tmCfgPath, valConfig)
 	return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Approx 30s speedup from changing the consensus settings. 

NOTE: When backporting this to v18, we should only backport the node.go changes.

## Testing and Verifying

Tested locally and passes CI