### PR TITLE
refactor/test: CreateGroup takes pool IDs; new tests

### DIFF
--- a/x/incentives/keeper/export_test.go
+++ b/x/incentives/keeper/export_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/osmosis-labs/osmosis/v19/x/incentives/types"
 )
 
+const PerpetualNumEpochsPaidOver = perpetualNumEpochsPaidOver
+
 // AddGaugeRefByKey appends the provided gauge ID into an array associated with the provided key.
 func (k Keeper) AddGaugeRefByKey(ctx sdk.Context, key []byte, gaugeID uint64) error {
 	return k.addGaugeRefByKey(ctx, key, gaugeID)

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -22,6 +22,11 @@ import (
 	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 )
 
+// numEpochPaidOver is the number of epochs that must be given
+// for a gauge to be perpetual. For any other number of epochs
+// other than zero, the gauge is non-perpetual. Zero is invalid.
+const perpetualNumEpochsPaidOver = 1
+
 // getGaugesFromIterator iterates over everything in a gauge's iterator, until it reaches the end. Return all gauges iterated over.
 func (k Keeper) getGaugesFromIterator(ctx sdk.Context, iterator db.Iterator) []types.Gauge {
 	gauges := []types.Gauge{}
@@ -50,8 +55,6 @@ func (k Keeper) setGauge(ctx sdk.Context, gauge *types.Gauge) error {
 	if err != nil {
 		return err
 	}
-
-	gauge.IsLastNonPerpetualDistribution()
 
 	store.Set(gaugeStoreKey(gauge.Id), bz)
 	return nil
@@ -212,31 +215,57 @@ func (k Keeper) CreateGauge(ctx sdk.Context, isPerpetual bool, owner sdk.AccAddr
 	return gauge.Id, nil
 }
 
-// CreateGroup creates a new group. The group is 1:1 mapped to a group gauage that allocates rewards dynamically across its internal pool gauges based on the given splitting policy.
-// Note: we should expect that the internal gauges consist of the gauges that are automatically created for each pool upon pool creation, as even non-perpetual
-// external incentives would likely want to route through these.
-// TODO: change this to take in list of pool IDs instead and fetch the gauge IDs under the hood.
-// Tracked in issue https://github.com/osmosis-labs/osmosis/issues/6404
-func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver uint64, owner sdk.AccAddress, internalGaugeIds []uint64, gaugetype lockuptypes.LockQueryType) (uint64, error) {
-	if len(internalGaugeIds) == 0 {
-		return 0, fmt.Errorf("No internalGauge provided.")
+// CreateGroup creates a new group. The group is 1:1 mapped to a group gauage that allocates rewards dynamically across its internal pool gauges based on
+// the volume splitting policy.
+// For each pool ID in the given slice, its main internal gauge is used to create gauge records to be associated with the Group.
+// Note, that implies that only perpetual pool gauges can be associated with the Group.
+// For Group's own distribution policy, a 1:1 group Gauge is created. This is the Gauge that receives incentives at the end of an epoch
+// in the pool incentives as defined by the DistrRecord. The Group's Gauge can either be perpetual or non-perpetual.
+// If numEpochPaidOver is 1, then the Group's Gauge is perpetual. Otherwise, it is non-perpetual.
+// Returns nil on success.
+// Returns error if:
+// - given pool IDs slice is empty or has 1 pool only
+// - numEpochPaidOver is 0
+// - fails to initialize gauge information for every pool ID
+// - fails to send coins from owner to the incentives module for the Group's Gauge
+// - fails to set the Group's Gauge to state
+func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver uint64, owner sdk.AccAddress, poolIDs []uint64) (uint64, error) {
+	if len(poolIDs) == 0 {
+		return 0, types.NoPoolIDsGivenError
+	}
+	if len(poolIDs) == 1 {
+		return 0, types.OnePoolIDGroupError{PoolID: poolIDs[0]}
+	}
+	if numEpochPaidOver == 0 {
+		return 0, types.ZeroNumEpochsPaidOverError
 	}
 
-	if gaugetype != lockuptypes.ByGroup {
-		return 0, fmt.Errorf("Invalid gauge type needs to be ByGroup, got %s.", gaugetype)
+	// Initialize gauge information for every pool ID.
+	initialInternalGaugeInfo, err := k.initGaugeInfo(ctx, poolIDs)
+	if err != nil {
+		return 0, err
 	}
+
+	// TODO: charge fixed fee. Make sure to update method spec and tests.
+	// https://github.com/osmosis-labs/osmosis/issues/6506
+
+	// TODO: subdao to bypass
+	// TODO: governance to bypass
+	// Make sure to update method spec and tests.
+	// https://github.com/osmosis-labs/osmosis/issues/6507
 
 	// TODO: remove gauge creation logic from here.
 	// Instead, call `CreateGauge` directly
 	// Update `CreateGauge` to be able to handle the group type.
+	// Make sure to update method spec and tests.
 	// https://github.com/osmosis-labs/osmosis/issues/6513
 	nextGaugeId := k.GetLastGaugeID(ctx) + 1
 
 	gauge := types.Gauge{
 		Id:          nextGaugeId,
-		IsPerpetual: numEpochPaidOver == 1,
+		IsPerpetual: numEpochPaidOver == perpetualNumEpochsPaidOver,
 		DistributeTo: lockuptypes.QueryCondition{
-			LockQueryType: gaugetype,
+			LockQueryType: lockuptypes.ByGroup,
 		},
 		Coins:             coins,
 		StartTime:         ctx.BlockTime(),
@@ -248,14 +277,6 @@ func (k Keeper) CreateGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver u
 	}
 
 	if err := k.setGauge(ctx, &gauge); err != nil {
-		return 0, err
-	}
-
-	// TODO: change CreateGroup method to take in pool IDs
-	// Tracked in issue https://github.com/osmosis-labs/osmosis/issues/6404
-	poolIDs := []uint64{}
-	initialInternalGaugeInfo, err := k.initGaugeInfo(ctx, poolIDs)
-	if err != nil {
 		return 0, err
 	}
 

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -1,12 +1,14 @@
 package keeper_test
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	incentiveskeeper "github.com/osmosis-labs/osmosis/v19/x/incentives/keeper"
 	"github.com/osmosis-labs/osmosis/v19/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v19/x/lockup/types"
 	poolincentivetypes "github.com/osmosis-labs/osmosis/v19/x/pool-incentives/types"
@@ -14,6 +16,13 @@ import (
 )
 
 var _ = suite.TestingSuite(nil)
+
+var (
+	defaultEmptyGaugeInfo = types.InternalGaugeInfo{
+		TotalWeight:  osmomath.ZeroInt(),
+		GaugeRecords: []types.InternalGaugeRecord{},
+	}
+)
 
 // TestInvalidDurationGaugeCreationValidation tests error handling for creating a gauge with an invalid duration.
 func (s *KeeperTestSuite) TestInvalidDurationGaugeCreationValidation() {
@@ -604,119 +613,6 @@ func (s *KeeperTestSuite) TestCreateGauge_NoLockGauges() {
 	}
 }
 
-func (s *KeeperTestSuite) TestCreateGroup() {
-	// TODO: Re-enable this once gauge creation refactor is complete in https://github.com/osmosis-labs/osmosis/issues/6404
-	s.T().Skip()
-
-	coinsToAdd := sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(100_000_000)))
-	tests := []struct {
-		name             string
-		coins            sdk.Coins
-		numEpochPaidOver uint64
-		internalGaugeIds []uint64
-		gaugeType        lockuptypes.LockQueryType
-		expectErr        bool
-	}{
-		{
-			name:             "Happy case: created valid gauge",
-			coins:            coinsToAdd,
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{2, 3, 4},
-			gaugeType:        lockuptypes.ByGroup,
-			expectErr:        false,
-		},
-
-		{
-			name:             "Error: Invalid InternalGauge Id",
-			coins:            coinsToAdd,
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{2, 3, 4, 5},
-			gaugeType:        lockuptypes.ByGroup,
-			expectErr:        true,
-		},
-		{
-			name:             "Error: owner doesnot have enough funds",
-			coins:            sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(200_000_000))),
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{2, 3, 4},
-			gaugeType:        lockuptypes.ByGroup,
-			expectErr:        true,
-		},
-		{
-			name:             "Error: One of the internal Gauge is non-perp",
-			coins:            sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(200_000_000))),
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{2, 3, 4, 5},
-			gaugeType:        lockuptypes.ByGroup,
-			expectErr:        true,
-		},
-		{
-			name:             "Error: No InternalGaugeIds provided",
-			coins:            sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(200_000_000))),
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{},
-			gaugeType:        lockuptypes.ByGroup,
-			expectErr:        true,
-		},
-		{
-			name:             "Error: Invalid Splitting Policy",
-			coins:            sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(200_000_000))),
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{},
-			gaugeType:        lockuptypes.ByGroup,
-			expectErr:        true,
-		},
-		{
-			name:             "Error: Invalid gauge type",
-			coins:            sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(200_000_000))),
-			numEpochPaidOver: 1,
-			internalGaugeIds: []uint64{},
-			gaugeType:        lockuptypes.NoLock,
-			expectErr:        true,
-		},
-	}
-
-	for _, tc := range tests {
-		s.Run(tc.name, func() {
-			s.SetupTest()
-			s.FundAcc(s.TestAccs[1], sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(100_000_000)))) // 1,000 osmo
-			clPool := s.PrepareConcentratedPool()                                                      // gaugeid = 1
-
-			// create 3 perp-internal Gauge
-			for i := 0; i <= 2; i++ {
-				s.CreateNoLockExternalGauges(clPool.GetId(), sdk.NewCoins(), s.TestAccs[1], uint64(1)) // gauge id = 2,3,4
-			}
-
-			//create 1 non-perp internal Gauge
-			s.CreateNoLockExternalGauges(clPool.GetId(), sdk.NewCoins(), s.TestAccs[1], uint64(2)) // gauge id = 5
-
-			groupGaugeId, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, tc.coins, tc.numEpochPaidOver, s.TestAccs[1], tc.internalGaugeIds, tc.gaugeType) // gauge id = 6
-			if tc.expectErr {
-				s.Require().Error(err)
-			} else {
-				s.Require().NoError(err)
-
-				// check that the gauge has been create with right value
-				groupGauge, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, groupGaugeId)
-				s.Require().NoError(err)
-
-				s.Require().Equal(groupGauge.Coins, tc.coins)
-				s.Require().Equal(groupGauge.NumEpochsPaidOver, tc.numEpochPaidOver)
-				s.Require().Equal(groupGauge.IsPerpetual, true)
-				s.Require().Equal(groupGauge.DistributeTo.LockQueryType, lockuptypes.ByGroup)
-
-				// check that Group has been added to state
-				group, err := s.App.IncentivesKeeper.GetGroupByGaugeID(s.Ctx, groupGaugeId)
-				s.Require().NoError(err)
-
-				s.Require().Equal(group.InternalGaugeInfo.GaugeRecords, tc.internalGaugeIds)
-				s.Require().Equal(group.SplittingPolicy, types.ByVolume)
-			}
-
-		})
-	}
-}
-
 // Validates that the initial gauge info is initialized with the appropriate gauge IDs given pool IDs.
 // All weights are set to zero in all cases.
 func (s *KeeperTestSuite) TestInitGaugeInfo() {
@@ -729,10 +625,12 @@ func (s *KeeperTestSuite) TestInitGaugeInfo() {
 	// Prepare pools, their IDs and associated gauge IDs.
 	poolInfo := s.PrepareAllSupportedPools()
 
-	defaultEmptyGaugeInfo := types.InternalGaugeInfo{
-		TotalWeight:  osmomath.ZeroInt(),
-		GaugeRecords: []types.InternalGaugeRecord{},
-	}
+	// Initialize expected gauge records
+	var (
+		concentratedGaugeRecord = withRecordGaugeId(defaultZeroWeightGaugeRecord, poolInfo.ConcentratedGaugeID)
+		balancerGaugeRecord     = withRecordGaugeId(defaultZeroWeightGaugeRecord, poolInfo.BalancerGaugeID)
+		stableSwapGaugeRecord   = withRecordGaugeId(defaultZeroWeightGaugeRecord, poolInfo.StableSwapGaugeID)
+	)
 
 	tests := map[string]struct {
 		poolIds           []uint64
@@ -741,16 +639,16 @@ func (s *KeeperTestSuite) TestInitGaugeInfo() {
 	}{
 		"one gauge record": {
 			poolIds:           []uint64{poolInfo.ConcentratedPoolID},
-			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo, []types.InternalGaugeRecord{{GaugeId: poolInfo.ConcentratedGaugeID, CurrentWeight: osmomath.ZeroInt(), CumulativeWeight: osmomath.ZeroInt()}}),
+			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo, []types.InternalGaugeRecord{concentratedGaugeRecord}),
 		},
 
 		"multiple gauge records": {
 			poolIds: []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID, poolInfo.StableSwapPoolID},
 			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo,
 				[]types.InternalGaugeRecord{
-					{GaugeId: poolInfo.ConcentratedGaugeID, CurrentWeight: osmomath.ZeroInt(), CumulativeWeight: osmomath.ZeroInt()},
-					{GaugeId: poolInfo.BalancerGaugeID, CurrentWeight: osmomath.ZeroInt(), CumulativeWeight: osmomath.ZeroInt()},
-					{GaugeId: poolInfo.StableSwapGaugeID, CurrentWeight: osmomath.ZeroInt(), CumulativeWeight: osmomath.ZeroInt()},
+					concentratedGaugeRecord,
+					balancerGaugeRecord,
+					stableSwapGaugeRecord,
 				}),
 		},
 
@@ -775,14 +673,168 @@ func (s *KeeperTestSuite) TestInitGaugeInfo() {
 			}
 			s.Require().NoError(err)
 
-			// Validate gauge info
-			s.Require().Equal(tc.expectedGaugeInfo.TotalWeight.String(), actualGaugeInfo.TotalWeight.String())
-			s.Require().Equal(len(tc.expectedGaugeInfo.GaugeRecords), len(actualGaugeInfo.GaugeRecords))
-			for i := range tc.expectedGaugeInfo.GaugeRecords {
-				s.Require().Equal(tc.expectedGaugeInfo.GaugeRecords[i].GaugeId, actualGaugeInfo.GaugeRecords[i].GaugeId)
-				s.Require().Equal(tc.expectedGaugeInfo.GaugeRecords[i].CurrentWeight.String(), actualGaugeInfo.GaugeRecords[i].CurrentWeight.String())
-				s.Require().Equal(tc.expectedGaugeInfo.GaugeRecords[i].CumulativeWeight.String(), actualGaugeInfo.GaugeRecords[i].CumulativeWeight.String())
+			// Validate InternalGaugeInfo
+			s.validateGaugeInfo(tc.expectedGaugeInfo, actualGaugeInfo)
+		})
+	}
+}
+
+// Validates that the Group is created as defined bu the CreateGroup spec with the
+// associated 1:1 group Gauge and the correct gauge records relating to the given pools'
+// internal perpetual gauge IDs.
+func (s *KeeperTestSuite) TestCreateGroup() {
+
+	// We setup test state once and reuse it for all test cases
+	s.SetupTest()
+
+	// index of s.TestAccs that gets funded
+	const fundedAddressIndex = 0
+
+	// Create 4 pools of each possible type
+	poolInfo := s.PrepareAllSupportedPools()
+
+	expectedGroupGaugeId := s.App.IncentivesKeeper.GetLastGaugeID(s.Ctx) + 1
+
+	// Initialize expected gauge records
+	var (
+		concentratedGaugeRecord = withRecordGaugeId(defaultZeroWeightGaugeRecord, poolInfo.ConcentratedGaugeID)
+		balancerGaugeRecord     = withRecordGaugeId(defaultZeroWeightGaugeRecord, poolInfo.BalancerGaugeID)
+		stableSwapGaugeRecord   = withRecordGaugeId(defaultZeroWeightGaugeRecord, poolInfo.StableSwapGaugeID)
+	)
+
+	tests := []struct {
+		name             string
+		coins            sdk.Coins
+		numEpochPaidOver uint64
+		// 0 by default unless overwritten
+		creatorAddressIndex int
+		poolIDs             []uint64
+
+		expectedGaugeInfo           types.InternalGaugeInfo
+		expectedPerpeutalGroupGauge bool
+		expectErr                   error
+	}{
+		{
+			name:             "two pools - created perpetual group gauge",
+			coins:            defaultCoins,
+			numEpochPaidOver: incentiveskeeper.PerpetualNumEpochsPaidOver,
+			poolIDs:          []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID},
+
+			expectedPerpeutalGroupGauge: true,
+			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo, []types.InternalGaugeRecord{
+				concentratedGaugeRecord,
+				balancerGaugeRecord,
+			}),
+		},
+		{
+			name:             "all incentive supported pools - created perpetual group gauge",
+			coins:            defaultCoins,
+			numEpochPaidOver: incentiveskeeper.PerpetualNumEpochsPaidOver,
+			poolIDs:          []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID, poolInfo.StableSwapPoolID},
+
+			expectedPerpeutalGroupGauge: true,
+			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo, []types.InternalGaugeRecord{
+				concentratedGaugeRecord,
+				balancerGaugeRecord,
+				stableSwapGaugeRecord,
+			}),
+		},
+		{
+			name:             "two pools - created non-perpetual group gauge",
+			coins:            defaultCoins,
+			numEpochPaidOver: incentiveskeeper.PerpetualNumEpochsPaidOver + 1,
+			poolIDs:          []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID},
+
+			expectedPerpeutalGroupGauge: false, // explicit for clarity
+			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo, []types.InternalGaugeRecord{
+				concentratedGaugeRecord,
+				balancerGaugeRecord,
+			}),
+		},
+
+		{
+			name:             "all incentive supported pools with custom amount - created non-perpetual group gauge",
+			coins:            defaultCoins.Add(defaultCoins...).Add(defaultCoins...),
+			numEpochPaidOver: incentiveskeeper.PerpetualNumEpochsPaidOver + 4,
+			poolIDs:          []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID, poolInfo.StableSwapPoolID},
+
+			expectedPerpeutalGroupGauge: false, // explicit for clarity
+			expectedGaugeInfo: addGaugeRecords(defaultEmptyGaugeInfo, []types.InternalGaugeRecord{
+				concentratedGaugeRecord,
+				balancerGaugeRecord,
+				stableSwapGaugeRecord,
+			}),
+		},
+
+		// error cases
+
+		{
+			name:             "error: fails to initialize group gauge due to cosmwasm pool that does not support incentives",
+			coins:            defaultCoins,
+			numEpochPaidOver: incentiveskeeper.PerpetualNumEpochsPaidOver,
+			poolIDs:          []uint64{poolInfo.BalancerPoolID, poolInfo.CosmWasmPoolID},
+
+			expectErr: poolincentivetypes.UnsupportedPoolTypeError{PoolID: poolInfo.CosmWasmPoolID, PoolType: poolmanagertypes.CosmWasm},
+		},
+
+		{
+			name:                "error: owner does not have enough funds",
+			coins:               defaultCoins,
+			creatorAddressIndex: fundedAddressIndex + 1,
+			numEpochPaidOver:    incentiveskeeper.PerpetualNumEpochsPaidOver,
+			poolIDs:             []uint64{poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID},
+			expectErr:           fmt.Errorf("0uosmo is smaller than %s: insufficient funds", defaultCoins),
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+
+			// Alwats fund the first account
+			s.FundAcc(s.TestAccs[fundedAddressIndex], tc.coins)
+
+			groupGaugeId, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, tc.coins, tc.numEpochPaidOver, s.TestAccs[tc.creatorAddressIndex], tc.poolIDs)
+			if tc.expectErr != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, tc.expectErr.Error())
+			} else {
+				s.Require().NoError(err)
+
+				s.Require().Equal(expectedGroupGaugeId, groupGaugeId)
+
+				// Validate group's Gauge
+				groupGauge, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, groupGaugeId)
+				s.Require().NoError(err)
+				s.Require().Equal(tc.coins, groupGauge.Coins)
+				s.Require().Equal(tc.numEpochPaidOver, groupGauge.NumEpochsPaidOver)
+				s.Require().Equal(tc.expectedPerpeutalGroupGauge, groupGauge.IsPerpetual)
+				s.Require().Equal(lockuptypes.ByGroup, groupGauge.DistributeTo.LockQueryType)
+
+				// Validate Group
+				group, err := s.App.IncentivesKeeper.GetGroupByGaugeID(s.Ctx, groupGaugeId)
+				s.Require().NoError(err)
+
+				s.Require().Equal(expectedGroupGaugeId, group.GroupGaugeId)
+				s.Require().Equal(types.ByVolume, group.SplittingPolicy)
+
+				// Validate InternalGaugeInfo
+				actualGaugeInfo := group.InternalGaugeInfo
+				s.validateGaugeInfo(tc.expectedGaugeInfo, actualGaugeInfo)
+
+				// Bump up expected gauge ID since we are reusing the same test state
+				expectedGroupGaugeId++
 			}
 		})
+	}
+}
+
+// validates that the expected gauge info equals the actual gauge info
+func (s *KeeperTestSuite) validateGaugeInfo(expected types.InternalGaugeInfo, actual types.InternalGaugeInfo) {
+	s.Require().Equal(expected.TotalWeight.String(), actual.TotalWeight.String())
+	s.Require().Equal(len(expected.GaugeRecords), len(actual.GaugeRecords))
+	for i := range expected.GaugeRecords {
+		s.Require().Equal(expected.GaugeRecords[i].GaugeId, actual.GaugeRecords[i].GaugeId)
+		s.Require().Equal(expected.GaugeRecords[i].CurrentWeight.String(), actual.GaugeRecords[i].CurrentWeight.String())
+		s.Require().Equal(expected.GaugeRecords[i].CumulativeWeight.String(), actual.GaugeRecords[i].CumulativeWeight.String())
 	}
 }

--- a/x/incentives/keeper/store_test.go
+++ b/x/incentives/keeper/store_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v19/x/incentives/types"
-	lockuptypes "github.com/osmosis-labs/osmosis/v19/x/lockup/types"
 )
 
 var _ = suite.TestingSuite(nil)
@@ -95,7 +94,7 @@ func (s *KeeperTestSuite) TestGetGroupByGaugeID() {
 				internalGauges = append(internalGauges, internalGauge)
 			}
 
-			_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(100_000_000))), 1, s.TestAccs[1], internalGauges, lockuptypes.ByGroup) // gauge id = 5
+			_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, sdk.NewCoins(sdk.NewCoin("uosmo", osmomath.NewInt(100_000_000))), 1, s.TestAccs[1], internalGauges) // gauge id = 5
 			s.Require().NoError(err)
 
 			record, err := s.App.IncentivesKeeper.GetGroupByGaugeID(s.Ctx, test.groupGaugeId)

--- a/x/incentives/types/errors.go
+++ b/x/incentives/types/errors.go
@@ -6,6 +6,11 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
+var (
+	NoPoolIDsGivenError        = fmt.Errorf("no pool IDs given")
+	ZeroNumEpochsPaidOverError = fmt.Errorf("num epochs paid over must be greater than zero")
+)
+
 type UnsupportedSplittingPolicyError struct {
 	GroupGaugeId    uint64
 	SplittingPolicy SplittingPolicy
@@ -55,4 +60,12 @@ type GaugeNotFoundError struct {
 
 func (e GaugeNotFoundError) Error() string {
 	return fmt.Sprintf("gauge with ID (%d) not found", e.GaugeID)
+}
+
+type OnePoolIDGroupError struct {
+	PoolID uint64
+}
+
+func (e OnePoolIDGroupError) Error() string {
+	return fmt.Sprintf("one pool ID %d given. Need at least two to create valid Group", e.PoolID)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6404

## What is the purpose of the change

This PR refactors `CreateGroup` to take in pool IDs instead of gauge IDs. See issue for details.

Additionally, it removes previous group creation tests and recreates a new one.

## Testing and Verifying

- `TestCreateGroup` added

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A