### PR TITLE
Speedup Fractional exponentiation, and make a benchmark

### DIFF
--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -144,7 +144,7 @@ func PowApprox(base Dec, exp Dec, precision Dec) Dec {
 		// On this line, bigK == i-1.
 		c, cneg := AbsDifferenceWithSign(a, bigK)
 		// On this line, bigK == i.
-		bigK.Set(NewDec(i)) // TODO: O(n) bigint allocation happens
+		bigK.SetInt64(i)
 		term.MulMut(c).MulMut(x).QuoMut(bigK)
 
 		// a is mutated on absDifferenceWithSign, reset

--- a/osmomath/pow_bench_test.go
+++ b/osmomath/pow_bench_test.go
@@ -82,3 +82,21 @@ func BenchmarkSqrtPow(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkSlowPowCases(b *testing.B) {
+	tests := []struct {
+		base Dec
+		exp  Dec
+	}{
+		{
+			base: MustNewDecFromStr("1.99999999999999"),
+			exp:  MustNewDecFromStr("0.1"),
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
+			Pow(test.base, test.exp)
+		}
+	}
+}


### PR DESCRIPTION
cref @samalws-tob

This state compatibly speeds up the Fractional exponentiation core loop by approximately 10%. Will look for more speed ups (the mul and quo _should_ be state compatibly speedup)