### PR TITLE
feat: improve msg server, test aute handler

### DIFF
--- a/proto/osmosis/authenticator/models.proto
+++ b/proto/osmosis/authenticator/models.proto
@@ -4,8 +4,8 @@ package osmosis.authenticator;
 option go_package = "github.com/osmosis-labs/osmosis/v19/x/authenticator/types";
 
 // AccountAuthenticator represents a foundational model for all authenticators.
-// It provides extensibility by allowing concrete types to interpret and validate
-// transactions based on the encapsulated data.
+// It provides extensibility by allowing concrete types to interpret and
+// validate transactions based on the encapsulated data.
 message AccountAuthenticator {
   // ID uniquely identifies the authenticator instance.
   uint64 id = 1;

--- a/proto/osmosis/authenticator/models.proto
+++ b/proto/osmosis/authenticator/models.proto
@@ -3,8 +3,21 @@ package osmosis.authenticator;
 
 option go_package = "github.com/osmosis-labs/osmosis/v19/x/authenticator/types";
 
+// AccountAuthenticator represents a foundational model for all authenticators.
+// It provides extensibility by allowing concrete types to interpret and validate
+// transactions based on the encapsulated data.
 message AccountAuthenticator {
+  // ID uniquely identifies the authenticator instance.
   uint64 id = 1;
+
+  // Type specifies the category of the AccountAuthenticator.
+  // This type information is essential for differentiating authenticators
+  // and ensuring precise data retrieval from the storage layer.
   string type = 2;
+
+  // Data is a versatile field used in conjunction with the specific type of
+  // account authenticator to facilitate complex authentication processes.
+  // The interpretation of this field is overloaded, enabling multiple
+  // authenticators to utilize it for their respective purposes.
   bytes data = 3;
 }

--- a/x/authenticator/ante/authenticator_test.go
+++ b/x/authenticator/ante/authenticator_test.go
@@ -1,0 +1,323 @@
+package ante_test
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/osmosis-labs/osmosis/v19/app"
+	"github.com/osmosis-labs/osmosis/v19/app/params"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/ante"
+	"github.com/stretchr/testify/suite"
+)
+
+type AutherticatorAnteSuite struct {
+	suite.Suite
+	OsmosisApp             *app.OsmosisApp
+	Ctx                    sdk.Context
+	EncodingConfig         params.EncodingConfig
+	AuthenticatorDecorator ante.AuthenticatorDecorator
+	TestKeys               []string
+	TestAccAddress         []sdk.AccAddress
+	TestPrivKeys           []*secp256k1.PrivKey
+}
+
+func TestAutherticatorAnteSuite(t *testing.T) {
+	suite.Run(t, new(AutherticatorAnteSuite))
+}
+
+func (s *AutherticatorAnteSuite) SetupTest() {
+	// Test data for authenticator signature verification
+	TestKeys := []string{
+		"6cf5103c60c939a5f38e383b52239c5296c968579eec1c68a47d70fbf1d19159",
+		"0dd4d1506e18a5712080708c338eb51ecf2afdceae01e8162e890b126ac190fe",
+		"49006a359803f0602a7ec521df88bf5527579da79112bb71f285dd3e7d438033",
+	}
+	s.EncodingConfig = app.MakeEncodingConfig()
+
+	s.OsmosisApp = app.Setup(false)
+
+	ak := s.OsmosisApp.AccountKeeper
+	s.Ctx = s.OsmosisApp.NewContext(false, tmproto.Header{})
+
+	// Set up test accounts
+	for _, key := range TestKeys {
+		bz, _ := hex.DecodeString(key)
+		priv := &secp256k1.PrivKey{Key: bz}
+
+		// add the test private keys to array for later use
+		s.TestPrivKeys = append(s.TestPrivKeys, priv)
+
+		accAddress := sdk.AccAddress(priv.PubKey().Address())
+		account := authtypes.NewBaseAccount(accAddress, priv.PubKey(), 0, 0)
+		ak.SetAccount(s.Ctx, account)
+
+		// add the test accounts to array for later use
+		s.TestAccAddress = append(s.TestAccAddress, accAddress)
+	}
+
+	s.AuthenticatorDecorator = ante.NewAuthenticatorDecorator(
+		s.OsmosisApp.AuthenticatorKeeper,
+		20_000,
+	)
+	s.Ctx = s.Ctx.WithGasMeter(sdk.NewGasMeter(1_000_000))
+}
+
+// TestSignatureVerificationNoAuthenticatorInStore test a non-smart account signature verification
+// with no authenticator in the store
+func (s *AutherticatorAnteSuite) TestSignatureVerificationNoAuthenticatorInStore() {
+	osmoToken := "osmo"
+	coins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Create a test messages for signing
+	testMsg1 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[0]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	testMsg2 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	tx, _ := GenTx(
+		s.EncodingConfig.TxConfig,
+		[]sdk.Msg{
+			testMsg1,
+			testMsg2,
+		},
+		feeCoins,
+		300000,
+		"",
+		[]uint64{0, 0},
+		[]uint64{0, 0},
+		[]cryptotypes.PrivKey{
+			s.TestPrivKeys[0],
+			s.TestPrivKeys[1],
+		},
+		[]cryptotypes.PrivKey{
+			s.TestPrivKeys[0],
+			s.TestPrivKeys[1],
+		},
+	)
+
+	anteHandler := sdk.ChainAnteDecorators(s.AuthenticatorDecorator)
+	_, err := anteHandler(s.Ctx, tx, false)
+
+	s.Require().NoError(err)
+}
+
+// TestSignatureVerificationWithAuthenticatorInStore test a non-smart account signature verification
+// with a single authenticator in the store
+func (s *AutherticatorAnteSuite) TestSignatureVerificationWithAuthenticatorInStore() {
+	osmoToken := "osmo"
+	coins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Create a test messages for signing
+	testMsg1 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[0]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	testMsg2 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+		s.Ctx,
+		s.TestAccAddress[0],
+		"SignatureVerificationAuthenticator",
+		s.TestPrivKeys[0].PubKey().Bytes(),
+	)
+	s.Require().NoError(err)
+
+	tx, _ := GenTx(
+		s.EncodingConfig.TxConfig,
+		[]sdk.Msg{
+			testMsg1,
+			testMsg2,
+		},
+		feeCoins,
+		300000,
+		"",
+		[]uint64{0, 0},
+		[]uint64{0, 0},
+		[]cryptotypes.PrivKey{
+			s.TestPrivKeys[0],
+			s.TestPrivKeys[1],
+		},
+		[]cryptotypes.PrivKey{
+			s.TestPrivKeys[0],
+			s.TestPrivKeys[1],
+		},
+	)
+
+	anteHandler := sdk.ChainAnteDecorators(s.AuthenticatorDecorator)
+	_, err = anteHandler(s.Ctx, tx, false)
+
+	s.Require().NoError(err)
+}
+
+// TestSignatureVerificationWithAuthenticatorInStore test out of gas error
+func (s *AutherticatorAnteSuite) TestSignatureVerificationOutOfGas() {
+	osmoToken := "osmo"
+	coins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Create a test messages for signing
+	testMsg1 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[0]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	testMsg2 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+		s.Ctx,
+		s.TestAccAddress[0],
+		"SignatureVerificationAuthenticator",
+		s.TestPrivKeys[0].PubKey().Bytes(),
+	)
+	err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+		s.Ctx,
+		s.TestAccAddress[0],
+		"SignatureVerificationAuthenticator",
+		s.TestPrivKeys[0].PubKey().Bytes(),
+	)
+	err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+		s.Ctx,
+		s.TestAccAddress[0],
+		"SignatureVerificationAuthenticator",
+		s.TestPrivKeys[0].PubKey().Bytes(),
+	)
+	err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+		s.Ctx,
+		s.TestAccAddress[0],
+		"SignatureVerificationAuthenticator",
+		s.TestPrivKeys[1].PubKey().Bytes(),
+	)
+	s.Require().NoError(err)
+
+	tx, _ := GenTx(
+		s.EncodingConfig.TxConfig,
+		[]sdk.Msg{
+			testMsg1,
+			testMsg2,
+		},
+		feeCoins,
+		300000,
+		"",
+		[]uint64{0, 0},
+		[]uint64{0, 0},
+		[]cryptotypes.PrivKey{
+			s.TestPrivKeys[0],
+			s.TestPrivKeys[1],
+		},
+		[]cryptotypes.PrivKey{
+			s.TestPrivKeys[1],
+			s.TestPrivKeys[1],
+		},
+	)
+
+	anteHandler := sdk.ChainAnteDecorators(s.AuthenticatorDecorator)
+	_, err = anteHandler(s.Ctx, tx, false)
+
+	// TODO: improve this test for gas consumption
+	fmt.Println("Gas Consumed: after txn gas over 20000")
+	fmt.Println(s.Ctx.GasMeter().GasConsumed())
+
+	s.Require().Error(err)
+}
+
+// GenTx generates a signed mock transaction.
+func GenTx(
+	gen client.TxConfig,
+	msgs []sdk.Msg,
+	feeAmt sdk.Coins,
+	gas uint64,
+	chainID string,
+	accNums,
+	accSeqs []uint64,
+	signers []cryptotypes.PrivKey,
+	signatures []cryptotypes.PrivKey,
+) (sdk.Tx, error) {
+	sigs := make([]signing.SignatureV2, len(signers))
+
+	// create a random length memo
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	memo := simulation.RandStringOfLength(r, simulation.RandIntBetween(r, 0, 100))
+	signMode := gen.SignModeHandler().DefaultMode()
+
+	// 1st round: set SignatureV2 with empty signatures, to set correct
+	// signer infos.
+	for i, p := range signers {
+		sigs[i] = signing.SignatureV2{
+			PubKey: p.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode: signMode,
+			},
+			Sequence: accSeqs[i],
+		}
+	}
+
+	txBuilder := gen.NewTxBuilder()
+
+	err := txBuilder.SetMsgs(msgs...)
+	if err != nil {
+		return nil, err
+	}
+	err = txBuilder.SetSignatures(sigs...)
+	if err != nil {
+		return nil, err
+	}
+	txBuilder.SetMemo(memo)
+	txBuilder.SetFeeAmount(feeAmt)
+	txBuilder.SetGasLimit(gas)
+	// TODO: set fee payer
+
+	// 2nd round: once all signer infos are set, every signer can sign.
+	for i, p := range signatures {
+		signerData := authsigning.SignerData{
+			ChainID:       chainID,
+			AccountNumber: accNums[i],
+			Sequence:      accSeqs[i],
+		}
+		signBytes, err := gen.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
+		if err != nil {
+			panic(err)
+		}
+		sig, err := p.Sign(signBytes)
+		if err != nil {
+			panic(err)
+		}
+		sigs[i].Data.(*signing.SingleSignatureData).Signature = sig
+		err = txBuilder.SetSignatures(sigs...)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return txBuilder.GetTx(), nil
+}

--- a/x/authenticator/ante/authenticator_test.go
+++ b/x/authenticator/ante/authenticator_test.go
@@ -249,6 +249,7 @@ func (s *AutherticatorAnteSuite) TestSignatureVerificationOutOfGas() {
 	fmt.Println(s.Ctx.GasMeter().GasConsumed())
 
 	s.Require().Error(err)
+	s.Require().ErrorContains(err, "gas")
 }
 
 // GenTx generates a signed mock transaction.

--- a/x/authenticator/authenticator/interface.go
+++ b/x/authenticator/authenticator/interface.go
@@ -5,61 +5,60 @@ import (
 )
 
 const (
-	// SignatureVerificationAuthenticator is a Type of authenticator that specific deals with
-	// secp256k1 signatures,
+	// SignatureVerificationAuthenticatorType represents a type of authenticator specifically designed for
+	// secp256k1 signature verification.
 	SignatureVerificationAuthenticatorType = "SignatureVerificationAuthenticator"
 )
 
-// AuthenticatorData represents the data needed to verify a signer address and message signature
-// TODO: make this less like a void pointer
+// AuthenticatorData represents the data required for verifying a signer's address and message signature.
 type AuthenticatorData interface{}
 
-// Authenticator is an interface used to represent all the authentication functionality needed to
-// verifiy a transaction, pay fees for a transaction and consume gas for verifing a transaction
+// Authenticator is an interface employed to encapsulate all authentication functionalities essential for
+// verifying transactions, paying transaction fees, and managing gas consumption during verification.
 type Authenticator interface {
-	// Type() defines the different types of authenticator, e.g SignatureVerificationAuthenticator
-	// or CosmWasmAuthenticator. Each type of authenticator needs to be registered in the AuthenticatorManager
-	// and these Types are used to store and link the data structure to the Authenticator logic
+	// Type() defines the various types of authenticators, such as SignatureVerificationAuthenticator
+	// or CosmWasmAuthenticator. Each authenticator type must be registered within the AuthenticatorManager,
+	// and these types are used to link the data structure with the authenticator's logic.
 	Type() string
 
-	// StaticGas defines what gas the authenticator uses per signatures verification
+	// StaticGas() specifies the gas consumption per signature verification by the authenticator.
 	StaticGas() uint64
 
-	// Initialize is used when the authenticator associated to an account is retrieved
-	// from the store. The data stored for each (account, authenticator) pair will be
-	// passed to this method.
-	// For example, the SignatureVerificationAuthenticator requires a PublicKey to check
-	// the signature, but the auth module is not aware of the public key.
-	// By storing the public key along with the authenticator, we can Initialize() the code with that
-	// data, which allows the same authenticator code to verify signatures for different public keys
+	// Initialize is used when an authenticator associated with an account is retrieved
+	// from storage. The data stored for each (account, authenticator) pair is provided
+	// to this method. For instance, the SignatureVerificationAuthenticator requires a PublicKey
+	// for signature verification, but the auth module is unaware of the public key. By storing
+	// the public key alongside the authenticator, we can Initialize() the code with that data,
+	// allowing the same authenticator code to verify signatures for different public keys.
 	Initialize(data []byte) (Authenticator, error)
 
-	// GetAuthenticationData gets any authentication data needed from a transaction
-	// it returns an interface that is defined as a concrete type by the implementer of the interface.
-	// This is used in an ante handler with Authenticate to ensure the user has correct permission to execute
-	// a message.
+	// GetAuthenticationData retrieves any required authentication data from a transaction.
+	// It returns an interface defined as a concrete type by the implementer of the interface.
+	// This is used within an ante handler in conjunction with Authenticate to ensure that
+	// the user possesses the correct permissions to execute a message.
 	GetAuthenticationData(
-		ctx sdk.Context, // sdk Context is used to get data associated with the authentication data
-		tx sdk.Tx, // we pass the transaction into the getter function to parse the signatures and signers
-		messageIndex int8, // the message index is used to pull specific signers and signatures from the authentication data
-		simulate bool, // simulate is used to simulate transactions
+		ctx sdk.Context, // The SDK Context is utilized to access data associated with authentication data.
+		tx sdk.Tx, // The transaction is passed to the getter function to parse signatures and signers.
+		messageIndex int8, // The message index is used to extract specific signers and signatures from the authentication data.
+		simulate bool, // Simulate is used to perform transaction simulation.
 	) (AuthenticatorData, error)
 
-	// Authenticate authenticates a message based on the signer and data parsed from the GetAuthenticationData function
-	// the returns true is authenticated or false if not authenticated. This is used in an ante handler.
-	// NOTE: Consume gas happens in this function.
+	// Authenticate validates a message based on the signer and data parsed from the GetAuthenticationData function.
+	// It returns true if authenticated, or false if not authenticated. This function is used within an ante handler.
+	// Note: Gas consumption occurs within this function.
 	Authenticate(
-		ctx sdk.Context, // sdk Context is used to get data for use in authentication and to consume gas
-		account sdk.AccAddress, // The account being authenticated for (usually msg.GetSigners()[0])
-		msg sdk.Msg, // a msg is passed into the authenticate function to allow the authenticators to use its information
-		authenticationData AuthenticatorData, // The authentication data is used to authenticate a message
+		ctx sdk.Context, // The SDK Context is used to access data for authentication and to consume gas.
+		account sdk.AccAddress, // The account being authenticated (typically msg.GetSigners()[0]).
+		msg sdk.Msg, // A message is passed into the authenticate function, allowing authenticators to utilize its information.
+		authenticationData AuthenticatorData, // The authentication data is used to authenticate a message.
 	) AuthenticationResult
 
-	// ConfirmExecution is used in the post handler function to enable transaction rules to be enforces.
-	// Rules such as spend and transaction limits. We access the state owned by the account to store and check these values.
+	// ConfirmExecution is employed in the post-handler function to enforce transaction rules,
+	// such as spending and transaction limits. It accesses the account's owned state to store
+	// and verify these values.
 	ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData AuthenticatorData) ConfirmationResult
 
-	// Optional Hooks. TODO: Revisit this
+	// Optional Hooks (TODO: Revisit this section)
 	// OnAuthenticatorAdded(...) bool
 	// OnAuthenticatorRemoved(...) bool
 }

--- a/x/authenticator/authenticator/interface.go
+++ b/x/authenticator/authenticator/interface.go
@@ -4,12 +4,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-const (
-	// SignatureVerificationAuthenticatorType represents a type of authenticator specifically designed for
-	// secp256k1 signature verification.
-	SignatureVerificationAuthenticatorType = "SignatureVerificationAuthenticator"
-)
-
 // AuthenticatorData represents the data required for verifying a signer's address and message signature.
 type AuthenticatorData interface{}
 

--- a/x/authenticator/authenticator/interface.go
+++ b/x/authenticator/authenticator/interface.go
@@ -21,7 +21,7 @@ type Authenticator interface {
 	// and these types are used to link the data structure with the authenticator's logic.
 	Type() string
 
-	// StaticGas() specifies the gas consumption per signature verification by the authenticator.
+	// StaticGas() specifies the gas consumption enforced on each call to the authenticator.
 	StaticGas() uint64
 
 	// Initialize is used when an authenticator associated with an account is retrieved

--- a/x/authenticator/authenticator/signature_authenticator.go
+++ b/x/authenticator/authenticator/signature_authenticator.go
@@ -102,7 +102,6 @@ func (sva SignatureVerificationAuthenticator) GetAuthenticationData(
 	}
 
 	// We get the signers here for an invariant check
-	signers := sigTx.GetSigners()
 	msgs := sigTx.GetMsgs()
 
 	msgSigners, msgSignatures, err := GetSignersAndSignatures(
@@ -114,18 +113,6 @@ func (sva SignatureVerificationAuthenticator) GetAuthenticationData(
 	)
 	if err != nil {
 		return SignatureData{}, err
-	}
-
-	// NOTE: added signer invariant check to ensure our code is working as before
-	if len(signers) != len(msgSigners) {
-		return SignatureData{},
-			sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invariant check failed, old signers don't match new signers")
-	}
-
-	// NOTE: added signature invariant check to ensure our code is working as before
-	if len(signatures) != len(msgSignatures) {
-		return SignatureData{},
-			sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invariant check failed, old signatures don't match new signatures")
 	}
 
 	// Get the signature for the message at msgIndex

--- a/x/authenticator/authenticator/signature_authenticator.go
+++ b/x/authenticator/authenticator/signature_authenticator.go
@@ -21,6 +21,12 @@ import (
 var _ Authenticator = &SignatureVerificationAuthenticator{}
 var _ AuthenticatorData = &SignatureData{}
 
+const (
+	// SignatureVerificationAuthenticatorType represents a type of authenticator specifically designed for
+	// secp256k1 signature verification.
+	SignatureVerificationAuthenticatorType = "SignatureVerificationAuthenticator"
+)
+
 // signature authenticator
 type SignatureVerificationAuthenticator struct {
 	ak      *authkeeper.AccountKeeper

--- a/x/authenticator/authenticator/spend_limits.go
+++ b/x/authenticator/authenticator/spend_limits.go
@@ -88,8 +88,8 @@ func (sla SpendLimitAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk
 	prevBalances := sla.GetBlockBalance(account, ctx.BlockHeight())
 	currentBalances := sla.bankKeeper.GetAllBalances(ctx, account)
 
-	totalPrevValue := sdk.NewInt(0)
-	totalCurrentValue := sdk.NewInt(0)
+	totalPrevValue := osmomath.NewInt(0)
+	totalCurrentValue := osmomath.NewInt(0)
 
 	for _, coin := range prevBalances {
 		price := sla.getPriceInQuoteDenom(coin)

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -3,6 +3,7 @@ package authenticator_test
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/testutils"

--- a/x/authenticator/keeper/msg_server.go
+++ b/x/authenticator/keeper/msg_server.go
@@ -2,8 +2,12 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/types"
 )
 
@@ -19,19 +23,43 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 
 var _ types.MsgServer = msgServer{}
 
+// AddAuthenticator adds any types of authenticator to an account
 func (m msgServer) AddAuthenticator(
 	goCtx context.Context,
 	msg *types.MsgAddAuthenticator,
 ) (*types.MsgAddAuthenticatorResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// TODO: validate based on type of authenticator
-	// TODO: do we want to create and account for the data/pubkey
-	// here? Or in ante handler
-
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
 		return nil, err
+	}
+
+	auths, err := m.Keeper.GetAuthenticatorsForAccount(ctx, sender)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that the data is correct for the type of authenticator
+	switch msg.Type {
+	case authenticator.SignatureVerificationAuthenticatorType:
+		if len(msg.Data) != secp256k1.PubKeySize {
+			return nil, fmt.Errorf("invalid secp256k1 pub key size expected %d, got %d", secp256k1.PubKeySize, len(msg.Data))
+		}
+		// If there are no other authenticators ensure that the first authenticator is associated
+		// with the original account
+		if len(auths) == 0 {
+			pubKey := secp256k1.PubKey{Key: msg.Data}
+			senderDataAccount := sdk.AccAddress(pubKey.Address())
+			if !senderDataAccount.Equals(sender) {
+				return nil, fmt.Errorf("first authenticator must be associated with account expected %s, got %s", sender, senderDataAccount)
+			}
+		}
+	}
+
+	// Limit the number of authenticators to stop over iteration in the ante handler
+	if len(auths) >= 15 {
+		return nil, fmt.Errorf("max authenticators: %d, tried to add more than the max amount of authenticator", 15)
 	}
 
 	err = m.Keeper.AddAuthenticator(ctx, sender, msg.Type, msg.Data)

--- a/x/authenticator/keeper/msg_server.go
+++ b/x/authenticator/keeper/msg_server.go
@@ -26,7 +26,6 @@ var _ types.MsgServer = msgServer{}
 // AddAuthenticator allows the addition of various types of authenticators to an account.
 // This method serves as a versatile function for adding diverse authenticator types
 // to an account, making it highly adaptable for different use cases.
-
 func (m msgServer) AddAuthenticator(
 	goCtx context.Context,
 	msg *types.MsgAddAuthenticator,

--- a/x/authenticator/types/models.pb.go
+++ b/x/authenticator/types/models.pb.go
@@ -22,9 +22,20 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// AccountAuthenticator represents a foundational model for all authenticators.
+// It provides extensibility by allowing concrete types to interpret and validate
+// transactions based on the encapsulated data.
 type AccountAuthenticator struct {
-	Id   uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// ID uniquely identifies the authenticator instance.
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Type specifies the category of the AccountAuthenticator.
+	// This type information is essential for differentiating authenticators
+	// and ensuring precise data retrieval from the storage layer.
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	// Data is a versatile field used in conjunction with the specific type of
+	// account authenticator to facilitate complex authentication processes.
+	// The interpretation of this field is overloaded, enabling multiple
+	// authenticators to utilize it for their respective purposes.
 	Data []byte `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`
 }
 

--- a/x/authenticator/types/models.pb.go
+++ b/x/authenticator/types/models.pb.go
@@ -23,8 +23,8 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // AccountAuthenticator represents a foundational model for all authenticators.
-// It provides extensibility by allowing concrete types to interpret and validate
-// transactions based on the encapsulated data.
+// It provides extensibility by allowing concrete types to interpret and
+// validate transactions based on the encapsulated data.
 type AccountAuthenticator struct {
 	// ID uniquely identifies the authenticator instance.
 	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`

--- a/x/authenticator/types/msgs.go
+++ b/x/authenticator/types/msgs.go
@@ -42,6 +42,7 @@ func (msg *MsgAddAuthenticator) GetSigners() []sdk.AccAddress {
 var _ sdk.Msg = &MsgRemoveAuthenticator{}
 
 func (msg *MsgRemoveAuthenticator) ValidateBasic() error {
+	// TODO: call validate here
 	return validateSender(msg.Sender)
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- Added initial test cases for the ante handler
- Updated the checks in the msg_server.go
- Added comments to the proto file model

### How to test

```
user1=$(osmosisd keys show user1 -a --keyring-backend=test)
pubkey=$(osmosisd keys show user1 -p --keyring-backend test | jq -r .key)

echo "y" | osmosisd keys add newKey1 --keyring-backend test 
pubkey1=$(osmosisd keys show newKey1 -p --keyring-backend test | jq -r .key)

echo "y" | osmosisd keys add newKey2 --keyring-backend test 
pubkey2=$(osmosisd keys show newKey2 -p --keyring-backend test | jq -r .key)

# this should fail
osmosisd tx authenticator add-authenticator SignatureVerificationAuthenticator $pubkey1 --from user1 --chain-id testing --keyring-backend test --fees 1000stake -b sync -y

sleep 4

osmosisd tx authenticator add-authenticator SignatureVerificationAuthenticator $pubkey --from user1 --chain-id testing --keyring-backend test --fees 1000stake -b sync -y

sleep 4

osmosisd tx authenticator add-authenticator SignatureVerificationAuthenticator $pubkey2 --from user1 --chain-id testing --keyring-backend test --fees 1000stake -b sync -y

sleep 4

osmosisd tx authenticator add-authenticator SignatureVerificationAuthenticator $pubkey1 --from user1 --chain-id testing --keyring-backend test --fees 1000stake -b sync -y

osmosisd q authenticator authenticators $user1 --output json | jq 

```