### PR TITLE
[AccountAbstraction] Simple remediation of custom fee payer skipping authenticatation

### DIFF
--- a/x/authenticator/ante/ante.go
+++ b/x/authenticator/ante/ante.go
@@ -162,6 +162,12 @@ func (ad AuthenticatorDecorator) AnteHandle(
 		}
 	}
 
+	// Ensure that the fee payer has been authenticated. For this to be true, the fee payer must be
+	// the signer of at least one message
+	if !feePayerAuthenticated {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "fee payer not authenticated")
+	}
+
 	// If the transaction has been authenticated, we call TrackMessages(...) to
 	// notify every authenticator so that they can handle any storage updates
 	// that need to happen regardless of how the message was authorized.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change


> When specifying a separate fee payer address the feePayerAuthenticated flag never becomes true as account.Equals(feePayer) always fails, the fee payer won't be a signer of a message even if they signed the transaction.

This PR checks that the fee payer has been authenticated and ensures the tx fails otherwise. 

## Testing and Verifying

All existing tests should fail.

TODO: add a test specific to a custom (bad) fee payer

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A