### PR TITLE
Change mergify rules to 2 >= Approvals for Automerge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ defaults:
 queue_rules:
   - name: default
     conditions:
-      - "#approved-reviews-by>=2"
+      - "#approved-reviews-by>=1"
 
 pull_request_rules:
   - name: automerge to the base branch with label automerge and branch protection passing

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,12 +7,12 @@ defaults:
 queue_rules:
   - name: default
     conditions:
-      - "#approved-reviews-by>=1"
+      - "#approved-reviews-by>=2"
 
 pull_request_rules:
   - name: automerge to the base branch with label automerge and branch protection passing
     conditions:
-      - "#approved-reviews-by>=1"
+      - "#approved-reviews-by>=2"
       - base=main
       - label=A:automerge
     actions:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
Current automerge mergify rules have 1 >= approvals. 
Although there might be instances where we don't need 2 >= approval for merging depending on the PR, I think this should not be the case with auto merge


## Testing and Verifying
This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A