### PR TITLE
fix: test failure on main stemming from group test

### DIFF
--- a/x/incentives/keeper/msg_server_test.go
+++ b/x/incentives/keeper/msg_server_test.go
@@ -326,14 +326,20 @@ func (s *KeeperTestSuite) TestCreateGroup_Fee() {
 			testAccountAddress = accountKeeper.GetModuleAddress(types.ModuleName)
 		}
 
-		s.PrepareAllSupportedPools()
+		poolInfo := s.PrepareAllSupportedPools()
+
+		poolIDs := []uint64{poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID, poolInfo.StableSwapPoolID}
 
 		msg := &types.MsgCreateGroup{
 			Coins:             tc.groupFunds,
 			NumEpochsPaidOver: tc.numEpochsPaidOver,
 			Owner:             testAccountAddress.String(),
-			PoolIds:           []uint64{1, 2, 3},
+			PoolIds:           poolIDs,
 		}
+
+		// setup volume so that the pool can be created
+		s.overwriteVolumes(poolIDs, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount, defaultVolumeAmount})
+
 		// System under test.
 		_, err := msgServer.CreateGroup(sdk.WrapSDKContext(ctx), msg)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The test failure was not caught by CI in PR due to being added by a concurrent PR. This fixes CI on main
