### PR TITLE
fix: concentrated pool should use types.ConcentratedGasFeeForSwap

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity/math"
 	"github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity/swapstrategy"
 	"github.com/osmosis-labs/osmosis/v20/x/concentrated-liquidity/types"
-	gammtypes "github.com/osmosis-labs/osmosis/v20/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v20/x/poolmanager/types"
 )
 
@@ -658,7 +657,7 @@ func (k Keeper) updatePoolForSwap(
 ) error {
 	// Fixed gas consumption per swap to prevent spam
 	poolId := pool.GetId()
-	ctx.GasMeter().ConsumeGas(gammtypes.BalancerGasFeeForSwap, "cl pool swap computation")
+	ctx.GasMeter().ConsumeGas(types.ConcentratedGasFeeForSwap, "cl pool swap computation")
 	pool, err := k.getPoolById(ctx, poolId)
 	if err != nil {
 		return err


### PR DESCRIPTION
concentrated pool should use `types.ConcentratedGasFeeForSwap` instead of `gammtypes.BalancerGasFeeForSwap`

## What is the purpose of the change

fix the wrong value used by concentrated pool module. Although the value of `gammtypes.BalancerGasFeeForSwap ` is equal to `types.ConcentratedGasFeeForSwap`. But this may lead to potential risk if the value of `gammtypes.BalancerGasFeeForSwap ` is different from `types.ConcentratedGasFeeForSwap` in the future.