### PR TITLE
fix: add wait for e2e go routine

### DIFF
--- a/tests/e2e/helpers_e2e_test.go
+++ b/tests/e2e/helpers_e2e_test.go
@@ -160,4 +160,5 @@ func runFuncsInParallelAndBlock(funcs []func()) {
 			g()
 		}(f)
 	}
+	wg.Wait()
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The following method was introduced to run methods in parallel and block progress until finished:

https://github.com/osmosis-labs/osmosis/blob/9c3ca88f0a1cf23746166aa77be01fc4938b37c8/tests/e2e/helpers_e2e_test.go#L154-L163

The problem is, we didn't add a wg.Wait()