### PR TITLE
dev-ux: create an issue for each TODO introduced in a merged PR

### DIFF
--- a/.github/workflows/todo-auto-issues.yml
+++ b/.github/workflows/todo-auto-issues.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - main
 
 jobs:
   scan-for-todos:
@@ -13,13 +15,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
+        fetch-depth: 0
         ref: ${{ github.event.pull_request.merge_commit_sha }}
     
     - name: Scan for TODOs
       id: todos
       run: |
+        git fetch origin main
         todos=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.merge_commit_sha }} --unified=0 | awk '/^\+.*TODO:/ { sub(/^.*TODO:\s*/, ""); sub(/^ */, ""); $0=toupper(substr($0,1,1)) substr($0,2); print $0 }')
-        echo TODOS: $todos
         
         # Set output
         echo "todo_list=$todos" >> $GITHUB_OUTPUT;
@@ -27,8 +30,11 @@ jobs:
     - name: Create GitHub issue for each TODO
       if: steps.todos.outputs.todo_list != ''
       run: |
-        # Read TODOs from the output
-        IFS=$'\n' read -rd '' -a todos <<< "${{ steps.todos.outputs.todo_list }}"
+        # Split the `todo_list` string into an array
+        SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
+        IFS=$'\n'      # Change IFS to newline char
+        todos=("${{ steps.todos.outputs.todo_list }}") # split the `todo_list` string into an array by the same name
+        IFS=$SAVEIFS   # Restore original IFS
         
         # Create an issue for each TODO
         for todo in "${todos[@]}"; do
@@ -38,5 +44,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/issues \
-            -d '{"title":"$todo","body":"Auto-generated issue triggered by the merge of ${{ github.event.pull_request.html_url }}","assignees":["${{ github.event.pull_request.user.login }}"],"labels":["T:auto"]}'
+            -d '{"title":"'"$todo"'","body":"Auto-generated issue triggered by the merge of ${{ github.event.pull_request.html_url }} with an introduced TODO","assignees":["${{ github.event.pull_request.user.login }}"],"labels":["T:auto"]}'
         done

--- a/.github/workflows/todo-auto-issues.yml
+++ b/.github/workflows/todo-auto-issues.yml
@@ -1,0 +1,42 @@
+name: Check for TODOs
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  scan-for-todos:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+    - name: Scan for TODOs
+      id: todos
+      run: |
+        # Get list of changed lines in the merged PR
+        changed_lines=git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.merge_commit_sha }} --unified=0 | grep -iP '^+.*?\bTODO:\s*\K.*$'
+        
+        # Set output
+        echo "::set-output name=todo_list::$changed_lines"
+
+    - name: Create GitHub issue for each TODO
+      if: steps.todos.outputs.todo_list != ''
+      run: |
+        # Read TODOs from the output
+        IFS=$'\n' read -rd '' -a todos <<< "${{ steps.todos.outputs.todo_list }}"
+        
+        # Create an issue for each TODO
+        for todo in "${todos[@]}"; do
+          echo "Creating issue for TODO: $todo"
+          curl -s \
+            -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues \
+            -d '{"title":"'$todo'"}'
+        done

--- a/.github/workflows/todo-auto-issues.yml
+++ b/.github/workflows/todo-auto-issues.yml
@@ -11,18 +11,18 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.merge_commit_sha }}
-
+    
     - name: Scan for TODOs
       id: todos
       run: |
-        # Get list of changed lines in the merged PR
-        changed_lines=git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.merge_commit_sha }} --unified=0 | grep -iP '^+.*?\bTODO:\s*\K.*$'
+        todos=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.merge_commit_sha }} --unified=0 | awk '/^\+.*TODO:/ { sub(/^.*TODO:\s*/, ""); sub(/^ */, ""); $0=toupper(substr($0,1,1)) substr($0,2); print $0 }')
+        echo TODOS: $todos
         
         # Set output
-        echo "::set-output name=todo_list::$changed_lines"
+        echo "todo_list=$todos" >> $GITHUB_OUTPUT;
 
     - name: Create GitHub issue for each TODO
       if: steps.todos.outputs.todo_list != ''
@@ -33,10 +33,10 @@ jobs:
         # Create an issue for each TODO
         for todo in "${todos[@]}"; do
           echo "Creating issue for TODO: $todo"
-          curl -s \
+          curl -L \
             -X POST \
+            -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/issues \
-            -d '{"title":"'$todo'"}'
+            -d '{"title":"$todo","body":"Auto-generated issue triggered by the merge of ${{ github.event.pull_request.html_url }}","assignees":["${{ github.event.pull_request.user.login }}"],"labels":["T:auto"]}'
         done


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6399 

## What is the purpose of the change

Add a workflow that runs when a PR is merged to main, checking if the PR has some TODOs left by searching for `TODO: <something>` pattern. If found, creates an issue assigned to the author of an initial PR with a title `<something>`. 

Also, for convenience, attaches a `T:auto` label to this issue

Note: if this PR gets merged, I suggest people start avoiding leaving TODOs like "fix this", "refactor this", etc, because it would make little sense in the issue title

## Testing and Verifying

[Fork
](https://github.com/pysel/osmosis/issues/81)

## Documentation and Release Note

 NA
