### PR TITLE
fix: set name, display and symbol of denom metadata in tokenfactory's CreateDenom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### State Breaking
+
+* [#6344](https://github.com/osmosis-labs/osmosis/pull/6344) fix: set name, display and symbol of denom metadata in tokenfactory's CreateDenom
+
 ### Bug Fixes
 
 * [#6334](https://github.com/osmosis-labs/osmosis/pull/6334) fix: enable taker fee cli

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -35,7 +35,10 @@ func (k Keeper) createDenomAfterValidation(ctx sdk.Context, creatorAddr string, 
 				Denom:    denom,
 				Exponent: 0,
 			}},
-			Base: denom,
+			Base:    denom,
+			Name:    denom,
+			Symbol:  denom,
+			Display: denom,
 		}
 
 		k.bankKeeper.SetDenomMetaData(ctx, denomMetaData)

--- a/x/tokenfactory/keeper/createdenom_test.go
+++ b/x/tokenfactory/keeper/createdenom_test.go
@@ -175,7 +175,10 @@ func (s *KeeperTestSuite) TestCreateDenom() {
 						Denom:    res.GetNewTokenDenom(),
 						Exponent: 0,
 					}},
-					Base: res.GetNewTokenDenom(),
+					Base:    res.GetNewTokenDenom(),
+					Display: res.GetNewTokenDenom(),
+					Name:    res.GetNewTokenDenom(),
+					Symbol:  res.GetNewTokenDenom(),
 				}, metadata)
 			} else {
 				s.Require().Error(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6343 

## What is the purpose of the change

This pull request sets the name, symbol and display fields of a denom metadata when denom is created by the tokenfactory module.

## Testing and Verifying

This change added tests and can be verified as follows:

  - *Extended unit tests of genesis and createdenom to reflect reproducing the bug being fixed by this change*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A