### PR TITLE
[goreleaser] Remove darwin binaries from goreleaser.yml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,22 +132,22 @@ universal_binaries:
 archives:
   - id: zipped
     builds:
-      - osmosisd-darwin-universal
+      # - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-      - osmosisd-darwin-amd64
-      - osmosisd-darwin-arm64
+      # - osmosisd-darwin-amd64
+      # - osmosisd-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     files:
       - none*
   - id: binaries
     builds:
-      - osmosisd-darwin-universal
+      # - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-      - osmosisd-darwin-amd64
-      - osmosisd-darwin-arm64
+      # - osmosisd-darwin-amd64
+      # - osmosisd-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:
@@ -176,8 +176,7 @@ release:
 
     ## ⚡️ Binaries
 
-    Binaries for Linux and Darwin (amd64 and arm64) are available below.
-    Darwin users can also use the same universal binary `osmosisd-{{ .Version }}-darwin-all` for both amd64 and arm64.
+    Binaries for Linux (amd64 and arm64) are available below.
 
     #### 🔨 Build from source
 


### PR DESCRIPTION
## What is the purpose of the change

This PRs removes darwin binaries from our goreleaser config

## Testing and Verifying

This change can be verified as follows:

```bash
cd <OSMOSIS_REPO>

# Build
 docker run -e COSMWASM_VERSION=v1.2.3     -v /var/run/docker.sock:/var/run/docker.sock     -v `pwd`:/go/src/osmosisd     -w /go/src/osmosisd ghcr.io/goreleaser/goreleaser-cross:v1.20.5 releas
e --clean --skip-publish --skip-validate

# Check dist folder
osmosis@test:~/release/osmosis$ ls dist/

artifacts.json  metadata.json                       osmosisd-19.2.0-linux-arm64.tar.gz     osmosisd-darwin-arm64_darwin_arm64    osmosisd-linux-amd64_linux_amd64_v1  sha256sum.txt
config.yaml     osmosisd-19.2.0-linux-amd64.tar.gz  osmosisd-darwin-amd64_darwin_amd64_v1  osmosisd-darwin-universal_darwin_all  osmosisd-linux-arm64_linux_arm64
```

Binaries are built but not added to the release. We can check the `sha256sum.txt`:

```bash
osmosis@test:~/release/osmosis$ cat dist/sha256sum.txt 
22946e09fe3ecef79abe6ea9b4b05c2f6762d445df65d4cc20cdbb8b28b3a45a  osmosisd-19.2.0-linux-arm64
32adcdfdad4caf47da27dedf93b07b29db2be081745eaa445ad117db5cc768bf  osmosisd-19.2.0-linux-amd64.tar.gz
87072929ebc75e76f5ab1c6c9c3959513d61f6c9b0e4de25e88ca3d445e2e815  osmosisd-19.2.0-linux-arm64.tar.gz
c0062b45822a2c902371fccf2fda8c3b45217114c7c3f937156d44f65f07a616  osmosisd-19.2.0-linux-amd64
```


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A