### PR TITLE
[AccountAbstraction] Validating AnyOf and AllOf

### DIFF
--- a/x/authenticator/authenticator/all_of.go
+++ b/x/authenticator/authenticator/all_of.go
@@ -62,6 +62,7 @@ func (aoa AllOfAuthenticator) Initialize(data []byte) (iface.Authenticator, erro
 					return nil, err
 				}
 				aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
+				continue
 			}
 		}
 	}
@@ -155,6 +156,7 @@ func validateSubAuthenticatorData(initDatas []InitializationData, am *Authentica
 		for _, authenticatorCode := range am.GetRegisteredAuthenticators() {
 			if authenticatorCode.Type() == initData.AuthenticatorType {
 				subAuthenticatorCount++
+				continue
 			}
 		}
 	}

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -66,6 +66,7 @@ func (aoa AnyOfAuthenticator) Initialize(data []byte) (iface.Authenticator, erro
 					return nil, err // Handling the error by returning it
 				}
 				aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
+				continue
 			}
 		}
 	}

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -70,6 +70,11 @@ func (aoa AnyOfAuthenticator) Initialize(data []byte) (iface.Authenticator, erro
 		}
 	}
 
+	// If not all sub-authenticators are registered, return an error
+	if len(aoa.SubAuthenticators) != len(initDatas) {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "failed to initialize all sub-authenticators")
+	}
+
 	return aoa, nil
 }
 
@@ -130,6 +135,9 @@ func (aoa AnyOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccA
 func (aoa AnyOfAuthenticator) OnAuthenticatorAdded(ctx sdk.Context, account sdk.AccAddress, data []byte) error {
 	var initDatas []InitializationData
 	if err := json.Unmarshal(data, &initDatas); err != nil {
+		return err
+	}
+	if err := validateSubAuthenticatorData(initDatas, aoa.am); err != nil {
 		return err
 	}
 	return nil

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -454,9 +454,6 @@ func (s *AuthenticatorSuite) TestCompositeAuthenticatorIntegration() {
 	anyOf := authenticator.NewAnyOfAuthenticator(s.app.AuthenticatorManager)
 	allOf := authenticator.NewAllOfAuthenticator(s.app.AuthenticatorManager)
 
-	s.app.AuthenticatorManager.RegisterAuthenticator(anyOf)
-	s.app.AuthenticatorManager.RegisterAuthenticator(allOf)
-
 	// construct InitializationData for each SigVerificationAuthenticator
 	initDataPrivKey0 := authenticator.InitializationData{
 		AuthenticatorType: "SignatureVerificationAuthenticator",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Ensuring AnyOf and AllOf have sub-authenticators, the sub-authenticators are registered (both when adding and when initializing), and defensively returning false for an empty all-of

## Testing and Verifying
all existing tests should pass
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A