### PR TITLE
fix(poolincentives): band-aid state export fix for cwpool gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc Improvements
 
 * [#6309](https://github.com/osmosis-labs/osmosis/pull/6309) Add  Cosmwasm Pool Queries to Stargate Query
+* [#6476](https://github.com/osmosis-labs/osmosis/pull/6476) band-aid state export fix for cwpool gauges
 
 ### State Breaking
 

--- a/x/pool-incentives/keeper/genesis.go
+++ b/x/pool-incentives/keeper/genesis.go
@@ -42,9 +42,19 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		if err != nil {
 			panic(err)
 		}
+
+		if pool.GetType() == poolmanagertypes.CosmWasm {
+			// TODO: remove this post-v19. In v19 we did not create a hook for cw pool gauges.
+			// Fix tracked in:
+			// https://github.com/osmosis-labs/osmosis/issues/6122
+			ctx.Logger().Info("Skipping pool ID", "poolId", poolId, "reason", "cosmwasm pool")
+			continue
+		}
+
 		isCLPool := pool.GetType() == poolmanagertypes.Concentrated
 		if isCLPool {
 			incParams := k.incentivesKeeper.GetEpochInfo(ctx)
+
 			gaugeID, err := k.GetPoolGaugeId(ctx, uint64(poolId), incParams.Duration)
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6230

## What is the purpose of the change

Context is in issue plus here: https://osmosis-network.slack.com/archives/C029XNL2L9G/p1695150489576199

This change is intended for v19.x backport only. The proper fix is to be created in a subsequent PR via https://github.com/osmosis-labs/osmosis/issues/6122

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A