### PR TITLE
Hoang/twap test

### DIFF
--- a/osmomath/binary_search.go
+++ b/osmomath/binary_search.go
@@ -9,7 +9,7 @@ import (
 // ErrTolerance is used to define a compare function, which checks if two
 // ints are within a certain error tolerance of one another,
 // and (optionally) that they are rounding in the correct direction.
-// ErrTolerance.Compare(a, b) returns true iff:
+// ErrTolerance.Compare(a, b) returns true if:
 // * RoundingMode = RoundUp, then a <= b
 // * RoundingMode = RoundDown, then a >= b
 // * |a - b| <= AdditiveTolerance

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -897,12 +897,12 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 			s.Require().NoError(err)
 
 			compareResult := osmomath.ErrTolerance{
-				MultiplicativeTolerance: osmomath.SmallestDec().Mul(osmomath.NewDec(32318177563)),
+				MultiplicativeTolerance: osmomath.SmallestDec().Mul(osmomath.NewDec(40000000000)),
 			}.CompareBigDec(
 				spotPrice,
 				osmomath.BigDecFromDec(twap),
 			)
-			s.Require().Equal(0, compareResult, "Geometric TWAP is not roughly close to spot price")
+			s.Require().Equal(0, compareResult, "Geometric TWAP is not roughly close to spot price at try: %d", i)
 		})
 	}
 }

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -896,12 +896,13 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 			twap, err := app.TwapKeeper.GetGeometricTwapToNow(ctx, 1, denom0, denom1, oldTime)
 			s.Require().NoError(err)
 
-			osmomath.ErrTolerance{
-				MultiplicativeTolerance: osmomath.SmallestDec(),
+			compareResult := osmomath.ErrTolerance{
+				MultiplicativeTolerance: osmomath.SmallestBigDec().Dec(),
 			}.CompareBigDec(
 				spotPrice,
 				osmomath.BigDecFromDec(twap),
 			)
+			s.Require().Equal(0, compareResult, "Geometric TWAP is not roughly close to spot price")
 		})
 	}
 }

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -897,7 +897,7 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 			s.Require().NoError(err)
 
 			compareResult := osmomath.ErrTolerance{
-				MultiplicativeTolerance: osmomath.SmallestBigDec().Dec(),
+				MultiplicativeTolerance: osmomath.SmallestDec().Mul(osmomath.NewDec(32318177563)),
 			}.CompareBigDec(
 				spotPrice,
 				osmomath.BigDecFromDec(twap),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6348 

## What is the purpose of the change
 TestGeometricTwapToNow_BalancerPool_Randomized add assert so that we can check Geometric TWAP is roughly close to spot price

## Testing and Verifying


This change added tests and can be verified as follows:

*(example:)*
- run TestGeometricTwapToNow_BalancerPool_Randomized


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A