### PR TITLE
dev-ux: fix go.mod auto update workflow bug

### DIFF
--- a/.github/workflows/go-mod-auto-bump.yml
+++ b/.github/workflows/go-mod-auto-bump.yml
@@ -50,8 +50,8 @@ jobs:
       
       - name: Run script
         run: |
-          COMMIT_AFTER_PUSH=${{ github.event.after }}
-          bash ./scripts/update-go-mod.sh ${{ steps.main_commit.outputs.LATEST_MAIN_COMMIT }} $COMMIT_AFTER_PUSH
+          LATEST_TARGET_COMMIT=$(git rev-parse ${{ inputs.target-branch }})
+          bash ./scripts/update-go-mod.sh ${{ steps.main_commit.outputs.LATEST_MAIN_COMMIT }} $LATEST_TARGET_COMMIT
 
       - name: Add Changes 
         id: add_changes


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6550

## What is the purpose of the change

Changes a logic for parsing latest target's commit in go.mod auto update workflow

## Testing and Verifying

trivial, same logic works for parsing main's latest commit in the same workflow

## Documentation and Release Note

  minor, N/A