### PR TITLE
feat: protorev no taker fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#6788](https://github.com/osmosis-labs/osmosis/pull/6788) Improve error message when CL LP fails due to slippage bound hit.
 * [#6858](https://github.com/osmosis-labs/osmosis/pull/6858) Merge mempool improvements from v20
+* [#6861](https://github.com/osmosis-labs/osmosis/pull/6861) Protorev address added to reduced taker fee whitelist
 
 ### API Breaks
 

--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -167,6 +167,12 @@ func CreateUpgradeHandler(
 		// Set CL param:
 		keepers.ConcentratedLiquidityKeeper.SetParam(ctx, concentratedliquiditytypes.KeyHookGasLimit, concentratedliquiditytypes.DefaultContractHookGasLimit)
 
+		// Add protorev to the taker fee exclusion list:
+		protorevModuleAccount := keepers.AccountKeeper.GetModuleAccount(ctx, protorevtypes.ModuleName)
+		poolManagerParams := keepers.PoolManagerKeeper.GetParams(ctx)
+		poolManagerParams.TakerFeeParams.ReducedFeeWhitelist = append(poolManagerParams.TakerFeeParams.ReducedFeeWhitelist, protorevModuleAccount.GetAddress().String())
+		keepers.PoolManagerKeeper.SetParams(ctx, poolManagerParams)
+
 		// Since we are now tracking all protocol rev, we set the accounting height to the current block height for each module
 		// that generates protocol rev.
 		keepers.PoolManagerKeeper.SetTakerFeeTrackerStartHeight(ctx, ctx.BlockHeight())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Right now, protrorev pays a taker fee on it's backruns. There is no need for this as this profit goes back to the protocol anyway.