### PR TITLE
Fix 1559 comments to align with new tuned params

### DIFF
--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -30,10 +30,10 @@ import (
    - DefaultBaseFee: Default base fee, initialized to 0.0025.
    - MinBaseFee: Minimum base fee, initialized to 0.0025.
    - MaxBaseFee: Maximum base fee, initialized to 10.
-   - MaxBlockChangeRate: The maximum block change rate, initialized to 1/16.
+   - MaxBlockChangeRate: The maximum block change rate, initialized to 1/10.
 
    Global constants:
-   - TargetGas: Gas wanted per block, initialized to 60,000,000.
+   - TargetGas: Gas wanted per block, initialized to 70,000,000.
    - ResetInterval: The interval at which eipState is reset, initialized to 1000 blocks.
    - BackupFile: File for backup, set to "eip1559state.json".
    - RecheckFeeConstant: A constant value for rechecking fees, initialized to 4.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fixes 1559 comments to align with changes in #6844

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.