### PR TITLE
v19.2.0 chores

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -2,16 +2,17 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v19.1.0",
+    "recommended_version": "v19.2.0",
     "compatible_versions": [
+      "v19.2.0",
       "v19.1.0",
       "v19.0.0"
     ],
     "binaries": {
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-amd64?checksum=sha256:723ff1c5349eb3c039c3dc5f55895bbde2e1499fe7c0a96960cc6fadeec814c4",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-arm64?checksum=sha256:d933b893d537422164a25bf161d7f269a59ea26d37f398cdb7dd575a9ec33ed2"
     },
-    "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230913192254-a2075590d5a3",
+    "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230927020814-2854ac001f06",
     "consensus": {
       "type": "tendermint",
       "version": "informalsystems/tendermint@0.34.24"
@@ -228,14 +229,15 @@
       },
       {
         "name": "v19",
-        "tag": "v19.1.0",
+        "tag": "v19.2.0",
         "height": 11317300,
-        "recommended_version": "v19.1.0",
+        "recommended_version": "v19.2.0",
         "compatible_versions": [
+          "v19.2.0",
           "v19.1.0",
           "v19.0.0"
         ],
-        "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230913192254-a2075590d5a3",
+        "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230927020814-2854ac001f06",
         "consensus": {
           "type": "tendermint",
           "version": "informalsystems/tendermint@0.34.24"
@@ -247,8 +249,8 @@
           "ics20-1"
         ],
         "binaries": {
-          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
-          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
+          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-amd64?checksum=sha256:723ff1c5349eb3c039c3dc5f55895bbde2e1499fe7c0a96960cc6fadeec814c4",
+          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-arm64?checksum=sha256:d933b893d537422164a25bf161d7f269a59ea26d37f398cdb7dd575a9ec33ed2"
         }
       }
     ]

--- a/networks/osmosis-1/README.md
+++ b/networks/osmosis-1/README.md
@@ -19,7 +19,7 @@ Each version is identified by a specific id, name, tag, block height and softwar
 | `v16` | Magnesium | `v16.1.1` | 10517000       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v16.1.1/) | [556](https://www.mintscan.io/osmosis/proposals/556) |
 | `v17` | Aluminium | `v17.0.0` | 11126100       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v17.0.0/) | [586](https://www.mintscan.io/osmosis/proposals/586) |
 | `v18` |   | `v18.0.0` | 11155350       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v18.0.0/) | [588](https://www.mintscan.io/osmosis/proposals/588) |
-| `v19` |   | `v19.1.0` | 11317300       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v19.1.0/) | [606](https://www.mintscan.io/osmosis/proposals/606) |
+| `v19` |   | `v19.2.0` | 11317300       | [Release](https://github.com/osmosis-labs/osmosis/releases/tag/v19.2.0/) | [606](https://www.mintscan.io/osmosis/proposals/606) |
 ## Upgrade binaries
 
 ### v3.1.0
@@ -164,13 +164,13 @@ Each version is identified by a specific id, name, tag, block height and softwar
 }
 ```
 
-### v19.1.0
+### v19.2.0
 
 ```json
 {
   "binaries": {
-    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
-    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
+    "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-amd64?checksum=sha256:723ff1c5349eb3c039c3dc5f55895bbde2e1499fe7c0a96960cc6fadeec814c4",
+    "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-arm64?checksum=sha256:d933b893d537422164a25bf161d7f269a59ea26d37f398cdb7dd575a9ec33ed2"
   }
 }
 ```
@@ -261,7 +261,7 @@ versions_info=(
     "v16:https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:f838618633c1d42f593dc33d26b25842f5900961e987fc08570bb81a062e311d"
     "v17:https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-amd64?checksum=sha256:d7fe62ae33cf2f0b48a17eb8b02644dadd9924f15861ed622cd90cb1a038135b"
     "v18:https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:d83b4122e3ff9c428c8d6dcfe89718f5229f80e9976dbab2deefeb68dceb0f38"
-    "v19:https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
+    "v19:https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-arm64?checksum=sha256:d933b893d537422164a25bf161d7f269a59ea26d37f398cdb7dd575a9ec33ed2"
 )
 
 # Create the cosmovisor directory

--- a/networks/osmosis-1/upgrades/v19/mainnet/guide.md
+++ b/networks/osmosis-1/upgrades/v19/mainnet/guide.md
@@ -82,7 +82,7 @@ source ~/.profile
 mkdir -p ~/.osmosisd/cosmovisor/upgrades/v19/bin
 cd $HOME/osmosis
 git pull
-git checkout v19.1.0
+git checkout v19.2.0
 make build
 cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/v19/bin
 ```
@@ -102,7 +102,7 @@ Follow these steps if you opt for a manual upgrade:
 ```sh
 cd $HOME/osmosis
 git pull
-git checkout v19.1.0
+git checkout v19.2.0
 make install
 ```
 

--- a/networks/osmosis-1/upgrades/v19/v19_binaries.json
+++ b/networks/osmosis-1/upgrades/v19/v19_binaries.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-arm64?checksum=sha256:b08fda8bcb6f3b46ffce15b1022b38bc4d01ebb7f7c4d39061d4c084ffbc576c",
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.1.0/osmosisd-19.1.0-linux-amd64?checksum=sha256:c170e0c4caf2a5170bcdc34689a0eabb99b1e7d6544b6f3ee3e0753bf96de0ef"
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-amd64?checksum=sha256:723ff1c5349eb3c039c3dc5f55895bbde2e1499fe7c0a96960cc6fadeec814c4",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-arm64?checksum=sha256:d933b893d537422164a25bf161d7f269a59ea26d37f398cdb7dd575a9ec33ed2"
     }
 }

--- a/scripts/release/create_binaries_json/create_all_binaries_json.sh
+++ b/scripts/release/create_binaries_json/create_all_binaries_json.sh
@@ -14,7 +14,7 @@ tags=(
     "v16.1.1"
     "v17.0.0"
     "v18.0.0"
-    "v19.1.0"
+    "v19.2.0"
 )
 
 echo "## Upgrade binaries"


### PR DESCRIPTION
## What is the purpose of the change

This PR:

- Updates the chain registry schema with latest `19.2.0` minor release 
- Updates cosmovisor binaries to use `19.2.0`
- Updates network upgrade docs to use `19.2.0`

## Testing and Verifying

Trivial/Docs changes.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A