### PR TITLE
remove continuous repetition code

### DIFF
--- a/x/concentrated-liquidity/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy.go
@@ -141,9 +141,6 @@ func GetSqrtPriceLimit(priceLimit osmomath.BigDec, zeroForOne bool) (osmomath.Bi
 		if err != nil {
 			return osmomath.BigDec{}, err
 		}
-		if err != nil {
-			return osmomath.BigDec{}, err
-		}
 		return osmomath.BigDecFromDec(sqrtPriceLimit), nil
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

remove following continuous repetition code:
```go
if priceLimit.GTE(types.MinSpotPriceBigDec) {
	// Truncation is fine since previous Osmosis version only supported
	// 18 decimal price ranges.
	sqrtPriceLimit, err := osmomath.MonotonicSqrt(priceLimit.Dec())
	if err != nil {
		return osmomath.BigDec{}, err
	}
	if err != nil {
		return osmomath.BigDec{}, err
	}
	return osmomath.BigDecFromDec(sqrtPriceLimit), nil
}
```

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A