### PR TITLE
[VS Incentives]: remaining after epoch group test vectors

### DIFF
--- a/app/apptesting/concentrated_liquidity.go
+++ b/app/apptesting/concentrated_liquidity.go
@@ -85,7 +85,7 @@ func (s *KeeperTestHelper) PrepareConcentratedPoolWithCoinsAndLockedFullRangePos
 // PrepareCustomConcentratedPool sets up a concentrated liquidity pool with the custom parameters.
 func (s *KeeperTestHelper) PrepareCustomConcentratedPool(owner sdk.AccAddress, denom0, denom1 string, tickSpacing uint64, spreadFactor osmomath.Dec) types.ConcentratedPoolExtension {
 	// Mint some assets to the account.
-	s.FundAcc(s.TestAccs[0], DefaultAcctFunds)
+	s.FundAcc(s.TestAccs[0], s.App.PoolManagerKeeper.GetParams(s.Ctx).PoolCreationFee)
 
 	// Create a concentrated pool via the poolmanager
 	poolID, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(owner, denom0, denom1, tickSpacing, spreadFactor))
@@ -101,6 +101,27 @@ func (s *KeeperTestHelper) PrepareCustomConcentratedPool(owner sdk.AccAddress, d
 
 	return pool
 }
+
+// // PrepareCustomConcentratedPool sets up a concentrated liquidity pool with the custom parameters.
+// func (s *KeeperTestHelper) PrepareCustomConcentratedPoolWithCoins(owner sdk.AccAddress, coins sdk.Coins, tickSpacing uint64, spreadFactor osmomath.Dec) types.ConcentratedPoolExtension {
+// 	// Mint some assets to the account.
+// 	s.FundAcc(s.TestAccs[0], s.App.PoolManagerKeeper.GetParams(s.Ctx).PoolCreationFee)
+// 	s.FundAcc(s.TestAccs[0], sdk.NewCoins(sdk.NewCoin(denom0, DefaultCoinAmount), sdk.NewCoin(denom1, DefaultCoinAmount)))
+
+// 	// Create a concentrated pool via the poolmanager
+// 	poolID, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(owner, denom0, denom1, tickSpacing, spreadFactor))
+// 	s.Require().NoError(err)
+
+// 	// Retrieve the poolInterface via the poolID
+// 	poolI, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
+// 	s.Require().NoError(err)
+
+// 	// Type cast the PoolInterface to a ConcentratedPoolExtension
+// 	pool, ok := poolI.(types.ConcentratedPoolExtension)
+// 	s.Require().True(ok)
+
+// 	return pool
+// }
 
 // PrepareMultipleConcentratedPools returns X cl pool's with X being provided by the user.
 func (s *KeeperTestHelper) PrepareMultipleConcentratedPools(poolsToCreate uint16) []uint64 {

--- a/app/apptesting/concentrated_liquidity.go
+++ b/app/apptesting/concentrated_liquidity.go
@@ -102,27 +102,6 @@ func (s *KeeperTestHelper) PrepareCustomConcentratedPool(owner sdk.AccAddress, d
 	return pool
 }
 
-// // PrepareCustomConcentratedPool sets up a concentrated liquidity pool with the custom parameters.
-// func (s *KeeperTestHelper) PrepareCustomConcentratedPoolWithCoins(owner sdk.AccAddress, coins sdk.Coins, tickSpacing uint64, spreadFactor osmomath.Dec) types.ConcentratedPoolExtension {
-// 	// Mint some assets to the account.
-// 	s.FundAcc(s.TestAccs[0], s.App.PoolManagerKeeper.GetParams(s.Ctx).PoolCreationFee)
-// 	s.FundAcc(s.TestAccs[0], sdk.NewCoins(sdk.NewCoin(denom0, DefaultCoinAmount), sdk.NewCoin(denom1, DefaultCoinAmount)))
-
-// 	// Create a concentrated pool via the poolmanager
-// 	poolID, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, clmodel.NewMsgCreateConcentratedPool(owner, denom0, denom1, tickSpacing, spreadFactor))
-// 	s.Require().NoError(err)
-
-// 	// Retrieve the poolInterface via the poolID
-// 	poolI, err := s.App.ConcentratedLiquidityKeeper.GetPool(s.Ctx, poolID)
-// 	s.Require().NoError(err)
-
-// 	// Type cast the PoolInterface to a ConcentratedPoolExtension
-// 	pool, ok := poolI.(types.ConcentratedPoolExtension)
-// 	s.Require().True(ok)
-
-// 	return pool
-// }
-
 // PrepareMultipleConcentratedPools returns X cl pool's with X being provided by the user.
 func (s *KeeperTestHelper) PrepareMultipleConcentratedPools(poolsToCreate uint16) []uint64 {
 	var poolIds []uint64

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2018,9 +2018,11 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 		denom0           = pool.GetToken0()
 		denom1           = pool.GetToken1()
 		rewardsPerSecond = osmomath.NewDec(1000)
+		incentiveCoin    = sdk.NewCoin("uosmo", osmomath.NewInt(1_000_000))
 	)
 
-	_, err := s.clk.CreateIncentive(s.Ctx, poolId, s.TestAccs[0], sdk.NewCoin("uosmo", osmomath.NewInt(1_000_000)), rewardsPerSecond, s.Ctx.BlockTime(), time.Nanosecond)
+	s.FundAcc(s.TestAccs[0], sdk.NewCoins(incentiveCoin))
+	_, err := s.clk.CreateIncentive(s.Ctx, poolId, s.TestAccs[0], incentiveCoin, rewardsPerSecond, s.Ctx.BlockTime(), time.Nanosecond)
 	s.Require().NoError(err)
 
 	// Estimates how much to swap in to approximately reach the given tick

--- a/x/incentives/keeper/hooks_test.go
+++ b/x/incentives/keeper/hooks_test.go
@@ -385,7 +385,7 @@ func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_CreateGroupsBetween() {
 	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+2, s.TestAccs[0], poolIDsGroup)
 	s.Require().NoError(err)
 
-	// Setup uneven volumes with volumeA total amount
+	// Setup even volumes with volumeA total amount
 	equalPoolVolumes, volumeA := setupEqualVolumeWeights(len(poolIDsGroup), volumeA)
 	poolIDToVolumeMap := map[uint64]osmomath.Int{}
 	s.setupVolumeForPools(poolIDsGroup, equalPoolVolumes, poolIDToVolumeMap)

--- a/x/incentives/keeper/hooks_test.go
+++ b/x/incentives/keeper/hooks_test.go
@@ -10,10 +10,20 @@ import (
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/osmoutils/coins"
 	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
+	"github.com/osmosis-labs/osmosis/v19/app/apptesting"
+	"github.com/osmosis-labs/osmosis/v19/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v19/x/incentives/types"
 )
 
 var (
+	USDC  = apptesting.USDC
+	ETH   = apptesting.ETH
+	BAR   = apptesting.BAR
+	FOO   = apptesting.FOO
+	UOSMO = apptesting.UOSMO
+
+	defaultAmount = osmomath.NewInt(100_000_000_000)
+
 	// Test volume values
 	oneMillionVolumeAmt = osmomath.NewInt(1_000_000_000_000)
 	sub10KVolumeAmount  = osmomath.NewInt(9_876_543_21)
@@ -352,11 +362,154 @@ func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_ChangeVolumeBetween() {
 	s.validateDistributionForGroup(poolIDsGroup, poolIDToExpectedDistributionMap)
 }
 
-// TODO: create the following tests:
-// https://github.com/osmosis-labs/osmosis/issues/6559
-//
-// Test_AfterEpochEnd_Group_CreateGroupsBetween
-// Test_AfterEpochEnd_Group_SwapAndDistribute
+// This test focuses on a new group being added in-between epochs
+// The structure is:
+// Setup even volume across pools
+// Create Group that is non-perpetual over 2 epochs with 2x defaultCoins
+// Call after epoch hook
+// Update volume to increase but keep being even
+// Create Group that is perpetual and has 1x defaultCoins
+// Call after epoch hook
+// Validate that 3x defaultCoins distributed evenly across pools
+func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_CreateGroupsBetween() {
+	s.SetupTest()
+
+	var volumeA = oneMillionVolumeAmt
+
+	// Create set of pools with internal gauges and a group for them.
+	poolAndGaugeInfo := s.PrepareAllSupportedPools()
+	poolIDsGroup := []uint64{poolAndGaugeInfo.ConcentratedPoolID, poolAndGaugeInfo.StableSwapPoolID}
+	// setup initial volumes so that a Group can be created.
+	s.overwriteVolumes(poolIDsGroup, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount})
+	// Create non-perpetual group distribution over 2 epochs.
+	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+2, s.TestAccs[0], poolIDsGroup)
+	s.Require().NoError(err)
+
+	// Setup uneven volumes with volumeA total amount
+	equalPoolVolumes, volumeA := setupEqualVolumeWeights(len(poolIDsGroup), volumeA)
+	poolIDToVolumeMap := map[uint64]osmomath.Int{}
+	s.setupVolumeForPools(poolIDsGroup, equalPoolVolumes, poolIDToVolumeMap)
+
+	distrEpochIdentifier := s.App.IncentivesKeeper.GetParams(s.Ctx).DistrEpochIdentifier
+
+	// Estimate the expected distribution
+	poolIDToExpectedDistributionMap := s.computeExpectedDistributonAmountsFromVolume(defaultCoins, poolIDToVolumeMap, volumeA)
+
+	// System under test
+	err = s.App.IncentivesKeeper.AfterEpochEnd(s.Ctx, distrEpochIdentifier, 1)
+	s.Require().NoError(err)
+
+	s.validateDistributionForGroup(poolIDsGroup, poolIDToExpectedDistributionMap)
+
+	// Create perpetual group distributing to the same pool (for ease of setup)
+	_, err = s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, types.PerpetualNumEpochsPaidOver, s.TestAccs[0], poolIDsGroup)
+	s.Require().NoError(err)
+
+	s.increaseVolumeForPools(poolIDsGroup, equalPoolVolumes)
+
+	// Compute the expected
+	// Since we have a non-perpetual gauge with 2x defaultCoins and a perpetual gauge with 1x defaultCoins,
+	// The final total is 3x the expected for the non-perpetual gauge in the first epoch.
+	// Merge operations below essentially do the 3x multiplication.
+	expectedFinalCoinsDistributed := osmoutils.MergeCoinMaps(poolIDToExpectedDistributionMap, poolIDToExpectedDistributionMap)
+	expectedFinalCoinsDistributed = osmoutils.MergeCoinMaps(expectedFinalCoinsDistributed, poolIDToExpectedDistributionMap)
+
+	// System under test
+	err = s.App.IncentivesKeeper.AfterEpochEnd(s.Ctx, distrEpochIdentifier, 2)
+	s.Require().NoError(err)
+
+	// Group should distribute expected amounts.
+	s.validateDistributionForGroup(poolIDsGroup, expectedFinalCoinsDistributed)
+}
+
+// This test focuses on configuring volume by swapping instead of using
+// a direct volume setter helper in poolmanager contrary to all other tests.
+// Since we track volume in bond denom (OSMO), we first setup2 pools that are paired with the bond denom.
+// Next, we setup two pools that are to be packaged in group. One of the tokens in the pool is a token that is also
+// paired with bond denom in one of the first 2 pools.
+// Increase volume by swapping in the second pair of pools.
+// Create a group with the second pair of pools.
+// Increase volume by swapping in the second pair of pools.
+// Call AfterEpochEnd hook.
+// Validate that the distribution is correct.
+func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_SwapAndDistribute() {
+	// Setup UOSMO as bond denom
+	stakingParams := s.App.StakingKeeper.GetParams(s.Ctx)
+	stakingParams.BondDenom = UOSMO
+	s.App.StakingKeeper.SetParams(s.Ctx, stakingParams)
+
+	// Create UOSMO / USDC pool
+	s.PrepareCustomBalancerPool([]balancer.PoolAsset{
+		{Token: sdk.NewCoin(UOSMO, defaultAmount), Weight: sdk.OneInt()},
+		{Token: sdk.NewCoin(USDC, defaultAmount), Weight: sdk.OneInt()},
+	}, balancer.PoolParams{
+		SwapFee: osmomath.ZeroDec(),
+		ExitFee: osmomath.ZeroDec(),
+	})
+
+	// Create UOSMO / BAR pool
+	s.PrepareCustomBalancerPool([]balancer.PoolAsset{
+		{Token: sdk.NewCoin(UOSMO, defaultAmount), Weight: sdk.OneInt()},
+		{Token: sdk.NewCoin(BAR, defaultAmount), Weight: sdk.OneInt()},
+	}, balancer.PoolParams{
+		SwapFee: osmomath.ZeroDec(),
+		ExitFee: osmomath.ZeroDec(),
+	})
+
+	// Create two pools for group
+	// ETH / USDC
+	ethUSDCPool := s.PrepareConcentratedPoolWithCoinsAndFullRangePosition(ETH, USDC)
+	ethUSDCPoolID := ethUSDCPool.GetId()
+	// FOO / BAR
+	fooBARPool := s.PrepareConcentratedPoolWithCoinsAndFullRangePosition(FOO, BAR)
+	fooBARPoolID := fooBARPool.GetId()
+
+	// Swap USDC in to create volume in concentrated pool
+	// Since we set up 1:1 ratio in all pools, we expect volume to be equal to amount in (defaultAmount)
+	usdcCoinIn := sdk.NewCoin(USDC, defaultAmount)
+	s.increaseVolumeBySwap(ethUSDCPoolID, usdcCoinIn, defaultAmount, ETH)
+
+	// Swap BAR in to create volume in concentrated pool
+	barCoinIn := sdk.NewCoin(BAR, defaultAmount)
+	s.increaseVolumeBySwap(fooBARPoolID, barCoinIn, defaultAmount, FOO)
+
+	// Create a perpetual group.
+	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, types.PerpetualNumEpochsPaidOver, s.TestAccs[0], []uint64{ethUSDCPoolID, fooBARPoolID})
+	s.Require().NoError(err)
+
+	distrEpochIdentifier := s.App.IncentivesKeeper.GetParams(s.Ctx).DistrEpochIdentifier
+
+	// Increase volume since group creation
+	s.increaseVolumeBySwap(ethUSDCPoolID, usdcCoinIn, defaultAmount, ETH)
+	s.increaseVolumeBySwap(fooBARPoolID, barCoinIn, defaultAmount, FOO)
+
+	// System under test
+	err = s.App.IncentivesKeeper.AfterEpochEnd(s.Ctx, distrEpochIdentifier, 1)
+	s.Require().NoError(err)
+
+	// Since volume was equal, we expect equal split of incentives
+	// across pools.
+	halfDefaultCoins := coins.QuoRaw(defaultCoins, 2)
+	s.validateDistributionForGroup([]uint64{ethUSDCPoolID, fooBARPoolID}, map[uint64]sdk.Coins{
+		ethUSDCPoolID: halfDefaultCoins,
+		fooBARPoolID:  halfDefaultCoins,
+	})
+}
+
+// increase volume in the given pool by swapping in the given amount of coins.
+// validates that the final volume is incerased by the expected amount.
+func (s *KeeperTestSuite) increaseVolumeBySwap(poolID uint64, tokeInCoin sdk.Coin, expectedVolumeAmtIncrease osmomath.Int, denomOut string) {
+	s.FundAcc(s.TestAccs[0], sdk.NewCoins(tokeInCoin))
+
+	originalVoume := s.App.PoolManagerKeeper.GetOsmoVolumeForPool(s.Ctx, poolID)
+
+	_, err := s.App.PoolManagerKeeper.SwapExactAmountIn(s.Ctx, s.TestAccs[0], poolID, tokeInCoin, denomOut, osmomath.ZeroInt())
+	s.Require().NoError(err)
+
+	finalVolume := s.App.PoolManagerKeeper.GetOsmoVolumeForPool(s.Ctx, poolID)
+	s.Require().NotEqual(osmomath.ZeroInt().String(), finalVolume.String())
+	s.Require().Equal(expectedVolumeAmtIncrease.String(), finalVolume.Sub(originalVoume).String())
+}
 
 // for each pool ID, retrieves its internal gauge and asserts that the gauge has coins according to the
 // poolIDToExpectedDistributionMapOne.

--- a/x/incentives/keeper/hooks_test.go
+++ b/x/incentives/keeper/hooks_test.go
@@ -424,7 +424,7 @@ func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_CreateGroupsBetween() {
 
 // This test focuses on configuring volume by swapping instead of using
 // a direct volume setter helper in poolmanager contrary to all other tests.
-// Since we track volume in bond denom (OSMO), we first setup2 pools that are paired with the bond denom.
+// Since we track volume in bond denom (OSMO), we first setup 2 pools that are paired with the bond denom.
 // Next, we setup two pools that are to be packaged in group. One of the tokens in the pool is a token that is also
 // paired with bond denom in one of the first 2 pools.
 // Increase volume by swapping in the second pair of pools.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6559

## What is the purpose of the change

This finalizes the planned tests for the incentive epoch end hook with groups.

Focuses on 2 tests:
1. Creating groups in-between distributions
2. Changing volume by swaps as opposed to setting it with a setter directly

