### PR TITLE
[VS Incentives]: prevent duplicate pool IDs in create group

### DIFF
--- a/x/incentives/keeper/group.go
+++ b/x/incentives/keeper/group.go
@@ -8,6 +8,7 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 	"github.com/osmosis-labs/osmosis/v19/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v19/x/lockup/types"
 )
@@ -110,6 +111,10 @@ func (k Keeper) createGroup(ctx sdk.Context, coins sdk.Coins, numEpochPaidOver u
 	}
 	if len(poolIDs) == 1 {
 		return types.Group{}, types.OnePoolIDGroupError{PoolID: poolIDs[0]}
+	}
+
+	if !osmoassert.Uint64ArrayValuesAreUnique(poolIDs) {
+		return types.Group{}, types.DuplicatePoolIDError{PoolIDs: poolIDs}
 	}
 
 	// Initialize gauge information for every pool ID.

--- a/x/incentives/keeper/group_test.go
+++ b/x/incentives/keeper/group_test.go
@@ -132,6 +132,14 @@ var (
 				poolVolumesToSet:    []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount},
 				expectErr:           errorNoCustomFeeInBalance,
 			},
+			{
+				name:             "error: duplicate pool IDs",
+				coins:            defaultCoins,
+				numEpochPaidOver: types.PerpetualNumEpochsPaidOver,
+				poolIDs:          []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID},
+				poolVolumesToSet: []osmomath.Int{defaultVolumeAmount, defaultVolumeAmount.Add(defaultVolumeAmount)},
+				expectErr:        types.DuplicatePoolIDError{PoolIDs: []uint64{poolInfo.ConcentratedPoolID, poolInfo.BalancerPoolID, poolInfo.ConcentratedPoolID}},
+			},
 		}
 	}
 )

--- a/x/incentives/types/errors.go
+++ b/x/incentives/types/errors.go
@@ -95,3 +95,11 @@ type NoVolumeSinceLastSyncError struct {
 func (e NoVolumeSinceLastSyncError) Error() string {
 	return fmt.Sprintf("Pool %d has no volume since last sync", e.PoolID)
 }
+
+type DuplicatePoolIDError struct {
+	PoolIDs []uint64
+}
+
+func (e DuplicatePoolIDError) Error() string {
+	return fmt.Sprintf("one or more pool IDs provided in the pool ID array contains a duplicate: %d", e.PoolIDs)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We prevented duplicate pool IDs in the validate basic of create group, but we decided it should also live in the createGroup method itself, in the event createGroup gets called outside of the message server. 

## Testing and Verifying

Added a default error case, in which any call the createGroup with duplicate pool IDs should error.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A