### PR TITLE
revert(1/3): swap tick conversion

### DIFF
--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -227,16 +227,6 @@ func (s *KeeperTestSuite) swapNearInitializedTickBoundary(r *rand.Rand, pool typ
 }
 
 func (s *KeeperTestSuite) swapNearTickBoundary(r *rand.Rand, pool types.ConcentratedPoolExtension, targetTick int64, zfo bool) (didSwap bool, fatalErr bool) {
-	// TODO: remove this limit upon completion of the refactor in:
-	// https://github.com/osmosis-labs/osmosis/issues/5726
-	// Due to an intermediary refactor step where we have
-	// full range positions created in the extended full range it
-	// sometimes tries to swap to the V2 MinInitializedTick that
-	// is not supported yet by the rest of the system.
-	if targetTick < types.MinInitializedTick {
-		return false, false
-	}
-
 	swapInDenom, swapOutDenom := zfoToDenoms(zfo, pool)
 	// TODO: Confirm accuracy of this method.
 	amountInRequired, curLiquidity, _ := s.computeSwapAmounts(pool.GetId(), pool.GetCurrentSqrtPrice(), targetTick, zfo, false)

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -250,6 +250,18 @@ func CalculateSqrtPriceToTick(sqrtPrice osmomath.BigDec) (tickIndex int64, err e
 		return 0, err
 	}
 
+	// TODO: remove this check. It is present to maintain backwards state-compatibility with
+	// v19.x and earlier major releases of Osmosis.
+	// Once https://github.com/osmosis-labs/osmosis/issues/5726 is fully complete,
+	// this should be removed.
+	//
+	// Backwards state-compatibility is maintained by having the swap and LP logic error
+	// here in case the price/tick falls below the origina minimum tick bounds that are
+	// consistent with v19.x and earlier release lines.
+	if tick < types.MinCurrentTick {
+		return 0, types.TickIndexMinimumError{MinTick: types.MinCurrentTick}
+	}
+
 	// We have a candidate bucket index `t`. We discern here if:
 	// * sqrtPrice in [TickToSqrtPrice(t - 1), TickToSqrtPrice(t))
 	// * sqrtPrice in [TickToSqrtPrice(t), TickToSqrtPrice(t + 1))

--- a/x/concentrated-liquidity/math/tick_test.go
+++ b/x/concentrated-liquidity/math/tick_test.go
@@ -833,6 +833,13 @@ func TestCalculatePriceToTick(t *testing.T) {
 
 // This test validates that conversions	at the new initialized boundary are sound.
 func TestSqrtPriceToTick_MinInitializedTickV2(t *testing.T) {
+
+	// TODO: remove this Skip(). It is present to maintain backwards state-compatibility with
+	// v19.x and earlier major releases of Osmosis.
+	// Once https://github.com/osmosis-labs/osmosis/issues/5726 is fully complete,
+	// this should be removed.
+	t.Skip()
+
 	minSqrtPrice, err := osmomath.MonotonicSqrtBigDec(types.MinSpotPriceV2)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Revert 1/3 for commits on main that should not be in v20

PR: https://github.com/osmosis-labs/osmosis/pull/6319

Commit: 6b3273fd5e883534200853970bc65af2c33c2fea
