### PR TITLE
[AccountAbstraction] Making authz aware of authenticators

### DIFF
--- a/app/keepers/authz.go
+++ b/app/keepers/authz.go
@@ -1,0 +1,108 @@
+package keepers
+
+import (
+	"context"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	"github.com/tendermint/tendermint/libs/log"
+	"time"
+)
+
+type AuthzKeeperInterface interface {
+	Logger(ctx types.Context) log.Logger
+	DispatchActions(ctx types.Context, grantee types.AccAddress, msgs []types.Msg) ([][]byte, error)
+	SaveGrant(ctx types.Context, grantee, granter types.AccAddress, authorization authz.Authorization, expiration time.Time) error
+	DeleteGrant(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) error
+	GetAuthorizations(ctx types.Context, grantee types.AccAddress, granter types.AccAddress) []authz.Authorization
+	GetCleanAuthorization(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) (authz.Authorization, time.Time)
+	IterateGrants(ctx types.Context, handler func(granterAddr types.AccAddress, granteeAddr types.AccAddress, grant authz.Grant) bool)
+	ExportGenesis(ctx types.Context) *authz.GenesisState
+	InitGenesis(ctx types.Context, data *authz.GenesisState)
+	Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz.QueryGrantsResponse, error)
+	GranterGrants(c context.Context, req *authz.QueryGranterGrantsRequest) (*authz.QueryGranterGrantsResponse, error)
+	GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRequest) (*authz.QueryGranteeGrantsResponse, error)
+	Grant(goCtx context.Context, msg *authz.MsgGrant) (*authz.MsgGrantResponse, error)
+	Revoke(goCtx context.Context, msg *authz.MsgRevoke) (*authz.MsgRevokeResponse, error)
+	Exec(goCtx context.Context, msg *authz.MsgExec) (*authz.MsgExecResponse, error)
+
+	Keeper() authzkeeper.Keeper
+}
+
+var _ AuthzKeeperInterface = &KeeperWrapper{}
+
+type KeeperWrapper struct {
+	K authzkeeper.Keeper
+}
+
+func NewKeeperWrapper(k authzkeeper.Keeper) *KeeperWrapper {
+	return &KeeperWrapper{K: k}
+}
+
+// Implementing KeeperInterface
+
+func (kw *KeeperWrapper) Keeper() authzkeeper.Keeper {
+	return kw.K
+}
+
+func (kw *KeeperWrapper) Logger(ctx types.Context) log.Logger {
+	return kw.K.Logger(ctx)
+}
+
+func (kw *KeeperWrapper) DispatchActions(ctx types.Context, grantee types.AccAddress, msgs []types.Msg) ([][]byte, error) {
+	// TODO: Here we could ensure that authenticators are properly called.
+	//       (if we don't want to make authz grants an authenticator)
+	return kw.K.DispatchActions(ctx, grantee, msgs)
+}
+
+func (kw *KeeperWrapper) SaveGrant(ctx types.Context, grantee, granter types.AccAddress, authorization authz.Authorization, expiration time.Time) error {
+	return kw.K.SaveGrant(ctx, grantee, granter, authorization, expiration)
+}
+
+func (kw *KeeperWrapper) DeleteGrant(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) error {
+	return kw.K.DeleteGrant(ctx, grantee, granter, msgType)
+}
+
+func (kw *KeeperWrapper) GetAuthorizations(ctx types.Context, grantee types.AccAddress, granter types.AccAddress) []authz.Authorization {
+	return kw.K.GetAuthorizations(ctx, grantee, granter)
+}
+
+func (kw *KeeperWrapper) GetCleanAuthorization(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) (authz.Authorization, time.Time) {
+	return kw.K.GetCleanAuthorization(ctx, grantee, granter, msgType)
+}
+
+func (kw *KeeperWrapper) IterateGrants(ctx types.Context, handler func(granterAddr types.AccAddress, granteeAddr types.AccAddress, grant authz.Grant) bool) {
+	kw.K.IterateGrants(ctx, handler)
+}
+
+func (kw *KeeperWrapper) ExportGenesis(ctx types.Context) *authz.GenesisState {
+	return kw.K.ExportGenesis(ctx)
+}
+
+func (kw *KeeperWrapper) InitGenesis(ctx types.Context, data *authz.GenesisState) {
+	kw.K.InitGenesis(ctx, data)
+}
+
+func (kw *KeeperWrapper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz.QueryGrantsResponse, error) {
+	return kw.K.Grants(c, req)
+}
+
+func (kw *KeeperWrapper) GranterGrants(c context.Context, req *authz.QueryGranterGrantsRequest) (*authz.QueryGranterGrantsResponse, error) {
+	return kw.K.GranterGrants(c, req)
+}
+
+func (kw *KeeperWrapper) GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRequest) (*authz.QueryGranteeGrantsResponse, error) {
+	return kw.K.GranteeGrants(c, req)
+}
+
+func (kw *KeeperWrapper) Grant(goCtx context.Context, msg *authz.MsgGrant) (*authz.MsgGrantResponse, error) {
+	return kw.K.Grant(goCtx, msg)
+}
+
+func (kw *KeeperWrapper) Revoke(goCtx context.Context, msg *authz.MsgRevoke) (*authz.MsgRevokeResponse, error) {
+	return kw.K.Revoke(goCtx, msg)
+}
+
+func (kw *KeeperWrapper) Exec(goCtx context.Context, msg *authz.MsgExec) (*authz.MsgExecResponse, error) {
+	return kw.K.Exec(goCtx, msg)
+}

--- a/app/keepers/authz.go
+++ b/app/keepers/authz.go
@@ -2,23 +2,31 @@ package keepers
 
 import (
 	"context"
-	"github.com/cosmos/cosmos-sdk/types"
+	"encoding/json"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/utils"
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
+	"math/rand"
 	"time"
 )
 
 type AuthzKeeperInterface interface {
-	Logger(ctx types.Context) log.Logger
-	DispatchActions(ctx types.Context, grantee types.AccAddress, msgs []types.Msg) ([][]byte, error)
-	SaveGrant(ctx types.Context, grantee, granter types.AccAddress, authorization authz.Authorization, expiration time.Time) error
-	DeleteGrant(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) error
-	GetAuthorizations(ctx types.Context, grantee types.AccAddress, granter types.AccAddress) []authz.Authorization
-	GetCleanAuthorization(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) (authz.Authorization, time.Time)
-	IterateGrants(ctx types.Context, handler func(granterAddr types.AccAddress, granteeAddr types.AccAddress, grant authz.Grant) bool)
-	ExportGenesis(ctx types.Context) *authz.GenesisState
-	InitGenesis(ctx types.Context, data *authz.GenesisState)
+	Logger(ctx sdk.Context) log.Logger
+	DispatchActions(ctx sdk.Context, grantee sdk.AccAddress, msgs []sdk.Msg) ([][]byte, error)
+	SaveGrant(ctx sdk.Context, grantee, granter sdk.AccAddress, authorization authz.Authorization, expiration time.Time) error
+	DeleteGrant(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) error
+	GetAuthorizations(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress) []authz.Authorization
+	GetCleanAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (authz.Authorization, time.Time)
+	IterateGrants(ctx sdk.Context, handler func(granterAddr sdk.AccAddress, granteeAddr sdk.AccAddress, grant authz.Grant) bool)
+	ExportGenesis(ctx sdk.Context) *authz.GenesisState
+	InitGenesis(ctx sdk.Context, data *authz.GenesisState)
 	Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz.QueryGrantsResponse, error)
 	GranterGrants(c context.Context, req *authz.QueryGranterGrantsRequest) (*authz.QueryGranterGrantsResponse, error)
 	GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRequest) (*authz.QueryGranteeGrantsResponse, error)
@@ -32,11 +40,12 @@ type AuthzKeeperInterface interface {
 var _ AuthzKeeperInterface = &KeeperWrapper{}
 
 type KeeperWrapper struct {
-	K authzkeeper.Keeper
+	K                    authzkeeper.Keeper
+	authenticatorStorage utils.AuthenticatorStorage
 }
 
-func NewKeeperWrapper(k authzkeeper.Keeper) *KeeperWrapper {
-	return &KeeperWrapper{K: k}
+func NewKeeperWrapper(k authzkeeper.Keeper, authenticatorKeeper utils.AuthenticatorStorage) *KeeperWrapper {
+	return &KeeperWrapper{K: k, authenticatorStorage: authenticatorKeeper}
 }
 
 // Implementing KeeperInterface
@@ -45,64 +54,170 @@ func (kw *KeeperWrapper) Keeper() authzkeeper.Keeper {
 	return kw.K
 }
 
-func (kw *KeeperWrapper) Logger(ctx types.Context) log.Logger {
+func (kw *KeeperWrapper) Logger(ctx sdk.Context) log.Logger {
 	return kw.K.Logger(ctx)
 }
 
-func (kw *KeeperWrapper) DispatchActions(ctx types.Context, grantee types.AccAddress, msgs []types.Msg) ([][]byte, error) {
-	// TODO: Here we could ensure that authenticators are properly called.
-	//       (if we don't want to make authz grants an authenticator)
-	return kw.K.DispatchActions(ctx, grantee, msgs)
+func (kw *KeeperWrapper) DispatchActions(ctx sdk.Context, grantee sdk.AccAddress, msgs []sdk.Msg) ([][]byte, error) {
+	err := utils.TrackMessages(ctx, kw.authenticatorStorage, msgs)
+	if err != nil {
+		return nil, err
+	}
+	results, err := kw.K.DispatchActions(ctx, grantee, msgs)
+	if err != nil {
+		return nil, err
+	}
+	err = utils.ConfirmExecutionWithoutTx(ctx, kw.authenticatorStorage, msgs)
+	if err != nil {
+		return nil, err
+	}
+	return results, err
 }
 
-func (kw *KeeperWrapper) SaveGrant(ctx types.Context, grantee, granter types.AccAddress, authorization authz.Authorization, expiration time.Time) error {
+func (kw *KeeperWrapper) SaveGrant(ctx sdk.Context, grantee, granter sdk.AccAddress, authorization authz.Authorization, expiration time.Time) error {
 	return kw.K.SaveGrant(ctx, grantee, granter, authorization, expiration)
 }
 
-func (kw *KeeperWrapper) DeleteGrant(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) error {
+func (kw *KeeperWrapper) DeleteGrant(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) error {
 	return kw.K.DeleteGrant(ctx, grantee, granter, msgType)
 }
 
-func (kw *KeeperWrapper) GetAuthorizations(ctx types.Context, grantee types.AccAddress, granter types.AccAddress) []authz.Authorization {
+func (kw *KeeperWrapper) GetAuthorizations(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress) []authz.Authorization {
 	return kw.K.GetAuthorizations(ctx, grantee, granter)
 }
 
-func (kw *KeeperWrapper) GetCleanAuthorization(ctx types.Context, grantee types.AccAddress, granter types.AccAddress, msgType string) (authz.Authorization, time.Time) {
+func (kw *KeeperWrapper) GetCleanAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (authz.Authorization, time.Time) {
 	return kw.K.GetCleanAuthorization(ctx, grantee, granter, msgType)
 }
 
-func (kw *KeeperWrapper) IterateGrants(ctx types.Context, handler func(granterAddr types.AccAddress, granteeAddr types.AccAddress, grant authz.Grant) bool) {
+func (kw *KeeperWrapper) IterateGrants(ctx sdk.Context, handler func(granterAddr sdk.AccAddress, granteeAddr sdk.AccAddress, grant authz.Grant) bool) {
 	kw.K.IterateGrants(ctx, handler)
 }
 
-func (kw *KeeperWrapper) ExportGenesis(ctx types.Context) *authz.GenesisState {
+func (kw *KeeperWrapper) ExportGenesis(ctx sdk.Context) *authz.GenesisState {
 	return kw.K.ExportGenesis(ctx)
 }
 
-func (kw *KeeperWrapper) InitGenesis(ctx types.Context, data *authz.GenesisState) {
+func (kw *KeeperWrapper) InitGenesis(ctx sdk.Context, data *authz.GenesisState) {
 	kw.K.InitGenesis(ctx, data)
 }
 
-func (kw *KeeperWrapper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz.QueryGrantsResponse, error) {
+func (kw KeeperWrapper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz.QueryGrantsResponse, error) {
 	return kw.K.Grants(c, req)
 }
 
-func (kw *KeeperWrapper) GranterGrants(c context.Context, req *authz.QueryGranterGrantsRequest) (*authz.QueryGranterGrantsResponse, error) {
+func (kw KeeperWrapper) GranterGrants(c context.Context, req *authz.QueryGranterGrantsRequest) (*authz.QueryGranterGrantsResponse, error) {
 	return kw.K.GranterGrants(c, req)
 }
 
-func (kw *KeeperWrapper) GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRequest) (*authz.QueryGranteeGrantsResponse, error) {
+func (kw KeeperWrapper) GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRequest) (*authz.QueryGranteeGrantsResponse, error) {
 	return kw.K.GranteeGrants(c, req)
 }
 
-func (kw *KeeperWrapper) Grant(goCtx context.Context, msg *authz.MsgGrant) (*authz.MsgGrantResponse, error) {
+func (kw KeeperWrapper) Grant(goCtx context.Context, msg *authz.MsgGrant) (*authz.MsgGrantResponse, error) {
 	return kw.K.Grant(goCtx, msg)
 }
 
-func (kw *KeeperWrapper) Revoke(goCtx context.Context, msg *authz.MsgRevoke) (*authz.MsgRevokeResponse, error) {
+func (kw KeeperWrapper) Revoke(goCtx context.Context, msg *authz.MsgRevoke) (*authz.MsgRevokeResponse, error) {
 	return kw.K.Revoke(goCtx, msg)
 }
 
-func (kw *KeeperWrapper) Exec(goCtx context.Context, msg *authz.MsgExec) (*authz.MsgExecResponse, error) {
-	return kw.K.Exec(goCtx, msg)
+func (kw KeeperWrapper) Exec(goCtx context.Context, msg *authz.MsgExec) (*authz.MsgExecResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	grantee, err := sdk.AccAddressFromBech32(msg.Grantee)
+	if err != nil {
+		return nil, err
+	}
+	msgs, err := msg.GetMessages()
+	if err != nil {
+		return nil, err
+	}
+	results, err := kw.DispatchActions(ctx, grantee, msgs)
+	if err != nil {
+		return nil, err
+	}
+	return &authz.MsgExecResponse{Results: results}, nil
+}
+
+// MODULE FORM HERE
+
+type AppModuleWrapper struct {
+	authzmodule.AppModule
+	keeperWrapper AuthzKeeperInterface // Replace original Keeper with KeeperWrapper
+}
+
+func NewAppModuleWrapper(original authzmodule.AppModule, keeperWrapper AuthzKeeperInterface) AppModuleWrapper {
+	return AppModuleWrapper{
+		AppModule:     original,
+		keeperWrapper: keeperWrapper,
+	}
+}
+
+func (amw AppModuleWrapper) RegisterServices(cfg module.Configurator) {
+	authz.RegisterQueryServer(cfg.QueryServer(), amw.keeperWrapper)
+	authz.RegisterMsgServer(cfg.MsgServer(), amw.keeperWrapper)
+}
+
+func (amw AppModuleWrapper) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState authz.GenesisState
+	cdc.MustUnmarshalJSON(data, &genesisState)
+	amw.keeperWrapper.InitGenesis(ctx, &genesisState)
+	return []abci.ValidatorUpdate{}
+}
+
+func (amw AppModuleWrapper) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	gs := amw.keeperWrapper.ExportGenesis(ctx)
+	return cdc.MustMarshalJSON(gs)
+}
+
+func (amw AppModuleWrapper) Name() string {
+	return amw.AppModule.Name()
+}
+
+func (amw AppModuleWrapper) RegisterInvariants(ir sdk.InvariantRegistry) {
+	amw.AppModule.RegisterInvariants(ir)
+}
+
+func (amw AppModuleWrapper) Route() sdk.Route {
+	return amw.AppModule.Route()
+}
+
+func (amw AppModuleWrapper) NewHandler() sdk.Handler {
+	return amw.AppModule.NewHandler()
+}
+
+func (amw AppModuleWrapper) QuerierRoute() string {
+	return amw.AppModule.QuerierRoute()
+}
+
+func (amw AppModuleWrapper) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
+	return amw.AppModule.LegacyQuerierHandler(legacyQuerierCdc)
+}
+
+func (amw AppModuleWrapper) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
+	amw.AppModule.BeginBlock(ctx, req)
+}
+
+func (amw AppModuleWrapper) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return amw.AppModule.EndBlock(ctx, req)
+}
+
+func (amw AppModuleWrapper) GenerateGenesisState(simState *module.SimulationState) {
+	amw.AppModule.GenerateGenesisState(simState)
+}
+
+func (amw AppModuleWrapper) ProposalContents(simState module.SimulationState) []simtypes.WeightedProposalContent {
+	return amw.AppModule.ProposalContents(simState)
+}
+
+func (amw AppModuleWrapper) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
+	return amw.AppModule.RandomizedParams(r)
+}
+
+func (amw AppModuleWrapper) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
+	amw.AppModule.RegisterStoreDecoder(sdr)
+}
+
+func (amw AppModuleWrapper) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
+	return amw.AppModule.WeightedOperations(simState)
 }

--- a/app/keepers/authz.go
+++ b/app/keepers/authz.go
@@ -3,6 +3,9 @@ package keepers
 import (
 	"context"
 	"encoding/json"
+	"math/rand"
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -13,8 +16,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/utils"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
-	"math/rand"
-	"time"
 )
 
 type AuthzKeeperInterface interface {

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -35,8 +35,8 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	icq "github.com/cosmos/ibc-apps/modules/async-icq/v4"
 	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v4/types"
-
 	appparams "github.com/osmosis-labs/osmosis/v19/app/params"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 	"github.com/osmosis-labs/osmosis/v19/x/cosmwasmpool"
 	cosmwasmpooltypes "github.com/osmosis-labs/osmosis/v19/x/cosmwasmpool/types"
 	downtimedetector "github.com/osmosis-labs/osmosis/v19/x/downtime-detector"
@@ -201,11 +201,30 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	)
 	appKeepers.BankKeeper = &bankKeeper
 
-	authzKeeper := NewKeeperWrapper(authzkeeper.NewKeeper(
-		appKeepers.keys[authzkeeper.StoreKey],
+	// Initialize authenticators
+	appKeepers.AuthenticatorManager = authenticator.NewAuthenticatorManager()
+	appKeepers.AuthenticatorManager.InitializeAuthenticators([]iface.Authenticator{
+		authenticator.NewSignatureVerificationAuthenticator(appKeepers.AccountKeeper, encodingConfig.TxConfig.SignModeHandler()), // default
+	})
+	appKeepers.AuthenticatorManager.SetDefaultAuthenticatorIndex(0)
+
+	authenticatorKeeper := authenticatorkeeper.NewKeeper(
 		appCodec,
-		bApp.MsgServiceRouter(),
-	))
+		appKeepers.keys[authenticatortypes.ManagerStoreKey],
+		appKeepers.keys[authenticatortypes.AuthenticatorStoreKey],
+		appKeepers.GetSubspace(authenticatortypes.ModuleName),
+		appKeepers.AuthenticatorManager,
+	)
+	appKeepers.AuthenticatorKeeper = &authenticatorKeeper
+
+	authzKeeper := NewKeeperWrapper(
+		authzkeeper.NewKeeper(
+			appKeepers.keys[authzkeeper.StoreKey],
+			appCodec,
+			bApp.MsgServiceRouter(),
+		),
+		appKeepers.AuthenticatorKeeper,
+	)
 	appKeepers.AuthzKeeper = authzKeeper
 
 	stakingKeeper := stakingkeeper.NewKeeper(
@@ -451,22 +470,6 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.DistrKeeper,
 		appKeepers.LockupKeeper,
 	)
-
-	// Initialize authenticators
-	appKeepers.AuthenticatorManager = authenticator.NewAuthenticatorManager()
-	appKeepers.AuthenticatorManager.InitializeAuthenticators([]authenticator.Authenticator{
-		authenticator.NewSignatureVerificationAuthenticator(appKeepers.AccountKeeper, encodingConfig.TxConfig.SignModeHandler()), // default
-	})
-	appKeepers.AuthenticatorManager.SetDefaultAuthenticatorIndex(0)
-
-	authenticatorKeeper := authenticatorkeeper.NewKeeper(
-		appCodec,
-		appKeepers.keys[authenticatortypes.ManagerStoreKey],
-		appKeepers.keys[authenticatortypes.AuthenticatorStoreKey],
-		appKeepers.GetSubspace(authenticatortypes.ModuleName),
-		appKeepers.AuthenticatorManager,
-	)
-	appKeepers.AuthenticatorKeeper = &authenticatorKeeper
 
 	appKeepers.ValidatorSetPreferenceKeeper = &validatorSetPreferenceKeeper
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -124,7 +124,7 @@ type AppKeepers struct {
 	// "Normal" keepers
 	AccountKeeper                *authkeeper.AccountKeeper
 	BankKeeper                   *bankkeeper.BaseKeeper
-	AuthzKeeper                  *authzkeeper.Keeper
+	AuthzKeeper                  AuthzKeeperInterface
 	StakingKeeper                *stakingkeeper.Keeper
 	DistrKeeper                  *distrkeeper.Keeper
 	DowntimeKeeper               *downtimedetector.Keeper
@@ -201,12 +201,12 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	)
 	appKeepers.BankKeeper = &bankKeeper
 
-	authzKeeper := authzkeeper.NewKeeper(
+	authzKeeper := NewKeeperWrapper(authzkeeper.NewKeeper(
 		appKeepers.keys[authzkeeper.StoreKey],
 		appCodec,
 		bApp.MsgServiceRouter(),
-	)
-	appKeepers.AuthzKeeper = &authzKeeper
+	))
+	appKeepers.AuthzKeeper = authzKeeper
 
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec,

--- a/app/modules.go
+++ b/app/modules.go
@@ -157,7 +157,7 @@ func appModules(
 		upgrade.NewAppModule(*app.UpgradeKeeper),
 		wasm.NewAppModule(appCodec, app.WasmKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
 		evidence.NewAppModule(*app.EvidenceKeeper),
-		authzmodule.NewAppModule(appCodec, *app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
+		authzmodule.NewAppModule(appCodec, app.AuthzKeeper.Keeper(), app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		ibc.NewAppModule(app.IBCKeeper),
 		ica.NewAppModule(nil, app.ICAHostKeeper),
 		params.NewAppModule(*app.ParamsKeeper),

--- a/app/modules.go
+++ b/app/modules.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	"github.com/cosmos/cosmos-sdk/client"
+	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	icq "github.com/cosmos/ibc-apps/modules/async-icq/v4"
@@ -25,6 +26,7 @@ import (
 	downtimemodule "github.com/osmosis-labs/osmosis/v19/x/downtime-detector/module"
 	downtimetypes "github.com/osmosis-labs/osmosis/v19/x/downtime-detector/types"
 
+	authzwrapper "github.com/osmosis-labs/osmosis/v19/app/keepers"
 	ibc_hooks "github.com/osmosis-labs/osmosis/x/ibc-hooks"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -33,7 +35,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/capability"
@@ -157,7 +158,7 @@ func appModules(
 		upgrade.NewAppModule(*app.UpgradeKeeper),
 		wasm.NewAppModule(appCodec, app.WasmKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
 		evidence.NewAppModule(*app.EvidenceKeeper),
-		authzmodule.NewAppModule(appCodec, app.AuthzKeeper.Keeper(), app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
+		authzwrapper.NewAppModuleWrapper(authzmodule.NewAppModule(appCodec, app.AuthzKeeper.Keeper(), app.AccountKeeper, app.BankKeeper, app.interfaceRegistry), app.AuthzKeeper),
 		ibc.NewAppModule(app.IBCKeeper),
 		ica.NewAppModule(nil, app.ICAHostKeeper),
 		params.NewAppModule(*app.ParamsKeeper),

--- a/x/authenticator/README.md
+++ b/x/authenticator/README.md
@@ -1,0 +1,119 @@
+# x/authenticators Module
+
+## General Explanation
+
+The `x/authenticators` module provides a robust and extensible framework for authenticating transactions. 
+
+Unlike traditional authentication methods, this module allows you to use multiple types of authenticators,
+each with their own set of rules and conditions for transaction approval.
+
+## Authenticator Interface
+
+The `Authenticator` interface is the cornerstone of this module, encapsulating the essential functionalities 
+for transaction authentication.
+
+Here is a look at the Go code defining the interface:
+
+```go
+type Authenticator interface {
+    Type() string
+    StaticGas() uint64
+    Initialize(data []byte) (Authenticator, error)
+    GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (AuthenticatorData, error)
+    Track(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg) error
+    Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData AuthenticatorData) AuthenticationResult
+    ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData AuthenticatorData) ConfirmationResult
+}
+```
+### Methods
+
+#### `Type`
+Returns the type of the authenticator (e.g., `SignatureVerificationAuthenticator`, `CosmWasmAuthenticator`). Each type must be registered within the `AuthenticatorManager`.
+
+#### `StaticGas`
+Defines the static gas consumption for each call to the authenticator.
+
+#### `Initialize`
+Initializes the authenticator when retrieved from storage. It takes stored data (e.g., PublicKey for signature verification) as an argument to set up the authenticator.
+
+#### `GetAuthenticationData`
+Retrieves required authentication data from a transaction. Used in ante handlers to ensure the user has the correct permissions to execute a message.
+
+#### `Track`
+Tracks any information the authenticator may need, regardless of how the transaction is authenticated (e.g., via authz, ICA).
+
+#### `Authenticate`
+Validates a message based on the signer and data. Returns true if authenticated, false otherwise. Consumes gas within this function.
+
+#### `ConfirmExecution`
+Used in post-handler functions to enforce transaction rules like spending and transaction limits.
+
+## Authenticator Manager
+
+The authenticator manager the chain to register authenticators and retrieve them by type. Each authenticator type
+represents the code to be executed. 
+
+To determine which authenticators will be used for each account, the authenticator manager also stores a mapping 
+between an account and a list of authenticators. A user can add or remove authenticators from their account using the
+`MsgAddAuthenticator` and `MsgRemoveAuthenticator` messages.
+
+Some authenticators may require additional data specific to the user being authenticated. To handle this, the user
+can store data for each authenticator type. 
+
+### Messages
+
+#### `MsgAddAuthenticator`
+Adds an authenticator to the user's account. The authenticator must be registered with the authenticator manager.
+
+Example:
+
+```go
+AddAuthenticator(account, "SignatureVerificationAuthenticator", pubKeyBytes) 
+```
+
+#### `MsgRemoveAuthenticator`
+Removes an authenticator from the user's account. The authenticator must be registered with the authenticator manager.
+
+example:
+
+```go
+RemoveAuthenticator(account, authenticatorGlobalId)
+``` 
+
+## Transaction Authentication Overview
+
+1. **Initial Gas Limit**: A temporary gas limit is set for fee payer authentication. This is a spam prevention measure to safeguard computational resources.
+
+2. **Identify Fee Payer**: By default, the first signer of the transaction is considered the fee payer.
+
+3. **Authenticate Each Message**:
+    - The associated account for every message is identified.
+    - The system fetches the appropriate authenticators for that account.
+    - Each authenticator tries to validate the message. Successful validation means the message is authenticated.
+
+4. **Gas Limit Reset**: Once the fee payer is authenticated, the gas limit is restored to its original value.
+
+5. **Track Authenticated Messages**: After all messages are authenticated, the `Track` function notifies each authenticator. This allows authenticators to store any transaction-specific data they might need for future reference, irrespective of the authentication method used for the transaction.
+
+6. **Execute Messages**: The transaction is executed.
+
+7**Confirm Execution**: After all messages are authenticated, the `ConfirmExecution` function is called for each authenticator. This allows authenticators to enforce transaction rules like spending and transaction limits.
+
+## Available Authenticator Types
+
+### Signature Verification Authenticator
+
+The signature verification authenticator is the default authenticator for all accounts. It verifies that the signer of a message is the same as the account associated with the message.
+
+### Spend Limit Authenticator
+
+The spend limit authenticator enforces a spend limit for each account. 
+
+### AnyOf Authenticator
+
+The anyOf authenticator allows you to specify a list of authenticators. If any of the authenticators in the list successfully authenticate a message, the message is authenticated.
+
+### AllOf Authenticator
+
+The allOf authenticator allows you to specify a list of authenticators. All authenticators in the list must successfully authenticate a message for the message to be authenticated.
+

--- a/x/authenticator/ante/authenticator.go
+++ b/x/authenticator/ante/authenticator.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	"fmt"
+
 	types "github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/utils"
 

--- a/x/authenticator/authenticator/all_of.go
+++ b/x/authenticator/authenticator/all_of.go
@@ -2,6 +2,7 @@ package authenticator
 
 import (
 	"encoding/json"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -18,8 +19,10 @@ type AllOfAuthenticatorData struct {
 	Data []iface.AuthenticatorData
 }
 
-var _ iface.Authenticator = &AllOfAuthenticator{}
-var _ iface.AuthenticatorData = &AllOfAuthenticatorData{}
+var (
+	_ iface.Authenticator     = &AllOfAuthenticator{}
+	_ iface.AuthenticatorData = &AllOfAuthenticatorData{}
+)
 
 func NewAllOfAuthenticator(am *AuthenticatorManager) AllOfAuthenticator {
 	return AllOfAuthenticator{

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -2,6 +2,7 @@ package authenticator
 
 import (
 	"encoding/json"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -19,8 +20,10 @@ type AnyOfAuthenticatorData struct {
 	Data []iface.AuthenticatorData
 }
 
-var _ iface.Authenticator = &AnyOfAuthenticator{}
-var _ iface.AuthenticatorData = &AnyOfAuthenticatorData{}
+var (
+	_ iface.Authenticator     = &AnyOfAuthenticator{}
+	_ iface.AuthenticatorData = &AnyOfAuthenticatorData{}
+)
 
 func NewAnyOfAuthenticator(am *AuthenticatorManager) AnyOfAuthenticator {
 	return AnyOfAuthenticator{

--- a/x/authenticator/authenticator/composition_test.go
+++ b/x/authenticator/authenticator/composition_test.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/v19/app"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/testutils"
 	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -57,54 +58,54 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 	// Define test cases
 	type testCase struct {
 		name             string
-		authenticators   []authenticator.Authenticator
+		authenticators   []iface.Authenticator
 		expectSuccessful bool
 	}
 
 	testCases := []testCase{
 		{
 			name:             "alwaysApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "neverApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "neverApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "alwaysApprove + neverApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "neverApprove + neverApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "neverApprove + neverApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
 		},
 	}
@@ -143,54 +144,54 @@ func (s *AggregatedAuthenticatorsTest) TestAllOfAuthenticator() {
 	// Define test cases
 	type testCase struct {
 		name             string
-		authenticators   []authenticator.Authenticator
+		authenticators   []iface.Authenticator
 		expectSuccessful bool
 	}
 
 	testCases := []testCase{
 		{
 			name:             "alwaysApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "neverApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "neverApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.alwaysApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "alwaysApprove + neverApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "neverApprove + neverApprove + alwaysApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: false,
 		},
 		{
 			name:             "neverApprove + neverApprove + neverApprove",
-			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
+			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
 		},
 	}
@@ -224,7 +225,7 @@ func (s *AggregatedAuthenticatorsTest) TestAllOfAuthenticator() {
 
 type testAuth struct {
 	name          string
-	authenticator authenticator.Authenticator
+	authenticator iface.Authenticator
 	subAuths      []testAuth
 }
 
@@ -238,7 +239,7 @@ func (s *AggregatedAuthenticatorsTest) TestComposedAuthenticator() {
 			names = append(names, s.name)
 		}
 		name := prefix + "(" + strings.Join(names, ", ") + ")"
-		var auth authenticator.Authenticator
+		var auth iface.Authenticator
 		if prefix == "AnyOf" {
 			auth = s.AnyOfAuth
 		} else {

--- a/x/authenticator/authenticator/manager.go
+++ b/x/authenticator/authenticator/manager.go
@@ -3,28 +3,29 @@ package authenticator
 import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 )
 
 type AuthenticatorManager struct {
-	registeredAuthenticators  []Authenticator
+	registeredAuthenticators  []iface.Authenticator
 	defaultAuthenticatorIndex int
 }
 
 // NewAuthenticatorManager creates a new AuthenticatorManager.
 func NewAuthenticatorManager() *AuthenticatorManager {
 	return &AuthenticatorManager{
-		registeredAuthenticators:  []Authenticator{},
+		registeredAuthenticators:  []iface.Authenticator{},
 		defaultAuthenticatorIndex: -1,
 	}
 }
 
 // ResetAuthenticators resets all registered authenticators.
 func (am *AuthenticatorManager) ResetAuthenticators() {
-	am.registeredAuthenticators = []Authenticator{}
+	am.registeredAuthenticators = []iface.Authenticator{}
 }
 
 // InitializeAuthenticators initializes authenticators. If already initialized, it will not overwrite.
-func (am *AuthenticatorManager) InitializeAuthenticators(initialAuthenticators []Authenticator) {
+func (am *AuthenticatorManager) InitializeAuthenticators(initialAuthenticators []iface.Authenticator) {
 	if len(am.registeredAuthenticators) > 0 {
 		return
 	}
@@ -32,12 +33,12 @@ func (am *AuthenticatorManager) InitializeAuthenticators(initialAuthenticators [
 }
 
 // RegisterAuthenticator adds a new authenticator to the list of registered authenticators.
-func (am *AuthenticatorManager) RegisterAuthenticator(authenticator Authenticator) {
+func (am *AuthenticatorManager) RegisterAuthenticator(authenticator iface.Authenticator) {
 	am.registeredAuthenticators = append(am.registeredAuthenticators, authenticator)
 }
 
 // UnregisterAuthenticator removes an authenticator from the list of registered authenticators.
-func (am *AuthenticatorManager) UnregisterAuthenticator(authenticator Authenticator) {
+func (am *AuthenticatorManager) UnregisterAuthenticator(authenticator iface.Authenticator) {
 	for i, auth := range am.registeredAuthenticators {
 		if auth == authenticator {
 			am.registeredAuthenticators = append(am.registeredAuthenticators[:i], am.registeredAuthenticators[i+1:]...)
@@ -47,7 +48,7 @@ func (am *AuthenticatorManager) UnregisterAuthenticator(authenticator Authentica
 }
 
 // GetRegisteredAuthenticators returns the list of registered authenticators.
-func (am *AuthenticatorManager) GetRegisteredAuthenticators() []Authenticator {
+func (am *AuthenticatorManager) GetRegisteredAuthenticators() []iface.Authenticator {
 	return am.registeredAuthenticators
 }
 
@@ -70,7 +71,7 @@ func (am *AuthenticatorManager) SetDefaultAuthenticatorIndex(index int) {
 }
 
 // GetDefaultAuthenticator retrieves the default authenticator.
-func (am *AuthenticatorManager) GetDefaultAuthenticator() Authenticator {
+func (am *AuthenticatorManager) GetDefaultAuthenticator() iface.Authenticator {
 	if am.defaultAuthenticatorIndex < 0 {
 		// ToDo: Instead of panicking, maybe return a FalseAuthenticator that never authenticates?
 		panic("Default authenticator not set")

--- a/x/authenticator/authenticator/signature_authenticator.go
+++ b/x/authenticator/authenticator/signature_authenticator.go
@@ -2,6 +2,7 @@ package authenticator
 
 import (
 	"fmt"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"

--- a/x/authenticator/authenticator/signature_authenticator.go
+++ b/x/authenticator/authenticator/signature_authenticator.go
@@ -2,6 +2,7 @@ package authenticator
 
 import (
 	"fmt"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -18,8 +19,8 @@ import (
 
 // Compile time type assertion for the SignatureData using the
 // SignatureVerificationAuthenticator struct
-var _ Authenticator = &SignatureVerificationAuthenticator{}
-var _ AuthenticatorData = &SignatureData{}
+var _ iface.Authenticator = &SignatureVerificationAuthenticator{}
+var _ iface.AuthenticatorData = &SignatureData{}
 
 const (
 	// SignatureVerificationAuthenticatorType represents a type of authenticator specifically designed for
@@ -62,7 +63,7 @@ func NewSignatureVerificationAuthenticator(
 // which should have a public key in the data field.
 func (sva SignatureVerificationAuthenticator) Initialize(
 	data []byte,
-) (Authenticator, error) {
+) (iface.Authenticator, error) {
 	if len(data) != secp256k1.PubKeySize {
 		sva.PubKey = nil
 	}
@@ -88,7 +89,7 @@ func (sva SignatureVerificationAuthenticator) GetAuthenticationData(
 	// TODO: revisit msg index functionality
 	messageIndex int8,
 	simulate bool,
-) (AuthenticatorData, error) {
+) (iface.AuthenticatorData, error) {
 	sigTx, ok := tx.(authsigning.Tx)
 	if !ok {
 		return SignatureData{},
@@ -132,10 +133,10 @@ func (sva SignatureVerificationAuthenticator) GetAuthenticationData(
 
 // Authenticate takes a SignaturesVerificationData struct and validates
 // each signer and signature using  signature verification
-func (sva SignatureVerificationAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData AuthenticatorData) AuthenticationResult {
+func (sva SignatureVerificationAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.AuthenticationResult {
 	verificationData, ok := authenticationData.(SignatureData)
 	if !ok {
-		return Rejected("invalid signature verification data", sdkerrors.ErrInvalidType)
+		return iface.Rejected("invalid signature verification data", sdkerrors.ErrInvalidType)
 	}
 
 	// First consume gas for verifing the signature
@@ -143,7 +144,7 @@ func (sva SignatureVerificationAuthenticator) Authenticate(ctx sdk.Context, acco
 	for _, sig := range verificationData.Signatures {
 		err := authante.DefaultSigVerificationGasConsumer(ctx.GasMeter(), sig, params)
 		if err != nil {
-			return Rejected("couldn't get gas consumer", err)
+			return iface.Rejected("couldn't get gas consumer", err)
 		}
 	}
 
@@ -151,7 +152,7 @@ func (sva SignatureVerificationAuthenticator) Authenticate(ctx sdk.Context, acco
 	for i, sig := range verificationData.Signatures {
 		acc, err := authante.GetSignerAcc(ctx, sva.ak, verificationData.Signers[i])
 		if err != nil {
-			return Rejected("couldn't get signer account", err)
+			return iface.Rejected("couldn't get signer account", err)
 		}
 
 		// Retrieve pubkey we use either the public key from the authenticator store
@@ -164,12 +165,12 @@ func (sva SignatureVerificationAuthenticator) Authenticate(ctx sdk.Context, acco
 			pubKey = acc.GetPubKey()
 		}
 		if !verificationData.Simulate && pubKey == nil {
-			return Rejected("pubkey on not set on account or authenticator", sdkerrors.ErrInvalidPubKey)
+			return iface.Rejected("pubkey on not set on account or authenticator", sdkerrors.ErrInvalidPubKey)
 		}
 
 		// Check account sequence number.
 		if sig.Sequence != acc.GetSequence() {
-			return Rejected(
+			return iface.Rejected(
 				fmt.Sprintf("account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence),
 				sdkerrors.ErrInvalidPubKey,
 			)
@@ -215,13 +216,17 @@ func (sva SignatureVerificationAuthenticator) Authenticate(ctx sdk.Context, acco
 				}
 				// Errors are reserved for when something unexpected happened. Here authentication just failed, so we
 				// return NotAuthenticated()
-				return NotAuthenticated()
+				return iface.NotAuthenticated()
 			}
 		}
 	}
-	return Authenticated()
+	return iface.Authenticated()
 }
 
-func (sva SignatureVerificationAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData AuthenticatorData) ConfirmationResult {
-	return Confirm()
+func (sva SignatureVerificationAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg) error {
+	return nil
+}
+
+func (sva SignatureVerificationAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
+	return iface.Confirm()
 }

--- a/x/authenticator/authenticator/spend_limits.go
+++ b/x/authenticator/authenticator/spend_limits.go
@@ -3,9 +3,10 @@ package authenticator
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 	"math/big"
 	"time"
+
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/osmosis-labs/osmosis/v19/x/poolmanager"
 	"github.com/osmosis-labs/osmosis/v19/x/twap"

--- a/x/authenticator/authenticator/spend_limits_test.go
+++ b/x/authenticator/authenticator/spend_limits_test.go
@@ -222,6 +222,8 @@ func (s *SpendLimitAuthenticatorTest) TestPeriodTransitionWithAccumulatedSpends(
 				s.Ctx = s.Ctx.WithBlockTime(pair.timePoint)
 
 				spendLimit.Authenticate(s.Ctx, account, nil, nil)
+				err := spendLimit.Track(s.Ctx, account, nil)
+				s.Require().NoError(err)
 
 				// Simulate spending
 				err = s.OsmosisApp.BankKeeper.SendCoins(s.Ctx, account, sdk.AccAddress([]byte("receiver")), sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(pair.spendingAmt))))

--- a/x/authenticator/iface/iface.go
+++ b/x/authenticator/iface/iface.go
@@ -1,4 +1,4 @@
-package authenticator
+package iface
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -37,6 +37,15 @@ type Authenticator interface {
 		simulate bool, // Simulate is used to perform transaction simulation.
 	) (AuthenticatorData, error)
 
+	// Track is used for authenticators to track any information they may need regardless of how the transactions is
+	// authenticated. For instance, if a message is authenticated via authz, ICA, or similar, those entrypoints should
+	// call authenticator.Track(...) so that the authenticator can know that the account has executed a specific message
+	Track(
+		ctx sdk.Context, // The SDK Context is used to access data for authentication and to consume gas.
+		account sdk.AccAddress, // The account being authenticated (typically msg.GetSigners()[0]).
+		msg sdk.Msg, // A message is passed into the authenticate function, allowing authenticators to utilize its information.
+	) error
+
 	// Authenticate validates a message based on the signer and data parsed from the GetAuthenticationData function.
 	// It returns true if authenticated, or false if not authenticated. This function is used within an ante handler.
 	// Note: Gas consumption occurs within this function.
@@ -56,3 +65,8 @@ type Authenticator interface {
 	// OnAuthenticatorAdded(...) bool
 	// OnAuthenticatorRemoved(...) bool
 }
+
+// EmptyAuthenticationData is a generic implementation used when no custom authentication data is needed or available
+type EmptyAuthenticationData struct{}
+
+var _ AuthenticatorData = EmptyAuthenticationData{}

--- a/x/authenticator/iface/result.go
+++ b/x/authenticator/iface/result.go
@@ -1,4 +1,4 @@
-package authenticator
+package iface
 
 import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 

--- a/x/authenticator/keeper/keeper.go
+++ b/x/authenticator/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/authenticator/keeper/keeper.go
+++ b/x/authenticator/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -77,12 +78,12 @@ func (k Keeper) GetAuthenticatorDataForAccount(
 func (k Keeper) GetAuthenticatorsForAccount(
 	ctx sdk.Context,
 	account sdk.AccAddress,
-) ([]authenticator.Authenticator, error) {
+) ([]iface.Authenticator, error) {
 	authenticatorData, err := k.GetAuthenticatorDataForAccount(ctx, account)
 	if err != nil {
 		return nil, err
 	}
-	authenticators := make([]authenticator.Authenticator, len(authenticatorData))
+	authenticators := make([]iface.Authenticator, len(authenticatorData))
 	for i, authenticator := range authenticatorData {
 		authenticators[i] = authenticator.AsAuthenticator(k.AuthenticatorManager)
 		if authenticators[i] == nil {
@@ -95,7 +96,7 @@ func (k Keeper) GetAuthenticatorsForAccount(
 func (k Keeper) GetAuthenticatorsForAccountOrDefault(
 	ctx sdk.Context,
 	account sdk.AccAddress,
-) ([]authenticator.Authenticator, error) {
+) ([]iface.Authenticator, error) {
 	authenticators, err := k.GetAuthenticatorsForAccount(ctx, account)
 	if err != nil {
 		return nil, err

--- a/x/authenticator/keeper/keeper_test.go
+++ b/x/authenticator/keeper/keeper_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"encoding/hex"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -27,7 +28,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.Reset()
 	s.am = authenticator.NewAuthenticatorManager()
 	// Register the SigVerificationAuthenticator
-	s.am.InitializeAuthenticators([]authenticator.Authenticator{authenticator.SignatureVerificationAuthenticator{}})
+	s.am.InitializeAuthenticators([]iface.Authenticator{authenticator.SignatureVerificationAuthenticator{}})
 }
 
 // ToDo: more and better tests

--- a/x/authenticator/testutils/generic_authenticator.go
+++ b/x/authenticator/testutils/generic_authenticator.go
@@ -2,14 +2,13 @@ package testutils
 
 import (
 	"fmt"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
 )
 
-var _ authenticator.Authenticator = &TestingAuthenticator{}
-var _ authenticator.AuthenticatorData = &TestingAuthenticatorData{}
+var _ iface.Authenticator = &TestingAuthenticator{}
+var _ iface.AuthenticatorData = &TestingAuthenticatorData{}
 
 type ApproveOn int
 
@@ -38,22 +37,26 @@ func (t TestingAuthenticator) StaticGas() uint64 {
 	return uint64(t.GasConsumption)
 }
 
-func (t TestingAuthenticator) Initialize(data []byte) (authenticator.Authenticator, error) {
+func (t TestingAuthenticator) Initialize(data []byte) (iface.Authenticator, error) {
 	return t, nil
 }
 
-func (t TestingAuthenticator) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (authenticator.AuthenticatorData, error) {
+func (t TestingAuthenticator) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (iface.AuthenticatorData, error) {
 	return TestingAuthenticatorData{}, nil
 }
 
-func (t TestingAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.AuthenticationResult {
+func (t TestingAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.AuthenticationResult {
 	if t.Approve == Always {
-		return authenticator.Authenticated()
+		return iface.Authenticated()
 	} else {
-		return authenticator.NotAuthenticated()
+		return iface.NotAuthenticated()
 	}
 }
 
-func (t TestingAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.ConfirmationResult {
-	return authenticator.Confirm()
+func (t TestingAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg) error {
+	return nil
+}
+
+func (t TestingAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
+	return iface.Confirm()
 }

--- a/x/authenticator/testutils/generic_authenticator.go
+++ b/x/authenticator/testutils/generic_authenticator.go
@@ -2,13 +2,16 @@ package testutils
 
 import (
 	"fmt"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var _ iface.Authenticator = &TestingAuthenticator{}
-var _ iface.AuthenticatorData = &TestingAuthenticatorData{}
+var (
+	_ iface.Authenticator     = &TestingAuthenticator{}
+	_ iface.AuthenticatorData = &TestingAuthenticatorData{}
+)
 
 type ApproveOn int
 
@@ -17,11 +20,13 @@ const (
 	Never
 )
 
-type TestingAuthenticatorData struct{}
-type TestingAuthenticator struct {
-	Approve        ApproveOn
-	GasConsumption int
-}
+type (
+	TestingAuthenticatorData struct{}
+	TestingAuthenticator     struct {
+		Approve        ApproveOn
+		GasConsumption int
+	}
+)
 
 func (t TestingAuthenticator) Type() string {
 	var when string

--- a/x/authenticator/testutils/max_value_authenticator.go
+++ b/x/authenticator/testutils/max_value_authenticator.go
@@ -2,18 +2,18 @@ package testutils
 
 import (
 	"encoding/json"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
 )
 
 // This is a very naive implementation of an authenticator that tracks sends and blocks if the total amount sent is greater than 3_000
-var _ authenticator.Authenticator = &MaxAmountAuthenticator{}
-var _ authenticator.AuthenticatorData = &MaxAmountAuthenticatorData{}
+var _ iface.Authenticator = &MaxAmountAuthenticator{}
+var _ iface.AuthenticatorData = &MaxAmountAuthenticatorData{}
 
 type MaxAmountAuthenticatorData struct {
 	Amount osmomath.Int
@@ -30,33 +30,37 @@ func (m MaxAmountAuthenticator) Type() string {
 	return "MaxAmountAuthenticator"
 }
 
-func (m MaxAmountAuthenticator) Initialize(data []byte) (authenticator.Authenticator, error) {
+func (m MaxAmountAuthenticator) Initialize(data []byte) (iface.Authenticator, error) {
 	return m, nil
 }
 
-func (m MaxAmountAuthenticator) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (authenticator.AuthenticatorData, error) {
+func (m MaxAmountAuthenticator) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (iface.AuthenticatorData, error) {
 	return MaxAmountAuthenticatorData{}, nil
 }
 
-func (m MaxAmountAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.AuthenticationResult {
+func (m MaxAmountAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.AuthenticationResult {
 	send, ok := msg.(*banktypes.MsgSend)
 	if !ok {
-		return authenticator.NotAuthenticated()
+		return iface.NotAuthenticated()
 	}
 	if m.GetAmount(ctx).Add(send.Amount[0].Amount).GTE(sdk.NewInt(3_000)) {
-		return authenticator.NotAuthenticated()
+		return iface.NotAuthenticated()
 	}
 
-	return authenticator.Authenticated()
+	return iface.Authenticated()
 }
 
-func (m MaxAmountAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.ConfirmationResult {
+func (m MaxAmountAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg) error {
+	return nil
+}
+
+func (m MaxAmountAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
 	send, ok := msg.(*banktypes.MsgSend)
 	if !ok {
-		return authenticator.Confirm()
+		return iface.Confirm()
 	}
 	m.SetAmount(ctx, m.GetAmount(ctx).Add(send.Amount[0].Amount))
-	return authenticator.Confirm()
+	return iface.Confirm()
 }
 
 // The following methods for MaxAmountAuthenticator are similar to the set and get value methods for StatefulAuthenticator but set and get an int

--- a/x/authenticator/testutils/max_value_authenticator.go
+++ b/x/authenticator/testutils/max_value_authenticator.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"encoding/json"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"

--- a/x/authenticator/testutils/stateful_authenticator.go
+++ b/x/authenticator/testutils/stateful_authenticator.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"encoding/json"
+
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -9,8 +10,10 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-var _ iface.Authenticator = &StatefulAuthenticator{}
-var _ iface.AuthenticatorData = &StatefulAuthenticatorData{}
+var (
+	_ iface.Authenticator     = &StatefulAuthenticator{}
+	_ iface.AuthenticatorData = &StatefulAuthenticatorData{}
+)
 
 type StatefulAuthenticatorData struct {
 	Value int

--- a/x/authenticator/types/account_authenticators.go
+++ b/x/authenticator/types/account_authenticators.go
@@ -1,13 +1,16 @@
 package types
 
-import "github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
+import (
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
+)
 
 // NOTE: This should never return a pointer
 // AUDIT: Check this function for security!
 // AsAuthenticator converts an AccountAuthenticator to its corresponding Authenticator.
 func (a *AccountAuthenticator) AsAuthenticator(
 	am *authenticator.AuthenticatorManager,
-) authenticator.Authenticator {
+) iface.Authenticator {
 	for _, authenticatorCode := range am.GetRegisteredAuthenticators() {
 		if authenticatorCode.Type() == a.Type {
 			instance, err := authenticatorCode.Initialize(a.Data)

--- a/x/authenticator/types/account_authenticators_test.go
+++ b/x/authenticator/types/account_authenticators_test.go
@@ -16,6 +16,10 @@ type MockAuthenticator struct {
 	authType string
 }
 
+func (m MockAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg) error {
+	return nil
+}
+
 func (m MockAuthenticator) Initialize(data []byte) (iface.Authenticator, error) {
 	return m, nil
 }
@@ -108,6 +112,10 @@ func TestAsAuthenticator(t *testing.T) {
 // Second mock that always fails authentication
 type MockAuthenticatorFail struct {
 	authType string
+}
+
+func (m MockAuthenticatorFail) Track(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg) error {
+	return nil
 }
 
 func (m MockAuthenticatorFail) Initialize(data []byte) (iface.Authenticator, error) {

--- a/x/authenticator/types/account_authenticators_test.go
+++ b/x/authenticator/types/account_authenticators_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,7 +16,7 @@ type MockAuthenticator struct {
 	authType string
 }
 
-func (m MockAuthenticator) Initialize(data []byte) (authenticator.Authenticator, error) {
+func (m MockAuthenticator) Initialize(data []byte) (iface.Authenticator, error) {
 	return m, nil
 }
 
@@ -23,33 +24,33 @@ func (m MockAuthenticator) StaticGas() uint64 {
 	return 1000
 }
 
-func (m MockAuthenticator) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (authenticator.AuthenticatorData, error) {
+func (m MockAuthenticator) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (iface.AuthenticatorData, error) {
 	return "mock", nil
 }
 
-func (m MockAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.AuthenticationResult {
-	return authenticator.Authenticated()
+func (m MockAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.AuthenticationResult {
+	return iface.Authenticated()
 }
 
-func (m MockAuthenticator) AuthenticationFailed(ctx sdk.Context, authenticatorData authenticator.AuthenticatorData, msg sdk.Msg) {
+func (m MockAuthenticator) AuthenticationFailed(ctx sdk.Context, authenticatorData iface.AuthenticatorData, msg sdk.Msg) {
 }
 
-func (m MockAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.ConfirmationResult {
-	return authenticator.Confirm()
+func (m MockAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
+	return iface.Confirm()
 }
 
 func (m MockAuthenticator) Type() string {
 	return m.authType
 }
 
-var _ authenticator.Authenticator = MockAuthenticator{}
+var _ iface.Authenticator = MockAuthenticator{}
 
 func TestInitializeAuthenticators(t *testing.T) {
 	am := authenticator.NewAuthenticatorManager()
 	auth1 := MockAuthenticator{"type1"}
 	auth2 := MockAuthenticator{"type2"}
 
-	am.InitializeAuthenticators([]authenticator.Authenticator{auth1, auth2})
+	am.InitializeAuthenticators([]iface.Authenticator{auth1, auth2})
 
 	authenticators := am.GetRegisteredAuthenticators()
 	require.Equal(t, 2, len(authenticators))
@@ -109,7 +110,7 @@ type MockAuthenticatorFail struct {
 	authType string
 }
 
-func (m MockAuthenticatorFail) Initialize(data []byte) (authenticator.Authenticator, error) {
+func (m MockAuthenticatorFail) Initialize(data []byte) (iface.Authenticator, error) {
 	return m, nil
 }
 
@@ -117,19 +118,19 @@ func (m MockAuthenticatorFail) StaticGas() uint64 {
 	return 1000
 }
 
-func (m MockAuthenticatorFail) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (authenticator.AuthenticatorData, error) {
+func (m MockAuthenticatorFail) GetAuthenticationData(ctx sdk.Context, tx sdk.Tx, messageIndex int8, simulate bool) (iface.AuthenticatorData, error) {
 	return "mock-fail", nil
 }
 
-func (m MockAuthenticatorFail) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.AuthenticationResult {
-	return authenticator.NotAuthenticated()
+func (m MockAuthenticatorFail) Authenticate(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.AuthenticationResult {
+	return iface.NotAuthenticated()
 }
 
-func (m MockAuthenticatorFail) AuthenticationFailed(ctx sdk.Context, authenticatorData authenticator.AuthenticatorData, msg sdk.Msg) {
+func (m MockAuthenticatorFail) AuthenticationFailed(ctx sdk.Context, authenticatorData iface.AuthenticatorData, msg sdk.Msg) {
 }
 
-func (m MockAuthenticatorFail) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData authenticator.AuthenticatorData) authenticator.ConfirmationResult {
-	return authenticator.Confirm()
+func (m MockAuthenticatorFail) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
+	return iface.Confirm()
 }
 
 func (m MockAuthenticatorFail) Type() string {
@@ -137,8 +138,8 @@ func (m MockAuthenticatorFail) Type() string {
 }
 
 // Ensure our mocks implement the Authenticator interface
-var _ authenticator.Authenticator = MockAuthenticator{}
-var _ authenticator.Authenticator = MockAuthenticatorFail{}
+var _ iface.Authenticator = MockAuthenticator{}
+var _ iface.Authenticator = MockAuthenticatorFail{}
 
 // Tests for the mocks behavior
 func TestMockAuthenticators(t *testing.T) {

--- a/x/authenticator/utils/track.go
+++ b/x/authenticator/utils/track.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	types "github.com/osmosis-labs/osmosis/v19/x/authenticator/iface"
+)
+
+// GetAccount retrieves the account associated with the first signer of a transaction message.
+// It returns the account's address or an error if no signers are present.
+func GetAccount(msg sdk.Msg) (sdk.AccAddress, error) {
+	if len(msg.GetSigners()) == 0 {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "no signers")
+	}
+	return msg.GetSigners()[0], nil
+}
+
+// AuthenticatorStorage is an interface abstracting the only method from the keeper that we care about
+type AuthenticatorStorage interface {
+	GetAuthenticatorsForAccountOrDefault(ctx sdk.Context, account sdk.AccAddress) ([]types.Authenticator, error)
+}
+
+func TrackMessages(ctx sdk.Context, authStorage AuthenticatorStorage, msgs []sdk.Msg) error {
+	for _, msg := range msgs {
+		account, err := GetAccount(msg)
+		if err != nil {
+			return err
+		}
+
+		allAuthenticators, err := authStorage.GetAuthenticatorsForAccountOrDefault(ctx, account)
+		if err != nil {
+			return err
+		}
+		for _, authenticator := range allAuthenticators {
+			err := authenticator.Track(ctx, account, msg)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ConfirmExecutionWithoutTx is a utility for msg executors that bypass the tx flow (i.e.: authz, ica)
+// If the account's authenticators depend on the authenticator data, this will fail and execution will be blocked
+func ConfirmExecutionWithoutTx(ctx sdk.Context, authStorage AuthenticatorStorage, msgs []sdk.Msg) error {
+	for _, msg := range msgs {
+		account, err := GetAccount(msg)
+		if err != nil {
+			return err
+		}
+
+		allAuthenticators, err := authStorage.GetAuthenticatorsForAccountOrDefault(ctx, account)
+		if err != nil {
+			return err
+		}
+		for _, authenticator := range allAuthenticators {
+			// Confirm Execution
+			success := authenticator.ConfirmExecution(ctx, account, msg, types.EmptyAuthenticationData{})
+
+			if success.IsBlock() {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "authenticator failed to confirm execution without AuthenticationData")
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This is a solution to ensure authenticators work properly with authz. A similar solution can be implemented for ICA or any other module that allows message execution without validating it via authenticators.

Alternative solutions:
 * fork authz so the same implementation is cleanner
 * let authz bypass authenticator checks
 * Remove authz mesages and create an authenticator that uses authz grants and verifies them the same way 

The last one is probably the cleanest solution but mixes authentication and authorization (which is something we don't all agree on) and breaks anyone that's currently using Exec (though migrating should be easy and in the meantime we can have a version of exec similar to what we do in this PR)

## Testing and Verifying

Added a test specifically to test spend limit with authz

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A