### PR TITLE
CI: Restrict PRs from being unmarked as draft if CI is failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,10 @@ jobs:
         with:
           name: osmosisd-${{ matrix.targetos }}-${{ matrix.arch }}
           path: cmd/osmosisd/osmosisd
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: build
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -36,3 +36,10 @@ jobs:
           checkNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: build
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -44,3 +44,10 @@ jobs:
           git add *.proto
           git commit -m "Generated protofile changes" || echo "No changes to commit"
           git push
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: check-proto
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -175,3 +175,10 @@ jobs:
       - name: 🧹 Clean up Osmosis Home
         if: always()
         run: rm -rf $HOME/.osmosisd/ || true
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: [compare_versions, check_state_compatibility]
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -130,4 +130,10 @@ jobs:
         working-directory: ${{ matrix.workdir }}
         run: >
           cargo clippy -- -D warnings
-
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: [test, tests, lints]
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,3 +61,10 @@ jobs:
         name: Run documentation linter
         if: env.GIT_DIFF
         run: make mdlint
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: [golangci, documentation-linter]
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mark-as-draft.yml
+++ b/.github/workflows/mark-as-draft.yml
@@ -1,0 +1,17 @@
+name: Draft on CI fail
+on:
+  workflow_call:
+    secrets:
+      gh_token:
+        required: true
+
+jobs:
+  mark-as-draft:
+    name: Mark as draft
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark as draft
+        uses: voiceflow/draft-pr@latest
+        with:
+          token: ${{ secrets.gh_token }}

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -36,3 +36,10 @@ jobs:
           mode: exactly
           count: 1
           labels: "V:state/breaking, V:state/compatible/no_backport, V:state/compatible/backport"
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: [state_compatability_labels]
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -36,3 +36,10 @@ jobs:
         run: |
           make test-sim-determinism
         if: env.GIT_DIFF
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: test
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,3 +181,10 @@ jobs:
           done
 
           echo "Done pruning osmosis-testnet networks."
+  mark-as-draft: 
+    name: Mark PR as draft
+    needs: [get_diff, go-split-test-files, go, e2e]
+    if: ${{failure()}}
+    uses: osmosis-labs/osmosis/.github/workflows/mark-as-draft.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes: #6522 

## What is the purpose of the change

> Add a reusable workflow to mark PR as draft if CI failing.
> We can still convert PR to open state and merge if we really don't care about the failed CI

## Testing and Verifying
Have tested on fork repo [here](https://github.com/anhductn2001/osmosis/pull/2).