### PR TITLE
fix: improve error message for slippage bound when LPing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#6758](https://github.com/osmosis-labs/osmosis/pull/6758) Add codec for MsgUndelegateFromRebalancedValidatorSet
 
+### Misc Improvements
+
+* [#6788](https://github.com/osmosis-labs/osmosis/pull/6788) Improve error message when CL LP fails due to slippage bound hit.
+
 ## v20.0.0
 
 ### Features

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -136,7 +136,7 @@ func (e InsufficientLiquidityCreatedError) Error() string {
 	if !e.IsTokenZero {
 		tokenNum = 1
 	}
-	return fmt.Sprintf("slippage bound: insufficient amount of token %d created. Actual: (%s). Minimum estimated (%s)", tokenNum, e.Actual, e.Minimum)
+	return fmt.Sprintf("slippage bound: insufficient amount of token %d created. Actual: (%s). Minimum estimated: (%s)", tokenNum, e.Actual, e.Minimum)
 }
 
 type NegativeLiquidityError struct {

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -136,7 +136,7 @@ func (e InsufficientLiquidityCreatedError) Error() string {
 	if !e.IsTokenZero {
 		tokenNum = 1
 	}
-	return fmt.Sprintf("insufficient amount of token %d created. Actual: (%s). Minimum (%s)", tokenNum, e.Actual, e.Minimum)
+	return fmt.Sprintf("slippage bound: insufficient amount of token %d created. Actual: (%s). Minimum estimated (%s)", tokenNum, e.Actual, e.Minimum)
 }
 
 type NegativeLiquidityError struct {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When slippage bound is hit during LP, the error message is confusing. This PR improves it.
