### PR TITLE
Fix CI for Pushing E2E Images to Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ build/
 docs/
 networks/
 proto/
-scripts/
 tools/
 tests/localosmosis/
 tests/localrelayer/


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

CI for pushing e2e images to docker have been failing recently on main. (cref:https://github.com/osmosis-labs/osmosis/actions/runs/6740991117/job/18324888461)

Digging down the root cause, I have saw a log in our CI failure saying: "scripts/makefiles/build.mk: No such file or directory".  This led me to thinking that maybe docker can't access the Makefiles under scripts/Makefile, and confirmed this was the case after noticing scripts folder under docker ignore. 

This PR removes scripts from docker ignore

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A