### PR TITLE
ci: fix missing target `check_version` and add eof blank line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ endif
 ###                            Build & Install                              ###
 ###############################################################################
 
-build: check_version go.sum
+build: build-check-version go.sum
 	mkdir -p $(BUILDDIR)/
 	GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/ $(GO_MODULE)/cmd/osmosisd
 
-install: check_version go.sum
+install: build-check-version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 
 ###############################################################################

--- a/scripts/makefiles/build.mk
+++ b/scripts/makefiles/build.mk
@@ -2,6 +2,19 @@
 ###                                  Build                                  ###
 ###############################################################################
 
+check_version:
+	@echo "Go version: $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION)"
+	@if [ $(GO_MAJOR_VERSION) -gt $(GO_MINIMUM_MAJOR_VERSION) ]; then \
+		echo "Go version is sufficient"; \
+		exit 0; \
+	elif [ $(GO_MAJOR_VERSION) -lt $(GO_MINIMUM_MAJOR_VERSION) ]; then \
+		echo '$(GO_VERSION_ERR_MSG)'; \
+		exit 1; \
+	elif [ $(GO_MINOR_VERSION) -lt $(GO_MINIMUM_MINOR_VERSION) ]; then \
+		echo '$(GO_VERSION_ERR_MSG)'; \
+		exit 1; \
+	fi
+
 build-help:
 	@echo "build subcommands"
 	@echo ""

--- a/scripts/makefiles/build.mk
+++ b/scripts/makefiles/build.mk
@@ -2,19 +2,6 @@
 ###                                  Build                                  ###
 ###############################################################################
 
-check_version:
-	@echo "Go version: $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION)"
-	@if [ $(GO_MAJOR_VERSION) -gt $(GO_MINIMUM_MAJOR_VERSION) ]; then \
-		echo "Go version is sufficient"; \
-		exit 0; \
-	elif [ $(GO_MAJOR_VERSION) -lt $(GO_MINIMUM_MAJOR_VERSION) ]; then \
-		echo '$(GO_VERSION_ERR_MSG)'; \
-		exit 1; \
-	elif [ $(GO_MINOR_VERSION) -lt $(GO_MINIMUM_MINOR_VERSION) ]; then \
-		echo '$(GO_VERSION_ERR_MSG)'; \
-		exit 1; \
-	fi
-
 build-help:
 	@echo "build subcommands"
 	@echo ""
@@ -46,7 +33,7 @@ build-check-version:
 		exit 1; \
 	fi
 
-build-all: check_version go.sum
+build-all: build-check-version go.sum
 	mkdir -p $(BUILDDIR)/
 	GOWORK=off go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./...
 
@@ -63,7 +50,7 @@ build-dev-build:
 	mkdir -p $(BUILDDIR)/
 	GOWORK=off go build $(GC_FLAGS) -mod=readonly -ldflags '$(DEBUG_LDFLAGS)' -trimpath -o $(BUILDDIR) ./...;
 
-build-install-with-autocomplete: check_version go.sum
+build-install-with-autocomplete: build-check-version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd
 	@PARENT_SHELL=$$(ps -o ppid= -p $$PPID | xargs ps -o comm= -p); \
 	if echo "$$PARENT_SHELL" | grep -q "zsh"; then \


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

This pull request introduces two changes to the `build.mk` file in the `scripts/makefiles` directory. 
1. It replace the usages of `check_version` target to `build-check-version`.
2. It adds an end-of-file (EOF) blank line at the end of the file.

NOTE: `check_version`  got renamed to `build-check-version` in #6776

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

- [x] Does this pull request introduce a new feature or user-facing behavior changes? - no
- [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? - no needed

Where is the change documented? 
- [ ] Specification (`x/{module}/README.md`)
- [ ] Osmosis documentation site
- [ ] Code comments?
- [x] N/A