### PR TITLE
[VS Incentives] refactor(poolmanager): trackVolume in swap exact amount in

### DIFF
--- a/x/poolmanager/create_pool_test.go
+++ b/x/poolmanager/create_pool_test.go
@@ -122,41 +122,41 @@ func (s *KeeperTestSuite) TestCreatePool() {
 	var (
 		validBalancerPoolMsg = balancer.NewMsgCreateBalancerPool(s.TestAccs[0], balancer.NewPoolParams(osmomath.ZeroDec(), osmomath.ZeroDec(), nil), []balancer.PoolAsset{
 			{
-				Token:  sdk.NewCoin(foo, defaultInitPoolAmount),
+				Token:  sdk.NewCoin(FOO, defaultInitPoolAmount),
 				Weight: osmomath.NewInt(1),
 			},
 			{
-				Token:  sdk.NewCoin(bar, defaultInitPoolAmount),
+				Token:  sdk.NewCoin(BAR, defaultInitPoolAmount),
 				Weight: osmomath.NewInt(1),
 			},
 		}, "")
 
 		invalidBalancerPoolMsg = balancer.NewMsgCreateBalancerPool(s.TestAccs[0], balancer.NewPoolParams(osmomath.ZeroDec(), osmomath.NewDecWithPrec(1, 2), nil), []balancer.PoolAsset{
 			{
-				Token:  sdk.NewCoin(foo, defaultInitPoolAmount),
+				Token:  sdk.NewCoin(FOO, defaultInitPoolAmount),
 				Weight: osmomath.NewInt(1),
 			},
 			{
-				Token:  sdk.NewCoin(bar, defaultInitPoolAmount),
+				Token:  sdk.NewCoin(BAR, defaultInitPoolAmount),
 				Weight: osmomath.NewInt(1),
 			},
 		}, "")
 
 		DefaultStableswapLiquidity = sdk.NewCoins(
-			sdk.NewCoin(foo, defaultInitPoolAmount),
-			sdk.NewCoin(bar, defaultInitPoolAmount),
+			sdk.NewCoin(FOO, defaultInitPoolAmount),
+			sdk.NewCoin(BAR, defaultInitPoolAmount),
 		)
 
 		validStableswapPoolMsg = stableswap.NewMsgCreateStableswapPool(s.TestAccs[0], stableswap.PoolParams{SwapFee: osmomath.NewDec(0), ExitFee: osmomath.NewDec(0)}, DefaultStableswapLiquidity, []uint64{}, "")
 
 		invalidStableswapPoolMsg = stableswap.NewMsgCreateStableswapPool(s.TestAccs[0], stableswap.PoolParams{SwapFee: osmomath.NewDec(0), ExitFee: osmomath.NewDecWithPrec(1, 2)}, DefaultStableswapLiquidity, []uint64{}, "")
 
-		validConcentratedPoolMsg = clmodel.NewMsgCreateConcentratedPool(s.TestAccs[0], foo, bar, 1, defaultPoolSpreadFactor)
+		validConcentratedPoolMsg = clmodel.NewMsgCreateConcentratedPool(s.TestAccs[0], FOO, BAR, 1, defaultPoolSpreadFactor)
 
 		validTransmuterCodeId = uint64(1)
 		validCWPoolMsg        = cwmodel.NewMsgCreateCosmWasmPool(validTransmuterCodeId, s.TestAccs[0], s.GetDefaultTransmuterInstantiateMsgBytes())
 
-		defaultFundAmount = sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount.Mul(osmomath.NewInt(2))), sdk.NewCoin(bar, defaultInitPoolAmount.Mul(osmomath.NewInt(2))))
+		defaultFundAmount = sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount.Mul(osmomath.NewInt(2))), sdk.NewCoin(BAR, defaultInitPoolAmount.Mul(osmomath.NewInt(2))))
 	)
 
 	tests := []struct {
@@ -271,16 +271,16 @@ func (s *KeeperTestSuite) TestCreatePoolZeroLiquidityNoCreationFee() {
 
 	balancerPoolMsg := balancer.NewMsgCreateBalancerPool(poolManagerModuleAcc.GetAddress(), balancer.NewPoolParams(osmomath.ZeroDec(), osmomath.ZeroDec(), nil), []balancer.PoolAsset{
 		{
-			Token:  sdk.NewCoin(foo, defaultInitPoolAmount),
+			Token:  sdk.NewCoin(FOO, defaultInitPoolAmount),
 			Weight: osmomath.NewInt(1),
 		},
 		{
-			Token:  sdk.NewCoin(bar, defaultInitPoolAmount),
+			Token:  sdk.NewCoin(BAR, defaultInitPoolAmount),
 			Weight: osmomath.NewInt(1),
 		},
 	}, "")
 
-	concentratedPoolMsg := clmodel.NewMsgCreateConcentratedPool(poolManagerModuleAcc.GetAddress(), foo, bar, 1, defaultPoolSpreadFactor)
+	concentratedPoolMsg := clmodel.NewMsgCreateConcentratedPool(poolManagerModuleAcc.GetAddress(), FOO, BAR, 1, defaultPoolSpreadFactor)
 
 	tests := []struct {
 		name               string

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -43,37 +43,10 @@ func (k Keeper) RouteExactAmountIn(
 			_outMinAmount = tokenOutMinAmount
 		}
 
-		// Get underlying pool type corresponding to the pool ID at the current routeStep.
-		swapModule, err := k.GetPoolModule(ctx, routeStep.PoolId)
+		tokenOutAmount, err := k.SwapExactAmountIn(ctx, sender, routeStep.PoolId, tokenIn, routeStep.TokenOutDenom, _outMinAmount)
 		if err != nil {
 			return osmomath.Int{}, err
 		}
-
-		// Execute the expected swap on the current routed pool
-		pool, poolErr := swapModule.GetPool(ctx, routeStep.PoolId)
-		if poolErr != nil {
-			return osmomath.Int{}, poolErr
-		}
-
-		// Check if pool has swaps enabled.
-		if !pool.IsActive(ctx) {
-			return osmomath.Int{}, types.InactivePoolError{PoolId: pool.GetId()}
-		}
-
-		spreadFactor := pool.GetSpreadFactor(ctx)
-
-		tokenInAfterSubTakerFee, err := k.chargeTakerFee(ctx, tokenIn, routeStep.TokenOutDenom, sender, true)
-		if err != nil {
-			return osmomath.Int{}, err
-		}
-
-		tokenOutAmount, err = swapModule.SwapExactAmountIn(ctx, sender, pool, tokenInAfterSubTakerFee, routeStep.TokenOutDenom, _outMinAmount, spreadFactor)
-		if err != nil {
-			return osmomath.Int{}, err
-		}
-
-		// Track volume for volume-splitting incentives
-		k.trackVolume(ctx, pool.GetId(), tokenIn)
 
 		// Chain output of current pool as the input for the next routed pool
 		tokenIn = sdk.NewCoin(routeStep.TokenOutDenom, tokenOutAmount)
@@ -185,12 +158,18 @@ func (k Keeper) SwapExactAmountIn(
 	if err != nil {
 		return osmomath.Int{}, err
 	}
+	if err != nil {
+		return osmomath.Int{}, err
+	}
 
 	// routeStep to the pool-specific SwapExactAmountIn implementation.
 	tokenOutAmount, err = swapModule.SwapExactAmountIn(ctx, sender, pool, tokenInAfterSubTakerFee, tokenOutDenom, tokenOutMinAmount, pool.GetSpreadFactor(ctx))
 	if err != nil {
 		return osmomath.Int{}, err
 	}
+
+	// Track volume for volume-splitting incentives
+	k.trackVolume(ctx, pool.GetId(), tokenIn)
 
 	return tokenOutAmount, nil
 }
@@ -232,6 +211,9 @@ func (k Keeper) SwapExactAmountInNoTakerFee(
 	if err != nil {
 		return osmomath.Int{}, err
 	}
+
+	// Track volume for volume-splitting incentives
+	k.trackVolume(ctx, pool.GetId(), tokenIn)
 
 	return tokenOutAmount, nil
 }

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -43,7 +43,7 @@ func (k Keeper) RouteExactAmountIn(
 			_outMinAmount = tokenOutMinAmount
 		}
 
-		tokenOutAmount, err := k.SwapExactAmountIn(ctx, sender, routeStep.PoolId, tokenIn, routeStep.TokenOutDenom, _outMinAmount)
+		tokenOutAmount, err = k.SwapExactAmountIn(ctx, sender, routeStep.PoolId, tokenIn, routeStep.TokenOutDenom, _outMinAmount)
 		if err != nil {
 			return osmomath.Int{}, err
 		}

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -158,9 +158,6 @@ func (k Keeper) SwapExactAmountIn(
 	if err != nil {
 		return osmomath.Int{}, err
 	}
-	if err != nil {
-		return osmomath.Int{}, err
-	}
 
 	// routeStep to the pool-specific SwapExactAmountIn implementation.
 	tokenOutAmount, err = swapModule.SwapExactAmountIn(ctx, sender, pool, tokenInAfterSubTakerFee, tokenOutDenom, tokenOutMinAmount, pool.GetSpreadFactor(ctx))

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -36,7 +36,7 @@ type expectedTakerFees struct {
 }
 
 const (
-	FOO   = apptesting.UOSMO
+	FOO   = apptesting.FOO
 	BAR   = apptesting.BAR
 	BAZ   = apptesting.BAZ
 	UOSMO = apptesting.UOSMO

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -36,10 +36,10 @@ type expectedTakerFees struct {
 }
 
 const (
-	foo   = "foo"
-	bar   = "bar"
-	baz   = "baz"
-	uosmo = "uosmo"
+	FOO   = apptesting.UOSMO
+	BAR   = apptesting.BAR
+	BAZ   = apptesting.BAZ
+	UOSMO = apptesting.UOSMO
 
 	// Not an authorized quote denom
 	// ("abc" ensures its always first lexicographically which simplifies setup)
@@ -69,10 +69,10 @@ var (
 	defaultPoolInitAmount     = osmomath.NewInt(10_000_000_000)
 	twentyFiveBaseUnitsAmount = osmomath.NewInt(25_000_000)
 
-	fooCoin   = sdk.NewCoin(foo, defaultPoolInitAmount)
-	barCoin   = sdk.NewCoin(bar, defaultPoolInitAmount)
-	bazCoin   = sdk.NewCoin(baz, defaultPoolInitAmount)
-	uosmoCoin = sdk.NewCoin(uosmo, defaultPoolInitAmount)
+	fooCoin   = sdk.NewCoin(FOO, defaultPoolInitAmount)
+	barCoin   = sdk.NewCoin(BAR, defaultPoolInitAmount)
+	bazCoin   = sdk.NewCoin(BAZ, defaultPoolInitAmount)
+	uosmoCoin = sdk.NewCoin(UOSMO, defaultPoolInitAmount)
 	abcCoin   = sdk.NewCoin(abc, defaultPoolInitAmount)
 
 	// Note: These are initialized in such a way as it makes
@@ -144,6 +144,8 @@ var (
 			takerFee:         defaultTakerFee,
 		},
 	}
+
+	emptyCoins = sdk.NewCoins()
 )
 
 // withTakerFees overrides the taker fees for the given pool setup info at the given indices and returns the full set of updated pool setup info.
@@ -445,56 +447,56 @@ func (s *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 	}{
 		{
 			name:             "One route: Swap - [foo -> bar], 1 percent fee",
-			poolCoins:        []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount))},
+			poolCoins:        []sdk.Coins{sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount))},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor},
 			poolType:         []types.PoolType{types.Balancer},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 			},
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
 		},
 		{
 			name: "Two routes: Swap - [foo -> bar](pool 1) - [bar -> baz](pool 2), both pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount)), // pool 2.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 			},
 			incentivizedGauges: []uint64{},
-			tokenIn:            sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:            sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:  osmomath.NewInt(1),
 		},
 		{
 			name: "Two routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2), both pools 1 percent fee, sanity check no more half fee applied",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAZ, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: uosmo,
+					TokenOutDenom: UOSMO,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
@@ -504,162 +506,162 @@ func (s *KeeperTestSuite) TestMultihopSwapExactAmountIn() {
 		{
 			name: "Three routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)),   // pool 3.
+				sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAZ, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount)),   // pool 3.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: uosmo,
+					TokenOutDenom: UOSMO,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 				{
 					PoolId:        3,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
-			tokenIn:            sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:            sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:  osmomath.NewInt(1),
 		},
 		{
 			name: "Two routes: Swap between four asset pools - [foo -> bar](pool 1) - [bar -> baz](pool 2), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
-			tokenIn:            sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:            sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:  osmomath.NewInt(1),
 		},
 		{
 			name: "Three routes: Swap between four asset pools - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 3.                                                                                      // pool 3.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 3.                                                                                      // pool 3.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: uosmo,
+					TokenOutDenom: UOSMO,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 				{
 					PoolId:        3,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
-			tokenIn:            sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:            sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:  osmomath.NewInt(1),
 		},
 		{
 			name: "[Concentrated] One route: Swap - [foo -> bar], 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, apptesting.DefaultCoinAmount), sdk.NewCoin(bar, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(FOO, apptesting.DefaultCoinAmount), sdk.NewCoin(BAR, apptesting.DefaultCoinAmount)),
 			},
 			poolType:         []types.PoolType{types.Concentrated},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 			},
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
 		},
 		{
 			name: "[Concentrated[ Three routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, apptesting.DefaultCoinAmount), sdk.NewCoin(uosmo, apptesting.DefaultCoinAmount)),
-				sdk.NewCoins(sdk.NewCoin(baz, apptesting.DefaultCoinAmount), sdk.NewCoin(uosmo, apptesting.DefaultCoinAmount)),
-				sdk.NewCoins(sdk.NewCoin(bar, apptesting.DefaultCoinAmount), sdk.NewCoin(baz, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(FOO, apptesting.DefaultCoinAmount), sdk.NewCoin(UOSMO, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(BAZ, apptesting.DefaultCoinAmount), sdk.NewCoin(UOSMO, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(BAR, apptesting.DefaultCoinAmount), sdk.NewCoin(BAZ, apptesting.DefaultCoinAmount)),
 			},
 			poolType:         []types.PoolType{types.Concentrated, types.Concentrated, types.Concentrated},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: uosmo,
+					TokenOutDenom: UOSMO,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 				{
 					PoolId:        3,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
-			tokenIn:            sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:            sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:  osmomath.NewInt(1),
 		},
 		{
 			name: "[Cosmwasm] One route: Swap - [foo -> bar], 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, apptesting.DefaultCoinAmount), sdk.NewCoin(bar, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(FOO, apptesting.DefaultCoinAmount), sdk.NewCoin(BAR, apptesting.DefaultCoinAmount)),
 			},
 			poolType:         []types.PoolType{types.CosmWasm},
 			poolSpreadFactor: []osmomath.Dec{osmomath.OneDec()},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 			},
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
 		},
 		{
 			name: "[Cosmwasm -> Concentrated] One route: Swap - [foo -> bar] -> [bar -> baz], 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, apptesting.DefaultCoinAmount), sdk.NewCoin(bar, apptesting.DefaultCoinAmount)),
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)),
+				sdk.NewCoins(sdk.NewCoin(FOO, apptesting.DefaultCoinAmount), sdk.NewCoin(BAR, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount)),
 			},
 			poolType:         []types.PoolType{types.CosmWasm, types.Concentrated},
 			poolSpreadFactor: []osmomath.Dec{osmomath.OneDec(), defaultPoolSpreadFactor},
 			routes: []types.SwapAmountInRoute{
 				{
 					PoolId:        1,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 				{
 					PoolId:        2,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 			},
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
 		},
 		//TODO:
@@ -723,179 +725,179 @@ func (s *KeeperTestSuite) TestMultihopSwapExactAmountOut() {
 	}{
 		{
 			name:             "One route: Swap - [foo -> bar], 1 percent fee",
-			poolCoins:        []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount))},
+			poolCoins:        []sdk.Coins{sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount))},
 			poolType:         []types.PoolType{types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 			},
 			tokenInMaxAmount: osmomath.NewInt(90000000),
-			tokenOut:         sdk.NewCoin(foo, defaultSwapAmount),
+			tokenOut:         sdk.NewCoin(FOO, defaultSwapAmount),
 		},
 		{
 			name: "Two routes: Swap - [foo -> bar](pool 1) - [bar -> baz](pool 2), both pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount)), // pool 2.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 			},
 			incentivizedGauges: []uint64{},
 
 			tokenInMaxAmount: osmomath.NewInt(90000000),
-			tokenOut:         sdk.NewCoin(baz, osmomath.NewInt(100000)),
+			tokenOut:         sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 		},
 		{
 			name: "Two routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2), both pools 1 percent fee, sanity check no more half fee applied",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAZ, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: uosmo,
+					TokenInDenom: UOSMO,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
 			tokenInMaxAmount:   osmomath.NewInt(90000000),
-			tokenOut:           sdk.NewCoin(baz, osmomath.NewInt(100000)),
+			tokenOut:           sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 		},
 		{
 			name: "Three routes: Swap - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(baz, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)),   // pool 3.
+				sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAZ, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount)),   // pool 3.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: uosmo,
+					TokenInDenom: UOSMO,
 				},
 				{
 					PoolId:       3,
-					TokenInDenom: baz,
+					TokenInDenom: BAZ,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
 			tokenInMaxAmount:   osmomath.NewInt(90000000),
-			tokenOut:           sdk.NewCoin(bar, osmomath.NewInt(100000)),
+			tokenOut:           sdk.NewCoin(BAR, osmomath.NewInt(100000)),
 		},
 		{
 			name: "Two routes: Swap between four asset pools - [foo -> bar](pool 1) - [bar -> baz](pool 2), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.                                                                                     // pool 3.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6},
-			tokenOut:           sdk.NewCoin(baz, osmomath.NewInt(100000)),
+			tokenOut:           sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 			tokenInMaxAmount:   osmomath.NewInt(90000000),
 		},
 		{
 			name: "Three routes: Swap between four asset pools - [foo -> uosmo](pool 1) - [uosmo -> baz](pool 2) - [baz -> bar](pool 3), all pools 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 2.
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount),
-					sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(uosmo, defaultInitPoolAmount)), // pool 3.                                                                                    // pool 3.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount),
+					sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(UOSMO, defaultInitPoolAmount)), // pool 3.                                                                                    // pool 3.
 			},
 			poolType:         []types.PoolType{types.Balancer, types.Balancer, types.Balancer},
 			poolSpreadFactor: []osmomath.Dec{defaultPoolSpreadFactor, defaultPoolSpreadFactor, defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: uosmo,
+					TokenInDenom: UOSMO,
 				},
 				{
 					PoolId:       3,
-					TokenInDenom: baz,
+					TokenInDenom: BAZ,
 				},
 			},
 			incentivizedGauges: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
-			tokenOut:           sdk.NewCoin(bar, osmomath.NewInt(100000)),
+			tokenOut:           sdk.NewCoin(BAR, osmomath.NewInt(100000)),
 			tokenInMaxAmount:   osmomath.NewInt(90000000),
 		},
 		{
 			name: "[Cosmwasm] One route: Swap - [foo -> bar], 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, apptesting.DefaultCoinAmount), sdk.NewCoin(bar, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(FOO, apptesting.DefaultCoinAmount), sdk.NewCoin(BAR, apptesting.DefaultCoinAmount)),
 			},
 			poolType:         []types.PoolType{types.CosmWasm},
 			poolSpreadFactor: []osmomath.Dec{osmomath.OneDec()},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 			},
-			tokenOut:         sdk.NewCoin(bar, osmomath.NewInt(100000)),
+			tokenOut:         sdk.NewCoin(BAR, osmomath.NewInt(100000)),
 			tokenInMaxAmount: osmomath.NewInt(90000000),
 		},
 		{
 			name: "[Cosmwasm -> Concentrated] One route: Swap - [foo -> bar] -> [bar -> baz], 1 percent fee",
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, apptesting.DefaultCoinAmount), sdk.NewCoin(bar, apptesting.DefaultCoinAmount)),
-				sdk.NewCoins(sdk.NewCoin(bar, defaultInitPoolAmount), sdk.NewCoin(baz, defaultInitPoolAmount)),
+				sdk.NewCoins(sdk.NewCoin(FOO, apptesting.DefaultCoinAmount), sdk.NewCoin(BAR, apptesting.DefaultCoinAmount)),
+				sdk.NewCoins(sdk.NewCoin(BAR, defaultInitPoolAmount), sdk.NewCoin(BAZ, defaultInitPoolAmount)),
 			},
 			poolType:         []types.PoolType{types.CosmWasm, types.Concentrated},
 			poolSpreadFactor: []osmomath.Dec{osmomath.OneDec(), defaultPoolSpreadFactor},
 			routes: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 			},
-			tokenOut:         sdk.NewCoin(baz, osmomath.NewInt(100000)),
+			tokenOut:         sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 			tokenInMaxAmount: osmomath.NewInt(90000000),
 		},
 		// TODO:
@@ -964,24 +966,24 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountIn() {
 				routes: []types.SwapAmountInRoute{
 					{
 						PoolId:        1,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 					{
 						PoolId:        2,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
 				estimateRoutes: []types.SwapAmountInRoute{
 					{
 						PoolId:        3,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 					{
 						PoolId:        4,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
-				tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+				tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 				tokenOutMinAmount: osmomath.NewInt(1),
 			},
 			expectPass: true,
@@ -992,24 +994,24 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountIn() {
 				routes: []types.SwapAmountInRoute{
 					{
 						PoolId:        1,
-						TokenOutDenom: uosmo,
+						TokenOutDenom: UOSMO,
 					},
 					{
 						PoolId:        2,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
 				estimateRoutes: []types.SwapAmountInRoute{
 					{
 						PoolId:        3,
-						TokenOutDenom: uosmo,
+						TokenOutDenom: UOSMO,
 					},
 					{
 						PoolId:        4,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
-				tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+				tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 				tokenOutMinAmount: osmomath.NewInt(1),
 			},
 			reducedFeeApplied: true,
@@ -1021,24 +1023,24 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountIn() {
 				routes: []types.SwapAmountInRoute{
 					{
 						PoolId:        1,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 					{
 						PoolId:        2,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
 				estimateRoutes: []types.SwapAmountInRoute{
 					{
 						PoolId:        3,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 					{
 						PoolId:        4,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
-				tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+				tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 				tokenOutMinAmount: osmomath.NewInt(1),
 			},
 			expectPass: true,
@@ -1050,24 +1052,24 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountIn() {
 				routes: []types.SwapAmountInRoute{
 					{
 						PoolId:        1,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 					{
 						PoolId:        2,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
 				estimateRoutes: []types.SwapAmountInRoute{
 					{
 						PoolId:        3,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 					{
 						PoolId:        4,
-						TokenOutDenom: baz,
+						TokenOutDenom: BAZ,
 					},
 				},
-				tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(9000000000000000000)),
+				tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(9000000000000000000)),
 				tokenOutMinAmount: osmomath.NewInt(1),
 			},
 			expectPass: false,
@@ -1146,25 +1148,25 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 				routes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       1,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       2,
-						TokenInDenom: bar,
+						TokenInDenom: BAR,
 					},
 				},
 				estimateRoutes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       3,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       4,
-						TokenInDenom: bar,
+						TokenInDenom: BAR,
 					},
 				},
 				tokenInMaxAmount: osmomath.NewInt(90000000),
-				tokenOut:         sdk.NewCoin(baz, osmomath.NewInt(100000)),
+				tokenOut:         sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 			},
 			expectPass: true,
 		},
@@ -1174,25 +1176,25 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 				routes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       1,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       2,
-						TokenInDenom: uosmo,
+						TokenInDenom: UOSMO,
 					},
 				},
 				estimateRoutes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       3,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       4,
-						TokenInDenom: uosmo,
+						TokenInDenom: UOSMO,
 					},
 				},
 				tokenInMaxAmount: osmomath.NewInt(90000000),
-				tokenOut:         sdk.NewCoin(baz, osmomath.NewInt(100000)),
+				tokenOut:         sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 			},
 			expectPass:        true,
 			reducedFeeApplied: true,
@@ -1203,25 +1205,25 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 				routes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       1,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       2,
-						TokenInDenom: bar,
+						TokenInDenom: BAR,
 					},
 				},
 				estimateRoutes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       3,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       4,
-						TokenInDenom: bar,
+						TokenInDenom: BAR,
 					},
 				},
 				tokenInMaxAmount: osmomath.NewInt(90000000),
-				tokenOut:         sdk.NewCoin(baz, osmomath.NewInt(100000)),
+				tokenOut:         sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 			},
 			expectPass: true,
 			poolType:   types.Stableswap,
@@ -1232,25 +1234,25 @@ func (s *KeeperTestSuite) TestEstimateMultihopSwapExactAmountOut() {
 				routes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       1,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       2,
-						TokenInDenom: bar,
+						TokenInDenom: BAR,
 					},
 				},
 				estimateRoutes: []types.SwapAmountOutRoute{
 					{
 						PoolId:       3,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 					{
 						PoolId:       4,
-						TokenInDenom: bar,
+						TokenInDenom: BAR,
 					},
 				},
 				tokenInMaxAmount: osmomath.NewInt(90000000),
-				tokenOut:         sdk.NewCoin(baz, osmomath.NewInt(9000000000000000000)),
+				tokenOut:         sdk.NewCoin(BAZ, osmomath.NewInt(9000000000000000000)),
 			},
 			expectPass: false,
 			poolType:   types.Stableswap,
@@ -1399,12 +1401,12 @@ func (s *KeeperTestSuite) TestSingleSwapExactAmountIn() {
 		{
 			name:                   "Swap - [foo -> bar], 0.1 percent swap fee, 0.25 percent taker fee",
 			poolId:                 1,
-			poolCoins:              sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
+			poolCoins:              sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)),
 			poolFee:                defaultPoolSpreadFactor,
 			takerFee:               osmomath.MustNewDecFromStr("0.0025"), // 0.25%
-			tokenIn:                sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:                sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:      osmomath.NewInt(1),
-			tokenOutDenom:          bar,
+			tokenOutDenom:          BAR,
 			expectedTokenOutAmount: osmomath.NewInt(99650), // 10000 - 0.35%
 		},
 		// Swap with taker fee:
@@ -1417,25 +1419,25 @@ func (s *KeeperTestSuite) TestSingleSwapExactAmountIn() {
 		{
 			name:                   "Swap - [foo -> bar], 0.1 percent swap fee, 0.25 percent taker fee",
 			poolId:                 1,
-			poolCoins:              sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
+			poolCoins:              sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)),
 			poolFee:                defaultPoolSpreadFactor,
 			takerFee:               osmomath.MustNewDecFromStr("0.0025"), // 0.25%
-			tokenIn:                sdk.NewCoin(bar, osmomath.NewInt(100000)),
+			tokenIn:                sdk.NewCoin(BAR, osmomath.NewInt(100000)),
 			tokenOutMinAmount:      osmomath.NewInt(1),
-			tokenOutDenom:          foo,
+			tokenOutDenom:          FOO,
 			expectedTokenOutAmount: osmomath.NewInt(99650), // 100000 - 0.35%
 		},
 		{
 			name:      "Swap - [foo -> bar], 0.1 percent swap fee, 0.33 percent taker fee",
 			poolId:    1,
-			poolCoins: sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(2000000000000)), sdk.NewCoin(bar, osmomath.NewInt(1000000000000))),
+			poolCoins: sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(2000000000000)), sdk.NewCoin(BAR, osmomath.NewInt(1000000000000))),
 			poolFee:   defaultPoolSpreadFactor,
 			takerFee:  osmomath.MustNewDecFromStr("0.0033"), // 0.33%
 			// We capture the expected fees in the input token to simplify the process for calculating output.
 			// 100000 / (1 - 0.0043) = 100432
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100432)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100432)),
 			tokenOutMinAmount: osmomath.NewInt(1),
-			tokenOutDenom:     bar,
+			tokenOutDenom:     BAR,
 			// Since spot price is 2 and the input after fees is 100000, the output should be 50000
 			// minus one due to truncation on rounding error.
 			expectedTokenOutAmount: osmomath.NewInt(50000 - 1),
@@ -1443,24 +1445,24 @@ func (s *KeeperTestSuite) TestSingleSwapExactAmountIn() {
 		{
 			name:                   "Swap - [foo -> bar], 0 percent swap fee, 0 percent taker fee",
 			poolId:                 1,
-			poolCoins:              sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(1000000000000)), sdk.NewCoin(bar, osmomath.NewInt(1000000000000))),
+			poolCoins:              sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(1000000000000)), sdk.NewCoin(BAR, osmomath.NewInt(1000000000000))),
 			poolFee:                osmomath.ZeroDec(),
 			takerFee:               osmomath.ZeroDec(),
-			tokenIn:                sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:                sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:      osmomath.NewInt(1),
-			tokenOutDenom:          bar,
+			tokenOutDenom:          BAR,
 			expectedTokenOutAmount: osmomath.NewInt(100000 - 1),
 		},
 		// 99% taker fee 99% swap fee
 		{
 			name:              "Swap - [foo -> bar], 99 percent swap fee, 99 percent taker fee",
 			poolId:            1,
-			poolCoins:         sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(1000000000000)), sdk.NewCoin(bar, osmomath.NewInt(1000000000000))),
+			poolCoins:         sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(1000000000000)), sdk.NewCoin(BAR, osmomath.NewInt(1000000000000))),
 			poolFee:           osmomath.MustNewDecFromStr("0.99"),
 			takerFee:          osmomath.MustNewDecFromStr("0.99"),
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(10000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(10000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
-			tokenOutDenom:     bar,
+			tokenOutDenom:     BAR,
 			// 10000 * 0.01 * 0.01 = 1 swapped at a spot price of 1
 			expectedTokenOutAmount: osmomath.NewInt(1),
 		},
@@ -1474,42 +1476,42 @@ func (s *KeeperTestSuite) TestSingleSwapExactAmountIn() {
 		{
 			name:                   "Swap - [foo -> bar], 0.1 percent fee",
 			poolId:                 1,
-			poolCoins:              sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
+			poolCoins:              sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)),
 			poolFee:                defaultPoolSpreadFactor,
-			tokenIn:                sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:                sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount:      osmomath.NewInt(1),
-			tokenOutDenom:          bar,
+			tokenOutDenom:          BAR,
 			swapWithNoTakerFee:     true,
 			expectedTokenOutAmount: osmomath.NewInt(99899),
 		},
 		{
 			name:              "Wrong pool id",
 			poolId:            2,
-			poolCoins:         sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
+			poolCoins:         sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)),
 			poolFee:           defaultPoolSpreadFactor,
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
-			tokenOutDenom:     bar,
+			tokenOutDenom:     BAR,
 			expectError:       true,
 		},
 		{
 			name:              "In denom not exist",
 			poolId:            1,
-			poolCoins:         sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
+			poolCoins:         sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)),
 			poolFee:           defaultPoolSpreadFactor,
-			tokenIn:           sdk.NewCoin(baz, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(BAZ, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
-			tokenOutDenom:     bar,
+			tokenOutDenom:     BAR,
 			expectError:       true,
 		},
 		{
 			name:              "Out denom not exist",
 			poolId:            1,
-			poolCoins:         sdk.NewCoins(sdk.NewCoin(foo, defaultInitPoolAmount), sdk.NewCoin(bar, defaultInitPoolAmount)),
+			poolCoins:         sdk.NewCoins(sdk.NewCoin(FOO, defaultInitPoolAmount), sdk.NewCoin(BAR, defaultInitPoolAmount)),
 			poolFee:           defaultPoolSpreadFactor,
-			tokenIn:           sdk.NewCoin(foo, osmomath.NewInt(100000)),
+			tokenIn:           sdk.NewCoin(FOO, osmomath.NewInt(100000)),
 			tokenOutMinAmount: osmomath.NewInt(1),
-			tokenOutDenom:     baz,
+			tokenOutDenom:     BAZ,
 			expectError:       true,
 		},
 	}
@@ -1825,7 +1827,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				Pools: []types.SwapAmountInRoute{
 					{
 						PoolId:        fooBarPoolId,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 				},
 				TokenInAmount: twentyFiveBaseUnitsAmount,
@@ -1835,11 +1837,11 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 		defaultTwoHopRoutes = []types.SwapAmountInRoute{
 			{
 				PoolId:        fooBarPoolId,
-				TokenOutDenom: bar,
+				TokenOutDenom: BAR,
 			},
 			{
 				PoolId:        barBazPoolId,
-				TokenOutDenom: baz,
+				TokenOutDenom: BAZ,
 			},
 		}
 
@@ -1856,7 +1858,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				},
 				{
 					PoolId:        bazAbcPoolId,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 			},
 			TokenInAmount: twentyFiveBaseUnitsAmount,
@@ -1866,15 +1868,15 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 			Pools: []types.SwapAmountInRoute{
 				{
 					PoolId:        fooBarPoolId,
-					TokenOutDenom: bar,
+					TokenOutDenom: BAR,
 				},
 				{
 					PoolId:        barUosmoPoolId,
-					TokenOutDenom: uosmo,
+					TokenOutDenom: UOSMO,
 				},
 				{
 					PoolId:        bazUosmoPoolId,
-					TokenOutDenom: baz,
+					TokenOutDenom: BAZ,
 				},
 			},
 			TokenInAmount: osmomath.NewInt(twentyFiveBaseUnitsAmount.Int64() * 3),
@@ -1905,7 +1907,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 	}{
 		"valid solo route one hop": {
 			routes:            defaultSingleRouteOneHop,
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			expectedTokenOutEstimate: twentyFiveBaseUnitsAmount,
@@ -1918,7 +1920,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 			routes: []types.SwapAmountInSplitRoute{
 				withInputSwapIn(defaultSingleRouteOneHop[0], osmomath.NewInt(1000)),
 			},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			// We expect the output to truncate
@@ -1936,12 +1938,12 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				// staking rewards.
 				communityPoolQuoteAssets:    sdk.NewCoins(),
 				communityPoolNonQuoteAssets: sdk.NewCoins(),
-				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(3))),
+				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(3))),
 			},
 		},
 		"valid solo route multi hop": {
 			routes:            []types.SwapAmountInSplitRoute{defaultSingleRouteTwoHops},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			expectedTokenOutEstimate: twentyFiveBaseUnitsAmount,
@@ -1952,7 +1954,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				defaultSingleRouteTwoHops,
 				defaultSingleRouteThreeHops,
 			},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			// 1x from single route two hops and 3x from single route three hops
@@ -1970,7 +1972,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				withInputSwapIn(defaultSingleRouteTwoHops, osmomath.NewInt(1000)),
 				withInputSwapIn(fooAbcBazTwoHops, osmomath.NewInt(1000)),
 			},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			// We charge taker fee on each hop and expect the output to truncate
@@ -1989,13 +1991,13 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 			expectedTakerFees: expectedTakerFees{
 				// 1foo & 1bar from first route, 1foo from second route
 				// Total: 2foo, 1bar
-				communityPoolQuoteAssets: sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(2)), sdk.NewCoin(bar, osmomath.NewInt(1))),
+				communityPoolQuoteAssets: sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(2)), sdk.NewCoin(BAR, osmomath.NewInt(1))),
 				// 1abc from second route
 				// Total: 1abc
 				communityPoolNonQuoteAssets: sdk.NewCoins(sdk.NewCoin(abc, osmomath.NewInt(1))),
 				// 3foo & 3bar from first route, 3foo & 3abc from second route
 				// Total: 6foo, 3bar, 3abc
-				stakingRewardAssets: sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(6)), sdk.NewCoin(bar, osmomath.NewInt(3)), sdk.NewCoin(abc, osmomath.NewInt(3))),
+				stakingRewardAssets: sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(6)), sdk.NewCoin(BAR, osmomath.NewInt(3)), sdk.NewCoin(abc, osmomath.NewInt(3))),
 			},
 		},
 		"split route multi hop with different taker fees (exact output check)": {
@@ -2009,7 +2011,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				withInputSwapIn(defaultSingleRouteTwoHops, osmomath.NewInt(1000)),
 				withInputSwapIn(fooAbcBazTwoHops, osmomath.NewInt(1000)),
 			},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			// Route 1:
@@ -2035,11 +2037,11 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 			// Recall that foo and bar are quote assets, while abc is not.
 			expectedTakerFees: expectedTakerFees{
 				// 1foo from first route, everything from second route is truncated
-				communityPoolQuoteAssets:    sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(1))),
+				communityPoolQuoteAssets:    sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(1))),
 				communityPoolNonQuoteAssets: sdk.NewCoins(),
 				// 3foo from first route, 2foo & 3abc from second route
 				// Total: 5foo, 3abc
-				stakingRewardAssets: sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(5)), sdk.NewCoin(abc, osmomath.NewInt(3))),
+				stakingRewardAssets: sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(5)), sdk.NewCoin(abc, osmomath.NewInt(3))),
 			},
 		},
 		"valid split route multi hop with price impact protection that would fail individual route if given per multihop": {
@@ -2047,7 +2049,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				defaultSingleRouteTwoHops,
 				defaultSingleRouteThreeHops,
 			},
-			tokenInDenom: foo,
+			tokenInDenom: FOO,
 			// equal to the expected amount
 			// every route individually would fail, but the split route should succeed
 			tokenOutMinAmount: priceImpactThreshold,
@@ -2061,7 +2063,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 				defaultSingleRouteTwoHops,
 				defaultSingleRouteThreeHops,
 			},
-			tokenInDenom: foo,
+			tokenInDenom: FOO,
 			// one greater than expected amount
 			tokenOutMinAmount: priceImpactThreshold.Add(osmomath.OneInt()),
 
@@ -2077,7 +2079,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 					TokenInAmount: defaultSingleRouteTwoHops.TokenInAmount.MulRaw(3),
 				},
 			},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			expectError: types.ErrDuplicateRoutesNotAllowed,
@@ -2089,13 +2091,13 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountIn() {
 					Pools: []types.SwapAmountInRoute{
 						{
 							PoolId:        uint64(len(defaultValidPools) + 1),
-							TokenOutDenom: bar,
+							TokenOutDenom: BAR,
 						},
 					},
 					TokenInAmount: twentyFiveBaseUnitsAmount,
 				},
 			},
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			expectError: types.FailedToFindRouteError{PoolId: uint64(len(defaultValidPools) + 1)},
@@ -2189,7 +2191,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 				Pools: []types.SwapAmountOutRoute{
 					{
 						PoolId:       fooBarPoolId,
-						TokenInDenom: foo,
+						TokenInDenom: FOO,
 					},
 				},
 				TokenOutAmount: twentyFiveBaseUnitsAmount,
@@ -2199,11 +2201,11 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 		defaultTwoHopRoutes = []types.SwapAmountOutRoute{
 			{
 				PoolId:       fooBarPoolId,
-				TokenInDenom: foo,
+				TokenInDenom: FOO,
 			},
 			{
 				PoolId:       barBazPoolId,
-				TokenInDenom: bar,
+				TokenInDenom: BAR,
 			},
 		}
 
@@ -2211,11 +2213,11 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 			Pools: []types.SwapAmountOutRoute{
 				{
 					PoolId:       fooUosmoPoolId,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       bazUosmoPoolId,
-					TokenInDenom: uosmo,
+					TokenInDenom: UOSMO,
 				},
 			},
 			TokenOutAmount: twentyFiveBaseUnitsAmount,
@@ -2230,15 +2232,15 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 			Pools: []types.SwapAmountOutRoute{
 				{
 					PoolId:       fooBarPoolId,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       barUosmoPoolId,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 				{
 					PoolId:       bazUosmoPoolId,
-					TokenInDenom: uosmo,
+					TokenInDenom: UOSMO,
 				},
 			},
 			TokenOutAmount: osmomath.NewInt(twentyFiveBaseUnitsAmount.Int64() * 3),
@@ -2268,7 +2270,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 	}{
 		"valid solo route one hop": {
 			routes:           defaultSingleRouteOneHop,
-			tokenOutDenom:    bar,
+			tokenOutDenom:    BAR,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			expectedTokenInEstimate: twentyFiveBaseUnitsAmount,
@@ -2280,7 +2282,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 			routes: []types.SwapAmountOutSplitRoute{
 				withInputSwapOut(defaultSingleRouteOneHop[0], osmomath.NewInt(1000)),
 			},
-			tokenOutDenom:    bar,
+			tokenOutDenom:    BAR,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			// (1000 / (1 - 0.003)) = 1003.009, rounded up = 1004. Post swap rounded up to 1005.
@@ -2289,7 +2291,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 		},
 		"valid solo route multi hop": {
 			routes:           []types.SwapAmountOutSplitRoute{defaultSingleRouteTwoHops},
-			tokenOutDenom:    baz,
+			tokenOutDenom:    BAZ,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			expectedTokenInEstimate: twentyFiveBaseUnitsAmount,
@@ -2299,7 +2301,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 				defaultSingleRouteTwoHops,
 				defaultSingleRouteThreeHops,
 			},
-			tokenOutDenom:    baz,
+			tokenOutDenom:    BAZ,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			// 1x from single route two hops and 3x from single route three hops
@@ -2316,7 +2318,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 				withInputSwapOut(defaultSingleRouteTwoHops, osmomath.NewInt(1000)),
 				withInputSwapOut(fooUosmoBazTwoHops, osmomath.NewInt(1000)),
 			},
-			tokenOutDenom:    baz,
+			tokenOutDenom:    BAZ,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			// We charge taker fee on each hop and expect the output to round up at each step
@@ -2340,7 +2342,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 				withInputSwapOut(defaultSingleRouteTwoHops, osmomath.NewInt(1000)),
 				withInputSwapOut(fooUosmoBazTwoHops, osmomath.NewInt(1000)),
 			},
-			tokenOutDenom:    baz,
+			tokenOutDenom:    BAZ,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			// Route 1:
@@ -2360,7 +2362,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 				defaultSingleRouteTwoHops,
 				defaultSingleRouteThreeHops,
 			},
-			tokenOutDenom: baz,
+			tokenOutDenom: BAZ,
 			// equal to the amount calculated.
 			// every route individually would fail, but the split route should succeed
 			tokenInMaxAmount: priceImpactThreshold,
@@ -2373,7 +2375,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 				defaultSingleRouteTwoHops,
 				defaultSingleRouteThreeHops,
 			},
-			tokenOutDenom: baz,
+			tokenOutDenom: BAZ,
 			// one less than expected amount
 			// every route individually would fail, but the split route should succeed
 			tokenInMaxAmount: priceImpactThreshold.Sub(osmomath.OneInt()),
@@ -2391,7 +2393,7 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 					TokenOutAmount: defaultSingleRouteTwoHops.TokenOutAmount.MulRaw(3),
 				},
 			},
-			tokenOutDenom:    foo,
+			tokenOutDenom:    FOO,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			expectError: types.ErrDuplicateRoutesNotAllowed,
@@ -2403,13 +2405,13 @@ func (s *KeeperTestSuite) TestSplitRouteExactAmountOut() {
 					Pools: []types.SwapAmountOutRoute{
 						{
 							PoolId:       uint64(len(defaultValidPools) + 1),
-							TokenInDenom: foo,
+							TokenInDenom: FOO,
 						},
 					},
 					TokenOutAmount: twentyFiveBaseUnitsAmount,
 				},
 			},
-			tokenOutDenom:    foo,
+			tokenOutDenom:    FOO,
 			tokenInMaxAmount: poolmanager.IntMaxValue,
 
 			expectError: types.FailedToFindRouteError{PoolId: uint64(len(defaultValidPools) + 1)},
@@ -2586,12 +2588,12 @@ func (suite *KeeperTestSuite) TestCreateMultihopExpectedSwapOuts() {
 			route: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 			},
-			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(100)), sdk.NewCoin(bar, osmomath.NewInt(100)))},
+			poolCoins: []sdk.Coins{sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(100)), sdk.NewCoin(BAR, osmomath.NewInt(100)))},
 
-			tokenOut: sdk.NewCoin(foo, osmomath.NewInt(10)),
+			tokenOut: sdk.NewCoin(FOO, osmomath.NewInt(10)),
 			// expectedSwapIns = (tokenOut * (poolTokenOutBalance / poolPostSwapOutBalance)).ceil()
 			// foo token = 10 * (100 / 90) ~ 12
 			expectedSwapIns: []osmomath.Int{osmomath.NewInt(12)},
@@ -2600,19 +2602,19 @@ func (suite *KeeperTestSuite) TestCreateMultihopExpectedSwapOuts() {
 			route: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 				{
 					PoolId:       2,
-					TokenInDenom: bar,
+					TokenInDenom: BAR,
 				},
 			},
 
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(100)), sdk.NewCoin(bar, osmomath.NewInt(100))), // pool 1.
-				sdk.NewCoins(sdk.NewCoin(bar, osmomath.NewInt(100)), sdk.NewCoin(baz, osmomath.NewInt(100))), // pool 2.
+				sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(100)), sdk.NewCoin(BAR, osmomath.NewInt(100))), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(BAR, osmomath.NewInt(100)), sdk.NewCoin(BAZ, osmomath.NewInt(100))), // pool 2.
 			},
-			tokenOut: sdk.NewCoin(baz, osmomath.NewInt(10)),
+			tokenOut: sdk.NewCoin(BAZ, osmomath.NewInt(10)),
 			// expectedSwapIns = (tokenOut * (poolTokenOutBalance / poolPostSwapOutBalance)).ceil()
 			// foo token = 10 * (100 / 90) ~ 12
 			// bar token = 12 * (100 / 88) ~ 14
@@ -2622,27 +2624,27 @@ func (suite *KeeperTestSuite) TestCreateMultihopExpectedSwapOuts() {
 			route: []types.SwapAmountOutRoute{
 				{
 					PoolId:       100,
-					TokenInDenom: foo,
+					TokenInDenom: FOO,
 				},
 			},
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(100)), sdk.NewCoin(bar, osmomath.NewInt(100))), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(100)), sdk.NewCoin(BAR, osmomath.NewInt(100))), // pool 1.
 			},
-			tokenOut:      sdk.NewCoin(baz, osmomath.NewInt(10)),
+			tokenOut:      sdk.NewCoin(BAZ, osmomath.NewInt(10)),
 			expectedError: true,
 		},
 		"error: calculating in given out": {
 			route: []types.SwapAmountOutRoute{
 				{
 					PoolId:       1,
-					TokenInDenom: uosmo,
+					TokenInDenom: UOSMO,
 				},
 			},
 
 			poolCoins: []sdk.Coins{
-				sdk.NewCoins(sdk.NewCoin(foo, osmomath.NewInt(100)), sdk.NewCoin(bar, osmomath.NewInt(100))), // pool 1.
+				sdk.NewCoins(sdk.NewCoin(FOO, osmomath.NewInt(100)), sdk.NewCoin(BAR, osmomath.NewInt(100))), // pool 1.
 			},
-			tokenOut:        sdk.NewCoin(baz, osmomath.NewInt(10)),
+			tokenOut:        sdk.NewCoin(BAZ, osmomath.NewInt(10)),
 			expectedSwapIns: []osmomath.Int{},
 
 			expectedError: true,
@@ -2683,8 +2685,8 @@ func (s *KeeperTestSuite) runMultipleTrackVolumes(poolId uint64, volume sdk.Coin
 // 4. Assert correct amount was added to pool volume
 func (s *KeeperTestSuite) TestTrackVolume() {
 	hundred := osmomath.NewInt(100)
-	hundredFoo := sdk.NewCoin(foo, hundred)
-	hundredUosmo := sdk.NewCoin(uosmo, hundred)
+	hundredFoo := sdk.NewCoin(FOO, hundred)
+	hundredUosmo := sdk.NewCoin(UOSMO, hundred)
 	oneRun := int64(1)
 	threeRuns := int64(3)
 
@@ -2729,8 +2731,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Balancer,
 			// 100 foo corresponds to 1000 osmo (spot price = 10)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(1000)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(1000)),
 			),
 
 			expectedVolume: osmomath.NewInt(10).Mul(hundred).MulRaw(oneRun),
@@ -2741,8 +2743,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Balancer,
 			// 100 foo corresponds to 10 osmo (spot price = 0.1)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(10)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(10)),
 			),
 
 			expectedVolume: hundred.MulRaw(oneRun).Quo(osmomath.NewInt(10)),
@@ -2753,8 +2755,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Balancer,
 			// 100 foo corresponds to 1000 osmo (spot price = 10)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(1000)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(1000)),
 			),
 
 			expectedVolume: osmomath.NewInt(10).Mul(hundred).MulRaw(threeRuns),
@@ -2765,8 +2767,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Balancer,
 			// 100 foo corresponds to 10 osmo (spot price = 0.1)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(10)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(10)),
 			),
 
 			expectedVolume: hundred.MulRaw(threeRuns).Quo(osmomath.NewInt(10)),
@@ -2789,8 +2791,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Concentrated,
 			// 100 foo corresponds to 1000 osmo (spot price = 10)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(1000)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(1000)),
 			),
 
 			expectedVolume: osmomath.NewInt(10).Mul(hundred).MulRaw(oneRun),
@@ -2801,8 +2803,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Concentrated,
 			// 100 foo corresponds to 10 osmo (spot price = 0.1)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(10)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(10)),
 			),
 
 			expectedVolume: hundred.MulRaw(oneRun).Quo(osmomath.NewInt(10)),
@@ -2813,8 +2815,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Concentrated,
 			// 100 foo corresponds to 1000 osmo (spot price = 10)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(1000)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(1000)),
 			),
 
 			expectedVolume: osmomath.NewInt(10).Mul(hundred).MulRaw(threeRuns),
@@ -2825,8 +2827,8 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			osmoPairedPoolType: types.Concentrated,
 			// 100 foo corresponds to 10 osmo (spot price = 0.1)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(10)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(10)),
 			),
 
 			expectedVolume: hundred.MulRaw(threeRuns).Quo(osmomath.NewInt(10)),
@@ -2847,7 +2849,7 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 		// --- Edge cases ---
 
 		"OSMO denominated volume, no volume added": {
-			generatedVolume:     sdk.NewCoin(uosmo, osmomath.NewInt(0)),
+			generatedVolume:     sdk.NewCoin(UOSMO, osmomath.NewInt(0)),
 			timesRun:            oneRun,
 			osmoPairedPoolType:  types.Balancer,
 			osmoPairedPoolCoins: fooUosmoCoins,
@@ -2855,7 +2857,7 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			expectedVolume: osmomath.NewInt(0),
 		},
 		"Non-OSMO volume priced with balancer pool, no volume added": {
-			generatedVolume:     sdk.NewCoin(foo, osmomath.NewInt(0)),
+			generatedVolume:     sdk.NewCoin(FOO, osmomath.NewInt(0)),
 			timesRun:            oneRun,
 			osmoPairedPoolType:  types.Balancer,
 			osmoPairedPoolCoins: fooUosmoCoins,
@@ -2863,13 +2865,13 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			expectedVolume: osmomath.NewInt(0),
 		},
 		"Added volume truncated to zero (no volume added)": {
-			generatedVolume:    sdk.NewCoin(foo, osmomath.NewInt(1)),
+			generatedVolume:    sdk.NewCoin(FOO, osmomath.NewInt(1)),
 			timesRun:           oneRun,
 			osmoPairedPoolType: types.Balancer,
 			// 100 foo corresponds to 10 osmo (spot price = 0.1)
 			osmoPairedPoolCoins: sdk.NewCoins(
-				sdk.NewCoin(foo, osmomath.NewInt(100)),
-				sdk.NewCoin(uosmo, osmomath.NewInt(10)),
+				sdk.NewCoin(FOO, osmomath.NewInt(100)),
+				sdk.NewCoin(UOSMO, osmomath.NewInt(10)),
 			),
 
 			expectedVolume: osmomath.NewInt(0),
@@ -2897,7 +2899,7 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			// If applicable, create an OSMO-paired pool and set it in protorev
 			if tc.osmoPairedPoolCoins != nil {
 				osmoPairedPoolId := s.CreatePoolFromTypeWithCoins(tc.osmoPairedPoolType, tc.osmoPairedPoolCoins)
-				s.App.ProtoRevKeeper.SetPoolForDenomPair(s.Ctx, uosmo, foo, osmoPairedPoolId)
+				s.App.ProtoRevKeeper.SetPoolForDenomPair(s.Ctx, UOSMO, FOO, osmoPairedPoolId)
 			}
 
 			// --- System under test ---
@@ -2913,7 +2915,7 @@ func (s *KeeperTestSuite) TestTrackVolume() {
 			//
 			// We wrap with sdk.NewCoins() to sanitize the outputs for comparison in case they are empty.
 			totalVolume := s.App.PoolManagerKeeper.GetTotalVolumeForPool(s.Ctx, targetPoolId)
-			s.Require().Equal(sdk.NewCoins(sdk.NewCoin(uosmo, tc.expectedVolume)), sdk.NewCoins(totalVolume...))
+			s.Require().Equal(sdk.NewCoins(sdk.NewCoin(UOSMO, tc.expectedVolume)), sdk.NewCoins(totalVolume...))
 		})
 	}
 }
@@ -2930,7 +2932,7 @@ func (s *KeeperTestSuite) TestTakerFee() {
 				Pools: []types.SwapAmountInRoute{
 					{
 						PoolId:        fooUosmoPoolId,
-						TokenOutDenom: foo,
+						TokenOutDenom: FOO,
 					},
 				},
 				TokenInAmount: twentyFiveBaseUnitsAmount,
@@ -2941,7 +2943,7 @@ func (s *KeeperTestSuite) TestTakerFee() {
 				Pools: []types.SwapAmountInRoute{
 					{
 						PoolId:        fooBarPoolId,
-						TokenOutDenom: bar,
+						TokenOutDenom: BAR,
 					},
 				},
 				TokenInAmount: twentyFiveBaseUnitsAmount,
@@ -2952,7 +2954,7 @@ func (s *KeeperTestSuite) TestTakerFee() {
 				Pools: []types.SwapAmountInRoute{
 					{
 						PoolId:        fooAbcPoolId,
-						TokenOutDenom: foo,
+						TokenOutDenom: FOO,
 					},
 				},
 				TokenInAmount: twentyFiveBaseUnitsAmount,
@@ -2979,33 +2981,33 @@ func (s *KeeperTestSuite) TestTakerFee() {
 	}{
 		"native denom taker fee": {
 			routes:            quoteNativeDenomRoute,
-			tokenInDenom:      uosmo,
+			tokenInDenom:      UOSMO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			expectedTokenOutEstimate: twentyFiveBaseUnitsAmount,
 			expectedTakerFees: expectedTakerFees{
 				communityPoolQuoteAssets:    sdk.NewCoins(),
 				communityPoolNonQuoteAssets: sdk.NewCoins(),
-				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(uosmo, totalExpectedTakerFee.Mul(osmoTakerFeeDistr.StakingRewards).TruncateInt())),
+				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(UOSMO, totalExpectedTakerFee.Mul(osmoTakerFeeDistr.StakingRewards).TruncateInt())),
 			},
 			// full native denom set in the main fee collector addr
-			expectedStakingRewardFeeCollectorMainBalanceDelta: sdk.NewCoins(sdk.NewCoin(uosmo, totalExpectedTakerFee.Mul(osmoTakerFeeDistr.StakingRewards).TruncateInt())),
+			expectedStakingRewardFeeCollectorMainBalanceDelta: sdk.NewCoins(sdk.NewCoin(UOSMO, totalExpectedTakerFee.Mul(osmoTakerFeeDistr.StakingRewards).TruncateInt())),
 		},
 		"quote denom taker fee": {
 			routes:            quoteQuoteDenomRoute,
-			tokenInDenom:      foo,
+			tokenInDenom:      FOO,
 			tokenOutMinAmount: osmomath.OneInt(),
 
 			expectedTokenOutEstimate: twentyFiveBaseUnitsAmount,
 			expectedTakerFees: expectedTakerFees{
-				communityPoolQuoteAssets:    sdk.NewCoins(sdk.NewCoin(foo, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.CommunityPool).TruncateInt())),
+				communityPoolQuoteAssets:    sdk.NewCoins(sdk.NewCoin(FOO, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.CommunityPool).TruncateInt())),
 				communityPoolNonQuoteAssets: sdk.NewCoins(),
-				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(foo, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).TruncateInt())),
+				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(FOO, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).TruncateInt())),
 			},
 			// since foo is whitelisted token, it is sent directly to community pool
-			expectedCommunityPoolBalancesDelta: sdk.NewCoins(sdk.NewCoin(foo, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.CommunityPool).TruncateInt())),
+			expectedCommunityPoolBalancesDelta: sdk.NewCoins(sdk.NewCoin(FOO, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.CommunityPool).TruncateInt())),
 			// foo swapped for uosmo, uosmo sent to main fee collector, 1 uosmo diff due to slippage from swap
-			expectedStakingRewardFeeCollectorMainBalanceDelta: sdk.NewCoins(sdk.NewCoin(uosmo, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).Sub(osmomath.OneDec()).TruncateInt())),
+			expectedStakingRewardFeeCollectorMainBalanceDelta: sdk.NewCoins(sdk.NewCoin(UOSMO, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).Sub(osmomath.OneDec()).TruncateInt())),
 		},
 		"non quote denom taker fee": {
 			routes:            quoteNonquoteDenomRoute,
@@ -3019,9 +3021,9 @@ func (s *KeeperTestSuite) TestTakerFee() {
 				stakingRewardAssets:         sdk.NewCoins(sdk.NewCoin(abc, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).TruncateInt())),
 			},
 			// since abc is not whitelisted token, it gets swapped for `CommunityPoolDenomToSwapNonWhitelistedAssetsTo`, which is set to baz, 1 baz diff due to slippage from swap
-			expectedCommunityPoolBalancesDelta: sdk.NewCoins(sdk.NewCoin(baz, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.CommunityPool).Sub(osmomath.OneDec()).TruncateInt())),
+			expectedCommunityPoolBalancesDelta: sdk.NewCoins(sdk.NewCoin(BAZ, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.CommunityPool).Sub(osmomath.OneDec()).TruncateInt())),
 			// abc swapped for uosmo, uosmo sent to main fee collector, 1 uosmo diff due to slippage from swap
-			expectedStakingRewardFeeCollectorMainBalanceDelta: sdk.NewCoins(sdk.NewCoin(uosmo, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).Sub(osmomath.OneDec()).TruncateInt())),
+			expectedStakingRewardFeeCollectorMainBalanceDelta: sdk.NewCoins(sdk.NewCoin(UOSMO, totalExpectedTakerFee.Mul(nonOsmoTakerFeeDistr.StakingRewards).Sub(osmomath.OneDec()).TruncateInt())),
 		},
 	}
 
@@ -3116,4 +3118,54 @@ func (s *KeeperTestSuite) TestTakerFee() {
 			s.Require().Equal(tc.expectedStakingRewardFeeCollectorTxfeesBalanceDelta, stakingRewardFeeCollectorTxfeesBalanceDelta) // should always be empty after hook if all routes exist
 		})
 	}
+}
+
+// This test validates that SwapExactAmountIn tracks volume correctly.
+// It is a simple check to make sure that trackVolume() is called.
+func (s *KeeperTestSuite) TestSwapExactAmountIn_VolumeTracked() {
+	const withTakerFee = false
+
+	s.Run("with taker fee", func() {
+		s.testSwapExactAmpountInVolumeTracked(withTakerFee)
+	})
+
+	s.Run("without taker fee", func() {
+		s.testSwapExactAmpountInVolumeTracked(!withTakerFee)
+	})
+}
+
+// test for ensuring that volume is tracked by variants of swap exact amount in
+func (s *KeeperTestSuite) testSwapExactAmpountInVolumeTracked(noTakerFeeVariant bool) {
+	s.SetupTest()
+
+	// Set UOSMO as bond denom
+
+	stakingParams := s.App.StakingKeeper.GetParams(s.Ctx)
+	stakingParams.BondDenom = UOSMO
+	s.App.StakingKeeper.SetParams(s.Ctx, stakingParams)
+
+	// Prepare pool with liquidity
+	concentratedPool := s.PrepareCustomConcentratedPool(s.TestAccs[0], UOSMO, FOO, 1, sdk.ZeroDec())
+	s.CreateFullRangePosition(concentratedPool, sdk.NewCoins(sdk.NewCoin(UOSMO, osmomath.NewInt(1_000_000_000)), sdk.NewCoin(FOO, osmomath.NewInt(5_000_000_000))))
+
+	// Validate that volume is zero
+	totalVolume := s.App.PoolManagerKeeper.GetTotalVolumeForPool(s.Ctx, concentratedPool.GetId())
+	s.Require().Equal(emptyCoins.String(), totalVolume.String())
+
+	// Fund sender
+	tokenIn := sdk.NewCoin(UOSMO, sdk.NewInt(1000))
+	s.FundAcc(s.TestAccs[0], sdk.NewCoins(tokenIn))
+
+	// System under test
+	if noTakerFeeVariant {
+		_, err := s.App.PoolManagerKeeper.SwapExactAmountInNoTakerFee(s.Ctx, s.TestAccs[0], concentratedPool.GetId(), tokenIn, FOO, sdk.ZeroInt())
+		s.Require().NoError(err)
+	} else {
+		_, err := s.App.PoolManagerKeeper.SwapExactAmountIn(s.Ctx, s.TestAccs[0], concentratedPool.GetId(), tokenIn, FOO, sdk.ZeroInt())
+		s.Require().NoError(err)
+	}
+
+	// Validate that volume was updated
+	totalVolume = s.App.PoolManagerKeeper.GetTotalVolumeForPool(s.Ctx, concentratedPool.GetId())
+	s.Require().Equal(tokenIn.String(), totalVolume.String())
 }

--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -111,8 +111,8 @@ func (k Keeper) swapNonNativeFeeToDenom(ctx sdk.Context, denomToSwapTo string, f
 			// However the idea of the txfees FeeToken gating is that the pool is sufficiently liquid for that base token.
 			minAmountOut := osmomath.ZeroInt()
 
-			// Note that we swap without charging a taker fee / sending to the non native fee collector, since these are funds that
-			// are accruing from the taker fee itself. Poolmanager does not apply the taker fee for the fee collector.
+			// We swap without charging a taker fee / sending to the non native fee collector, since these are funds that
+			// are accruing from the taker fee itself.
 			_, err := k.poolManager.SwapExactAmountIn(cacheCtx, feeCollectorAddress, poolId, coin, denomToSwapTo, minAmountOut)
 			return err
 		})

--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -111,9 +111,9 @@ func (k Keeper) swapNonNativeFeeToDenom(ctx sdk.Context, denomToSwapTo string, f
 			// However the idea of the txfees FeeToken gating is that the pool is sufficiently liquid for that base token.
 			minAmountOut := osmomath.ZeroInt()
 
-			// We swap without charging a taker fee / sending to the non native fee collector, since these are funds that
-			// are accruing from the taker fee itself.
-			_, err := k.poolManager.SwapExactAmountInNoTakerFee(cacheCtx, feeCollectorAddress, poolId, coin, denomToSwapTo, minAmountOut)
+			// Note that we swap without charging a taker fee / sending to the non native fee collector, since these are funds that
+			// are accruing from the taker fee itself. Poolmanager does not apply the taker fee for the fee collector.
+			_, err := k.poolManager.SwapExactAmountIn(cacheCtx, feeCollectorAddress, poolId, coin, denomToSwapTo, minAmountOut)
 			return err
 		})
 	}

--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -113,7 +113,7 @@ func (k Keeper) swapNonNativeFeeToDenom(ctx sdk.Context, denomToSwapTo string, f
 
 			// We swap without charging a taker fee / sending to the non native fee collector, since these are funds that
 			// are accruing from the taker fee itself.
-			_, err := k.poolManager.SwapExactAmountIn(cacheCtx, feeCollectorAddress, poolId, coin, denomToSwapTo, minAmountOut)
+			_, err := k.poolManager.SwapExactAmountInNoTakerFee(cacheCtx, feeCollectorAddress, poolId, coin, denomToSwapTo, minAmountOut)
 			return err
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6573

## What is the purpose of the change

We have several swap helpers. As a result, we missed adding call to `trackVolume` to some of them.

This PR adds the check to `SwapExactAmountIn` and `SwapExactAmountInNoTakerFee`. It tests them both.
For the future, I propose we remove `SwapExactAmountInNoTakerFee` and instead create a whitelist for no fee payers: https://github.com/osmosis-labs/osmosis/issues/6572

In the current PR, I also made `RouteExactAmountIn` call `SwapExactAmountIn` to reduce code duplication.

Having low-level swap logic such as tracking volume and charging taker fees be called in `SwapExactAmountIn` and all other methods call it reduces the changes of missing adding new logic in the future.

## Testing and Verifying

- Added tests that `SwapExactAmountIn` and `SwapExactAmountInNoTakerFee` track volume

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A