### PR TITLE
refactor(SQS): convert poolmanager taker fee calc methods to functions

### DIFF
--- a/x/poolmanager/export_test.go
+++ b/x/poolmanager/export_test.go
@@ -45,14 +45,6 @@ func (k Keeper) CreateMultihopExpectedSwapOuts(
 	return k.createMultihopExpectedSwapOuts(ctx, route, tokenOut)
 }
 
-func (k Keeper) CalcTakerFeeExactIn(tokenIn sdk.Coin, takerFee osmomath.Dec) (sdk.Coin, sdk.Coin) {
-	return k.calcTakerFeeExactIn(tokenIn, takerFee)
-}
-
-func (k Keeper) CalcTakerFeeExactOut(tokenOut sdk.Coin, takerFee osmomath.Dec) (sdk.Coin, sdk.Coin) {
-	return k.calcTakerFeeExactOut(tokenOut, takerFee)
-}
-
 func (k Keeper) TrackVolume(ctx sdk.Context, poolId uint64, volumeGenerated sdk.Coin) {
 	k.trackVolume(ctx, poolId, volumeGenerated)
 }

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -256,7 +256,7 @@ func (k Keeper) MultihopEstimateOutGivenExactAmountIn(
 			return osmomath.Int{}, err
 		}
 
-		tokenInAfterSubTakerFee, _ := k.calcTakerFeeExactIn(tokenIn, takerFee)
+		tokenInAfterSubTakerFee, _ := CalcTakerFeeExactIn(tokenIn, takerFee)
 
 		tokenOut, err := swapModule.CalcOutAmtGivenIn(ctx, poolI, tokenInAfterSubTakerFee, routeStep.TokenOutDenom, spreadFactor)
 		if err != nil {
@@ -581,7 +581,7 @@ func (k Keeper) createMultihopExpectedSwapOuts(
 			return nil, err
 		}
 
-		tokenInAfterTakerFee, _ := k.calcTakerFeeExactOut(tokenIn, takerFee)
+		tokenInAfterTakerFee, _ := CalcTakerFeeExactOut(tokenIn, takerFee)
 
 		insExpected[i] = tokenInAfterTakerFee.Amount
 		tokenOut = tokenInAfterTakerFee

--- a/x/poolmanager/router_test.go
+++ b/x/poolmanager/router_test.go
@@ -1341,7 +1341,7 @@ func (s *KeeperTestSuite) calcInGivenOutAmountAsSeparateSwaps(routes []types.Swa
 		s.Require().NoError(err)
 
 		tokenInCoin := sdk.NewCoin(hop.TokenInDenom, tokenInAmt)
-		tokenInCoinAfterAddTakerFee, _ := s.App.PoolManagerKeeper.CalcTakerFeeExactOut(tokenInCoin, takerFee)
+		tokenInCoinAfterAddTakerFee, _ := poolmanager.CalcTakerFeeExactOut(tokenInCoin, takerFee)
 
 		nextTokenOut = tokenInCoinAfterAddTakerFee
 	}
@@ -1366,7 +1366,7 @@ func (s *KeeperTestSuite) calcOutGivenInAmountAsSeparatePoolSwaps(routes []types
 		takerFee, err := s.App.PoolManagerKeeper.GetTradingPairTakerFee(cacheCtx, hop.TokenOutDenom, nextTokenIn.Denom)
 		s.Require().NoError(err)
 
-		nextTokenInAfterSubTakerFee, _ := s.App.PoolManagerKeeper.CalcTakerFeeExactIn(nextTokenIn, takerFee)
+		nextTokenInAfterSubTakerFee, _ := poolmanager.CalcTakerFeeExactIn(nextTokenIn, takerFee)
 
 		// we then do individual swaps until we reach the end of the swap route
 		tokenOut, err := swapModule.SwapExactAmountIn(cacheCtx, s.TestAccs[0], pool, nextTokenInAfterSubTakerFee, hop.TokenOutDenom, osmomath.OneInt(), spreadFactor)

--- a/x/poolmanager/taker_fee.go
+++ b/x/poolmanager/taker_fee.go
@@ -100,9 +100,9 @@ func (k Keeper) chargeTakerFee(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom 
 	var tokenInAfterTakerFee sdk.Coin
 	var takerFeeCoin sdk.Coin
 	if exactIn {
-		tokenInAfterTakerFee, takerFeeCoin = k.calcTakerFeeExactIn(tokenIn, takerFee)
+		tokenInAfterTakerFee, takerFeeCoin = CalcTakerFeeExactIn(tokenIn, takerFee)
 	} else {
-		tokenInAfterTakerFee, takerFeeCoin = k.calcTakerFeeExactOut(tokenIn, takerFee)
+		tokenInAfterTakerFee, takerFeeCoin = CalcTakerFeeExactOut(tokenIn, takerFee)
 	}
 
 	// N.B. We truncate from the community pool calculation, then remove that from the total, and use the remaining for staking rewards.
@@ -176,7 +176,7 @@ func (k Keeper) chargeTakerFee(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom 
 
 // Returns remaining amount in to swap, and takerFeeCoins.
 // returns (1 - takerFee) * tokenIn, takerFee * tokenIn
-func (k Keeper) calcTakerFeeExactIn(tokenIn sdk.Coin, takerFee osmomath.Dec) (sdk.Coin, sdk.Coin) {
+func CalcTakerFeeExactIn(tokenIn sdk.Coin, takerFee osmomath.Dec) (sdk.Coin, sdk.Coin) {
 	amountInAfterSubTakerFee := tokenIn.Amount.ToLegacyDec().MulTruncate(osmomath.OneDec().Sub(takerFee))
 	tokenInAfterSubTakerFee := sdk.NewCoin(tokenIn.Denom, amountInAfterSubTakerFee.TruncateInt())
 	takerFeeCoin := sdk.NewCoin(tokenIn.Denom, tokenIn.Amount.Sub(tokenInAfterSubTakerFee.Amount))
@@ -184,7 +184,7 @@ func (k Keeper) calcTakerFeeExactIn(tokenIn sdk.Coin, takerFee osmomath.Dec) (sd
 	return tokenInAfterSubTakerFee, takerFeeCoin
 }
 
-func (k Keeper) calcTakerFeeExactOut(tokenIn sdk.Coin, takerFee osmomath.Dec) (sdk.Coin, sdk.Coin) {
+func CalcTakerFeeExactOut(tokenIn sdk.Coin, takerFee osmomath.Dec) (sdk.Coin, sdk.Coin) {
 	amountInAfterAddTakerFee := tokenIn.Amount.ToLegacyDec().Quo(osmomath.OneDec().Sub(takerFee))
 	tokenInAfterAddTakerFee := sdk.NewCoin(tokenIn.Denom, amountInAfterAddTakerFee.Ceil().TruncateInt())
 	takerFeeCoin := sdk.NewCoin(tokenIn.Denom, tokenInAfterAddTakerFee.Amount.Sub(tokenIn.Amount))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://app.clickup.com/t/86a1af4tp

## What is the purpose of the change

This PR converts some poolmanager taker fee calc methods to functions. In https://github.com/osmosis-labs/osmosis/pull/6785, these are used in SQS calculations directly.