### PR TITLE
fix: fixes eip1559state.json reading/writing

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -213,6 +213,7 @@ func NewOsmosisApp(
 	}
 
 	app.homePath = homePath
+	dataDir := filepath.Join(homePath, "data")
 	wasmDir := filepath.Join(homePath, "wasm")
 	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
 	// Uncomment this for debugging contracts. In the future this could be made into a param passed by the tests
@@ -234,6 +235,7 @@ func NewOsmosisApp(
 		appCodec,
 		bApp,
 		maccPerms,
+		dataDir,
 		wasmDir,
 		wasmConfig,
 		wasmEnabledProposals,

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -170,6 +170,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	appCodec codec.Codec,
 	bApp *baseapp.BaseApp,
 	maccPerms map[string][]string,
+	dataDir string,
 	wasmDir string,
 	wasmConfig wasm.Config,
 	wasmEnabledProposals []wasm.ProposalType,
@@ -381,6 +382,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.GAMMKeeper,
 		appKeepers.ProtoRevKeeper,
 		appKeepers.DistrKeeper,
+		dataDir,
 	)
 	appKeepers.TxFeesKeeper = &txFeesKeeper
 

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"path/filepath"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -27,6 +28,10 @@ type MempoolFeeDecorator struct {
 }
 
 func NewMempoolFeeDecorator(txFeesKeeper Keeper, opts types.MempoolFeeOptions) MempoolFeeDecorator {
+	if opts.Mempool1559Enabled {
+		mempool1559.CurEipState.BackupFilePath = filepath.Join(txFeesKeeper.dataDir, mempool1559.BackupFilename)
+	}
+
 	return MempoolFeeDecorator{
 		TxFeesKeeper: txFeesKeeper,
 		Opts:         opts,

--- a/x/txfees/keeper/keeper.go
+++ b/x/txfees/keeper/keeper.go
@@ -20,6 +20,7 @@ type Keeper struct {
 	spotPriceCalculator types.SpotPriceCalculator
 	protorevKeeper      types.ProtorevKeeper
 	distributionKeeper  types.DistributionKeeper
+	dataDir             string
 }
 
 var _ types.TxFeesKeeper = (*Keeper)(nil)
@@ -32,6 +33,7 @@ func NewKeeper(
 	spotPriceCalculator types.SpotPriceCalculator,
 	protorevKeeper types.ProtorevKeeper,
 	distributionKeeper types.DistributionKeeper,
+	dataDir string,
 ) Keeper {
 	return Keeper{
 		accountKeeper:       accountKeeper,
@@ -41,6 +43,7 @@ func NewKeeper(
 		spotPriceCalculator: spotPriceCalculator,
 		protorevKeeper:      protorevKeeper,
 		distributionKeeper:  distributionKeeper,
+		dataDir:             dataDir,
 	}
 }
 

--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -55,7 +55,7 @@ var (
 )
 
 const (
-	BackupFile = "eip1559state.json"
+	BackupFilename = "eip1559state.json"
 )
 
 // EipState tracks the current base fee and totalGasWantedThisBlock
@@ -63,8 +63,8 @@ const (
 type EipState struct {
 	lastBlockHeight         int64
 	totalGasWantedThisBlock int64
-
-	CurBaseFee osmomath.Dec `json:"cur_base_fee"`
+	BackupFilePath          string
+	CurBaseFee              osmomath.Dec `json:"cur_base_fee"`
 }
 
 // CurEipState is a global variable used in the BeginBlock, EndBlock and
@@ -73,6 +73,7 @@ type EipState struct {
 var CurEipState = EipState{
 	lastBlockHeight:         0,
 	totalGasWantedThisBlock: 0,
+	BackupFilePath:          "",
 	CurBaseFee:              sdk.NewDec(0),
 }
 
@@ -156,7 +157,7 @@ func (e *EipState) tryPersist() {
 		return
 	}
 
-	err = os.WriteFile(BackupFile, bz, 0644)
+	err = os.WriteFile(e.BackupFilePath, bz, 0644)
 	if err != nil {
 		fmt.Println("Error writing eip1559 state", err)
 		return
@@ -166,7 +167,7 @@ func (e *EipState) tryPersist() {
 // tryLoad reads eip1559 state from disk and initializes the CurEipState to
 // the previous state when a node is restarted
 func (e *EipState) tryLoad() osmomath.Dec {
-	bz, err := os.ReadFile(BackupFile)
+	bz, err := os.ReadFile(e.BackupFilePath)
 	if err != nil {
 		fmt.Println("Error reading eip1559 state", err)
 		fmt.Println("Setting eip1559 state to default value", MinBaseFee)


### PR DESCRIPTION
Plumbs the data directory path based on the homedir through the txfees Keeper to be joined with the Backup filename in the EipState

```
$ ls ~/.osmosisd/data/
application.db  blockstore.db  cs.wal  eip1559state.json  evidence.db  priv_validator_state.json  snapshots  state.db  upgrade-info.json
```

Fixes #6856 