### PR TITLE
chore(CLI):Usage 'estimate-trade-based-on-price-impact' is long and repetitive

### DIFF
--- a/x/poolmanager/client/cli/query.go
+++ b/x/poolmanager/client/cli/query.go
@@ -195,7 +195,7 @@ func GetCmdEstimateTradeBasedOnPriceImpact() (
 	*osmocli.QueryDescriptor, *queryproto.EstimateTradeBasedOnPriceImpactRequest,
 ) {
 	return &osmocli.QueryDescriptor{
-		Use:   "estimate-trade-based-on-price-impact  <fromCoin> <toCoinDenom> <poolId> <maxPriceImpact> <externalPrice>",
+		Use:   "estimate-trade-based-on-price-impact",
 		Short: "Query estimate-trade-based-on-price-impact",
 		Long: `{{.Short}}
 		{{.CommandPrefix}} estimate-trade-based-on-price-impact 100uosmo stosmo  833 0.001 1.00`,


### PR DESCRIPTION
I suddenly found this line unusually long:
<img width="812" alt="image" src="https://github.com/osmosis-labs/osmosis/assets/93205232/64f4fe99-b46a-4d6e-8c91-5c40f7c64b45">
I think it needs to be deleted