### PR TITLE
chore: check all authenticators for anyOf in ConfirmExecution

### DIFF
--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -122,12 +122,11 @@ func (aoa AnyOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, msg
 func (aoa AnyOfAuthenticator) ConfirmExecution(ctx sdk.Context, account sdk.AccAddress, msg sdk.Msg, authenticationData iface.AuthenticatorData) iface.ConfirmationResult {
 	for _, auth := range aoa.SubAuthenticators {
 		result := auth.ConfirmExecution(ctx, account, msg, authenticationData)
-		if result.IsConfirm() {
-			return iface.Confirm()
+		if result.IsBlock() {
+			return result
 		}
 	}
-
-	return iface.Block(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "No sub authenticators can confirm the transaction"))
+	return iface.Confirm()
 }
 
 func (aoa AnyOfAuthenticator) OnAuthenticatorAdded(ctx sdk.Context, account sdk.AccAddress, data []byte) error {

--- a/x/authenticator/authenticator/composition_test.go
+++ b/x/authenticator/authenticator/composition_test.go
@@ -86,7 +86,7 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 			name:             "alwaysApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove},
 			expectSuccessful: true,
-			expectConfirm:    true,
+			expectConfirm:    false,
 		},
 		{
 			name:             "neverApprove + neverApprove",
@@ -104,7 +104,7 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 			name:             "neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
-			expectConfirm:    true,
+			expectConfirm:    false,
 		},
 		{
 			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
@@ -116,19 +116,19 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 			name:             "alwaysApprove + alwaysApprove + neverApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
 			expectSuccessful: true,
-			expectConfirm:    true,
+			expectConfirm:    false,
 		},
 		{
 			name:             "alwaysApprove + neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
-			expectConfirm:    true,
+			expectConfirm:    false,
 		},
 		{
 			name:             "neverApprove + neverApprove + alwaysApprove",
 			authenticators:   []iface.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
 			expectSuccessful: true,
-			expectConfirm:    true,
+			expectConfirm:    false,
 		},
 		{
 			name:             "neverApprove + neverApprove + neverApprove",
@@ -152,7 +152,7 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfAuthenticator() {
 			name:             "approveAndBlock + rejectAndConfirm",
 			authenticators:   []iface.Authenticator{s.approveAndBlock, s.rejectAndConfirm},
 			expectSuccessful: true,
-			expectConfirm:    true,
+			expectConfirm:    false,
 		},
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This change represent the final iteration in the `AnyOf` authenticator.

We check all authenticators in confirm execution, as we expect that any authenticator added to an `AnyOf` will either always return true, or have some rules that need to be checked in the ConfirmExecution.

### How to test

- `cd ./x/authenticators`
- `go test -cover ./... -v -test.run TestAggregatedAuthenticatorsTest/TestAnyOfAuthenticator`