### PR TITLE
fix: LP error message improvements when zero liquidity

### DIFF
--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -111,17 +111,20 @@ func (k Keeper) CreatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		// Note that it is impossible to reach the case with both tokens being zero because that case is handled above.
 
 		if !amount0Desired.IsZero() && !amount1Desired.IsZero() {
-			return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) and amount1 (%d) to positive liquidity. Either try to provide more liquidity or confirm that the desired tick range is still active.
-			If range becomes inactive before getting on chain, you might need to provide more of one token as opposed to two of the original amount`, amount0Desired, amount1Desired)
+			return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) and amount1 (%d) to positive liquidity. Possible reasons could be:
+			Not providing enough liquidity in both tokens
+			The desired tick range becoming inactive. If range becomes inactive before getting on chain, more of one token will be required as opposed to two tokens of the original amount`, amount0Desired, amount1Desired)
 		} else if amount0Desired.IsZero() {
-			return CreatePositionData{}, fmt.Errorf(`failed to translate amount1 (%d) to positive liquidity. Either try providing more liquidity or confirm that given range is still inactive.
-			If the given range becomes activated, two tokens will be needed as opposed to one.`, amount1Desired)
+			return CreatePositionData{}, fmt.Errorf(`failed to translate amount1 (%d) to positive liquidity. Possible reasons could be:
+			Not providing enough liquidity in token 1.
+			The given tick range becoming activated after being inactive. If the given range becomes activated, two tokens will be needed as opposed to one.`, amount1Desired)
 		}
 
 		// amount1Desired is zero
 
-		return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) to positive liquidity. Either try providing more liquidity or confirm that given range is still inactive.
-			If the given range becomes activated, two tokens will be needed as opposed to one.`, amount0Desired)
+		return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) to positive liquidity. Possible reasons could be:
+		Not providing enough liquidity in token 0.
+		The given tick range becoming activated after being inactive. If the given range becomes activated, two tokens will be needed as opposed to one.`, amount0Desired)
 	}
 
 	// Initialize / update the position in the pool based on the provided tick range and liquidity delta.

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -108,7 +108,6 @@ func (k Keeper) CreatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 	// Calculate the amount of liquidity that will be added to the pool when this position is created.
 	liquidityDelta := math.GetLiquidityFromAmounts(pool.GetCurrentSqrtPrice(), sqrtPriceLowerTick, sqrtPriceUpperTick, amount0Desired, amount1Desired)
 	if liquidityDelta.IsZero() {
-
 		// Note that it is impossible to reach the case with both tokens being zero because that case is handled above.
 
 		if !amount0Desired.IsZero() && !amount1Desired.IsZero() {

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -112,16 +112,16 @@ func (k Keeper) CreatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 		// Note that it is impossible to reach the case with both tokens being zero because that case is handled above.
 
 		if !amount0Desired.IsZero() && !amount1Desired.IsZero() {
-			return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) and amount1 (%d) to positive liquidity. Either try to provide more liquidity or confirm that the desired tick range is still in range.
+			return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) and amount1 (%d) to positive liquidity. Either try to provide more liquidity or confirm that the desired tick range is still active.
 			If range becomes inactive before getting on chain, you might need to provide more of one token as opposed to two of the original amount`, amount0Desired, amount1Desired)
 		} else if amount0Desired.IsZero() {
-			return CreatePositionData{}, fmt.Errorf(`failed to translate amount1 (%d) to positive liquidity. Either try providing more liquidity or confirm that you are still out of range.
+			return CreatePositionData{}, fmt.Errorf(`failed to translate amount1 (%d) to positive liquidity. Either try providing more liquidity or confirm that given range is still inactive.
 			If the given range becomes activated, two tokens will be needed as opposed to one.`, amount1Desired)
 		}
 
 		// amount1Desired is zero
 
-		return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) to positive liquidity. Either try providing more liquidity or confirm that you are still out of range.
+		return CreatePositionData{}, fmt.Errorf(`failed to translate amount0 (%d) to positive liquidity. Either try providing more liquidity or confirm that given range is still inactive.
 			If the given range becomes activated, two tokens will be needed as opposed to one.`, amount0Desired)
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Smarter error message when LP ranges get out of range near bounds due to significant price movements. Prompted by the TIA launch