### PR TITLE
Add debug build options to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,19 @@ build-all: check_version go.sum
 install: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 
+# disables optimization, inlining and symbol removal
+GC_FLAGS := -gcflags="all=-N -l"
+REMOVE_STRING := -w -s
+DEBUG_BUILD_FLAGS:= $(subst $(REMOVE_STRING),,$(BUILD_FLAGS))
+DEBUG_LDFLAGS = $(subst $(REMOVE_STRING),,$(ldflags))
+
+dev-install: go.sum
+	GOWORK=off go install $(DEBUG_BUILD_FLAGS) $(GC_FLAGS) $(GO_MODULE)/cmd/osmosisd
+
+dev-build:
+	mkdir -p $(BUILDDIR)/
+	GOWORK=off go build $(GC_FLAGS) -mod=readonly -ldflags '$(DEBUG_LDFLAGS)' -trimpath -o $(BUILDDIR) ./...;
+
 install-with-autocomplete: check_version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p); \


### PR DESCRIPTION
## What is the purpose of the change

This adds two new options to make to build and install a dev binary that then allows debugging, which then allows VS Code/Goland to attach to a running process.

## Testing and Verifying

This change is a trivial addition to make, not sure how to add tests for this, but I did build it and successfully attach Goland to the running process.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A