### PR TITLE
chore: compare branch diffs script

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,9 @@
   "[proto3]": {
     "editor.defaultFormatter": "xaver.clang-format"
   },
-  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 120, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}"
+  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 120, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}",
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8"
+  },
+  "python.formatting.provider": "none"
 }

--- a/scripts/compare_git.py
+++ b/scripts/compare_git.py
@@ -1,0 +1,54 @@
+import subprocess
+import re
+
+
+def get_commits(branch):
+    try:
+        # Get the list of commits in the specified branch
+        commit_hashes = subprocess.check_output(
+            ['git', 'log', '--oneline', 'origin/' + branch]).decode().splitlines()
+        return commit_hashes
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+        return []
+
+
+def get_pr_number(commit_message):
+    # Extract PR number from commit message
+    pr_number = re.search(r'#\d+', commit_message)
+    return pr_number.group(0) if pr_number else None
+
+
+def main():
+    release_branch = input("Enter the release branch name: ")
+    main_branch = input("Enter the main branch name (default: main): ")
+
+    if not main_branch:
+        main_branch = "main"
+
+    # Fetch the latest branches
+    subprocess.call(['git', 'fetch'], stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+
+    main_commits = get_commits(main_branch)
+    release_commits = get_commits(release_branch)
+
+    main_pr_numbers = {get_pr_number(commit) for commit in main_commits}
+    release_pr_numbers = {get_pr_number(commit) for commit in release_commits}
+
+    # Find commits in main branch that are not backported to release branch
+    missing_commits = [commit for commit in main_commits if get_pr_number(
+        commit) not in release_pr_numbers]
+
+    if not missing_commits:
+        print(
+            f"All commits from {main_branch} are present in {release_branch}.")
+    else:
+        print(
+            f"\nCommits present in {main_branch} but missing in {release_branch}:")
+        for commit in missing_commits:
+            print(commit)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When creating a release, its important to check if any commits are missing from the feature branch. This script returns the delta between two branches. It is also smart enough to link a PR and its backport as the "same" PR and does not include it in its delta.

## Testing and Verifying

Used to check diff between main and v20.x

```
scripts % python3 compare_git.py
Enter the release branch name: v20.x
Enter the main branch name (default: main): 

Commits present in main but missing in v20.x:
c9e9b1004 Improve localosmosis docs (#6679)
6da6b231e auto: update Go import paths to v20 on branch main (#6688)
eec71f86b Test/max tick test (#6661)
bac369861 chore(deps): bump tj-actions/changed-files from 39.2.1 to 39.2.2 (#6675)
```

And conversely, check commits in v20.x but not main

```
scripts % python3 compare_git.py
Enter the release branch name: main
Enter the main branch name (default: main): v20.x

Commits present in v20.x but missing in main:
8516e1873 chore: revert commits not desired in v20 (#6682)
1cbcf46cb auto: update Go import paths to v20 on branch v20.x (#6690)
```

You will notice that the go imports paths shows up in both, but this was because this was done in two separate PRs, and not a backport.