### PR TITLE
osmomath: ChopPrecision exceeds limit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/arch v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230815205213-6bfd019c3878 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -972,8 +972,6 @@ github.com/osmosis-labs/osmosis/osmomath v0.0.7-0.20230920194803-25ef84411155 h1
 github.com/osmosis-labs/osmosis/osmomath v0.0.7-0.20230920194803-25ef84411155/go.mod h1:pIItelRYvonB+H8A6KqucOi7xFnJxzDHaWJqOdFNLI4=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.7-0.20230923195756-82c9af6e1dea h1:YyseJ5rWEraasbJIQMkwhAU0J982wtmmHrIblQifbOg=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.7-0.20230923195756-82c9af6e1dea/go.mod h1:zoyTl8Jns0JbAHc8xZeFR9hlFMKLRyLcu3lTkZynzTk=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.7 h1:HnOgJiOo3XH2MQ2bsUTL7b0Xj29fObN4tVacza8M13g=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.7/go.mod h1:ukjFgxfR9obDrMd8ZsxKcp3HWL7+boYORVL7Bt7YOZM=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.3-0.20230911120014-b14342e08daf h1:8lkIsAj3L7zxvOZbqVLNJRpSdDxaYhYfAIG7XjPaJiU=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.3-0.20230911120014-b14342e08daf/go.mod h1:C0Uqe6X4N5ASA+1xZ6guaaJyUVKLcaVJIQa4Q4LG9Vk=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.9-0.20230911120014-b14342e08daf h1:ZEi+yJJPgpYtmNwZ1bMiP5cMBDQ83FK/YGgmTnWmoAI=
@@ -1340,7 +1338,6 @@ go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.5.0 h1:jpGode6huXQxcskEIpOCvrU+tzo81b6+oFLUYXWtH/Y=
-golang.org/x/arch v0.5.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -1663,7 +1663,7 @@ func (s *decimalTestSuite) TestQuoTruncate_MutativeAndNonMutative() {
 			osmomath.NewBigDec(3), osmomath.NewBigDec(7), osmomath.MustNewBigDecFromStr("0.428571428571428571428571428571428571"),
 		},
 		{
-			osmomath.NewBigDec(2), osmomath.NewBigDec(4), osmomath.NewBigDecWithPrec(5, 1),
+			osmomath.NewBigDec(2) osmomath.NewBigDec(4), osmomath.NewBigDecWithPrec(5, 1),
 		},
 
 		{osmomath.NewBigDec(100), osmomath.NewBigDec(100), osmomath.NewBigDec(1)},

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -1377,7 +1377,6 @@ func (s *decimalTestSuite) TestPowerInteger_Mutation() {
 
 	for name, tc := range tests {
 		s.Run(name, func() {
-
 			startMut := tc.startValue.Clone()
 			startNonMut := tc.startValue.Clone()
 
@@ -1534,17 +1533,18 @@ func (s *decimalTestSuite) TestDec_WithPrecision() {
 	}
 
 	for tcIndex, tc := range tests {
-		if tc.expPanic {
-			s.Require().Panics(func() { tc.d.DecWithPrecision(tc.precision) })
-		} else {
-			var got osmomath.Dec
-			if tc.precision == osmomath.PrecisionDec {
-				got = tc.d.Dec()
-			} else {
-				got = tc.d.DecWithPrecision(tc.precision)
-			}
-			s.Require().Equal(tc.want, got, "bad Dec conversion, index: %v", tcIndex)
-		}
+		name := "testcase_" + fmt.Sprint(tcIndex)
+		s.Run(name, func() {
+			osmomath.ConditionalPanic(s.T(), tc.expPanic, func() {
+				var got osmomath.Dec
+				if tc.precision == osmomath.PrecisionDec {
+					got = tc.d.Dec()
+				} else {
+					got = tc.d.DecWithPrecision(tc.precision)
+				}
+				s.Require().Equal(tc.want, got, "bad Dec conversion, index: %v", tcIndex)
+			})
+		})
 	}
 }
 
@@ -1621,27 +1621,26 @@ func (s *decimalTestSuite) TestQuoRoundUp_MutativeAndNonMutative() {
 
 	for tcIndex, tc := range tests {
 		tc := tc
+		name := "testcase_" + fmt.Sprint(tcIndex)
+		s.Run(name, func() {
+			osmomath.ConditionalPanic(s.T(), tc.d2.IsZero(), func() {
+				copy := tc.d1.Clone()
 
-		if tc.d2.IsZero() { // panic for divide by zero
-			s.Require().Panics(func() { tc.d1.QuoRoundUpMut(tc.d2) })
-		} else {
+				nonMutResult := copy.QuoRoundUp(tc.d2)
 
-			copy := tc.d1.Clone()
+				// Return is as expected
+				s.Require().Equal(tc.expQuoRoundUpMut, nonMutResult, "exp %v, res %v, tc %d", tc.expQuoRoundUpMut.String(), tc.d1.String(), tcIndex)
 
-			nonMutResult := copy.QuoRoundUp(tc.d2)
+				// Receiver is not mutated
+				s.Require().Equal(tc.d1, copy, "exp %v, res %v, tc %d", tc.expQuoRoundUpMut.String(), tc.d1.String(), tcIndex)
 
-			// Return is as expected
-			s.Require().Equal(tc.expQuoRoundUpMut, nonMutResult, "exp %v, res %v, tc %d", tc.expQuoRoundUpMut.String(), tc.d1.String(), tcIndex)
+				// Receiver is mutated.
+				tc.d1.QuoRoundUpMut(tc.d2)
 
-			// Receiver is not mutated
-			s.Require().Equal(tc.d1, copy, "exp %v, res %v, tc %d", tc.expQuoRoundUpMut.String(), tc.d1.String(), tcIndex)
-
-			// Receiver is mutated.
-			tc.d1.QuoRoundUpMut(tc.d2)
-
-			// Make sure d1 equals to expected
-			s.Require().True(tc.expQuoRoundUpMut.Equal(tc.d1), "exp %v, res %v, tc %d", tc.expQuoRoundUpMut.String(), tc.d1.String(), tcIndex)
-		}
+				// Make sure d1 equals to expected
+				s.Require().True(tc.expQuoRoundUpMut.Equal(tc.d1), "exp %v, res %v, tc %d", tc.expQuoRoundUpMut.String(), tc.d1.String(), tcIndex)
+			})
+		})
 	}
 }
 
@@ -1680,25 +1679,25 @@ func (s *decimalTestSuite) TestQuoTruncate_MutativeAndNonMutative() {
 	for tcIndex, tc := range tests {
 		tc := tc
 
-		if tc.d2.IsZero() { // panic for divide by zero
-			s.Require().Panics(func() { tc.d1.QuoTruncateMut(tc.d2) })
-		} else {
+		name := "testcase_" + fmt.Sprint(tcIndex)
+		s.Run(name, func() {
+			osmomath.ConditionalPanic(s.T(), tc.d2.IsZero(), func() {
+				copy := tc.d1.Clone()
 
-			copy := tc.d1.Clone()
+				nonMutResult := copy.QuoTruncate(tc.d2)
 
-			nonMutResult := copy.QuoTruncate(tc.d2)
+				// Return is as expected
+				s.Require().Equal(tc.expQuoTruncateMut, nonMutResult, "exp %v, res %v, tc %d", tc.expQuoTruncateMut.String(), tc.d1.String(), tcIndex)
 
-			// Return is as expected
-			s.Require().Equal(tc.expQuoTruncateMut, nonMutResult, "exp %v, res %v, tc %d", tc.expQuoTruncateMut.String(), tc.d1.String(), tcIndex)
+				// Receiver is not mutated
+				s.Require().Equal(tc.d1, copy, "exp %v, res %v, tc %d", tc.expQuoTruncateMut.String(), tc.d1.String(), tcIndex)
 
-			// Receiver is not mutated
-			s.Require().Equal(tc.d1, copy, "exp %v, res %v, tc %d", tc.expQuoTruncateMut.String(), tc.d1.String(), tcIndex)
+				// Receiver is mutated.
+				tc.d1.QuoTruncateMut(tc.d2)
 
-			// Receiver is mutated.
-			tc.d1.QuoTruncateMut(tc.d2)
-
-			// Make sure d1 equals to expected
-			s.Require().True(tc.expQuoTruncateMut.Equal(tc.d1), "exp %v, res %v, tc %d", tc.expQuoTruncateMut.String(), tc.d1.String(), tcIndex)
-		}
+				// Make sure d1 equals to expected
+				s.Require().True(tc.expQuoTruncateMut.Equal(tc.d1), "exp %v, res %v, tc %d", tc.expQuoTruncateMut.String(), tc.d1.String(), tcIndex)
+			})
+		})
 	}
 }

--- a/osmomath/decimal_test.go
+++ b/osmomath/decimal_test.go
@@ -1663,7 +1663,7 @@ func (s *decimalTestSuite) TestQuoTruncate_MutativeAndNonMutative() {
 			osmomath.NewBigDec(3), osmomath.NewBigDec(7), osmomath.MustNewBigDecFromStr("0.428571428571428571428571428571428571"),
 		},
 		{
-			osmomath.NewBigDec(2) osmomath.NewBigDec(4), osmomath.NewBigDecWithPrec(5, 1),
+			osmomath.NewBigDec(2), osmomath.NewBigDec(4), osmomath.NewBigDecWithPrec(5, 1),
 		},
 
 		{osmomath.NewBigDec(100), osmomath.NewBigDec(100), osmomath.NewBigDec(1)},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6469 

## What is the purpose of the change

* Check that using precision exceeding `PrecisionBigDec` will panic `ChopPrecision`
* Use `osmomath.ConditionalPanic` in decimal tests where applicable

## Testing and Verifying

Only tests were modified

## Documentation and Release Note

NA