### PR TITLE
bug: send non osmo txfees to community pool instead of stakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6334](https://github.com/osmosis-labs/osmosis/pull/6334) fix: enable taker fee cli
 * [#6352](https://github.com/osmosis-labs/osmosis/pull/6352) Reduce error blow-up in CalcAmount0Delta by changing the order of math operations.
 * [#6368](https://github.com/osmosis-labs/osmosis/pull/6368) Stricter rounding behavior in CL math's CalcAmount0Delta and GetNextSqrtPriceFromAmount0InRoundingUp
+* [#6426](https://github.com/osmosis-labs/osmosis/pull/6426) bug: send non osmo txfees to community pool instead of stakers
 
 
 ### API Breaks

--- a/scripts/empty_upgrade_handler_gen.sh
+++ b/scripts/empty_upgrade_handler_gen.sh
@@ -105,7 +105,7 @@ sed -i "s/E2E_UPGRADE_VERSION := ${bracks}v$latest_version$bracks/E2E_UPGRADE_VE
 
 # bumps up prev e2e version
 e2e_file=./tests/e2e/containers/config.go
-PREV_OSMOSIS_DEV_TAG=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/osmolabs/osmosis/tags?page=1&page_size=100' | jq -r '.results[] | .name | select(.|test("^(?:v|)[0-9]+\\.0\\.0-alpine$"))' | \grep --max-count=1 "")
+PREV_OSMOSIS_DEV_TAG=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/osmolabs/osmosis/tags?page=1&page_size=100' | jq -r '.results[] | .name | select(.|test("^(?:v|)[0-9]+\\.0\\.0-alpine$"))' | grep --max-count=1 "")
 PREV_OSMOSIS_E2E_TAG=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/osmolabs/osmosis-e2e-init-chain/tags?page=1&page_size=100' | jq -r '.results[] | .name | select(.|test("^(?:v|)[0-9]+\\.[0-9]+(?:$|\\.[0-9]+$)"))' | grep --max-count=1 "")
 
 # previousVersionOsmoTag  = PREV_OSMOSIS_DEV_TAG

--- a/scripts/empty_upgrade_handler_gen.sh
+++ b/scripts/empty_upgrade_handler_gen.sh
@@ -105,7 +105,7 @@ sed -i "s/E2E_UPGRADE_VERSION := ${bracks}v$latest_version$bracks/E2E_UPGRADE_VE
 
 # bumps up prev e2e version
 e2e_file=./tests/e2e/containers/config.go
-PREV_OSMOSIS_DEV_TAG=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/osmolabs/osmosis-dev/tags?page=1&page_size=100'            | jq -r '.results[] | .name | select(.|test("^(?:v|)[0-9]+\\.[0-9]+(?:$|\\.[0-9]+$)"))' | grep --max-count=1 "")
+PREV_OSMOSIS_DEV_TAG=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/osmolabs/osmosis/tags?page=1&page_size=100' | jq -r '.results[] | .name | select(.|test("^(?:v|)[0-9]+\\.0\\.0-alpine$"))' | \grep --max-count=1 "")
 PREV_OSMOSIS_E2E_TAG=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/osmolabs/osmosis-e2e-init-chain/tags?page=1&page_size=100' | jq -r '.results[] | .name | select(.|test("^(?:v|)[0-9]+\\.[0-9]+(?:$|\\.[0-9]+$)"))' | grep --max-count=1 "")
 
 # previousVersionOsmoTag  = PREV_OSMOSIS_DEV_TAG

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -47,7 +47,9 @@ Conceptually, we can split the e2e setup into 2 parts:
     If with the upgrade, the same `chain.Init(...)` function is run inside a Docker container
     of the previous Osmosis version, inside `configurer/upgrade.go`. This is
     needed to initialize chain configs and the genesis of the previous version that
-    we are upgrading from.
+    we are upgrading from. Note, we use the alpine image of the previous version,
+    as functionality such as copying mnemonics across containers in unavailable in the
+    stripped down images.
 
     The decision of what configuration type to use is decided by the `Configurer`.
     This is an interface that has `CurrentBranchConfigurer` and `UpgradeConfigurer` implementations.

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,7 +24,7 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis"
-	previousVersionOsmoTag        = "19.0"
+	previousVersionOsmoTag        = "19.0.0-alpine"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
 	previousVersionInitTag        = "19.0.0"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -45,114 +45,114 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 		s.SetDefaultTakerFeeChainB()
 	})
 
-	// // Zero Dependent Tests
-	// s.T().Run("CreateConcentratedLiquidityPoolVoting_And_TWAP", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.CreateConcentratedLiquidityPoolVoting_And_TWAP()
-	// })
+	// Zero Dependent Tests
+	s.T().Run("CreateConcentratedLiquidityPoolVoting_And_TWAP", func(t *testing.T) {
+		t.Parallel()
+		s.CreateConcentratedLiquidityPoolVoting_And_TWAP()
+	})
 
-	// s.T().Run("ProtoRev", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.ProtoRev()
-	// })
+	s.T().Run("ProtoRev", func(t *testing.T) {
+		t.Parallel()
+		s.ProtoRev()
+	})
 
-	// s.T().Run("ConcentratedLiquidity", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.ConcentratedLiquidity()
-	// })
+	s.T().Run("ConcentratedLiquidity", func(t *testing.T) {
+		t.Parallel()
+		s.ConcentratedLiquidity()
+	})
 
-	// s.T().Run("SuperfluidVoting", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.SuperfluidVoting()
-	// })
+	s.T().Run("SuperfluidVoting", func(t *testing.T) {
+		t.Parallel()
+		s.SuperfluidVoting()
+	})
 
-	// s.T().Run("AddToExistingLock", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.AddToExistingLock()
-	// })
+	s.T().Run("AddToExistingLock", func(t *testing.T) {
+		t.Parallel()
+		s.AddToExistingLock()
+	})
 
-	// s.T().Run("ExpeditedProposals", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.ExpeditedProposals()
-	// })
+	s.T().Run("ExpeditedProposals", func(t *testing.T) {
+		t.Parallel()
+		s.ExpeditedProposals()
+	})
 
-	// s.T().Run("GeometricTWAP", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.GeometricTWAP()
-	// })
+	s.T().Run("GeometricTWAP", func(t *testing.T) {
+		t.Parallel()
+		s.GeometricTWAP()
+	})
 
-	// s.T().Run("LargeWasmUpload", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.LargeWasmUpload()
-	// })
+	s.T().Run("LargeWasmUpload", func(t *testing.T) {
+		t.Parallel()
+		s.LargeWasmUpload()
+	})
 
 	s.T().Run("StableSwap", func(t *testing.T) {
 		t.Parallel()
 		s.StableSwap()
 	})
 
-	// // Test currently disabled
-	// // s.T().Run("ArithmeticTWAP", func(t *testing.T) {
-	// // 	t.Parallel()
-	// // 	s.ArithmeticTWAP()
-	// // })
+	// Test currently disabled
+	// s.T().Run("ArithmeticTWAP", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.ArithmeticTWAP()
+	// })
 
-	// // State Sync Dependent Tests
+	// State Sync Dependent Tests
 
-	// if s.skipStateSync || !s.runScheduledTest {
-	// 	s.T().Skip()
-	// } else {
-	// 	s.T().Run("StateSync", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.StateSync()
-	// 	})
-	// }
+	if s.skipStateSync || !s.runScheduledTest {
+		s.T().Skip()
+	} else {
+		s.T().Run("StateSync", func(t *testing.T) {
+			t.Parallel()
+			s.StateSync()
+		})
+	}
 
-	// // Upgrade Dependent Tests
+	// Upgrade Dependent Tests
 
-	// if s.skipUpgrade {
-	// 	s.T().Skip("Skipping GeometricTwapMigration test")
-	// } else {
-	// 	s.T().Run("GeometricTwapMigration", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.GeometricTwapMigration()
-	// 	})
-	// }
+	if s.skipUpgrade {
+		s.T().Skip("Skipping GeometricTwapMigration test")
+	} else {
+		s.T().Run("GeometricTwapMigration", func(t *testing.T) {
+			t.Parallel()
+			s.GeometricTwapMigration()
+		})
+	}
 
-	// if s.skipUpgrade {
-	// 	s.T().Skip("Skipping AddToExistingLockPostUpgrade test")
-	// } else {
-	// 	s.T().Run("AddToExistingLockPostUpgrade", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.AddToExistingLockPostUpgrade()
-	// 	})
-	// }
+	if s.skipUpgrade {
+		s.T().Skip("Skipping AddToExistingLockPostUpgrade test")
+	} else {
+		s.T().Run("AddToExistingLockPostUpgrade", func(t *testing.T) {
+			t.Parallel()
+			s.AddToExistingLockPostUpgrade()
+		})
+	}
 
-	// // IBC Dependent Tests
+	// IBC Dependent Tests
 
-	// if s.skipIBC {
-	// 	s.T().Skip("Skipping IBC tests")
-	// } else {
-	// 	s.T().Run("IBCTokenTransferRateLimiting", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.IBCTokenTransferRateLimiting()
-	// 	})
+	if s.skipIBC {
+		s.T().Skip("Skipping IBC tests")
+	} else {
+		s.T().Run("IBCTokenTransferRateLimiting", func(t *testing.T) {
+			t.Parallel()
+			s.IBCTokenTransferRateLimiting()
+		})
 
-	// 	s.T().Run("IBCTokenTransferAndCreatePool", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.IBCTokenTransferAndCreatePool()
-	// 	})
+		s.T().Run("IBCTokenTransferAndCreatePool", func(t *testing.T) {
+			t.Parallel()
+			s.IBCTokenTransferAndCreatePool()
+		})
 
-	// 	s.T().Run("IBCWasmHooks", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.IBCWasmHooks()
-	// 	})
+		s.T().Run("IBCWasmHooks", func(t *testing.T) {
+			t.Parallel()
+			s.IBCWasmHooks()
+		})
 
-	// 	s.T().Run("PacketForwarding", func(t *testing.T) {
-	// 		t.Parallel()
-	// 		s.PacketForwarding()
-	// 	})
-	// }
+		s.T().Run("PacketForwarding", func(t *testing.T) {
+			t.Parallel()
+			s.PacketForwarding()
+		})
+	}
 }
 
 // TestProtoRev is a test that ensures that the protorev module is working as expected. In particular, this tests and ensures that:

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -45,114 +45,114 @@ func (s *IntegrationTestSuite) TestAllE2E() {
 		s.SetDefaultTakerFeeChainB()
 	})
 
-	// Zero Dependent Tests
-	s.T().Run("CreateConcentratedLiquidityPoolVoting_And_TWAP", func(t *testing.T) {
-		t.Parallel()
-		s.CreateConcentratedLiquidityPoolVoting_And_TWAP()
-	})
+	// // Zero Dependent Tests
+	// s.T().Run("CreateConcentratedLiquidityPoolVoting_And_TWAP", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.CreateConcentratedLiquidityPoolVoting_And_TWAP()
+	// })
 
-	s.T().Run("ProtoRev", func(t *testing.T) {
-		t.Parallel()
-		s.ProtoRev()
-	})
+	// s.T().Run("ProtoRev", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.ProtoRev()
+	// })
 
-	s.T().Run("ConcentratedLiquidity", func(t *testing.T) {
-		t.Parallel()
-		s.ConcentratedLiquidity()
-	})
+	// s.T().Run("ConcentratedLiquidity", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.ConcentratedLiquidity()
+	// })
 
-	s.T().Run("SuperfluidVoting", func(t *testing.T) {
-		t.Parallel()
-		s.SuperfluidVoting()
-	})
+	// s.T().Run("SuperfluidVoting", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.SuperfluidVoting()
+	// })
 
-	s.T().Run("AddToExistingLock", func(t *testing.T) {
-		t.Parallel()
-		s.AddToExistingLock()
-	})
+	// s.T().Run("AddToExistingLock", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.AddToExistingLock()
+	// })
 
-	s.T().Run("ExpeditedProposals", func(t *testing.T) {
-		t.Parallel()
-		s.ExpeditedProposals()
-	})
+	// s.T().Run("ExpeditedProposals", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.ExpeditedProposals()
+	// })
 
-	s.T().Run("GeometricTWAP", func(t *testing.T) {
-		t.Parallel()
-		s.GeometricTWAP()
-	})
+	// s.T().Run("GeometricTWAP", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.GeometricTWAP()
+	// })
 
-	s.T().Run("LargeWasmUpload", func(t *testing.T) {
-		t.Parallel()
-		s.LargeWasmUpload()
-	})
+	// s.T().Run("LargeWasmUpload", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	s.LargeWasmUpload()
+	// })
 
 	s.T().Run("StableSwap", func(t *testing.T) {
 		t.Parallel()
 		s.StableSwap()
 	})
 
-	// Test currently disabled
-	// s.T().Run("ArithmeticTWAP", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	s.ArithmeticTWAP()
-	// })
+	// // Test currently disabled
+	// // s.T().Run("ArithmeticTWAP", func(t *testing.T) {
+	// // 	t.Parallel()
+	// // 	s.ArithmeticTWAP()
+	// // })
 
-	// State Sync Dependent Tests
+	// // State Sync Dependent Tests
 
-	if s.skipStateSync || !s.runScheduledTest {
-		s.T().Skip()
-	} else {
-		s.T().Run("StateSync", func(t *testing.T) {
-			t.Parallel()
-			s.StateSync()
-		})
-	}
+	// if s.skipStateSync || !s.runScheduledTest {
+	// 	s.T().Skip()
+	// } else {
+	// 	s.T().Run("StateSync", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.StateSync()
+	// 	})
+	// }
 
-	// Upgrade Dependent Tests
+	// // Upgrade Dependent Tests
 
-	if s.skipUpgrade {
-		s.T().Skip("Skipping GeometricTwapMigration test")
-	} else {
-		s.T().Run("GeometricTwapMigration", func(t *testing.T) {
-			t.Parallel()
-			s.GeometricTwapMigration()
-		})
-	}
+	// if s.skipUpgrade {
+	// 	s.T().Skip("Skipping GeometricTwapMigration test")
+	// } else {
+	// 	s.T().Run("GeometricTwapMigration", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.GeometricTwapMigration()
+	// 	})
+	// }
 
-	if s.skipUpgrade {
-		s.T().Skip("Skipping AddToExistingLockPostUpgrade test")
-	} else {
-		s.T().Run("AddToExistingLockPostUpgrade", func(t *testing.T) {
-			t.Parallel()
-			s.AddToExistingLockPostUpgrade()
-		})
-	}
+	// if s.skipUpgrade {
+	// 	s.T().Skip("Skipping AddToExistingLockPostUpgrade test")
+	// } else {
+	// 	s.T().Run("AddToExistingLockPostUpgrade", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.AddToExistingLockPostUpgrade()
+	// 	})
+	// }
 
-	// IBC Dependent Tests
+	// // IBC Dependent Tests
 
-	if s.skipIBC {
-		s.T().Skip("Skipping IBC tests")
-	} else {
-		s.T().Run("IBCTokenTransferRateLimiting", func(t *testing.T) {
-			t.Parallel()
-			s.IBCTokenTransferRateLimiting()
-		})
+	// if s.skipIBC {
+	// 	s.T().Skip("Skipping IBC tests")
+	// } else {
+	// 	s.T().Run("IBCTokenTransferRateLimiting", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.IBCTokenTransferRateLimiting()
+	// 	})
 
-		s.T().Run("IBCTokenTransferAndCreatePool", func(t *testing.T) {
-			t.Parallel()
-			s.IBCTokenTransferAndCreatePool()
-		})
+	// 	s.T().Run("IBCTokenTransferAndCreatePool", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.IBCTokenTransferAndCreatePool()
+	// 	})
 
-		s.T().Run("IBCWasmHooks", func(t *testing.T) {
-			t.Parallel()
-			s.IBCWasmHooks()
-		})
+	// 	s.T().Run("IBCWasmHooks", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.IBCWasmHooks()
+	// 	})
 
-		s.T().Run("PacketForwarding", func(t *testing.T) {
-			t.Parallel()
-			s.PacketForwarding()
-		})
-	}
+	// 	s.T().Run("PacketForwarding", func(t *testing.T) {
+	// 		t.Parallel()
+	// 		s.PacketForwarding()
+	// 	})
+	// }
 }
 
 // TestProtoRev is a test that ensures that the protorev module is working as expected. In particular, this tests and ensures that:

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -249,8 +249,8 @@ func DeductFees(txFeesKeeper types.TxFeesKeeper, bankKeeper types.BankKeeper, ct
 			return errorsmod.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
 		}
 	} else {
-		// sends to FeeCollectorForStakingRewardsName module account
-		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), types.FeeCollectorForStakingRewardsName, fees)
+		// sends to FeeCollectorForCommunityPoolName module account
+		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), types.FeeCollectorForCommunityPoolName, fees)
 		if err != nil {
 			return errorsmod.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
 		}

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -209,7 +209,7 @@ func (s *KeeperTestSuite) TestFeeDecorator() {
 				if !tc.txFee.IsZero() {
 					moduleName := types.FeeCollectorName
 					if tc.txFee[0].Denom != baseDenom {
-						moduleName = types.FeeCollectorForStakingRewardsName
+						moduleName = types.FeeCollectorForCommunityPoolName
 					}
 					moduleAddr := s.App.AccountKeeper.GetModuleAddress(moduleName)
 					s.Require().Equal(tc.txFee[0], s.App.BankKeeper.GetBalance(s.Ctx, moduleAddr, tc.txFee[0].Denom), tc.name)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Txfees collected in non osmo should be swapped to osmo at epoch and sent to the community pool. The taker fee feature implemented a new module account that collects non osmo funds, swaps them, and sends the to stakers instead. This module account was mistakenly used in the txfees logic instead of the old community pool txfees collector.

Very low impact from this bug, and simply swapping the module accounts fixes this.