### PR TITLE
chore: handle negative selected authenticators

### DIFF
--- a/x/authenticator/ante/ante.go
+++ b/x/authenticator/ante/ante.go
@@ -115,17 +115,16 @@ func (ad AuthenticatorDecorator) AnteHandle(
 			return sdk.Context{}, err
 		}
 
-		msgAuthenticated := false
-		var authenticators []types.Authenticator
-		if selectedAuthenticators[msgIndex] == -1 {
-			authenticators = allAuthenticators
-		} else {
+		// Check if there has been a selected authenticator in the transaction
+		authenticators := allAuthenticators
+		if selectedAuthenticators[msgIndex] >= 0 {
 			if int(selectedAuthenticators[msgIndex]) >= len(allAuthenticators) {
 				return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, fmt.Sprintf("invalid authenticator index for message %d", msgIndex))
 			}
 			authenticators = []types.Authenticator{allAuthenticators[selectedAuthenticators[msgIndex]]}
 		}
 
+		msgAuthenticated := false
 		for _, authenticator := range authenticators {
 			// Consume the authenticator's static gas
 			cacheCtx.GasMeter().ConsumeGas(authenticator.StaticGas(), "authenticator static gas")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

allow selectedAuthenticators indices to  be negative

> The ante handler for the Authenticator allows users to specify which authenticator to
use for any message. Every account has a registered list of authenticators which can
be used. The users specify the Authenticator index for the Authenticator to be used.

### How to test

- `cd x/authenticators`
- `go test ./...`