### PR TITLE
fix: remove executedAuths in favor of using the Track function  

### DIFF
--- a/x/authenticator/authenticator/all_of.go
+++ b/x/authenticator/authenticator/all_of.go
@@ -11,7 +11,6 @@ import (
 
 type AllOfAuthenticator struct {
 	SubAuthenticators []iface.Authenticator
-	executedAuths     []iface.Authenticator
 	am                *AuthenticatorManager
 }
 
@@ -28,7 +27,6 @@ func NewAllOfAuthenticator(am *AuthenticatorManager) AllOfAuthenticator {
 	return AllOfAuthenticator{
 		am:                am,
 		SubAuthenticators: []iface.Authenticator{},
-		executedAuths:     []iface.Authenticator{},
 	}
 }
 
@@ -109,6 +107,7 @@ func (aoa AllOfAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddre
 			return result
 		}
 	}
+
 	return iface.Authenticated()
 }
 
@@ -123,11 +122,6 @@ func (aoa AllOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg
 }
 
 func (aoa AllOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
-	for _, auth := range aoa.executedAuths {
-		if confirmation := auth.ConfirmExecution(ctx, nil, msg, authenticationData); confirmation.IsBlock() {
-			return confirmation
-		}
-	}
 	return iface.Confirm()
 }
 

--- a/x/authenticator/authenticator/all_of.go
+++ b/x/authenticator/authenticator/all_of.go
@@ -122,6 +122,12 @@ func (aoa AllOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg
 }
 
 func (aoa AllOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
+	for _, auth := range aoa.SubAuthenticators {
+		result := auth.ConfirmExecution(ctx, account, msg, authenticationData)
+		if result.IsBlock() {
+			return result
+		}
+	}
 	return iface.Confirm()
 }
 

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -120,6 +120,12 @@ func (aoa AnyOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg
 }
 
 func (aoa AnyOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
+	for _, auth := range aoa.SubAuthenticators {
+		result := auth.ConfirmExecution(ctx, account, msg, authenticationData)
+		if result.IsBlock() {
+			return result
+		}
+	}
 	return iface.Confirm()
 }
 

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -122,11 +122,12 @@ func (aoa AnyOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg
 func (aoa AnyOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
 	for _, auth := range aoa.SubAuthenticators {
 		result := auth.ConfirmExecution(ctx, account, msg, authenticationData)
-		if result.IsBlock() {
-			return result
+		if result.IsConfirm() {
+			return iface.Confirm()
 		}
 	}
-	return iface.Confirm()
+
+	return iface.Block(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "No sub authenticators can confirm the transaction"))
 }
 
 func (aoa AnyOfAuthenticator) OnAuthenticatorAdded(ctx sdk.Context, account sdk.AccAddress, data []byte) error {

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -11,9 +11,7 @@ import (
 
 type AnyOfAuthenticator struct {
 	SubAuthenticators []iface.Authenticator
-	executedAuths     []iface.Authenticator // track which sub-authenticators were executed
-
-	am *AuthenticatorManager
+	am                *AuthenticatorManager
 }
 
 type AnyOfAuthenticatorData struct {
@@ -29,7 +27,6 @@ func NewAnyOfAuthenticator(am *AuthenticatorManager) AnyOfAuthenticator {
 	return AnyOfAuthenticator{
 		am:                am,
 		SubAuthenticators: []iface.Authenticator{},
-		executedAuths:     []iface.Authenticator{},
 	}
 }
 
@@ -106,7 +103,6 @@ func (aoa AnyOfAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAddre
 	for idx, auth := range aoa.SubAuthenticators {
 		result := auth.Authenticate(ctx, nil, msg, anyOfData.Data[idx])
 		if result.IsAuthenticated() || result.IsRejected() {
-			// TODO: Do we want to wrap the error in  case or rejection?
 			return result
 		}
 	}
@@ -124,12 +120,6 @@ func (aoa AnyOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg
 }
 
 func (aoa AnyOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
-	// Call ConfirmExecution on executed sub-authenticators
-	for _, auth := range aoa.executedAuths {
-		if confirmation := auth.ConfirmExecution(ctx, nil, msg, authenticationData); confirmation.IsBlock() {
-			return confirmation
-		}
-	}
 	return iface.Confirm()
 }
 

--- a/x/authenticator/authenticator/composition_test.go
+++ b/x/authenticator/authenticator/composition_test.go
@@ -17,12 +17,14 @@ import (
 
 type AggregatedAuthenticatorsTest struct {
 	suite.Suite
-	Ctx           sdk.Context
-	OsmosisApp    *app.OsmosisApp
-	AnyOfAuth     authenticator.AnyOfAuthenticator
-	AllOfAuth     authenticator.AllOfAuthenticator
-	alwaysApprove testutils.TestingAuthenticator
-	neverApprove  testutils.TestingAuthenticator
+	Ctx              sdk.Context
+	OsmosisApp       *app.OsmosisApp
+	AnyOfAuth        authenticator.AnyOfAuthenticator
+	AllOfAuth        authenticator.AllOfAuthenticator
+	alwaysApprove    testutils.TestingAuthenticator
+	neverApprove     testutils.TestingAuthenticator
+	approveAndBlock  testutils.TestingAuthenticator
+	rejectAndConfirm testutils.TestingAuthenticator
 }
 
 func TestAggregatedAuthenticatorsTest(t *testing.T) {
@@ -41,16 +43,30 @@ func (s *AggregatedAuthenticatorsTest) SetupTest() {
 	s.alwaysApprove = testutils.TestingAuthenticator{
 		Approve:        testutils.Always,
 		GasConsumption: 10,
+		Confirm:        testutils.Always,
 	}
 	s.neverApprove = testutils.TestingAuthenticator{
 		Approve:        testutils.Never,
 		GasConsumption: 10,
+		Confirm:        testutils.Never,
+	}
+	s.approveAndBlock = testutils.TestingAuthenticator{
+		Approve:        testutils.Always,
+		GasConsumption: 10,
+		Confirm:        testutils.Never,
+	}
+	s.rejectAndConfirm = testutils.TestingAuthenticator{
+		Approve:        testutils.Never,
+		GasConsumption: 10,
+		Confirm:        testutils.Always,
 	}
 
 	am.RegisterAuthenticator(s.AnyOfAuth)
 	am.RegisterAuthenticator(s.AllOfAuth)
 	am.RegisterAuthenticator(s.alwaysApprove)
 	am.RegisterAuthenticator(s.neverApprove)
+	am.RegisterAuthenticator(s.approveAndBlock)
+	am.RegisterAuthenticator(s.rejectAndConfirm)
 }
 
 func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
@@ -62,6 +78,7 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 		name             string
 		authenticators   []iface.Authenticator
 		expectSuccessful bool
+		expectConfirm    bool
 	}
 
 	testCases := []testCase{
@@ -69,46 +86,73 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 			name:             "alwaysApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "neverApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "alwaysApprove + neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "neverApprove + neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "neverApprove + neverApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "approveAndBlock",
+			authenticators:   []iface.Authenticator{s.approveAndBlock},
+			expectSuccessful: true,
+			expectConfirm:    false,
+		},
+		{
+			name:             "rejectAndConfirm",
+			authenticators:   []iface.Authenticator{s.rejectAndConfirm},
+			expectSuccessful: false,
+			expectConfirm:    true,
+		},
+		{
+			name:             "approveAndBlock + rejectAndConfirm",
+			authenticators:   []iface.Authenticator{s.approveAndBlock, s.rejectAndConfirm},
+			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 	}
 
@@ -135,6 +179,9 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 
 			success := initializedAuth.Authenticate(s.Ctx, nil, nil, authData)
 			s.Require().Equal(tc.expectSuccessful, success.IsAuthenticated())
+
+			result := initializedAuth.ConfirmExecution(s.Ctx, nil, nil, authData)
+			s.Require().Equal(tc.expectConfirm, result.IsConfirm())
 		})
 	}
 }
@@ -148,6 +195,7 @@ func (s *AggregatedAuthenticatorsTest) TestAllOfAuthenticator() {
 		name             string
 		authenticators   []iface.Authenticator
 		expectSuccessful bool
+		expectConfirm    bool
 	}
 
 	testCases := []testCase{
@@ -155,46 +203,73 @@ func (s *AggregatedAuthenticatorsTest) TestAllOfAuthenticator() {
 			name:             "alwaysApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "neverApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.alwaysApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
 			expectSuccessful: true,
+			expectConfirm:    true,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "alwaysApprove + neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "neverApprove + neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 		{
 			name:             "neverApprove + neverApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
 			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "approveAndBlock",
+			authenticators:   []iface.Authenticator{s.approveAndBlock},
+			expectSuccessful: true,
+			expectConfirm:    false,
+		},
+		{
+			name:             "rejectAndConfirm",
+			authenticators:   []iface.Authenticator{s.rejectAndConfirm},
+			expectSuccessful: false,
+			expectConfirm:    true,
+		},
+		{
+			name:             "approveAndBlock + rejectAndConfirm",
+			authenticators:   []iface.Authenticator{s.approveAndBlock, s.rejectAndConfirm},
+			expectSuccessful: false,
+			expectConfirm:    false,
 		},
 	}
 
@@ -221,6 +296,9 @@ func (s *AggregatedAuthenticatorsTest) TestAllOfAuthenticator() {
 
 			success := initializedAuth.Authenticate(s.Ctx, nil, nil, authData)
 			s.Require().Equal(tc.expectSuccessful, success.IsAuthenticated())
+
+			result := initializedAuth.ConfirmExecution(s.Ctx, nil, nil, authData)
+			s.Require().Equal(tc.expectConfirm, result.IsConfirm())
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

### Summary

>The Authenticator interface implements a ConfirmExecution handler, which is executed by the post-handler. This can be used to enforce transaction rules, or validate any post transaction changes. The ConfirmExecution handler can reject a transaction if any rules are violated

> The ConfirmExecution handler for these authenticators iterate over executedAuths and invoke ConfirmExecution for the Sub-Authenticators. However, executedAuths is never actually set anywhere

### Fix

We remove executed auths in favour of `authenticator.Track`

## Testing and Verifying

- Review code
- Run tests