### PR TITLE
Demo: break spot price API to operate on BigDec

### DIFF
--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -294,7 +294,7 @@ func (s *KeeperTestHelper) CalcAmoutOfTokenToGetTargetPrice(ctx sdk.Context, poo
 	// Amount of quote token need to trade to get target spot price
 	// AmoutQuoteTokenNeedToTrade = AmoutQuoTokenNow * ((targetSpotPrice/spotPriceNow)^((weight_base/(weight_base + weight_quote))) -1 )
 
-	ratioPrice := targetSpotPrice.Quo(spotPriceNow)
+	ratioPrice := targetSpotPrice.Quo(spotPriceNow.Dec())
 	ratioWeight := (baseAsset.Weight.ToLegacyDec()).Quo(baseAsset.Weight.ToLegacyDec().Add(quoteAsset.Weight.ToLegacyDec()))
 
 	amountTrade = quoteAsset.Token.Amount.ToLegacyDec().Mul(osmomath.Pow(ratioPrice, ratioWeight).Sub(osmomath.OneDec()))

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -393,7 +393,7 @@ func (s *KeeperTestHelper) SetupGammPoolsWithBondDenomMultiplier(multipliers []o
 
 // SwapAndSetSpotPrice runs a swap to set Spot price of a pool using arbitrary values
 // returns spot price after the arbitrary swap.
-func (s *KeeperTestHelper) SwapAndSetSpotPrice(poolId uint64, fromAsset sdk.Coin, toAsset sdk.Coin) osmomath.Dec {
+func (s *KeeperTestHelper) SwapAndSetSpotPrice(poolId uint64, fromAsset sdk.Coin, toAsset sdk.Coin) osmomath.BigDec {
 	// create a dummy account
 	acc1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address().Bytes())
 

--- a/app/upgrades/v16/upgrades_test.go
+++ b/app/upgrades/v16/upgrades_test.go
@@ -147,7 +147,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 				s.Require().Equal(v16.DAIIBCDenom, concentratedTypePool.GetToken1())
 
 				// Validate that the spot price of the CL pool is what we expect
-				osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), osmomath.BigDecFromDec(balancerSpotPrice))
+				osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), balancerSpotPrice)
 
 				// Validate that link was created.
 				migrationInfo, err := s.App.GAMMKeeper.GetAllMigrationInfo(s.Ctx)

--- a/app/upgrades/v17/upgrades_test.go
+++ b/app/upgrades/v17/upgrades_test.go
@@ -295,7 +295,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 					s.Require().Equal(assetPair.QuoteAsset, concentratedTypePool.GetToken1())
 
 					// Validate that the spot price of the CL pool is what we expect
-					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), osmomath.BigDecFromDec(balancerSpotPrice))
+					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), balancerSpotPrice)
 
 					// Validate that the link is correct.
 					migrationInfo, err := s.App.GAMMKeeper.GetAllMigrationInfo(s.Ctx)
@@ -461,7 +461,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 					s.Require().Equal(quoteAsset, concentratedTypePool.GetToken1())
 
 					// Validate that the spot price of the CL pool is what we expect
-					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), osmomath.BigDecFromDec(balancerSpotPrice))
+					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), balancerSpotPrice)
 
 					// Validate that the link is correct.
 					migrationInfo, err := s.App.GAMMKeeper.GetAllMigrationInfo(s.Ctx)

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -486,8 +486,8 @@ func updateTWAPGenesis(appGenState map[string]json.RawMessage) func(twapGenState
 					Asset1Denom:                 denomPair.Denom0,
 					Height:                      1,
 					Time:                        time.Date(2023, 0o2, 1, 0, 0, 0, 0, time.UTC), // some time in the past.
-					P0LastSpotPrice:             sp0,
-					P1LastSpotPrice:             sp1,
+					P0LastSpotPrice:             sp0.Dec(),
+					P1LastSpotPrice:             sp1.Dec(),
 					P0ArithmeticTwapAccumulator: osmomath.ZeroDec(),
 					P1ArithmeticTwapAccumulator: osmomath.ZeroDec(),
 					GeometricTwapAccumulator:    osmomath.ZeroDec(),

--- a/tests/mocks/cfmm_pool.go
+++ b/tests/mocks/cfmm_pool.go
@@ -10,6 +10,7 @@ import (
 
 	types "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
+	osmomath "github.com/osmosis-labs/osmosis/osmomath"
 	types0 "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 )
 
@@ -51,7 +52,7 @@ func (mr *MockCFMMPoolIMockRecorder) AsSerializablePool() *gomock.Call {
 }
 
 // CalcExitPoolCoinsFromShares mocks base method.
-func (m *MockCFMMPoolI) CalcExitPoolCoinsFromShares(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockCFMMPoolI) CalcExitPoolCoinsFromShares(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcExitPoolCoinsFromShares", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -66,7 +67,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcExitPoolCoinsFromShares(ctx, numShares,
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockCFMMPoolI) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -81,10 +82,10 @@ func (mr *MockCFMMPoolIMockRecorder) CalcInAmtGivenOut(ctx, tokenOut, tokenInDen
 }
 
 // CalcJoinPoolNoSwapShares mocks base method.
-func (m *MockCFMMPoolI) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockCFMMPoolI) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -97,10 +98,10 @@ func (mr *MockCFMMPoolIMockRecorder) CalcJoinPoolNoSwapShares(ctx, tokensIn, spr
 }
 
 // CalcJoinPoolShares mocks base method.
-func (m *MockCFMMPoolI) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockCFMMPoolI) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -113,7 +114,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcJoinPoolShares(ctx, tokensIn, spreadFac
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -128,7 +129,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDen
 }
 
 // ExitPool mocks base method.
-func (m *MockCFMMPoolI) ExitPool(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockCFMMPoolI) ExitPool(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitPool", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -157,10 +158,10 @@ func (mr *MockCFMMPoolIMockRecorder) GetAddress() *gomock.Call {
 }
 
 // GetExitFee mocks base method.
-func (m *MockCFMMPoolI) GetExitFee(ctx types.Context) types.Dec {
+func (m *MockCFMMPoolI) GetExitFee(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExitFee", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -185,10 +186,10 @@ func (mr *MockCFMMPoolIMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockCFMMPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockCFMMPoolI) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -196,20 +197,6 @@ func (m *MockCFMMPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
 func (mr *MockCFMMPoolIMockRecorder) GetSpreadFactor(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockCFMMPoolI)(nil).GetSpreadFactor), ctx)
-}
-
-// GetTakerFee mocks base method.
-func (m *MockCFMMPoolI) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockCFMMPoolIMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockCFMMPoolI)(nil).GetTakerFee))
 }
 
 // GetTotalPoolLiquidity mocks base method.
@@ -227,10 +214,10 @@ func (mr *MockCFMMPoolIMockRecorder) GetTotalPoolLiquidity(ctx interface{}) *gom
 }
 
 // GetTotalShares mocks base method.
-func (m *MockCFMMPoolI) GetTotalShares() types.Int {
+func (m *MockCFMMPoolI) GetTotalShares() osmomath.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalShares")
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	return ret0
 }
 
@@ -269,10 +256,10 @@ func (mr *MockCFMMPoolIMockRecorder) IsActive(ctx interface{}) *gomock.Call {
 }
 
 // JoinPool mocks base method.
-func (m *MockCFMMPoolI) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockCFMMPoolI) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPool", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -284,10 +271,10 @@ func (mr *MockCFMMPoolIMockRecorder) JoinPool(ctx, tokensIn, spreadFactor interf
 }
 
 // JoinPoolNoSwap mocks base method.
-func (m *MockCFMMPoolI) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockCFMMPoolI) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -322,23 +309,11 @@ func (mr *MockCFMMPoolIMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockCFMMPoolI)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockCFMMPoolI) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockCFMMPoolIMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockCFMMPoolI)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockCFMMPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockCFMMPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -364,7 +339,7 @@ func (mr *MockCFMMPoolIMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockCFMMPoolI) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -379,7 +354,7 @@ func (mr *MockCFMMPoolIMockRecorder) SwapInAmtGivenOut(ctx, tokenOut, tokenInDen
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -431,7 +406,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) AsSerializablePool() *gomock.C
 }
 
 // CalcExitPoolCoinsFromShares mocks base method.
-func (m *MockPoolAmountOutExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockPoolAmountOutExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcExitPoolCoinsFromShares", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -446,7 +421,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcExitPoolCoinsFromShares(ct
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -461,10 +436,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcInAmtGivenOut(ctx, tokenOu
 }
 
 // CalcJoinPoolNoSwapShares mocks base method.
-func (m *MockPoolAmountOutExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockPoolAmountOutExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -477,10 +452,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolNoSwapShares(ctx, 
 }
 
 // CalcJoinPoolShares mocks base method.
-func (m *MockPoolAmountOutExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockPoolAmountOutExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -493,7 +468,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolShares(ctx, tokens
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -508,10 +483,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcOutAmtGivenIn(ctx, tokenIn
 }
 
 // CalcTokenInShareAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) CalcTokenInShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount types.Int, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) CalcTokenInShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount osmomath.Int, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcTokenInShareAmountOut", ctx, tokenInDenom, shareOutAmount, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -523,7 +498,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcTokenInShareAmountOut(ctx,
 }
 
 // ExitPool mocks base method.
-func (m *MockPoolAmountOutExtension) ExitPool(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockPoolAmountOutExtension) ExitPool(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitPool", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -538,10 +513,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) ExitPool(ctx, numShares, exitF
 }
 
 // ExitSwapExactAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) ExitSwapExactAmountOut(ctx types.Context, tokenOut types.Coin, shareInMaxAmount types.Int) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) ExitSwapExactAmountOut(ctx types.Context, tokenOut types.Coin, shareInMaxAmount osmomath.Int) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitSwapExactAmountOut", ctx, tokenOut, shareInMaxAmount)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -567,10 +542,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetAddress() *gomock.Call {
 }
 
 // GetExitFee mocks base method.
-func (m *MockPoolAmountOutExtension) GetExitFee(ctx types.Context) types.Dec {
+func (m *MockPoolAmountOutExtension) GetExitFee(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExitFee", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -595,10 +570,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockPoolAmountOutExtension) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockPoolAmountOutExtension) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -606,20 +581,6 @@ func (m *MockPoolAmountOutExtension) GetSpreadFactor(ctx types.Context) types.De
 func (mr *MockPoolAmountOutExtensionMockRecorder) GetSpreadFactor(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).GetSpreadFactor), ctx)
-}
-
-// GetTakerFee mocks base method.
-func (m *MockPoolAmountOutExtension) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockPoolAmountOutExtensionMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).GetTakerFee))
 }
 
 // GetTotalPoolLiquidity mocks base method.
@@ -637,10 +598,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetTotalPoolLiquidity(ctx inte
 }
 
 // GetTotalShares mocks base method.
-func (m *MockPoolAmountOutExtension) GetTotalShares() types.Int {
+func (m *MockPoolAmountOutExtension) GetTotalShares() osmomath.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalShares")
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	return ret0
 }
 
@@ -665,7 +626,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetType() *gomock.Call {
 }
 
 // IncreaseLiquidity mocks base method.
-func (m *MockPoolAmountOutExtension) IncreaseLiquidity(sharesOut types.Int, coinsIn types.Coins) {
+func (m *MockPoolAmountOutExtension) IncreaseLiquidity(sharesOut osmomath.Int, coinsIn types.Coins) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "IncreaseLiquidity", sharesOut, coinsIn)
 }
@@ -691,10 +652,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) IsActive(ctx interface{}) *gom
 }
 
 // JoinPool mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPool", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -706,10 +667,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPool(ctx, tokensIn, spread
 }
 
 // JoinPoolNoSwap mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -721,10 +682,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPoolNoSwap(ctx, tokensIn, 
 }
 
 // JoinPoolTokenInMaxShareAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPoolTokenInMaxShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount types.Int) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) JoinPoolTokenInMaxShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount osmomath.Int) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolTokenInMaxShareAmountOut", ctx, tokenInDenom, shareOutAmount)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -759,23 +720,11 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockPoolAmountOutExtension) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockPoolAmountOutExtensionMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockPoolAmountOutExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockPoolAmountOutExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -801,7 +750,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockPoolAmountOutExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -816,7 +765,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) SwapInAmtGivenOut(ctx, tokenOu
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -868,7 +817,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) AsSerializablePool() *gomock.Ca
 }
 
 // CalcExitPoolCoinsFromShares mocks base method.
-func (m *MockWeightedPoolExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockWeightedPoolExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcExitPoolCoinsFromShares", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -883,7 +832,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcExitPoolCoinsFromShares(ctx
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockWeightedPoolExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -898,10 +847,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcInAmtGivenOut(ctx, tokenOut
 }
 
 // CalcJoinPoolNoSwapShares mocks base method.
-func (m *MockWeightedPoolExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockWeightedPoolExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -914,10 +863,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcJoinPoolNoSwapShares(ctx, t
 }
 
 // CalcJoinPoolShares mocks base method.
-func (m *MockWeightedPoolExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockWeightedPoolExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -930,7 +879,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcJoinPoolShares(ctx, tokensI
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -945,7 +894,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcOutAmtGivenIn(ctx, tokenIn,
 }
 
 // ExitPool mocks base method.
-func (m *MockWeightedPoolExtension) ExitPool(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockWeightedPoolExtension) ExitPool(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitPool", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -974,10 +923,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetAddress() *gomock.Call {
 }
 
 // GetExitFee mocks base method.
-func (m *MockWeightedPoolExtension) GetExitFee(ctx types.Context) types.Dec {
+func (m *MockWeightedPoolExtension) GetExitFee(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExitFee", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -1002,10 +951,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockWeightedPoolExtension) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockWeightedPoolExtension) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -1015,25 +964,11 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetSpreadFactor(ctx interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockWeightedPoolExtension)(nil).GetSpreadFactor), ctx)
 }
 
-// GetTakerFee mocks base method.
-func (m *MockWeightedPoolExtension) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockWeightedPoolExtensionMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockWeightedPoolExtension)(nil).GetTakerFee))
-}
-
 // GetTokenWeight mocks base method.
-func (m *MockWeightedPoolExtension) GetTokenWeight(denom string) (types.Int, error) {
+func (m *MockWeightedPoolExtension) GetTokenWeight(denom string) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTokenWeight", denom)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1059,10 +994,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetTotalPoolLiquidity(ctx inter
 }
 
 // GetTotalShares mocks base method.
-func (m *MockWeightedPoolExtension) GetTotalShares() types.Int {
+func (m *MockWeightedPoolExtension) GetTotalShares() osmomath.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalShares")
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	return ret0
 }
 
@@ -1101,10 +1036,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) IsActive(ctx interface{}) *gomo
 }
 
 // JoinPool mocks base method.
-func (m *MockWeightedPoolExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockWeightedPoolExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPool", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1116,10 +1051,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) JoinPool(ctx, tokensIn, spreadF
 }
 
 // JoinPoolNoSwap mocks base method.
-func (m *MockWeightedPoolExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockWeightedPoolExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1166,23 +1101,11 @@ func (mr *MockWeightedPoolExtensionMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockWeightedPoolExtension)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockWeightedPoolExtension) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockWeightedPoolExtensionMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockWeightedPoolExtension)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockWeightedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockWeightedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1208,7 +1131,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockWeightedPoolExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -1223,7 +1146,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) SwapInAmtGivenOut(ctx, tokenOut
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)

--- a/tests/mocks/cl_pool.go
+++ b/tests/mocks/cl_pool.go
@@ -38,7 +38,7 @@ func (m *MockConcentratedPoolExtension) EXPECT() *MockConcentratedPoolExtensionM
 }
 
 // ApplySwap mocks base method.
-func (m *MockConcentratedPoolExtension) ApplySwap(newLiquidity types.Dec, newCurrentTick int64, newCurrentSqrtPrice osmomath.BigDec) error {
+func (m *MockConcentratedPoolExtension) ApplySwap(newLiquidity osmomath.Dec, newCurrentTick int64, newCurrentSqrtPrice osmomath.BigDec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplySwap", newLiquidity, newCurrentTick, newCurrentSqrtPrice)
 	ret0, _ := ret[0].(error)
@@ -66,11 +66,11 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) AsSerializablePool() *gomoc
 }
 
 // CalcActualAmounts mocks base method.
-func (m *MockConcentratedPoolExtension) CalcActualAmounts(ctx types.Context, lowerTick, upperTick int64, liquidityDelta types.Dec) (types.Dec, types.Dec, error) {
+func (m *MockConcentratedPoolExtension) CalcActualAmounts(ctx types.Context, lowerTick, upperTick int64, liquidityDelta osmomath.Dec) (osmomath.Dec, osmomath.Dec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcActualAmounts", ctx, lowerTick, upperTick, liquidityDelta)
-	ret0, _ := ret[0].(types.Dec)
-	ret1, _ := ret[1].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
+	ret1, _ := ret[1].(osmomath.Dec)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -180,10 +180,10 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) GetLastLiquidityUpdate() *g
 }
 
 // GetLiquidity mocks base method.
-func (m *MockConcentratedPoolExtension) GetLiquidity() types.Dec {
+func (m *MockConcentratedPoolExtension) GetLiquidity() osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLiquidity")
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -194,10 +194,10 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) GetLiquidity() *gomock.Call
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockConcentratedPoolExtension) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockConcentratedPoolExtension) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -219,20 +219,6 @@ func (m *MockConcentratedPoolExtension) GetSpreadRewardsAddress() types.AccAddre
 func (mr *MockConcentratedPoolExtensionMockRecorder) GetSpreadRewardsAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadRewardsAddress", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).GetSpreadRewardsAddress))
-}
-
-// GetTakerFee mocks base method.
-func (m *MockConcentratedPoolExtension) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockConcentratedPoolExtensionMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).GetTakerFee))
 }
 
 // GetTickSpacing mocks base method.
@@ -379,18 +365,6 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) SetLastLiquidityUpdate(newT
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastLiquidityUpdate", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).SetLastLiquidityUpdate), newTime)
 }
 
-// SetTakerFee mocks base method.
-func (m *MockConcentratedPoolExtension) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockConcentratedPoolExtensionMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).SetTakerFee), newTakerFee)
-}
-
 // SetTickSpacing mocks base method.
 func (m *MockConcentratedPoolExtension) SetTickSpacing(newTickSpacing uint64) {
 	m.ctrl.T.Helper()
@@ -404,10 +378,10 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) SetTickSpacing(newTickSpaci
 }
 
 // SpotPrice mocks base method.
-func (m *MockConcentratedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockConcentratedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -433,7 +407,7 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) String() *gomock.Call {
 }
 
 // UpdateLiquidity mocks base method.
-func (m *MockConcentratedPoolExtension) UpdateLiquidity(newLiquidity types.Dec) {
+func (m *MockConcentratedPoolExtension) UpdateLiquidity(newLiquidity osmomath.Dec) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateLiquidity", newLiquidity)
 }
@@ -445,7 +419,7 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) UpdateLiquidity(newLiquidit
 }
 
 // UpdateLiquidityIfActivePosition mocks base method.
-func (m *MockConcentratedPoolExtension) UpdateLiquidityIfActivePosition(ctx types.Context, lowerTick, upperTick int64, liquidityDelta types.Dec) bool {
+func (m *MockConcentratedPoolExtension) UpdateLiquidityIfActivePosition(ctx types.Context, lowerTick, upperTick int64, liquidityDelta osmomath.Dec) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLiquidityIfActivePosition", ctx, lowerTick, upperTick, liquidityDelta)
 	ret0, _ := ret[0].(bool)

--- a/tests/mocks/pool.go
+++ b/tests/mocks/pool.go
@@ -9,6 +9,7 @@ import (
 
 	types "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
+	osmomath "github.com/osmosis-labs/osmosis/osmomath"
 	types0 "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 )
 
@@ -78,10 +79,10 @@ func (mr *MockPoolIMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockPoolI) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -89,20 +90,6 @@ func (m *MockPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
 func (mr *MockPoolIMockRecorder) GetSpreadFactor(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockPoolI)(nil).GetSpreadFactor), ctx)
-}
-
-// GetTakerFee mocks base method.
-func (m *MockPoolI) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockPoolIMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockPoolI)(nil).GetTakerFee))
 }
 
 // GetType mocks base method.
@@ -157,23 +144,11 @@ func (mr *MockPoolIMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockPoolI)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockPoolI) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockPoolIMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockPoolI)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/tests/mocks/pool_module.go
+++ b/tests/mocks/pool_module.go
@@ -11,6 +11,7 @@ import (
 	types0 "github.com/cosmos/cosmos-sdk/x/auth/types"
 	types1 "github.com/cosmos/cosmos-sdk/x/bank/types"
 	gomock "github.com/golang/mock/gomock"
+	osmomath "github.com/osmosis-labs/osmosis/osmomath"
 	types2 "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 )
 
@@ -229,7 +230,7 @@ func (m *MockPoolModuleI) EXPECT() *MockPoolModuleIMockRecorder {
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockPoolModuleI) CalcInAmtGivenOut(ctx types.Context, poolI types2.PoolI, tokenOut types.Coin, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolModuleI) CalcInAmtGivenOut(ctx types.Context, poolI types2.PoolI, tokenOut types.Coin, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, poolI, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -244,7 +245,7 @@ func (mr *MockPoolModuleIMockRecorder) CalcInAmtGivenOut(ctx, poolI, tokenOut, t
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockPoolModuleI) CalcOutAmtGivenIn(ctx types.Context, poolI types2.PoolI, tokenIn types.Coin, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolModuleI) CalcOutAmtGivenIn(ctx types.Context, poolI types2.PoolI, tokenIn types.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, poolI, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -259,10 +260,10 @@ func (mr *MockPoolModuleIMockRecorder) CalcOutAmtGivenIn(ctx, poolI, tokenIn, to
 }
 
 // CalculateSpotPrice mocks base method.
-func (m *MockPoolModuleI) CalculateSpotPrice(ctx types.Context, poolId uint64, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockPoolModuleI) CalculateSpotPrice(ctx types.Context, poolId uint64, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalculateSpotPrice", ctx, poolId, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -363,10 +364,10 @@ func (mr *MockPoolModuleIMockRecorder) InitializePool(ctx, pool, creatorAddress 
 }
 
 // SwapExactAmountIn mocks base method.
-func (m *MockPoolModuleI) SwapExactAmountIn(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenIn types.Coin, tokenOutDenom string, tokenOutMinAmount types.Int, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolModuleI) SwapExactAmountIn(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenIn types.Coin, tokenOutDenom string, tokenOutMinAmount osmomath.Int, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapExactAmountIn", ctx, sender, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -378,10 +379,10 @@ func (mr *MockPoolModuleIMockRecorder) SwapExactAmountIn(ctx, sender, pool, toke
 }
 
 // SwapExactAmountOut mocks base method.
-func (m *MockPoolModuleI) SwapExactAmountOut(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenInDenom string, tokenInMaxAmount types.Int, tokenOut types.Coin, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolModuleI) SwapExactAmountOut(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenInDenom string, tokenInMaxAmount osmomath.Int, tokenOut types.Coin, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapExactAmountOut", ctx, sender, pool, tokenInDenom, tokenInMaxAmount, tokenOut, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -506,4 +507,79 @@ func (m *MockMultihopRoute) PoolIds() []uint64 {
 func (mr *MockMultihopRouteMockRecorder) PoolIds() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PoolIds", reflect.TypeOf((*MockMultihopRoute)(nil).PoolIds))
+}
+
+// MockStakingKeeper is a mock of StakingKeeper interface.
+type MockStakingKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockStakingKeeperMockRecorder
+}
+
+// MockStakingKeeperMockRecorder is the mock recorder for MockStakingKeeper.
+type MockStakingKeeperMockRecorder struct {
+	mock *MockStakingKeeper
+}
+
+// NewMockStakingKeeper creates a new mock instance.
+func NewMockStakingKeeper(ctrl *gomock.Controller) *MockStakingKeeper {
+	mock := &MockStakingKeeper{ctrl: ctrl}
+	mock.recorder = &MockStakingKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
+	return m.recorder
+}
+
+// BondDenom mocks base method.
+func (m *MockStakingKeeper) BondDenom(ctx types.Context) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BondDenom", ctx)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// BondDenom indicates an expected call of BondDenom.
+func (mr *MockStakingKeeperMockRecorder) BondDenom(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BondDenom", reflect.TypeOf((*MockStakingKeeper)(nil).BondDenom), ctx)
+}
+
+// MockProtorevKeeper is a mock of ProtorevKeeper interface.
+type MockProtorevKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockProtorevKeeperMockRecorder
+}
+
+// MockProtorevKeeperMockRecorder is the mock recorder for MockProtorevKeeper.
+type MockProtorevKeeperMockRecorder struct {
+	mock *MockProtorevKeeper
+}
+
+// NewMockProtorevKeeper creates a new mock instance.
+func NewMockProtorevKeeper(ctrl *gomock.Controller) *MockProtorevKeeper {
+	mock := &MockProtorevKeeper{ctrl: ctrl}
+	mock.recorder = &MockProtorevKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockProtorevKeeper) EXPECT() *MockProtorevKeeperMockRecorder {
+	return m.recorder
+}
+
+// GetPoolForDenomPair mocks base method.
+func (m *MockProtorevKeeper) GetPoolForDenomPair(ctx types.Context, baseDenom, denomToMatch string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPoolForDenomPair", ctx, baseDenom, denomToMatch)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPoolForDenomPair indicates an expected call of GetPoolForDenomPair.
+func (mr *MockProtorevKeeperMockRecorder) GetPoolForDenomPair(ctx, baseDenom, denomToMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPoolForDenomPair", reflect.TypeOf((*MockProtorevKeeper)(nil).GetPoolForDenomPair), ctx, baseDenom, denomToMatch)
 }

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -108,20 +108,20 @@ func (p Pool) IsActive(ctx sdk.Context) bool {
 // SpotPrice returns the spot price of the pool.
 // If base asset is the Token0 of the pool, we use the current sqrt price of the pool.
 // If not, we calculate the inverse of the current sqrt price of the pool.
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error) {
 	// validate base asset is in pool
 	if baseAssetDenom != p.Token0 && baseAssetDenom != p.Token1 {
-		return osmomath.Dec{}, fmt.Errorf("base asset denom (%s) is not in pool with (%s, %s) pair", baseAssetDenom, p.Token0, p.Token1)
+		return osmomath.BigDec{}, fmt.Errorf("base asset denom (%s) is not in pool with (%s, %s) pair", baseAssetDenom, p.Token0, p.Token1)
 	}
 	// validate quote asset is in pool
 	if quoteAssetDenom != p.Token0 && quoteAssetDenom != p.Token1 {
-		return osmomath.Dec{}, fmt.Errorf("quote asset denom (%s) is not in pool with (%s, %s) pair", quoteAssetDenom, p.Token0, p.Token1)
+		return osmomath.BigDec{}, fmt.Errorf("quote asset denom (%s) is not in pool with (%s, %s) pair", quoteAssetDenom, p.Token0, p.Token1)
 	}
 
 	if baseAssetDenom == p.Token0 {
-		return p.CurrentSqrtPrice.PowerInteger(2).Dec(), nil
+		return p.CurrentSqrtPrice.PowerInteger(2), nil
 	}
-	return osmomath.OneBigDec().Quo(p.CurrentSqrtPrice.PowerInteger(2)).Dec(), nil
+	return osmomath.OneBigDec().Quo(p.CurrentSqrtPrice.PowerInteger(2)), nil
 }
 
 // GetToken0 returns the token0 of the pool

--- a/x/concentrated-liquidity/model/pool_test.go
+++ b/x/concentrated-liquidity/model/pool_test.go
@@ -215,8 +215,8 @@ func (s *ConcentratedPoolTestSuite) TestSpotPrice() {
 				s.Require().NoError(err)
 
 				// We use elipson due to sqrt approximation
-				elipson := osmomath.MustNewDecFromStr("0.0000000000000001")
-				s.Require().True(spotPriceFromMethod.Sub(tc.expectedSpotPrice).Abs().LT(elipson))
+				elipson := osmomath.MustNewBigDecFromStr("0.0000000000000001")
+				s.Require().True(spotPriceFromMethod.Sub(osmomath.BigDecFromDec(tc.expectedSpotPrice)).Abs().LT(elipson))
 			}
 		})
 	}

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -144,31 +144,31 @@ func (k Keeper) CalculateSpotPrice(
 	poolId uint64,
 	quoteAssetDenom string,
 	baseAssetDenom string,
-) (spotPrice osmomath.Dec, err error) {
+) (spotPrice osmomath.BigDec, err error) {
 	concentratedPool, err := k.getPoolById(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	hasPositions, err := k.HasAnyPositionForPool(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	if !hasPositions {
-		return osmomath.Dec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
+		return osmomath.BigDec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
 	}
 
 	price, err := concentratedPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	if price.IsZero() {
-		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: osmomath.BigDecFromDec(price), MinSpotPrice: types.MinSpotPriceV2, MaxSpotPrice: types.MaxSpotPrice}
+		return osmomath.BigDec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceV2, MaxSpotPrice: types.MaxSpotPrice}
 	}
-	if price.GT(types.MaxSpotPrice) || price.LT(types.MinSpotPrice) {
-		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: osmomath.BigDecFromDec(price), MinSpotPrice: types.MinSpotPriceBigDec, MaxSpotPrice: types.MaxSpotPrice}
+	if price.GT(types.MaxSpotPriceBigDec) || price.LT(types.MinSpotPriceBigDec) {
+		return osmomath.BigDec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceBigDec, MaxSpotPrice: types.MaxSpotPrice}
 	}
 
 	return price, nil

--- a/x/cosmwasmpool/model/pool.go
+++ b/x/cosmwasmpool/model/pool.go
@@ -72,7 +72,7 @@ func (p Pool) IsActive(ctx sdk.Context) bool {
 }
 
 // SpotPrice returns the spot price of the pool.
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error) {
 	request := msg.SpotPriceQueryMsg{
 		SpotPrice: msg.SpotPrice{
 			QuoteAssetDenom: quoteAssetDenom,
@@ -81,9 +81,9 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom 
 	}
 	response, err := cosmwasmutils.Query[msg.SpotPriceQueryMsg, msg.SpotPriceQueryMsgResponse](ctx, p.WasmKeeper, p.ContractAddress, request)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
-	return osmomath.MustNewDecFromStr(response.SpotPrice), nil
+	return osmomath.MustNewBigDecFromStr(response.SpotPrice), nil
 }
 
 // GetType returns the type of the pool.

--- a/x/cosmwasmpool/model/store_model.go
+++ b/x/cosmwasmpool/model/store_model.go
@@ -46,7 +46,7 @@ func (p CosmWasmPool) IsActive(ctx sdk.Context) bool {
 	panic("CosmWasmPool.IsActive not implemented")
 }
 
-func (p CosmWasmPool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (osmomath.Dec, error) {
+func (p CosmWasmPool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (osmomath.BigDec, error) {
 	panic("CosmWasmPool.SpotPrice not implemented")
 }
 

--- a/x/cosmwasmpool/pool_module.go
+++ b/x/cosmwasmpool/pool_module.go
@@ -168,13 +168,18 @@ func (k Keeper) CalculateSpotPrice(
 	poolId uint64,
 	quoteAssetDenom string,
 	baseAssetDenom string,
-) (price osmomath.Dec, err error) {
+) (price osmomath.BigDec, err error) {
 	cosmwasmPool, err := k.GetPoolById(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
-	return cosmwasmPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
+	spotPriceDec, err := cosmwasmPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	return spotPriceDec, nil
 }
 
 // SwapExactAmountIn performs a swap operation with a specified input amount in a CosmWasm-based liquidity pool.

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -424,7 +424,7 @@ func (s *KeeperTestSuite) TestSpotPriceOverflow() {
 			poolId := s.PrepareBalancerPoolWithCoinsAndWeights(tc.poolLiquidity, tc.poolWeights)
 			pool, err := s.App.GAMMKeeper.GetPoolAndPoke(s.Ctx, poolId)
 			s.Require().NoError(err)
-			var poolSpotPrice osmomath.Dec
+			var poolSpotPrice osmomath.BigDec
 			var poolErr error
 			osmoassert.ConditionalPanic(s.T(), tc.panics, func() {
 				poolSpotPrice, poolErr = pool.SpotPrice(s.Ctx, tc.baseAssetDenom, tc.quoteAssetDenom)

--- a/x/gamm/keeper/swap_test.go
+++ b/x/gamm/keeper/swap_test.go
@@ -162,7 +162,7 @@ func (s *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountIn() {
 
 				// Ratio of the token out should be between the before spot price and after spot price.
 				tradeAvgPrice := test.param.tokenIn.Amount.ToLegacyDec().Quo(tokenOutAmount.ToLegacyDec())
-				s.True(tradeAvgPrice.GT(spotPriceBefore) && tradeAvgPrice.LT(spotPriceAfter), "test: %v", test.name)
+				s.True(tradeAvgPrice.GT(spotPriceBefore.Dec()) && tradeAvgPrice.LT(spotPriceAfter.Dec()), "test: %v", test.name)
 			} else {
 				_, err := keeper.SwapExactAmountIn(ctx, s.TestAccs[0], pool, test.param.tokenIn, test.param.tokenOutDenom, test.param.tokenOutMinAmount, spreadFactor)
 				s.Error(err, "test: %v", test.name)
@@ -414,7 +414,7 @@ func (s *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountOut() {
 
 				// Ratio of the token out should be between the before spot price and after spot price.
 				tradeAvgPrice := tokenInAmount.ToLegacyDec().Quo(test.param.tokenOut.Amount.ToLegacyDec())
-				s.True(tradeAvgPrice.GT(spotPriceBefore) && tradeAvgPrice.LT(spotPriceAfter), "test: %v", test.name)
+				s.True(tradeAvgPrice.GT(spotPriceBefore.Dec()) && tradeAvgPrice.LT(spotPriceAfter.Dec()), "test: %v", test.name)
 			} else {
 				_, err := keeper.SwapExactAmountOut(s.Ctx, s.TestAccs[0], pool, test.param.tokenInDenom, test.param.tokenInMaxAmount, test.param.tokenOut, spreadFactor)
 				s.Error(err, "test: %v", test.name)

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -629,13 +629,13 @@ func (p *Pool) applySwap(ctx sdk.Context, tokensIn sdk.Coins, tokensOut sdk.Coin
 // In other words, it costs 0.5 uosmo to get one uatom.
 //
 // panics if the pool in state is incorrect, and has any weight that is 0.
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPrice osmomath.Dec, err error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPrice osmomath.BigDec, err error) {
 	quote, base, err := p.parsePoolAssetsByDenoms(quoteAsset, baseAsset)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 	if base.Weight.IsZero() || quote.Weight.IsZero() {
-		return osmomath.Dec{}, errors.New("pool is misconfigured, got 0 weight")
+		return osmomath.BigDec{}, errors.New("pool is misconfigured, got 0 weight")
 	}
 
 	// spot_price = (Quote Supply / Quote Weight) / (Base Supply / Base Weight)
@@ -643,9 +643,9 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPric
 	//            = (Base Weight  / Quote Weight) * (Quote Supply / Base Supply)
 	invWeightRatio := base.Weight.ToLegacyDec().Quo(quote.Weight.ToLegacyDec())
 	supplyRatio := quote.Token.Amount.ToLegacyDec().Quo(base.Token.Amount.ToLegacyDec())
-	spotPrice = supplyRatio.Mul(invWeightRatio)
+	spotPriceDec := supplyRatio.Mul(invWeightRatio)
 
-	return spotPrice, err
+	return osmomath.BigDecFromDec(spotPriceDec), err
 }
 
 // calcPoolOutGivenSingleIn - balance pAo.

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -702,7 +702,7 @@ func (s *KeeperTestSuite) TestBalancerSpotPrice() {
 					s.Require().Error(err, "test: %s", tc.name)
 				} else {
 					s.Require().NoError(err, "test: %s", tc.name)
-					s.Require().True(spotPrice.Equal(tc.expectedOutput),
+					s.Require().True(spotPrice.Dec().Equal(tc.expectedOutput),
 						"test: %s\nSpot price wrong, got %s, expected %s\n", tc.name,
 						spotPrice, tc.expectedOutput)
 				}
@@ -819,7 +819,7 @@ func (s *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 					s.Require().Error(err, "test: %s", tc.name)
 				} else {
 					s.Require().NoError(err, "test: %s", tc.name)
-					s.Require().True(spotPrice.Equal(tc.expectedOutput),
+					s.Require().True(spotPrice.Dec().Equal(tc.expectedOutput),
 						"test: %s\nSpot price wrong, got %s, expected %s\n", tc.name,
 						spotPrice, tc.expectedOutput)
 				}

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -312,8 +312,12 @@ func (p *Pool) SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDen
 
 // SpotPrice calculates the approximate amount of `baseDenom` one would receive for
 // an input dx of `quoteDenom` (to simplify calculations, we approximate dx = 1)
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error) {
-	return p.spotPrice(quoteAssetDenom, baseAssetDenom)
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error) {
+	spotPriceDec, err := p.spotPrice(quoteAssetDenom, baseAssetDenom)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+	return osmomath.BigDecFromDec(spotPriceDec), nil
 }
 
 func (p Pool) Copy() Pool {

--- a/x/gamm/pool-models/stableswap/pool_test.go
+++ b/x/gamm/pool-models/stableswap/pool_test.go
@@ -1339,7 +1339,8 @@ func TestStableswapSpotPrice(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := sdk.Context{}
 			p := poolStructFromAssets(tc.poolAssets, tc.scalingFactors)
-			spotPrice, err := p.SpotPrice(ctx, tc.quoteDenom, tc.baseDenom)
+			spotPriceBigDec, err := p.SpotPrice(ctx, tc.quoteDenom, tc.baseDenom)
+			spotPrice := spotPriceBigDec.Dec()
 
 			if tc.expectPass {
 				require.NoError(t, err)

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -33,7 +33,8 @@ var (
 	// Internal note: Ctrl+F for MaxSpotPrice in code if ever changed.
 	// Other tests depend on being equal to MaxSpotPrice,
 	// but don't directly import it due to import issues.
-	MaxSpotPrice = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+	MaxSpotPrice       = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+	MaxSpotPriceBigDec = osmomath.BigDecFromDec(MaxSpotPrice)
 	// MinSpotPrice is the minimum supported spot price. Anything less than this will error.
 	// It is limited by osmomath.Dec's precision.
 	MinSpotPrice = osmomath.SmallestDec()

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -554,15 +554,15 @@ func (k Keeper) RouteCalculateSpotPrice(
 	poolId uint64,
 	quoteAssetDenom string,
 	baseAssetDenom string,
-) (price osmomath.Dec, err error) {
+) (price osmomath.BigDec, err error) {
 	swapModule, err := k.GetPoolModule(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	price, err = swapModule.CalculateSpotPrice(ctx, poolId, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	return price, nil
@@ -886,7 +886,7 @@ func (k Keeper) trackVolume(ctx sdk.Context, poolId uint64, volumeGenerated sdk.
 
 	// Multiply `volumeGenerated.Amount.ToDec()` by this spot price.
 	// While rounding does not particularly matter here, we round down to ensure that we do not overcount volume.
-	volumeInOsmo := volumeGenerated.Amount.ToLegacyDec().Mul(osmoPerInputToken).TruncateInt()
+	volumeInOsmo := osmomath.BigDecFromDec(volumeGenerated.Amount.ToLegacyDec()).Mul(osmoPerInputToken).Dec().TruncateInt()
 
 	// Add this new volume to the global tracked volume for the pool ID
 	k.addVolume(ctx, poolId, sdk.NewCoin(OSMO, volumeInOsmo))

--- a/x/poolmanager/types/expected_keepers.go
+++ b/x/poolmanager/types/expected_keepers.go
@@ -48,7 +48,7 @@ type PoolModuleI interface {
 		poolId uint64,
 		quoteAssetDenom string,
 		baseAssetDenom string,
-	) (price osmomath.Dec, err error)
+	) (price osmomath.BigDec, err error)
 
 	SwapExactAmountIn(
 		ctx sdk.Context,

--- a/x/poolmanager/types/pool.go
+++ b/x/poolmanager/types/pool.go
@@ -27,7 +27,7 @@ type PoolI interface {
 	// errors if either baseAssetDenom, or quoteAssetDenom does not exist.
 	// For example, if this was a UniV2 50-50 pool, with 2 ETH, and 8000 UST
 	// pool.SpotPrice(ctx, "eth", "ust") = 4000.00
-	SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error)
+	SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error)
 	// GetType returns the type of the pool (Balancer, Stableswap, Concentrated, etc.)
 	GetType() PoolType
 	// AsSerializablePool returns the pool in a serializable form (useful when a model wraps the proto)

--- a/x/superfluid/keeper/migrate_test.go
+++ b/x/superfluid/keeper/migrate_test.go
@@ -1315,7 +1315,7 @@ func (s *KeeperTestSuite) TestFunctional_VaryingPositions_Migrations() {
 		s.Require().NoError(err)
 		balancerSpotPrice, err := balancerPool.SpotPrice(s.Ctx, DefaultCoin1.Denom, DefaultCoin0.Denom)
 		s.Require().NoError(err)
-		s.CreateFullRangePosition(clPool, sdk.NewCoins(sdk.NewCoin(DefaultCoin0.Denom, osmomath.NewInt(100000000)), sdk.NewCoin(DefaultCoin1.Denom, osmomath.NewDec(100000000).Mul(balancerSpotPrice).TruncateInt())))
+		s.CreateFullRangePosition(clPool, sdk.NewCoins(sdk.NewCoin(DefaultCoin0.Denom, osmomath.NewInt(100000000)), sdk.NewCoin(DefaultCoin1.Denom, osmomath.NewDec(100000000).Mul(balancerSpotPrice.Dec()).TruncateInt())))
 
 		// Add a gov sanctioned link between the balancer and concentrated liquidity pool.
 		migrationRecord := gammmigration.MigrationRecords{BalancerToConcentratedPoolLinks: []gammmigration.BalancerToConcentratedPoolLink{

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -899,7 +899,7 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 			osmomath.ErrTolerance{
 				MultiplicativeTolerance: osmomath.SmallestDec(),
 			}.CompareBigDec(
-				osmomath.BigDecFromDec(spotPrice),
+				spotPrice,
 				osmomath.BigDecFromDec(twap),
 			)
 		})

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -44,7 +44,7 @@ func getSpotPrices(
 	poolId uint64,
 	denom0, denom1 string,
 	previousErrorTime time.Time,
-) (sp0 osmomath.Dec, sp1 osmomath.Dec, latestErrTime time.Time) {
+) (sp0Dec osmomath.Dec, sp1Dec osmomath.Dec, latestErrTime time.Time) {
 	latestErrTime = previousErrorTime
 	// sp0 = denom0 quote, denom1 base.
 	sp0, err0 := k.RouteCalculateSpotPrice(ctx, poolId, denom0, denom1)
@@ -55,20 +55,20 @@ func getSpotPrices(
 		// In the event of an error, we just sanity replace empty values with zero values
 		// so that the numbers can be still be calculated within TWAPs over error values
 		// TODO: Should we be using the last spot price?
-		if (sp0 == osmomath.Dec{}) {
-			sp0 = osmomath.ZeroDec()
+		if (sp0 == osmomath.BigDec{}) {
+			sp0 = osmomath.ZeroBigDec()
 		}
-		if (sp1 == osmomath.Dec{}) {
-			sp1 = osmomath.ZeroDec()
+		if (sp1 == osmomath.BigDec{}) {
+			sp1 = osmomath.ZeroBigDec()
 		}
 	}
-	if sp0.GT(types.MaxSpotPrice) {
-		sp0, latestErrTime = types.MaxSpotPrice, ctx.BlockTime()
+	if sp0.GT(types.MaxSpotPriceBigDec) {
+		sp0, latestErrTime = types.MaxSpotPriceBigDec, ctx.BlockTime()
 	}
-	if sp1.GT(types.MaxSpotPrice) {
-		sp1, latestErrTime = types.MaxSpotPrice, ctx.BlockTime()
+	if sp1.GT(types.MaxSpotPriceBigDec) {
+		sp1, latestErrTime = types.MaxSpotPriceBigDec, ctx.BlockTime()
 	}
-	return sp0, sp1, latestErrTime
+	return sp0.Dec(), sp1.Dec(), latestErrTime
 }
 
 // mustTrackCreatedPool is a wrapper around afterCreatePool that panics on error.

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -42,8 +42,8 @@ func (s *TestSuite) TestGetSpotPrices() {
 	testCases := map[string]struct {
 		poolID                uint64
 		prevErrTime           time.Time
-		mockSp0               osmomath.Dec
-		mockSp1               osmomath.Dec
+		mockSp0               osmomath.BigDec
+		mockSp1               osmomath.BigDec
 		mockSp0Err            error
 		mockSp1Err            error
 		expectedSp0           osmomath.Dec
@@ -53,8 +53,8 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"zero sp": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			mockSp0:               osmomath.ZeroDec(),
-			mockSp1:               osmomath.ZeroDec(),
+			mockSp0:               osmomath.ZeroBigDec(),
+			mockSp1:               osmomath.ZeroBigDec(),
 			mockSp0Err:            fmt.Errorf("foo"),
 			expectedSp0:           osmomath.ZeroDec(),
 			expectedSp1:           osmomath.ZeroDec(),
@@ -63,8 +63,8 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"exceeds max spot price": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			mockSp0:               types.MaxSpotPrice.Add(osmomath.OneDec()),
-			mockSp1:               types.MaxSpotPrice.Add(osmomath.OneDec()),
+			mockSp0:               types.MaxSpotPriceBigDec.Add(osmomath.OneBigDec()),
+			mockSp1:               types.MaxSpotPriceBigDec.Add(osmomath.OneBigDec()),
 			expectedSp0:           types.MaxSpotPrice,
 			expectedSp1:           types.MaxSpotPrice,
 			expectedLatestErrTime: ctx.BlockTime(),
@@ -72,8 +72,8 @@ func (s *TestSuite) TestGetSpotPrices() {
 		"valid spot prices": {
 			poolID:                poolID,
 			prevErrTime:           currTime,
-			mockSp0:               osmomath.NewDecWithPrec(55, 2),
-			mockSp1:               osmomath.NewDecWithPrec(6, 1),
+			mockSp0:               osmomath.NewBigDecWithPrec(55, 2),
+			mockSp1:               osmomath.NewBigDecWithPrec(6, 1),
 			expectedSp0:           osmomath.NewDecWithPrec(55, 2),
 			expectedSp1:           osmomath.NewDecWithPrec(6, 1),
 			expectedLatestErrTime: currTime,
@@ -170,9 +170,9 @@ func (s *TestSuite) TestUpdateRecord() {
 	programmableAmmInterface := twapmock.NewProgrammedAmmInterface(s.App.TwapKeeper.GetAmmInterface())
 	s.App.TwapKeeper.SetAmmInterface(programmableAmmInterface)
 
-	spotPriceResOne := twapmock.SpotPriceResult{Sp: osmomath.OneDec(), Err: nil}
-	spotPriceResOneErr := twapmock.SpotPriceResult{Sp: osmomath.OneDec(), Err: errors.New("dummy err")}
-	spotPriceResOneErrNilDec := twapmock.SpotPriceResult{Sp: osmomath.Dec{}, Err: errors.New("dummy err")}
+	spotPriceResOne := twapmock.SpotPriceResult{Sp: osmomath.OneBigDec(), Err: nil}
+	spotPriceResOneErr := twapmock.SpotPriceResult{Sp: osmomath.OneBigDec(), Err: errors.New("dummy err")}
+	spotPriceResOneErrNilDec := twapmock.SpotPriceResult{Sp: osmomath.BigDec{}, Err: errors.New("dummy err")}
 	baseTime := time.Unix(2, 0).UTC()
 	updateTime := time.Unix(3, 0).UTC()
 	baseTimeMinusOne := time.Unix(1, 0).UTC()
@@ -230,10 +230,10 @@ func (s *TestSuite) TestUpdateRecord() {
 			test.record.PoolId = poolId
 			test.expRecord.PoolId = poolId
 			if (test.expRecord.P0LastSpotPrice == osmomath.Dec{}) {
-				test.expRecord.P0LastSpotPrice = test.spotPriceResult0.Sp
+				test.expRecord.P0LastSpotPrice = test.spotPriceResult0.Sp.Dec()
 			}
 			if (test.expRecord.P1LastSpotPrice == osmomath.Dec{}) {
-				test.expRecord.P1LastSpotPrice = test.spotPriceResult1.Sp
+				test.expRecord.P1LastSpotPrice = test.spotPriceResult1.Sp.Dec()
 			}
 			test.expRecord.Height = s.Ctx.BlockHeight()
 			test.expRecord.Time = s.Ctx.BlockTime()
@@ -643,7 +643,7 @@ func (s *TestSuite) TestUpdateRecords() {
 	type spOverride struct {
 		baseDenom   string
 		quoteDenom  string
-		overrideSp  osmomath.Dec
+		overrideSp  osmomath.BigDec
 		overrideErr error
 	}
 
@@ -701,17 +701,17 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.NewDec(2),
+					overrideSp: osmomath.NewBigDec(2),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: baseRecord.Asset0Denom,
-					overrideSp: osmomath.NewDecWithPrec(2, 1),
+					overrideSp: osmomath.NewBigDecWithPrec(2, 1),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: "extradenom",
-					overrideSp: osmomath.NewDecWithPrec(3, 1),
+					overrideSp: osmomath.NewBigDecWithPrec(3, 1),
 				},
 			},
 
@@ -726,12 +726,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.NewDec(2),
+					overrideSp: osmomath.NewBigDec(2),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: baseRecord.Asset0Denom,
-					overrideSp: osmomath.NewDecWithPrec(2, 1),
+					overrideSp: osmomath.NewBigDecWithPrec(2, 1),
 				},
 			},
 
@@ -763,7 +763,7 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:   baseRecord.Asset1Denom,
 					quoteDenom:  baseRecord.Asset0Denom,
-					overrideSp:  osmomath.NewDecWithPrec(2, 1),
+					overrideSp:  osmomath.NewBigDecWithPrec(2, 1),
 					overrideErr: spError,
 				},
 			},
@@ -792,12 +792,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:   baseRecord.Asset1Denom,
 					quoteDenom:  baseRecord.Asset0Denom,
-					overrideSp:  types.MaxSpotPrice.Add(osmomath.OneDec()),
+					overrideSp:  types.MaxSpotPriceBigDec.Add(osmomath.OneBigDec()),
 					overrideErr: nil, // twap logic should identify the large spot price and mark it as error.
 				},
 			},
@@ -826,12 +826,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: baseRecord.Asset0Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 			},
 
@@ -860,7 +860,7 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:   baseRecord.Asset1Denom,
@@ -895,12 +895,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: baseRecord.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 			},
 
@@ -934,12 +934,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: baseRecord.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 			},
 
@@ -964,12 +964,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  mostRecentRecordPoolOne.Asset0Denom,
 					quoteDenom: mostRecentRecordPoolOne.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  mostRecentRecordPoolOne.Asset1Denom,
 					quoteDenom: mostRecentRecordPoolOne.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 			},
 
@@ -992,12 +992,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  baseRecord.Asset0Denom,
 					quoteDenom: baseRecord.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  baseRecord.Asset1Denom,
 					quoteDenom: baseRecord.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 			},
 
@@ -1023,12 +1023,12 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  mostRecentRecordPoolOne.Asset0Denom,
 					quoteDenom: mostRecentRecordPoolOne.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  mostRecentRecordPoolOne.Asset1Denom,
 					quoteDenom: mostRecentRecordPoolOne.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 			},
 			expectError: types.InvalidUpdateRecordError{},
@@ -1041,32 +1041,32 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  threeAssetRecordAB.Asset0Denom,
 					quoteDenom: threeAssetRecordAB.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  threeAssetRecordAB.Asset1Denom,
 					quoteDenom: threeAssetRecordAB.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 				{
 					baseDenom:  threeAssetRecordAC.Asset0Denom,
 					quoteDenom: threeAssetRecordAC.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  threeAssetRecordAC.Asset1Denom,
 					quoteDenom: threeAssetRecordAC.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()).Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()).Add(osmomath.OneBigDec()),
 				},
 				{
 					baseDenom:  threeAssetRecordBC.Asset0Denom,
 					quoteDenom: threeAssetRecordBC.Asset1Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 				{
 					baseDenom:  threeAssetRecordBC.Asset1Denom,
 					quoteDenom: threeAssetRecordBC.Asset0Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 			},
 
@@ -1129,33 +1129,33 @@ func (s *TestSuite) TestUpdateRecords() {
 				{
 					baseDenom:  threeAssetRecordAB.Asset0Denom,
 					quoteDenom: threeAssetRecordAB.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  threeAssetRecordAB.Asset1Denom,
 					quoteDenom: threeAssetRecordAB.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 				{
 					baseDenom:  threeAssetRecordAC.Asset0Denom,
 					quoteDenom: threeAssetRecordAC.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:   threeAssetRecordAC.Asset1Denom,
 					quoteDenom:  threeAssetRecordAC.Asset0Denom,
-					overrideSp:  types.MaxSpotPrice.Add(osmomath.OneDec()),
+					overrideSp:  types.MaxSpotPriceBigDec.Add(osmomath.OneBigDec()),
 					overrideErr: nil, // twap logic should identify the large spot price and mark it as error.
 				},
 				{
 					baseDenom:  threeAssetRecordBC.Asset0Denom,
 					quoteDenom: threeAssetRecordBC.Asset1Denom,
-					overrideSp: osmomath.OneDec(),
+					overrideSp: osmomath.OneBigDec(),
 				},
 				{
 					baseDenom:  threeAssetRecordBC.Asset1Denom,
 					quoteDenom: threeAssetRecordBC.Asset0Denom,
-					overrideSp: osmomath.OneDec().Add(osmomath.OneDec()),
+					overrideSp: osmomath.OneBigDec().Add(osmomath.OneBigDec()),
 				},
 			},
 

--- a/x/twap/types/expected_interfaces.go
+++ b/x/twap/types/expected_interfaces.go
@@ -18,5 +18,5 @@ type PoolManagerInterface interface {
 		poolID uint64,
 		quoteAssetDenom string,
 		baseAssetDenom string,
-	) (price osmomath.Dec, err error)
+	) (price osmomath.BigDec, err error)
 }

--- a/x/twap/types/twapmock/amminterface.go
+++ b/x/twap/types/twapmock/amminterface.go
@@ -22,7 +22,7 @@ type SpotPriceInput struct {
 	quoteDenom string
 }
 type SpotPriceResult struct {
-	Sp  osmomath.Dec
+	Sp  osmomath.BigDec
 	Err error
 }
 
@@ -53,7 +53,7 @@ func (p *ProgrammedPoolManagerInterface) ProgramPoolDenomsOverride(poolId uint64
 }
 
 func (p *ProgrammedPoolManagerInterface) ProgramPoolSpotPriceOverride(poolId uint64,
-	quoteDenom, baseDenom string, overrideSp osmomath.Dec, overrideErr error,
+	quoteDenom, baseDenom string, overrideSp osmomath.BigDec, overrideErr error,
 ) {
 	input := SpotPriceInput{poolId, baseDenom, quoteDenom}
 	p.programmedSpotPrice[input] = SpotPriceResult{overrideSp, overrideErr}
@@ -74,7 +74,7 @@ func (p *ProgrammedPoolManagerInterface) RouteCalculateSpotPrice(ctx sdk.Context
 	poolId uint64,
 	quoteDenom,
 	baseDenom string,
-) (price osmomath.Dec, err error) {
+) (price osmomath.BigDec, err error) {
 	input := SpotPriceInput{poolId, baseDenom, quoteDenom}
 	if res, ok := p.programmedSpotPrice[input]; ok {
 		return res.Sp, res.Err

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -8,7 +8,10 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
-var MaxSpotPrice = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+var (
+	MaxSpotPrice       = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+	MaxSpotPriceBigDec = osmomath.BigDecFromDec(MaxSpotPrice)
+)
 
 // GetAllUniqueDenomPairs returns all unique pairs of denoms, where for every pair
 // (X, Y), X < Y.

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -32,27 +32,28 @@ func (k Keeper) ConvertToBaseToken(ctx sdk.Context, inputFee sdk.Coin) (sdk.Coin
 		return sdk.Coin{}, err
 	}
 
-	return sdk.NewCoin(baseDenom, spotPrice.MulInt(inputFee.Amount).RoundInt()), nil
+	// TODO (perf)
+	return sdk.NewCoin(baseDenom, sdk.NewIntFromBigInt(spotPrice.Mul(osmomath.NewBigDecFromBigInt(inputFee.Amount.BigInt())).RoundInt().BigInt())), nil
 }
 
 // CalcFeeSpotPrice converts the provided tx fees into their equivalent value in the base denomination.
 // Spot Price Calculation: spotPrice / (1 - spreadFactor),
 // where spotPrice is defined as:
 // (tokenBalanceIn / tokenWeightIn) / (tokenBalanceOut / tokenWeightOut)
-func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (osmomath.Dec, error) {
+func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (osmomath.BigDec, error) {
 	baseDenom, err := k.GetBaseDenom(ctx)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	feeToken, err := k.GetFeeToken(ctx, inputDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 	return spotPrice, nil
 }

--- a/x/txfees/keeper/grpc_query.go
+++ b/x/txfees/keeper/grpc_query.go
@@ -51,7 +51,7 @@ func (q Querier) DenomSpotPrice(ctx context.Context, req *types.QueryDenomSpotPr
 		return nil, err
 	}
 
-	return &types.QueryDenomSpotPriceResponse{PoolID: feeToken.PoolID, SpotPrice: spotPrice}, nil
+	return &types.QueryDenomSpotPriceResponse{PoolID: feeToken.PoolID, SpotPrice: spotPrice.Dec()}, nil
 }
 
 func (q Querier) DenomPoolId(ctx context.Context, req *types.QueryDenomPoolIdRequest) (*types.QueryDenomPoolIdResponse, error) {

--- a/x/txfees/types/expected_keepers.go
+++ b/x/txfees/types/expected_keepers.go
@@ -11,7 +11,7 @@ import (
 // SpotPriceCalculator defines the contract that must be fulfilled by a spot price calculator
 // The x/gamm keeper is expected to satisfy this interface.
 type SpotPriceCalculator interface {
-	CalculateSpotPrice(ctx sdk.Context, poolId uint64, quoteDenom, baseDenom string) (osmomath.Dec, error)
+	CalculateSpotPrice(ctx sdk.Context, poolId uint64, quoteDenom, baseDenom string) (osmomath.BigDec, error)
 }
 
 // PoolManager defines the contract needed for swap related APIs.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This is the demo to decide on the best way of implementing a 36-decimal spot price query.

The suggestion in this PR is to avoid code duplication as much as possible and attempt to break `PoolI` and `PoolModuleI` interfaces to operate on 36 decimals in a state-compatible way.

In the querier, we can expose two APIs:
1. Old V1: returns a string representing decimal with 18 precision 
2. New V2: returns a string representing decimal with 36 precision.

It is unclear to me whether it would be client-breaking if we were to start returning a 36 decimal string post-upgrade or not. As a result, we can end up duplicating the querier only

Note that there are probably state breaks present in this PR currently. However, I think that it would be possible to implement it in a state-compatible way incrementally:
- First, break `PoolI` API, backport and test
- Break `PoolModuleI` API, backport and test
- Make the state-breaking change in CL to allow pools with larger spot prices.
- Solve `x/twap` issue separately (in the future). Accept that pools with spot spot price below 10^-18 will not have twap functioning on-chain.

## Pros
- No code duplication for essentially the same methods operating on `BigDec`
- Lesser maintenance burden for us long-term

## Cons
- Should implement carefully, ensuring that no unexpected state-breaks or client breakages