### PR TITLE
revert: bug: send non osmo txfees to community pool instead of stakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6334](https://github.com/osmosis-labs/osmosis/pull/6334) fix: enable taker fee cli
 * [#6352](https://github.com/osmosis-labs/osmosis/pull/6352) Reduce error blow-up in CalcAmount0Delta by changing the order of math operations.
 * [#6368](https://github.com/osmosis-labs/osmosis/pull/6368) Stricter rounding behavior in CL math's CalcAmount0Delta and GetNextSqrtPriceFromAmount0InRoundingUp
-* [#6426](https://github.com/osmosis-labs/osmosis/pull/6426) bug: send non osmo txfees to community pool instead of stakers
-
 
 ### API Breaks
 

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -243,14 +243,14 @@ func DeductFees(txFeesKeeper types.TxFeesKeeper, bankKeeper types.BankKeeper, ct
 
 	// checks if input fee is uOSMO (assumes only one fee token exists in the fees array (as per the check in mempoolFeeDecorator))
 	if fees[0].Denom == baseDenom {
-		// sends to FeeCollectorName module account
+		// sends to FeeCollectorName module account, which sends to staking rewards
 		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), types.FeeCollectorName, fees)
 		if err != nil {
 			return errorsmod.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
 		}
 	} else {
-		// sends to FeeCollectorForCommunityPoolName module account
-		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), types.FeeCollectorForCommunityPoolName, fees)
+		// sends to FeeCollectorForStakingRewardsName module account
+		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), types.FeeCollectorForStakingRewardsName, fees)
 		if err != nil {
 			return errorsmod.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
 		}

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -209,7 +209,7 @@ func (s *KeeperTestSuite) TestFeeDecorator() {
 				if !tc.txFee.IsZero() {
 					moduleName := types.FeeCollectorName
 					if tc.txFee[0].Denom != baseDenom {
-						moduleName = types.FeeCollectorForCommunityPoolName
+						moduleName = types.FeeCollectorForStakingRewardsName
 					}
 					moduleAddr := s.App.AccountKeeper.GetModuleAddress(moduleName)
 					s.Require().Equal(tc.txFee[0], s.App.BankKeeper.GetBalance(s.Ctx, moduleAddr, tc.txFee[0].Denom), tc.name)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

I was mistaken/confused on what we were doing prior to the taker fee upgrade. I thought we were sending non osmo txfees to the community pool, when in reality, it was always getting swapped to osmo and sent to stakers. Will prove here:

From v17, we send non osmo txfees to the NonNativeFeeCollector https://github.com/osmosis-labs/osmosis/blob/ea8b7410e66f4aa7f360e1ce09e7b0cfd5e6e4bf/x/txfees/keeper/feedecorator.go#L250-L256

The NonNativeFeeCollector swaps to osmo and sends to the fee collector in the epoch hook here https://github.com/osmosis-labs/osmosis/blob/ea8b7410e66f4aa7f360e1ce09e7b0cfd5e6e4bf/x/txfees/keeper/hooks.go#L17-L48

So this value being FeeCollectorForStakingRewards was correct.
