### PR TITLE
[AccountAbstraction] Validating that there is only one signer per message

### DIFF
--- a/x/authenticator/utils/track.go
+++ b/x/authenticator/utils/track.go
@@ -9,8 +9,8 @@ import (
 // GetAccount retrieves the account associated with the first signer of a transaction message.
 // It returns the account's address or an error if no signers are present.
 func GetAccount(msg sdk.Msg) (sdk.AccAddress, error) {
-	if len(msg.GetSigners()) == 0 {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "no signers")
+	if len(msg.GetSigners()) != 1 {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "messages must have exactly one signer")
 	}
 	return msg.GetSigners()[0], nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

> Since the accounts authenticators are based in the first signer, I think it would allow for a malicious account authenticator to essentially skip the other signer if they wanted. The authz module has a check to prevent messages with multiple signers from being dispatched, should there be a similar check before using an account authenticator?

This PR adds validation to ensure a message only has one signer. 

## Testing and Verifying
all existing tests should pass
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A