### PR TITLE
[VS Incentives]: disable non perpetual group gauge creation

### DIFF
--- a/x/incentives/types/msgs.go
+++ b/x/incentives/types/msgs.go
@@ -177,7 +177,7 @@ func (m MsgCreateGroup) ValidateBasic() error {
 	}
 
 	// Temporarily disable non perpetual group creation
-	if m.NumEpochsPaidOver != 0 {
+	if m.NumEpochsPaidOver != PerpetualNumEpochsPaidOver {
 		return errors.New("non-perpetual group creation is disabled")
 	}
 

--- a/x/incentives/types/msgs.go
+++ b/x/incentives/types/msgs.go
@@ -176,6 +176,11 @@ func (m MsgCreateGroup) ValidateBasic() error {
 		return errors.New("pool ids should be unique")
 	}
 
+	// Temporarily disable non perpetual group creation
+	if m.NumEpochsPaidOver != 0 {
+		return errors.New("non-perpetual group creation is disabled")
+	}
+
 	return nil
 }
 

--- a/x/incentives/types/msgs.go
+++ b/x/incentives/types/msgs.go
@@ -177,6 +177,7 @@ func (m MsgCreateGroup) ValidateBasic() error {
 	}
 
 	// Temporarily disable non perpetual group creation
+	// https://github.com/osmosis-labs/osmosis/issues/6540
 	if m.NumEpochsPaidOver != PerpetualNumEpochsPaidOver {
 		return errors.New("non-perpetual group creation is disabled")
 	}

--- a/x/incentives/types/msgs_test.go
+++ b/x/incentives/types/msgs_test.go
@@ -311,7 +311,7 @@ func TestMsgCreateGroup(t *testing.T) {
 	createMsg := func(after func(msg incentivestypes.MsgCreateGroup) incentivestypes.MsgCreateGroup) incentivestypes.MsgCreateGroup {
 		properMsg := *incentivestypes.NewMsgCreateGroup(
 			sdk.Coins{sdk.NewInt64Coin("stake", 10)},
-			1,
+			0,
 			addr1,
 			[]uint64{1, 2, 3},
 		)
@@ -369,6 +369,14 @@ func TestMsgCreateGroup(t *testing.T) {
 			name: "repeated pool id",
 			msg: createMsg(func(msg incentivestypes.MsgCreateGroup) incentivestypes.MsgCreateGroup {
 				msg.PoolIds = []uint64{1, 2, 1}
+				return msg
+			}),
+			expectPass: false,
+		},
+		{
+			name: "non-perpetual group creation is disabled",
+			msg: createMsg(func(msg incentivestypes.MsgCreateGroup) incentivestypes.MsgCreateGroup {
+				msg.NumEpochsPaidOver = 2
 				return msg
 			}),
 			expectPass: false,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6592

## What is the purpose of the change

We temporarily disable non-perpetual group creation at the message server level until we implement the necessary logic for this.

## Testing and Verifying

Since we just disable at the validate basic level, we add a check just to the validate basic test.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A