### PR TITLE
Replace VERSION with SDK_VERSION in Makefile target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,20 +245,20 @@ distclean: clean
 ###                           Dependency Updates                            ###
 ###############################################################################
 
-VERSION := 
+SDK_VERSION :=
 MODFILES := ./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod
-# run with VERSION argument specified
-# e.g) make update-sdk-version VERSION=v0.45.1-0.20230523200430-193959b898ec
+# run with SDK_VERSION argument specified
+# e.g) make update-sdk-version SDK_VERSION=v0.45.1-0.20230523200430-193959b898ec
 # This will change sdk dependencyu version for go.mod in root directory + all sub-modules in this repo.
 update-sdk-version:
-	@if [ -z "$(VERSION)" ]; then \
-		echo "VERSION not set"; \
+	@if [ -z "$(SDK_VERSION)" ]; then \
+		echo "SDK_VERSION not set"; \
 		exit 1; \
 	fi
-	@echo "Updating version to $(VERSION)"
+	@echo "Updating version to $(SDK_VERSION)"
 	@for modfile in $(MODFILES); do \
 		if [ -e "$$modfile" ]; then \
-			sed -i '' 's|github.com/osmosis-labs/cosmos-sdk v[0-9a-z.\-]*|github.com/osmosis-labs/cosmos-sdk $(VERSION)|g' $$modfile; \
+			sed -i '' 's|github.com/osmosis-labs/cosmos-sdk v[0-9a-z.\-]*|github.com/osmosis-labs/cosmos-sdk $(SDK_VERSION)|g' $$modfile; \
 			cd `dirname $$modfile`; \
 			go mod tidy; \
 			cd - > /dev/null; \


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the Makefile to change the `VERSION` argument to `SDK_VERSION` in the update-sdk-version target.

This avoids overwriting the `VERSION` variable set before.

```
#!/usr/bin/make -f

VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
```

This was the cause of the bug showing empty `osmosisd version` in previous builds. 

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
You can check that it's working using:

```make
make update-sdk-version SDK_VERSION=v0.45.1-0.20230523200430-193959b898ec
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A