### PR TITLE
refactor: change validate routes code inline

### DIFF
--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -35,8 +35,7 @@ func (k Keeper) RouteExactAmountIn(
 	tokenOutMinAmount osmomath.Int,
 ) (tokenOutAmount osmomath.Int, err error) {
 	// Ensure that provided route is not empty and has valid denom format.
-	routeStep := types.SwapAmountInRoutes(route)
-	if err := routeStep.Validate(); err != nil {
+	if err := types.SwapAmountInRoutes(route).Validate(); err != nil {
 		return osmomath.Int{}, err
 	}
 
@@ -290,8 +289,7 @@ func (k Keeper) RouteExactAmountOut(ctx sdk.Context,
 ) (tokenInAmount osmomath.Int, err error) {
 	isMultiHopRouted, routeSpreadFactor, sumOfSpreadFactors := false, osmomath.Dec{}, osmomath.Dec{}
 	// Ensure that provided route is not empty and has valid denom format.
-	routeStep := types.SwapAmountOutRoutes(route)
-	if err := routeStep.Validate(); err != nil {
+	if err := types.SwapAmountOutRoutes(route).Validate(); err != nil {
 		return osmomath.Int{}, err
 	}
 

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -233,8 +233,7 @@ func (k Keeper) MultihopEstimateOutGivenExactAmountIn(
 		}
 	}()
 
-	routeStep := types.SwapAmountInRoutes(route)
-	if err := routeStep.Validate(); err != nil {
+	if err := types.SwapAmountInRoutes(route).Validate(); err != nil {
 		return osmomath.Int{}, err
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves code readability of module x/poolmanager by change 
```go
routeStep := types.SwapAmountOutRoutes(route)
if err := routeStep.Validate(); err != nil {
	return osmomath.Int{}, err
}
```
to
```go
if err := types.SwapAmountOutRoutes(route).Validate(); err != nil {
	return osmomath.Int{}, err
}
```
because "routeStep" variable has define as `routeStep := types.SwapAmountOutRoutes(route)` , but redefined following with `for i, routeStep := range route {}` , that looks confusing

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A