### PR TITLE
Make goreleaser-cross the default way to build binaries with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,4 +681,4 @@ goreleaser-build: go.sum
 	test test-all test-build test-cover test-unit test-race benchmark \
 	release release-dry-run release-snapshot \
 	goreleaser-build goreleaser-build-linux-arm64 goreleaser-build-linux-amd64 \
-	goreleaser-build-linux-arm64 goreleaser-build-linux-arm64
+	goreleaser-build-darwin-arm64 goreleaser-build-darwin-arm64


### PR DESCRIPTION
## What is the purpose of the change

This PR refactors the "docker" build process of the Makefile deprecating old build targets, and introducing new ones that leverage goreleaser for building binaries.

### Changes

- Deprecated `build-reproducible`, `build-reproducible-amd64`, and `build-reproducible-arm64` targets. Now, a deprecation message will be displayed when these targets are used.
- Added new targets `goreleaser-build-darwin-amd64`, `goreleaser-build-darwin-arm64`, `goreleaser-build-linux-amd64`, and `goreleaser-build-linux-arm64`. These targets use GoReleaser to build the binaries for specific OS/architecture combinations.
- Introduced a `goreleaser-build` target that builds a binary for the user's current architecture.

## Testing and Verifying

1. Pull the changes from this PR.
2. Run `make goreleaser-build` to build a binary for your current architecture.
3. Run `make goreleaser-build-darwin-amd64` or any of the new targets to build for a specific OS/architecture.
4. Try running one of the deprecated targets to see the deprecation message.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A