### PR TITLE
fix: enable taker fee cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#6334](https://github.com/osmosis-labs/osmosis/pull/6334) fix: enable taker fee cli
+
 ### API Breaks
 
 * [#6256](https://github.com/osmosis-labs/osmosis/pull/6256) Refactor CalcPriceToTick to operate on BigDec price to support new price range.

--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -43,6 +43,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v19/x/mint"
 	poolincentives "github.com/osmosis-labs/osmosis/v19/x/pool-incentives"
 	poolincentivesclient "github.com/osmosis-labs/osmosis/v19/x/pool-incentives/client"
+	poolmanagerclient "github.com/osmosis-labs/osmosis/v19/x/poolmanager/client"
 	poolmanager "github.com/osmosis-labs/osmosis/v19/x/poolmanager/module"
 	"github.com/osmosis-labs/osmosis/v19/x/protorev"
 	superfluid "github.com/osmosis-labs/osmosis/v19/x/superfluid"
@@ -89,6 +90,7 @@ var AppModuleBasics = []module.AppModuleBasic{
 			cwpoolclient.UploadCodeIdAndWhitelistProposalHandler,
 			cwpoolclient.MigratePoolContractsProposalHandler,
 			txfeesclient.SubmitUpdateFeeTokenProposalHandler,
+			poolmanagerclient.DenomPairTakerFeeProposalHandler,
 		)...,
 	),
 	params.AppModuleBasic{},

--- a/x/poolmanager/client/cli/tx.go
+++ b/x/poolmanager/client/cli/tx.go
@@ -35,6 +35,7 @@ func NewTxCmd() *cobra.Command {
 	osmocli.AddTxCmd(txCmd, NewSwapExactAmountOutCmd)
 	osmocli.AddTxCmd(txCmd, NewSplitRouteSwapExactAmountIn)
 	osmocli.AddTxCmd(txCmd, NewSplitRouteSwapExactAmountOut)
+	txCmd.AddCommand(NewSetDenomPairTakerFeeCmd())
 
 	txCmd.AddCommand(
 		NewCreatePoolCmd(),

--- a/x/poolmanager/client/proposal_handler.go
+++ b/x/poolmanager/client/proposal_handler.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"github.com/osmosis-labs/osmosis/v19/x/poolmanager/client/cli"
+	"github.com/osmosis-labs/osmosis/v19/x/poolmanager/client/rest"
+
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+)
+
+var (
+	DenomPairTakerFeeProposalHandler = govclient.NewProposalHandler(cli.NewCmdHandleDenomPairTakerFeeProposal, rest.ProposalDenomPairTakerFeeRESTHandler)
+)

--- a/x/poolmanager/client/rest/tx.go
+++ b/x/poolmanager/client/rest/tx.go
@@ -1,0 +1,20 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	govrest "github.com/cosmos/cosmos-sdk/x/gov/client/rest"
+)
+
+func ProposalDenomPairTakerFeeRESTHandler(clientCtx client.Context) govrest.ProposalRESTHandler {
+	return govrest.ProposalRESTHandler{
+		SubRoute: "denom-pair-taker-fee",
+		Handler:  emptyHandler(clientCtx),
+	}
+}
+
+func emptyHandler(clientCtx client.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The "denom pair taker fee" prop CLI was not enabled. Also, the CLI that the DAO contract can use to set denom pairs was also not activated. This does both.

## Testing and Verifying

Locally installed and now see the CLI entry.
