### PR TITLE
[x/lockup] reduce log verbosity on `InitializeAllLocks()` 

### DIFF
--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -619,7 +619,7 @@ func (k Keeper) InitializeAllLocks(ctx sdk.Context, locks []types.PeriodLock) er
 	for i, lock := range locks {
 		if i%25000 == 0 {
 			msg := fmt.Sprintf("Reset %d lock refs, cur lock ID %d", i, lock.ID)
-			ctx.Logger().Info(msg)
+			ctx.Logger().Debug(msg)
 		}
 		err := k.setLockAndAddLockRefs(ctx, lock)
 		if err != nil {
@@ -666,7 +666,7 @@ func (k Keeper) writeDurationValuesToAccumTree(ctx sdk.Context, denom string, du
 	// add them all to accumulation store
 	msg := fmt.Sprintf("Setting accumulation entries for locks for %s, there are %d distinct durations",
 		denom, len(durations))
-	ctx.Logger().Info(msg)
+	ctx.Logger().Debug(msg)
 	for _, d := range durations {
 		amt := durationValueMap[d]
 		k.accumulationStore(ctx, denom).Increase(accumulationKey(d), amt)
@@ -683,7 +683,7 @@ func (k Keeper) InitializeAllSyntheticLocks(ctx sdk.Context, syntheticLocks []ty
 	for i, synthLock := range syntheticLocks {
 		if i%25000 == 0 {
 			msg := fmt.Sprintf("Reset %d synthetic lock refs", i)
-			ctx.Logger().Info(msg)
+			ctx.Logger().Debug(msg)
 		}
 
 		// Add to the accumlation store cache
@@ -730,7 +730,7 @@ func (k Keeper) InitializeAllSyntheticLocks(ctx sdk.Context, syntheticLocks []ty
 		// add them all to accumulation store
 		msg := fmt.Sprintf("Setting accumulation entries for locks for %s, there are %d distinct durations",
 			denom, len(durations))
-		ctx.Logger().Info(msg)
+		ctx.Logger().Debug(msg)
 		for _, d := range durations {
 			amt := curDurationMap[d]
 			k.accumulationStore(ctx, denom).Increase(accumulationKey(d), amt)


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this change is to reduce the verbosity of the logs generated during the initialization of the x/lockup module. Currently, there are many log lines that are not particularly useful in normal operations.

(small sample)

```
...
4:43PM INF Setting accumulation entries for locks for gamm/pool/837/superbonding/osmovaloper1zlymlax05tg9km9jyw496jx60v86m454a3xf3m, there are 1 distinct durations
4:43PM INF Setting accumulation entries for locks for gamm/pool/837/superunbonding/osmovaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9ua8h4lf, there are 1 distinct durations
4:43PM INF Setting accumulation entries for locks for gamm/pool/840/superbonding/osmovaloper103s29j7dyc3utljce802m38p2kk89taj0r2hxa, there are 1 distinct durations
...
```

This PR updates the logging level from INFO to DEBUG to reduce the verbosity of the logs.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A