### PR TITLE
fix: ensure pubkey ante handler works as expected

### DIFF
--- a/x/authenticator/ante/ante.go
+++ b/x/authenticator/ante/ante.go
@@ -179,19 +179,33 @@ func (ad AuthenticatorDecorator) AnteHandle(
 	return next(ctx, tx, simulate)
 }
 
+// GetSelectedAuthenticators retrieves the selected authenticators for the provided transaction extension
+// and matches them with the number of messages in the transaction.
+// If no selected authenticators are found in the extension, the function initializes the list with -1 values.
+// It returns an array of selected authenticators or an error if the number of selected authenticators does not match
+// the number of messages in the transaction.
 func (ad AuthenticatorDecorator) GetSelectedAuthenticators(extTx authante.HasExtensionOptionsTx, msgCount int) ([]int32, error) {
+	// Initialize the list of selected authenticators with -1 values.
 	selectedAuthenticators := make([]int32, msgCount)
 	for i := range selectedAuthenticators {
 		selectedAuthenticators[i] = -1
 	}
 
+	// Get the transaction options from the AuthenticatorKeeper extension.
 	txOptions := ad.authenticatorKeeper.GetAuthenticatorExtension(extTx.GetNonCriticalExtensionOptions())
+
 	if txOptions != nil {
+		// Retrieve the selected authenticators from the extension.
 		selectedAuthenticatorsFromExtension := txOptions.GetSelectedAuthenticators()
+
 		if len(selectedAuthenticatorsFromExtension) != msgCount {
+			// Return an error if the number of selected authenticators does not match the number of messages.
 			return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Mismatch between the number of selected authenticators and messages")
 		}
+
+		// Use the selected authenticators from the extension.
 		selectedAuthenticators = selectedAuthenticatorsFromExtension
 	}
+
 	return selectedAuthenticators, nil
 }

--- a/x/authenticator/ante/fees.go
+++ b/x/authenticator/ante/fees.go
@@ -1,1 +1,0 @@
-package ante

--- a/x/authenticator/ante/pubkey.go
+++ b/x/authenticator/ante/pubkey.go
@@ -71,7 +71,6 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 			}
 			spkd.ak.SetAccount(ctx, acc)
 		}
-
 	}
 
 	// Also emit the following events, so that txs can be indexed by these

--- a/x/authenticator/ante/pubkey.go
+++ b/x/authenticator/ante/pubkey.go
@@ -55,6 +55,11 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 			}
 			pk = simSecp256k1Pubkey
 		}
+
+		// This is the only change from the original ante handler in the cosmos sdk
+		// we do this change because in the authenticator implementation we allow
+		// users to send transactions with differnet public keys that can authenticate as an account
+		// but we never want to set an incorrect public key in the original account store
 		// Only set key if simulate=false
 		if !simulate && bytes.Equal(pk.Address(), signers[i]) {
 			acc, err := authante.GetSignerAcc(ctx, spkd.ak, signers[i])

--- a/x/authenticator/ante/pubkey_test.go
+++ b/x/authenticator/ante/pubkey_test.go
@@ -119,7 +119,7 @@ func (s *AutherticatorSetPubKeyAnteSuite) TestSetPubKeyAnte() {
 		pk, err := s.OsmosisApp.AccountKeeper.GetPubKey(ctx, addr)
 		s.Require().NoError(err, "Error on retrieving pubkey from the account")
 		s.Require().True(s.TestPrivKeys[i].PubKey().Equals(pk),
-			"Wrong Pubkey retrieved from AccountKeeper, idx=%d\nexpected=%s\n     got=%s", i, s.TestPrivKeys[i].PubKey(), pk)
+			"Wrong Pubkey retrieved from AccountKeeper, idx=%d expected=%s got=%s", i, s.TestPrivKeys[i].PubKey(), pk)
 	}
 }
 

--- a/x/authenticator/ante/pubkey_test.go
+++ b/x/authenticator/ante/pubkey_test.go
@@ -1,0 +1,159 @@
+package ante_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v20/app"
+	"github.com/osmosis-labs/osmosis/v20/app/params"
+	"github.com/osmosis-labs/osmosis/v20/x/authenticator/ante"
+)
+
+// AutherticatorSetPubKeyAnteSuite is a test suite for the authenticator and SetPubKey AnteDecorator.
+type AutherticatorSetPubKeyAnteSuite struct {
+	suite.Suite
+	OsmosisApp             *app.OsmosisApp
+	Ctx                    sdk.Context
+	EncodingConfig         params.EncodingConfig
+	AuthenticatorDecorator ante.AuthenticatorDecorator
+	TestKeys               []string
+	TestAccAddress         []sdk.AccAddress
+	TestPrivKeys           []*secp256k1.PrivKey
+}
+
+// TestAutherticatorSetPubKeyAnteSuite runs the test suite for the authenticator and SetPubKey AnteDecorator.
+func TestAutherticatorSetPubKeyAnteSuite(t *testing.T) {
+	suite.Run(t, new(AutherticatorSetPubKeyAnteSuite))
+}
+
+// SetupTest initializes the test data and prepares the test environment.
+func (s *AutherticatorSetPubKeyAnteSuite) SetupTest() {
+	// Test data for authenticator signature verification
+	TestKeys := []string{
+		"6cf5103c60c939a5f38e383b52239c5296c968579eec1c68a47d70fbf1d19159",
+		"0dd4d1506e18a5712080708c338eb51ecf2afdceae01e8162e890b126ac190fe",
+		"49006a359803f0602a7ec521df88bf5527579da79112bb71f285dd3e7d438033",
+		"05d2f57e30fb44835da1cad5274cefd4c80f6652c425fb9e6cc9c6749126497c",
+		"f98d0b79c0cc9805b905bfc5104f31293a270e60c6fc613a037eeb484fddb974",
+	}
+	s.EncodingConfig = app.MakeEncodingConfig()
+
+	// Initialize the Osmosis application
+	s.OsmosisApp = app.Setup(false)
+
+	// Access the AccountKeeper from the Osmosis app
+	ak := s.OsmosisApp.AccountKeeper
+	s.Ctx = s.OsmosisApp.NewContext(false, tmproto.Header{})
+
+	// Set up test accounts
+	for _, key := range TestKeys {
+		bz, _ := hex.DecodeString(key)
+		priv := &secp256k1.PrivKey{Key: bz}
+
+		// Add the test private keys to an array for later use
+		s.TestPrivKeys = append(s.TestPrivKeys, priv)
+
+		// Generate an account address from the public key
+		accAddress := sdk.AccAddress(priv.PubKey().Address())
+
+		// Create a new BaseAccount for the test account
+		account := authtypes.NewBaseAccount(accAddress, nil, 0, 0)
+
+		// Set the test account in the AccountKeeper
+		ak.SetAccount(s.Ctx, account)
+
+		// Add the test accounts' addresses to an array for later use
+		s.TestAccAddress = append(s.TestAccAddress, accAddress)
+	}
+}
+
+// TestSetPubKeyAnte verifies that the SetPubKey AnteDecorator functions correctly.
+func (s *AutherticatorSetPubKeyAnteSuite) TestSetPubKeyAnte() {
+	osmoToken := "osmo"
+	coins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Create test messages for signing
+	testMsg1 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[0]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	testMsg2 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[1]),
+		Amount:      coins,
+	}
+	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Generate a test transaction
+	tx, _ := GenTx(s.EncodingConfig.TxConfig, []sdk.Msg{
+		testMsg1,
+		testMsg2,
+	}, feeCoins, 300000, "", []uint64{0, 0}, []uint64{0, 0}, []cryptotypes.PrivKey{
+		s.TestPrivKeys[0],
+		s.TestPrivKeys[1],
+	}, []cryptotypes.PrivKey{
+		s.TestPrivKeys[0],
+		s.TestPrivKeys[1],
+	}, []int32{})
+
+	// Create a SetPubKey AnteDecorator
+	spkd := ante.NewSetPubKeyDecorator(s.OsmosisApp.AccountKeeper)
+	antehandler := sdk.ChainAnteDecorators(spkd)
+
+	// Run the AnteDecorator on the transaction
+	ctx, err := antehandler(s.Ctx, tx, false)
+	s.Require().NoError(err)
+
+	// Require that all accounts have a pubkey set after the Decorator runs
+	for i, addr := range s.TestAccAddress[:2] {
+		pk, err := s.OsmosisApp.AccountKeeper.GetPubKey(ctx, addr)
+		s.Require().NoError(err, "Error on retrieving pubkey from the account")
+		s.Require().True(s.TestPrivKeys[i].PubKey().Equals(pk),
+			"Wrong Pubkey retrieved from AccountKeeper, idx=%d\nexpected=%s\n     got=%s", i, s.TestPrivKeys[i].PubKey(), pk)
+	}
+}
+
+// TestSetPubKeyAnteWithSenderNotSigner verifies that SetPubKey AnteDecorator correctly handles a non-signer sender.
+func (s *AutherticatorSetPubKeyAnteSuite) TestSetPubKeyAnteWithSenderNotSigner() {
+	osmoToken := "osmo"
+	coins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Create a test message with a sender that is not a signer
+	testMsg1 := &banktypes.MsgSend{
+		FromAddress: sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[4]),
+		ToAddress:   sdk.MustBech32ifyAddressBytes(osmoToken, s.TestAccAddress[3]),
+		Amount:      coins,
+	}
+	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
+
+	// Generate a test transaction
+	tx, _ := GenTx(s.EncodingConfig.TxConfig, []sdk.Msg{
+		testMsg1,
+	}, feeCoins, 300000, "", []uint64{0, 0}, []uint64{0, 0}, []cryptotypes.PrivKey{
+		s.TestPrivKeys[3],
+	}, []cryptotypes.PrivKey{
+		s.TestPrivKeys[3],
+	}, []int32{})
+
+	// Create a SetPubKey AnteDecorator
+	spkd := ante.NewSetPubKeyDecorator(s.OsmosisApp.AccountKeeper)
+	antehandler := sdk.ChainAnteDecorators(spkd)
+
+	// Run the AnteDecorator on the transaction
+	ctx, err := antehandler(s.Ctx, tx, false)
+	s.Require().NoError(err)
+
+	// Ensure that the public key has not been set for a non-signer sender
+	pk, err := s.OsmosisApp.AccountKeeper.GetPubKey(ctx, s.TestAccAddress[4])
+	s.Require().Equal(pk, nil, "Public Key has not been set")
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Test the public key ante handler and fix issue with setting incorrect public key

## Testing and Verifying

Added a test case to ensure issue is fixed

- `cd /x/authenticator/ante`
- `go test -v -cover ./...`