### PR TITLE
[VS Incentives] upgrade handler distr record redirection sketch

### DIFF
--- a/app/upgrades/v20/upgrades.go
+++ b/app/upgrades/v20/upgrades.go
@@ -1,6 +1,8 @@
 package v20
 
 import (
+	"errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
@@ -9,6 +11,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v19/app/upgrades"
 	cltypes "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
 	incentivestypes "github.com/osmosis-labs/osmosis/v19/x/incentives/types"
+	lockuptypes "github.com/osmosis-labs/osmosis/v19/x/lockup/types"
 )
 
 func CreateUpgradeHandler(
@@ -31,6 +34,54 @@ func CreateUpgradeHandler(
 		// Initialize the new params in incentives for group creation.
 		keepers.IncentivesKeeper.SetParam(ctx, incentivestypes.KeyGroupCreationFee, incentivestypes.DefaultGroupCreationFee)
 		keepers.IncentivesKeeper.SetParam(ctx, incentivestypes.KeyCreatorWhitelist, []string{})
+
+		migrationInfo, err := keepers.GAMMKeeper.GetAllMigrationInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create map from CL pools ID to CFMM pools ID
+		clPoolsIDToCFMMPoolsID := make(map[uint64]uint64)
+		for _, info := range migrationInfo.BalancerToConcentratedPoolLinks {
+			clPoolsIDToCFMMPoolsID[info.ClPoolId] = info.BalancerPoolId
+		}
+
+		distrInfo := keepers.PoolIncentivesKeeper.GetDistrInfo(ctx)
+		for i, distrRecord := range distrInfo.Records {
+			gaugeID := distrRecord.GaugeId
+			gauge, err := keepers.IncentivesKeeper.GetGaugeByID(ctx, gaugeID)
+			if err != nil {
+				return nil, err
+			}
+
+			if gauge.DistributeTo.LockQueryType != lockuptypes.NoLock {
+				continue
+			}
+
+			incentivesEpochDuration := keepers.IncentivesKeeper.GetEpochInfo(ctx).Duration
+			poolID, err := keepers.PoolIncentivesKeeper.GetPoolIdFromGaugeId(ctx, gaugeID, incentivesEpochDuration)
+			if err != nil {
+				return nil, err
+			}
+
+			associatedGammPoolID, ok := clPoolsIDToCFMMPoolsID[poolID]
+			if !ok {
+				return nil, errors.New("pool id not found in migration info")
+			}
+
+			// Get incentives module account
+			incentivesModuleAcc := keepers.AccountKeeper.GetModuleAccount(ctx, incentivestypes.ModuleName)
+
+			// Create group
+			groupedPoolIDs := []uint64{poolID, associatedGammPoolID}
+			groupGaugeID, err := keepers.IncentivesKeeper.CreateGroupNoWeightSync(ctx, sdk.NewCoins(), incentivestypes.PerpetualNumEpochsPaidOver, incentivesModuleAcc.GetAddress(), groupedPoolIDs)
+			if err != nil {
+				return nil, err
+			}
+
+			// Replace gauge ID in the distribution record
+			distrInfo.Records[i].GaugeId = groupGaugeID
+		}
 
 		return migrations, nil
 	}

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -410,7 +410,7 @@ func (k Keeper) syncGroupWeights(ctx sdk.Context, group types.Group) error {
 		// This error implies that there was volume initialized at some point
 		// but has not been updated since the last epoch.
 		// For this case, we accept to fallback to the previous weights.
-		if err != nil && !errors.As(err, &types.NoVolumeSinceLastSync{}) {
+		if err != nil && !errors.As(err, &types.NoVolumeSinceLastSyncError{}) {
 			return err
 		}
 	} else {
@@ -491,7 +491,7 @@ func (k Keeper) syncVolumeSplitGroup(ctx sdk.Context, group types.Group) error {
 		// We expect to handle this in the caller (syncGroupWeights) and
 		// fallback to the previous weights in that case.
 		if volumeDelta.IsZero() {
-			return types.NoVolumeSinceLastSync{PoolID: poolId}
+			return types.NoVolumeSinceLastSyncError{PoolID: poolId}
 		}
 
 		gaugeRecord.CurrentWeight = volumeDelta

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -407,7 +407,10 @@ func (k Keeper) distributeSyntheticInternal(
 func (k Keeper) syncGroupWeights(ctx sdk.Context, group types.Group) error {
 	if group.SplittingPolicy == types.ByVolume {
 		err := k.syncVolumeSplitGroup(ctx, group)
-		if err != nil {
+		// This error implies that there was volume initialized at some point
+		// but has not been updated since the last epoch.
+		// For this case, we accept to fallback to the previous weights.
+		if err != nil && !errors.As(err, &types.NoVolumeSinceLastSync{}) {
 			return err
 		}
 	} else {
@@ -483,12 +486,12 @@ func (k Keeper) syncVolumeSplitGroup(ctx sdk.Context, group types.Group) error {
 			return types.CumulativeVolumeDecreasedError{PoolId: poolId, PreviousVolume: gaugeRecord.CumulativeWeight, NewVolume: cumulativePoolVolume}
 		}
 
-		// TODO: update this error and cover by tests
-		// If this is not present, getting a division by zero panic
-		// See:
-		// https://github.com/osmosis-labs/osmosis/issues/6558
+		// This check implies that there was volume initialized at some point
+		// but has not been updated since the last epoch.
+		// We expect to handle this in the caller (AllocateAcrossGauges) and
+		// fallback to the previous weights in that case.
 		if volumeDelta.IsZero() {
-			return errors.New("volume delta is zero")
+			return types.NoVolumeSinceLastSync{PoolID: poolId}
 		}
 
 		gaugeRecord.CurrentWeight = volumeDelta

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -488,7 +488,7 @@ func (k Keeper) syncVolumeSplitGroup(ctx sdk.Context, group types.Group) error {
 
 		// This check implies that there was volume initialized at some point
 		// but has not been updated since the last epoch.
-		// We expect to handle this in the caller (AllocateAcrossGauges) and
+		// We expect to handle this in the caller (syncGroupWeights) and
 		// fallback to the previous weights in that case.
 		if volumeDelta.IsZero() {
 			return types.NoVolumeSinceLastSync{PoolID: poolId}

--- a/x/incentives/keeper/distribute_test.go
+++ b/x/incentives/keeper/distribute_test.go
@@ -1432,7 +1432,7 @@ func (s *KeeperTestSuite) TestSyncVolumeSplitGroup() {
 				defaultGroup.InternalGaugeInfo.GaugeRecords[1].CumulativeWeight,
 			},
 
-			expectedError: types.NoVolumeSinceLastSync{PoolID: clPoolID},
+			expectedError: types.NoVolumeSinceLastSyncError{PoolID: clPoolID},
 		},
 	}
 

--- a/x/incentives/keeper/distribute_test.go
+++ b/x/incentives/keeper/distribute_test.go
@@ -1349,6 +1349,7 @@ func withGaugeDistrType(gauge types.Gauge, gaugeType lockuptypes.LockQueryType) 
 }
 
 func (s *KeeperTestSuite) TestSyncVolumeSplitGroup() {
+	const clPoolID uint64 = 1
 	tests := map[string]struct {
 		groupToSync types.Group
 
@@ -1423,6 +1424,16 @@ func (s *KeeperTestSuite) TestSyncVolumeSplitGroup() {
 
 			expectedError: types.GroupTotalWeightZeroError{GroupID: defaultGroupGaugeId},
 		},
+
+		"no volume since the last sync": {
+			groupToSync: deepCopyGroup(defaultGroup),
+			updatedPoolVolumes: []osmomath.Int{
+				defaultGroup.InternalGaugeInfo.GaugeRecords[0].CumulativeWeight,
+				defaultGroup.InternalGaugeInfo.GaugeRecords[1].CumulativeWeight,
+			},
+
+			expectedError: types.NoVolumeSinceLastSync{PoolID: clPoolID},
+		},
 	}
 
 	for name, tc := range tests {
@@ -1432,6 +1443,7 @@ func (s *KeeperTestSuite) TestSyncVolumeSplitGroup() {
 
 			// Prepare pools so gauges and pool ids are set in state
 			clPool := s.PrepareConcentratedPool()
+			s.Require().Equal(clPoolID, clPool.GetId())
 			balPoolId := s.PrepareBalancerPool()
 
 			poolIds := []uint64{clPool.GetId(), balPoolId}
@@ -1475,24 +1487,39 @@ func (s *KeeperTestSuite) TestSyncVolumeSplitGroup() {
 }
 
 func (s *KeeperTestSuite) TestSyncGroupWeights() {
+	defaultVolumeOverwrite := []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount}
 	tests := map[string]struct {
-		groupToSync types.Group
+		groupToSync     types.Group
+		volumeOverwrite []osmomath.Int
 
 		expectedSyncedGroup types.Group
 		expectedError       error
 	}{
 		"happy path: valid volume splitting group": {
-			groupToSync: withSplittingPolicy(defaultGroup, types.ByVolume),
+			groupToSync:     withSplittingPolicy(defaultGroup, types.ByVolume),
+			volumeOverwrite: defaultVolumeOverwrite,
 
 			// Note: setup logic runs default setup based on groupToSync's splitting policy.
 			// More involved tests related to syncing logic for specific splitting policies are in their respective tests.
-			expectedSyncedGroup: s.withUpdatedVolumes(defaultGroup, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount}),
+			expectedSyncedGroup: s.withUpdatedVolumes(defaultGroup, defaultVolumeOverwrite),
 			expectedError:       nil,
+		},
+		"no volume since last sync - does not error - fallback to previous weights": {
+			groupToSync: withSplittingPolicy(defaultGroup, types.ByVolume),
+
+			// Note: we set the volume to be equal to the cumulative volume to simulate no volume since last sync.
+			volumeOverwrite: []osmomath.Int{defaultGroup.InternalGaugeInfo.GaugeRecords[0].CumulativeWeight, defaultGroup.InternalGaugeInfo.GaugeRecords[1].CumulativeWeight},
+
+			expectedSyncedGroup: withSplittingPolicy(defaultGroup, types.ByVolume),
+
+			// No error occurs, implying that we fall back to the previous weights
+			expectedError: nil,
 		},
 
 		// Error catching
 		"unsupported splitting policy": {
-			groupToSync: withSplittingPolicy(defaultGroup, types.SplittingPolicy(100)),
+			groupToSync:     withSplittingPolicy(defaultGroup, types.SplittingPolicy(100)),
+			volumeOverwrite: defaultVolumeOverwrite,
 
 			expectedError: types.UnsupportedSplittingPolicyError{GroupGaugeId: uint64(5), SplittingPolicy: types.SplittingPolicy(100)},
 		},
@@ -1513,7 +1540,7 @@ func (s *KeeperTestSuite) TestSyncGroupWeights() {
 			// When more are added in the future, setup logic should route to the appropriate setup function here.
 			switch tc.groupToSync.SplittingPolicy {
 			case types.ByVolume:
-				s.overwriteVolumes(poolIds, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount})
+				s.overwriteVolumes(poolIds, tc.volumeOverwrite)
 			}
 
 			// Save original input to help with mutation-related assertions
@@ -1546,7 +1573,7 @@ func (s *KeeperTestSuite) TestSyncGroupWeights() {
 
 			updatedGroup, err := ik.GetGroupByGaugeID(s.Ctx, tc.groupToSync.GroupGaugeId)
 			s.Require().NoError(err)
-			s.Require().Equal(tc.expectedSyncedGroup, updatedGroup)
+			s.Require().Equal(tc.expectedSyncedGroup.String(), updatedGroup.String())
 		})
 	}
 }
@@ -1777,10 +1804,23 @@ func (s *KeeperTestSuite) TestAllocateAcrossGauges() {
 			volumeToSet: balancerAndCLVolumeConfig,
 		},
 
+		"6: fallback to old weights due to no volume update": {
+			groups: []groupConfig{
+				{
+					group:      singleRecordGroup,
+					groupGauge: defaultPerpetualGauge,
+				},
+			},
+
+			volumeToSet: []osmomath.Int{
+				singleRecordGroup.InternalGaugeInfo.GaugeRecords[0].CumulativeWeight,
+			},
+		},
+
 		//// skipping
 
 		// skipping on sync failure
-		"6: skipped: synching fails due to no volume set": {
+		"7: skipped: synching fails due to no volume set": {
 			groups: []groupConfig{
 				{
 					group:      defaultGroup,
@@ -1794,7 +1834,7 @@ func (s *KeeperTestSuite) TestAllocateAcrossGauges() {
 		},
 
 		// skipping on gauge being inactive
-		"7: skipping on gauge being inactive": {
+		"8: skipping on gauge being inactive": {
 			groups: []groupConfig{
 				{
 					group: defaultGroup,
@@ -1810,7 +1850,7 @@ func (s *KeeperTestSuite) TestAllocateAcrossGauges() {
 
 		// skipping because this gauge has no pool associated with it.
 		// we only distributed to internal gauges.
-		"8: associated group gauge is non perpetual and finished": {
+		"9: associated group gauge is non perpetual and finished": {
 			groups: []groupConfig{
 				{
 					group:      groupToInvalidUnderlying,
@@ -1826,7 +1866,7 @@ func (s *KeeperTestSuite) TestAllocateAcrossGauges() {
 		///////////////// multi-gauges
 
 		// Note that groups distribute to overlapping gauges.
-		"9: multiple groups with varying number of underlying gauges": {
+		"10: multiple groups with varying number of underlying gauges": {
 			groups: []groupConfig{
 				{
 					group:      singleRecordGroup,
@@ -1841,7 +1881,7 @@ func (s *KeeperTestSuite) TestAllocateAcrossGauges() {
 			volumeToSet: balancerAndCLVolumeConfig,
 		},
 
-		"10: skipping one does not fail the other": {
+		"11: skipping one does not fail the other": {
 			groups: []groupConfig{
 				{
 					group: defaultGroup,
@@ -1862,7 +1902,7 @@ func (s *KeeperTestSuite) TestAllocateAcrossGauges() {
 
 		///////////////// error cases
 
-		"11: invalid underlying group gauge (cannot add to finished pool gauge)": {
+		"12: invalid underlying group gauge (cannot add to finished pool gauge)": {
 			groups: []groupConfig{
 				{
 					group:      singleRecordGroup,

--- a/x/incentives/keeper/hooks_test.go
+++ b/x/incentives/keeper/hooks_test.go
@@ -217,8 +217,12 @@ func (s *KeeperTestSuite) TestAfterEpochEnd_Group_OverlappingPoolsInGroups() {
 
 	overlappingPoolIDs := []uint64{poolAndGaugeInfo.ConcentratedPoolID, poolAndGaugeInfo.StableSwapPoolID, poolAndGaugeInfo.BalancerPoolID}
 
-	// setup inital volumes so that a Group can be created.
-	s.overwriteVolumes(overlappingPoolIDs, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount, defaultVolumeAmount})
+	// Setup uneven volumes
+	unevenPoolVolumes := setupUnequalVolumeWeights(len(overlappingPoolIDs), oneMillionVolumeAmt)
+	// Configure the volumes
+	poolIDToVolumeMap := map[uint64]osmomath.Int{}
+	s.setupVolumeForPools(overlappingPoolIDs, unevenPoolVolumes, poolIDToVolumeMap)
+
 	// Create first group
 	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, types.PerpetualNumEpochsPaidOver, s.TestAccs[0], overlappingPoolIDs)
 	s.Require().NoError(err)
@@ -226,13 +230,6 @@ func (s *KeeperTestSuite) TestAfterEpochEnd_Group_OverlappingPoolsInGroups() {
 	// Create second group
 	_, err = s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...).Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+3, s.TestAccs[0], overlappingPoolIDs)
 	s.Require().NoError(err)
-
-	// Setup uneven volumes
-	unevenPoolVolumes := setupUnequalVolumeWeights(len(overlappingPoolIDs), oneMillionVolumeAmt)
-
-	// Configure the volumes
-	poolIDToVolumeMap := map[uint64]osmomath.Int{}
-	s.setupVolumeForPools(overlappingPoolIDs, unevenPoolVolumes, poolIDToVolumeMap)
 
 	// Calculate the expected distribution
 	poolIDToExpectedDistributionMap := s.computeExpectedDistributonAmountsFromVolume(defaultCoins, poolIDToVolumeMap, oneMillionVolumeAmt)
@@ -278,6 +275,9 @@ func (s *KeeperTestSuite) TestAfterEpochEnd_Group_NoVolumeOnePool_SkipSilent() {
 	_, err = s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins, types.PerpetualNumEpochsPaidOver, s.TestAccs[0], poolIDsGroupTwo)
 	s.Require().NoError(err)
 
+	// Overwrite the volumes with zero amounts to trigger an error.
+	s.overwriteVolumes(poolIDsGroupTwo, []osmomath.Int{osmomath.ZeroInt(), osmomath.ZeroInt()})
+
 	// Configure the volume only for the pools in the first group.
 	// Setup uneven volumes
 	unevenPoolVolumes := setupUnequalVolumeWeights(len(poolIDsGroupOne), oneMillionVolumeAmt)
@@ -318,16 +318,15 @@ func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_ChangeVolumeBetween() {
 	// Create the first set of pools with internal gauges and a group for them.
 	poolAndGaugeInfo := s.PrepareAllSupportedPools()
 	poolIDsGroup := []uint64{poolAndGaugeInfo.ConcentratedPoolID, poolAndGaugeInfo.StableSwapPoolID}
-	// setup initial volumes so that a Group can be created.
-	s.overwriteVolumes(poolIDsGroup, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount})
-	// Create non-perpetual group distribution over 2 epochs.
-	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+2, s.TestAccs[0], poolIDsGroup)
-	s.Require().NoError(err)
 
 	// Setup uneven volumes with volumeA total amount
 	unevenPoolVolumes := setupUnequalVolumeWeights(len(poolIDsGroup), volumeA)
 	poolIDToVolumeMap := map[uint64]osmomath.Int{}
 	s.setupVolumeForPools(poolIDsGroup, unevenPoolVolumes, poolIDToVolumeMap)
+
+	// Create non-perpetual group distribution over 2 epochs.
+	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+2, s.TestAccs[0], poolIDsGroup)
+	s.Require().NoError(err)
 
 	distrEpochIdentifier := s.App.IncentivesKeeper.GetParams(s.Ctx).DistrEpochIdentifier
 
@@ -379,16 +378,15 @@ func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_CreateGroupsBetween() {
 	// Create set of pools with internal gauges and a group for them.
 	poolAndGaugeInfo := s.PrepareAllSupportedPools()
 	poolIDsGroup := []uint64{poolAndGaugeInfo.ConcentratedPoolID, poolAndGaugeInfo.StableSwapPoolID}
-	// setup initial volumes so that a Group can be created.
-	s.overwriteVolumes(poolIDsGroup, []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount})
-	// Create non-perpetual group distribution over 2 epochs.
-	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+2, s.TestAccs[0], poolIDsGroup)
-	s.Require().NoError(err)
 
 	// Setup even volumes with volumeA total amount
 	equalPoolVolumes, volumeA := setupEqualVolumeWeights(len(poolIDsGroup), volumeA)
 	poolIDToVolumeMap := map[uint64]osmomath.Int{}
 	s.setupVolumeForPools(poolIDsGroup, equalPoolVolumes, poolIDToVolumeMap)
+
+	// Create non-perpetual group distribution over 2 epochs.
+	_, err := s.App.IncentivesKeeper.CreateGroup(s.Ctx, defaultCoins.Add(defaultCoins...), types.PerpetualNumEpochsPaidOver+2, s.TestAccs[0], poolIDsGroup)
+	s.Require().NoError(err)
 
 	distrEpochIdentifier := s.App.IncentivesKeeper.GetParams(s.Ctx).DistrEpochIdentifier
 
@@ -489,7 +487,7 @@ func (s *KeeperTestSuite) Test_AfterEpochEnd_Group_SwapAndDistribute() {
 
 	// Since volume was equal, we expect equal split of incentives
 	// across pools.
-	halfDefaultCoins := coins.QuoRaw(defaultCoins, 2)
+	halfDefaultCoins := coinutil.QuoRaw(defaultCoins, 2)
 	s.validateDistributionForGroup([]uint64{ethUSDCPoolID, fooBARPoolID}, map[uint64]sdk.Coins{
 		ethUSDCPoolID: halfDefaultCoins,
 		fooBARPoolID:  halfDefaultCoins,

--- a/x/incentives/types/errors.go
+++ b/x/incentives/types/errors.go
@@ -78,10 +78,10 @@ func (e GroupTotalWeightZeroError) Error() string {
 	return fmt.Sprintf("Group with ID %d has total weight of zero", e.GroupID)
 }
 
-type NoVolumeSinceLastSync struct {
+type NoVolumeSinceLastSyncError struct {
 	PoolID uint64
 }
 
-func (e NoVolumeSinceLastSync) Error() string {
+func (e NoVolumeSinceLastSyncError) Error() string {
 	return fmt.Sprintf("Pool %d has no volume since last sync", e.PoolID)
 }

--- a/x/incentives/types/errors.go
+++ b/x/incentives/types/errors.go
@@ -77,3 +77,11 @@ type GroupTotalWeightZeroError struct {
 func (e GroupTotalWeightZeroError) Error() string {
 	return fmt.Sprintf("Group with ID %d has total weight of zero", e.GroupID)
 }
+
+type NoVolumeSinceLastSync struct {
+	PoolID uint64
+}
+
+func (e NoVolumeSinceLastSync) Error() string {
+	return fmt.Sprintf("Pool %d has no volume since last sync", e.PoolID)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6603

## What is the purpose of the change

- Implement `CreateGroupNoSync` that can only be called by the incentives module ACC
- Implement logic in the upgrade handler to convert all NoLock gauges that have pairs to Groups

## Testing and Verifying

TBD

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A