### PR TITLE
[AccountAbstraction] FeePayer handling

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -61,7 +61,7 @@ func NewAnteHandler(
 		ante.NewValidateSigCountDecorator(accountKeeper),
 		ante.NewSigGasConsumeDecorator(accountKeeper, sigGasConsumer),
 		// Our authenticator decorator
-		authante.NewAuthenticatorDecorator(authenticatorKeeper),
+		authante.NewAuthenticatorDecorator(authenticatorKeeper, 20_000), // TODO: what's a good value for maxFeePayerGas?
 		ante.NewIncrementSequenceDecorator(accountKeeper),
 		ibcante.NewAnteDecorator(channelKeeper),
 	)

--- a/x/authenticator/ante/authenticator.go
+++ b/x/authenticator/ante/authenticator.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -23,14 +24,17 @@ var _ authenticatortypes.AccountGetter = DefaultAccountGetter{}
 type AuthenticatorDecorator struct {
 	authenticatorKeeper *authenticatorkeeper.Keeper
 	accountGetter       authenticatortypes.AccountGetter
+	maxFeePayerGas      uint64
 }
 
 func NewAuthenticatorDecorator(
 	authenticatorKeeper *authenticatorkeeper.Keeper,
+	maxFeePayerGas uint64,
 ) AuthenticatorDecorator {
 	return AuthenticatorDecorator{
 		authenticatorKeeper: authenticatorKeeper,
 		accountGetter:       DefaultAccountGetter{},
+		maxFeePayerGas:      maxFeePayerGas,
 	}
 }
 
@@ -47,8 +51,47 @@ func (ad AuthenticatorDecorator) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (newCtx sdk.Context, err error) {
-	// keep track of called authenticators so they can be notified of failed txs
+	// keep track of called authenticators so that they can be notified of failed txs
 	calledAuthenticators := make([]callData, 0)
+
+	// Authenticate the fee payer
+
+	// Authenticating the fee payer needs to be done with very little gas
+	// This is a spam-prevention strategy. If the fee payer is not authenticated, there will be no one to pay
+	// for the cost of the tx, which would allow an attacker to force a validator to spend resources by running
+	// authenticators on a tx that will never be executed
+	originalGasMeter := ctx.GasMeter()
+	// TODO: Here we actually want to use min(gasRemaining, maxFeePayerGas), but this may leat to problems because
+	//   of the implementation of the InfiniteGasMeter. I think it's ok to allow an overflow here as long as it's
+	//   bellow the fee payer gas limit
+	payerGasMeter := sdk.NewGasMeter(ad.maxFeePayerGas)
+	ctx = ctx.WithGasMeter(payerGasMeter)
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feePayer := feeTx.FeePayer()
+	feePayerAuthenticated := false
+
+	// Recover from any OutOfGas panic to return an error with information of the gas limit having been reduced
+	defer func() {
+		if r := recover(); r != nil {
+			if feePayerAuthenticated {
+				panic(r)
+			}
+			switch r.(type) {
+			case sdk.ErrorOutOfGas:
+				log := fmt.Sprintf(
+					"FeePayer not authenticated yet. The gas limit has been reduced to %d. Consumed: %d",
+					ad.maxFeePayerGas, payerGasMeter.GasConsumed())
+				err = sdkerrors.Wrap(sdkerrors.ErrOutOfGas, log)
+			default:
+				panic(r)
+			}
+		}
+	}()
 
 	// Authenticate the accounts of all messages
 	for msgIndex, msg := range tx.GetMsgs() {
@@ -59,21 +102,20 @@ func (ad AuthenticatorDecorator) AnteHandle(
 		}
 
 		// Get all authenticators for the executing account
-		authenticators, err := ad.authenticatorKeeper.GetAuthenticatorsForAccount(ctx, account)
-		if err != nil {
-			return sdk.Context{}, err
-		}
-
 		// If no authenticators are found, use the default authenticator
 		// This is done to keep backwards compatibility by defaulting to a signature verifier on accounts without authenticators
-		if len(authenticators) == 0 {
-			authenticators = append(authenticators, ad.authenticatorKeeper.AuthenticatorManager.GetDefaultAuthenticator())
+		authenticators, err := ad.authenticatorKeeper.GetAuthenticatorsForAccountOrDefault(ctx, account)
+		if err != nil {
+			return sdk.Context{}, err
 		}
 
 		msgAuthenticated := false
 		// ToDo: We should consider adding a way for the user to specify which authenticator to use as part of the tx (likely in the signature)
 		// Note: we have to make sure that doing that does not make the signature malleable
 		for _, authenticator := range authenticators {
+			// Consume the authenticator's static gas
+			ctx.GasMeter().ConsumeGas(authenticator.StaticGas(), "authenticator static gas")
+
 			// Get the authentication data for the transaction
 			cacheCtx, _ := ctx.CacheContext() // GetAuthenticationData is not allowed to modify the state
 			authData, err := authenticator.GetAuthenticationData(cacheCtx, tx, uint8(msgIndex), simulate)
@@ -92,6 +134,12 @@ func (ad AuthenticatorDecorator) AnteHandle(
 
 			if authenticated {
 				msgAuthenticated = true
+				// Once the fee payer is authenticated, we can set the gas limit to its original value
+				if !feePayerAuthenticated && account.Equals(feePayer) {
+					originalGasMeter.ConsumeGas(payerGasMeter.GasConsumed(), "fee payer gas")
+					ctx = ctx.WithGasMeter(originalGasMeter)
+					feePayerAuthenticated = true
+				}
 				break
 			}
 		}

--- a/x/authenticator/ante/authenticator.go
+++ b/x/authenticator/ante/authenticator.go
@@ -1,8 +1,9 @@
 package ante
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/x/authenticator/authenticator/interface.go
+++ b/x/authenticator/authenticator/interface.go
@@ -11,10 +11,9 @@ const (
 type AuthenticatorData interface{}
 
 type Authenticator interface {
-	// TODO: Rename to DefaultGas or StaticGas. Alt. pass the context and consume the gas here
-	Gas() uint64
-
 	Type() string
+
+	StaticGas() uint64
 
 	Initialize(data []byte) (Authenticator, error)
 

--- a/x/authenticator/authenticator/signature_authenticator.go
+++ b/x/authenticator/authenticator/signature_authenticator.go
@@ -32,9 +32,9 @@ func (sva SignatureVerificationAuthenticator) Type() string {
 	return SignatureVerificationAuthenticatorType
 }
 
-func (sva SignatureVerificationAuthenticator) Gas() uint64 {
-	// The default gas for verifying a secp256k1 signature is 1000
-	return 1000
+func (sva SignatureVerificationAuthenticator) StaticGas() uint64 {
+	// using 0 gas here. The gas is consumed based on the pubkey type in Authenticate()
+	return 0
 }
 
 // NewSignatureVerificationAuthenticator creates a new SignatureVerificationAuthenticator

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -35,6 +35,8 @@ type AuthenticatorSuite struct {
 	Account  authtypes.AccountI
 }
 
+type pks = []cryptotypes.PrivKey
+
 func TestAuthenticatorSuite(t *testing.T) {
 	suite.Run(t, new(AuthenticatorSuite))
 }
@@ -66,7 +68,6 @@ func (s *AuthenticatorSuite) SetupTest() {
 
 	// get the account
 	s.Account = s.app.AccountKeeper.GetAccount(s.chainA.GetContext(), accountAddr)
-
 }
 
 func (s *AuthenticatorSuite) TestKeyRotationStory() {
@@ -78,7 +79,7 @@ func (s *AuthenticatorSuite) TestKeyRotationStory() {
 	}
 
 	// Send msg from accounts default privkey
-	_, err := s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], sendMsg)
+	_, err := s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, sendMsg)
 	s.Require().NoError(err, "Failed to send bank tx using the first private key")
 
 	// Change account's authenticator
@@ -86,11 +87,11 @@ func (s *AuthenticatorSuite) TestKeyRotationStory() {
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// Submit a bank send tx using the second private key
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[1], sendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[1]}, sendMsg)
 	s.Require().NoError(err, "Failed to send bank tx using the second private key")
 
 	// Try to send again osing the original PrivKey. This should fail
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], sendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, sendMsg)
 	s.Require().Error(err, "Sending from the original PrivKey succeeded. This should fail")
 
 	// Remove the account's authenticator
@@ -98,7 +99,7 @@ func (s *AuthenticatorSuite) TestKeyRotationStory() {
 	s.Require().NoError(err, "Failed to remove authenticator")
 
 	// Sending from the default PrivKey now works again
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], sendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, sendMsg)
 	s.Require().NoError(err, "Failed to send bank tx using the first private key after removing the authenticator")
 
 }
@@ -188,8 +189,8 @@ func (s *AuthenticatorSuite) TestKeyRotation() {
 					KeysToAdd:              []int{0, 1},
 					AuthenticatorsToRemove: []int{},
 					Sends: []SendTest{
-						{PrivKeyIndex: 1, ShouldSucceed: true},
 						{PrivKeyIndex: 0, ShouldSucceed: true},
+						{PrivKeyIndex: 1, ShouldSucceed: true},
 					},
 				},
 			},
@@ -282,7 +283,7 @@ func (s *AuthenticatorSuite) TestKeyRotation() {
 
 				// Send for the current step
 				for _, send := range step.Sends {
-					_, err := s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[send.PrivKeyIndex], sendMsg)
+					_, err := s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[send.PrivKeyIndex]}, sendMsg)
 					if send.ShouldSucceed {
 						s.Require().NoError(err, tc.Description)
 					} else {
@@ -315,14 +316,14 @@ func (s *AuthenticatorSuite) TestAuthenticatorStateExperiment() {
 
 	// check account balances
 
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], failSendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, failSendMsg)
 	fmt.Println("err: ", err)
 	s.Require().Error(err, "Succeeded sending tx that should fail")
 
 	// Incremented by one. Only on the ante.
 	s.Require().Equal(1, stateful.GetValue(s.chainA.GetContext()))
 
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], successSendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, successSendMsg)
 	fmt.Println("err: ", err)
 	s.Require().NoError(err, "Failed to send bank tx with enough funds")
 
@@ -351,14 +352,81 @@ func (s *AuthenticatorSuite) TestAuthenticatorMultiMsgExperiment() {
 	//s.Require().NoError(err, "Failed to add authenticator")
 	// check account balances
 
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], successSendMsg, successSendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, successSendMsg, successSendMsg)
 	fmt.Println("err: ", err)
 	s.Require().NoError(err)
 	s.Require().Equal(int64(2_000), maxAmount.GetAmount(s.chainA.GetContext()).Int64())
 
-	_, err = s.chainA.SendMsgsFromPrivKey(s.Account, s.PrivKeys[0], successSendMsg, successSendMsg)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, successSendMsg, successSendMsg)
 	fmt.Println("err: ", err)
 	s.Require().Error(err)
 	s.Require().Equal(int64(2_000), maxAmount.GetAmount(s.chainA.GetContext()).Int64())
+}
 
+// This is an experiment to determine how internal authenticator state is managed
+func (s *AuthenticatorSuite) TestAuthenticatorGas() {
+	sendFromAcc1 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes("osmo", s.Account.GetAddress()),
+		ToAddress:   sdk.MustBech32ifyAddressBytes("osmo", s.Account.GetAddress()),
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000)),
+	}
+
+	// Initialize the second account
+	accountAddr := sdk.AccAddress(s.PrivKeys[1].PubKey().Address())
+
+	// fund the account
+	coins := sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100_000))
+	err := s.app.BankKeeper.SendCoins(s.chainA.GetContext(), s.chainA.SenderAccount.GetAddress(), accountAddr, coins)
+	s.Require().NoError(err, "Failed to send bank tx using the first private key")
+
+	// get the account
+	account2 := s.app.AccountKeeper.GetAccount(s.chainA.GetContext(), accountAddr)
+
+	sendFromAcc2 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes("osmo", account2.GetAddress()),
+		ToAddress:   sdk.MustBech32ifyAddressBytes("osmo", account2.GetAddress()),
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000)),
+	}
+
+	alwaysLow := TestingAuthenticator{Approve: Always, GasConsumption: 0}
+	alwaysHigh := TestingAuthenticator{Approve: Always, GasConsumption: 4_000}
+	neverHigh := TestingAuthenticator{Approve: Never, GasConsumption: 8_000}
+
+	s.app.AuthenticatorManager.RegisterAuthenticator(alwaysLow)
+	s.app.AuthenticatorManager.RegisterAuthenticator(alwaysHigh)
+	s.app.AuthenticatorManager.RegisterAuthenticator(neverHigh)
+
+	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), alwaysLow.Type(), []byte{})
+	s.Require().NoError(err, "Failed to add authenticator")
+	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
+	s.Require().NoError(err, "Failed to add authenticator")
+
+	// Both account 0 and account 1 can send
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, sendFromAcc1)
+	s.Require().NoError(err)
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[1]}, sendFromAcc2)
+	s.Require().NoError(err)
+
+	// Remove account2's authenticator
+	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), account2.GetAddress(), 1)
+	s.Require().NoError(err, "Failed to remove authenticator")
+
+	// Add two authenticators that are never high, and one always high.
+	// This allows account2 to execute but *only* after consuming >9k gas
+	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), neverHigh.Type(), []byte{})
+	s.Require().NoError(err, "Failed to add authenticator")
+	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), neverHigh.Type(), []byte{})
+	s.Require().NoError(err, "Failed to add authenticator")
+	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
+	s.Require().NoError(err, "Failed to add authenticator")
+
+	// This should fail, as authenticating the fee payer needs to be done with low gas
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[1]}, sendFromAcc2)
+	fmt.Println(err.Error())
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "gas")
+
+	// This should work, since the fee payer has already been authenticated so the gas limit is raised
+	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0], s.PrivKeys[1]}, sendFromAcc1, sendFromAcc2)
+	s.Require().NoError(err)
 }

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -331,6 +331,8 @@ func (s *AuthenticatorSuite) TestAuthenticatorStateExperiment() {
 	s.Require().Equal(3, stateful.GetValue(s.chainA.GetContext()))
 }
 
+// TODO: Cleanup experiment tests
+
 // This is an experiment to determine how to deal with some authenticators succeeding and others failing
 func (s *AuthenticatorSuite) TestAuthenticatorMultiMsgExperiment() {
 	successSendMsg := &banktypes.MsgSend{

--- a/x/authenticator/keeper/keeper.go
+++ b/x/authenticator/keeper/keeper.go
@@ -85,6 +85,23 @@ func (k Keeper) GetAuthenticatorsForAccount(
 	return authenticators, nil
 }
 
+func (k Keeper) GetAuthenticatorsForAccountOrDefault(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+) ([]authenticator.Authenticator, error) {
+	authenticators, err := k.GetAuthenticatorsForAccount(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(authenticators) == 0 {
+		authenticators = append(authenticators, k.AuthenticatorManager.GetDefaultAuthenticator())
+	}
+
+	return authenticators, nil
+
+}
+
 // GetNextAuthenticatorId returns the next authenticator id.
 func (k Keeper) GetNextAuthenticatorId(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)

--- a/x/authenticator/keeper/keeper.go
+++ b/x/authenticator/keeper/keeper.go
@@ -99,7 +99,6 @@ func (k Keeper) GetAuthenticatorsForAccountOrDefault(
 	}
 
 	return authenticators, nil
-
 }
 
 // GetNextAuthenticatorId returns the next authenticator id.

--- a/x/authenticator/stateful_authenticator_test.go
+++ b/x/authenticator/stateful_authenticator_test.go
@@ -48,6 +48,7 @@ func (s StatefulAuthenticator) Authenticate(ctx sdk.Context, msg sdk.Msg, authen
 	//ctx.GasMeter().ConsumeGas(100_000_000, "loads of gas")
 	s.SetValue(ctx, statefulData.Value+1)
 	return true, nil
+
 }
 
 func (s StatefulAuthenticator) SetValue(ctx sdk.Context, value int) {

--- a/x/authenticator/types/account_authenticators_test.go
+++ b/x/authenticator/types/account_authenticators_test.go
@@ -19,7 +19,7 @@ func (m MockAuthenticator) Initialize(data []byte) (authenticator.Authenticator,
 	return m, nil
 }
 
-func (m MockAuthenticator) Gas() uint64 {
+func (m MockAuthenticator) StaticGas() uint64 {
 	return 1000
 }
 
@@ -113,7 +113,7 @@ func (m MockAuthenticatorFail) Initialize(data []byte) (authenticator.Authentica
 	return m, nil
 }
 
-func (m MockAuthenticatorFail) Gas() uint64 {
+func (m MockAuthenticatorFail) StaticGas() uint64 {
 	return 1000
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/6082

## What is the purpose of the change

The fee payer needs to be authenticated with low gas. This ensures that a malicious user cannot force validators to spend compute on authenticating expensive txs if there isn't anyone to pay the fee.

## Testing and Verifying

Added a test for this. All other tests pass.

We should add many more tests for all of this feature. Ref #6377

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A