### PR TITLE
fix: set denom pair taker fee CLI

### DIFF
--- a/x/poolmanager/client/cli/tx.go
+++ b/x/poolmanager/client/cli/tx.go
@@ -546,8 +546,6 @@ Ex) set-denom-pair-taker-fee uion,uosmo,0.0016,stake,uosmo,0.005,uatom,uosmo,0.0
 	cmd.Flags().AddFlagSet(FlagSetCreatePool())
 	flags.AddTxFlagsToCmd(cmd)
 
-	_ = cmd.MarkFlagRequired(FlagPoolFile)
-
 	return cmd
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

CLI had an extra required value that is not actually needed. This PR removes that mistake.

## Testing

Johnny tested the CLI and it now works:

```
{"body":{"messages":[{"@type":"/osmosis.poolmanager.v1beta1.MsgSetDenomPairTakerFee","sender":"osmo19mywfjzj324w5ukf7ss6jak0dg9hnljfp0rfx4","denom_pair_taker_fee":[{"denom0":"uosmo","denom1":"ibc/D176154","taker_fee":"0.002000000000000000"},{"denom0":"ibc/4ABB","denom1":"ibc/2108F","taker_fee":"0.000000000000000000"}]}],"memo":"","timeout_height":"0","extension_options":[],"non_critical_extension_options":[]},"auth_info":{"signer_infos":[],"fee":{"amount":[],"gas_limit":"350000","payer":"","granter":""}},"signatures":[]}
```
