### PR TITLE
[Volume Splitting] refactor: sync weights on group creation

### DIFF
--- a/x/incentives/keeper/genesis_test.go
+++ b/x/incentives/keeper/genesis_test.go
@@ -236,7 +236,15 @@ func createAllGaugeTypes(t *testing.T, app *osmoapp.OsmosisApp, ctx sdk.Context,
 	require.NoError(t, err)
 
 	// create a group which in turn creates a byGroup gauge
-	_, err = app.IncentivesKeeper.CreateGroup(ctx, sdk.Coins{}, 0, addr, []uint64{1, 2})
+	// we must set volume for each of the pools in the group
+	// so that the group gauge can be created.
+	bondDenom := app.StakingKeeper.GetParams(ctx).BondDenom
+	volumeCoins := sdk.NewCoins(sdk.NewInt64Coin(bondDenom, 100000000000))
+	groupPoolIDs := []uint64{1, 2}
+	for _, poolID := range groupPoolIDs {
+		app.PoolManagerKeeper.SetVolume(ctx, poolID, volumeCoins)
+	}
+	_, err = app.IncentivesKeeper.CreateGroup(ctx, sdk.Coins{}, 0, addr, groupPoolIDs)
 	require.NoError(t, err)
 }
 

--- a/x/pool-incentives/keeper/distr_test.go
+++ b/x/pool-incentives/keeper/distr_test.go
@@ -143,14 +143,21 @@ func (s *KeeperTestSuite) TestAllocateAsset_GroupGauge() {
 	s.Setup()
 	poolInfo := s.PrepareAllSupportedPools()
 
+	poolIDs := []uint64{poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID, poolInfo.StableSwapPoolID}
+
 	// Fund fee and initial coins for each group.
 	groupCreationFee := s.App.IncentivesKeeper.GetParams(s.Ctx).GroupCreationFee
 	s.FundAcc(s.TestAccs[1], groupCreationFee.Add(groupCreationFee...).Add(defaultCoins...).Add(defaultCoins...))
 
-	groupGaugeIDOne, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, 0, s.TestAccs[1], []uint64{poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID, poolInfo.StableSwapPoolID})
+	// Setup initial volume for each pool.
+	for _, poolID := range poolIDs {
+		s.App.PoolManagerKeeper.SetVolume(s.Ctx, poolID, defaultCoins)
+	}
+
+	groupGaugeIDOne, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, 0, s.TestAccs[1], poolIDs)
 	s.Require().NoError(err)
 
-	groupGaugeIDTwo, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, 0, s.TestAccs[1], []uint64{poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID, poolInfo.StableSwapPoolID})
+	groupGaugeIDTwo, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, 0, s.TestAccs[1], poolIDs)
 	s.Require().NoError(err)
 
 	err = s.App.PoolIncentivesKeeper.ReplaceDistrRecords(s.Ctx, types.DistrRecord{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6581

## What is the purpose of the change

See #6581 for details.

We would like to sync weights on group creation to make sure that the given pools are valid and have the volume

Updated tests, including an additional test case where CreateGroup fails due to lack of volume in one of the pools.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A