### PR TITLE
refactor: break PoolI.SpotPrice API to return BigDec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#6256](https://github.com/osmosis-labs/osmosis/pull/6256) Refactor CalcPriceToTick to operate on BigDec price to support new price range.
 * [#6317](https://github.com/osmosis-labs/osmosis/pull/6317) Remove price return from CL `math.TickToSqrtPrice`
+* [#6371](https://github.com/osmosis-labs/osmosis/pull/6371) Change PoolI.SpotPrice API from Dec (18 decimals) to BigDec (36 decimals), maintain state-compatibility. 
 
 ## v19.0.0
 

--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -294,7 +294,7 @@ func (s *KeeperTestHelper) CalcAmoutOfTokenToGetTargetPrice(ctx sdk.Context, poo
 	// Amount of quote token need to trade to get target spot price
 	// AmoutQuoteTokenNeedToTrade = AmoutQuoTokenNow * ((targetSpotPrice/spotPriceNow)^((weight_base/(weight_base + weight_quote))) -1 )
 
-	ratioPrice := targetSpotPrice.Quo(spotPriceNow)
+	ratioPrice := targetSpotPrice.Quo(spotPriceNow.Dec())
 	ratioWeight := (baseAsset.Weight.ToLegacyDec()).Quo(baseAsset.Weight.ToLegacyDec().Add(quoteAsset.Weight.ToLegacyDec()))
 
 	amountTrade = quoteAsset.Token.Amount.ToLegacyDec().Mul(osmomath.Pow(ratioPrice, ratioWeight).Sub(osmomath.OneDec()))

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -481,13 +481,14 @@ func updateTWAPGenesis(appGenState map[string]json.RawMessage) func(twapGenState
 				}
 
 				twapRecord := twaptypes.TwapRecord{
-					PoolId:                      balancerPool.Id,
-					Asset0Denom:                 denomPair.Denom0,
-					Asset1Denom:                 denomPair.Denom0,
-					Height:                      1,
-					Time:                        time.Date(2023, 0o2, 1, 0, 0, 0, 0, time.UTC), // some time in the past.
-					P0LastSpotPrice:             sp0,
-					P1LastSpotPrice:             sp1,
+					PoolId:      balancerPool.Id,
+					Asset0Denom: denomPair.Denom0,
+					Asset1Denom: denomPair.Denom0,
+					Height:      1,
+					Time:        time.Date(2023, 0o2, 1, 0, 0, 0, 0, time.UTC), // some time in the past.
+					// Note: truncation is acceptable as x/twap is guaranteed to work only on pools with spot prices > 10^-18.
+					P0LastSpotPrice:             sp0.Dec(),
+					P1LastSpotPrice:             sp1.Dec(),
 					P0ArithmeticTwapAccumulator: osmomath.ZeroDec(),
 					P1ArithmeticTwapAccumulator: osmomath.ZeroDec(),
 					GeometricTwapAccumulator:    osmomath.ZeroDec(),

--- a/tests/mocks/cfmm_pool.go
+++ b/tests/mocks/cfmm_pool.go
@@ -10,6 +10,7 @@ import (
 
 	types "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
+	osmomath "github.com/osmosis-labs/osmosis/osmomath"
 	types0 "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 )
 
@@ -51,7 +52,7 @@ func (mr *MockCFMMPoolIMockRecorder) AsSerializablePool() *gomock.Call {
 }
 
 // CalcExitPoolCoinsFromShares mocks base method.
-func (m *MockCFMMPoolI) CalcExitPoolCoinsFromShares(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockCFMMPoolI) CalcExitPoolCoinsFromShares(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcExitPoolCoinsFromShares", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -66,7 +67,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcExitPoolCoinsFromShares(ctx, numShares,
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockCFMMPoolI) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -81,10 +82,10 @@ func (mr *MockCFMMPoolIMockRecorder) CalcInAmtGivenOut(ctx, tokenOut, tokenInDen
 }
 
 // CalcJoinPoolNoSwapShares mocks base method.
-func (m *MockCFMMPoolI) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockCFMMPoolI) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -97,10 +98,10 @@ func (mr *MockCFMMPoolIMockRecorder) CalcJoinPoolNoSwapShares(ctx, tokensIn, spr
 }
 
 // CalcJoinPoolShares mocks base method.
-func (m *MockCFMMPoolI) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockCFMMPoolI) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -113,7 +114,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcJoinPoolShares(ctx, tokensIn, spreadFac
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -128,7 +129,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDen
 }
 
 // ExitPool mocks base method.
-func (m *MockCFMMPoolI) ExitPool(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockCFMMPoolI) ExitPool(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitPool", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -157,10 +158,10 @@ func (mr *MockCFMMPoolIMockRecorder) GetAddress() *gomock.Call {
 }
 
 // GetExitFee mocks base method.
-func (m *MockCFMMPoolI) GetExitFee(ctx types.Context) types.Dec {
+func (m *MockCFMMPoolI) GetExitFee(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExitFee", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -185,10 +186,10 @@ func (mr *MockCFMMPoolIMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockCFMMPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockCFMMPoolI) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -196,20 +197,6 @@ func (m *MockCFMMPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
 func (mr *MockCFMMPoolIMockRecorder) GetSpreadFactor(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockCFMMPoolI)(nil).GetSpreadFactor), ctx)
-}
-
-// GetTakerFee mocks base method.
-func (m *MockCFMMPoolI) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockCFMMPoolIMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockCFMMPoolI)(nil).GetTakerFee))
 }
 
 // GetTotalPoolLiquidity mocks base method.
@@ -227,10 +214,10 @@ func (mr *MockCFMMPoolIMockRecorder) GetTotalPoolLiquidity(ctx interface{}) *gom
 }
 
 // GetTotalShares mocks base method.
-func (m *MockCFMMPoolI) GetTotalShares() types.Int {
+func (m *MockCFMMPoolI) GetTotalShares() osmomath.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalShares")
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	return ret0
 }
 
@@ -269,10 +256,10 @@ func (mr *MockCFMMPoolIMockRecorder) IsActive(ctx interface{}) *gomock.Call {
 }
 
 // JoinPool mocks base method.
-func (m *MockCFMMPoolI) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockCFMMPoolI) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPool", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -284,10 +271,10 @@ func (mr *MockCFMMPoolIMockRecorder) JoinPool(ctx, tokensIn, spreadFactor interf
 }
 
 // JoinPoolNoSwap mocks base method.
-func (m *MockCFMMPoolI) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockCFMMPoolI) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -322,23 +309,11 @@ func (mr *MockCFMMPoolIMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockCFMMPoolI)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockCFMMPoolI) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockCFMMPoolIMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockCFMMPoolI)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockCFMMPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockCFMMPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -364,7 +339,7 @@ func (mr *MockCFMMPoolIMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockCFMMPoolI) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -379,7 +354,7 @@ func (mr *MockCFMMPoolIMockRecorder) SwapInAmtGivenOut(ctx, tokenOut, tokenInDen
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -431,7 +406,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) AsSerializablePool() *gomock.C
 }
 
 // CalcExitPoolCoinsFromShares mocks base method.
-func (m *MockPoolAmountOutExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockPoolAmountOutExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcExitPoolCoinsFromShares", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -446,7 +421,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcExitPoolCoinsFromShares(ct
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -461,10 +436,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcInAmtGivenOut(ctx, tokenOu
 }
 
 // CalcJoinPoolNoSwapShares mocks base method.
-func (m *MockPoolAmountOutExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockPoolAmountOutExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -477,10 +452,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolNoSwapShares(ctx, 
 }
 
 // CalcJoinPoolShares mocks base method.
-func (m *MockPoolAmountOutExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockPoolAmountOutExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -493,7 +468,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolShares(ctx, tokens
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -508,10 +483,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcOutAmtGivenIn(ctx, tokenIn
 }
 
 // CalcTokenInShareAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) CalcTokenInShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount types.Int, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) CalcTokenInShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount osmomath.Int, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcTokenInShareAmountOut", ctx, tokenInDenom, shareOutAmount, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -523,7 +498,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcTokenInShareAmountOut(ctx,
 }
 
 // ExitPool mocks base method.
-func (m *MockPoolAmountOutExtension) ExitPool(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockPoolAmountOutExtension) ExitPool(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitPool", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -538,10 +513,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) ExitPool(ctx, numShares, exitF
 }
 
 // ExitSwapExactAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) ExitSwapExactAmountOut(ctx types.Context, tokenOut types.Coin, shareInMaxAmount types.Int) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) ExitSwapExactAmountOut(ctx types.Context, tokenOut types.Coin, shareInMaxAmount osmomath.Int) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitSwapExactAmountOut", ctx, tokenOut, shareInMaxAmount)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -567,10 +542,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetAddress() *gomock.Call {
 }
 
 // GetExitFee mocks base method.
-func (m *MockPoolAmountOutExtension) GetExitFee(ctx types.Context) types.Dec {
+func (m *MockPoolAmountOutExtension) GetExitFee(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExitFee", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -595,10 +570,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockPoolAmountOutExtension) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockPoolAmountOutExtension) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -606,20 +581,6 @@ func (m *MockPoolAmountOutExtension) GetSpreadFactor(ctx types.Context) types.De
 func (mr *MockPoolAmountOutExtensionMockRecorder) GetSpreadFactor(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).GetSpreadFactor), ctx)
-}
-
-// GetTakerFee mocks base method.
-func (m *MockPoolAmountOutExtension) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockPoolAmountOutExtensionMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).GetTakerFee))
 }
 
 // GetTotalPoolLiquidity mocks base method.
@@ -637,10 +598,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetTotalPoolLiquidity(ctx inte
 }
 
 // GetTotalShares mocks base method.
-func (m *MockPoolAmountOutExtension) GetTotalShares() types.Int {
+func (m *MockPoolAmountOutExtension) GetTotalShares() osmomath.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalShares")
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	return ret0
 }
 
@@ -665,7 +626,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) GetType() *gomock.Call {
 }
 
 // IncreaseLiquidity mocks base method.
-func (m *MockPoolAmountOutExtension) IncreaseLiquidity(sharesOut types.Int, coinsIn types.Coins) {
+func (m *MockPoolAmountOutExtension) IncreaseLiquidity(sharesOut osmomath.Int, coinsIn types.Coins) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "IncreaseLiquidity", sharesOut, coinsIn)
 }
@@ -691,10 +652,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) IsActive(ctx interface{}) *gom
 }
 
 // JoinPool mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPool", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -706,10 +667,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPool(ctx, tokensIn, spread
 }
 
 // JoinPoolNoSwap mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -721,10 +682,10 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) JoinPoolNoSwap(ctx, tokensIn, 
 }
 
 // JoinPoolTokenInMaxShareAmountOut mocks base method.
-func (m *MockPoolAmountOutExtension) JoinPoolTokenInMaxShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount types.Int) (types.Int, error) {
+func (m *MockPoolAmountOutExtension) JoinPoolTokenInMaxShareAmountOut(ctx types.Context, tokenInDenom string, shareOutAmount osmomath.Int) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolTokenInMaxShareAmountOut", ctx, tokenInDenom, shareOutAmount)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -759,23 +720,11 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockPoolAmountOutExtension) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockPoolAmountOutExtensionMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockPoolAmountOutExtension)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockPoolAmountOutExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockPoolAmountOutExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -801,7 +750,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockPoolAmountOutExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -816,7 +765,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) SwapInAmtGivenOut(ctx, tokenOu
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -868,7 +817,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) AsSerializablePool() *gomock.Ca
 }
 
 // CalcExitPoolCoinsFromShares mocks base method.
-func (m *MockWeightedPoolExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockWeightedPoolExtension) CalcExitPoolCoinsFromShares(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcExitPoolCoinsFromShares", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -883,7 +832,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcExitPoolCoinsFromShares(ctx
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockWeightedPoolExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -898,10 +847,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcInAmtGivenOut(ctx, tokenOut
 }
 
 // CalcJoinPoolNoSwapShares mocks base method.
-func (m *MockWeightedPoolExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockWeightedPoolExtension) CalcJoinPoolNoSwapShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolNoSwapShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -914,10 +863,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcJoinPoolNoSwapShares(ctx, t
 }
 
 // CalcJoinPoolShares mocks base method.
-func (m *MockWeightedPoolExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, types.Coins, error) {
+func (m *MockWeightedPoolExtension) CalcJoinPoolShares(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcJoinPoolShares", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(types.Coins)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -930,7 +879,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcJoinPoolShares(ctx, tokensI
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -945,7 +894,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcOutAmtGivenIn(ctx, tokenIn,
 }
 
 // ExitPool mocks base method.
-func (m *MockWeightedPoolExtension) ExitPool(ctx types.Context, numShares types.Int, exitFee types.Dec) (types.Coins, error) {
+func (m *MockWeightedPoolExtension) ExitPool(ctx types.Context, numShares osmomath.Int, exitFee osmomath.Dec) (types.Coins, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExitPool", ctx, numShares, exitFee)
 	ret0, _ := ret[0].(types.Coins)
@@ -974,10 +923,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetAddress() *gomock.Call {
 }
 
 // GetExitFee mocks base method.
-func (m *MockWeightedPoolExtension) GetExitFee(ctx types.Context) types.Dec {
+func (m *MockWeightedPoolExtension) GetExitFee(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExitFee", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -1002,10 +951,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockWeightedPoolExtension) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockWeightedPoolExtension) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -1015,25 +964,11 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetSpreadFactor(ctx interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockWeightedPoolExtension)(nil).GetSpreadFactor), ctx)
 }
 
-// GetTakerFee mocks base method.
-func (m *MockWeightedPoolExtension) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockWeightedPoolExtensionMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockWeightedPoolExtension)(nil).GetTakerFee))
-}
-
 // GetTokenWeight mocks base method.
-func (m *MockWeightedPoolExtension) GetTokenWeight(denom string) (types.Int, error) {
+func (m *MockWeightedPoolExtension) GetTokenWeight(denom string) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTokenWeight", denom)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1059,10 +994,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) GetTotalPoolLiquidity(ctx inter
 }
 
 // GetTotalShares mocks base method.
-func (m *MockWeightedPoolExtension) GetTotalShares() types.Int {
+func (m *MockWeightedPoolExtension) GetTotalShares() osmomath.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalShares")
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	return ret0
 }
 
@@ -1101,10 +1036,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) IsActive(ctx interface{}) *gomo
 }
 
 // JoinPool mocks base method.
-func (m *MockWeightedPoolExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockWeightedPoolExtension) JoinPool(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPool", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1116,10 +1051,10 @@ func (mr *MockWeightedPoolExtensionMockRecorder) JoinPool(ctx, tokensIn, spreadF
 }
 
 // JoinPoolNoSwap mocks base method.
-func (m *MockWeightedPoolExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockWeightedPoolExtension) JoinPoolNoSwap(ctx types.Context, tokensIn types.Coins, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JoinPoolNoSwap", ctx, tokensIn, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1166,23 +1101,11 @@ func (mr *MockWeightedPoolExtensionMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockWeightedPoolExtension)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockWeightedPoolExtension) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockWeightedPoolExtensionMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockWeightedPoolExtension)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockWeightedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockWeightedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1208,7 +1131,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) String() *gomock.Call {
 }
 
 // SwapInAmtGivenOut mocks base method.
-func (m *MockWeightedPoolExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) SwapInAmtGivenOut(ctx types.Context, tokenOut types.Coins, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapInAmtGivenOut", ctx, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -1223,7 +1146,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) SwapInAmtGivenOut(ctx, tokenOut
 }
 
 // SwapOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) SwapOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)

--- a/tests/mocks/cl_pool.go
+++ b/tests/mocks/cl_pool.go
@@ -38,7 +38,7 @@ func (m *MockConcentratedPoolExtension) EXPECT() *MockConcentratedPoolExtensionM
 }
 
 // ApplySwap mocks base method.
-func (m *MockConcentratedPoolExtension) ApplySwap(newLiquidity types.Dec, newCurrentTick int64, newCurrentSqrtPrice osmomath.BigDec) error {
+func (m *MockConcentratedPoolExtension) ApplySwap(newLiquidity osmomath.Dec, newCurrentTick int64, newCurrentSqrtPrice osmomath.BigDec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplySwap", newLiquidity, newCurrentTick, newCurrentSqrtPrice)
 	ret0, _ := ret[0].(error)
@@ -66,11 +66,11 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) AsSerializablePool() *gomoc
 }
 
 // CalcActualAmounts mocks base method.
-func (m *MockConcentratedPoolExtension) CalcActualAmounts(ctx types.Context, lowerTick, upperTick int64, liquidityDelta types.Dec) (types.Dec, types.Dec, error) {
+func (m *MockConcentratedPoolExtension) CalcActualAmounts(ctx types.Context, lowerTick, upperTick int64, liquidityDelta osmomath.Dec) (osmomath.Dec, osmomath.Dec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcActualAmounts", ctx, lowerTick, upperTick, liquidityDelta)
-	ret0, _ := ret[0].(types.Dec)
-	ret1, _ := ret[1].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
+	ret1, _ := ret[1].(osmomath.Dec)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -180,10 +180,10 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) GetLastLiquidityUpdate() *g
 }
 
 // GetLiquidity mocks base method.
-func (m *MockConcentratedPoolExtension) GetLiquidity() types.Dec {
+func (m *MockConcentratedPoolExtension) GetLiquidity() osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLiquidity")
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -194,10 +194,10 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) GetLiquidity() *gomock.Call
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockConcentratedPoolExtension) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockConcentratedPoolExtension) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -219,20 +219,6 @@ func (m *MockConcentratedPoolExtension) GetSpreadRewardsAddress() types.AccAddre
 func (mr *MockConcentratedPoolExtensionMockRecorder) GetSpreadRewardsAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadRewardsAddress", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).GetSpreadRewardsAddress))
-}
-
-// GetTakerFee mocks base method.
-func (m *MockConcentratedPoolExtension) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockConcentratedPoolExtensionMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).GetTakerFee))
 }
 
 // GetTickSpacing mocks base method.
@@ -379,18 +365,6 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) SetLastLiquidityUpdate(newT
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastLiquidityUpdate", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).SetLastLiquidityUpdate), newTime)
 }
 
-// SetTakerFee mocks base method.
-func (m *MockConcentratedPoolExtension) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockConcentratedPoolExtensionMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockConcentratedPoolExtension)(nil).SetTakerFee), newTakerFee)
-}
-
 // SetTickSpacing mocks base method.
 func (m *MockConcentratedPoolExtension) SetTickSpacing(newTickSpacing uint64) {
 	m.ctrl.T.Helper()
@@ -404,10 +378,10 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) SetTickSpacing(newTickSpaci
 }
 
 // SpotPrice mocks base method.
-func (m *MockConcentratedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockConcentratedPoolExtension) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -433,7 +407,7 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) String() *gomock.Call {
 }
 
 // UpdateLiquidity mocks base method.
-func (m *MockConcentratedPoolExtension) UpdateLiquidity(newLiquidity types.Dec) {
+func (m *MockConcentratedPoolExtension) UpdateLiquidity(newLiquidity osmomath.Dec) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateLiquidity", newLiquidity)
 }
@@ -445,7 +419,7 @@ func (mr *MockConcentratedPoolExtensionMockRecorder) UpdateLiquidity(newLiquidit
 }
 
 // UpdateLiquidityIfActivePosition mocks base method.
-func (m *MockConcentratedPoolExtension) UpdateLiquidityIfActivePosition(ctx types.Context, lowerTick, upperTick int64, liquidityDelta types.Dec) bool {
+func (m *MockConcentratedPoolExtension) UpdateLiquidityIfActivePosition(ctx types.Context, lowerTick, upperTick int64, liquidityDelta osmomath.Dec) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLiquidityIfActivePosition", ctx, lowerTick, upperTick, liquidityDelta)
 	ret0, _ := ret[0].(bool)

--- a/tests/mocks/pool.go
+++ b/tests/mocks/pool.go
@@ -9,6 +9,7 @@ import (
 
 	types "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
+	osmomath "github.com/osmosis-labs/osmosis/osmomath"
 	types0 "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 )
 
@@ -78,10 +79,10 @@ func (mr *MockPoolIMockRecorder) GetId() *gomock.Call {
 }
 
 // GetSpreadFactor mocks base method.
-func (m *MockPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
+func (m *MockPoolI) GetSpreadFactor(ctx types.Context) osmomath.Dec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSpreadFactor", ctx)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	return ret0
 }
 
@@ -89,20 +90,6 @@ func (m *MockPoolI) GetSpreadFactor(ctx types.Context) types.Dec {
 func (mr *MockPoolIMockRecorder) GetSpreadFactor(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpreadFactor", reflect.TypeOf((*MockPoolI)(nil).GetSpreadFactor), ctx)
-}
-
-// GetTakerFee mocks base method.
-func (m *MockPoolI) GetTakerFee() types.Dec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTakerFee")
-	ret0, _ := ret[0].(types.Dec)
-	return ret0
-}
-
-// GetTakerFee indicates an expected call of GetTakerFee.
-func (mr *MockPoolIMockRecorder) GetTakerFee() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTakerFee", reflect.TypeOf((*MockPoolI)(nil).GetTakerFee))
 }
 
 // GetType mocks base method.
@@ -157,23 +144,11 @@ func (mr *MockPoolIMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockPoolI)(nil).Reset))
 }
 
-// SetTakerFee mocks base method.
-func (m *MockPoolI) SetTakerFee(newTakerFee types.Dec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTakerFee", newTakerFee)
-}
-
-// SetTakerFee indicates an expected call of SetTakerFee.
-func (mr *MockPoolIMockRecorder) SetTakerFee(newTakerFee interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTakerFee", reflect.TypeOf((*MockPoolI)(nil).SetTakerFee), newTakerFee)
-}
-
 // SpotPrice mocks base method.
-func (m *MockPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockPoolI) SpotPrice(ctx types.Context, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotPrice", ctx, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/tests/mocks/pool_module.go
+++ b/tests/mocks/pool_module.go
@@ -11,6 +11,7 @@ import (
 	types0 "github.com/cosmos/cosmos-sdk/x/auth/types"
 	types1 "github.com/cosmos/cosmos-sdk/x/bank/types"
 	gomock "github.com/golang/mock/gomock"
+	osmomath "github.com/osmosis-labs/osmosis/osmomath"
 	types2 "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
 )
 
@@ -229,7 +230,7 @@ func (m *MockPoolModuleI) EXPECT() *MockPoolModuleIMockRecorder {
 }
 
 // CalcInAmtGivenOut mocks base method.
-func (m *MockPoolModuleI) CalcInAmtGivenOut(ctx types.Context, poolI types2.PoolI, tokenOut types.Coin, tokenInDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolModuleI) CalcInAmtGivenOut(ctx types.Context, poolI types2.PoolI, tokenOut types.Coin, tokenInDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcInAmtGivenOut", ctx, poolI, tokenOut, tokenInDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -244,7 +245,7 @@ func (mr *MockPoolModuleIMockRecorder) CalcInAmtGivenOut(ctx, poolI, tokenOut, t
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockPoolModuleI) CalcOutAmtGivenIn(ctx types.Context, poolI types2.PoolI, tokenIn types.Coin, tokenOutDenom string, spreadFactor types.Dec) (types.Coin, error) {
+func (m *MockPoolModuleI) CalcOutAmtGivenIn(ctx types.Context, poolI types2.PoolI, tokenIn types.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, poolI, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -259,10 +260,10 @@ func (mr *MockPoolModuleIMockRecorder) CalcOutAmtGivenIn(ctx, poolI, tokenIn, to
 }
 
 // CalculateSpotPrice mocks base method.
-func (m *MockPoolModuleI) CalculateSpotPrice(ctx types.Context, poolId uint64, quoteAssetDenom, baseAssetDenom string) (types.Dec, error) {
+func (m *MockPoolModuleI) CalculateSpotPrice(ctx types.Context, poolId uint64, quoteAssetDenom, baseAssetDenom string) (osmomath.Dec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalculateSpotPrice", ctx, poolId, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(types.Dec)
+	ret0, _ := ret[0].(osmomath.Dec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -363,10 +364,10 @@ func (mr *MockPoolModuleIMockRecorder) InitializePool(ctx, pool, creatorAddress 
 }
 
 // SwapExactAmountIn mocks base method.
-func (m *MockPoolModuleI) SwapExactAmountIn(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenIn types.Coin, tokenOutDenom string, tokenOutMinAmount types.Int, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolModuleI) SwapExactAmountIn(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenIn types.Coin, tokenOutDenom string, tokenOutMinAmount osmomath.Int, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapExactAmountIn", ctx, sender, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -378,10 +379,10 @@ func (mr *MockPoolModuleIMockRecorder) SwapExactAmountIn(ctx, sender, pool, toke
 }
 
 // SwapExactAmountOut mocks base method.
-func (m *MockPoolModuleI) SwapExactAmountOut(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenInDenom string, tokenInMaxAmount types.Int, tokenOut types.Coin, spreadFactor types.Dec) (types.Int, error) {
+func (m *MockPoolModuleI) SwapExactAmountOut(ctx types.Context, sender types.AccAddress, pool types2.PoolI, tokenInDenom string, tokenInMaxAmount osmomath.Int, tokenOut types.Coin, spreadFactor osmomath.Dec) (osmomath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwapExactAmountOut", ctx, sender, pool, tokenInDenom, tokenInMaxAmount, tokenOut, spreadFactor)
-	ret0, _ := ret[0].(types.Int)
+	ret0, _ := ret[0].(osmomath.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -506,4 +507,79 @@ func (m *MockMultihopRoute) PoolIds() []uint64 {
 func (mr *MockMultihopRouteMockRecorder) PoolIds() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PoolIds", reflect.TypeOf((*MockMultihopRoute)(nil).PoolIds))
+}
+
+// MockStakingKeeper is a mock of StakingKeeper interface.
+type MockStakingKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockStakingKeeperMockRecorder
+}
+
+// MockStakingKeeperMockRecorder is the mock recorder for MockStakingKeeper.
+type MockStakingKeeperMockRecorder struct {
+	mock *MockStakingKeeper
+}
+
+// NewMockStakingKeeper creates a new mock instance.
+func NewMockStakingKeeper(ctrl *gomock.Controller) *MockStakingKeeper {
+	mock := &MockStakingKeeper{ctrl: ctrl}
+	mock.recorder = &MockStakingKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
+	return m.recorder
+}
+
+// BondDenom mocks base method.
+func (m *MockStakingKeeper) BondDenom(ctx types.Context) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BondDenom", ctx)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// BondDenom indicates an expected call of BondDenom.
+func (mr *MockStakingKeeperMockRecorder) BondDenom(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BondDenom", reflect.TypeOf((*MockStakingKeeper)(nil).BondDenom), ctx)
+}
+
+// MockProtorevKeeper is a mock of ProtorevKeeper interface.
+type MockProtorevKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockProtorevKeeperMockRecorder
+}
+
+// MockProtorevKeeperMockRecorder is the mock recorder for MockProtorevKeeper.
+type MockProtorevKeeperMockRecorder struct {
+	mock *MockProtorevKeeper
+}
+
+// NewMockProtorevKeeper creates a new mock instance.
+func NewMockProtorevKeeper(ctrl *gomock.Controller) *MockProtorevKeeper {
+	mock := &MockProtorevKeeper{ctrl: ctrl}
+	mock.recorder = &MockProtorevKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockProtorevKeeper) EXPECT() *MockProtorevKeeperMockRecorder {
+	return m.recorder
+}
+
+// GetPoolForDenomPair mocks base method.
+func (m *MockProtorevKeeper) GetPoolForDenomPair(ctx types.Context, baseDenom, denomToMatch string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPoolForDenomPair", ctx, baseDenom, denomToMatch)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPoolForDenomPair indicates an expected call of GetPoolForDenomPair.
+func (mr *MockProtorevKeeperMockRecorder) GetPoolForDenomPair(ctx, baseDenom, denomToMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPoolForDenomPair", reflect.TypeOf((*MockProtorevKeeper)(nil).GetPoolForDenomPair), ctx, baseDenom, denomToMatch)
 }

--- a/x/concentrated-liquidity/model/pool.go
+++ b/x/concentrated-liquidity/model/pool.go
@@ -108,20 +108,23 @@ func (p Pool) IsActive(ctx sdk.Context) bool {
 // SpotPrice returns the spot price of the pool.
 // If base asset is the Token0 of the pool, we use the current sqrt price of the pool.
 // If not, we calculate the inverse of the current sqrt price of the pool.
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error) {
 	// validate base asset is in pool
 	if baseAssetDenom != p.Token0 && baseAssetDenom != p.Token1 {
-		return osmomath.Dec{}, fmt.Errorf("base asset denom (%s) is not in pool with (%s, %s) pair", baseAssetDenom, p.Token0, p.Token1)
+		return osmomath.BigDec{}, fmt.Errorf("base asset denom (%s) is not in pool with (%s, %s) pair", baseAssetDenom, p.Token0, p.Token1)
 	}
 	// validate quote asset is in pool
 	if quoteAssetDenom != p.Token0 && quoteAssetDenom != p.Token1 {
-		return osmomath.Dec{}, fmt.Errorf("quote asset denom (%s) is not in pool with (%s, %s) pair", quoteAssetDenom, p.Token0, p.Token1)
+		return osmomath.BigDec{}, fmt.Errorf("quote asset denom (%s) is not in pool with (%s, %s) pair", quoteAssetDenom, p.Token0, p.Token1)
 	}
 
+	// The reason why we convert the result to Dec and then back to BigDec is to temporarily
+	// maintain backwards compatibility with the original implementation.
+	// TODO: remove before https://github.com/osmosis-labs/osmosis/issues/5726 is complete
 	if baseAssetDenom == p.Token0 {
-		return p.CurrentSqrtPrice.PowerInteger(2).Dec(), nil
+		return osmomath.BigDecFromDec(p.CurrentSqrtPrice.PowerInteger(2).Dec()), nil
 	}
-	return osmomath.OneBigDec().Quo(p.CurrentSqrtPrice.PowerInteger(2)).Dec(), nil
+	return osmomath.BigDecFromDec(osmomath.OneBigDec().Quo(p.CurrentSqrtPrice.PowerInteger(2)).Dec()), nil
 }
 
 // GetToken0 returns the token0 of the pool

--- a/x/concentrated-liquidity/model/pool_test.go
+++ b/x/concentrated-liquidity/model/pool_test.go
@@ -216,7 +216,9 @@ func (s *ConcentratedPoolTestSuite) TestSpotPrice() {
 
 				// We use elipson due to sqrt approximation
 				elipson := osmomath.MustNewDecFromStr("0.0000000000000001")
-				s.Require().True(spotPriceFromMethod.Sub(tc.expectedSpotPrice).Abs().LT(elipson))
+				// TODO: truncation is acceptable temporary
+				// remove before https://github.com/osmosis-labs/osmosis/issues/5726 is complete
+				s.Require().True(spotPriceFromMethod.Dec().Sub(tc.expectedSpotPrice).Abs().LT(elipson))
 			}
 		})
 	}

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -165,13 +165,15 @@ func (k Keeper) CalculateSpotPrice(
 	}
 
 	if price.IsZero() {
-		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: osmomath.BigDecFromDec(price), MinSpotPrice: types.MinSpotPriceV2, MaxSpotPrice: types.MaxSpotPrice}
+		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceV2, MaxSpotPrice: types.MaxSpotPrice}
 	}
-	if price.GT(types.MaxSpotPrice) || price.LT(types.MinSpotPrice) {
-		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: osmomath.BigDecFromDec(price), MinSpotPrice: types.MinSpotPriceBigDec, MaxSpotPrice: types.MaxSpotPrice}
+	if price.GT(types.MaxSpotPriceBigDec) || price.LT(types.MinSpotPriceBigDec) {
+		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceBigDec, MaxSpotPrice: types.MaxSpotPrice}
 	}
 
-	return price, nil
+	// TODO: remove before https://github.com/osmosis-labs/osmosis/issues/5726 is complete.
+	// Acceptable for backwards compatibility with v19.x.
+	return price.Dec(), nil
 }
 
 // GetTotalPoolLiquidity returns the coins in the pool owned by all LPs

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -3094,7 +3094,9 @@ func (s *KeeperTestSuite) inverseRelationshipInvariants(firstTokenIn, firstToken
 	multiplicativeTolerance = osmomath.ErrTolerance{
 		MultiplicativeTolerance: osmomath.MustNewDecFromStr("0.001"),
 	}
-	osmoassert.Equal(s.T(), multiplicativeTolerance, oldSpotPrice.RoundInt(), newSpotPrice.RoundInt())
+	// Note: spot price truncation is made because the test was created before we changed in from Dec to BigDec
+	// As a result, it is acceptable to truncate for test correctness.
+	osmoassert.Equal(s.T(), multiplicativeTolerance, oldSpotPrice.Dec().RoundInt(), newSpotPrice.Dec().RoundInt())
 
 	// Assure that user balance now as it was before both swaps.
 	// TODO: Come back to this choice after deciding if we are using BigDec for swaps

--- a/x/cosmwasmpool/model/pool.go
+++ b/x/cosmwasmpool/model/pool.go
@@ -72,7 +72,7 @@ func (p Pool) IsActive(ctx sdk.Context) bool {
 }
 
 // SpotPrice returns the spot price of the pool.
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error) {
 	request := msg.SpotPriceQueryMsg{
 		SpotPrice: msg.SpotPrice{
 			QuoteAssetDenom: quoteAssetDenom,
@@ -81,9 +81,9 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom 
 	}
 	response, err := cosmwasmutils.Query[msg.SpotPriceQueryMsg, msg.SpotPriceQueryMsgResponse](ctx, p.WasmKeeper, p.ContractAddress, request)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
-	return osmomath.MustNewDecFromStr(response.SpotPrice), nil
+	return osmomath.MustNewBigDecFromStr(response.SpotPrice), nil
 }
 
 // GetType returns the type of the pool.

--- a/x/cosmwasmpool/model/pool_test.go
+++ b/x/cosmwasmpool/model/pool_test.go
@@ -42,7 +42,7 @@ func (s *CosmWasmPoolSuite) TestGetSpreadFactor() {
 // TestSpotPrice validates that spot price is returned as one.
 func (s *CosmWasmPoolSuite) TestSpotPrice() {
 	var (
-		expectedSpotPrice = osmomath.OneDec()
+		expectedSpotPrice = osmomath.OneBigDec()
 	)
 
 	pool := s.PrepareCosmWasmPool()

--- a/x/cosmwasmpool/model/store_model.go
+++ b/x/cosmwasmpool/model/store_model.go
@@ -46,7 +46,7 @@ func (p CosmWasmPool) IsActive(ctx sdk.Context) bool {
 	panic("CosmWasmPool.IsActive not implemented")
 }
 
-func (p CosmWasmPool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (osmomath.Dec, error) {
+func (p CosmWasmPool) SpotPrice(ctx sdk.Context, baseAssetDenom string, quoteAssetDenom string) (osmomath.BigDec, error) {
 	panic("CosmWasmPool.SpotPrice not implemented")
 }
 

--- a/x/cosmwasmpool/pool_module.go
+++ b/x/cosmwasmpool/pool_module.go
@@ -174,7 +174,13 @@ func (k Keeper) CalculateSpotPrice(
 		return osmomath.Dec{}, err
 	}
 
-	return cosmwasmPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
+	spotPriceBigDec, err := cosmwasmPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
+	if err != nil {
+		return osmomath.Dec{}, err
+	}
+	// Truncation is acceptable here since the only reason cosmwasmPool returns a BigDec
+	// is to maintain compatibility with the `PoolI.SpotPrice` API.
+	return spotPriceBigDec.Dec(), nil
 }
 
 // SwapExactAmountIn performs a swap operation with a specified input amount in a CosmWasm-based liquidity pool.

--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -40,10 +40,15 @@ func (k Keeper) CalculateSpotPrice(
 		}
 	}()
 
-	spotPrice, err = pool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
+	spotPriceBigDec, err := pool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
 		return osmomath.Dec{}, err
 	}
+
+	// Truncation is acceptable here because both stableswap and balancer
+	// only support 18 decimal places and wrap around the 36 BigDec for
+	// compatibility with the `PoolI.SpotPrice` API
+	spotPrice = spotPriceBigDec.Dec()
 
 	// if spotPrice greater than max spot price, return an error
 	if spotPrice.GT(types.MaxSpotPrice) {

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -424,7 +424,7 @@ func (s *KeeperTestSuite) TestSpotPriceOverflow() {
 			poolId := s.PrepareBalancerPoolWithCoinsAndWeights(tc.poolLiquidity, tc.poolWeights)
 			pool, err := s.App.GAMMKeeper.GetPoolAndPoke(s.Ctx, poolId)
 			s.Require().NoError(err)
-			var poolSpotPrice osmomath.Dec
+			var poolSpotPrice osmomath.BigDec
 			var poolErr error
 			osmoassert.ConditionalPanic(s.T(), tc.panics, func() {
 				poolSpotPrice, poolErr = pool.SpotPrice(s.Ctx, tc.baseAssetDenom, tc.quoteAssetDenom)
@@ -442,7 +442,10 @@ func (s *KeeperTestSuite) TestSpotPriceOverflow() {
 			} else {
 				s.Require().NoError(poolErr)
 				s.Require().NoError(keeperErr)
-				s.Require().Equal(poolSpotPrice, keeperSpotPrice)
+				// Truncation is acceptable here because both stableswap and balancer
+				// only support 18 decimal places and wrap around the 36 BigDec for
+				// compatibility with the `PoolI.SpotPrice` API
+				s.Require().Equal(poolSpotPrice.Dec(), keeperSpotPrice)
 			}
 		})
 	}

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -629,13 +629,13 @@ func (p *Pool) applySwap(ctx sdk.Context, tokensIn sdk.Coins, tokensOut sdk.Coin
 // In other words, it costs 0.5 uosmo to get one uatom.
 //
 // panics if the pool in state is incorrect, and has any weight that is 0.
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPrice osmomath.Dec, err error) {
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPrice osmomath.BigDec, err error) {
 	quote, base, err := p.parsePoolAssetsByDenoms(quoteAsset, baseAsset)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 	if base.Weight.IsZero() || quote.Weight.IsZero() {
-		return osmomath.Dec{}, errors.New("pool is misconfigured, got 0 weight")
+		return osmomath.BigDec{}, errors.New("pool is misconfigured, got 0 weight")
 	}
 
 	// spot_price = (Quote Supply / Quote Weight) / (Base Supply / Base Weight)
@@ -643,9 +643,9 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAsset, baseAsset string) (spotPric
 	//            = (Base Weight  / Quote Weight) * (Quote Supply / Base Supply)
 	invWeightRatio := base.Weight.ToLegacyDec().Quo(quote.Weight.ToLegacyDec())
 	supplyRatio := quote.Token.Amount.ToLegacyDec().Quo(base.Token.Amount.ToLegacyDec())
-	spotPrice = supplyRatio.Mul(invWeightRatio)
+	spotPriceDec := supplyRatio.Mul(invWeightRatio)
 
-	return spotPrice, err
+	return osmomath.BigDecFromDec(spotPriceDec), err
 }
 
 // calcPoolOutGivenSingleIn - balance pAo.

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -312,8 +312,12 @@ func (p *Pool) SwapInAmtGivenOut(ctx sdk.Context, tokenOut sdk.Coins, tokenInDen
 
 // SpotPrice calculates the approximate amount of `baseDenom` one would receive for
 // an input dx of `quoteDenom` (to simplify calculations, we approximate dx = 1)
-func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error) {
-	return p.spotPrice(quoteAssetDenom, baseAssetDenom)
+func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error) {
+	spotPriceDec, err := p.spotPrice(quoteAssetDenom, baseAssetDenom)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+	return osmomath.BigDecFromDec(spotPriceDec), nil
 }
 
 func (p Pool) Copy() Pool {

--- a/x/gamm/pool-models/stableswap/pool_test.go
+++ b/x/gamm/pool-models/stableswap/pool_test.go
@@ -1339,7 +1339,14 @@ func TestStableswapSpotPrice(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := sdk.Context{}
 			p := poolStructFromAssets(tc.poolAssets, tc.scalingFactors)
-			spotPrice, err := p.SpotPrice(ctx, tc.quoteDenom, tc.baseDenom)
+			spotPriceBigDec, err := p.SpotPrice(ctx, tc.quoteDenom, tc.baseDenom)
+
+			// Note that while the PoolI.SpotPrice API returns a BigDec, stableswap
+			// pool only supports spot price up to precision of 18 and simply converts
+			// the Dec result to BigDec before returning.
+			// For implementation simplicity, we simply convert the BigDec back to Dec
+			// here since invariants have unchanged.
+			spotPrice := spotPriceBigDec.Dec()
 
 			if tc.expectPass {
 				require.NoError(t, err)

--- a/x/poolmanager/types/pool.go
+++ b/x/poolmanager/types/pool.go
@@ -27,7 +27,7 @@ type PoolI interface {
 	// errors if either baseAssetDenom, or quoteAssetDenom does not exist.
 	// For example, if this was a UniV2 50-50 pool, with 2 ETH, and 8000 UST
 	// pool.SpotPrice(ctx, "eth", "ust") = 4000.00
-	SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.Dec, error)
+	SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom string) (osmomath.BigDec, error)
 	// GetType returns the type of the pool (Balancer, Stableswap, Concentrated, etc.)
 	GetType() PoolType
 	// AsSerializablePool returns the pool in a serializable form (useful when a model wraps the proto)

--- a/x/superfluid/keeper/migrate_test.go
+++ b/x/superfluid/keeper/migrate_test.go
@@ -1315,7 +1315,9 @@ func (s *KeeperTestSuite) TestFunctional_VaryingPositions_Migrations() {
 		s.Require().NoError(err)
 		balancerSpotPrice, err := balancerPool.SpotPrice(s.Ctx, DefaultCoin1.Denom, DefaultCoin0.Denom)
 		s.Require().NoError(err)
-		s.CreateFullRangePosition(clPool, sdk.NewCoins(sdk.NewCoin(DefaultCoin0.Denom, osmomath.NewInt(100000000)), sdk.NewCoin(DefaultCoin1.Denom, osmomath.NewDec(100000000).Mul(balancerSpotPrice).TruncateInt())))
+		// balancerSpotPrice truncation is acceptable because all CFMM pools only allow 18 decimals.
+		// The reason why BigDec is returned is to maintain compatibility with the generalized `PoolI.SpotPrice`API.
+		s.CreateFullRangePosition(clPool, sdk.NewCoins(sdk.NewCoin(DefaultCoin0.Denom, osmomath.NewInt(100000000)), sdk.NewCoin(DefaultCoin1.Denom, osmomath.NewDec(100000000).Mul(balancerSpotPrice.Dec()).TruncateInt())))
 
 		// Add a gov sanctioned link between the balancer and concentrated liquidity pool.
 		migrationRecord := gammmigration.MigrationRecords{BalancerToConcentratedPoolLinks: []gammmigration.BalancerToConcentratedPoolLink{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: https://github.com/osmosis-labs/osmosis/issues/6064

## What is the purpose of the change

This PR is an incremental step towards implementing a 36 decimal spot price query.

The proposal and demo of what the end result would roughly look like can be seen here: https://github.com/osmosis-labs/osmosis/pull/6371

The goal is to incrementally break APIs in a state-compatible manner while backporting them to `v19.x`

The assumptions made:
- x/twap will continue to support only 18 decimal prices and not function correctly for pools with smaller spot price
- x/gamm pools will continue to support 18 decimal spot price only. Fixing/changing them is outside of scope.

## Testing and Verifying

- Covered by existing tests

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A