### PR TITLE
Add cleanup step to release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
       - 
         name: Make release
         run: |
-          sudo rm -rf dist
           make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: 🧹 Clean release folder
+        run: |
+          sudo rm -rf dist


### PR DESCRIPTION
## What is the purpose of the change

These steps include a cleanup procedure at the end of the release process to prevent the permission error found here: https://github.com/osmosis-labs/osmosis/actions/runs/6550289656/job/17789063555

The cleanup is necessary to ensure that the runner is left in a clean state. Otherwise, subsequent GitHub Actions that attempt to check out a reference could fail due to permission issues, as evidenced in the linked run.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A