### PR TITLE
[Volume Splitting] feat: implement initGaugeInfo helper

### DIFF
--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -61,6 +61,22 @@ type KeeperTestHelper struct {
 	TestAccs    []sdk.AccAddress
 }
 
+// Defines IDs for all supported
+// Osmosis pools. Additionally, encapsulates
+// an internal gauge ID for each pool.
+// This struct is initialized and returned by
+// PrepareAllSupportedPools().
+type SupportedPoolAndGaugeInfo struct {
+	ConcentratedPoolID uint64
+	BalancerPoolID     uint64
+	StableSwapPoolID   uint64
+	CosmWasmPoolID     uint64
+
+	ConcentratedGaugeID uint64
+	BalancerGaugeID     uint64
+	StableSwapGaugeID   uint64
+}
+
 var (
 	SecondaryDenom       = "uion"
 	SecondaryAmount      = osmomath.NewInt(100000000)
@@ -82,6 +98,42 @@ func (s *KeeperTestHelper) Setup() {
 	s.T().Cleanup(func() { os.RemoveAll(dir); s.withCaching = false })
 	s.App = app.SetupWithCustomHome(false, dir)
 	s.setupGeneral()
+}
+
+// PrepareAllSupportedPools creates all supported pools and returns their IDs.
+// Additionally, attaches an internal gauge ID for each pool.
+func (s *KeeperTestHelper) PrepareAllSupportedPools() SupportedPoolAndGaugeInfo {
+	// This is the ID of the first gauge created next (concentrated).
+	nextGaugeID := s.App.IncentivesKeeper.GetLastGaugeID(s.Ctx) + 1
+
+	numLockableDurations := uint64(len(s.App.PoolIncentivesKeeper.GetLockableDurations(s.Ctx)))
+
+	var (
+		// Prepare pools and their IDs
+		concentratedPool   = s.PrepareConcentratedPool()
+		concentratedPoolID = concentratedPool.GetId()
+		balancerPoolID     = s.PrepareBalancerPool()
+		stableswapPoolID   = s.PrepareBasicStableswapPool()
+		cosmWasmPool       = s.PrepareCosmWasmPool()
+		cosmWasmPoolID     = cosmWasmPool.GetId()
+	)
+	return SupportedPoolAndGaugeInfo{
+		ConcentratedPoolID: concentratedPoolID,
+		BalancerPoolID:     balancerPoolID,
+		StableSwapPoolID:   stableswapPoolID,
+		CosmWasmPoolID:     cosmWasmPoolID,
+
+		// Define expected gauge IDs:
+
+		// CL creates 1 gauge
+		ConcentratedGaugeID: nextGaugeID,
+
+		// Balancer creates 3 gauges and the longest duration ID is returned.
+		BalancerGaugeID: nextGaugeID + numLockableDurations,
+
+		// Stableswap creates 3 gauges and the longest duration ID is returned.
+		StableSwapGaugeID: nextGaugeID + 2*numLockableDurations,
+	}
 }
 
 // resets the test environment

--- a/x/incentives/keeper/distribute_test.go
+++ b/x/incentives/keeper/distribute_test.go
@@ -1389,6 +1389,34 @@ func deepCopyGauge(src types.Gauge) types.Gauge {
 	return gauge
 }
 
+// deepCopyGaugeInfo creates a deep copy of the passed in gauge info.
+func deepCopyGaugeInfo(gaugeInfo types.InternalGaugeInfo) types.InternalGaugeInfo {
+	copy := gaugeInfo
+
+	copy.TotalWeight = osmomath.NewIntFromBigInt(gaugeInfo.TotalWeight.BigInt())
+	copy.GaugeRecords = make([]types.InternalGaugeRecord, 0, len(gaugeInfo.GaugeRecords))
+	for _, gaugeRecord := range gaugeInfo.GaugeRecords {
+		copy.GaugeRecords = append(copy.GaugeRecords, types.InternalGaugeRecord{
+			GaugeId:          gaugeRecord.GaugeId,
+			CurrentWeight:    osmomath.NewIntFromBigInt(gaugeRecord.CurrentWeight.BigInt()),
+			CumulativeWeight: osmomath.NewIntFromBigInt(gaugeRecord.CumulativeWeight.BigInt()),
+		})
+	}
+	return copy
+}
+
+// addGaugeRecords takes in a gauge and a list of gauge records and adds them to the gauge.
+// Returns a deep copy and does not mutate the original gauge info.
+func addGaugeRecords(gaugeInfo types.InternalGaugeInfo, gaugeRecords []types.InternalGaugeRecord) types.InternalGaugeInfo {
+	copy := deepCopyGaugeInfo(gaugeInfo)
+
+	for _, gaugeRecord := range gaugeRecords {
+		copy.GaugeRecords = append(copy.GaugeRecords, gaugeRecord)
+		copy.TotalWeight = copy.TotalWeight.Add(gaugeRecord.CurrentWeight)
+	}
+	return copy
+}
+
 // withUpdatedVolumes takes in a group and a list of updated cumulative volumes (ordered) and updates the contents of the gauge to
 // reflect these new volumes.
 // It is only intended to be used to set expected values for test cases.

--- a/x/incentives/keeper/export_test.go
+++ b/x/incentives/keeper/export_test.go
@@ -66,6 +66,10 @@ func (k Keeper) HandleGroupPostDistribute(ctx sdk.Context, groupGauge types.Gaug
 	return k.handleGroupPostDistribute(ctx, groupGauge, coinsDistributed)
 }
 
+func (k Keeper) InitGaugeInfo(ctx sdk.Context, poolIds []uint64) (types.InternalGaugeInfo, error) {
+	return k.initGaugeInfo(ctx, poolIds)
+}
+
 func RegularGaugeStoreKey(ID uint64) []byte {
 	return gaugeStoreKey(ID)
 }

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -251,7 +251,7 @@ func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver u
 		return 0, err
 	}
 
-	// TODO: change method to take in pool IDs
+	// TODO: change CreateGroup method to take in pool IDs
 	// Tracked in issue https://github.com/osmosis-labs/osmosis/issues/6404
 	poolIDs := []uint64{}
 	initialInternalGaugeInfo, err := k.initGaugeInfo(ctx, poolIDs)
@@ -463,6 +463,7 @@ func (k Keeper) chargeFeeIfSufficientFeeDenomBalance(ctx sdk.Context, address sd
 }
 
 // initGaugeInfo takes in a list of pool IDs and a splitting policy and returns a InternalGaugeInfo struct with weights initialized to zero.
+// Returns error if fails to retrieve gauge ID for a pool.
 func (k Keeper) initGaugeInfo(ctx sdk.Context, poolIds []uint64) (types.InternalGaugeInfo, error) {
 	gaugeRecords := make([]types.InternalGaugeRecord, 0, len(poolIds))
 	for _, poolID := range poolIds {

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -229,6 +229,7 @@ func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver u
 	// TODO: remove gauge creation logic from here.
 	// Instead, call `CreateGauge` directly
 	// Update `CreateGauge` to be able to handle the group type.
+	// https://github.com/osmosis-labs/osmosis/issues/6513
 	nextGaugeId := k.GetLastGaugeID(ctx) + 1
 
 	gauge := types.Gauge{
@@ -250,9 +251,13 @@ func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver u
 		return 0, err
 	}
 
-	// TODO: initialize using initGaugeInfo
-	// Tracked in issue https://github.com/osmosis-labs/osmosis/issues/6401
-	initialInternalGaugeInfo := types.InternalGaugeInfo{}
+	// TODO: change method to take in pool IDs
+	// Tracked in issue https://github.com/osmosis-labs/osmosis/issues/6404
+	poolIDs := []uint64{}
+	initialInternalGaugeInfo, err := k.initGaugeInfo(ctx, poolIDs)
+	if err != nil {
+		return 0, err
+	}
 
 	newGroup := types.Group{
 		GroupGaugeId:      nextGaugeId,
@@ -266,13 +271,6 @@ func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver u
 	k.SetGroup(ctx, newGroup)
 	k.SetLastGaugeID(ctx, gauge.Id)
 
-	// TODO: check if this is necessary.
-	// Tracked in issue https://github.com/osmosis-labs/osmosis/issues/6405
-	combinedKeys := combineKeys(types.KeyPrefixUpcomingGauges, getTimeKey(gauge.StartTime))
-
-	if err := k.CreateGaugeRefKeys(ctx, &gauge, combinedKeys); err != nil {
-		return 0, err
-	}
 	k.hooks.AfterCreateGauge(ctx, gauge.Id)
 
 	return nextGaugeId, nil
@@ -462,4 +460,26 @@ func (k Keeper) chargeFeeIfSufficientFeeDenomBalance(ctx sdk.Context, address sd
 		return err
 	}
 	return nil
+}
+
+// initGaugeInfo takes in a list of pool IDs and a splitting policy and returns a InternalGaugeInfo struct with weights initialized to zero.
+func (k Keeper) initGaugeInfo(ctx sdk.Context, poolIds []uint64) (types.InternalGaugeInfo, error) {
+	gaugeRecords := make([]types.InternalGaugeRecord, 0, len(poolIds))
+	for _, poolID := range poolIds {
+		gaugeID, err := k.pik.GetInternalGaugeIDForPool(ctx, poolID)
+		if err != nil {
+			return types.InternalGaugeInfo{}, err
+		}
+
+		gaugeRecords = append(gaugeRecords, types.InternalGaugeRecord{
+			GaugeId:          gaugeID,
+			CurrentWeight:    osmomath.ZeroInt(),
+			CumulativeWeight: osmomath.ZeroInt(),
+		})
+	}
+
+	return types.InternalGaugeInfo{
+		TotalWeight:  osmomath.ZeroInt(),
+		GaugeRecords: gaugeRecords,
+	}, nil
 }

--- a/x/incentives/types/expected_keepers.go
+++ b/x/incentives/types/expected_keepers.go
@@ -58,6 +58,7 @@ type AccountKeeper interface {
 
 type PoolIncentiveKeeper interface {
 	GetPoolIdFromGaugeId(ctx sdk.Context, gaugeId uint64, lockableDuration time.Duration) (uint64, error)
+	GetInternalGaugeIDForPool(ctx sdk.Context, poolID uint64) (uint64, error)
 	SetPoolGaugeIdNoLock(ctx sdk.Context, poolId uint64, gaugeId uint64)
 	GetLongestLockableDuration(ctx sdk.Context) (time.Duration, error)
 }

--- a/x/pool-incentives/keeper/keeper_test.go
+++ b/x/pool-incentives/keeper/keeper_test.go
@@ -380,3 +380,62 @@ func (s *KeeperTestSuite) TestIsPoolIncentivized() {
 		})
 	}
 }
+
+// Tests that for every supported internally incentivized pool,
+// the appropriate gauge ID is returned.
+// For balancer and stableswap, returns the longest duration gauge ID.
+// For CL, returns the gauge ID for the current epoch incentive duration.
+// For cosmwasm pool, returns an error.
+// For non-existent pool ID, returns an error.
+func (suite *KeeperTestSuite) TestGetInternalGaugeIDForPool() {
+
+	// Note that we initialize the same state for all pools.
+	suite.SetupTest()
+
+	// Prepare pools and their IDs
+	poolInfo := suite.PrepareAllSupportedPools()
+
+	tests := map[string]struct {
+		poolID          uint64
+		expectedGaugeID uint64
+		expectError     error
+	}{
+		"concentrated pool": {
+			poolID:          poolInfo.ConcentratedPoolID,
+			expectedGaugeID: poolInfo.ConcentratedGaugeID,
+		},
+		"balancer pool": {
+			poolID:          poolInfo.BalancerPoolID,
+			expectedGaugeID: poolInfo.BalancerGaugeID,
+		},
+		"stableswap pool": {
+			poolID:          poolInfo.StableSwapPoolID,
+			expectedGaugeID: poolInfo.StableSwapGaugeID,
+		},
+		"cosmwasm pool": {
+			poolID:      poolInfo.CosmWasmPoolID,
+			expectError: types.UnsupportedPoolTypeError{PoolID: poolInfo.CosmWasmPoolID, PoolType: poolmanagertypes.CosmWasm},
+		},
+		"pool with given ID does not exist": {
+			poolID:      poolInfo.CosmWasmPoolID + 1,
+			expectError: poolmanagertypes.FailedToFindRouteError{PoolId: poolInfo.CosmWasmPoolID + 1},
+		},
+	}
+
+	for name, tc := range tests {
+		suite.Run(name, func() {
+
+			poolIncentivesKeeper := suite.App.PoolIncentivesKeeper
+
+			gaugeID, err := poolIncentivesKeeper.GetInternalGaugeIDForPool(suite.Ctx, tc.poolID)
+
+			if tc.expectError != nil {
+				suite.Require().Error(err)
+				suite.Require().ErrorIs(tc.expectError, err)
+				return
+			}
+			suite.Require().NoError(err)
+			suite.Require().Equal(tc.expectedGaugeID, gaugeID)
+		})
+	}
+}

--- a/x/pool-incentives/types/errors.go
+++ b/x/pool-incentives/types/errors.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v19/x/poolmanager/types"
+
 	errorsmod "cosmossdk.io/errors"
 )
 
@@ -35,4 +37,13 @@ type NoPoolAssociatedWithGaugeError struct {
 
 func (e NoPoolAssociatedWithGaugeError) Error() string {
 	return fmt.Sprintf("no pool associated with gauge id (%d) and duration (%d)", e.GaugeId, e.Duration)
+}
+
+type UnsupportedPoolTypeError struct {
+	PoolID   uint64
+	PoolType poolmanagertypes.PoolType
+}
+
+func (e UnsupportedPoolTypeError) Error() string {
+	return fmt.Sprintf("unsupported pool type for incentives (%d), pool id (%d)", e.PoolType, e.PoolID)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6401

## What is the purpose of the change

Implements and tests `initGaugeInfo` helper per issue requirements.

Removed volume splitting policy param from proposed design due to no need.

Added `GetInternalGaugeIDForPool` helper in pool incentives.

Added `PrepareAllSupportedPools` test helper in test-global scope since it was helpful across modules.

Added `deepCopyGaugeInfo` and `addGaugeRecords` in the incentives module test scope. I expect them to be useful in future tests as well.


## Testing and Verifying

- Unit tested all new additions

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A