### PR TITLE
fix: chain.schema.json v19 height

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -228,7 +228,7 @@
       {
         "name": "v19",
         "tag": "v19.0.0",
-        "height": "11317300",
+        "height": 11317300,
         "recommended_version": "v19.0.0",
         "compatible_versions": [
           "v19.0.0"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To fix chain.schema.json, the v19 height must be a number, not a string
(see that this PR failed checks https://github.com/cosmos/chain-registry/pull/2826)


## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.
(Checks failed: does this really need changelog update?) 