### PR TITLE
[Post-Release Automation] Add script to update chain registry on a major release

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -1,14 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "codebase":{
+  "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v18.0.0",
+    "recommended_version": "v19.0.0",
     "compatible_versions": [
-      "v18.0.0"
+      "v19.0.0"
     ],
     "binaries": {
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-arm64?checksum=sha256:4331f9a318f6dd2f012c36f6ef19af8378fd1e9bc85c751e3f56f7018176ed58",
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:9a98a57946e936e7380ae897a205b4e18a188332e91ca84a1f62c21cbb437845"
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-arm64?checksum=sha256:39fb492914ef45f81e91e4472ddfdd83a56d3db820e48ed430df4c59aab90736",
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
     },
     "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
     "consensus": {
@@ -28,7 +28,7 @@
     "versions": [
       {
         "name": "v3",
-        "tag" : "v3.1.0",
+        "tag": "v3.1.0",
         "height": 0,
         "binaries": {
           "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-darwin-amd64?checksum=sha256:a532f25ae754d2573f6a3c91ba59496ddb9f6766ccf6f69f408f6e1597144a74",
@@ -39,7 +39,7 @@
       },
       {
         "name": "v4",
-        "tag" : "v4.2.0",
+        "tag": "v4.2.0",
         "height": 1314500,
         "binaries": {
           "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-darwin-amd64?checksum=sha256:eee08350b223dd06a2aa16aab44aa51eb116f6267924ee1e788ca28fb54fe02d",
@@ -50,7 +50,7 @@
       },
       {
         "name": "v5",
-        "tag" : "v6.4.0",
+        "tag": "v6.4.0",
         "height": 2383300,
         "binaries": {
           "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-darwin-amd64?checksum=sha256:735c7828b0bc311381f4c18081fa648f849df03aeccf173425cc52a634e3c7d8",
@@ -61,7 +61,7 @@
       },
       {
         "name": "v7",
-        "tag" : "v8.0.0",
+        "tag": "v8.0.0",
         "height": 3401000,
         "binaries": {
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v8.0.0/osmosisd-8.0.0-linux-amd64?checksum=sha256:4559ffe7d1e83b1519c2d45a709d35a89b51f8b35f8bba3b58aef92e667e254c"
@@ -70,7 +70,7 @@
       },
       {
         "name": "v9",
-        "tag" : "v10.1.1",
+        "tag": "v10.1.1",
         "height": 4707300,
         "binaries": {
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.1.1/osmosisd-10.1.1-linux-amd64?checksum=sha256:aeae58f8b0be86d5e6e3aec1a8774eab4947207c88c7d4f309c46da98f6694e8",
@@ -80,7 +80,7 @@
       },
       {
         "name": "v11",
-        "tag" : "v11.0.1",
+        "tag": "v11.0.1",
         "height": 5432450,
         "binaries": {
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v11.0.1/osmosisd-11.0.1-linux-amd64?checksum=sha256:41b8fd2345a5e5b77ee5ed9b9ec5370d94bd1b1aa0d4ac2ac0ab02ee98ddd0d8",
@@ -90,7 +90,7 @@
       },
       {
         "name": "v12",
-        "tag" : "v12.3.0",
+        "tag": "v12.3.0",
         "height": 6246000,
         "binaries": {
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v12.3.0/osmosisd-12.3.0-linux-amd64?checksum=sha256:958210c919d13c281896fa9773c323c5534f0fa46d74807154f737609a00db70",
@@ -100,7 +100,7 @@
       },
       {
         "name": "v13",
-        "tag" : "v13.1.2",
+        "tag": "v13.1.2",
         "height": 7241500,
         "binaries": {
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v13.1.2/osmosisd-13.1.2-linux-amd64?checksum=sha256:67ed53046667c72ec6bfe962bcb4d6b122610876b3adf75fb7820ce52c34872d",
@@ -110,7 +110,7 @@
       },
       {
         "name": "v14",
-        "tag" : "v14.0.1",
+        "tag": "v14.0.1",
         "height": 7937500,
         "binaries": {
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v14.0.1/osmosisd-14.0.1-linux-amd64?checksum=sha256:2cc4172bcf000f0f06b30b16864d875a8de2ee12df994a593dfd52a506851bce",
@@ -120,7 +120,7 @@
       },
       {
         "name": "v15",
-        "tag" : "v15.2.0",
+        "tag": "v15.2.0",
         "height": 8732500,
         "recommended_version": "v15.2.0",
         "compatible_versions": [
@@ -147,7 +147,7 @@
       },
       {
         "name": "v16",
-        "tag" : "v16.1.1",
+        "tag": "v16.1.1",
         "height": 10517000,
         "recommended_version": "v16.1.1",
         "compatible_versions": [
@@ -175,7 +175,7 @@
       },
       {
         "name": "v17",
-        "tag" : "v17.0.0",
+        "tag": "v17.0.0",
         "height": 11126100,
         "recommended_version": "v17.0.0",
         "compatible_versions": [
@@ -202,7 +202,7 @@
       },
       {
         "name": "v18",
-        "tag" : "v18.0.0",
+        "tag": "v18.0.0",
         "height": 11155350,
         "recommended_version": "v18.0.0",
         "compatible_versions": [
@@ -222,6 +222,31 @@
         "binaries": {
           "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-arm64?checksum=sha256:4331f9a318f6dd2f012c36f6ef19af8378fd1e9bc85c751e3f56f7018176ed58",
           "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:9a98a57946e936e7380ae897a205b4e18a188332e91ca84a1f62c21cbb437845"
+        },
+        "next_version_name": "v19"
+      },
+      {
+        "name": "v19",
+        "tag": "v19.0.0",
+        "height": "11317300",
+        "recommended_version": "v19.0.0",
+        "compatible_versions": [
+          "v19.0.0"
+        ],
+        "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
+        "consensus": {
+          "type": "tendermint",
+          "version": "informalsystems/tendermint@0.34.24"
+        },
+        "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "4.3.1",
+        "ics_enabled": [
+          "ics20-1"
+        ],
+        "binaries": {
+          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-arm64?checksum=sha256:39fb492914ef45f81e91e4472ddfdd83a56d3db820e48ed430df4c59aab90736",
+          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
         }
       }
     ]

--- a/scripts/release/update_chain_registry/requirements.txt
+++ b/scripts/release/update_chain_registry/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2023.7.22
+charset-normalizer==3.2.0
+idna==3.4
+requests==2.31.0
+urllib3==2.0.4

--- a/scripts/release/update_chain_registry/run.sh
+++ b/scripts/release/update_chain_registry/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Check if exactly 2 arguments are passed
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <upgrade_version> <upgrade_height>"
+    exit 1
+fi
+
+# Extract arguments
+UPGRADE_VERSION="$1"
+UPGRADE_HEIGHT="$2"
+
+# Run the Python script and redirect output to chain.schema.json
+python update_chain_registry.py --upgrade_version "$UPGRADE_VERSION" --upgrade_height "$UPGRADE_HEIGHT" > ../../../chain.schema.json

--- a/scripts/release/update_chain_registry/update_chain_registry.py
+++ b/scripts/release/update_chain_registry/update_chain_registry.py
@@ -1,0 +1,200 @@
+# Usage: update_chain_registry.py [OPTIONS]
+
+# Description:
+# This script fetches the current chain-registry entry for Osmosis and returns an updated registry 
+# with the new version and height information.
+#
+# The script fetches 
+# - the checksums from the osmosis release page
+# - package informations from the `go.mod` in osmosis repository 
+
+# Options:
+#   --upgrade_version VERSION  Required. The version tag for the upgrade (e.g., v19.0.0).
+#   --upgrade_height HEIGHT   Required. The blockchain height at which the upgrade will happen (e.g., 11317300).
+#   --debug                   Optional. Enable debug mode for more verbose output. Defaults to False.
+
+# Example:
+#   python update_chain_registry.py --upgrade_version v19.0.0 --upgrade_height 11317300
+
+import requests
+import json
+import argparse
+import sys
+
+from utils.versions import compare_versions, same_major
+from utils.go_mod import fetch_go_mod_from_tag, get_package_version
+
+chain_json_url = "https://raw.githubusercontent.com/osmosis-labs/osmosis/main/chain.schema.json"
+DEBUG = False
+
+def fetch_data(url, url_type):
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        if url_type == "json":
+            return response.json()
+        elif url_type == "schema":
+            return json.loads(response.text)
+        elif url_type == "text":
+            return response.text
+        else:
+            raise ValueError("Invalid url_type. Use 'json' / 'schema' / 'text'")
+    except requests.exceptions.RequestException as e:
+        raise Exception(f"An error occurred while fetching data from {url}: {e}")
+    except json.JSONDecodeError as e:
+        raise Exception(f"Failed to parse JSON data from {url}: {e}")
+
+
+def download_checksums(checksums_url):
+
+    response = requests.get(checksums_url)
+    if response.status_code != 200:
+        raise ValueError(f"Failed to fetch sha256sum.txt. Status code: {response.status_code}")
+    return response.text
+
+
+def checksums_to_binaries_json(checksums):
+
+    binaries = {}
+    for line in checksums.splitlines():
+        checksum, filename = line.split('  ')
+
+        if not filename.endswith('.tar.gz') and filename.startswith('osmosisd'):
+            try:
+                _, tag, platform, arch = filename.split('-')
+            except ValueError:
+                print(f"Error: Expected binary name in the form: osmosisd-X.Y.Z-platform-architecture, but got {filename}")
+                sys.exit(1)
+            _, tag, platform, arch,  = filename.split('-')
+            # exclude universal binaries and windows binaries
+            if arch == 'all' or platform == 'windows':
+                continue
+
+            binaries[f"{platform}/{arch}"] = f"https://github.com/osmosis-labs/osmosis/releases/download/v{tag}/{filename}?checksum=sha256:{checksum}"
+
+    return {
+        "binaries": binaries
+    }
+
+
+def create_version_info(version, height):
+
+    # Update packages versions
+    go_mod = fetch_go_mod_from_tag(version)
+
+    cosmos_sdk_version = get_package_version(go_mod, "github.com/cosmos/cosmos-sdk")
+    cosmwasm_version = get_package_version(go_mod, "github.com/CosmWasm/wasmd")
+    tendermint_version = get_package_version(go_mod, "github.com/tendermint/tendermint")
+    ibc_go_version = get_package_version(go_mod, "github.com/cosmos/ibc-go/v4")
+
+    if DEBUG:
+        print(f"Cosmos SDK version  {cosmos_sdk_version}")
+        print(f"CosmWasm version    {cosmwasm_version}")
+        print(f"Tendermint version  {tendermint_version}")
+        print(f"IBC Go version      {ibc_go_version}")
+
+    version_info = {
+        "name": version.split('.')[0],
+        "tag" : version,
+        "height": str(height),
+        "recommended_version": version,
+        "compatible_versions": [
+            version
+        ],
+        "cosmos_sdk_version": cosmos_sdk_version,
+        "consensus": {
+            "type": "tendermint",
+            "version": tendermint_version
+        },
+        "cosmwasm_version":cosmwasm_version,
+        "cosmwasm_enabled": True,
+        "ibc_go_version": ibc_go_version,
+        "ics_enabled": [
+            "ics20-1"
+        ],
+    }
+    # Read binaries from the release sha256sum.txt
+    checksums_url = f"https://github.com/osmosis-labs/osmosis/releases/download/{version}/sha256sum.txt"
+    checksums = fetch_data(checksums_url, 'text')
+
+    binaries_json = checksums_to_binaries_json(checksums)
+    version_info['binaries'] = binaries_json['binaries']
+
+    return version_info
+
+
+def update_codebase(codebase, version, height):
+
+    curr_recommended_version = codebase["recommended_version"]
+    curr_compatible_versions = codebase["compatible_versions"]
+
+    if DEBUG:
+        print(f"New version: {version}")
+        print(f"Current version: {curr_recommended_version}")
+        print(f"Current compatible versions: {curr_compatible_versions}")
+
+    if compare_versions(version, curr_recommended_version) < 0:
+        if DEBUG:
+            print("New version is older than recommended version")
+            print("Skipping update")
+        return
+    elif compare_versions(version, curr_recommended_version) == 0:
+        if DEBUG:
+            print("New version is equal than recommended version")
+            print("Skipping update")
+        return
+    else:
+
+        if same_major(version, curr_recommended_version):
+            if DEBUG:
+                print(f"Minor release from {version} to {curr_recommended_version}")
+                print("Logic not yet implemented...")
+                print("Skipping update.")
+            return
+        else:
+            if DEBUG:
+                print(f"Major release from {version} to {curr_recommended_version}")
+
+            version_info = create_version_info(version, height)
+
+            # Add new version to versions list
+            codebase["versions"].append(version_info)
+            
+            # Update top level info
+            codebase["recommended_version"] = version_info["recommended_version"]
+            codebase["compatible_versions"] = version_info["compatible_versions"]
+            codebase["binaries"] = version_info["binaries"]
+            codebase["cosmos_sdk_version"] = version_info["cosmos_sdk_version"]
+            codebase["consensus"] = version_info["consensus"]
+            codebase["cosmwasm_version"] = version_info["cosmwasm_version"]
+            codebase["ibc_go_version"] = version_info["ibc_go_version"]
+
+            # Update previous release "next_version_name" to current one
+            codebase["versions"][-2]["next_version_name"] = version_info["name"]
+
+    return codebase
+
+def main():
+
+    parser = argparse.ArgumentParser(description="Create binaries json")
+    parser.add_argument('--upgrade_version', required=True, type=str, help='The upgrade tag to use (e.g v19.0.0)')
+    parser.add_argument('--upgrade_height', required=True, type=str, help='The height of the upgrade (e.g. 10000000)')
+    parser.add_argument('--debug', action='store_true', default=False)
+
+    args = parser.parse_args()
+    DEBUG = args.debug
+
+    try:
+        if DEBUG:
+            print(f"Fetching chain json from {chain_json_url}...")
+        chain_json = fetch_data(chain_json_url, "json")
+
+        updated_codebase = update_codebase(chain_json["codebase"], args.upgrade_version, args.upgrade_height)
+        chain_json["codebase"] = updated_codebase
+        print(json.dumps(chain_json, indent=2))
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/update_chain_registry/utils/go_mod.py
+++ b/scripts/release/update_chain_registry/utils/go_mod.py
@@ -1,0 +1,74 @@
+import requests
+import re
+
+def fetch_go_mod_from_tag(tag):
+    url = f"https://raw.githubusercontent.com/osmosis-labs/osmosis/{tag}/go.mod"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        go_mod = response.text
+        return go_mod
+    except requests.exceptions.RequestException as e:
+        raise Exception(f"An error occurred while fetching data from {url}: {e}")
+
+
+def extract_specific_package_versions(go_mod_content, package_name):
+    # Regular expression to find lines containing package names and versions in require section
+    require_pattern = r'^\s*(github.com/[^\s]+)\s+([^\s]+)\s*$'
+
+    # Regular expression to find lines containing package names and versions in replace section
+    replace_pattern = r'^\s*github.com/([^/]+/[^/]+)\s+=>\s+github.com/([^/]+/[^/]+)\s+([^\s]+)\s*$'
+
+    # Find all matches in the require section using the regular expression
+    require_matches = re.findall(require_pattern, go_mod_content, re.MULTILINE)
+
+    # Check if the package_name has a replace in the replace section
+    replace_match = re.search(replace_pattern.replace('package_name', package_name), go_mod_content, re.MULTILINE)
+
+    # If there is a match in the replace section, return the replace package_name version
+    if replace_match:
+        return f"{replace_match.group(2)}@{replace_match.group(3)}"
+    
+    # If there is no match in the replace section, check the require section for the package_name version
+    for match in require_matches:
+        if match[0].endswith(package_name):
+            return match[1]
+
+    # If the package_name is not found in the require and replace sections, return None
+    return None
+
+
+def get_package_require_version(go_mod, package_name):
+    # Find package version in the "require" block only
+    require_block = re.search(r'require \((.*?)\)', go_mod, re.DOTALL)
+    
+    # If "require" block is found
+    if require_block:
+        # Define regex pattern for version extraction
+        version_pattern = re.compile(package_name + r' v([a-zA-Z0-9.\-]+)')
+        version = version_pattern.search(require_block.group(1))
+        
+        # If version is found
+        if version:
+            return version.group(1)
+    
+    # Return None if no match found
+    return None
+
+
+def get_package_replace_version(go_mod, package_name):
+    # Find package version in the "replace" block only
+    replace_block = re.search(r'replace \((.*?)\)', go_mod, re.DOTALL)
+
+    if replace_block:
+        # Define regex pattern for version extraction
+        replace_pattern = re.compile(package_name + r' => (\S+) v([a-zA-Z0-9.\-]+)')
+        replace = replace_pattern.search(replace_block.group(1))
+
+        if replace:
+            return replace.group(1).replace("github.com/", "") + "@" + replace.group(2)
+
+    return None
+
+def get_package_version(go_mod, package_name):
+    return get_package_replace_version(go_mod, package_name) or get_package_require_version(go_mod, package_name)

--- a/scripts/release/update_chain_registry/utils/versions.py
+++ b/scripts/release/update_chain_registry/utils/versions.py
@@ -1,0 +1,38 @@
+def parse_version(version):
+
+    major, minor, patch = map(int, version[1:].split('.'))
+    return major, minor, patch
+
+def same_major(version_1, version_2):
+    # Parse the major versions
+    major_1, _, _ = parse_version(version_1)
+    major_2, _, _ = parse_version(version_2)
+
+    # Compare the major versions
+    return major_1 == major_2
+
+def compare_versions(version_1, version_2):
+    # Parse the versions into major, minor, patch
+    major_1, minor_1, patch1 = parse_version(version_1)
+    major_2, minor_2, patch2 = parse_version(version_2)
+
+    # Compare the major versions
+    if major_1 > major_2:
+        return 1
+    elif major_1 < major_2:
+        return -1
+
+    # If major versions are equal, compare the minor versions
+    if minor_1 > minor_2:
+        return 1
+    elif minor_1 < minor_2:
+        return -1
+
+    # If minor versions are equal, compare the patch versions
+    if patch1 > patch2:
+        return 1
+    elif patch1 < patch2:
+        return -1
+
+    # If all parts are equal, the versions are the same
+    return 0


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

This PR introduces a new script `update_chain_registry.py` aimed at automating the post-release updates to the chain schema. Currently, this script is designed to work only for major releases.

### Changes

- Add `update_chain_registry.py` in `scripts/release` folder.
- Update chain schema for v19.0.0 using the new script.

### Context

The `scripts/release` folder already contains automation scripts for various tasks:
- `create_upgrade_guide.py` for generating upgrade guides.
- `create_binaries_json.py` for generating the cosmovisor JSON with binaries information.

The new `update_chain_registry.py` script will be a valuable addition to this suite of automations.

### Future Work

- This script will be integrated into the release CI pipeline, allowing for seamless and automatic updates to the chain schema post-release.
- Add minor release case

## Test

I have used this script to successfully update the current chain schema for v19.0.0.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A