### PR TITLE
[VS Incentives]: upgrade handler redirects pool incentives distribution records to groups

### DIFF
--- a/app/apptesting/incentives.go
+++ b/app/apptesting/incentives.go
@@ -1,0 +1,10 @@
+package apptesting
+
+// validates that Group and group Gauge exist
+func (s *KeeperTestHelper) ValidateGroupExists(gaugeID uint64) {
+	_, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, gaugeID)
+	s.Require().NoError(err)
+
+	_, err = s.App.IncentivesKeeper.GetGroupByGaugeID(s.Ctx, gaugeID)
+	s.Require().NoError(err)
+}

--- a/app/upgrades/v20/export_test.go
+++ b/app/upgrades/v20/export_test.go
@@ -1,0 +1,11 @@
+package v20
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/v19/app/keepers"
+)
+
+func CreateGroupsForIncentivePairs(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	return createGroupsForIncentivePairs(ctx, keepers)
+}

--- a/app/upgrades/v20/upgrades.go
+++ b/app/upgrades/v20/upgrades.go
@@ -83,7 +83,7 @@ func createGroupsForIncentivePairs(ctx sdk.Context, keepers *keepers.AppKeepers)
 	// retrieve the gauge associated with the record
 	// If gauge directs incentives to a concentrated pool AND the concentrated pool
 	// is linked to balancer via migration map, create
-	// a group gauge and replace it in the distirbution record.
+	// a group gauge and replace it in the distribution record.
 	// Note that if there is a concentrated pool that is not
 	// linked to balancer, nothing is done.
 	// Stableswap pools are expected to be silently ignored. We do not
@@ -106,7 +106,6 @@ func createGroupsForIncentivePairs(ctx sdk.Context, keepers *keepers.AppKeepers)
 		// it is not incentivized individually when concentrated pool already retroactively
 		// distributed rewards to it.
 		if gauge.DistributeTo.LockQueryType != lockuptypes.NoLock {
-
 			// Validate that if there is a migration record pair between a concentrated
 			// and a cfmm pool, only concentrated is present in the distribution records.
 			longestLockableDuration, err := keepers.PoolIncentivesKeeper.GetLongestLockableDuration(ctx)

--- a/app/upgrades/v20/upgrades.go
+++ b/app/upgrades/v20/upgrades.go
@@ -144,7 +144,7 @@ func createGroupsForIncentivePairs(ctx sdk.Context, keepers *keepers.AppKeepers)
 
 		associatedGammPoolID, ok := poolIDMigrationRecordMap[concentratedPoolID]
 		if !ok {
-			// There is no CFMM pool ID for the concentrated pool ID, contniue to the next.
+			// There is no CFMM pool ID for the concentrated pool ID, continue to the next.
 			continue
 		}
 

--- a/app/upgrades/v20/upgrades.go
+++ b/app/upgrades/v20/upgrades.go
@@ -1,6 +1,8 @@
 package v20
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
@@ -9,7 +11,18 @@ import (
 	"github.com/osmosis-labs/osmosis/v19/app/upgrades"
 	cltypes "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
 	incentivestypes "github.com/osmosis-labs/osmosis/v19/x/incentives/types"
+	lockuptypes "github.com/osmosis-labs/osmosis/v19/x/lockup/types"
 )
+
+type IncentivizedCFMMDirectWhenMigrationLinkPresentError struct {
+	CFMMPoolID         uint64
+	ConcentratedPoolID uint64
+	CFMMGaugeID        uint64
+}
+
+func (e IncentivizedCFMMDirectWhenMigrationLinkPresentError) Error() string {
+	return fmt.Sprintf("CFMM gauge ID (%d) incentivized CFMM pool (%d) directly when migration link is present with concentrated pool (%d)", e.CFMMGaugeID, e.CFMMPoolID, e.ConcentratedPoolID)
+}
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
@@ -32,6 +45,123 @@ func CreateUpgradeHandler(
 		keepers.IncentivesKeeper.SetParam(ctx, incentivestypes.KeyGroupCreationFee, incentivestypes.DefaultGroupCreationFee)
 		keepers.IncentivesKeeper.SetParam(ctx, incentivestypes.KeyCreatorWhitelist, []string{})
 
+		// Converts pool incentive distribution records from concentrated gauges to group gauges.
+		err = createGroupsForIncentivePairs(ctx, keepers)
+		if err != nil {
+			return nil, err
+		}
+
 		return migrations, nil
 	}
+}
+
+// createGroupsForIncentivePairs converts pool incentive distribution records from concentrated gauges to group gauges.
+// The expected update is to convert concentrated gauges to group gauges iff
+//   - migration record exists for the concentrated pool and another CFMM pool
+//   - if migration between concentrated and CFMM exists, then the CFMM pool is not incentivized individually
+//
+// All other distribution records are not modified.
+//
+// The updated distribution records are saved in the store.
+func createGroupsForIncentivePairs(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	// Create map from CL pools ID to CFMM pools ID
+	// from migration records
+	migrationInfo, err := keepers.GAMMKeeper.GetAllMigrationInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	poolIDMigrationRecordMap := make(map[uint64]uint64)
+	for _, info := range migrationInfo.BalancerToConcentratedPoolLinks {
+		poolIDMigrationRecordMap[info.ClPoolId] = info.BalancerPoolId
+		poolIDMigrationRecordMap[info.BalancerPoolId] = info.ClPoolId
+	}
+
+	distrInfo := keepers.PoolIncentivesKeeper.GetDistrInfo(ctx)
+
+	// For all incentive distribution records,
+	// retrieve the gauge associated with the record
+	// If gauge directs incentives to a concentrated pool AND the concentrated pool
+	// is linked to balancer via migration map, create
+	// a group gauge and replace it in the distirbution record.
+	// Note that if there is a concentrated pool that is not
+	// linked to balancer, nothing is done.
+	// Stableswap pools are expected to be silently ignored. We do not
+	// expect any stableswap pool to be linked to concentrated.
+	for i, distrRecord := range distrInfo.Records {
+		gaugeID := distrRecord.GaugeId
+		gauge, err := keepers.IncentivesKeeper.GetGaugeByID(ctx, gaugeID)
+		if err != nil {
+			return err
+		}
+
+		// At the time of v20 upgrade, we only have concentrated pools
+		// that are linked to balancer. Concentrated gauges receive all rewards
+		// and then retroactively update balancer.
+		// Concentrated pools have NoLock Gauge associated with them.
+		// As a result, we look for this specific type here.
+		// If type mismatched, this is a CFMM pool gauge. In that case,
+		// we continue to the next incentive record after validating
+		// that there is no migration record present for this CFMM pool. That is
+		// it is not incentivized individually when concentrated pool already retroactively
+		// distributed rewards to it.
+		if gauge.DistributeTo.LockQueryType != lockuptypes.NoLock {
+
+			// Validate that if there is a migration record pair between a concentrated
+			// and a cfmm pool, only concentrated is present in the distribution records.
+			longestLockableDuration, err := keepers.PoolIncentivesKeeper.GetLongestLockableDuration(ctx)
+			if err != nil {
+				return err
+			}
+			cfmmPoolID, err := keepers.PoolIncentivesKeeper.GetPoolIdFromGaugeId(ctx, gaugeID, longestLockableDuration)
+			if err != nil {
+				return err
+			}
+
+			// If we had a migration record present and a balancer pool is still incentivized individually,
+			// something went wrong. This is because the presence of migration record implies retroactive
+			// incentive distribution from concentrated to balancer.
+			linkedConcentratedPoolID, hasAssociatedConcentratedPoolLinked := poolIDMigrationRecordMap[cfmmPoolID]
+			if hasAssociatedConcentratedPoolLinked {
+				return IncentivizedCFMMDirectWhenMigrationLinkPresentError{
+					CFMMPoolID:         cfmmPoolID,
+					ConcentratedPoolID: linkedConcentratedPoolID,
+					CFMMGaugeID:        gaugeID,
+				}
+			}
+
+			// Validation passed. This was an individual CFMM pool with no link to concentrated
+			// Silently skip it.
+			continue
+		}
+
+		// Get PoolID associated with the given NoLock gauge ID
+		// NoLock gauges are associated with an incentives epoch duration.
+		incentivesEpochDuration := keepers.IncentivesKeeper.GetEpochInfo(ctx).Duration
+		concentratedPoolID, err := keepers.PoolIncentivesKeeper.GetPoolIdFromGaugeId(ctx, gaugeID, incentivesEpochDuration)
+		if err != nil {
+			return err
+		}
+
+		associatedGammPoolID, ok := poolIDMigrationRecordMap[concentratedPoolID]
+		if !ok {
+			// There is no CFMM pool ID for the concentrated pool ID, contniue to the next.
+			continue
+		}
+
+		// Found concentrated and CFMM pools that are linked by
+		// migration records. Create a Group for them
+		groupedPoolIDs := []uint64{concentratedPoolID, associatedGammPoolID}
+		groupGaugeID, err := keepers.IncentivesKeeper.CreateGroupAsIncentivesModuleAcc(ctx, incentivestypes.PerpetualNumEpochsPaidOver, groupedPoolIDs)
+		if err != nil {
+			return err
+		}
+
+		// Replace the gauge ID with the group gauge ID in the distribution records
+		distrInfo.Records[i].GaugeId = groupGaugeID
+	}
+
+	keepers.PoolIncentivesKeeper.SetDistrInfo(ctx, distrInfo)
+
+	return nil
 }

--- a/app/upgrades/v20/upgrades_test.go
+++ b/app/upgrades/v20/upgrades_test.go
@@ -1,0 +1,290 @@
+package v20_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v19/app/apptesting"
+	v20 "github.com/osmosis-labs/osmosis/v19/app/upgrades/v20"
+	gammmigration "github.com/osmosis-labs/osmosis/v19/x/gamm/types/migration"
+	poolincentivestypes "github.com/osmosis-labs/osmosis/v19/x/pool-incentives/types"
+)
+
+type UpgradeTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	s.Setup()
+}
+
+func TestUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+// Validates that the pool incentive distribution records are updated correctly.
+// The expected update is to convert concentrated gauges to group gauges iff
+// - migration record exists for the concentrated pool and another CFMM pool
+// - if migration between concentrated and CFMM exists, then the CFMM pool is not incentivized individually
+// It is expected that all other distribution records are not modified.
+func (s *UpgradeTestSuite) TestCreateGroupsForIncentivePairs() {
+	s.SetupTest()
+
+	// Create pools once for all tests
+	poolInfo := s.PrepareAllSupportedPools()
+	secondPoolInfo := s.PrepareAllSupportedPools()
+	thirdPoolInfo := s.PrepareAllSupportedPools()
+
+	var (
+		expectedGroupGaugeID  = s.App.IncentivesKeeper.GetLastGaugeID(s.Ctx) + 1
+		defaultWeight         = osmomath.NewInt(10)
+		groupGaugeDistrRecord = []poolincentivestypes.DistrRecord{
+			{
+				GaugeId: expectedGroupGaugeID,
+				Weight:  defaultWeight,
+			},
+		}
+		concentratedDistRecord = []poolincentivestypes.DistrRecord{
+			{
+				GaugeId: poolInfo.ConcentratedGaugeID,
+				Weight:  defaultWeight,
+			},
+		}
+		balancerDistrRecord = []poolincentivestypes.DistrRecord{
+			{
+				GaugeId: poolInfo.BalancerGaugeID,
+				Weight:  defaultWeight,
+			},
+		}
+		stableswapDistrRecord = []poolincentivestypes.DistrRecord{
+			{
+				GaugeId: poolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+		}
+
+		noMigrationInfo = []gammmigration.BalancerToConcentratedPoolLink{}
+	)
+
+	// Test for individual distribution record configurations.
+	tests := map[string]struct {
+		migrationInfo               []gammmigration.BalancerToConcentratedPoolLink
+		distributionRecords         []poolincentivestypes.DistrRecord
+		expectError                 error
+		expectedDistributionRecords []poolincentivestypes.DistrRecord
+	}{
+		"one distr record with concentrated pool linked to gamm (converted to group)": {
+			migrationInfo: []gammmigration.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: poolInfo.BalancerPoolID,
+					ClPoolId:       poolInfo.ConcentratedPoolID,
+				},
+			},
+			distributionRecords: concentratedDistRecord,
+
+			expectedDistributionRecords: groupGaugeDistrRecord,
+		},
+		"one distr record with balancer pool (no-op)": {
+			// No migration link
+			migrationInfo:       noMigrationInfo,
+			distributionRecords: balancerDistrRecord,
+
+			expectedDistributionRecords: balancerDistrRecord,
+		},
+		"one distr record with stableswap pool (no-op)": {
+			// No migration link
+			migrationInfo:       noMigrationInfo,
+			distributionRecords: stableswapDistrRecord,
+
+			expectedDistributionRecords: stableswapDistrRecord,
+		},
+		"one distr record with concentrated pool that is not linked to gamm (no-op)": {
+			// No migration link
+			migrationInfo: noMigrationInfo,
+
+			distributionRecords: concentratedDistRecord,
+
+			expectedDistributionRecords: concentratedDistRecord,
+		},
+		"migration link between gamm pool and concentrated pool exists but no distr record (no-op)": {
+			migrationInfo: []gammmigration.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: poolInfo.BalancerPoolID,
+					ClPoolId:       poolInfo.ConcentratedPoolID,
+				},
+			},
+
+			distributionRecords: []poolincentivestypes.DistrRecord{},
+
+			expectedDistributionRecords: []poolincentivestypes.DistrRecord(nil),
+		},
+
+		// error cases
+
+		"error: one distr record with balancer pool but migration link present": {
+			migrationInfo: []gammmigration.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: poolInfo.BalancerPoolID,
+					ClPoolId:       poolInfo.ConcentratedPoolID,
+				},
+			},
+			distributionRecords: balancerDistrRecord,
+
+			expectError: v20.IncentivizedCFMMDirectWhenMigrationLinkPresentError{
+				CFMMPoolID:         poolInfo.BalancerPoolID,
+				ConcentratedPoolID: poolInfo.ConcentratedPoolID,
+				CFMMGaugeID:        poolInfo.BalancerGaugeID,
+			},
+		},
+		// This is an invalid setup since we do not support stableswap in migration
+		// link but we test it for completeness.
+		"error: one distr record with stableswap pool but migration link present": {
+			migrationInfo: []gammmigration.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: poolInfo.StableSwapPoolID,
+					ClPoolId:       poolInfo.ConcentratedPoolID,
+				},
+			},
+			distributionRecords: stableswapDistrRecord,
+
+			expectError: v20.IncentivizedCFMMDirectWhenMigrationLinkPresentError{
+				CFMMPoolID:         poolInfo.StableSwapPoolID,
+				ConcentratedPoolID: poolInfo.ConcentratedPoolID,
+				CFMMGaugeID:        poolInfo.StableSwapGaugeID,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+			s.runCreateGroupsForIncentivePairsTest(tc.migrationInfo, tc.distributionRecords, tc.expectedDistributionRecords, expectedGroupGaugeID, tc.expectError)
+		})
+	}
+
+	// 2 concentrated pools linked to 2 balancer pools - converted to group
+	// linked balancer pools are not incentivized individually
+	// separete individual balancer pool - no-op
+	// 2 separete individual stableswap pools - no-op
+	// concentrated pool that does not have migration link - no-op
+	s.Run("valid multi distr record test", func() {
+
+		// Refetch updated expected group gauge ID
+		// since previous tests might have modified it by creating their own groups
+		// during tests
+		var expectedGroupGaugeID = s.App.IncentivesKeeper.GetLastGaugeID(s.Ctx) + 1
+
+		// Configure migration records only for 2 groups of concentrated and balancer pools.
+		// Note that the third one does not have a migration record.
+		migrationInfo := []gammmigration.BalancerToConcentratedPoolLink{
+			{
+				BalancerPoolId: poolInfo.BalancerPoolID,
+				ClPoolId:       poolInfo.ConcentratedPoolID,
+			},
+			{
+				BalancerPoolId: secondPoolInfo.BalancerPoolID,
+				ClPoolId:       secondPoolInfo.ConcentratedPoolID,
+			},
+		}
+
+		distributionRecords := []poolincentivestypes.DistrRecord{
+			{
+				GaugeId: poolInfo.ConcentratedGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: poolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: secondPoolInfo.ConcentratedGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: secondPoolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: thirdPoolInfo.ConcentratedGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: thirdPoolInfo.BalancerGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: thirdPoolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+		}
+
+		expectedDistributionRecords := []poolincentivestypes.DistrRecord{
+			{
+				// Replaced with group gauge
+				GaugeId: expectedGroupGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: poolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				// Replaced with group gauge
+				GaugeId: expectedGroupGaugeID + 1,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: secondPoolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				// Not replaced with group gauge because
+				// migration record does not exist for this pool and another balancer pool
+				GaugeId: thirdPoolInfo.ConcentratedGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: thirdPoolInfo.BalancerGaugeID,
+				Weight:  defaultWeight,
+			},
+			{
+				GaugeId: thirdPoolInfo.StableSwapGaugeID,
+				Weight:  defaultWeight,
+			},
+		}
+
+		noError := error(nil)
+		s.runCreateGroupsForIncentivePairsTest(migrationInfo, distributionRecords, expectedDistributionRecords, expectedGroupGaugeID, noError)
+	})
+}
+
+func (s *UpgradeTestSuite) runCreateGroupsForIncentivePairsTest(migrationInfo []gammmigration.BalancerToConcentratedPoolLink, distributionRecords []poolincentivestypes.DistrRecord, expectedDistributionRecords []poolincentivestypes.DistrRecord, expectedGroupGaugeID uint64, expectedError error) {
+	// Confgiure migration records for each test individually (overwrites previous migration records).
+	err := s.App.GAMMKeeper.OverwriteMigrationRecordsAndRedirectDistrRecords(s.Ctx, gammmigration.MigrationRecords{BalancerToConcentratedPoolLinks: migrationInfo})
+	s.Require().NoError(err)
+
+	// Configure distribution records for each test individually (overwrites previous distribution records).
+	err = s.App.PoolIncentivesKeeper.ReplaceDistrRecords(s.Ctx, distributionRecords...)
+	s.Require().NoError(err)
+
+	err = v20.CreateGroupsForIncentivePairs(s.Ctx, &s.App.AppKeepers)
+	if expectedError != nil {
+		s.Require().Error(err)
+		s.Require().ErrorIs(expectedError, err)
+		return
+	}
+
+	s.Require().NoError(err)
+
+	// Validate that final distribution records are as expected
+	updatedDistrInfo := s.App.PoolIncentivesKeeper.GetDistrInfo(s.Ctx)
+	s.Require().Equal(expectedDistributionRecords, updatedDistrInfo.Records)
+
+	// Validate that the group gauge along with the group were created if applicable.
+	for _, expectedRecord := range expectedDistributionRecords {
+		if expectedRecord.GaugeId == expectedGroupGaugeID {
+			s.ValidateGroupExists(expectedGroupGaugeID)
+		}
+	}
+}

--- a/x/incentives/keeper/group_test.go
+++ b/x/incentives/keeper/group_test.go
@@ -633,15 +633,6 @@ func (s *KeeperTestSuite) validateGroup(expectedGroup types.Group, actualGroup t
 	s.validateGaugeInfo(expectedGroup.InternalGaugeInfo, actualGroup.InternalGaugeInfo)
 }
 
-// validates that Group and group Gauge exist
-func (s *KeeperTestSuite) validateGroupExists(gaugeID uint64) {
-	_, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, gaugeID)
-	s.Require().NoError(err)
-
-	_, err = s.App.IncentivesKeeper.GetGroupByGaugeID(s.Ctx, gaugeID)
-	s.Require().NoError(err)
-}
-
 // validates that Group and group Gauge do not exist
 func (s *KeeperTestSuite) validateGroupNotExists(nonPerpetualGroupGaugeID uint64) {
 	_, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, nonPerpetualGroupGaugeID)

--- a/x/incentives/keeper/hooks_test.go
+++ b/x/incentives/keeper/hooks_test.go
@@ -201,7 +201,7 @@ func (s *KeeperTestSuite) TestAfterEpochEnd_Group_General() {
 	s.validateDistributionForGroup(nonPerpetualGroupPoolIDs, nonPerpetualPoolIDToExpectedDistributionMap)
 
 	// Validate that perpetual gauge is still present
-	s.validateGroupExists(perpetualGroupGaugeID)
+	s.ValidateGroupExists(perpetualGroupGaugeID)
 }
 
 // This test focuses on validating groups distributing to pools that are in both groups.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6603

## What is the purpose of the change

Our current mechanism for incentivizing pairs of the same denom first directs incentives to CL gauges. Then, CL module retroactively pipes the eligible amounts to balancer based on its liquidity relative to CL.

On main, we already removed the retroactive mechanism from CL module. However, on-chain CL gauges continue to receive all rewards a denom pair is entitled to.

We should update all distribution records to detect CL gauges and associate Group gauges in their place.

This is done by introducing an upgrade handler method `createGroupsForIncentivePairs`

This method converts pool incentive distribution records from concentrated gauges to group gauges.
The expected update is to convert concentrated gauges to group gauges iff
 - migration record exists for the concentrated pool and another CFMM pool
 - if migration between concentrated and CFMM exists, then the CFMM pool is not incentivized individually

All other distribution records are not modified.
The updated distribution records are saved in the store.

## Testing and Verifying

- Added unit tests for the method with various distribution record configurations
- This will be further validated by running mainnet state exported upgrade handler tests

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A