### PR TITLE
chore: return error from twap

### DIFF
--- a/tests/osmosisibctesting/chain.go
+++ b/tests/osmosisibctesting/chain.go
@@ -113,7 +113,7 @@ func SignAndDeliver(
 	tx, _ := helpers.GenTx(
 		txCfg,
 		msgs,
-		sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 2500)},
+		sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 5000)},
 		helpers.DefaultGenTxGas,
 		chainID,
 		accNums,

--- a/x/authenticator/authenticator/spend_limits.go
+++ b/x/authenticator/authenticator/spend_limits.go
@@ -199,7 +199,7 @@ func (sla SpendLimitAuthenticator) getPriceInQuoteDenom(ctx sdk.Context, coin sd
 		numPools := sla.poolManagerKeeper.GetNextPoolId(ctx)
 		for i := uint64(1); i < numPools; i++ {
 			price, err := sla.twapKeeper.GetArithmeticTwapToNow(ctx, i, coin.Denom, sla.quoteDenom, oneWeekAgo)
-			if err != nil {
+			if err == nil {
 				return price, nil
 			}
 		}

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -3,9 +3,10 @@ package authenticator_test
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	"time"
 
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/authenticator"
 	"github.com/osmosis-labs/osmosis/v19/x/authenticator/testutils"
@@ -733,7 +734,7 @@ func (s *AuthenticatorSuite) TestSpendWithinLimitWithAuthzTableTest() {
 	}
 
 	// Create account for the second private key. This is needed for executing the grant
-	s.CreateAccount(s.PrivKeys[1], 50_000)
+	s.CreateAccount(s.PrivKeys[1], 100_000)
 
 	// Store the grant
 	_, err = s.chainA.SendMsgsFromPrivKeys(pks{s.PrivKeys[0]}, grantMsg)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When getting the price for a coin using the Twap strategy, sla.twapKeeper.GetArithme
ticTwapToNow is called to calculate the price

The issue is that the error check is inverted, causing the error to be ignored and an
empty price to be returned instead

## Testing and Verifying

run tests

- `cd x/authenticator`
- `go test ./...`
