### PR TITLE
fix: skip community pool for incentivized pools query

### DIFF
--- a/x/pool-incentives/keeper/grpc_query.go
+++ b/x/pool-incentives/keeper/grpc_query.go
@@ -133,6 +133,10 @@ func (q Querier) IncentivizedPools(ctx context.Context, _ *types.QueryIncentiviz
 
 	// Loop over the distribution records and fill in the incentivized pools struct.
 	for _, record := range distrInfo.Records {
+		// Skip community pool gauge
+		if record.GaugeId == 0 {
+			continue
+		}
 		gauge, err := q.incentivesKeeper.GetGaugeByID(sdkCtx, record.GaugeId)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())

--- a/x/pool-incentives/keeper/keeper.go
+++ b/x/pool-incentives/keeper/keeper.go
@@ -335,6 +335,10 @@ func (k Keeper) IsPoolIncentivized(ctx sdk.Context, providedPoolId uint64) (bool
 	distrInfo := k.GetDistrInfo(ctx)
 
 	for _, record := range distrInfo.Records {
+		// Skip community pool gauge
+		if record.GaugeId == 0 {
+			continue
+		}
 		gauge, err := k.incentivesKeeper.GetGaugeByID(ctx, record.GaugeId)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We recently got rid of silently skipping errors in the incentivized pools query. We did not take into consideration gauge 0, which distributes to the community pool. This fix skips gauge 0.

## Testing and Verifying

Without fix on state exported testnet

```
osmosis# osmosisd q poolincentives incentivized-pools
Error: rpc error: code = Unknown desc = rpc error: code = Internal desc = gauge with ID (0) not found: unknown request
```

With fix

```
root@ale-roman-state-comp:~/osmosis# ./build/osmosisd q poolincentives incentivized-pools
incentivized_pools:
- gauge_id: "29899"
  lockable_duration: 1209600s
  pool_id: "833"
- gauge_id: "35532"
  lockable_duration: 86400s
  pool_id: "1066"
- gauge_id: "35532"
  lockable_duration: 1209600s
  pool_id: "674"
- gauge_id: "33257"
  lockable_duration: 86400s
  pool_id: "1076"
- gauge_id: "33258"
  lockable_duration: 86400s
  pool_id: "1077"
- gauge_id: "33259"
  lockable_duration: 86400s
  pool_id: "1078"
- gauge_id: "33260"
  lockable_duration: 86400s
  pool_id: "1079"
- gauge_id: "35533"
  lockable_duration: 86400s
  pool_id: "1090"
- gauge_id: "35533"
  lockable_duration: 1209600s
  pool_id: "712"
- gauge_id: "35534"
  lockable_duration: 86400s
  pool_id: "1107"
- gauge_id: "35534"
  lockable_duration: 1209600s
  pool_id: "1039"
- gauge_id: "34466"
  lockable_duration: 86400s
  pool_id: "1128"
- gauge_id: "35535"
  lockable_duration: 86400s
  pool_id: "1133"
- gauge_id: "35535"
  lockable_duration: 1209600s
  pool_id: "678"
- gauge_id: "35536"
  lockable_duration: 86400s
  pool_id: "1134"
- gauge_id: "35536"
  lockable_duration: 1209600s
  pool_id: "704"
- gauge_id: "35537"
  lockable_duration: 86400s
  pool_id: "1135"
- gauge_id: "35537"
  lockable_duration: 1209600s
  pool_id: "1"
- gauge_id: "35538"
  lockable_duration: 86400s
  pool_id: "1136"
- gauge_id: "35538"
  lockable_duration: 1209600s
  pool_id: "803"
- gauge_id: "35433"
  lockable_duration: 86400s
  pool_id: "1220"
- gauge_id: "35434"
  lockable_duration: 86400s
  pool_id: "1221"
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A