### PR TITLE
[VS Incentives] fix upgrade handler bug with zero ID community pool gauge

### DIFF
--- a/app/upgrades/v20/upgrades.go
+++ b/app/upgrades/v20/upgrades.go
@@ -12,6 +12,7 @@ import (
 	cltypes "github.com/osmosis-labs/osmosis/v19/x/concentrated-liquidity/types"
 	incentivestypes "github.com/osmosis-labs/osmosis/v19/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v19/x/lockup/types"
+	poolincenitvestypes "github.com/osmosis-labs/osmosis/v19/x/pool-incentives/types"
 )
 
 type IncentivizedCFMMDirectWhenMigrationLinkPresentError struct {
@@ -90,6 +91,12 @@ func createGroupsForIncentivePairs(ctx sdk.Context, keepers *keepers.AppKeepers)
 	// expect any stableswap pool to be linked to concentrated.
 	for i, distrRecord := range distrInfo.Records {
 		gaugeID := distrRecord.GaugeId
+
+		// Gauge with ID zero goes to community pool.
+		if gaugeID == poolincenitvestypes.CommunityPoolDistributionGaugeID {
+			continue
+		}
+
 		gauge, err := keepers.IncentivesKeeper.GetGaugeByID(ctx, gaugeID)
 		if err != nil {
 			return err

--- a/app/upgrades/v20/upgrades_test.go
+++ b/app/upgrades/v20/upgrades_test.go
@@ -120,6 +120,24 @@ func (s *UpgradeTestSuite) TestCreateGroupsForIncentivePairs() {
 
 			expectedDistributionRecords: []poolincentivestypes.DistrRecord(nil),
 		},
+		"migration link between gamm pool and concentrated pool exists; no distr record with community pool gauge ID (no-op)": {
+			migrationInfo: []gammmigration.BalancerToConcentratedPoolLink{
+				{
+					BalancerPoolId: poolInfo.BalancerPoolID,
+					ClPoolId:       poolInfo.ConcentratedPoolID,
+				},
+			},
+
+			distributionRecords: []poolincentivestypes.DistrRecord{{
+				GaugeId: poolincentivestypes.CommunityPoolDistributionGaugeID,
+				Weight:  defaultWeight,
+			}},
+
+			expectedDistributionRecords: []poolincentivestypes.DistrRecord{{
+				GaugeId: poolincentivestypes.CommunityPoolDistributionGaugeID,
+				Weight:  defaultWeight,
+			}},
+		},
 
 		// error cases
 

--- a/x/pool-incentives/keeper/distr.go
+++ b/x/pool-incentives/keeper/distr.go
@@ -54,7 +54,7 @@ func (k Keeper) AllocateAsset(ctx sdk.Context) error {
 			continue
 		}
 
-		if record.GaugeId == 0 { // fund community pool if gaugeId is zero
+		if record.GaugeId == types.CommunityPoolDistributionGaugeID { // fund community pool if gaugeId is zero
 			if err := k.FundCommunityPoolFromModule(ctx, sdk.NewCoin(asset.Denom, allocatingAmount)); err != nil {
 				return err
 			}

--- a/x/pool-incentives/types/constants.go
+++ b/x/pool-incentives/types/constants.go
@@ -1,0 +1,4 @@
+package types
+
+// If pool incentive distribution record gauge ID is 0, it means the distribution is for the community pool.
+const CommunityPoolDistributionGaugeID uint64 = 0


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fix upgrade handler bugs where the gauge ID of zero that represents community pool is not handled correctly.

Validated that gauge ID of zero record is indeed present on mainnet and such a gauge does not exist

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A