### PR TITLE
chore: CL apptesting helpers for SQS

### DIFF
--- a/app/apptesting/concentrated_liquidity.go
+++ b/app/apptesting/concentrated_liquidity.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	clmath "github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity/math"
 	clmodel "github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity/model"
 	"github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v20/x/poolmanager/types"
@@ -13,14 +14,782 @@ import (
 	cl "github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity"
 )
 
+type ConcentratedKeeperTestHelper struct {
+	KeeperTestHelper
+	Clk               *cl.Keeper
+	AuthorizedUptimes []time.Duration
+}
+
+// Defines a concentrated liquidity swap test case.
+type ConcentratedSwapTest struct {
+	// Specific to swap out given in.
+	TokenIn       sdk.Coin
+	TokenOutDenom string
+
+	// Specific to swap in given out.
+	TokenOut     sdk.Coin
+	TokenInDenom string
+
+	// Shared.
+	PriceLimit               osmomath.BigDec
+	SpreadFactor             osmomath.Dec
+	SecondPositionLowerPrice osmomath.Dec
+	SecondPositionUpperPrice osmomath.Dec
+
+	ExpectedTokenIn                            sdk.Coin
+	ExpectedTokenOut                           sdk.Coin
+	ExpectedTick                               int64
+	ExpectedSqrtPrice                          osmomath.BigDec
+	ExpectedLowerTickSpreadRewardGrowth        sdk.DecCoins
+	ExpectedUpperTickSpreadRewardGrowth        sdk.DecCoins
+	ExpectedSpreadRewardGrowthAccumulatorValue osmomath.Dec
+	// since we use different values for the seondary position's tick, save (tick, expectedSpreadRewardGrowth) tuple
+	ExpectedSecondLowerTickSpreadRewardGrowth SecondConcentratedPosition
+	ExpectedSecondUpperTickSpreadRewardGrowth SecondConcentratedPosition
+
+	NewLowerPrice  osmomath.Dec
+	NewUpperPrice  osmomath.Dec
+	PoolLiqAmount0 osmomath.Int
+	PoolLiqAmount1 osmomath.Int
+	ExpectErr      bool
+}
+
+type SecondConcentratedPosition struct {
+	TickIndex                  int64
+	ExpectedSpreadRewardGrowth sdk.DecCoins
+}
+
 var (
-	ETH                = "eth"
-	USDC               = "usdc"
-	WBTC               = "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
-	DefaultTickSpacing = uint64(100)
-	DefaultLowerTick   = int64(30545000)
-	DefaultUpperTick   = int64(31500000)
-	DefaultCoinAmount  = osmomath.NewInt(1000000000000000000)
+	WBTC                       = "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
+	DefaultTickSpacing         = uint64(100)
+	DefaultLowerPrice          = osmomath.NewDec(4545)
+	DefaultLowerTick           = int64(30545000)
+	DefaultUpperPrice          = osmomath.NewDec(5500)
+	DefaultUpperTick           = int64(31500000)
+	DefaultCurrPrice           = osmomath.NewDec(5000)
+	DefaultCurrTick      int64 = 31000000
+	DefaultCurrSqrtPrice       = func() osmomath.BigDec {
+		curSqrtPrice, _ := osmomath.MonotonicSqrt(DefaultCurrPrice) // 70.710678118654752440
+		return osmomath.BigDecFromDec(curSqrtPrice)
+	}()
+
+	DefaultSpreadRewardAccumCoins = sdk.NewDecCoins(sdk.NewDecCoin("foo", osmomath.NewInt(50)))
+
+	DefaultCoinAmount = osmomath.NewInt(1000000000000000000)
+
+	// Default tokens and amounts
+	ETH                 = "eth"
+	DefaultAmt0         = osmomath.NewInt(1000000)
+	DefaultAmt0Expected = osmomath.NewInt(998976)
+	DefaultCoin0        = sdk.NewCoin(ETH, DefaultAmt0)
+	USDC                = "usdc"
+	DefaultAmt1         = osmomath.NewInt(5000000000)
+	DefaultAmt1Expected = osmomath.NewInt(5000000000)
+	DefaultCoin1        = sdk.NewCoin(USDC, DefaultAmt1)
+	DefaultCoins        = sdk.NewCoins(DefaultCoin0, DefaultCoin1)
+
+	// Both of the following liquidity values are calculated in x/concentrated-liquidity/python/swap_test.py
+	DefaultLiquidityAmt   = osmomath.MustNewDecFromStr("1517882343.751510417627556287")
+	FullRangeLiquidityAmt = osmomath.MustNewDecFromStr("70710678.118654752941000000")
+
+	swapFundCoins = sdk.NewCoins(sdk.NewCoin("eth", osmomath.NewInt(10000000000000)), sdk.NewCoin("usdc", osmomath.NewInt(1000000000000)))
+
+	roundingError = osmomath.OneInt()
+	EmptyCoins    = sdk.DecCoins(nil)
+
+	// Various sqrt estimates
+	Sqrt4994 = osmomath.MustNewDecFromStr("70.668238976219012614")
+
+	// swap out given in test cases
+	SwapOutGivenInCases = map[string]ConcentratedSwapTest{
+		//  One price range
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		"single position within one tick: usdc -> eth": {
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.NewBigDec(5004),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// from math import *
+			// from decimal import *
+
+			// token_in = Decimal("42000000")
+			// liq = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+
+			// rounding_direction = ROUND_DOWN # round delta down since we're swapping asset 1 in
+			// sqrt_delta = (token_in / liq).quantize(precision, rounding=rounding_direction)
+			// sqrt_next = sqrt_cur + sqrt_delta
+
+			// token_out = floor(liq * (sqrt_next - sqrt_cur) / (sqrt_next * sqrt_cur))
+			// token_in = ceil(liq * abs(sqrt_cur - sqrt_next))
+
+			// print(sqrt_next)
+			// print(token_in)
+			// print(token_out)
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8396)),
+			ExpectedTick:     31003913,
+			// Corresponds to sqrt_next in script above
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738348247484497718514800000003600626"),
+			// tick's accum coins stay same since crossing tick does not occur in this case
+		},
+		"single position within one tick: usdc -> eth, with zero price limit": {
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.ZeroBigDec(),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// from math import *
+			// from decimal import *
+
+			// token_in = Decimal("42000000")
+			// liq = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+
+			// rounding_direction = ROUND_DOWN # round delta down since we're swapping asset 1 in
+			// sqrt_delta = (token_in / liq).quantize(precision, rounding=rounding_direction)
+			// sqrt_next = sqrt_cur + sqrt_delta
+
+			// token_out = floor(liq * (sqrt_next - sqrt_cur) / (sqrt_next * sqrt_cur))
+			// token_in = ceil(liq * abs(sqrt_cur - sqrt_next))
+
+			// print(sqrt_next)
+			// print(token_in)
+			// print(token_out)
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8396)),
+			ExpectedTick:     31003913,
+			// Corresponds to sqrt_next in script above
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738348247484497718514800000003600626"),
+			// tick's accum coins stay same since crossing tick does not occur in this case
+		},
+		"single position within one tick: eth -> usdc": {
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4993),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// from math import *
+			// from decimal import *
+
+			// liquidity = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// token_in = 13370
+
+			// sqrt_next = get_next_sqrt_price_from_amount0_in_round_up(liquidity, sqrt_cur, token_in)
+			// token_out = round_sdk_prec_down(calc_amount_one_delta(liquidity, sqrt_cur, sqrt_next, False))
+			// token_in = ceil(calc_amount_zero_delta(liquidity, sqrt_cur, sqrt_next, True))
+
+			// # Summary
+			// print(sqrt_next)
+			// print(token_out)
+			// print(token_in)
+			ExpectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(66808388)),
+			ExpectedTick:      30993777,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.666663910857144332134093938182290274"),
+		},
+		"single position within one tick: eth -> usdc, with zero price limit": {
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.ZeroBigDec(),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// liquidity = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// token_in = 13370
+
+			// sqrt_next = (liquidity * sqrt_cur / (liquidity + token_in * sqrt_cur)).quantize(precision, rounding=ROUND_UP)
+
+			// # CalcAmount0Delta rounded up
+			// expectedTokenIn = ((liquidity * (sqrt_cur - sqrt_next)) / (sqrt_cur * sqrt_next)).quantize(Decimal('1'), rounding=ROUND_UP)
+			// # CalcAmount1Delta rounded down
+			// expectedTokenOut = (liquidity * (sqrt_cur - sqrt_next)).quantize(Decimal('1'), rounding=ROUND_DOWN)
+
+			// # Summary
+			// print(sqrt_next)
+			// print(expectedTokenIn)
+			// print(expectedTokenOut)
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66808388)),
+			ExpectedTick:     30993777,
+			// True value with arbitrary precision: 70.6666639108571443321...
+			// Expected value due to our monotonic sqrt's >= true value guarantee: 70.666663910857144333
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.666663910857144332134093938182290274"),
+		},
+		//  Two equal price ranges
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		//  4545 -----|----- 5500
+		"two positions within one tick: usdc -> eth": {
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(5002),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
+			// from math import *
+			// from decimal import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// token_in = Decimal("42000000")
+			// liq = 2 * Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+
+			// rounding_direction = ROUND_DOWN # round delta down since we're swapping asset 1 in
+			// sqrt_delta = (token_in / liq).quantize(precision, rounding=rounding_direction)
+			// sqrt_next = sqrt_cur + sqrt_delta
+
+			// token_out = floor(liq * (sqrt_next - sqrt_cur) / (sqrt_next * sqrt_cur))
+			// token_in = ceil(liq * abs(sqrt_cur - sqrt_next))
+
+			// print(sqrt_next)
+			// print(token_in)
+			// print(token_out)
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8398)),
+			ExpectedTick:     31001956,
+			// Corresponds to sqrt_next in script above
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724513183069625079757400000001800313"),
+			// two positions with same liquidity entered
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+		},
+		"two positions within one tick: eth -> usdc": {
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4996),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
+			// from math import *
+			// from decimal import *
+			// getcontext().prec = 60
+
+			// liquidity = 2 * Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// token_in = 13370
+
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// sqrt_next = (liquidity * sqrt_cur / (liquidity + token_in * sqrt_cur)).quantize(precision, rounding=ROUND_UP)
+
+			// # CalcAmount0Delta rounded up
+			// expectedTokenIn = ((liquidity * (sqrt_cur - sqrt_next)) / (sqrt_cur * sqrt_next)).quantize(Decimal('1'), rounding=ROUND_UP)
+			// # CalcAmount1Delta rounded down
+			// expectedTokenOut = (liquidity * (sqrt_cur - sqrt_next)).quantize(Decimal('1'), rounding=ROUND_DOWN)
+
+			// # Summary
+			// print(sqrt_next)
+			// print(expectedTokenIn)
+			// print(expectedTokenOut)
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
+			ExpectedTick:     30996887,
+			// True value with arbitrary precision: 70.6886641634088363202...
+			// Expected value due to our monotonic sqrt's >= true value guarantee: 70.688664163408836321
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.688664163408836320215015370847179540"),
+			// two positions with same liquidity entered
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+		},
+		//  Consecutive price ranges
+
+		//          5000
+		//  4545 -----|----- 5500
+		//             5500 ----------- 6250
+
+		"two positions with consecutive price ranges: usdc -> eth": {
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6255),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5500),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			// from math import *
+			// from decimal import *
+			// # Range 1: From 5000 to 5500
+			// token_in = Decimal("10000000000")
+			// liq_1 = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// sqrt_next_1 = Decimal("74.161984870956629488") # sqrt5500
+
+			// token_out_1 = liq_1 * (sqrt_next_1 - sqrt_cur ) / (sqrt_next_1 * sqrt_cur)
+			// token_in_1 = ceil(liq_1 * abs(sqrt_cur - sqrt_next_1 ))
+
+			// token_in = token_in - token_in_1
+
+			// # Range 2: from 5500 till end
+			// # Using clmath.py scripts: get_liquidity_from_amounts(DefaultCurrSqrtPrice, sqrt5500, sqrt6250, DefaultPoolLiq0, DefaultPoolLiq1)
+			// liq_2 = Decimal("1197767444.955508123483846019")
+
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+			// rounding_direction = ROUND_DOWN # round delta down since we're swapping asset 1 in
+			// sqrt_delta = (token_in / liq_2).quantize(precision, rounding=rounding_direction)
+			// sqrt_next_2 = sqrt_next_1 + sqrt_delta
+
+			// token_out_2 = liq_2 * (sqrt_next_2 - sqrt_next_1 ) / (sqrt_next_1 * sqrt_next_2)
+			// token_in_2 = ceil(liq_2 * abs(sqrt_next_2 - sqrt_next_1 ))
+
+			// # Summary:
+			// token_in = token_in_1 + token_in_2
+			// token_out = (token_out_1 + token_out_2).quantize(Decimal('1'), rounding=ROUND_DOWN)
+			// print(sqrt_next_2)
+			// print(token_in)
+			// print(token_out)
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(1820630)),
+			ExpectedTick:     32105414,
+			// Equivalent to sqrt_next_2 in the script above
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137149196095607130096044752300452857"),
+			//  second positions both have greater tick than the current tick, thus never initialized
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 315000, ExpectedSpreadRewardGrowth: EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5500),
+			NewUpperPrice: osmomath.NewDec(6250),
+		},
+		//  Consecutive price ranges
+		//
+		//                     5000
+		//             4545 -----|----- 5500
+		//  4000 ----------- 4545
+		//
+		"two positions with consecutive price ranges: eth -> usdc": {
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(3900),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4545),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
+			// crosses one tick with spread reward growth outside
+			ExpectedTick: 30095166,
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// token_in = Decimal("2000000")
+
+			// # Swap step 1
+			// liq = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// sqrt_next_1 = Decimal("67.416615162732695594")
+			// token_out = round_sdk_prec_down(calc_amount_one_delta(liq, sqrt_cur, sqrt_next_1, False))
+			// token_in = token_in - ceil(calc_amount_zero_delta(liq, sqrt_cur, sqrt_next_1, True))
+
+			// # Swap step 2
+			// liq_2 = Decimal("1198735489.597250295669959397")
+			// sqrt_next_2 = get_next_sqrt_price_from_amount0_in_round_up(liq_2, sqrt_next_1, token_in)
+			// token_out = token_out + round_sdk_prec_down(calc_amount_one_delta(liq_2, sqrt_next_1, sqrt_next_2, False))
+			// token_in = token_in - ceil(calc_amount_zero_delta(liq_2, sqrt_next_1, sqrt_next_2, True))
+
+			// print(sqrt_next_2)
+			// print(token_out)
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("63.993489023323078692803734142129673908"),
+			// crossing tick happens single time for each upper tick and lower tick.
+			// Thus the tick's spread reward growth is DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins
+			ExpectedLowerTickSpreadRewardGrowth: DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth: DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			//  second positions both have greater tick than the current tick, thus never initialized
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 305450, ExpectedSpreadRewardGrowth: EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4545),
+		},
+		//  Partially overlapping price ranges
+
+		//          5000
+		//  4545 -----|----- 5500
+		//        5001 ----------- 6250
+		//
+		"two positions with partially overlapping price ranges: usdc -> eth": {
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6056),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5001),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1864161)),
+			ExpectedTick:             32055919,
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// from math import *
+			// from decimal import *
+			// # Range 1: From 5000 to 5500
+			// token_in = Decimal("10000000000")
+
+			// # Swap step 1
+			// liq = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// sqrt_next_1 = Decimal("70.717748832948578243")
+			// token_out = round_sdk_prec_down(calc_amount_zero_delta(liq, sqrt_cur, sqrt_next_1, False))
+			// token_in = token_in - ceil(calc_amount_one_delta(liq, sqrt_cur, sqrt_next_1, True))
+
+			// # Swap step 2
+			// liq_2 = Decimal("2188298432.357179144666797069")
+			// sqrt_next_2 = Decimal("74.161984870956629488")
+			// token_out = token_out + round_sdk_prec_down(calc_amount_zero_delta(liq_2, sqrt_next_1, sqrt_next_2, False))
+			// token_in = token_in - ceil(calc_amount_one_delta(liq_2, sqrt_next_1, sqrt_next_2, True))
+
+			// # Swap step 3
+			// liq_3 = Decimal("670416088.605668727039240782")
+			// sqrt_next_3 = get_next_sqrt_price_from_amount1_in_round_down(liq_3, sqrt_next_2, token_in)
+
+			// print(sqrt_next_3)
+			// print(token_out)
+			ExpectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("77.819789636800169393792766394158739007"),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: EmptyCoins},
+			NewLowerPrice:                             osmomath.NewDec(5001),
+			NewUpperPrice:                             osmomath.NewDec(6250),
+		},
+		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc -> eth": {
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(8500000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.NewBigDec(6056),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+			// getcontext().prec = 60
+			// # Range 1: From 5000 to 5001
+			// token_in = Decimal("8500000000")
+			// liq_1 = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// sqrt_next_1 = Decimal("70.717748832948578243") # sqrt5001
+
+			// token_out_1 = liq_1 * (sqrt_next_1 - sqrt_cur ) / (sqrt_next_1 * sqrt_cur)
+			// token_in_1 = ceil(liq_1 * (sqrt_next_1 - sqrt_cur ))
+
+			// token_in = token_in - token_in_1
+
+			// # Range 2: from 5001 to 5500:
+			// # Using clmath.py scripts: get_liquidity_from_amounts(DefaultCurrSqrtPrice, sqrt5001, sqrt6250, DefaultPoolLiq0, DefaultPoolLiq1)
+			// second_pos_liq = Decimal("670416088.605668727039240782")
+			// liq_2 = liq_1 + second_pos_liq
+			// sqrt_next_2 = Decimal("74.161984870956629488") # sqrt5500
+
+			// token_out_2 = liq_2 * (sqrt_next_2 - sqrt_next_1 ) / (sqrt_next_1 * sqrt_next_2)
+			// token_in_2 = ceil(liq_2 * (sqrt_next_2 - sqrt_next_1 ))
+
+			// token_in = token_in - token_in_2
+
+			// # Range 3: from 5500 till end
+			// liq_3 = second_pos_liq
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+			// rounding_direction = ROUND_DOWN # round delta down since we're swapping asset 1 in
+			// sqrt_delta = (token_in / liq_3).quantize(precision, rounding=rounding_direction)
+			// sqrt_next_3 = sqrt_next_2 + sqrt_delta
+
+			// token_out_3 = liq_3 * (sqrt_next_3 - sqrt_next_2 ) / (sqrt_next_3 * sqrt_next_2)
+			// token_in_3 = ceil(liq_3 * (sqrt_next_3 - sqrt_next_2 ))
+
+			// # Summary:
+			// token_in = token_in_1 + token_in_2 + token_in_3
+			// token_out = (token_out_1 + token_out_2 + token_out_3).quantize(Decimal('1'), rounding=ROUND_DOWN)
+			// print(sqrt_next_3)
+			// print(token_in)
+			// print(token_out)
+			SecondPositionLowerPrice:                  osmomath.NewDec(5001),
+			SecondPositionUpperPrice:                  osmomath.NewDec(6250),
+			ExpectedTokenIn:                           sdk.NewCoin("usdc", osmomath.NewInt(8500000000)),
+			ExpectedTokenOut:                          sdk.NewCoin("eth", osmomath.NewInt(1609138)),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedTick:                              31712695,
+			// Corresponds to sqrt_next_3 in the script above
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582373164412551492069079174313215667"),
+			NewLowerPrice:     osmomath.NewDec(5001),
+			NewUpperPrice:     osmomath.NewDec(6250),
+		},
+		//  Partially overlapping price ranges
+		//
+		//                5000
+		//        4545 -----|----- 5500
+		//  4000 ----------- 4999
+		//
+		"two positions with partially overlapping price ranges: eth -> usdc": {
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4128),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+			// rounding_direction = ROUND_UP # round delta up since we're swapping asset 0 in
+
+			// # Setup
+			// token_in = Decimal("2000000")
+			// liq_pos_1 = Decimal("1517882343.751510417627556287")
+			// # Using clmath.py scripts: get_liquidity_from_amounts(DefaultCurrSqrtPrice, sqrt4000, sqrt4999, DefaultPoolLiq0, DefaultPoolLiq1)
+			// liq_pos_2 = Decimal("670416215.718827443660400593")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+
+			// # Swapping through range 5000 -> 4999
+			// liq_0 = liq_pos_1
+			// sqrt_next_0 = Decimal("70.703606697254136613") # sqrt4999
+			// token_out_0 = liq_0 * abs(sqrt_cur - sqrt_next_0 )
+			// token_in_0 = ceil(liq_0 * abs(sqrt_cur - sqrt_next_0 ) / (sqrt_next_0 * sqrt_cur))
+			// token_in = token_in - token_in_0
+
+			// # Swapping through range 4999 -> 4545
+			// liq_1 = liq_pos_1 + liq_pos_2
+			// sqrt_next_1 = Decimal("67.416615162732695594") # sqrt4545
+			// token_out_1 = liq_1 * abs(sqrt_next_0 - sqrt_next_1 )
+			// token_in_1 = ceil(liq_1 * abs(sqrt_next_0 - sqrt_next_1 ) / (sqrt_next_1 * sqrt_next_0))
+
+			// token_in = token_in - token_in_1
+
+			// # Swapping through range 4545 -> end
+			// liq_2 = liq_pos_2
+			// sqrt_next_2 = (liq_2 * sqrt_next_1 / (liq_2 + token_in * sqrt_next_1)).quantize(precision, rounding=rounding_direction)
+			// token_out_2 = liq_2 * (sqrt_next_1 - sqrt_next_2 )
+			// token_in_2 = ceil(liq_2 * (sqrt_next_1 - sqrt_next_2 ) / (sqrt_next_2 * sqrt_next_1))
+
+			// # Summary:
+			// token_in = token_in_0 + token_in_1 + token_in_2
+			// token_out = (token_out_0 + token_out_1 + token_out_2).quantize(Decimal('1'), rounding=ROUND_DOWN)
+			// print(sqrt_next_2)
+			// print(token_in)
+			// print(token_out)
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
+			ExpectedTick:             30129083,
+			// Corresponds to sqrt_next_2 in the script above
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943794993248953756640624575523292"),
+			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
+			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
+		},
+		//          		5000
+		//  		4545 -----|----- 5500
+		//  4000 ---------- 4999
+		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc": {
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(1800000)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4128),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(1800000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8479320318)),
+			ExpectedTick:             30292059,
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// token_in = Decimal("1800000")
+
+			// # Swap step 1
+			// liq = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// sqrt_next_1 = Decimal("70.703606697254136613")
+			// token_out = round_sdk_prec_down(calc_amount_one_delta(liq, sqrt_cur, sqrt_next_1, False))
+			// token_in = token_in - ceil(calc_amount_zero_delta(liq, sqrt_cur, sqrt_next_1, True))
+
+			// # Swap step 2
+			// liq_2 = Decimal("2188298559.470337861287956880")
+			// sqrt_next_2 = Decimal("67.416615162732695594")
+			// token_out = token_out + round_sdk_prec_down(calc_amount_one_delta(liq_2, sqrt_next_1, sqrt_next_2, False))
+			// token_in = token_in - ceil(calc_amount_zero_delta(liq_2, sqrt_next_1, sqrt_next_2, True))
+
+			// # Swap step 3
+			// liq_3 = Decimal("670416215.718827443660400593")
+			// sqrt_next_3 = get_next_sqrt_price_from_amount0_in_round_up(liq_3, sqrt_next_2, token_in)
+			// token_out = token_out + round_sdk_prec_down(calc_amount_one_delta(liq_3, sqrt_next_2, sqrt_next_3, False))
+			// token_in = token_in - ceil(calc_amount_zero_delta(liq_3, sqrt_next_2, sqrt_next_3, True))
+
+			// print(sqrt_next_3)
+			// print(token_out)
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.513815285481060959469337552596846421"),
+			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
+			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
+		},
+		//  Sequential price ranges with a gap
+		//
+		//          5000
+		//  4545 -----|----- 5500
+		//              5501 ----------- 6250
+		//
+		"two sequential positions with a gap": {
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5501),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1820545)),
+			ExpectedTick:             32105555,
+			// from math import *
+			// from decimal import *
+
+			// import sys
+
+			// # import custom CL script
+			// sys.path.insert(0, 'x/concentrated-liquidity/python')
+			// from clmath import *
+
+			// getcontext().prec = 60
+			// precision = Decimal('1.000000000000000000000000000000000000') # 36 decimal precision
+
+			// token_in = Decimal("10000000000")
+
+			// # Swap step 1
+			// liq = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// sqrt_next_1 = Decimal("74.161984870956629488")
+			// token_out = round_sdk_prec_down(calc_amount_zero_delta(liq, sqrt_cur, sqrt_next_1, False))
+			// token_in = token_in - ceil(calc_amount_one_delta(liq, sqrt_cur, sqrt_next_1, True))
+
+			// # Swap step 2
+			// liq_2 = Decimal("0.000000000000000000")
+			// sqrt_next_2 = Decimal("74.168726563154635304")
+			// token_out = token_out + round_sdk_prec_down(calc_amount_zero_delta(liq_2, sqrt_next_1, sqrt_next_2, False))
+			// token_in = token_in - ceil(calc_amount_one_delta(liq_2, sqrt_next_1, sqrt_next_2, True))
+
+			// # Swap step 3
+			// liq_3 = Decimal("1199528406.187413669481596330")
+			// sqrt_next_3 = get_next_sqrt_price_from_amount1_in_round_down(liq_3, sqrt_next_2, token_in)
+			// token_out = token_out + round_sdk_prec_down(calc_amount_zero_delta(liq_3, sqrt_next_2, sqrt_next_3, False))
+			// token_in = token_in - ceil(calc_amount_one_delta(liq_3, sqrt_next_2, sqrt_next_3, True))
+
+			// print(sqrt_next_3)
+			// print(token_out)
+			ExpectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("78.138055169663761658508234345605157554"),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedSecondLowerTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 315010, ExpectedSpreadRewardGrowth: EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: SecondConcentratedPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: EmptyCoins},
+			NewLowerPrice:                             osmomath.NewDec(5501),
+			NewUpperPrice:                             osmomath.NewDec(6250),
+		},
+		// Slippage protection doesn't cause a failure but interrupts early.
+		//          5000
+		//  4545 ---!-|----- 5500
+		"single position within one tick, trade completes but slippage protection interrupts trade early: eth -> usdc": {
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4994),
+			SpreadFactor:  osmomath.ZeroDec(),
+			// from math import *
+			// from decimal import *
+			//
+			// liquidity = Decimal("1517882343.751510417627556287")
+			// sqrt_cur = Decimal("70.710678118654752441") # sqrt5000
+			// token_in = 13370
+			//
+			// # Exact since we hit price limit before next initialized tick
+			// sqrt_next = Decimal("70.668238976219012614") # sqrt4994
+			//
+			// # CalcAmount0Delta rounded up
+			// expectedTokenIn = ((liquidity * (sqrt_cur - sqrt_next)) / (sqrt_cur * sqrt_next)).quantize(Decimal('1'), rounding=ROUND_UP)
+			// # CalcAmount1Delta rounded down
+			// expectedTokenOut = (liquidity * (sqrt_cur - sqrt_next)).quantize(Decimal('1'), rounding=ROUND_DOWN)
+			//
+			// # Summary
+			// print(sqrt_next)
+			// print(expectedTokenIn)
+			// print(expectedTokenOut)
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(12892)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
+			ExpectedTick: func() int64 {
+				tick, _ := clmath.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(Sqrt4994), DefaultTickSpacing)
+				return tick
+			}(),
+			// Since the next sqrt price is based on the price limit, we can calculate this directly.
+			ExpectedSqrtPrice: osmomath.BigDecFromDec(osmomath.MustMonotonicSqrt(osmomath.NewDec(4994))),
+		},
+	}
 )
 
 // PrepareConcentratedPool sets up an eth usdc concentrated liquidity pool with a tick spacing of 100,
@@ -146,4 +915,69 @@ func (s *KeeperTestHelper) SetupConcentratedLiquidityDenomsAndPoolCreation() {
 	poolManagerParams := s.App.PoolManagerKeeper.GetParams(s.Ctx)
 	poolManagerParams.AuthorizedQuoteDenoms = append(poolmanagertypes.DefaultParams().AuthorizedQuoteDenoms, ETH, USDC, BAR, BAZ, FOO, UOSMO, STAKE, WBTC)
 	s.App.PoolManagerKeeper.SetParams(s.Ctx, poolManagerParams)
+}
+
+func (s *ConcentratedKeeperTestHelper) SetupTest() {
+	s.Reset()
+	s.setupClGeneral()
+}
+
+func (s *ConcentratedKeeperTestHelper) SetupAndFundSwapTest() {
+	s.SetupTest()
+	s.FundAcc(s.TestAccs[0], swapFundCoins)
+	s.FundAcc(s.TestAccs[1], swapFundCoins)
+}
+
+func (s *ConcentratedKeeperTestHelper) PreparePoolWithCustSpread(spread osmomath.Dec) types.ConcentratedPoolExtension {
+	clParams := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
+	clParams.AuthorizedSpreadFactors = append(clParams.AuthorizedSpreadFactors, spread)
+	s.App.ConcentratedLiquidityKeeper.SetParams(s.Ctx, clParams)
+	return s.PrepareCustomConcentratedPool(s.TestAccs[0], "eth", "usdc", DefaultTickSpacing, spread)
+}
+
+func (s *ConcentratedKeeperTestHelper) SetupDefaultPosition(poolId uint64) {
+	s.SetupPosition(poolId, s.TestAccs[0], DefaultCoins, DefaultLowerTick, DefaultUpperTick, false)
+}
+
+func (s *ConcentratedKeeperTestHelper) SetupPosition(poolId uint64, owner sdk.AccAddress, providedCoins sdk.Coins, lowerTick, upperTick int64, addRoundingError bool) (osmomath.Dec, uint64) {
+	roundingErrorCoins := sdk.NewCoins()
+	if addRoundingError {
+		roundingErrorCoins = sdk.NewCoins(sdk.NewCoin(ETH, roundingError), sdk.NewCoin(USDC, roundingError))
+	}
+
+	s.FundAcc(owner, providedCoins.Add(roundingErrorCoins...))
+	positionData, err := s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, poolId, owner, providedCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), lowerTick, upperTick)
+	s.Require().NoError(err)
+	liquidity, err := s.App.ConcentratedLiquidityKeeper.GetPositionLiquidity(s.Ctx, positionData.ID)
+	s.Require().NoError(err)
+	return liquidity, positionData.ID
+}
+
+func (s *ConcentratedKeeperTestHelper) SetupSecondPosition(test ConcentratedSwapTest, pool types.ConcentratedPoolExtension) {
+	if !test.SecondPositionLowerPrice.IsNil() {
+		newLowerTick, newUpperTick := s.LowerUpperPricesToTick(test.SecondPositionLowerPrice, test.SecondPositionUpperPrice, pool.GetTickSpacing())
+
+		_, err := s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), newLowerTick, newUpperTick)
+		s.Require().NoError(err)
+	}
+}
+
+func (s *ConcentratedKeeperTestHelper) LowerUpperPricesToTick(lowerPrice, upperPrice osmomath.Dec, tickSpacing uint64) (int64, int64) {
+	lowerSqrtPrice := osmomath.MustMonotonicSqrt(lowerPrice)
+	newLowerTick, err := clmath.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(lowerSqrtPrice), tickSpacing)
+	s.Require().NoError(err)
+	upperSqrtPrice := osmomath.MustMonotonicSqrt(upperPrice)
+	newUpperTick, err := clmath.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(upperSqrtPrice), tickSpacing)
+	s.Require().NoError(err)
+	return newLowerTick, newUpperTick
+}
+
+func (s *ConcentratedKeeperTestHelper) setupClGeneral() {
+	s.Clk = s.App.ConcentratedLiquidityKeeper
+
+	if s.AuthorizedUptimes != nil {
+		clParams := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
+		clParams.AuthorizedUptimes = s.AuthorizedUptimes
+		s.App.ConcentratedLiquidityKeeper.SetParams(s.Ctx, clParams)
+	}
 }

--- a/app/apptesting/pool_manager.go
+++ b/app/apptesting/pool_manager.go
@@ -31,21 +31,25 @@ func (s *KeeperTestHelper) RunBasicSwap(poolId uint64) {
 }
 
 // CreatePoolFromType creates a basic pool of the given type for testing.
-func (s *KeeperTestHelper) CreatePoolFromType(poolType poolmanagertypes.PoolType) {
+func (s *KeeperTestHelper) CreatePoolFromType(poolType poolmanagertypes.PoolType) uint64 {
 	switch poolType {
 	case poolmanagertypes.Balancer:
-		s.PrepareBalancerPool()
-		return
+		balancerPoolID := s.PrepareBalancerPool()
+		return balancerPoolID
 	case poolmanagertypes.Stableswap:
-		s.PrepareBasicStableswapPool()
-		return
+		stableswapPoolID := s.PrepareBasicStableswapPool()
+		return stableswapPoolID
 	case poolmanagertypes.Concentrated:
-		s.PrepareConcentratedPool()
-		return
+		concentratedPool := s.PrepareConcentratedPool()
+		return concentratedPool.GetId()
 	case poolmanagertypes.CosmWasm:
-		s.PrepareCosmWasmPool()
-		return
+		cosmwasmPool := s.PrepareCosmWasmPool()
+		return cosmwasmPool.GetId()
+	default:
+		s.FailNow(fmt.Sprintf("unsupported pool type for this operation (%s)", poolmanagertypes.PoolType_name[int32(poolType)]))
 	}
+
+	return 0
 }
 
 // CreatePoolFromTypeWithCoins creates a pool with the given type and initialized with the given coins.

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -91,7 +91,7 @@ func (s *KeeperTestSuite) individualFuzz(r *rand.Rand, fuzzNum int, numSwaps int
 	s.CreateFullRangePosition(pool, defaultCoins)
 
 	// Refetch pool
-	pool, err := s.clk.GetPoolById(s.Ctx, pool.GetId())
+	pool, err := s.Clk.GetPoolById(s.Ctx, pool.GetId())
 	s.Require().NoError(err)
 
 	fmt.Printf("SINGLE FUZZ START: %d. initialAmt0 %s initialAmt1 %s \n", fuzzNum, initialAmt0, initialAmt1)
@@ -146,7 +146,7 @@ func (s *KeeperTestSuite) fuzzTestWithSeed(r *rand.Rand, poolId uint64, numSwaps
 }
 
 func (s *KeeperTestSuite) randomSwap(r *rand.Rand, poolId uint64) (fatalErr bool) {
-	pool, err := s.clk.GetPoolById(s.Ctx, poolId)
+	pool, err := s.Clk.GetPoolById(s.Ctx, poolId)
 	s.Require().NoError(err)
 
 	updateStrategy := func() (swapStrategy int, zfo bool) {
@@ -293,7 +293,7 @@ func (s *KeeperTestSuite) swap(pool types.ConcentratedPoolExtension, swapInFunde
 	// // Execute swap
 	fmt.Printf("swap in: %s\n", swapInFunded)
 	cacheCtx, writeOutGivenIn := s.Ctx.CacheContext()
-	_, tokenOut, _, err := s.clk.SwapOutAmtGivenIn(cacheCtx, s.TestAccs[0], pool, swapInFunded, swapOutDenom, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
+	_, tokenOut, _, err := s.Clk.SwapOutAmtGivenIn(cacheCtx, s.TestAccs[0], pool, swapInFunded, swapOutDenom, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
 	if errors.As(err, &types.InvalidAmountCalculatedError{}) {
 		// If the swap we're about to execute will not generate enough output, we skip the swap.
 		// it would error for a real user though. This is good though, since that user would just be burning funds.
@@ -312,7 +312,7 @@ func (s *KeeperTestSuite) swap(pool types.ConcentratedPoolExtension, swapInFunde
 	// We expect the returned amountIn to be roughly equal to the original swapInFunded.
 	cacheCtx, _ = s.Ctx.CacheContext()
 	fmt.Printf("swap out: %s\n", tokenOut)
-	amountInSwapResult, _, _, err := s.clk.SwapInAmtGivenOut(cacheCtx, s.TestAccs[0], pool, tokenOut, swapInFunded.Denom, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
+	amountInSwapResult, _, _, err := s.Clk.SwapInAmtGivenOut(cacheCtx, s.TestAccs[0], pool, tokenOut, swapInFunded.Denom, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
 	if errors.As(err, &types.InvalidAmountCalculatedError{}) {
 		// If the swap we're about to execute will not generate enough output, we skip the swap.
 		// it would error for a real user though. This is good though, since that user would just be burning funds.

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -485,7 +485,7 @@ func (s *KeeperTestSuite) TestCreateAndGetUptimeAccumulatorValues() {
 }
 
 func (s *KeeperTestSuite) getAllIncentiveRecordsForPool(poolId uint64) []types.IncentiveRecord {
-	records, err := s.clk.GetAllIncentiveRecordsForPool(s.Ctx, poolId)
+	records, err := s.Clk.GetAllIncentiveRecordsForPool(s.Ctx, poolId)
 	s.Require().NoError(err)
 	return records
 }
@@ -719,7 +719,7 @@ func (s *KeeperTestSuite) TestCalcAccruedIncentivesForAccum() {
 
 					// If incentives are fully emitted, we ensure they are cleared from state
 					if tc.recordsCleared {
-						err := s.clk.SetMultipleIncentiveRecords(s.Ctx, updatedPoolRecords)
+						err := s.Clk.SetMultipleIncentiveRecords(s.Ctx, updatedPoolRecords)
 						s.Require().NoError(err)
 
 						updatedRecordsInState := s.getAllIncentiveRecordsForPool(tc.poolId)
@@ -765,7 +765,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 			s.Require().ErrorContains(err, tc.expectedError.Error())
 
 			// Ensure accumulators remain unchanged
-			newUptimeAccumValues, err := s.clk.GetUptimeAccumulatorValues(ctx, poolId)
+			newUptimeAccumValues, err := s.Clk.GetUptimeAccumulatorValues(ctx, poolId)
 			s.Require().NoError(err)
 			s.Require().Equal(initUptimeAccumValues, newUptimeAccumValues)
 
@@ -779,7 +779,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 		s.Require().NoError(err)
 
 		// Get updated pool for testing purposes
-		clPool, err := s.clk.GetPoolById(ctx, tc.poolId)
+		clPool, err := s.Clk.GetPoolById(ctx, tc.poolId)
 		s.Require().NoError(err)
 
 		// Calculate expected uptime deltas using qualifying liquidity deltas.
@@ -801,7 +801,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 		}
 
 		// Get new uptime accum values for comparison
-		newUptimeAccumValues, err := s.clk.GetUptimeAccumulatorValues(ctx, tc.poolId)
+		newUptimeAccumValues, err := s.Clk.GetUptimeAccumulatorValues(ctx, tc.poolId)
 		s.Require().NoError(err)
 
 		// Ensure that each accumulator value changes by the correct amount
@@ -817,7 +817,7 @@ func (s *KeeperTestSuite) TestUpdateUptimeAccumulatorsToNow() {
 		s.Require().Equal(ctx.BlockTime(), clPool.GetLastLiquidityUpdate())
 
 		// Ensure that pool's IncentiveRecords are updated to reflect emitted incentives
-		updatedIncentiveRecords, err := s.clk.GetAllIncentiveRecordsForPool(ctx, tc.poolId)
+		updatedIncentiveRecords, err := s.Clk.GetAllIncentiveRecordsForPool(ctx, tc.poolId)
 		s.Require().NoError(err)
 		s.Require().Equal(tc.expectedIncentiveRecords, updatedIncentiveRecords)
 
@@ -1400,9 +1400,9 @@ func (s *KeeperTestSuite) TestGetUptimeGrowthRange() {
 }
 
 func (s *KeeperTestSuite) TestGetUptimeGrowthErrors() {
-	_, err := s.clk.GetUptimeGrowthInsideRange(s.Ctx, defaultPoolId, 0, 0)
+	_, err := s.Clk.GetUptimeGrowthInsideRange(s.Ctx, defaultPoolId, 0, 0)
 	s.Require().Error(err)
-	_, err = s.clk.GetUptimeGrowthOutsideRange(s.Ctx, defaultPoolId, 0, 0)
+	_, err = s.Clk.GetUptimeGrowthOutsideRange(s.Ctx, defaultPoolId, 0, 0)
 	s.Require().Error(err)
 }
 
@@ -2823,7 +2823,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 				}
 
 				// Initialize position
-				err := s.clk.InitOrUpdatePosition(s.Ctx, validPoolId, defaultSender, DefaultLowerTick, DefaultUpperTick, tc.numShares, joinTime, tc.positionIdCreate)
+				err := s.Clk.InitOrUpdatePosition(s.Ctx, validPoolId, defaultSender, DefaultLowerTick, DefaultUpperTick, tc.numShares, joinTime, tc.positionIdCreate)
 				s.Require().NoError(err)
 
 				clPool.SetCurrentTick(DefaultCurrTick)
@@ -2835,7 +2835,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 					s.addUptimeGrowthInsideRange(s.Ctx, validPoolId, defaultSender, DefaultCurrTick, DefaultLowerTick, DefaultUpperTick, tc.growthInside)
 				}
 
-				err = s.clk.SetPool(s.Ctx, clPool)
+				err = s.Clk.SetPool(s.Ctx, clPool)
 				s.Require().NoError(err)
 
 				preCommunityPoolBalance := bankKeeper.GetAllBalances(s.Ctx, accountKeeper.GetModuleAddress(distributiontypes.ModuleName))
@@ -2844,14 +2844,14 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 				initSenderBalances := s.App.BankKeeper.GetAllBalances(s.Ctx, defaultSender)
 				initPoolBalances := s.App.BankKeeper.GetAllBalances(s.Ctx, clPool.GetAddress())
 
-				largestSupportedUptime := s.clk.GetLargestSupportedUptimeDuration(s.Ctx)
+				largestSupportedUptime := s.Clk.GetLargestSupportedUptimeDuration(s.Ctx)
 				if !tc.forfeitIncentives {
 					// Let enough time elapse for the position to accrue rewards for all supported uptimes.
 					s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(largestSupportedUptime))
 				}
 
 				// --- System under test ---
-				amountClaimedQuery, amountForfeitedQuery, err := s.clk.GetClaimableIncentives(s.Ctx, tc.positionIdClaim)
+				amountClaimedQuery, amountForfeitedQuery, err := s.Clk.GetClaimableIncentives(s.Ctx, tc.positionIdClaim)
 
 				// Pull new balances for comparison
 				newSenderBalances := s.App.BankKeeper.GetAllBalances(s.Ctx, defaultSender)
@@ -2865,7 +2865,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 				s.Require().Equal(initSenderBalances, newSenderBalances)
 				s.Require().Equal(initPoolBalances, newPoolBalances)
 
-				amountClaimed, amountForfeited, err := s.clk.PrepareClaimAllIncentivesForPosition(s.Ctx, tc.positionIdClaim)
+				amountClaimed, amountForfeited, err := s.Clk.PrepareClaimAllIncentivesForPosition(s.Ctx, tc.positionIdClaim)
 
 				// --- Assertions ---
 
@@ -2981,7 +2981,7 @@ func (s *KeeperTestSuite) TestPrepareClaimAllIncentivesForPosition() {
 			pool := s.PrepareConcentratedPool()
 
 			// Set up position
-			positionOneData, err := s.clk.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[0], requiredBalances, osmomath.ZeroInt(), osmomath.ZeroInt(), DefaultLowerTick, DefaultUpperTick)
+			positionOneData, err := s.Clk.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[0], requiredBalances, osmomath.ZeroInt(), osmomath.ZeroInt(), DefaultLowerTick, DefaultUpperTick)
 			s.Require().NoError(err)
 
 			// Set incentives for pool to ensure accumulators work correctly
@@ -2994,18 +2994,18 @@ func (s *KeeperTestSuite) TestPrepareClaimAllIncentivesForPosition() {
 				},
 				MinUptime: tc.minUptimeIncentiveRecord,
 			}
-			err = s.clk.SetMultipleIncentiveRecords(s.Ctx, []types.IncentiveRecord{testIncentiveRecord})
+			err = s.Clk.SetMultipleIncentiveRecords(s.Ctx, []types.IncentiveRecord{testIncentiveRecord})
 			s.Require().NoError(err)
 
 			s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(tc.blockTimeElapsed))
 
 			// Update the uptime accumulators to the current block time.
 			// This is done to determine the exact amount of incentives we expect to be forfeited, if any.
-			err = s.clk.UpdatePoolUptimeAccumulatorsToNow(s.Ctx, pool.GetId())
+			err = s.Clk.UpdatePoolUptimeAccumulatorsToNow(s.Ctx, pool.GetId())
 			s.Require().NoError(err)
 
 			// Retrieve the uptime accumulators for the pool.
-			uptimeAccumulatorsPreClaim, err := s.clk.GetUptimeAccumulators(s.Ctx, pool.GetId())
+			uptimeAccumulatorsPreClaim, err := s.Clk.GetUptimeAccumulators(s.Ctx, pool.GetId())
 			s.Require().NoError(err)
 
 			expectedForfeitedIncentives := sdk.NewCoins()
@@ -3032,7 +3032,7 @@ func (s *KeeperTestSuite) TestPrepareClaimAllIncentivesForPosition() {
 			}
 
 			// System under test
-			collectedInc, forfeitedIncentives, err := s.clk.PrepareClaimAllIncentivesForPosition(s.Ctx, positionOneData.ID)
+			collectedInc, forfeitedIncentives, err := s.Clk.PrepareClaimAllIncentivesForPosition(s.Ctx, positionOneData.ID)
 			s.Require().NoError(err)
 			s.Require().Equal(tc.expectedCoins.String(), collectedInc.String())
 			s.Require().Equal(expectedForfeitedIncentives.String(), forfeitedIncentives.String())
@@ -3040,7 +3040,7 @@ func (s *KeeperTestSuite) TestPrepareClaimAllIncentivesForPosition() {
 			// The difference accumulator value should have increased if we forfeited incentives by claiming.
 			uptimeAccumsDiffPostClaim := sdk.NewDecCoins()
 			if tc.blockTimeElapsed < tc.minUptimeIncentiveRecord {
-				uptimeAccumulatorsPostClaim, err := s.clk.GetUptimeAccumulators(s.Ctx, pool.GetId())
+				uptimeAccumulatorsPostClaim, err := s.Clk.GetUptimeAccumulators(s.Ctx, pool.GetId())
 				s.Require().NoError(err)
 				for i, acc := range uptimeAccumulatorsPostClaim {
 					totalSharesAccum := acc.GetTotalShares()
@@ -3080,7 +3080,7 @@ func (s *KeeperTestSuite) TestFunctional_ClaimIncentives_LiquidityChange_Varying
 		requiredBalances := sdk.NewCoins(sdk.NewCoin(ETH, DefaultAmt0), sdk.NewCoin(USDC, DefaultAmt1))
 
 		// Set test authorized uptime params.
-		clParams := s.clk.GetParams(s.Ctx)
+		clParams := s.Clk.GetParams(s.Ctx)
 		clParams.AuthorizedUptimes = []time.Duration{time.Nanosecond, testFullChargeDuration}
 		s.App.ConcentratedLiquidityKeeper.SetParams(s.Ctx, clParams)
 
@@ -3339,12 +3339,12 @@ func (s *KeeperTestSuite) TestGetLargestAuthorizedAndSupportedUptimes() {
 			s.Run(name, func() {
 				s.SetupTest()
 
-				clParams := s.clk.GetParams(s.Ctx)
+				clParams := s.Clk.GetParams(s.Ctx)
 				clParams.AuthorizedUptimes = tc.preSetAuthorizedParams
-				s.clk.SetParams(s.Ctx, clParams)
+				s.Clk.SetParams(s.Ctx, clParams)
 
-				actualAuthorized := s.clk.GetLargestAuthorizedUptimeDuration(s.Ctx)
-				actualSupported := s.clk.GetLargestSupportedUptimeDuration(s.Ctx)
+				actualAuthorized := s.Clk.GetLargestAuthorizedUptimeDuration(s.Ctx)
+				actualSupported := s.Clk.GetLargestSupportedUptimeDuration(s.Ctx)
 
 				s.Require().Equal(tc.expectedAuthorized, actualAuthorized)
 				s.Require().Equal(longestSupportedUptime, actualSupported)
@@ -3358,7 +3358,7 @@ var defaultGlobalRewardGrowth = sdk.NewDecCoins(oneEth.Add(oneEth))
 
 func (s *KeeperTestSuite) prepareSpreadRewardsAccumulator() *accum.AccumulatorObject {
 	pool := s.PrepareConcentratedPool()
-	testAccumulator, err := s.clk.GetSpreadRewardAccumulator(s.Ctx, pool.GetId())
+	testAccumulator, err := s.Clk.GetSpreadRewardAccumulator(s.Ctx, pool.GetId())
 	s.Require().NoError(err)
 	return testAccumulator
 }

--- a/x/concentrated-liquidity/invariant_test.go
+++ b/x/concentrated-liquidity/invariant_test.go
@@ -31,7 +31,7 @@ func (s *KeeperTestSuite) assertGlobalInvariants(expectedGlobalRewardValues Expe
 // * Total pool incentives across all pools
 func (s *KeeperTestSuite) getAllPositionsAndPoolBalances(ctx sdk.Context) ([]model.Position, sdk.Coins, sdk.Coins, sdk.Coins) {
 	// Get total spread rewards distributed to all pools
-	allPools, err := s.clk.GetPools(ctx)
+	allPools, err := s.Clk.GetPools(ctx)
 	totalPoolAssets, totalSpreadRewards, totalIncentives := sdk.NewCoins(), sdk.NewCoins(), sdk.NewCoins()
 
 	// Sum up pool balances across all pools
@@ -46,7 +46,7 @@ func (s *KeeperTestSuite) getAllPositionsAndPoolBalances(ctx sdk.Context) ([]mod
 	}
 
 	// Get all positions in state
-	allPoolPositions, err := s.clk.GetAllPositions(ctx)
+	allPoolPositions, err := s.Clk.GetAllPositions(ctx)
 	s.Require().NoError(err)
 
 	return allPoolPositions, totalPoolAssets, totalSpreadRewards, totalIncentives
@@ -82,7 +82,7 @@ func (s *KeeperTestSuite) assertTotalRewardsInvariant(expectedGlobalRewardValues
 		initialBalance := s.App.BankKeeper.GetAllBalances(cachedCtx, owner)
 
 		// Collect spread rewards.
-		collectedSpread, err := s.clk.CollectSpreadRewards(cachedCtx, owner, position.PositionId)
+		collectedSpread, err := s.Clk.CollectSpreadRewards(cachedCtx, owner, position.PositionId)
 		s.Require().NoError(err)
 
 		// Collect incentives.
@@ -92,7 +92,7 @@ func (s *KeeperTestSuite) assertTotalRewardsInvariant(expectedGlobalRewardValues
 		//
 		// Balancer full range incentives are also not factored in because they are claimed and sent to
 		// gauge immediately upon distribution.
-		collectedIncentives, _, err := s.clk.CollectIncentives(cachedCtx, owner, position.PositionId)
+		collectedIncentives, _, err := s.Clk.CollectIncentives(cachedCtx, owner, position.PositionId)
 		s.Require().NoError(err)
 
 		// Ensure position owner's balance was updated correctly
@@ -168,11 +168,11 @@ func (s *KeeperTestSuite) assertWithdrawAllInvariant() {
 		s.Require().NoError(err)
 
 		// Withdraw all assets from position
-		amt0Withdrawn, amt1Withdrawn, err := s.clk.WithdrawPosition(cachedCtx, owner, position.PositionId, position.Liquidity)
+		amt0Withdrawn, amt1Withdrawn, err := s.Clk.WithdrawPosition(cachedCtx, owner, position.PositionId, position.Liquidity)
 		s.Require().NoError(err)
 
 		// Convert withdrawn assets to coins
-		positionPool, err := s.clk.GetPoolById(cachedCtx, position.PoolId)
+		positionPool, err := s.Clk.GetPoolById(cachedCtx, position.PoolId)
 		s.Require().NoError(err)
 		withdrawn := sdk.NewCoins(
 			sdk.NewCoin(positionPool.GetToken0(), amt0Withdrawn),

--- a/x/concentrated-liquidity/lp_test.go
+++ b/x/concentrated-liquidity/lp_test.go
@@ -533,13 +533,13 @@ func (s *KeeperTestSuite) createPositionWithLockState(ls lockState, poolId uint6
 	)
 
 	if ls == locked {
-		fullRangePositionData, _, err = s.clk.CreateFullRangePositionLocked(s.Ctx, poolId, owner, providedCoins, dur)
+		fullRangePositionData, _, err = s.Clk.CreateFullRangePositionLocked(s.Ctx, poolId, owner, providedCoins, dur)
 	} else if ls == unlocking {
-		fullRangePositionData, _, err = s.clk.CreateFullRangePositionUnlocking(s.Ctx, poolId, owner, providedCoins, dur+time.Hour)
+		fullRangePositionData, _, err = s.Clk.CreateFullRangePositionUnlocking(s.Ctx, poolId, owner, providedCoins, dur+time.Hour)
 	} else if ls == unlocked {
-		fullRangePositionData, _, err = s.clk.CreateFullRangePositionUnlocking(s.Ctx, poolId, owner, providedCoins, dur-time.Hour)
+		fullRangePositionData, _, err = s.Clk.CreateFullRangePositionUnlocking(s.Ctx, poolId, owner, providedCoins, dur-time.Hour)
 	} else {
-		positionData, err = s.clk.CreatePosition(s.Ctx, poolId, owner, providedCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), lowerTick, upperTick)
+		positionData, err = s.Clk.CreatePosition(s.Ctx, poolId, owner, providedCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), lowerTick, upperTick)
 		s.Require().NoError(err)
 		return positionData.ID, positionData.Liquidity
 	}
@@ -765,7 +765,7 @@ func (s *KeeperTestSuite) TestWithdrawPosition() {
 			communityPoolBalanceBefore := s.App.BankKeeper.GetAllBalances(s.Ctx, s.App.AccountKeeper.GetModuleAddress(distributiontypes.ModuleName))
 
 			// Fund full amount since forfeited incentives for the last position are sent to the community pool.
-			largestSupportedUptime := s.clk.GetLargestSupportedUptimeDuration(s.Ctx)
+			largestSupportedUptime := s.Clk.GetLargestSupportedUptimeDuration(s.Ctx)
 			expectedFullIncentivesFromAllUptimes := expectedIncentivesFromUptimeGrowth(defaultUptimeGrowth, liquidityCreated, largestSupportedUptime, defaultMultiplier)
 			s.FundAcc(pool.GetIncentivesAddress(), expectedFullIncentivesFromAllUptimes)
 
@@ -1393,7 +1393,7 @@ func (s *KeeperTestSuite) TestSingleSidedAddToPosition() {
 
 			// Create a position from the parameters in the test case.
 			testCoins := sdk.NewCoins(sdk.NewCoin(ETH, tc.amount0ToAdd), sdk.NewCoin(USDC, tc.amount1ToAdd))
-			positionData, err := s.clk.CreatePosition(s.Ctx, pool.GetId(), owner, testCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), config.lowerTick, config.upperTick)
+			positionData, err := s.Clk.CreatePosition(s.Ctx, pool.GetId(), owner, testCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), config.lowerTick, config.upperTick)
 			s.Require().NoError(err)
 
 			// Move the block time forward
@@ -2386,11 +2386,11 @@ func (s *KeeperTestSuite) TestValidatePositionUpdateById() {
 			updateInitiator := s.TestAccs[tc.updateInitiatorIndex]
 
 			if tc.modifyPositionLiquidity {
-				position, err := s.clk.GetPosition(s.Ctx, tc.positionId)
+				position, err := s.Clk.GetPosition(s.Ctx, tc.positionId)
 				s.Require().NoError(err)
 				owner, err := sdk.AccAddressFromBech32(position.Address)
 				s.Require().NoError(err)
-				s.clk.SetPosition(s.Ctx, defaultPoolId, owner, position.LowerTick, position.UpperTick, position.JoinTime, osmomath.OneDec(), position.PositionId, 0)
+				s.Clk.SetPosition(s.Ctx, defaultPoolId, owner, position.LowerTick, position.UpperTick, position.JoinTime, osmomath.OneDec(), position.PositionId, 0)
 			}
 
 			err := clKeeper.ValidatePositionUpdateById(s.Ctx, tc.positionId, updateInitiator, tc.lowerTickGiven, tc.upperTickGiven, tc.liquidityDeltaGiven, tc.joinTimeGiven, tc.poolIdGiven)

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -32,7 +32,7 @@ var (
 
 // AssertPositionsDoNotExist checks that the positions with the given IDs do not exist on uptime accumulators.
 func (s *KeeperTestSuite) AssertPositionsDoNotExist(positionIds []uint64) {
-	uptimeAccumulators, err := s.clk.GetUptimeAccumulators(s.Ctx, defaultPoolId)
+	uptimeAccumulators, err := s.Clk.GetUptimeAccumulators(s.Ctx, defaultPoolId)
 	s.Require().NoError(err)
 
 	for _, positionId := range positionIds {
@@ -52,7 +52,7 @@ func (s *KeeperTestSuite) AssertPositionsDoNotExist(positionIds []uint64) {
 
 // GetTotalAccruedRewardsByAccumulator returns the total accrued rewards for the given position on each uptime accumulator.
 func (s *KeeperTestSuite) GetTotalAccruedRewardsByAccumulator(positionId uint64, requireHasPosition bool) []sdk.DecCoins {
-	uptimeAccumulators, err := s.clk.GetUptimeAccumulators(s.Ctx, defaultPoolId)
+	uptimeAccumulators, err := s.Clk.GetUptimeAccumulators(s.Ctx, defaultPoolId)
 	s.Require().NoError(err)
 
 	unclaimedRewardsForEachUptimeNewPosition := make([]sdk.DecCoins, len(uptimeAccumulators))
@@ -84,14 +84,14 @@ func (s *KeeperTestSuite) GetTotalAccruedRewardsByAccumulator(positionId uint64,
 // It also asserts that no more incentives can be claimed for the position.
 func (s *KeeperTestSuite) ExecuteAndValidateSuccessfulIncentiveClaim(positionId uint64, expectedRewards sdk.Coins, expectedForfeited sdk.Coins) {
 	// Initial claim and assertion
-	claimedRewards, forfeitedRewards, err := s.clk.PrepareClaimAllIncentivesForPosition(s.Ctx, positionId)
+	claimedRewards, forfeitedRewards, err := s.Clk.PrepareClaimAllIncentivesForPosition(s.Ctx, positionId)
 	s.Require().NoError(err)
 
 	s.Require().Equal(expectedRewards, claimedRewards)
 	s.Require().Equal(expectedForfeited, forfeitedRewards)
 
 	// Sanity check that cannot claim again.
-	claimedRewards, _, err = s.clk.PrepareClaimAllIncentivesForPosition(s.Ctx, positionId)
+	claimedRewards, _, err = s.Clk.PrepareClaimAllIncentivesForPosition(s.Ctx, positionId)
 	s.Require().NoError(err)
 
 	s.Require().Equal(sdk.Coins(nil), claimedRewards)
@@ -1797,13 +1797,13 @@ func (s *KeeperTestSuite) TestTickRoundingEdgeCase() {
 	swapAddr := testAccs[2]
 	desiredTokenOut := sdk.NewCoin(USDC, osmomath.NewInt(10000))
 	s.FundAcc(swapAddr, sdk.NewCoins(sdk.NewCoin(ETH, osmomath.NewInt(1000000000000000000))))
-	_, _, _, err := s.clk.SwapInAmtGivenOut(s.Ctx, swapAddr, pool, desiredTokenOut, ETH, osmomath.ZeroDec(), osmomath.ZeroBigDec())
+	_, _, _, err := s.Clk.SwapInAmtGivenOut(s.Ctx, swapAddr, pool, desiredTokenOut, ETH, osmomath.ZeroDec(), osmomath.ZeroBigDec())
 	s.Require().NoError(err)
 
 	// Both positions should be able to withdraw successfully
-	_, _, err = s.clk.WithdrawPosition(s.Ctx, firstPositionAddr, firstPosId, firstPosLiq)
+	_, _, err = s.Clk.WithdrawPosition(s.Ctx, firstPositionAddr, firstPosId, firstPosLiq)
 	s.Require().NoError(err)
-	_, _, err = s.clk.WithdrawPosition(s.Ctx, secondPositionAddr, secondPosId, secondPosLiq)
+	_, _, err = s.Clk.WithdrawPosition(s.Ctx, secondPositionAddr, secondPosId, secondPosLiq)
 	s.Require().NoError(err)
 }
 
@@ -2023,7 +2023,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	)
 
 	s.FundAcc(s.TestAccs[0], sdk.NewCoins(incentiveCoin))
-	_, err := s.clk.CreateIncentive(s.Ctx, poolId, s.TestAccs[0], incentiveCoin, rewardsPerSecond, s.Ctx.BlockTime(), time.Nanosecond)
+	_, err := s.Clk.CreateIncentive(s.Ctx, poolId, s.TestAccs[0], incentiveCoin, rewardsPerSecond, s.Ctx.BlockTime(), time.Nanosecond)
 	s.Require().NoError(err)
 
 	// Estimates how much to swap in to approximately reach the given tick
@@ -2031,7 +2031,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	// from the refeteched pool as well as its liquidity. Assumes that
 	// liquidity is constant between current tick and toTick.
 	estimateCoinZeroIn := func(toTick int64) sdk.Coin {
-		pool, err := s.clk.GetPoolById(s.Ctx, poolId)
+		pool, err := s.Clk.GetPoolById(s.Ctx, poolId)
 		s.Require().NoError(err)
 
 		s.Require().True(toTick < pool.GetCurrentTick())
@@ -2047,7 +2047,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	// from the refeteched pool as well as its liquidity. Assumes that
 	// liquidity is constant between current tick and toTick.
 	estimateCoinOneIn := func(toTick int64) sdk.Coin {
-		pool, err := s.clk.GetPoolById(s.Ctx, poolId)
+		pool, err := s.Clk.GetPoolById(s.Ctx, poolId)
 		s.Require().NoError(err)
 
 		s.Require().True(toTick > pool.GetCurrentTick())
@@ -2084,7 +2084,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor)
 
 	// Refetch pool
-	pool, err = s.clk.GetPoolById(s.Ctx, poolId)
+	pool, err = s.Clk.GetPoolById(s.Ctx, poolId)
 	s.Require().NoError(err)
 
 	// Swap to approximately DefaultCurrTick + 150
@@ -2231,7 +2231,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 
 	// Export and import genesis to make sure that negative accumulation does not lead to unexpected
 	// panics in serialization and deserialization.
-	spreadRewardAccumulator, err := s.clk.GetSpreadRewardAccumulator(s.Ctx, poolId)
+	spreadRewardAccumulator, err := s.Clk.GetSpreadRewardAccumulator(s.Ctx, poolId)
 	s.Require().NoError(err)
 
 	accum, err := spreadRewardAccumulator.GetPosition(types.KeySpreadRewardPositionAccumulator(negativeIntervalAccumPositionData.ID))
@@ -2240,11 +2240,11 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	// Validate that at least one accumulator is negative for the test to be valid.
 	s.Require().True(accum.AccumValuePerShare.IsAnyNegative())
 
-	export := s.clk.ExportGenesis(s.Ctx)
+	export := s.Clk.ExportGenesis(s.Ctx)
 
 	s.SetupTest()
 
-	s.clk.InitGenesis(s.Ctx, *export)
+	s.Clk.InitGenesis(s.Ctx, *export)
 }
 
 // TestTransferPositions validates the following:

--- a/x/concentrated-liquidity/range_test.go
+++ b/x/concentrated-liquidity/range_test.go
@@ -168,7 +168,7 @@ func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.Concentrated
 		emissionRate := testParams.baseEmissionRate
 		incentiveCoin := sdk.NewCoin(fmt.Sprintf("%s%d", testParams.baseIncentiveDenom, 0), incentiveAmt)
 		s.FundAcc(incentiveAddr, sdk.NewCoins(incentiveCoin))
-		_, err := s.clk.CreateIncentive(s.Ctx, pool.GetId(), incentiveAddr, incentiveCoin, emissionRate, s.Ctx.BlockTime(), types.DefaultAuthorizedUptimes[0])
+		_, err := s.Clk.CreateIncentive(s.Ctx, pool.GetId(), incentiveAddr, incentiveCoin, emissionRate, s.Ctx.BlockTime(), types.DefaultAuthorizedUptimes[0])
 		s.Require().NoError(err)
 	}
 
@@ -216,7 +216,7 @@ func (s *KeeperTestSuite) setupRangesAndAssertInvariants(pool types.Concentrated
 			cumulativeEmittedIncentives, lastIncentiveTrackerUpdate = s.trackEmittedIncentives(cumulativeEmittedIncentives, lastIncentiveTrackerUpdate)
 
 			// Set up position
-			positionData, err := s.clk.CreatePosition(s.Ctx, pool.GetId(), curAddr, curAssets, osmomath.ZeroInt(), osmomath.ZeroInt(), ranges[curRange][0], ranges[curRange][1])
+			positionData, err := s.Clk.CreatePosition(s.Ctx, pool.GetId(), curAddr, curAssets, osmomath.ZeroInt(), osmomath.ZeroInt(), ranges[curRange][0], ranges[curRange][1])
 			s.Require().NoError(err)
 
 			// Ensure position was set up correctly and didn't break global invariants
@@ -345,7 +345,7 @@ func (s *KeeperTestSuite) executeRandomizedSwap(pool types.ConcentratedPoolExten
 
 	// If the swap we're about to execute will not generate enough input, we skip the swap.
 	if swapOutDenom == pool.GetToken1() {
-		pool, err := s.clk.GetPoolById(s.Ctx, pool.GetId())
+		pool, err := s.Clk.GetPoolById(s.Ctx, pool.GetId())
 		s.Require().NoError(err)
 
 		poolSpotPrice := pool.GetCurrentSqrtPrice().PowerInteger(2)
@@ -357,7 +357,7 @@ func (s *KeeperTestSuite) executeRandomizedSwap(pool types.ConcentratedPoolExten
 	}
 
 	// Note that we set the price limit to zero to ensure that the swap can execute in either direction (gets automatically set to correct limit)
-	swappedIn, swappedOut, _, err := s.clk.SwapInAmtGivenOut(s.Ctx, swapAddress, pool, swapOutCoin, swapInDenom, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
+	swappedIn, swappedOut, _, err := s.Clk.SwapInAmtGivenOut(s.Ctx, swapAddress, pool, swapOutCoin, swapInDenom, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
 	s.Require().NoError(err)
 
 	return swappedIn, swappedOut
@@ -389,11 +389,11 @@ func (s *KeeperTestSuite) addRandomizedBlockTime(baseTimeToAdd time.Duration, fu
 // CONTRACT: cumulativeTrackedIncentives has been updated immediately before each new incentive record that was created
 func (s *KeeperTestSuite) trackEmittedIncentives(cumulativeTrackedIncentives sdk.DecCoins, lastTrackerUpdateTime time.Time) (sdk.DecCoins, time.Time) {
 	// Fetch all incentive records across all pools
-	allPools, err := s.clk.GetPools(s.Ctx)
+	allPools, err := s.Clk.GetPools(s.Ctx)
 	s.Require().NoError(err)
 	allIncentiveRecords := make([]types.IncentiveRecord, 0)
 	for _, pool := range allPools {
-		curPoolRecords, err := s.clk.GetAllIncentiveRecordsForPool(s.Ctx, pool.GetId())
+		curPoolRecords, err := s.Clk.GetAllIncentiveRecordsForPool(s.Ctx, pool.GetId())
 		s.Require().NoError(err)
 
 		allIncentiveRecords = append(allIncentiveRecords, curPoolRecords...)

--- a/x/concentrated-liquidity/spread_rewards_test.go
+++ b/x/concentrated-liquidity/spread_rewards_test.go
@@ -495,11 +495,11 @@ func (s *KeeperTestSuite) TestGetInitialSpreadRewardGrowthOppositeDirectionOfLas
 	// utilizing the production listeners, because we are testing a case that should be impossible
 	s.setListenerMockOnConcentratedLiquidityKeeper()
 
-	err = s.clk.SetPool(s.Ctx, &pool)
+	err = s.Clk.SetPool(s.Ctx, &pool)
 	s.Require().NoError(err)
 
 	// System under test.
-	_, err = s.clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, &pool, 0)
+	_, err = s.Clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, &pool, 0)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, accum.AccumDoesNotExistError{AccumName: types.KeySpreadRewardPoolAccumulator(validPoolId)})
 }
@@ -537,9 +537,9 @@ func (s *KeeperTestSuite) TestGetInitialSpreadRewardGrowthOppositeDirectionOfLas
 			pool := s.preparePoolAndDefaultPosition()
 			s.AddToSpreadRewardAccumulator(pool.GetId(), initialGlobalSpreadRewardGrowth)
 
-			clpool, err := s.clk.GetPoolById(s.Ctx, pool.GetId())
+			clpool, err := s.Clk.GetPoolById(s.Ctx, pool.GetId())
 			s.Require().NoError(err)
-			initialSpreadRewardGrowthOppositeDirectionOfLastTraversal, err := s.clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, clpool, tc.tick)
+			initialSpreadRewardGrowthOppositeDirectionOfLastTraversal, err := s.Clk.GetInitialSpreadRewardGrowthOppositeDirectionOfLastTraversalForTick(s.Ctx, clpool, tc.tick)
 			s.Require().NoError(err)
 			s.Require().Equal(tc.expectedInitialSpreadRewardGrowthOppositeDirectionOfLastTraversal, initialSpreadRewardGrowthOppositeDirectionOfLastTraversal)
 		})

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -18,44 +18,6 @@ import (
 
 var _ = suite.TestingSuite(nil)
 
-type secondPosition struct {
-	tickIndex                  int64
-	expectedSpreadRewardGrowth sdk.DecCoins
-}
-
-type SwapTest struct {
-	// Specific to swap out given in.
-	tokenIn       sdk.Coin
-	tokenOutDenom string
-
-	// Specific to swap in given out.
-	tokenOut     sdk.Coin
-	tokenInDenom string
-
-	// Shared.
-	priceLimit               osmomath.BigDec
-	spreadFactor             osmomath.Dec
-	secondPositionLowerPrice osmomath.Dec
-	secondPositionUpperPrice osmomath.Dec
-
-	expectedTokenIn                            sdk.Coin
-	expectedTokenOut                           sdk.Coin
-	expectedTick                               int64
-	expectedSqrtPrice                          osmomath.BigDec
-	expectedLowerTickSpreadRewardGrowth        sdk.DecCoins
-	expectedUpperTickSpreadRewardGrowth        sdk.DecCoins
-	expectedSpreadRewardGrowthAccumulatorValue osmomath.Dec
-	// since we use different values for the seondary position's tick, save (tick, expectedSpreadRewardGrowth) tuple
-	expectedSecondLowerTickSpreadRewardGrowth secondPosition
-	expectedSecondUpperTickSpreadRewardGrowth secondPosition
-
-	newLowerPrice  osmomath.Dec
-	newUpperPrice  osmomath.Dec
-	poolLiqAmount0 osmomath.Int
-	poolLiqAmount1 osmomath.Int
-	expectErr      bool
-}
-
 // positionMeta defines the metadata of a position
 // after its creation.
 type positionMeta struct {
@@ -65,9 +27,9 @@ type positionMeta struct {
 	liquidity  osmomath.Dec
 }
 
-var (
-	swapFundCoins = sdk.NewCoins(sdk.NewCoin("eth", osmomath.NewInt(10000000000000)), sdk.NewCoin("usdc", osmomath.NewInt(1000000000000)))
+type secondPosition = apptesting.SecondConcentratedPosition
 
+var (
 	// Allow 0.01% margin of error.
 	multiplicativeTolerance = osmomath.ErrTolerance{
 		MultiplicativeTolerance: osmomath.MustNewDecFromStr("0.0001"),
@@ -83,16 +45,16 @@ var (
 		RoundingDir:       osmomath.RoundDown,
 	}
 
-	swapOutGivenInCases = map[string]SwapTest{
+	swapOutGivenInCases = map[string]apptesting.ConcentratedSwapTest{
 		//  One price range
 		//
 		//          5000
 		//  4545 -----|----- 5500
 		"single position within one tick: usdc -> eth": {
-			tokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			tokenOutDenom: "eth",
-			priceLimit:    osmomath.NewBigDec(5004),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.NewBigDec(5004),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 
@@ -122,18 +84,18 @@ var (
 			// print(sqrt_next)
 			// print(token_in)
 			// print(token_out)
-			expectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			expectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8396)),
-			expectedTick:     31003913,
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8396)),
+			ExpectedTick:     31003913,
 			// Corresponds to sqrt_next in script above
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738348247484497718514800000003600626"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738348247484497718514800000003600626"),
 			// tick's accum coins stay same since crossing tick does not occur in this case
 		},
 		"single position within one tick: usdc -> eth, with zero price limit": {
-			tokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			tokenOutDenom: "eth",
-			priceLimit:    osmomath.ZeroBigDec(),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.ZeroBigDec(),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 
@@ -163,18 +125,18 @@ var (
 			// print(sqrt_next)
 			// print(token_in)
 			// print(token_out)
-			expectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			expectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8396)),
-			expectedTick:     31003913,
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8396)),
+			ExpectedTick:     31003913,
 			// Corresponds to sqrt_next in script above
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738348247484497718514800000003600626"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738348247484497718514800000003600626"),
 			// tick's accum coins stay same since crossing tick does not occur in this case
 		},
 		"single position within one tick: eth -> usdc": {
-			tokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			tokenOutDenom: "usdc",
-			priceLimit:    osmomath.NewBigDec(4993),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4993),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 
@@ -202,16 +164,16 @@ var (
 			// print(sqrt_next)
 			// print(token_out)
 			// print(token_in)
-			expectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			expectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(66808388)),
-			expectedTick:      30993777,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.666663910857144332134093938182290274"),
+			ExpectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(66808388)),
+			ExpectedTick:      30993777,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.666663910857144332134093938182290274"),
 		},
 		"single position within one tick: eth -> usdc, with zero price limit": {
-			tokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			tokenOutDenom: "usdc",
-			priceLimit:    osmomath.ZeroBigDec(),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.ZeroBigDec(),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 
@@ -233,12 +195,12 @@ var (
 			// print(sqrt_next)
 			// print(expectedTokenIn)
 			// print(expectedTokenOut)
-			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66808388)),
-			expectedTick:     30993777,
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66808388)),
+			ExpectedTick:     30993777,
 			// True value with arbitrary precision: 70.6666639108571443321...
 			// Expected value due to our monotonic sqrt's >= true value guarantee: 70.666663910857144333
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.666663910857144332134093938182290274"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.666663910857144332134093938182290274"),
 		},
 		//  Two equal price ranges
 		//
@@ -246,12 +208,12 @@ var (
 		//  4545 -----|----- 5500
 		//  4545 -----|----- 5500
 		"two positions within one tick: usdc -> eth": {
-			tokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			tokenOutDenom:            "eth",
-			priceLimit:               osmomath.NewBigDec(5002),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: DefaultLowerPrice,
-			secondPositionUpperPrice: DefaultUpperPrice,
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(5002),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
 			// from math import *
 			// from decimal import *
 
@@ -272,22 +234,22 @@ var (
 			// print(sqrt_next)
 			// print(token_in)
 			// print(token_out)
-			expectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			expectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8398)),
-			expectedTick:     31001956,
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(8398)),
+			ExpectedTick:     31001956,
 			// Corresponds to sqrt_next in script above
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724513183069625079757400000001800313"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724513183069625079757400000001800313"),
 			// two positions with same liquidity entered
-			poolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
 		},
 		"two positions within one tick: eth -> usdc": {
-			tokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			tokenOutDenom:            "usdc",
-			priceLimit:               osmomath.NewBigDec(4996),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: DefaultLowerPrice,
-			secondPositionUpperPrice: DefaultUpperPrice,
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4996),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
 			// from math import *
 			// from decimal import *
 			// getcontext().prec = 60
@@ -309,15 +271,15 @@ var (
 			// print(sqrt_next)
 			// print(expectedTokenIn)
 			// print(expectedTokenOut)
-			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
-			expectedTick:     30996887,
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
+			ExpectedTick:     30996887,
 			// True value with arbitrary precision: 70.6886641634088363202...
 			// Expected value due to our monotonic sqrt's >= true value guarantee: 70.688664163408836321
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.688664163408836320215015370847179540"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.688664163408836320215015370847179540"),
 			// two positions with same liquidity entered
-			poolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
 		},
 		//  Consecutive price ranges
 
@@ -326,12 +288,12 @@ var (
 		//             5500 ----------- 6250
 
 		"two positions with consecutive price ranges: usdc -> eth": {
-			tokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			tokenOutDenom:            "eth",
-			priceLimit:               osmomath.NewBigDec(6255),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5500),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6255),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5500),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
 			// from math import *
 			// from decimal import *
 			// # Range 1: From 5000 to 5500
@@ -363,16 +325,16 @@ var (
 			// print(sqrt_next_2)
 			// print(token_in)
 			// print(token_out)
-			expectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			expectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(1820630)),
-			expectedTick:     32105414,
+			ExpectedTokenIn:  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut: sdk.NewCoin("eth", osmomath.NewInt(1820630)),
+			ExpectedTick:     32105414,
 			// Equivalent to sqrt_next_2 in the script above
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137149196095607130096044752300452857"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137149196095607130096044752300452857"),
 			//  second positions both have greater tick than the current tick, thus never initialized
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 315000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(5500),
-			newUpperPrice: osmomath.NewDec(6250),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 315000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5500),
+			NewUpperPrice: osmomath.NewDec(6250),
 		},
 		//  Consecutive price ranges
 		//
@@ -381,16 +343,16 @@ var (
 		//  4000 ----------- 4545
 		//
 		"two positions with consecutive price ranges: eth -> usdc": {
-			tokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			tokenOutDenom:            "usdc",
-			priceLimit:               osmomath.NewBigDec(3900),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4545),
-			expectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			expectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(3900),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4545),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
 			// crosses one tick with spread reward growth outside
-			expectedTick: 30095166,
+			ExpectedTick: 30095166,
 			// from math import *
 			// from decimal import *
 
@@ -420,16 +382,16 @@ var (
 
 			// print(sqrt_next_2)
 			// print(token_out)
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("63.993489023323078692803734142129673908"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("63.993489023323078692803734142129673908"),
 			// crossing tick happens single time for each upper tick and lower tick.
 			// Thus the tick's spread reward growth is DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins
-			expectedLowerTickSpreadRewardGrowth: DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth: DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedLowerTickSpreadRewardGrowth: DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth: DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
 			//  second positions both have greater tick than the current tick, thus never initialized
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 300000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 305450, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(4000),
-			newUpperPrice: osmomath.NewDec(4545),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 305450, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4545),
 		},
 		//  Partially overlapping price ranges
 
@@ -438,15 +400,15 @@ var (
 		//        5001 ----------- 6250
 		//
 		"two positions with partially overlapping price ranges: usdc -> eth": {
-			tokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			tokenOutDenom:            "eth",
-			priceLimit:               osmomath.NewBigDec(6056),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5001),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
-			expectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			expectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1864161)),
-			expectedTick:             32055919,
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6056),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5001),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1864161)),
+			ExpectedTick:             32055919,
 			// from math import *
 			// from decimal import *
 
@@ -483,19 +445,19 @@ var (
 
 			// print(sqrt_next_3)
 			// print(token_out)
-			expectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("77.819789636800169393792766394158739007"),
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice:                             osmomath.NewDec(5001),
-			newUpperPrice:                             osmomath.NewDec(6250),
+			ExpectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("77.819789636800169393792766394158739007"),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice:                             osmomath.NewDec(5001),
+			NewUpperPrice:                             osmomath.NewDec(6250),
 		},
 		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc -> eth": {
-			tokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(8500000000)),
-			tokenOutDenom: "eth",
-			priceLimit:    osmomath.NewBigDec(6056),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(8500000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.NewBigDec(6056),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 			// getcontext().prec = 60
@@ -537,19 +499,19 @@ var (
 			// print(sqrt_next_3)
 			// print(token_in)
 			// print(token_out)
-			secondPositionLowerPrice:                  osmomath.NewDec(5001),
-			secondPositionUpperPrice:                  osmomath.NewDec(6250),
-			expectedTokenIn:                           sdk.NewCoin("usdc", osmomath.NewInt(8500000000)),
-			expectedTokenOut:                          sdk.NewCoin("eth", osmomath.NewInt(1609138)),
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedTick:                              31712695,
+			SecondPositionLowerPrice:                  osmomath.NewDec(5001),
+			SecondPositionUpperPrice:                  osmomath.NewDec(6250),
+			ExpectedTokenIn:                           sdk.NewCoin("usdc", osmomath.NewInt(8500000000)),
+			ExpectedTokenOut:                          sdk.NewCoin("eth", osmomath.NewInt(1609138)),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedTick:                              31712695,
 			// Corresponds to sqrt_next_3 in the script above
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582373164412551492069079174313215667"),
-			newLowerPrice:     osmomath.NewDec(5001),
-			newUpperPrice:     osmomath.NewDec(6250),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582373164412551492069079174313215667"),
+			NewLowerPrice:     osmomath.NewDec(5001),
+			NewUpperPrice:     osmomath.NewDec(6250),
 		},
 		//  Partially overlapping price ranges
 		//
@@ -558,10 +520,10 @@ var (
 		//  4000 ----------- 4999
 		//
 		"two positions with partially overlapping price ranges: eth -> usdc": {
-			tokenIn:       sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			tokenOutDenom: "usdc",
-			priceLimit:    osmomath.NewBigDec(4128),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4128),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 			// getcontext().prec = 60
@@ -602,35 +564,35 @@ var (
 			// print(sqrt_next_2)
 			// print(token_in)
 			// print(token_out)
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4999),
-			expectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			expectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
-			expectedTick:             30129083,
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
+			ExpectedTick:             30129083,
 			// Corresponds to sqrt_next_2 in the script above
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943794993248953756640624575523292"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943794993248953756640624575523292"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 300000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 309990, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(4000),
-			newUpperPrice: osmomath.NewDec(4999),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
 		},
 		//          		5000
 		//  		4545 -----|----- 5500
 		//  4000 ---------- 4999
 		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc": {
-			tokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(1800000)),
-			tokenOutDenom:            "usdc",
-			priceLimit:               osmomath.NewBigDec(4128),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4999),
-			expectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(1800000)),
-			expectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8479320318)),
-			expectedTick:             30292059,
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(1800000)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4128),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(1800000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8479320318)),
+			ExpectedTick:             30292059,
 			// from math import *
 			// from decimal import *
 
@@ -666,15 +628,15 @@ var (
 
 			// print(sqrt_next_3)
 			// print(token_out)
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.513815285481060959469337552596846421"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.513815285481060959469337552596846421"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 300000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 309990, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(4000),
-			newUpperPrice: osmomath.NewDec(4999),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
 		},
 		//  Sequential price ranges with a gap
 		//
@@ -683,15 +645,15 @@ var (
 		//              5501 ----------- 6250
 		//
 		"two sequential positions with a gap": {
-			tokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			tokenOutDenom:            "eth",
-			priceLimit:               osmomath.NewBigDec(6106),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5501),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
-			expectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			expectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1820545)),
-			expectedTick:             32105555,
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5501),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1820545)),
+			ExpectedTick:             32105555,
 			// from math import *
 			// from decimal import *
 
@@ -727,22 +689,22 @@ var (
 
 			// print(sqrt_next_3)
 			// print(token_out)
-			expectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("78.138055169663761658508234345605157554"),
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice:                             osmomath.NewDec(5501),
-			newUpperPrice:                             osmomath.NewDec(6250),
+			ExpectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("78.138055169663761658508234345605157554"),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins,
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 315010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice:                             osmomath.NewDec(5501),
+			NewUpperPrice:                             osmomath.NewDec(6250),
 		},
 		// Slippage protection doesn't cause a failure but interrupts early.
 		//          5000
 		//  4545 ---!-|----- 5500
 		"single position within one tick, trade completes but slippage protection interrupts trade early: eth -> usdc": {
-			tokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			tokenOutDenom: "usdc",
-			priceLimit:    osmomath.NewBigDec(4994),
-			spreadFactor:  osmomath.ZeroDec(),
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4994),
+			SpreadFactor:  osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 			//
@@ -762,32 +724,32 @@ var (
 			// print(sqrt_next)
 			// print(expectedTokenIn)
 			// print(expectedTokenOut)
-			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(12892)),
-			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
-			expectedTick: func() int64 {
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(12892)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
+			ExpectedTick: func() int64 {
 				tick, _ := math.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(sqrt4994), DefaultTickSpacing)
 				return tick
 			}(),
 			// Since the next sqrt price is based on the price limit, we can calculate this directly.
-			expectedSqrtPrice: osmomath.BigDecFromDec(osmomath.MustMonotonicSqrt(osmomath.NewDec(4994))),
+			ExpectedSqrtPrice: osmomath.BigDecFromDec(osmomath.MustMonotonicSqrt(osmomath.NewDec(4994))),
 		},
 	}
 
-	swapOutGivenInSpreadRewardCases = map[string]SwapTest{
+	swapOutGivenInSpreadRewardCases = map[string]apptesting.ConcentratedSwapTest{
 		//          5000
 		//  4545 -----|----- 5500
 		"spread factor 1 - single position within one tick: usdc -> eth (1% spread factor)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:           sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			tokenOutDenom:     "eth",
-			priceLimit:        osmomath.NewBigDec(5004),
-			spreadFactor:      osmomath.MustNewDecFromStr("0.01"),
-			expectedTokenIn:   sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
-			expectedTokenOut:  sdk.NewCoin("eth", osmomath.NewInt(8312)),
-			expectedTick:      31003800,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738071546196200264"),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000276701288297452"),
+			TokenIn:           sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			TokenOutDenom:     "eth",
+			PriceLimit:        osmomath.NewBigDec(5004),
+			SpreadFactor:      osmomath.MustNewDecFromStr("0.01"),
+			ExpectedTokenIn:   sdk.NewCoin("usdc", osmomath.NewInt(42000000)),
+			ExpectedTokenOut:  sdk.NewCoin("eth", osmomath.NewInt(8312)),
+			ExpectedTick:      31003800,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.738071546196200264"),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000276701288297452"),
 		},
 		//          5000
 		//  4545 -----|----- 5500
@@ -795,20 +757,20 @@ var (
 		"spread factor 2 - two positions within one tick: eth -> usdc (3% spread factor) ": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			tokenOutDenom:            "usdc",
-			priceLimit:               osmomath.NewBigDec(4990),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.03"),
-			secondPositionLowerPrice: DefaultLowerPrice,
-			secondPositionUpperPrice: DefaultUpperPrice,
-			expectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			expectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(64824917)),
-			expectedTick:             30996900,
-			expectedSqrtPrice:        osmomath.MustNewBigDecFromStr("70.689324382628080102"),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000132091924532"),
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4990),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.03"),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(64824917)),
+			ExpectedTick:             30996900,
+			ExpectedSqrtPrice:        osmomath.MustNewBigDecFromStr("70.689324382628080102"),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000132091924532"),
 			// two positions with same liquidity entered
-			poolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
 		},
 		//          		   5000
 		//  		   4545 -----|----- 5500
@@ -816,19 +778,19 @@ var (
 		"spread factor 3 - two positions with consecutive price ranges: eth -> usdc (5% spread factor)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			tokenOutDenom:            "usdc",
-			priceLimit:               osmomath.NewBigDec(4094),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.05"),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4545),
-			expectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			expectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8691708221)),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000073738597832046"),
-			expectedTick:      30139200,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.336946417392457832"),
-			newLowerPrice:     osmomath.NewDec(4000),
-			newUpperPrice:     osmomath.NewDec(4545),
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4094),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.05"),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4545),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8691708221)),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000073738597832046"),
+			ExpectedTick:      30139200,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.336946417392457832"),
+			NewLowerPrice:     osmomath.NewDec(4000),
+			NewUpperPrice:     osmomath.NewDec(4545),
 		},
 		//          5000
 		//  4545 -----|----- 5500
@@ -836,19 +798,19 @@ var (
 		"spread factor 4 - two positions with partially overlapping price ranges: usdc -> eth (10% spread factor)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			tokenOutDenom:            "eth",
-			priceLimit:               osmomath.NewBigDec(6056),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.1"),
-			secondPositionLowerPrice: osmomath.NewDec(5001),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
-			expectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			expectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1695807)),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.624166726347032857"),
-			expectedTick:      31825900,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("76.328178655208424124"),
-			newLowerPrice:     osmomath.NewDec(5001),
-			newUpperPrice:     osmomath.NewDec(6250),
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6056),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.1"),
+			SecondPositionLowerPrice: osmomath.NewDec(5001),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1695807)),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.624166726347032857"),
+			ExpectedTick:      31825900,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("76.328178655208424124"),
+			NewLowerPrice:     osmomath.NewDec(5001),
+			NewUpperPrice:     osmomath.NewDec(6250),
 		},
 		//          		5000
 		//  		4545 -----|----- 5500
@@ -856,19 +818,19 @@ var (
 		"spread factor 5 - two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc (0.5% spread factor)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(1800000)),
-			tokenOutDenom:            "usdc",
-			priceLimit:               osmomath.NewBigDec(4128),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.005"),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4999),
-			expectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(1800000)),
-			expectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8440657775)),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000005569829831408"),
-			expectedTick:      30299600,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.571484748647169032"),
-			newLowerPrice:     osmomath.NewDec(4000),
-			newUpperPrice:     osmomath.NewDec(4999),
+			TokenIn:                  sdk.NewCoin("eth", osmomath.NewInt(1800000)),
+			TokenOutDenom:            "usdc",
+			PriceLimit:               osmomath.NewBigDec(4128),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.005"),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
+			ExpectedTokenIn:          sdk.NewCoin("eth", osmomath.NewInt(1800000)),
+			ExpectedTokenOut:         sdk.NewCoin("usdc", osmomath.NewInt(8440657775)),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000005569829831408"),
+			ExpectedTick:      30299600,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.571484748647169032"),
+			NewLowerPrice:     osmomath.NewDec(4000),
+			NewUpperPrice:     osmomath.NewDec(4999),
 		},
 		//          5000
 		//  4545 -----|----- 5500
@@ -876,68 +838,68 @@ var (
 		"spread factor 6 - two sequential positions with a gap usdc -> eth (3% spread factor)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			tokenOutDenom:            "eth",
-			priceLimit:               osmomath.NewBigDec(6106),
-			secondPositionLowerPrice: osmomath.NewDec(5501),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.03"),
-			expectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
-			expectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1771252)),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.221769187794051751"),
-			expectedTick:      32066500,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("77.887956882326389372"),
-			newLowerPrice:     osmomath.NewDec(5501),
-			newUpperPrice:     osmomath.NewDec(6250),
+			TokenIn:                  sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			TokenOutDenom:            "eth",
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SecondPositionLowerPrice: osmomath.NewDec(5501),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.03"),
+			ExpectedTokenIn:          sdk.NewCoin("usdc", osmomath.NewInt(10000000000)),
+			ExpectedTokenOut:         sdk.NewCoin("eth", osmomath.NewInt(1771252)),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.221769187794051751"),
+			ExpectedTick:      32066500,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("77.887956882326389372"),
+			NewLowerPrice:     osmomath.NewDec(5501),
+			NewUpperPrice:     osmomath.NewDec(6250),
 		},
 		//          5000
 		//  4545 ---!-|----- 5500
 		"spread factor 7: single position within one tick, trade completes but slippage protection interrupts trade early: eth -> usdc (1% spread factor)": {
 			// parameters and results of this test case
 			// are estimated by utilizing scripts from scripts/cl/main.py
-			tokenIn:          sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			tokenOutDenom:    "usdc",
-			priceLimit:       osmomath.NewBigDec(4994),
-			spreadFactor:     osmomath.MustNewDecFromStr("0.01"),
-			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13023)),
-			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000085792039652"),
-			expectedTick: func() int64 {
+			TokenIn:          sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			TokenOutDenom:    "usdc",
+			PriceLimit:       osmomath.NewBigDec(4994),
+			SpreadFactor:     osmomath.MustNewDecFromStr("0.01"),
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13023)),
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(64417624)),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000085792039652"),
+			ExpectedTick: func() int64 {
 				tick, _ := math.SqrtPriceToTickRoundDownSpacing(osmomath.BigDecFromDec(sqrt4994), DefaultTickSpacing)
 				return tick
 			}(),
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.668238976219012614"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.668238976219012614"),
 		},
 	}
 
-	swapOutGivenInErrorCases = map[string]SwapTest{
+	swapOutGivenInErrorCases = map[string]apptesting.ConcentratedSwapTest{
 		"single position within one tick, trade does not complete due to lack of liquidity: usdc -> eth": {
-			tokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(5300000000)),
-			tokenOutDenom: "eth",
-			priceLimit:    osmomath.NewBigDec(6000),
-			spreadFactor:  osmomath.ZeroDec(),
-			expectErr:     true,
+			TokenIn:       sdk.NewCoin("usdc", osmomath.NewInt(5300000000)),
+			TokenOutDenom: "eth",
+			PriceLimit:    osmomath.NewBigDec(6000),
+			SpreadFactor:  osmomath.ZeroDec(),
+			ExpectErr:     true,
 		},
 		"single position within one tick, trade does not complete due to lack of liquidity: eth -> usdc": {
-			tokenIn:       sdk.NewCoin("eth", osmomath.NewInt(1100000)),
-			tokenOutDenom: "usdc",
-			priceLimit:    osmomath.NewBigDec(4000),
-			spreadFactor:  osmomath.ZeroDec(),
-			expectErr:     true,
+			TokenIn:       sdk.NewCoin("eth", osmomath.NewInt(1100000)),
+			TokenOutDenom: "usdc",
+			PriceLimit:    osmomath.NewBigDec(4000),
+			SpreadFactor:  osmomath.ZeroDec(),
+			ExpectErr:     true,
 		},
 	}
 
 	// Note: liquidity value for the default position is 1517882343.751510417627556287
-	swapInGivenOutTestCases = map[string]SwapTest{
+	swapInGivenOutTestCases = map[string]apptesting.ConcentratedSwapTest{
 		//  One price range
 		//
 		//          5000
 		//  4545 -----|----- 5500
 		"single position within one tick: eth (in) -> usdc (out) | zfo": {
-			tokenOut:     sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
-			tokenInDenom: ETH,
-			priceLimit:   osmomath.NewBigDec(4993),
-			spreadFactor: osmomath.ZeroDec(),
+			TokenOut:     sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
+			TokenInDenom: ETH,
+			PriceLimit:   osmomath.NewBigDec(4993),
+			SpreadFactor: osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 
@@ -957,16 +919,16 @@ var (
 			// token_in = token_in = liq * (sqrt_cur - sqrt_next) / (sqrt_cur * sqrt_next)
 			// print(sqrt_next)
 			// print(token_in)
-			expectedTokenOut:  sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
-			expectedTokenIn:   sdk.NewCoin(ETH, osmomath.NewInt(8404)),
-			expectedTick:      30996087,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.683007989825007163485199999996399373"),
+			ExpectedTokenOut:  sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
+			ExpectedTokenIn:   sdk.NewCoin(ETH, osmomath.NewInt(8404)),
+			ExpectedTick:      30996087,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.683007989825007163485199999996399373"),
 		},
 		"single position within one tick: usdc (in) -> eth (out) ofz": {
-			tokenOut:     sdk.NewCoin(ETH, osmomath.NewInt(13370)),
-			tokenInDenom: USDC,
-			priceLimit:   osmomath.NewBigDec(5010),
-			spreadFactor: osmomath.ZeroDec(),
+			TokenOut:     sdk.NewCoin(ETH, osmomath.NewInt(13370)),
+			TokenInDenom: USDC,
+			PriceLimit:   osmomath.NewBigDec(5010),
+			SpreadFactor: osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 			// import sys
@@ -981,10 +943,10 @@ var (
 			// token_in = ceil(liq * abs(sqrt_cur - sqrt_next))
 			// print(sqrt_next)
 			// print(token_in)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(13370)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(66891663)),
-			expectedTick:      31006234,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.754747188468900467378792612053774781"),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(13370)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(66891663)),
+			ExpectedTick:      31006234,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.754747188468900467378792612053774781"),
 		},
 		//  Two equal price ranges
 		//
@@ -992,12 +954,12 @@ var (
 		//  4545 -----|----- 5500
 		//  4545 -----|----- 5500
 		"two positions within one tick: eth (in) -> usdc (out) | zfo": {
-			tokenOut:                 sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
-			tokenInDenom:             "eth",
-			priceLimit:               osmomath.NewBigDec(4990),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: DefaultLowerPrice,
-			secondPositionUpperPrice: DefaultUpperPrice,
+			TokenOut:                 sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
+			TokenInDenom:             "eth",
+			PriceLimit:               osmomath.NewBigDec(4990),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
 			// from math import *
 			// from decimal import *
 
@@ -1018,23 +980,23 @@ var (
 			// token_in = token_in = liq * (sqrt_cur - sqrt_next) / (sqrt_cur * sqrt_next)
 			// print(sqrt_next)
 			// print(token_in)
-			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
-			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
-			expectedTick:     30996887,
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(66829187)),
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(13370)),
+			ExpectedTick:     30996887,
 			// This value is the direct output of sqrt_next in the script above.
 			// The precision is exact because we properly handle rounding behavior in intermediate steps.
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.688664163727643651554720661097135393"),
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.688664163727643651554720661097135393"),
 			// two positions with same liquidity entered
-			poolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
 		},
 		"two positions within one tick: usdc (in) -> eth (out) | ofz": {
-			tokenOut:                 sdk.NewCoin("eth", osmomath.NewInt(8398)),
-			tokenInDenom:             "usdc",
-			priceLimit:               osmomath.NewBigDec(5020),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: DefaultLowerPrice,
-			secondPositionUpperPrice: DefaultUpperPrice,
+			TokenOut:                 sdk.NewCoin("eth", osmomath.NewInt(8398)),
+			TokenInDenom:             "usdc",
+			PriceLimit:               osmomath.NewBigDec(5020),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
 			// from math import *
 			// from decimal import *
 			// import sys
@@ -1049,13 +1011,13 @@ var (
 			// token_in = ceil(liq * abs(sqrt_cur - sqrt_next))
 			// print(sqrt_next)
 			// print(token_in)
-			expectedTokenOut:  sdk.NewCoin("eth", osmomath.NewInt(8398)),
-			expectedTokenIn:   sdk.NewCoin("usdc", osmomath.NewInt(41998216)),
-			expectedTick:      31001956,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724512595179305566327821490232558005"),
+			ExpectedTokenOut:  sdk.NewCoin("eth", osmomath.NewInt(8398)),
+			ExpectedTokenIn:   sdk.NewCoin("usdc", osmomath.NewInt(41998216)),
+			ExpectedTick:      31001956,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724512595179305566327821490232558005"),
 			// two positions with same liquidity entered
-			poolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
 		},
 		//  Consecutive price ranges
 		//
@@ -1063,12 +1025,12 @@ var (
 		//             4545 -----|----- 5500
 		//  4000 ----------- 4545
 		"two positions with consecutive price ranges: eth (in) -> usdc (out) | zfo": {
-			tokenOut:                 sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
-			tokenInDenom:             "eth",
-			priceLimit:               osmomath.NewBigDec(3900),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4545),
+			TokenOut:                 sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
+			TokenInDenom:             "eth",
+			PriceLimit:               osmomath.NewBigDec(3900),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4545),
 			// from math import *
 			// from decimal import *
 
@@ -1105,17 +1067,17 @@ var (
 			// print(sqrt_next_2)
 			// print(token_in)
 			// print(token_out_2)
-			expectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
-			expectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			expectedTick:     30095166,
+			ExpectedTokenOut: sdk.NewCoin("usdc", osmomath.NewInt(9103422788)),
+			ExpectedTokenIn:  sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTick:     30095166,
 
-			expectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("63.993489023888951975210711246458277671"),
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice:                             osmomath.NewDec(4000),
-			newUpperPrice:                             osmomath.NewDec(4545),
+			ExpectedSqrtPrice:                         osmomath.MustNewBigDecFromStr("63.993489023888951975210711246458277671"),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 315000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice:                             osmomath.NewDec(4000),
+			NewUpperPrice:                             osmomath.NewDec(4545),
 		},
 		//  Consecutive price ranges
 		//
@@ -1124,12 +1086,12 @@ var (
 		//             5500 ----------- 6250
 		//
 		"two positions with consecutive price ranges: usdc (in) -> eth (out) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6106),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5500), // 315000
-			secondPositionUpperPrice: osmomath.NewDec(6250), // 322500
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5500), // 315000
+			SecondPositionUpperPrice: osmomath.NewDec(6250), // 322500
 			// from math import *
 			// from decimal import *
 
@@ -1166,14 +1128,14 @@ var (
 			// print(sqrt_next_2)
 			// print(token_in)
 			// print(token_out_2)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(9999999570)),
-			expectedTick:      32105414,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137148837036751554352224945360339905"),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(5500),
-			newUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(9999999570)),
+			ExpectedTick:      32105414,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137148837036751554352224945360339905"),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 315000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5500),
+			NewUpperPrice: osmomath.NewDec(6250),
 		},
 		//  Partially overlapping price ranges
 		//
@@ -1182,12 +1144,12 @@ var (
 		//  4000 ----------- 4999
 		//
 		"two positions with partially overlapping price ranges: eth (in) -> usdc (out) | zfo": {
-			tokenOut:                 sdk.NewCoin(USDC, osmomath.NewInt(9321276930)),
-			tokenInDenom:             ETH,
-			priceLimit:               osmomath.NewBigDec(4128),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4999),
+			TokenOut:                 sdk.NewCoin(USDC, osmomath.NewInt(9321276930)),
+			TokenInDenom:             ETH,
+			PriceLimit:               osmomath.NewBigDec(4128),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
 			// from math import *
 			// from decimal import *
 
@@ -1234,29 +1196,29 @@ var (
 			// print(sqrt_next_3)
 			// print(token_in)
 			// print(token_out_2)
-			expectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(2000000)),
-			expectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
-			expectedTick:      30129083,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943796086567725876595411582357676"),
+			ExpectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(2000000)),
+			ExpectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
+			ExpectedTick:      30129083,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943796086567725876595411582357676"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 300000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 309990, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(4000),
-			newUpperPrice: osmomath.NewDec(4999),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
 		},
 		//          		5000
 		//  		4545 -----|----- 5500
 		//  4000 ---------- 4999
 		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth (in) -> usdc (out) | zfo": {
-			tokenOut:                 sdk.NewCoin(USDC, osmomath.NewInt(8479320318)),
-			tokenInDenom:             ETH,
-			priceLimit:               osmomath.NewBigDec(4128),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4999),
+			TokenOut:                 sdk.NewCoin(USDC, osmomath.NewInt(8479320318)),
+			TokenInDenom:             ETH,
+			PriceLimit:               osmomath.NewBigDec(4128),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
 			// from math import *
 			// from decimal import *
 
@@ -1302,18 +1264,18 @@ var (
 			// print(sqrt_next_3)
 			// print(token_in)
 			// print(token_out_2)
-			expectedTokenIn:   sdk.NewCoin(ETH, osmomath.NewInt(1800000)),
-			expectedTokenOut:  sdk.NewCoin(USDC, osmomath.NewInt(8479320318)),
-			expectedTick:      30292059,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.513815286452064191403749708246274698"),
+			ExpectedTokenIn:   sdk.NewCoin(ETH, osmomath.NewInt(1800000)),
+			ExpectedTokenOut:  sdk.NewCoin(USDC, osmomath.NewInt(8479320318)),
+			ExpectedTick:      30292059,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("65.513815286452064191403749708246274698"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 300000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 309990, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(4000),
-			newUpperPrice: osmomath.NewDec(4999),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
 		},
 		//  Partially overlapping price ranges
 
@@ -1322,12 +1284,12 @@ var (
 		//        5001 ----------- 6250
 		//
 		"two positions with partially overlapping price ranges: usdc (in) -> eth (out) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1864161)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6056),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5001),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1864161)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6056),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5001),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
 			// from math import *
 			// from decimal import *
 
@@ -1373,22 +1335,22 @@ var (
 			// print(sqrt_next_3)
 			// print(token_in)
 			// print(token_out_2)
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(9999994688)),
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1864161)),
-			expectedTick:      32055918,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("77.819781711876553578435870496972242531"),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(5001),
-			newUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(9999994688)),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1864161)),
+			ExpectedTick:      32055918,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("77.819781711876553578435870496972242531"),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5001),
+			NewUpperPrice: osmomath.NewDec(6250),
 		},
 		"two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc (in) -> eth (out) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6056),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5001),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6056),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5001),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
 			// from math import *
 			// from decimal import *
 
@@ -1440,14 +1402,14 @@ var (
 			// print(token_in)
 			// print(spread_rewards_growth)
 			// print(token_out_2)
-			expectedTokenIn:  sdk.NewCoin(USDC, osmomath.NewInt(8499999458)),
-			expectedTokenOut: sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedTick:      31712695,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582372355128594342857800328292876450"),
-			newLowerPrice:     osmomath.NewDec(5001),
-			newUpperPrice:     osmomath.NewDec(6250),
+			ExpectedTokenIn:  sdk.NewCoin(USDC, osmomath.NewInt(8499999458)),
+			ExpectedTokenOut: sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedTick:      31712695,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582372355128594342857800328292876450"),
+			NewLowerPrice:     osmomath.NewDec(5001),
+			NewUpperPrice:     osmomath.NewDec(6250),
 		},
 		//  Sequential price ranges with a gap
 		//
@@ -1456,12 +1418,12 @@ var (
 		//              5501 ----------- 6250
 		//
 		"two sequential positions with a gap usdc (in) -> eth (out) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6106),
-			spreadFactor:             osmomath.ZeroDec(),
-			secondPositionLowerPrice: osmomath.NewDec(5501), // 315010
-			secondPositionUpperPrice: osmomath.NewDec(6250), // 322500
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SpreadFactor:             osmomath.ZeroDec(),
+			SecondPositionLowerPrice: osmomath.NewDec(5501), // 315010
+			SecondPositionUpperPrice: osmomath.NewDec(6250), // 322500
 			// from math import *
 			// from decimal import *
 
@@ -1498,21 +1460,21 @@ var (
 			// print(sqrt_next_2)
 			// print(token_in_2)
 			// print(token_out_2)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(9999994756)),
-			expectedTick:      32105554,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.138050797173647031951910080474560428"),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(5501),
-			newUpperPrice: osmomath.NewDec(6250),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(9999994756)),
+			ExpectedTick:      32105554,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.138050797173647031951910080474560428"),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 315010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5501),
+			NewUpperPrice: osmomath.NewDec(6250),
 		},
 		// Slippage protection doesn't cause a failure but interrupts early.
 		"single position within one tick, trade completes but slippage protection interrupts trade early: usdc (in) -> eth (out) | ofz": {
-			tokenOut:     sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
-			tokenInDenom: USDC,
-			priceLimit:   osmomath.NewBigDec(5002),
-			spreadFactor: osmomath.ZeroDec(),
+			TokenOut:     sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
+			TokenInDenom: USDC,
+			PriceLimit:   osmomath.NewBigDec(5002),
+			SpreadFactor: osmomath.ZeroDec(),
 			// from math import *
 			// from decimal import *
 			// # Range 1: From 5000 to 5002
@@ -1527,20 +1489,20 @@ var (
 			// # Summary:
 			// print(sqrt_next_1)
 			// print(token_in_1)
-			expectedTokenOut: sdk.NewCoin(ETH, osmomath.NewInt(4291)),
-			expectedTokenIn:  sdk.NewCoin(USDC, osmomath.NewInt(21463952)),
-			expectedTick:     31002000,
+			ExpectedTokenOut: sdk.NewCoin(ETH, osmomath.NewInt(4291)),
+			ExpectedTokenIn:  sdk.NewCoin(USDC, osmomath.NewInt(21463952)),
+			ExpectedTick:     31002000,
 			// Since we know we're going up to the price limit, we can calculate the sqrt price exactly.
-			expectedSqrtPrice: osmomath.BigDecFromDec(osmomath.MustMonotonicSqrt(osmomath.NewDec(5002))),
+			ExpectedSqrtPrice: osmomath.BigDecFromDec(osmomath.MustMonotonicSqrt(osmomath.NewDec(5002))),
 		},
 	}
 
-	swapInGivenOutSpreadRewardTestCases = map[string]SwapTest{
+	swapInGivenOutSpreadRewardTestCases = map[string]apptesting.ConcentratedSwapTest{
 		"spread factor 1: single position within one tick: eth (in) -> usdc (out) (1% spread factor) | zfo": {
-			tokenOut:     sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
-			tokenInDenom: ETH,
-			priceLimit:   osmomath.NewBigDec(4993),
-			spreadFactor: osmomath.MustNewDecFromStr("0.01"),
+			TokenOut:     sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
+			TokenInDenom: ETH,
+			PriceLimit:   osmomath.NewBigDec(4993),
+			SpreadFactor: osmomath.MustNewDecFromStr("0.01"),
 			// from math import *
 			// from decimal import *
 
@@ -1565,21 +1527,21 @@ var (
 			// print(sqrt_next)
 			// print(token_in)
 			// print(spread_rewards_growth)
-			expectedTokenOut: sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
-			expectedTokenIn:  sdk.NewCoin(ETH, osmomath.NewInt(8489)),
-			expectedTick:     30996087,
+			ExpectedTokenOut: sdk.NewCoin(USDC, osmomath.NewInt(42000000)),
+			ExpectedTokenIn:  sdk.NewCoin(ETH, osmomath.NewInt(8489)),
+			ExpectedTick:     30996087,
 			// This value is the direct output of sqrt_next in the script above.
 			// The precision is exact because we properly handle rounding behavior in intermediate steps.
-			expectedSqrtPrice:                          osmomath.MustNewBigDecFromStr("70.683007989825007163485199999996399373"),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000055925868851"),
+			ExpectedSqrtPrice:                          osmomath.MustNewBigDecFromStr("70.683007989825007163485199999996399373"),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000000055925868851"),
 		},
 		"spread factor 2: two positions within one tick: usdc (in) -> eth (out) (3% spread factor) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(8398)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(5020),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.03"),
-			secondPositionLowerPrice: DefaultLowerPrice,
-			secondPositionUpperPrice: DefaultUpperPrice,
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(8398)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(5020),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.03"),
+			SecondPositionLowerPrice: DefaultLowerPrice,
+			SecondPositionUpperPrice: DefaultUpperPrice,
 			// from math import *
 			// from decimal import *
 
@@ -1607,22 +1569,22 @@ var (
 			// print(sqrt_next)
 			// print(token_in)
 			// print(spread_rewards_growth)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(8398)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(43297130)),
-			expectedTick:      31001956,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724512595179305566327821490232558005"),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(8398)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(43297130)),
+			ExpectedTick:      31001956,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724512595179305566327821490232558005"),
 			// two positions with same liquidity entered
-			poolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
-			poolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000427870415073442"),
+			PoolLiqAmount0: osmomath.NewInt(1000000).MulRaw(2),
+			PoolLiqAmount1: osmomath.NewInt(5000000000).MulRaw(2),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000427870415073442"),
 		},
 		"spread factor 3: two positions with consecutive price ranges: usdc (in) -> eth (out) (0.1% spread factor) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6106),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.001"),
-			secondPositionLowerPrice: osmomath.NewDec(5500), // 315000
-			secondPositionUpperPrice: osmomath.NewDec(6250), // 322500
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.001"),
+			SecondPositionLowerPrice: osmomath.NewDec(5500), // 315000
+			SecondPositionUpperPrice: osmomath.NewDec(6250), // 322500
 			// from math import *
 			// from decimal import *
 
@@ -1665,23 +1627,23 @@ var (
 			// print(sqrt_next_2)
 			// print(token_in)
 			// print(spread_rewards_growth)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(10010009580)),
-			expectedTick:      32105414,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137148837036751554352224945360339905"),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(5500),
-			newUpperPrice: osmomath.NewDec(6250),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.007433904623597252"),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820630)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(10010009580)),
+			ExpectedTick:      32105414,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.137148837036751554352224945360339905"),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 315000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5500),
+			NewUpperPrice: osmomath.NewDec(6250),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.007433904623597252"),
 		},
 		"spread factor 4: two positions with partially overlapping price ranges: eth (in) -> usdc (out) (10% spread factor) | zfo": {
-			tokenOut:                 sdk.NewCoin(USDC, osmomath.NewInt(9321276930)),
-			tokenInDenom:             ETH,
-			priceLimit:               osmomath.NewBigDec(4128),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.1"),
-			secondPositionLowerPrice: osmomath.NewDec(4000),
-			secondPositionUpperPrice: osmomath.NewDec(4999),
+			TokenOut:                 sdk.NewCoin(USDC, osmomath.NewInt(9321276930)),
+			TokenInDenom:             ETH,
+			PriceLimit:               osmomath.NewBigDec(4128),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.1"),
+			SecondPositionLowerPrice: osmomath.NewDec(4000),
+			SecondPositionUpperPrice: osmomath.NewDec(4999),
 			// from math import *
 			// from decimal import *
 
@@ -1733,27 +1695,27 @@ var (
 			// print(token_in)
 			// print(spread_rewards_growth)
 			// print(token_out_2)
-			expectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(2222223)),
-			expectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
-			expectedTick:      30129083,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943796086567725876595411582357676"),
+			ExpectedTokenIn:   sdk.NewCoin("eth", osmomath.NewInt(2222223)),
+			ExpectedTokenOut:  sdk.NewCoin("usdc", osmomath.NewInt(9321276930)),
+			ExpectedTick:      30129083,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("64.257943796086567725876595411582357676"),
 			// Started from DefaultSpreadRewardAccumCoins * 3, crossed tick once, thus becoming
 			// DefaultSpreadRewardAccumCoins * 3 - DefaultSpreadRewardAccumCoins = DefaultSpreadRewardAccumCoins * 2
-			expectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 300000, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 309990, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(4000),
-			newUpperPrice: osmomath.NewDec(4999),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000157793641388331"),
+			ExpectedLowerTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedUpperTickSpreadRewardGrowth:       DefaultSpreadRewardAccumCoins.MulDec(osmomath.NewDec(2)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 300000, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 309990, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(4000),
+			NewUpperPrice: osmomath.NewDec(4999),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000157793641388331"),
 		},
 		"spread factor 5: two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc (in) -> eth (out) (5% spread factor) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6056),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.05"),
-			secondPositionLowerPrice: osmomath.NewDec(5001),
-			secondPositionUpperPrice: osmomath.NewDec(6250),
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6056),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.05"),
+			SecondPositionLowerPrice: osmomath.NewDec(5001),
+			SecondPositionUpperPrice: osmomath.NewDec(6250),
 			// from math import *
 			// from decimal import *
 
@@ -1805,23 +1767,23 @@ var (
 			// print(token_in)
 			// print(spread_rewards_growth)
 			// print(token_out_2)
-			expectedTokenIn:  sdk.NewCoin(USDC, osmomath.NewInt(8947367851)),
-			expectedTokenOut: sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 310010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedTick:      31712695,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582372355128594342857800328292876450"),
-			newLowerPrice:     osmomath.NewDec(5001),
-			newUpperPrice:     osmomath.NewDec(6250),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.256404959888119530"),
+			ExpectedTokenIn:  sdk.NewCoin(USDC, osmomath.NewInt(8947367851)),
+			ExpectedTokenOut: sdk.NewCoin(ETH, osmomath.NewInt(1609138)),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 310010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedTick:      31712695,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("75.582372355128594342857800328292876450"),
+			NewLowerPrice:     osmomath.NewDec(5001),
+			NewUpperPrice:     osmomath.NewDec(6250),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.256404959888119530"),
 		},
 		"spread factor 6: two sequential positions with a gap usdc (in) -> eth (out) (0.03% spread factor) | ofz": {
-			tokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
-			tokenInDenom:             USDC,
-			priceLimit:               osmomath.NewBigDec(6106),
-			spreadFactor:             osmomath.MustNewDecFromStr("0.0003"),
-			secondPositionLowerPrice: osmomath.NewDec(5501), // 315010
-			secondPositionUpperPrice: osmomath.NewDec(6250), // 322500
+			TokenOut:                 sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
+			TokenInDenom:             USDC,
+			PriceLimit:               osmomath.NewBigDec(6106),
+			SpreadFactor:             osmomath.MustNewDecFromStr("0.0003"),
+			SecondPositionLowerPrice: osmomath.NewDec(5501), // 315010
+			SecondPositionUpperPrice: osmomath.NewDec(6250), // 322500
 			// from math import *
 			// from decimal import *
 
@@ -1863,21 +1825,21 @@ var (
 			// print(token_in)
 			// print(spread_rewards_growth)
 			// print(token_out_2)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(10002995655)),
-			expectedTick:      32105554,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.138050797173647031951910080474560428"),
-			expectedSecondLowerTickSpreadRewardGrowth: secondPosition{tickIndex: 315010, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			expectedSecondUpperTickSpreadRewardGrowth: secondPosition{tickIndex: 322500, expectedSpreadRewardGrowth: cl.EmptyCoins},
-			newLowerPrice: osmomath.NewDec(5501),
-			newUpperPrice: osmomath.NewDec(6250),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.002226857353494143"),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(10002995655)),
+			ExpectedTick:      32105554,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("78.138050797173647031951910080474560428"),
+			ExpectedSecondLowerTickSpreadRewardGrowth: secondPosition{TickIndex: 315010, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			ExpectedSecondUpperTickSpreadRewardGrowth: secondPosition{TickIndex: 322500, ExpectedSpreadRewardGrowth: cl.EmptyCoins},
+			NewLowerPrice: osmomath.NewDec(5501),
+			NewUpperPrice: osmomath.NewDec(6250),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.002226857353494143"),
 		},
 		"spread factor 7: single position within one tick, trade completes but slippage protection interrupts trade early: usdc (in) -> eth (out) (1% spread factor) | ofz": {
-			tokenOut:     sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
-			tokenInDenom: USDC,
-			priceLimit:   osmomath.NewBigDec(5002),
-			spreadFactor: osmomath.MustNewDecFromStr("0.01"),
+			TokenOut:     sdk.NewCoin(ETH, osmomath.NewInt(1820545)),
+			TokenInDenom: USDC,
+			PriceLimit:   osmomath.NewBigDec(5002),
+			SpreadFactor: osmomath.MustNewDecFromStr("0.01"),
 			// from math import *
 			// from decimal import *
 			// # Range 1: From 5000 to 5002
@@ -1897,28 +1859,28 @@ var (
 			// print(sqrt_next_1)
 			// print(token_in)
 			// print(spread_rewards_growth)
-			expectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(4291)),
-			expectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(21680760)),
-			expectedTick:      31002000,
-			expectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724818840347693040"),
-			expectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000142835574082604"),
+			ExpectedTokenOut:  sdk.NewCoin(ETH, osmomath.NewInt(4291)),
+			ExpectedTokenIn:   sdk.NewCoin(USDC, osmomath.NewInt(21680760)),
+			ExpectedTick:      31002000,
+			ExpectedSqrtPrice: osmomath.MustNewBigDecFromStr("70.724818840347693040"),
+			ExpectedSpreadRewardGrowthAccumulatorValue: osmomath.MustNewDecFromStr("0.000142835574082604"),
 		},
 	}
 
-	swapInGivenOutErrorTestCases = map[string]SwapTest{
+	swapInGivenOutErrorTestCases = map[string]apptesting.ConcentratedSwapTest{
 		"single position within one tick, trade does not complete due to lack of liquidity: usdc -> eth ": {
-			tokenOut:     sdk.NewCoin("usdc", osmomath.NewInt(5300000000)),
-			tokenInDenom: "eth",
-			priceLimit:   osmomath.NewBigDec(6000),
-			spreadFactor: osmomath.ZeroDec(),
-			expectErr:    true,
+			TokenOut:     sdk.NewCoin("usdc", osmomath.NewInt(5300000000)),
+			TokenInDenom: "eth",
+			PriceLimit:   osmomath.NewBigDec(6000),
+			SpreadFactor: osmomath.ZeroDec(),
+			ExpectErr:    true,
 		},
 		"single position within one tick, trade does not complete due to lack of liquidity: eth -> usdc ": {
-			tokenOut:     sdk.NewCoin("eth", osmomath.NewInt(1100000)),
-			tokenInDenom: "usdc",
-			priceLimit:   osmomath.NewBigDec(4000),
-			spreadFactor: osmomath.ZeroDec(),
-			expectErr:    true,
+			TokenOut:     sdk.NewCoin("eth", osmomath.NewInt(1100000)),
+			TokenInDenom: "usdc",
+			PriceLimit:   osmomath.NewBigDec(4000),
+			SpreadFactor: osmomath.ZeroDec(),
+			ExpectErr:    true,
 		},
 	}
 
@@ -1935,22 +1897,16 @@ func init() {
 	populateSwapTestFields(swapInGivenOutErrorTestCases)
 }
 
-func populateSwapTestFields(cases map[string]SwapTest) {
+func populateSwapTestFields(cases map[string]apptesting.ConcentratedSwapTest) {
 	for k, v := range cases {
-		if v.expectedLowerTickSpreadRewardGrowth == nil {
-			v.expectedLowerTickSpreadRewardGrowth = DefaultSpreadRewardAccumCoins
+		if v.ExpectedLowerTickSpreadRewardGrowth == nil {
+			v.ExpectedLowerTickSpreadRewardGrowth = DefaultSpreadRewardAccumCoins
 		}
-		if v.expectedUpperTickSpreadRewardGrowth == nil {
-			v.expectedUpperTickSpreadRewardGrowth = DefaultSpreadRewardAccumCoins
+		if v.ExpectedUpperTickSpreadRewardGrowth == nil {
+			v.ExpectedUpperTickSpreadRewardGrowth = DefaultSpreadRewardAccumCoins
 		}
 		cases[k] = v
 	}
-}
-
-func (s *KeeperTestSuite) setupAndFundSwapTest() {
-	s.SetupTest()
-	s.FundAcc(s.TestAccs[0], swapFundCoins)
-	s.FundAcc(s.TestAccs[1], swapFundCoins)
 }
 
 func (s *KeeperTestSuite) preparePoolAndDefaultPosition() types.ConcentratedPoolExtension {
@@ -1959,18 +1915,11 @@ func (s *KeeperTestSuite) preparePoolAndDefaultPosition() types.ConcentratedPool
 	return pool
 }
 
-func (s *KeeperTestSuite) preparePoolAndDefaultPositions(test SwapTest) types.ConcentratedPoolExtension {
+func (s *KeeperTestSuite) preparePoolAndDefaultPositions(test apptesting.ConcentratedSwapTest) types.ConcentratedPoolExtension {
 	pool := s.preparePoolAndDefaultPosition()
-	s.setupSecondPosition(test, pool)
-	pool, _ = s.clk.GetConcentratedPoolById(s.Ctx, pool.GetId())
+	s.SetupSecondPosition(test, pool)
+	pool, _ = s.Clk.GetConcentratedPoolById(s.Ctx, pool.GetId())
 	return pool
-}
-
-func (s *KeeperTestSuite) preparePoolWithCustSpread(spread osmomath.Dec) types.ConcentratedPoolExtension {
-	clParams := s.App.ConcentratedLiquidityKeeper.GetParams(s.Ctx)
-	clParams.AuthorizedSpreadFactors = append(clParams.AuthorizedSpreadFactors, spread)
-	s.App.ConcentratedLiquidityKeeper.SetParams(s.Ctx, clParams)
-	return s.PrepareCustomConcentratedPool(s.TestAccs[0], "eth", "usdc", DefaultTickSpacing, spread)
 }
 
 func makeTests[T any](tests ...map[string]T) map[string]T {
@@ -1996,25 +1945,25 @@ func (s *KeeperTestSuite) assertPoolNotModified(poolBeforeCalc types.Concentrate
 	s.Require().Equal(poolBeforeCalc.GetTickSpacing(), poolAfterCalc.GetTickSpacing())
 }
 
-func (s *KeeperTestSuite) assertSpreadRewardAccum(test SwapTest, poolId uint64) {
+func (s *KeeperTestSuite) assertSpreadRewardAccum(test apptesting.ConcentratedSwapTest, poolId uint64) {
 	spreadRewardAccum, err := s.App.ConcentratedLiquidityKeeper.GetSpreadRewardAccumulator(s.Ctx, poolId)
 	s.Require().NoError(err)
 
 	spreadRewardAccumValue := spreadRewardAccum.GetValue()
-	if test.expectedSpreadRewardGrowthAccumulatorValue.IsNil() {
+	if test.ExpectedSpreadRewardGrowthAccumulatorValue.IsNil() {
 		s.Require().Equal(0, spreadRewardAccumValue.Len())
 		return
 	}
-	amountOfDenom := test.tokenIn.Denom
+	amountOfDenom := test.TokenIn.Denom
 	if amountOfDenom == "" {
-		amountOfDenom = test.tokenInDenom
+		amountOfDenom = test.TokenInDenom
 	}
 	spreadRewardVal := spreadRewardAccumValue.AmountOf(amountOfDenom)
 	s.Require().Equal(1, spreadRewardAccumValue.Len(), "spread reward accumulator should only have one denom, was (%s)", spreadRewardAccumValue)
 	osmoassert.Equal(
 		s.T(),
 		additiveSpreadRewardGrowthGlobalErrTolerance,
-		osmomath.BigDecFromDec(test.expectedSpreadRewardGrowthAccumulatorValue),
+		osmomath.BigDecFromDec(test.ExpectedSpreadRewardGrowthAccumulatorValue),
 		osmomath.BigDecFromDec(spreadRewardVal),
 	)
 }
@@ -2025,25 +1974,25 @@ func (s *KeeperTestSuite) assertZeroSpreadRewards(poolId uint64) {
 	s.Require().Equal(0, spreadRewardAccum.GetValue().Len())
 }
 
-func (s *KeeperTestSuite) getExpectedLiquidity(test SwapTest, pool types.ConcentratedPoolExtension) osmomath.Dec {
-	if test.newLowerPrice.IsNil() && test.newUpperPrice.IsNil() {
-		test.newLowerPrice = DefaultLowerPrice
-		test.newUpperPrice = DefaultUpperPrice
+func (s *KeeperTestSuite) getExpectedLiquidity(test apptesting.ConcentratedSwapTest, pool types.ConcentratedPoolExtension) osmomath.Dec {
+	if test.NewLowerPrice.IsNil() && test.NewUpperPrice.IsNil() {
+		test.NewLowerPrice = DefaultLowerPrice
+		test.NewUpperPrice = DefaultUpperPrice
 	}
 
-	newLowerTick, newUpperTick := s.lowerUpperPricesToTick(test.newLowerPrice, test.newUpperPrice, pool.GetTickSpacing())
+	newLowerTick, newUpperTick := s.lowerUpperPricesToTick(test.NewLowerPrice, test.NewUpperPrice, pool.GetTickSpacing())
 
 	lowerSqrtPrice, err := math.TickToSqrtPrice(newLowerTick)
 	s.Require().NoError(err)
 	upperSqrtPrice, err := math.TickToSqrtPrice(newUpperTick)
 	s.Require().NoError(err)
 
-	if test.poolLiqAmount0.IsNil() && test.poolLiqAmount1.IsNil() {
-		test.poolLiqAmount0 = DefaultAmt0
-		test.poolLiqAmount1 = DefaultAmt1
+	if test.PoolLiqAmount0.IsNil() && test.PoolLiqAmount1.IsNil() {
+		test.PoolLiqAmount0 = DefaultAmt0
+		test.PoolLiqAmount1 = DefaultAmt1
 	}
 
-	expectedLiquidity := math.GetLiquidityFromAmounts(DefaultCurrSqrtPrice, lowerSqrtPrice, upperSqrtPrice, test.poolLiqAmount0, test.poolLiqAmount1)
+	expectedLiquidity := math.GetLiquidityFromAmounts(DefaultCurrSqrtPrice, lowerSqrtPrice, upperSqrtPrice, test.PoolLiqAmount0, test.PoolLiqAmount1)
 	return expectedLiquidity
 }
 
@@ -2059,16 +2008,16 @@ func (s *KeeperTestSuite) lowerUpperPricesToTick(lowerPrice, upperPrice osmomath
 
 func (s *KeeperTestSuite) TestComputeAndSwapOutAmtGivenIn() {
 	// add error cases as well
-	tests := makeTests(swapOutGivenInCases, swapOutGivenInCases, swapOutGivenInErrorCases)
+	tests := makeTests(swapOutGivenInCases, swapOutGivenInErrorCases)
 
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
-			pool := s.preparePoolWithCustSpread(test.spreadFactor)
+			s.SetupAndFundSwapTest()
+			pool := s.PreparePoolWithCustSpread(test.SpreadFactor)
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())
-			s.setupSecondPosition(test, pool)
+			s.SetupSecondPosition(test, pool)
 
 			poolBeforeCalc, err := s.App.ConcentratedLiquidityKeeper.GetPoolById(s.Ctx, pool.GetId())
 			s.Require().NoError(err)
@@ -2082,10 +2031,10 @@ func (s *KeeperTestSuite) TestComputeAndSwapOutAmtGivenIn() {
 			swapResult, poolUpdates, err := s.App.ConcentratedLiquidityKeeper.ComputeOutAmtGivenIn(
 				cacheCtx,
 				pool.GetId(),
-				test.tokenIn, test.tokenOutDenom,
-				test.spreadFactor, test.priceLimit)
+				test.TokenIn, test.TokenOutDenom,
+				test.SpreadFactor, test.PriceLimit)
 
-			if test.expectErr {
+			if test.ExpectErr {
 				s.Require().Error(err)
 			} else {
 				s.testSwapResult(test, pool, swapResult.AmountIn, swapResult.AmountOut, poolUpdates, err)
@@ -2100,11 +2049,11 @@ func (s *KeeperTestSuite) TestComputeAndSwapOutAmtGivenIn() {
 			// perform swap
 			tokenIn, tokenOut, poolUpdates, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
 				s.Ctx, s.TestAccs[0], pool,
-				test.tokenIn, test.tokenOutDenom,
-				test.spreadFactor, test.priceLimit,
+				test.TokenIn, test.TokenOutDenom,
+				test.SpreadFactor, test.PriceLimit,
 			)
 
-			if test.expectErr {
+			if test.ExpectErr {
 				s.Require().Error(err)
 			} else {
 				s.testSwapResult(test, pool, tokenIn.Amount, tokenOut.Amount, poolUpdates, err)
@@ -2141,7 +2090,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 
 			// Create default CL pool
 			pool := s.PrepareCustomConcentratedPool(s.TestAccs[0], ETH, USDC, DefaultTickSpacing, osmomath.ZeroDec())
@@ -2153,7 +2102,7 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())
-			s.setupSecondPosition(test, pool)
+			s.SetupSecondPosition(test, pool)
 
 			// add 2*DefaultSpreadRewardAccumCoins to spread factor accumulator, now spread factor accumulator has 3*DefaultSpreadRewardAccumCoins as its value
 			spreadFactorAccum, err = s.App.ConcentratedLiquidityKeeper.GetSpreadRewardAccumulator(s.Ctx, 1)
@@ -2163,32 +2112,32 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 			// perform swap
 			_, _, _, err = s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
 				s.Ctx, s.TestAccs[0], pool,
-				test.tokenIn, test.tokenOutDenom,
-				test.spreadFactor, test.priceLimit)
+				test.TokenIn, test.TokenOutDenom,
+				test.SpreadFactor, test.PriceLimit)
 
 			s.Require().NoError(err)
 
 			// check lower tick and upper tick spread reward growth
 			lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), DefaultLowerTick)
 			s.Require().NoError(err)
-			s.Require().Equal(test.expectedLowerTickSpreadRewardGrowth, lowerTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
+			s.Require().Equal(test.ExpectedLowerTickSpreadRewardGrowth, lowerTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
 
 			upperTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), DefaultLowerTick)
 			s.Require().NoError(err)
-			s.Require().Equal(test.expectedUpperTickSpreadRewardGrowth, upperTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
+			s.Require().Equal(test.ExpectedUpperTickSpreadRewardGrowth, upperTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
 
-			if test.expectedSecondLowerTickSpreadRewardGrowth.expectedSpreadRewardGrowth != nil {
-				newTickIndex := test.expectedSecondLowerTickSpreadRewardGrowth.tickIndex
-				expectedSpreadRewardGrowth := test.expectedSecondLowerTickSpreadRewardGrowth.expectedSpreadRewardGrowth
+			if test.ExpectedSecondLowerTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth != nil {
+				newTickIndex := test.ExpectedSecondLowerTickSpreadRewardGrowth.TickIndex
+				expectedSpreadRewardGrowth := test.ExpectedSecondLowerTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth
 
 				newLowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), newTickIndex)
 				s.Require().NoError(err)
 				s.Require().Equal(expectedSpreadRewardGrowth, newLowerTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
 			}
 
-			if test.expectedSecondUpperTickSpreadRewardGrowth.expectedSpreadRewardGrowth != nil {
-				newTickIndex := test.expectedSecondUpperTickSpreadRewardGrowth.tickIndex
-				expectedSpreadRewardGrowth := test.expectedSecondUpperTickSpreadRewardGrowth.expectedSpreadRewardGrowth
+			if test.ExpectedSecondUpperTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth != nil {
+				newTickIndex := test.ExpectedSecondUpperTickSpreadRewardGrowth.TickIndex
+				expectedSpreadRewardGrowth := test.ExpectedSecondUpperTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth
 
 				newLowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), newTickIndex)
 				s.Require().NoError(err)
@@ -2197,15 +2146,14 @@ func (s *KeeperTestSuite) TestSwapOutAmtGivenIn_TickUpdates() {
 		})
 	}
 }
-
-func (s *KeeperTestSuite) testSwapResult(test SwapTest, pool types.ConcentratedPoolExtension, amountIn, amountOut osmomath.Int, poolUpdates cl.PoolUpdates, err error) {
+func (s *KeeperTestSuite) testSwapResult(test apptesting.ConcentratedSwapTest, pool types.ConcentratedPoolExtension, amountIn, amountOut osmomath.Int, poolUpdates cl.PoolUpdates, err error) {
 	s.Require().NoError(err)
 
 	// check that tokenIn, tokenOut, tick, and sqrtPrice from CalcOut are all what we expected
-	s.Require().Equal(test.expectedSqrtPrice, poolUpdates.NewSqrtPrice, "resultant sqrt price not equal to expected sqrt price")
-	s.Require().Equal(test.expectedTokenOut.Amount.String(), amountOut.String())
-	s.Require().Equal(test.expectedTokenIn.Amount.String(), amountIn.String())
-	s.Require().Equal(test.expectedTick, poolUpdates.NewCurrentTick)
+	s.Require().Equal(test.ExpectedSqrtPrice, poolUpdates.NewSqrtPrice, "resultant sqrt price not equal to expected sqrt price")
+	s.Require().Equal(test.ExpectedTokenOut.Amount.String(), amountOut.String())
+	s.Require().Equal(test.ExpectedTokenIn.Amount.String(), amountIn.String())
+	s.Require().Equal(test.ExpectedTick, poolUpdates.NewCurrentTick)
 
 	expectedLiquidity := s.getExpectedLiquidity(test, pool)
 	s.Require().Equal(expectedLiquidity.String(), poolUpdates.NewLiquidity.String())
@@ -2217,19 +2165,19 @@ func (s *KeeperTestSuite) TestComputeAndSwapInAmtGivenOut() {
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
-			pool := s.preparePoolWithCustSpread(test.spreadFactor)
+			s.SetupAndFundSwapTest()
+			pool := s.PreparePoolWithCustSpread(test.SpreadFactor)
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())
-			s.setupSecondPosition(test, pool)
+			s.SetupSecondPosition(test, pool)
 
 			// perform compute
 			cacheCtx, _ := s.Ctx.CacheContext()
 			swapResult, poolUpdates, err := s.App.ConcentratedLiquidityKeeper.ComputeInAmtGivenOut(
 				cacheCtx,
-				test.tokenOut, test.tokenInDenom,
-				test.spreadFactor, test.priceLimit, pool.GetId())
-			if test.expectErr {
+				test.TokenOut, test.TokenInDenom,
+				test.SpreadFactor, test.PriceLimit, pool.GetId())
+			if test.ExpectErr {
 				s.Require().Error(err)
 			} else {
 				s.testSwapResult(test, pool, swapResult.AmountIn, swapResult.AmountOut, poolUpdates, err)
@@ -2241,9 +2189,9 @@ func (s *KeeperTestSuite) TestComputeAndSwapInAmtGivenOut() {
 			// perform swap
 			tokenIn, tokenOut, poolUpdates, err := s.App.ConcentratedLiquidityKeeper.SwapInAmtGivenOut(
 				s.Ctx, s.TestAccs[0], pool,
-				test.tokenOut, test.tokenInDenom,
-				test.spreadFactor, test.priceLimit)
-			if test.expectErr {
+				test.TokenOut, test.TokenInDenom,
+				test.SpreadFactor, test.PriceLimit)
+			if test.ExpectErr {
 				s.Require().Error(err)
 				return
 			}
@@ -2257,12 +2205,12 @@ func (s *KeeperTestSuite) TestComputeAndSwapInAmtGivenOut() {
 
 			// Check variables on pool were set correctly
 			// - ensure the pool's currentTick and currentSqrtPrice was updated due to calling a mutative method
-			s.Require().Equal(test.expectedTick, pool.GetCurrentTick())
+			s.Require().Equal(test.ExpectedTick, pool.GetCurrentTick())
 			// check that liquidity is what we expected
 			expectedLiquidity := s.getExpectedLiquidity(test, pool)
 			s.Require().Equal(expectedLiquidity.String(), pool.GetLiquidity().String())
 
-			if test.spreadFactor.IsZero() {
+			if test.SpreadFactor.IsZero() {
 				s.assertZeroSpreadRewards(pool.GetId())
 				return
 			}
@@ -2275,7 +2223,7 @@ func (s *KeeperTestSuite) TestSwapInAmtGivenOut_TickUpdates() {
 	tests := makeTests(swapInGivenOutTestCases)
 	for name, test := range tests {
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 
 			// Create default CL pool
 			pool := s.PrepareConcentratedPool()
@@ -2287,7 +2235,7 @@ func (s *KeeperTestSuite) TestSwapInAmtGivenOut_TickUpdates() {
 
 			// add default position
 			s.SetupDefaultPosition(pool.GetId())
-			s.setupSecondPosition(test, pool)
+			s.SetupSecondPosition(test, pool)
 
 			// add 2*DefaultSpreadRewardAccumCoins to spread factor accumulator, now spread factor accumulator has 3*DefaultSpreadRewardAccumCoins as its value
 			spreadFactorAccum, err = s.App.ConcentratedLiquidityKeeper.GetSpreadRewardAccumulator(s.Ctx, 1)
@@ -2297,31 +2245,31 @@ func (s *KeeperTestSuite) TestSwapInAmtGivenOut_TickUpdates() {
 			// perform swap
 			_, _, _, err = s.App.ConcentratedLiquidityKeeper.SwapInAmtGivenOut(
 				s.Ctx, s.TestAccs[0], pool,
-				test.tokenOut, test.tokenInDenom,
-				test.spreadFactor, test.priceLimit)
+				test.TokenOut, test.TokenInDenom,
+				test.SpreadFactor, test.PriceLimit)
 			s.Require().NoError(err)
 
 			// check lower tick and upper tick spread reward growth
 			lowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), DefaultLowerTick)
 			s.Require().NoError(err)
-			s.Require().Equal(test.expectedLowerTickSpreadRewardGrowth, lowerTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
+			s.Require().Equal(test.ExpectedLowerTickSpreadRewardGrowth, lowerTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
 
 			upperTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), DefaultLowerTick)
 			s.Require().NoError(err)
-			s.Require().Equal(test.expectedUpperTickSpreadRewardGrowth, upperTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
+			s.Require().Equal(test.ExpectedUpperTickSpreadRewardGrowth, upperTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
 
-			if test.expectedSecondLowerTickSpreadRewardGrowth.expectedSpreadRewardGrowth != nil {
-				newTickIndex := test.expectedSecondLowerTickSpreadRewardGrowth.tickIndex
-				expectedSpreadRewardGrowth := test.expectedSecondLowerTickSpreadRewardGrowth.expectedSpreadRewardGrowth
+			if test.ExpectedSecondLowerTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth != nil {
+				newTickIndex := test.ExpectedSecondLowerTickSpreadRewardGrowth.TickIndex
+				expectedSpreadRewardGrowth := test.ExpectedSecondLowerTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth
 
 				newLowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), newTickIndex)
 				s.Require().NoError(err)
 				s.Require().Equal(expectedSpreadRewardGrowth, newLowerTickInfo.SpreadRewardGrowthOppositeDirectionOfLastTraversal)
 			}
 
-			if test.expectedSecondUpperTickSpreadRewardGrowth.expectedSpreadRewardGrowth != nil {
-				newTickIndex := test.expectedSecondUpperTickSpreadRewardGrowth.tickIndex
-				expectedSpreadRewardGrowth := test.expectedSecondUpperTickSpreadRewardGrowth.expectedSpreadRewardGrowth
+			if test.ExpectedSecondUpperTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth != nil {
+				newTickIndex := test.ExpectedSecondUpperTickSpreadRewardGrowth.TickIndex
+				expectedSpreadRewardGrowth := test.ExpectedSecondUpperTickSpreadRewardGrowth.ExpectedSpreadRewardGrowth
 
 				newLowerTickInfo, err := s.App.ConcentratedLiquidityKeeper.GetTickInfo(s.Ctx, pool.GetId(), newTickIndex)
 				s.Require().NoError(err)
@@ -2711,7 +2659,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountOut() {
 // We expect to only change spread factor accum state, since pool state change is not handled by ComputeOutAmtGivenIn.
 func (s *KeeperTestSuite) TestComputeOutAmtGivenIn() {
 	// we only use spread factor cases here since write Ctx only takes effect in the spread factor accumulator
-	tests := make(map[string]SwapTest, len(swapOutGivenInSpreadRewardCases))
+	tests := make(map[string]apptesting.ConcentratedSwapTest, len(swapOutGivenInSpreadRewardCases))
 
 	for name, test := range swapOutGivenInSpreadRewardCases {
 		tests[name] = test
@@ -2720,15 +2668,15 @@ func (s *KeeperTestSuite) TestComputeOutAmtGivenIn() {
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 			poolBeforeCalc := s.preparePoolAndDefaultPositions(test)
 
 			// perform calc
 			_, _, err := s.App.ConcentratedLiquidityKeeper.ComputeOutAmtGivenIn(
 				s.Ctx,
 				poolBeforeCalc.GetId(),
-				test.tokenIn, test.tokenOutDenom,
-				test.spreadFactor, test.priceLimit)
+				test.TokenIn, test.TokenOutDenom,
+				test.SpreadFactor, test.PriceLimit)
 			s.Require().NoError(err)
 
 			// check that the pool has not been modified after performing calc
@@ -2745,15 +2693,15 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn_NonMutative() {
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 			poolBeforeCalc := s.preparePoolAndDefaultPositions(test)
 
 			// perform calc
 			_, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(
 				s.Ctx,
 				poolBeforeCalc,
-				test.tokenIn, test.tokenOutDenom,
-				test.spreadFactor)
+				test.TokenIn, test.TokenOutDenom,
+				test.SpreadFactor)
 			s.Require().NoError(err)
 
 			// check that the pool has not been modified after performing calc
@@ -2763,9 +2711,9 @@ func (s *KeeperTestSuite) TestCalcOutAmtGivenIn_NonMutative() {
 	}
 }
 
-func (s *KeeperTestSuite) setupSecondPosition(test SwapTest, pool types.ConcentratedPoolExtension) {
-	if !test.secondPositionLowerPrice.IsNil() {
-		newLowerTick, newUpperTick := s.lowerUpperPricesToTick(test.secondPositionLowerPrice, test.secondPositionUpperPrice, pool.GetTickSpacing())
+func (s *KeeperTestSuite) SetupSecondPosition(test apptesting.ConcentratedSwapTest, pool types.ConcentratedPoolExtension) {
+	if !test.SecondPositionLowerPrice.IsNil() {
+		newLowerTick, newUpperTick := s.LowerUpperPricesToTick(test.SecondPositionLowerPrice, test.SecondPositionUpperPrice, pool.GetTickSpacing())
 
 		_, err := s.App.ConcentratedLiquidityKeeper.CreatePosition(s.Ctx, pool.GetId(), s.TestAccs[1], DefaultCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), newLowerTick, newUpperTick)
 		s.Require().NoError(err)
@@ -2780,15 +2728,15 @@ func (s *KeeperTestSuite) TestCalcInAmtGivenOut_NonMutative() {
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 			poolBeforeCalc := s.preparePoolAndDefaultPositions(test)
 
 			// perform calc
 			_, err := s.App.ConcentratedLiquidityKeeper.CalcOutAmtGivenIn(
 				s.Ctx,
 				poolBeforeCalc,
-				test.tokenIn, test.tokenOutDenom,
-				test.spreadFactor)
+				test.TokenIn, test.TokenOutDenom,
+				test.SpreadFactor)
 			s.Require().NoError(err)
 
 			// check that the pool has not been modified after performing calc
@@ -2806,14 +2754,14 @@ func (s *KeeperTestSuite) TestComputeInAmtGivenOut() {
 	for name, test := range tests {
 		test := test
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 			poolBeforeCalc := s.preparePoolAndDefaultPositions(test)
 
 			// perform calc
 			_, _, err := s.App.ConcentratedLiquidityKeeper.ComputeInAmtGivenOut(
 				s.Ctx,
-				test.tokenOut, test.tokenInDenom,
-				test.spreadFactor, test.priceLimit, poolBeforeCalc.GetId())
+				test.TokenOut, test.TokenInDenom,
+				test.SpreadFactor, test.PriceLimit, poolBeforeCalc.GetId())
 			s.Require().NoError(err)
 
 			// check that the pool has not been modified after performing calc
@@ -2828,7 +2776,7 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapOutAmtGivenIn() {
 
 	for name, test := range tests {
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 			poolBefore := s.preparePoolAndDefaultPositions(test)
 			userBalanceBeforeSwap := s.App.BankKeeper.GetAllBalances(s.Ctx, s.TestAccs[0])
 			poolBalanceBeforeSwap := s.App.BankKeeper.GetAllBalances(s.Ctx, poolBefore.GetAddress())
@@ -2836,8 +2784,8 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapOutAmtGivenIn() {
 			// system under test
 			firstTokenIn, firstTokenOut, _, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
 				s.Ctx, s.TestAccs[0], poolBefore,
-				test.tokenIn, test.tokenOutDenom,
-				DefaultZeroSpreadFactor, test.priceLimit)
+				test.TokenIn, test.TokenOutDenom,
+				DefaultZeroSpreadFactor, test.PriceLimit)
 			s.Require().NoError(err)
 
 			secondTokenIn, secondTokenOut, _, err := s.App.ConcentratedLiquidityKeeper.SwapOutAmtGivenIn(
@@ -2905,7 +2853,7 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapInAmtGivenOut() {
 
 	for name, test := range tests {
 		s.Run(name, func() {
-			s.setupAndFundSwapTest()
+			s.SetupAndFundSwapTest()
 			poolBefore := s.preparePoolAndDefaultPositions(test)
 			userBalanceBeforeSwap := s.App.BankKeeper.GetAllBalances(s.Ctx, s.TestAccs[0])
 			poolBalanceBeforeSwap := s.App.BankKeeper.GetAllBalances(s.Ctx, poolBefore.GetAddress())
@@ -2913,8 +2861,8 @@ func (s *KeeperTestSuite) TestInverseRelationshipSwapInAmtGivenOut() {
 			// system under test
 			firstTokenIn, firstTokenOut, _, err := s.App.ConcentratedLiquidityKeeper.SwapInAmtGivenOut(
 				s.Ctx, s.TestAccs[0], poolBefore,
-				test.tokenOut, test.tokenInDenom,
-				DefaultZeroSpreadFactor, test.priceLimit)
+				test.TokenOut, test.TokenInDenom,
+				DefaultZeroSpreadFactor, test.PriceLimit)
 			s.Require().NoError(err)
 
 			secondTokenIn, secondTokenOut, _, err := s.App.ConcentratedLiquidityKeeper.SwapInAmtGivenOut(
@@ -2996,7 +2944,7 @@ func (s *KeeperTestSuite) TestUpdatePoolForSwap() {
 		tc := tc
 		s.Run(name, func() {
 			s.SetupTest()
-			pool := s.preparePoolWithCustSpread(tc.spreadFactor)
+			pool := s.PreparePoolWithCustSpread(tc.spreadFactor)
 
 			s.FundAcc(pool.GetAddress(), tc.poolInitialBalance)
 			// Create account with empty balance and fund with initial balance
@@ -3008,7 +2956,7 @@ func (s *KeeperTestSuite) TestUpdatePoolForSwap() {
 			s.Require().NoError(err)
 
 			// Write default pool to state.
-			err = s.clk.SetPool(s.Ctx, pool)
+			err = s.Clk.SetPool(s.Ctx, pool)
 			s.Require().NoError(err)
 
 			// Set mock listener to make sure that is is called when desired.
@@ -3018,10 +2966,10 @@ func (s *KeeperTestSuite) TestUpdatePoolForSwap() {
 			expectedSpreadFactorsCoins := sdk.NewCoins(sdk.NewCoin(tc.tokenIn.Denom, expectedSpreadFactors.TruncateInt()))
 			swapDetails := cl.SwapDetails{sender, tc.tokenIn, tc.tokenOut}
 			poolUpdates := cl.PoolUpdates{tc.newCurrentTick, tc.newLiquidity, tc.newSqrtPrice}
-			err = s.clk.UpdatePoolForSwap(s.Ctx, pool, swapDetails, poolUpdates, expectedSpreadFactors)
+			err = s.Clk.UpdatePoolForSwap(s.Ctx, pool, swapDetails, poolUpdates, expectedSpreadFactors)
 
 			// Test that pool is updated
-			poolAfterUpdate, err2 := s.clk.GetPoolById(s.Ctx, pool.GetId())
+			poolAfterUpdate, err2 := s.Clk.GetPoolById(s.Ctx, pool.GetId())
 			s.Require().NoError(err2)
 
 			if tc.expectError != nil {
@@ -3404,7 +3352,7 @@ func (s *KeeperTestSuite) TestInfiniteSwapLoop_OutGivenIn() {
 
 	// Create position near min tick
 	s.FundAcc(positionOwner, DefaultRangeTestParams.baseAssets.Add(DefaultRangeTestParams.baseAssets...))
-	_, err := s.clk.CreatePosition(s.Ctx, pool.GetId(), positionOwner, DefaultRangeTestParams.baseAssets, osmomath.ZeroInt(), osmomath.ZeroInt(), -108000000, -107999900)
+	_, err := s.Clk.CreatePosition(s.Ctx, pool.GetId(), positionOwner, DefaultRangeTestParams.baseAssets, osmomath.ZeroInt(), osmomath.ZeroInt(), -108000000, -107999900)
 	s.Require().NoError(err)
 
 	// Swap small amount to get current tick to position above, triggering the problematic function/branch (CalcAmount0Delta)
@@ -3412,11 +3360,11 @@ func (s *KeeperTestSuite) TestInfiniteSwapLoop_OutGivenIn() {
 	swapEthFunded := sdk.NewCoin(ETH, osmomath.Int(osmomath.MustNewDecFromStr("10000000000000000000000000000000000000000")))
 	swapUSDCFunded := sdk.NewCoin(USDC, osmomath.Int(osmomath.MustNewDecFromStr("10000")))
 	s.FundAcc(swapAddress, sdk.NewCoins(swapEthFunded, swapUSDCFunded))
-	_, tokenOut, _, err := s.clk.SwapInAmtGivenOut(s.Ctx, swapAddress, pool, sdk.NewCoin(USDC, osmomath.NewInt(10000)), ETH, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
+	_, tokenOut, _, err := s.Clk.SwapInAmtGivenOut(s.Ctx, swapAddress, pool, sdk.NewCoin(USDC, osmomath.NewInt(10000)), ETH, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
 	s.Require().NoError(err)
 
 	// Swap back in the amount that was swapped out to test the inverse relationship
-	_, _, _, err = s.clk.SwapOutAmtGivenIn(s.Ctx, swapAddress, pool, tokenOut, ETH, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
+	_, _, _, err = s.Clk.SwapOutAmtGivenIn(s.Ctx, swapAddress, pool, tokenOut, ETH, pool.GetSpreadFactor(s.Ctx), osmomath.ZeroBigDec())
 	s.Require().NoError(err)
 }
 

--- a/x/concentrated-liquidity/tick_test.go
+++ b/x/concentrated-liquidity/tick_test.go
@@ -611,7 +611,7 @@ func (s *KeeperTestSuite) TestCrossTick() {
 
 			if test.poolToGet == validPoolId {
 				s.FundAcc(s.TestAccs[0], sdk.NewCoins(DefaultCoin0, DefaultCoin1))
-				_, err := s.clk.CreatePosition(s.Ctx, test.poolToGet, s.TestAccs[0], DefaultCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), DefaultLowerTick, DefaultUpperTick)
+				_, err := s.Clk.CreatePosition(s.Ctx, test.poolToGet, s.TestAccs[0], DefaultCoins, osmomath.ZeroInt(), osmomath.ZeroInt(), DefaultLowerTick, DefaultUpperTick)
 				s.Require().NoError(err)
 			}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR moves CL test helpers into the `apptesting` package so that these heleprs can be reused in SQS.

This is partial transfer of https://github.com/osmosis-labs/osmosis/pull/6785 where the CL apptesting suite is already in-use

