### PR TITLE
feat: make PoolModuleI CalculateSpotPrice API  return BigDec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6279](https://github.com/osmosis-labs/osmosis/pull/6279) fix prop-597 introduced issue
 * [#6282](https://github.com/osmosis-labs/osmosis/pull/6282) Fix CreateCanonicalConcentratedLiquidityPoolAndMigrationLink overriding migration records
 
+### API Breaks
+
+* [#6487](https://github.com/osmosis-labs/osmosis/pull/6487) make PoolModuleI CalculateSpotPrice API return BigDec
+
 ## v19.1.0
 
 ### Features

--- a/app/apptesting/gamm.go
+++ b/app/apptesting/gamm.go
@@ -87,8 +87,8 @@ func (s *KeeperTestHelper) PrepareBalancerPoolWithCoinsAndWeights(coins sdk.Coin
 }
 
 var zeroDec = osmomath.ZeroDec()
-var oneThirdSpotPriceUnits = osmomath.NewDec(1).Quo(osmomath.NewDec(3)).
-	MulIntMut(gammtypes.SpotPriceSigFigs).RoundInt().ToLegacyDec().QuoInt(gammtypes.SpotPriceSigFigs)
+var oneThirdSpotPriceUnits = osmomath.BigDecFromDec(osmomath.NewDec(1).Quo(osmomath.NewDec(3)).
+	MulIntMut(gammtypes.SpotPriceSigFigs).RoundInt().ToLegacyDec().QuoInt(gammtypes.SpotPriceSigFigs))
 
 // PrepareBalancerPool returns a Balancer pool's pool-ID with pool params set in PrepareBalancerPoolWithPoolParams.
 func (s *KeeperTestHelper) PrepareBalancerPool() uint64 {
@@ -99,10 +99,10 @@ func (s *KeeperTestHelper) PrepareBalancerPool() uint64 {
 
 	spotPrice, err := s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, FOO, BAR)
 	s.NoError(err)
-	s.Equal(osmomath.NewDec(2), spotPrice)
+	s.Equal(osmomath.NewBigDec(2), spotPrice)
 	spotPrice, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, BAR, BAZ)
 	s.NoError(err)
-	s.Equal(osmomath.NewDecWithPrec(15, 1), spotPrice)
+	s.Equal(osmomath.NewBigDecWithPrec(15, 1), spotPrice)
 	spotPrice, err = s.App.GAMMKeeper.CalculateSpotPrice(s.Ctx, poolId, BAZ, FOO)
 	s.NoError(err)
 	s.Equal(oneThirdSpotPriceUnits, spotPrice)

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -393,7 +393,7 @@ func (s *KeeperTestHelper) SetupGammPoolsWithBondDenomMultiplier(multipliers []o
 
 // SwapAndSetSpotPrice runs a swap to set Spot price of a pool using arbitrary values
 // returns spot price after the arbitrary swap.
-func (s *KeeperTestHelper) SwapAndSetSpotPrice(poolId uint64, fromAsset sdk.Coin, toAsset sdk.Coin) osmomath.Dec {
+func (s *KeeperTestHelper) SwapAndSetSpotPrice(poolId uint64, fromAsset sdk.Coin, toAsset sdk.Coin) osmomath.BigDec {
 	// create a dummy account
 	acc1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address().Bytes())
 

--- a/app/upgrades/v16/upgrades_test.go
+++ b/app/upgrades/v16/upgrades_test.go
@@ -147,7 +147,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 				s.Require().Equal(v16.DAIIBCDenom, concentratedTypePool.GetToken1())
 
 				// Validate that the spot price of the CL pool is what we expect
-				osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), osmomath.BigDecFromDec(balancerSpotPrice))
+				osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), balancerSpotPrice)
 
 				// Validate that link was created.
 				migrationInfo, err := s.App.GAMMKeeper.GetAllMigrationInfo(s.Ctx)

--- a/app/upgrades/v17/upgrades_test.go
+++ b/app/upgrades/v17/upgrades_test.go
@@ -295,7 +295,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 					s.Require().Equal(assetPair.QuoteAsset, concentratedTypePool.GetToken1())
 
 					// Validate that the spot price of the CL pool is what we expect
-					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), osmomath.BigDecFromDec(balancerSpotPrice))
+					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), balancerSpotPrice)
 
 					// Validate that the link is correct.
 					migrationInfo, err := s.App.GAMMKeeper.GetAllMigrationInfo(s.Ctx)
@@ -461,7 +461,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 					s.Require().Equal(quoteAsset, concentratedTypePool.GetToken1())
 
 					// Validate that the spot price of the CL pool is what we expect
-					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), osmomath.BigDecFromDec(balancerSpotPrice))
+					osmoassert.Equal(s.T(), multiplicativeTolerance, concentratedTypePool.GetCurrentSqrtPrice().PowerInteger(2), balancerSpotPrice)
 
 					// Validate that the link is correct.
 					migrationInfo, err := s.App.GAMMKeeper.GetAllMigrationInfo(s.Ctx)

--- a/tests/mocks/pool_module.go
+++ b/tests/mocks/pool_module.go
@@ -260,10 +260,10 @@ func (mr *MockPoolModuleIMockRecorder) CalcOutAmtGivenIn(ctx, poolI, tokenIn, to
 }
 
 // CalculateSpotPrice mocks base method.
-func (m *MockPoolModuleI) CalculateSpotPrice(ctx types.Context, poolId uint64, quoteAssetDenom, baseAssetDenom string) (osmomath.Dec, error) {
+func (m *MockPoolModuleI) CalculateSpotPrice(ctx types.Context, poolId uint64, quoteAssetDenom, baseAssetDenom string) (osmomath.BigDec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalculateSpotPrice", ctx, poolId, quoteAssetDenom, baseAssetDenom)
-	ret0, _ := ret[0].(osmomath.Dec)
+	ret0, _ := ret[0].(osmomath.BigDec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -165,36 +165,34 @@ func (k Keeper) CalculateSpotPrice(
 	poolId uint64,
 	quoteAssetDenom string,
 	baseAssetDenom string,
-) (spotPrice osmomath.Dec, err error) {
+) (spotPrice osmomath.BigDec, err error) {
 	concentratedPool, err := k.getPoolById(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	hasPositions, err := k.HasAnyPositionForPool(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	if !hasPositions {
-		return osmomath.Dec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
+		return osmomath.BigDec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
 	}
 
 	price, err := concentratedPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	if price.IsZero() {
-		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceV2, MaxSpotPrice: types.MaxSpotPrice}
+		return osmomath.BigDec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceV2, MaxSpotPrice: types.MaxSpotPrice}
 	}
 	if price.GT(types.MaxSpotPriceBigDec) || price.LT(types.MinSpotPriceBigDec) {
-		return osmomath.Dec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceBigDec, MaxSpotPrice: types.MaxSpotPrice}
+		return osmomath.BigDec{}, types.PriceBoundError{ProvidedPrice: price, MinSpotPrice: types.MinSpotPriceBigDec, MaxSpotPrice: types.MaxSpotPrice}
 	}
 
-	// TODO: remove before https://github.com/osmosis-labs/osmosis/issues/5726 is complete.
-	// Acceptable for backwards compatibility with v19.x.
-	return price.Dec(), nil
+	return price, nil
 }
 
 // GetTotalPoolLiquidity returns the coins in the pool owned by all LPs

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -271,7 +271,7 @@ func (s *KeeperTestSuite) TestCalculateSpotPrice() {
 	spotPrice, err := s.App.ConcentratedLiquidityKeeper.CalculateSpotPrice(s.Ctx, poolId, ETH, USDC)
 	s.Require().Error(err)
 	s.Require().ErrorAs(err, &types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId})
-	s.Require().Equal(osmomath.Dec{}, spotPrice)
+	s.Require().Equal(osmomath.BigDec{}, spotPrice)
 
 	// set up default position to have proper spot price
 	s.SetupDefaultPosition(defaultPoolId)
@@ -279,12 +279,16 @@ func (s *KeeperTestSuite) TestCalculateSpotPrice() {
 	// ETH is token0 so its price will be the DefaultCurrSqrtPrice squared
 	spotPriceBaseETH, err := s.App.ConcentratedLiquidityKeeper.CalculateSpotPrice(s.Ctx, poolId, USDC, ETH)
 	s.Require().NoError(err)
-	s.Require().Equal(spotPriceBaseETH, DefaultCurrSqrtPrice.PowerInteger(2).Dec())
+	// TODO: remove Dec truncation before https://github.com/osmosis-labs/osmosis/issues/5726 is complete
+	// Currently exists for state-compatibility with v19.x
+	s.Require().Equal(spotPriceBaseETH.Dec(), DefaultCurrSqrtPrice.PowerInteger(2).Dec())
 
 	// test that we have correct values for reversed quote asset and base asset
 	spotPriceBaseUSDC, err := s.App.ConcentratedLiquidityKeeper.CalculateSpotPrice(s.Ctx, poolId, ETH, USDC)
 	s.Require().NoError(err)
-	s.Require().Equal(spotPriceBaseUSDC, osmomath.OneBigDec().Quo(DefaultCurrSqrtPrice.PowerInteger(2)).Dec())
+	// TODO: remove Dec truncation before https://github.com/osmosis-labs/osmosis/issues/5726 is complete
+	// Currently exists for state-compatibility with v19.x
+	s.Require().Equal(spotPriceBaseUSDC.Dec(), osmomath.OneBigDec().Quo(DefaultCurrSqrtPrice.PowerInteger(2)).Dec())
 
 	// try getting spot price from a non-existent pool
 	spotPrice, err = s.App.ConcentratedLiquidityKeeper.CalculateSpotPrice(s.Ctx, poolId+1, USDC, ETH)

--- a/x/cosmwasmpool/pool_module.go
+++ b/x/cosmwasmpool/pool_module.go
@@ -168,19 +168,19 @@ func (k Keeper) CalculateSpotPrice(
 	poolId uint64,
 	quoteAssetDenom string,
 	baseAssetDenom string,
-) (price osmomath.Dec, err error) {
+) (price osmomath.BigDec, err error) {
 	cosmwasmPool, err := k.GetPoolById(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	spotPriceBigDec, err := cosmwasmPool.SpotPrice(ctx, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 	// Truncation is acceptable here since the only reason cosmwasmPool returns a BigDec
 	// is to maintain compatibility with the `PoolI.SpotPrice` API.
-	return spotPriceBigDec.Dec(), nil
+	return spotPriceBigDec, nil
 }
 
 // SwapExactAmountIn performs a swap operation with a specified input amount in a CosmWasm-based liquidity pool.

--- a/x/gamm/keeper/grpc_query.go
+++ b/x/gamm/keeper/grpc_query.go
@@ -383,7 +383,9 @@ func (q Querier) SpotPrice(ctx context.Context, req *types.QuerySpotPriceRequest
 	}
 
 	return &types.QuerySpotPriceResponse{
-		SpotPrice: sp.String(),
+		// Note: truncation exists here to maintain backwards compatibility.
+		// This query has historically had 18 decimals in response.
+		SpotPrice: sp.Dec().String(),
 	}, nil
 }
 
@@ -412,7 +414,9 @@ func (q QuerierV2) SpotPrice(ctx context.Context, req *v2types.QuerySpotPriceReq
 	// Deeprecated: use alternate in x/poolmanager
 	// nolint: staticcheck
 	return &v2types.QuerySpotPriceResponse{
-		SpotPrice: sp.String(),
+		// Note: truncation exists here to maintain backwards compatibility.
+		// This query has historically had 18 decimals in response.
+		SpotPrice: sp.Dec().String(),
 	}, nil
 }
 

--- a/x/gamm/keeper/grpc_query_test.go
+++ b/x/gamm/keeper/grpc_query_test.go
@@ -897,12 +897,12 @@ func (s *KeeperTestSuite) TestQueryStableswapPoolSpotPrice() {
 			} else {
 				s.Require().NoError(err, "unexpected error")
 				// We allow for a small geometric error due to our spot price being an approximation
-				expectedSpotPrice := osmomath.MustNewDecFromStr(tc.result)
-				actualSpotPrice := osmomath.MustNewDecFromStr(result.SpotPrice)
+				expectedSpotPrice := osmomath.MustNewBigDecFromStr(tc.result)
+				actualSpotPrice := osmomath.MustNewBigDecFromStr(result.SpotPrice)
 				diff := (expectedSpotPrice.Sub(actualSpotPrice)).Abs()
-				errTerm := diff.Quo(osmomath.MinDec(expectedSpotPrice, actualSpotPrice))
+				errTerm := diff.Quo(osmomath.MinBigDec(expectedSpotPrice, actualSpotPrice))
 
-				s.Require().True(errTerm.LT(osmomath.NewDecWithPrec(1, 3)), "Expected: %d, Actual: %d", expectedSpotPrice, actualSpotPrice)
+				s.Require().True(errTerm.LT(osmomath.NewBigDecWithPrec(1, 3)), "Expected: %d, Actual: %d", expectedSpotPrice, actualSpotPrice)
 			}
 		})
 	}
@@ -980,12 +980,12 @@ func (s *KeeperTestSuite) TestV2QueryStableswapPoolSpotPrice() {
 				s.Require().NoError(err, "unexpected error")
 
 				// We allow for a small geometric error due to our spot price being an approximation
-				expectedSpotPrice := osmomath.MustNewDecFromStr(tc.result)
-				actualSpotPrice := osmomath.MustNewDecFromStr(result.SpotPrice)
+				expectedSpotPrice := osmomath.MustNewBigDecFromStr(tc.result)
+				actualSpotPrice := osmomath.MustNewBigDecFromStr(result.SpotPrice)
 				diff := (expectedSpotPrice.Sub(actualSpotPrice)).Abs()
-				errTerm := diff.Quo(osmomath.MinDec(expectedSpotPrice, actualSpotPrice))
+				errTerm := diff.Quo(osmomath.MinBigDec(expectedSpotPrice, actualSpotPrice))
 
-				s.Require().True(errTerm.LT(osmomath.NewDecWithPrec(1, 3)), "Expected: %d, Actual: %d", expectedSpotPrice, actualSpotPrice)
+				s.Require().True(errTerm.LT(osmomath.NewBigDecWithPrec(1, 3)), "Expected: %d, Actual: %d", expectedSpotPrice, actualSpotPrice)
 			}
 		})
 	}

--- a/x/gamm/keeper/pool_service_test.go
+++ b/x/gamm/keeper/pool_service_test.go
@@ -434,11 +434,11 @@ func (s *KeeperTestSuite) TestSpotPriceOverflow() {
 				s.Require().NoError(poolErr)
 				s.Require().ErrorIs(keeperErr, types.ErrSpotPriceOverflow)
 				s.Require().Error(keeperErr)
-				s.Require().Equal(types.MaxSpotPrice, keeperSpotPrice)
+				s.Require().Equal(types.MaxSpotPriceBigDec, keeperSpotPrice)
 			} else if tc.panics {
 				s.Require().ErrorIs(keeperErr, types.ErrSpotPriceInternal)
 				s.Require().Error(keeperErr)
-				s.Require().Equal(osmomath.Dec{}, keeperSpotPrice)
+				s.Require().Equal(osmomath.BigDec{}, keeperSpotPrice)
 			} else {
 				s.Require().NoError(poolErr)
 				s.Require().NoError(keeperErr)

--- a/x/gamm/keeper/swap_test.go
+++ b/x/gamm/keeper/swap_test.go
@@ -161,7 +161,7 @@ func (s *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountIn() {
 				}
 
 				// Ratio of the token out should be between the before spot price and after spot price.
-				tradeAvgPrice := test.param.tokenIn.Amount.ToLegacyDec().Quo(tokenOutAmount.ToLegacyDec())
+				tradeAvgPrice := osmomath.BigDecFromDec(test.param.tokenIn.Amount.ToLegacyDec().Quo(tokenOutAmount.ToLegacyDec()))
 				s.True(tradeAvgPrice.GT(spotPriceBefore) && tradeAvgPrice.LT(spotPriceAfter), "test: %v", test.name)
 			} else {
 				_, err := keeper.SwapExactAmountIn(ctx, s.TestAccs[0], pool, test.param.tokenIn, test.param.tokenOutDenom, test.param.tokenOutMinAmount, spreadFactor)
@@ -413,7 +413,7 @@ func (s *KeeperTestSuite) TestBalancerPoolSimpleSwapExactAmountOut() {
 				s.NoError(err, "test: %v", test.name)
 
 				// Ratio of the token out should be between the before spot price and after spot price.
-				tradeAvgPrice := tokenInAmount.ToLegacyDec().Quo(test.param.tokenOut.Amount.ToLegacyDec())
+				tradeAvgPrice := osmomath.BigDecFromDec(tokenInAmount.ToLegacyDec().Quo(test.param.tokenOut.Amount.ToLegacyDec()))
 				s.True(tradeAvgPrice.GT(spotPriceBefore) && tradeAvgPrice.LT(spotPriceAfter), "test: %v", test.name)
 			} else {
 				_, err := keeper.SwapExactAmountOut(s.Ctx, s.TestAccs[0], pool, test.param.tokenInDenom, test.param.tokenInMaxAmount, test.param.tokenOut, spreadFactor)

--- a/x/gamm/pool-models/balancer/pool_suite_test.go
+++ b/x/gamm/pool-models/balancer/pool_suite_test.go
@@ -638,49 +638,49 @@ func (s *KeeperTestSuite) TestBalancerSpotPrice() {
 		baseDenomPoolInput  sdk.Coin
 		quoteDenomPoolInput sdk.Coin
 		expectError         bool
-		expectedOutput      osmomath.Dec
+		expectedOutput      osmomath.BigDec
 	}{
 		{
 			name:                "equal value",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
 			expectError:         false,
-			expectedOutput:      osmomath.MustNewDecFromStr("1"),
+			expectedOutput:      osmomath.MustNewBigDecFromStr("1"),
 		},
 		{
 			name:                "1:2 ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 200),
 			expectError:         false,
-			expectedOutput:      osmomath.MustNewDecFromStr("0.500000000000000000"),
+			expectedOutput:      osmomath.MustNewBigDecFromStr("0.500000000000000000"),
 		},
 		{
 			name:                "2:1 ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 200),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 100),
 			expectError:         false,
-			expectedOutput:      osmomath.MustNewDecFromStr("2.000000000000000000"),
+			expectedOutput:      osmomath.MustNewBigDecFromStr("2.000000000000000000"),
 		},
 		{
 			name:                "rounding after sigfig ratio",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 220),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 115),
 			expectError:         false,
-			expectedOutput:      osmomath.MustNewDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
+			expectedOutput:      osmomath.MustNewBigDecFromStr("1.913043480000000000"), // ans is 1.913043478260869565, rounded is 1.91304348
 		},
 		{
 			name:                "check number of sig figs",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 100),
 			quoteDenomPoolInput: sdk.NewInt64Coin(quoteDenom, 300),
 			expectError:         false,
-			expectedOutput:      osmomath.MustNewDecFromStr("0.333333330000000000"),
+			expectedOutput:      osmomath.MustNewBigDecFromStr("0.333333330000000000"),
 		},
 		{
 			name:                "check number of sig figs high sizes",
 			baseDenomPoolInput:  sdk.NewInt64Coin(baseDenom, 343569192534),
 			quoteDenomPoolInput: sdk.NewCoin(quoteDenom, osmomath.MustNewDecFromStr("186633424395479094888742").TruncateInt()),
 			expectError:         false,
-			expectedOutput:      osmomath.MustNewDecFromStr("0.000000000001840877"),
+			expectedOutput:      osmomath.MustNewBigDecFromStr("0.000000000001840877"),
 		},
 	}
 
@@ -819,7 +819,7 @@ func (s *KeeperTestSuite) TestBalancerSpotPriceBounds() {
 					s.Require().Error(err, "test: %s", tc.name)
 				} else {
 					s.Require().NoError(err, "test: %s", tc.name)
-					s.Require().True(spotPrice.Equal(tc.expectedOutput),
+					s.Require().True(spotPrice.Equal(osmomath.BigDecFromDec(tc.expectedOutput)),
 						"test: %s\nSpot price wrong, got %s, expected %s\n", tc.name,
 						spotPrice, tc.expectedOutput)
 				}

--- a/x/gamm/types/constants.go
+++ b/x/gamm/types/constants.go
@@ -33,7 +33,8 @@ var (
 	// Internal note: Ctrl+F for MaxSpotPrice in code if ever changed.
 	// Other tests depend on being equal to MaxSpotPrice,
 	// but don't directly import it due to import issues.
-	MaxSpotPrice = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+	MaxSpotPrice       = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+	MaxSpotPriceBigDec = osmomath.BigDecFromDec(MaxSpotPrice)
 	// MinSpotPrice is the minimum supported spot price. Anything less than this will error.
 	// It is limited by osmomath.Dec's precision.
 	MinSpotPrice = osmomath.SmallestDec()

--- a/x/poolmanager/client/query_proto_wrap.go
+++ b/x/poolmanager/client/query_proto_wrap.go
@@ -219,7 +219,9 @@ func (q Querier) SpotPrice(ctx sdk.Context, req queryproto.SpotPriceRequest) (*q
 	}
 
 	return &queryproto.SpotPriceResponse{
-		SpotPrice: sp.String(),
+		// Note: truncation exists here to maintain backwards compatibility.
+		// This query has historically had 18 decimals in response.
+		SpotPrice: sp.Dec().String(),
 	}, err
 }
 

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -554,15 +554,15 @@ func (k Keeper) RouteCalculateSpotPrice(
 	poolId uint64,
 	quoteAssetDenom string,
 	baseAssetDenom string,
-) (price osmomath.Dec, err error) {
+) (price osmomath.BigDec, err error) {
 	swapModule, err := k.GetPoolModule(ctx, poolId)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	price, err = swapModule.CalculateSpotPrice(ctx, poolId, quoteAssetDenom, baseAssetDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	return price, nil
@@ -886,7 +886,7 @@ func (k Keeper) trackVolume(ctx sdk.Context, poolId uint64, volumeGenerated sdk.
 
 	// Multiply `volumeGenerated.Amount.ToDec()` by this spot price.
 	// While rounding does not particularly matter here, we round down to ensure that we do not overcount volume.
-	volumeInOsmo := volumeGenerated.Amount.ToLegacyDec().Mul(osmoPerInputToken).TruncateInt()
+	volumeInOsmo := osmomath.BigDecFromSDKInt(volumeGenerated.Amount).Mul(osmoPerInputToken).Dec().TruncateInt()
 
 	// Add this new volume to the global tracked volume for the pool ID
 	k.addVolume(ctx, poolId, sdk.NewCoin(OSMO, volumeInOsmo))

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -320,7 +320,7 @@ func (s *KeeperTestSuite) TestRouteCalculateSpotPrice() {
 		setPositionForCLPool bool
 
 		routesOverwrite   map[types.PoolType]types.PoolModuleI
-		expectedSpotPrice osmomath.Dec
+		expectedSpotPrice osmomath.BigDec
 
 		expectError error
 	}{
@@ -329,14 +329,14 @@ func (s *KeeperTestSuite) TestRouteCalculateSpotPrice() {
 			poolId:            1,
 			quoteAssetDenom:   "bar",
 			baseAssetDenom:    "baz",
-			expectedSpotPrice: osmomath.MustNewDecFromStr("1.5"),
+			expectedSpotPrice: osmomath.MustNewBigDecFromStr("1.5"),
 		},
 		"valid stableswap pool": {
 			preCreatePoolType: types.Stableswap,
 			poolId:            1,
 			quoteAssetDenom:   "bar",
 			baseAssetDenom:    "baz",
-			expectedSpotPrice: osmomath.MustNewDecFromStr("0.99999998"),
+			expectedSpotPrice: osmomath.MustNewBigDecFromStr("0.99999998"),
 		},
 		"valid concentrated liquidity pool with position": {
 			preCreatePoolType:    types.Concentrated,
@@ -347,7 +347,7 @@ func (s *KeeperTestSuite) TestRouteCalculateSpotPrice() {
 			// We generate this value using the scripts in x/concentrated-liquidity/python
 			// Exact output: 5000.000000000000000129480272834995458481
 			// SDK Bankers rounded output: 5000.000000000000000129
-			expectedSpotPrice: osmomath.MustNewDecFromStr("5000.000000000000000129"),
+			expectedSpotPrice: osmomath.MustNewBigDecFromStr("5000.000000000000000129"),
 		},
 		"valid concentrated liquidity pool without position": {
 			preCreatePoolType: types.Concentrated,
@@ -365,7 +365,7 @@ func (s *KeeperTestSuite) TestRouteCalculateSpotPrice() {
 			quoteAssetDenom:   apptesting.DefaultTransmuterDenomA,
 			baseAssetDenom:    apptesting.DefaultTransmuterDenomB,
 			// For transmuter, the spot price is always 1. (hard-coded even if no liquidity)
-			expectedSpotPrice: osmomath.OneDec(),
+			expectedSpotPrice: osmomath.OneBigDec(),
 		},
 		"non-existent pool": {
 			preCreatePoolType: types.Balancer,

--- a/x/poolmanager/types/expected_keepers.go
+++ b/x/poolmanager/types/expected_keepers.go
@@ -48,7 +48,7 @@ type PoolModuleI interface {
 		poolId uint64,
 		quoteAssetDenom string,
 		baseAssetDenom string,
-	) (price osmomath.Dec, err error)
+	) (price osmomath.BigDec, err error)
 
 	SwapExactAmountIn(
 		ctx sdk.Context,

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -899,7 +899,7 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 			osmomath.ErrTolerance{
 				MultiplicativeTolerance: osmomath.SmallestDec(),
 			}.CompareBigDec(
-				osmomath.BigDecFromDec(spotPrice),
+				spotPrice,
 				osmomath.BigDecFromDec(twap),
 			)
 		})

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -205,7 +205,8 @@ func (s *TestSuite) TestEndBlock() {
 				// check if spot price has been correctly updated in twap record
 				asset0sp, err := s.App.PoolManagerKeeper.RouteCalculateSpotPrice(s.Ctx, poolId, twapAfterBlock1.Asset0Denom, twapAfterBlock1.Asset1Denom)
 				s.Require().NoError(err)
-				s.Require().Equal(asset0sp, twapAfterBlock1.P0LastSpotPrice)
+				// Note: twap only supports decimal precision of 18. Thus, truncation.
+				s.Require().Equal(asset0sp.Dec(), twapAfterBlock1.P0LastSpotPrice)
 
 				// run basic swap on block two for price change
 				if tc.block2Swap {
@@ -233,7 +234,8 @@ func (s *TestSuite) TestEndBlock() {
 				// check if spot price has been correctly updated in twap record
 				asset0sp, err = s.App.PoolManagerKeeper.RouteCalculateSpotPrice(s.Ctx, poolId, twapAfterBlock1.Asset0Denom, twapAfterBlock2.Asset1Denom)
 				s.Require().NoError(err)
-				s.Require().Equal(asset0sp, twapAfterBlock2.P0LastSpotPrice)
+				// Note: twap only supports decimal precision of 18. Thus, truncation.
+				s.Require().Equal(asset0sp.Dec(), twapAfterBlock2.P0LastSpotPrice)
 			})
 		}
 	}

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -70,16 +70,6 @@ func getSpotPrices(
 		sp1BigDec, latestErrTime = types.MaxSpotPriceBigDec, ctx.BlockTime()
 	}
 
-	// Note: truncation is appropriate since we don not support greater precision by design.
-	// If support for pools with outlier spot prices is needed in the future, then this should be revisited.
-	// if !sp0BigDec.IsNil() {
-	// 	sp0 = sp0BigDec.Dec()
-	// }
-
-	// if !sp1BigDec.IsNil() {
-	// 	sp1 = sp1BigDec.Dec()
-	// }
-
 	return sp0BigDec.Dec(), sp1BigDec.Dec(), latestErrTime
 }
 

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -47,28 +47,40 @@ func getSpotPrices(
 ) (sp0 osmomath.Dec, sp1 osmomath.Dec, latestErrTime time.Time) {
 	latestErrTime = previousErrorTime
 	// sp0 = denom0 quote, denom1 base.
-	sp0, err0 := k.RouteCalculateSpotPrice(ctx, poolId, denom0, denom1)
+	sp0BigDec, err0 := k.RouteCalculateSpotPrice(ctx, poolId, denom0, denom1)
 	// sp1 = denom0 base, denom1 quote.
-	sp1, err1 := k.RouteCalculateSpotPrice(ctx, poolId, denom1, denom0)
+	sp1BigDec, err1 := k.RouteCalculateSpotPrice(ctx, poolId, denom1, denom0)
+
 	if err0 != nil || err1 != nil {
 		latestErrTime = ctx.BlockTime()
 		// In the event of an error, we just sanity replace empty values with zero values
 		// so that the numbers can be still be calculated within TWAPs over error values
 		// TODO: Should we be using the last spot price?
-		if (sp0 == osmomath.Dec{}) {
-			sp0 = osmomath.ZeroDec()
+		if (sp0BigDec == osmomath.BigDec{}) {
+			sp0BigDec = osmomath.ZeroBigDec()
 		}
-		if (sp1 == osmomath.Dec{}) {
-			sp1 = osmomath.ZeroDec()
+		if (sp1BigDec == osmomath.BigDec{}) {
+			sp1BigDec = osmomath.ZeroBigDec()
 		}
 	}
-	if sp0.GT(types.MaxSpotPrice) {
-		sp0, latestErrTime = types.MaxSpotPrice, ctx.BlockTime()
+	if sp0BigDec.GT(types.MaxSpotPriceBigDec) {
+		sp0BigDec, latestErrTime = types.MaxSpotPriceBigDec, ctx.BlockTime()
 	}
-	if sp1.GT(types.MaxSpotPrice) {
-		sp1, latestErrTime = types.MaxSpotPrice, ctx.BlockTime()
+	if sp1BigDec.GT(types.MaxSpotPriceBigDec) {
+		sp1BigDec, latestErrTime = types.MaxSpotPriceBigDec, ctx.BlockTime()
 	}
-	return sp0, sp1, latestErrTime
+
+	// Note: truncation is appropriate since we don not support greater precision by design.
+	// If support for pools with outlier spot prices is needed in the future, then this should be revisited.
+	// if !sp0BigDec.IsNil() {
+	// 	sp0 = sp0BigDec.Dec()
+	// }
+
+	// if !sp1BigDec.IsNil() {
+	// 	sp1 = sp1BigDec.Dec()
+	// }
+
+	return sp0BigDec.Dec(), sp1BigDec.Dec(), latestErrTime
 }
 
 // mustTrackCreatedPool is a wrapper around afterCreatePool that panics on error.

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -70,6 +70,8 @@ func getSpotPrices(
 		sp1BigDec, latestErrTime = types.MaxSpotPriceBigDec, ctx.BlockTime()
 	}
 
+	// Note: truncation is appropriate since we don not support greater precision by design.
+	// If support for pools with outlier spot prices is needed in the future, then this should be revisited.
 	return sp0BigDec.Dec(), sp1BigDec.Dec(), latestErrTime
 }
 

--- a/x/twap/types/expected_interfaces.go
+++ b/x/twap/types/expected_interfaces.go
@@ -18,5 +18,5 @@ type PoolManagerInterface interface {
 		poolID uint64,
 		quoteAssetDenom string,
 		baseAssetDenom string,
-	) (price osmomath.Dec, err error)
+	) (price osmomath.BigDec, err error)
 }

--- a/x/twap/types/twapmock/amminterface.go
+++ b/x/twap/types/twapmock/amminterface.go
@@ -77,7 +77,6 @@ func (p *ProgrammedPoolManagerInterface) RouteCalculateSpotPrice(ctx sdk.Context
 ) (price osmomath.BigDec, err error) {
 	input := SpotPriceInput{poolId, baseDenom, quoteDenom}
 	if res, ok := p.programmedSpotPrice[input]; ok {
-
 		if (res.Sp == osmomath.Dec{}) {
 			return osmomath.BigDec{}, res.Err
 		}

--- a/x/twap/types/twapmock/amminterface.go
+++ b/x/twap/types/twapmock/amminterface.go
@@ -74,10 +74,15 @@ func (p *ProgrammedPoolManagerInterface) RouteCalculateSpotPrice(ctx sdk.Context
 	poolId uint64,
 	quoteDenom,
 	baseDenom string,
-) (price osmomath.Dec, err error) {
+) (price osmomath.BigDec, err error) {
 	input := SpotPriceInput{poolId, baseDenom, quoteDenom}
 	if res, ok := p.programmedSpotPrice[input]; ok {
-		return res.Sp, res.Err
+
+		if (res.Sp == osmomath.Dec{}) {
+			return osmomath.BigDec{}, res.Err
+		}
+
+		return osmomath.BigDecFromDec(res.Sp), res.Err
 	}
 	return p.underlyingKeeper.RouteCalculateSpotPrice(ctx, poolId, quoteDenom, baseDenom)
 }

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -8,7 +8,10 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
-var MaxSpotPrice = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+var (
+	MaxSpotPrice       = osmomath.NewDec(2).Power(128).Sub(osmomath.OneDec())
+	MaxSpotPriceBigDec = osmomath.BigDecFromDec(MaxSpotPrice)
+)
 
 // GetAllUniqueDenomPairs returns all unique pairs of denoms, where for every pair
 // (X, Y), X < Y.

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -32,27 +32,30 @@ func (k Keeper) ConvertToBaseToken(ctx sdk.Context, inputFee sdk.Coin) (sdk.Coin
 		return sdk.Coin{}, err
 	}
 
-	return sdk.NewCoin(baseDenom, spotPrice.MulInt(inputFee.Amount).RoundInt()), nil
+	// Note: spotPrice truncation is done here for maintaining state-compatibility with v19.x
+	// It should be changed to support full spot price precision before
+	// https://github.com/osmosis-labs/osmosis/issues/6064 is complete
+	return sdk.NewCoin(baseDenom, spotPrice.Dec().MulInt(inputFee.Amount).RoundInt()), nil
 }
 
 // CalcFeeSpotPrice converts the provided tx fees into their equivalent value in the base denomination.
 // Spot Price Calculation: spotPrice / (1 - spreadFactor),
 // where spotPrice is defined as:
 // (tokenBalanceIn / tokenWeightIn) / (tokenBalanceOut / tokenWeightOut)
-func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (osmomath.Dec, error) {
+func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (osmomath.BigDec, error) {
 	baseDenom, err := k.GetBaseDenom(ctx)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	feeToken, err := k.GetFeeToken(ctx, inputDenom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 
 	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
 	if err != nil {
-		return osmomath.Dec{}, err
+		return osmomath.BigDec{}, err
 	}
 	return spotPrice, nil
 }

--- a/x/txfees/keeper/grpc_query.go
+++ b/x/txfees/keeper/grpc_query.go
@@ -51,7 +51,8 @@ func (q Querier) DenomSpotPrice(ctx context.Context, req *types.QueryDenomSpotPr
 		return nil, err
 	}
 
-	return &types.QueryDenomSpotPriceResponse{PoolID: feeToken.PoolID, SpotPrice: spotPrice}, nil
+	// TODO: remove truncation before https://github.com/osmosis-labs/osmosis/issues/6064 is fully complete.
+	return &types.QueryDenomSpotPriceResponse{PoolID: feeToken.PoolID, SpotPrice: spotPrice.Dec()}, nil
 }
 
 func (q Querier) DenomPoolId(ctx context.Context, req *types.QueryDenomPoolIdRequest) (*types.QueryDenomPoolIdResponse, error) {

--- a/x/txfees/types/expected_keepers.go
+++ b/x/txfees/types/expected_keepers.go
@@ -11,7 +11,7 @@ import (
 // SpotPriceCalculator defines the contract that must be fulfilled by a spot price calculator
 // The x/gamm keeper is expected to satisfy this interface.
 type SpotPriceCalculator interface {
-	CalculateSpotPrice(ctx sdk.Context, poolId uint64, quoteDenom, baseDenom string) (osmomath.Dec, error)
+	CalculateSpotPrice(ctx sdk.Context, poolId uint64, quoteDenom, baseDenom string) (osmomath.BigDec, error)
 }
 
 // PoolManager defines the contract needed for swap related APIs.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: https://github.com/osmosis-labs/osmosis/issues/6064

## What is the purpose of the change

This PR aims to continue the progress toward introducing a BigDec spot price query.

It should be state-compatible. The current clients are not expected to be broken because we truncate the spot price to 18 decimals before returning.

In the subsequent PR, a new spot price query is to be introduced that returns a 36-decimal spot price.

## Testing and Verifying

- Covered by existing tests
- To be backported to v19.x and tested on a node

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A