### PR TITLE
fix failing CI for go mod update instructions

### DIFF
--- a/.github/workflows/e2e-initialization-instructions.yaml
+++ b/.github/workflows/e2e-initialization-instructions.yaml
@@ -26,6 +26,8 @@ permissions:
 
 jobs:
   comment:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Recently I've seen several instances where go mod update instruction CI would be failing:
https://github.com/osmosis-labs/osmosis/actions/runs/6846633458/job/18613544135?pr=6867

This PR grants writing permission for the PR to fix the current error occuring. 

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A