### PR TITLE
V19.1.0/post release chores

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -229,7 +229,7 @@
       {
         "name": "v19",
         "tag": "v19.1.0",
-        "height": "11317300",
+        "height": 11317300,
         "recommended_version": "v19.1.0",
         "compatible_versions": [
           "v19.1.0",

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -2,15 +2,16 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v19.0.0",
+    "recommended_version": "v19.1.0",
     "compatible_versions": [
+      "v19.1.0",
       "v19.0.0"
     ],
     "binaries": {
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-arm64?checksum=sha256:39fb492914ef45f81e91e4472ddfdd83a56d3db820e48ed430df4c59aab90736",
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
     },
-    "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
+    "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230913192254-a2075590d5a3",
     "consensus": {
       "type": "tendermint",
       "version": "informalsystems/tendermint@0.34.24"
@@ -227,13 +228,14 @@
       },
       {
         "name": "v19",
-        "tag": "v19.0.0",
-        "height": 11317300,
-        "recommended_version": "v19.0.0",
+        "tag": "v19.1.0",
+        "height": "11317300",
+        "recommended_version": "v19.1.0",
         "compatible_versions": [
+          "v19.1.0",
           "v19.0.0"
         ],
-        "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
+        "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230913192254-a2075590d5a3",
         "consensus": {
           "type": "tendermint",
           "version": "informalsystems/tendermint@0.34.24"
@@ -245,8 +247,8 @@
           "ics20-1"
         ],
         "binaries": {
-          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-arm64?checksum=sha256:39fb492914ef45f81e91e4472ddfdd83a56d3db820e48ed430df4c59aab90736",
-          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
+          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
+          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
         }
       }
     ]

--- a/networks/osmosis-1/README.md
+++ b/networks/osmosis-1/README.md
@@ -27,7 +27,6 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-darwin-amd64?checksum=sha256:a532f25ae754d2573f6a3c91ba59496ddb9f6766ccf6f69f408f6e1597144a74",
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-linux-amd64?checksum=sha256:6a73d75e9c75ea402c13edc8c5c4ed08e26c5d8e517d540a9ca8b7e7afa67f79",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-linux-arm64?checksum=sha256:893f8a9786ae76d4217260201cd94ab67010f68d98b9676a9b31c0a5e68d1eae"
   }
@@ -39,7 +38,6 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-darwin-amd64?checksum=sha256:eee08350b223dd06a2aa16aab44aa51eb116f6267924ee1e788ca28fb54fe02d",
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-linux-amd64?checksum=sha256:a11c61a737983d176f23ce83fa5ff985000ce8d5107d738ee6fa7d59b8dd3053",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-linux-arm64?checksum=sha256:41260be15e874fbc6cc49757d9fe3d4e459634729e2b745923e508e9cb26f837"
   }
@@ -51,7 +49,6 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-darwin-amd64?checksum=sha256:735c7828b0bc311381f4c18081fa648f849df03aeccf173425cc52a634e3c7d8",
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-amd64?checksum=sha256:e4017da5d1a0a3b37b4f6936ba7ef16f39972ae25f95feae43e506f14933cf94",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-arm64?checksum=sha256:a101bb3feb0419293a3ecee17d732a312bf9e864a829905ed509c65b5944040b"
   }
@@ -141,8 +138,6 @@ Each version is identified by a specific id, name, tag, block height and softwar
   "binaries": {
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:0ec66e32584fff24b6d62fc9938c69ff1a1bbdd8641d2ec9e0fd084aaa767ed3",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-arm64?checksum=sha256:e2ccc743dd66da91d1df1ae4ecf92b36d658575f4ff507d5056eb640804e0401",
-    "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-arm64?checksum=sha256:c743da4d3632a2bc3ea0ce784bbd13383492a4a34d53295eb2c96987bacf8e8c",
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-amd64?checksum=sha256:d856ebda9c31f052d10a78443967a93374f2033292f0afdb6434b82b4ed79790"
   }
 }
 ```
@@ -152,8 +147,6 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
-    "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-arm64?checksum=sha256:5ca1b120a62ba473e7772682d89db949ae67aa10dc9bf4629b0022a95e7ff1df",
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-amd64?checksum=sha256:b5e4deb0d659eeeaee791dab765433bdb8d6a7e37d909628e0f9becb7d1f154b",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-arm64?checksum=sha256:d5eeab6a15e2acd7e24e7caf4fe3336c35367ff376da6299d404defd09ce52f9",
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:d7fe62ae33cf2f0b48a17eb8b02644dadd9924f15861ed622cd90cb1a038135b"
   }
@@ -165,8 +158,6 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-darwin-amd64?checksum=sha256:218f230a2418faab7b980a312a59e7b38a28eab8e3a857c46d78ab7ce10a7aaa",
-    "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-darwin-arm64?checksum=sha256:31280f32538e4e353d1a68adff6219c197ab63166faaca6eced9114c90a5a5f9",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-arm64?checksum=sha256:6d02ac17c720c2b7e01d364a3303b8a04c81b9e52038e0f81e1806d0d254d96e",
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:d83b4122e3ff9c428c8d6dcfe89718f5229f80e9976dbab2deefeb68dceb0f38"
   }

--- a/networks/osmosis-1/README.md
+++ b/networks/osmosis-1/README.md
@@ -19,7 +19,7 @@ Each version is identified by a specific id, name, tag, block height and softwar
 | `v16` | Magnesium | `v16.1.1` | 10517000       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v16.1.1/) | [556](https://www.mintscan.io/osmosis/proposals/556) |
 | `v17` | Aluminium | `v17.0.0` | 11126100       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v17.0.0/) | [586](https://www.mintscan.io/osmosis/proposals/586) |
 | `v18` |   | `v18.0.0` | 11155350       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v18.0.0/) | [588](https://www.mintscan.io/osmosis/proposals/588) |
-| `v19` |   | `v19.1.0` | 11317300       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v19.0.0/) | [606](https://www.mintscan.io/osmosis/proposals/606) |
+| `v19` |   | `v19.1.0` | 11317300       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v19.1.0/) | [606](https://www.mintscan.io/osmosis/proposals/606) |
 ## Upgrade binaries
 
 ### v3.1.0

--- a/networks/osmosis-1/README.md
+++ b/networks/osmosis-1/README.md
@@ -19,9 +19,8 @@ Each version is identified by a specific id, name, tag, block height and softwar
 | `v16` | Magnesium | `v16.1.1` | 10517000       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v16.1.1/) | [556](https://www.mintscan.io/osmosis/proposals/556) |
 | `v17` | Aluminium | `v17.0.0` | 11126100       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v17.0.0/) | [586](https://www.mintscan.io/osmosis/proposals/586) |
 | `v18` |   | `v18.0.0` | 11155350       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v18.0.0/) | [588](https://www.mintscan.io/osmosis/proposals/588) |
-| `v19` |   | `v19.0.0` | 11317300       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v19.0.0/) | [606](https://www.mintscan.io/osmosis/proposals/606) |
-
-## Upgrade Binaries
+| `v19` |   | `v19.1.0` | 11317300       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v19.0.0/) | [606](https://www.mintscan.io/osmosis/proposals/606) |
+## Upgrade binaries
 
 ### v3.1.0
 
@@ -140,10 +139,10 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
-    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-arm64?checksum=sha256:b96ff1f4c9b4abecb1b38998b1a1f891cfed2cc8078ab64914b151183c0c199b",
+    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:0ec66e32584fff24b6d62fc9938c69ff1a1bbdd8641d2ec9e0fd084aaa767ed3",
+    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-arm64?checksum=sha256:e2ccc743dd66da91d1df1ae4ecf92b36d658575f4ff507d5056eb640804e0401",
     "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-arm64?checksum=sha256:c743da4d3632a2bc3ea0ce784bbd13383492a4a34d53295eb2c96987bacf8e8c",
-    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-amd64?checksum=sha256:d856ebda9c31f052d10a78443967a93374f2033292f0afdb6434b82b4ed79790",
-    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:f838618633c1d42f593dc33d26b25842f5900961e987fc08570bb81a062e311d"
+    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-amd64?checksum=sha256:d856ebda9c31f052d10a78443967a93374f2033292f0afdb6434b82b4ed79790"
   }
 }
 ```
@@ -166,20 +165,22 @@ Each version is identified by a specific id, name, tag, block height and softwar
 ```json
 {
   "binaries": {
+    "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-darwin-amd64?checksum=sha256:218f230a2418faab7b980a312a59e7b38a28eab8e3a857c46d78ab7ce10a7aaa",
+    "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-darwin-arm64?checksum=sha256:31280f32538e4e353d1a68adff6219c197ab63166faaca6eced9114c90a5a5f9",
     "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-arm64?checksum=sha256:6d02ac17c720c2b7e01d364a3303b8a04c81b9e52038e0f81e1806d0d254d96e",
     "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:d83b4122e3ff9c428c8d6dcfe89718f5229f80e9976dbab2deefeb68dceb0f38"
   }
 }
 ```
 
-### v19.0.0
+### v19.1.0
 
 ```json
 {
-    "binaries": {
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-arm64?checksum=sha256:39fb492914ef45f81e91e4472ddfdd83a56d3db820e48ed430df4c59aab90736",
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
-    }
+  "binaries": {
+    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
+    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
+  }
 }
 ```
 
@@ -269,7 +270,7 @@ versions_info=(
     "v16:https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:f838618633c1d42f593dc33d26b25842f5900961e987fc08570bb81a062e311d"
     "v17:https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:d7fe62ae33cf2f0b48a17eb8b02644dadd9924f15861ed622cd90cb1a038135b"
     "v18:https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:d83b4122e3ff9c428c8d6dcfe89718f5229f80e9976dbab2deefeb68dceb0f38"
-    "v19:https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
+    "v19:https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
 )
 
 # Create the cosmovisor directory

--- a/networks/osmosis-1/upgrades/v19/mainnet/guide.md
+++ b/networks/osmosis-1/upgrades/v19/mainnet/guide.md
@@ -82,7 +82,7 @@ source ~/.profile
 mkdir -p ~/.osmosisd/cosmovisor/upgrades/v19/bin
 cd $HOME/osmosis
 git pull
-git checkout v19.0.0
+git checkout v19.1.0
 make build
 cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/v19/bin
 ```
@@ -102,7 +102,7 @@ Follow these steps if you opt for a manual upgrade:
 ```sh
 cd $HOME/osmosis
 git pull
-git checkout v19.0.0
+git checkout v19.1.0
 make install
 ```
 

--- a/networks/osmosis-1/upgrades/v19/v19_binaries.json
+++ b/networks/osmosis-1/upgrades/v19/v19_binaries.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-arm64?checksum=sha256:39fb492914ef45f81e91e4472ddfdd83a56d3db820e48ed430df4c59aab90736",
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.0.0/osmosisd-19.0.0-linux-amd64?checksum=sha256:e2a105e6bbbc2efa7681aadcf286f8f646f1ab3a8552261aa5bb914f497ad77d"
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
     }
 }

--- a/scripts/release/create_binaries_json/create_all_binaries_json.sh
+++ b/scripts/release/create_binaries_json/create_all_binaries_json.sh
@@ -14,14 +14,14 @@ tags=(
     "v16.1.1"
     "v17.0.0"
     "v18.0.0"
-    "v19.0.0"
+    "v19.1.0"
 )
 
-echo "# Cosmovisor binaries"
+echo "## Upgrade binaries"
 
 for tag in ${tags[@]}; do
     echo
-    echo "## ${tag}"
+    echo "### ${tag}"
     echo
     echo '```json'
     python create_binaries_json.py --tag $tag

--- a/scripts/release/update_chain_registry/update_chain_registry.py
+++ b/scripts/release/update_chain_registry/update_chain_registry.py
@@ -21,7 +21,7 @@ import json
 import argparse
 import sys
 
-from utils.versions import compare_versions, same_major
+from utils.versions import compare_versions, same_major, validate_tag
 from utils.go_mod import fetch_go_mod_from_tag, get_package_version
 
 chain_json_url = "https://raw.githubusercontent.com/osmosis-labs/osmosis/main/chain.schema.json"
@@ -125,6 +125,8 @@ def create_version_info(version, height):
 
 def update_codebase(codebase, version, height):
 
+    global DEBUG
+
     curr_recommended_version = codebase["recommended_version"]
     curr_compatible_versions = codebase["compatible_versions"]
 
@@ -135,6 +137,8 @@ def update_codebase(codebase, version, height):
 
     if compare_versions(version, curr_recommended_version) < 0:
         if DEBUG:
+            # I should still handle this case as it could be
+            # a minor release for a previous major verson
             print("New version is older than recommended version")
             print("Skipping update")
         return
@@ -148,9 +152,25 @@ def update_codebase(codebase, version, height):
         if same_major(version, curr_recommended_version):
             if DEBUG:
                 print(f"Minor release from {version} to {curr_recommended_version}")
-                print("Logic not yet implemented...")
-                print("Skipping update.")
-            return
+
+            version_info = create_version_info(version, height)
+            version_info["compatible_versions"].extend(codebase["compatible_versions"])
+
+            # Replace minor version
+            for idx, codebase_version in enumerate(codebase["versions"]):
+                if codebase_version['name'] == version.split('.')[0]: # same major version
+                    codebase["versions"][idx] = version_info
+                    break
+
+            # Since it's a latest release, I have also to update the top info
+            codebase["recommended_version"] = version_info["recommended_version"]
+            codebase["compatible_versions"] = version_info["compatible_versions"]
+            codebase["binaries"] = version_info["binaries"]
+            codebase["cosmos_sdk_version"] = version_info["cosmos_sdk_version"]
+            codebase["consensus"] = version_info["consensus"]
+            codebase["cosmwasm_version"] = version_info["cosmwasm_version"]
+            codebase["ibc_go_version"] = version_info["ibc_go_version"]
+
         else:
             if DEBUG:
                 print(f"Major release from {version} to {curr_recommended_version}")
@@ -176,12 +196,21 @@ def update_codebase(codebase, version, height):
 
 def main():
 
+    global DEBUG
+
     parser = argparse.ArgumentParser(description="Create binaries json")
     parser.add_argument('--upgrade_version', required=True, type=str, help='The upgrade tag to use (e.g v19.0.0)')
+    # TODO: Upgrade height is required only with new major release
     parser.add_argument('--upgrade_height', required=True, type=str, help='The height of the upgrade (e.g. 10000000)')
     parser.add_argument('--debug', action='store_true', default=False)
 
     args = parser.parse_args()
+
+    # Validate the tag format
+    if args.upgrade_version and not validate_tag(args.upgrade_version):
+        print("Error: The provided version does not follow the 'vX.Y.Z' format.")
+        sys.exit(1)
+
     DEBUG = args.debug
 
     try:
@@ -190,8 +219,12 @@ def main():
         chain_json = fetch_data(chain_json_url, "json")
 
         updated_codebase = update_codebase(chain_json["codebase"], args.upgrade_version, args.upgrade_height)
-        chain_json["codebase"] = updated_codebase
-        print(json.dumps(chain_json, indent=2))
+
+        if updated_codebase:
+            chain_json["codebase"] = updated_codebase
+            print(json.dumps(chain_json, indent=2))
+        else:
+            print("Couldn't update codebase")
 
     except Exception as e:
         print(f"An error occurred: {e}")

--- a/scripts/release/update_chain_registry/update_chain_registry.py
+++ b/scripts/release/update_chain_registry/update_chain_registry.py
@@ -96,7 +96,7 @@ def create_version_info(version, height):
     version_info = {
         "name": version.split('.')[0],
         "tag" : version,
-        "height": str(height),
+        "height": int(height),
         "recommended_version": version,
         "compatible_versions": [
             version
@@ -201,7 +201,7 @@ def main():
     parser = argparse.ArgumentParser(description="Create binaries json")
     parser.add_argument('--upgrade_version', required=True, type=str, help='The upgrade tag to use (e.g v19.0.0)')
     # TODO: Upgrade height is required only with new major release
-    parser.add_argument('--upgrade_height', required=True, type=str, help='The height of the upgrade (e.g. 10000000)')
+    parser.add_argument('--upgrade_height', required=True, type=int, help='The height of the upgrade (e.g. 10000000)')
     parser.add_argument('--debug', action='store_true', default=False)
 
     args = parser.parse_args()

--- a/scripts/release/update_chain_registry/utils/versions.py
+++ b/scripts/release/update_chain_registry/utils/versions.py
@@ -1,3 +1,5 @@
+import re
+
 def parse_version(version):
 
     major, minor, patch = map(int, version[1:].split('.'))
@@ -36,3 +38,7 @@ def compare_versions(version_1, version_2):
 
     # If all parts are equal, the versions are the same
     return 0
+
+def validate_tag(tag):
+    pattern = '^v[0-9]+.[0-9]+.[0-9]+$'
+    return bool(re.match(pattern, tag))


### PR DESCRIPTION
## What is the purpose of the change

This PR:

- Updates the chain registry schema with latest `19.1.0` minor release 
- Updates cosmovisor binaries to use `19.1.0`
- Updates network upgrade docs to use `19.1.0`
- Updates the chain registry script to  handle minor release updates

## Testing and Verifying

Trivial/Docs changes.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A