### PR TITLE
refactor: improve ListPoolsByDenom filter logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6788](https://github.com/osmosis-labs/osmosis/pull/6788) Improve error message when CL LP fails due to slippage bound hit.
 * [#6858](https://github.com/osmosis-labs/osmosis/pull/6858) Merge mempool improvements from v20
 * [#6861](https://github.com/osmosis-labs/osmosis/pull/6861) Protorev address added to reduced taker fee whitelist
+* [#6884](https://github.com/osmosis-labs/osmosis/pull/6884) Improve ListPoolsByDenom function filter denom logic
 
 ### API Breaks
 

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -21,7 +21,8 @@ import (
 
 var (
 	// 1 << 256 - 1 where 256 is the max bit length defined for osmomath.Int
-	intMaxValue   = osmomath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+	intMaxValue = osmomath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+	// lessPoolIFunc is used for sorting pools by poolID
 	lessPoolIFunc = func(i, j types.PoolI) bool {
 		return i.GetId() < j.GetId()
 	}

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -18,8 +19,13 @@ import (
 	"github.com/osmosis-labs/osmosis/v20/x/poolmanager/types"
 )
 
-// 1 << 256 - 1 where 256 is the max bit length defined for osmomath.Int
-var intMaxValue = osmomath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+var (
+	// 1 << 256 - 1 where 256 is the max bit length defined for osmomath.Int
+	intMaxValue   = osmomath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+	lessPoolIFunc = func(i, j types.PoolI) bool {
+		return i.GetId() < j.GetId()
+	}
+)
 
 // RouteExactAmountIn processes a swap along the given route using the swap function
 // corresponding to poolID's pool type. It takes in the input denom and amount for
@@ -526,10 +532,6 @@ func (k Keeper) GetPool(
 func (k Keeper) AllPools(
 	ctx sdk.Context,
 ) ([]types.PoolI, error) {
-	less := func(i, j types.PoolI) bool {
-		return i.GetId() < j.GetId()
-	}
-
 	//	Allocate the slice with the exact capacity to avoid reallocations.
 	poolCount := k.GetNextPoolId(ctx)
 	sortedPools := make([]types.PoolI, 0, poolCount)
@@ -539,7 +541,7 @@ func (k Keeper) AllPools(
 			return nil, err
 		}
 
-		sortedPools = osmoutils.MergeSlices(sortedPools, currentModulePools, less)
+		sortedPools = osmoutils.MergeSlices(sortedPools, currentModulePools, lessPoolIFunc)
 	}
 
 	return sortedPools, nil
@@ -552,9 +554,6 @@ func (k Keeper) ListPoolsByDenom(
 	ctx sdk.Context,
 	denom string,
 ) ([]types.PoolI, error) {
-	less := func(i, j types.PoolI) bool {
-		return i.GetId() < j.GetId()
-	}
 	var sortedPools []types.PoolI
 	for _, poolModule := range k.poolModules {
 		currentModulePools, err := poolModule.GetPools(ctx)
@@ -564,15 +563,15 @@ func (k Keeper) ListPoolsByDenom(
 
 		var poolsByDenom []types.PoolI
 		for _, pool := range currentModulePools {
-			coins, err := k.GetTotalPoolLiquidity(ctx, pool.GetId())
+			poolDenoms, err := poolModule.GetPoolDenoms(ctx, pool.GetId())
 			if err != nil {
 				return nil, err
 			}
-			if coins.AmountOf(denom).GT(osmomath.ZeroInt()) {
+			if slices.Contains(poolDenoms, denom) {
 				poolsByDenom = append(poolsByDenom, pool)
 			}
 		}
-		sortedPools = osmoutils.MergeSlices(sortedPools, poolsByDenom, less)
+		sortedPools = osmoutils.MergeSlices(sortedPools, poolsByDenom, lessPoolIFunc)
 	}
 	return sortedPools, nil
 }

--- a/x/poolmanager/router.go
+++ b/x/poolmanager/router.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"slices"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -568,7 +567,7 @@ func (k Keeper) ListPoolsByDenom(
 			if err != nil {
 				return nil, err
 			}
-			if slices.Contains(poolDenoms, denom) {
+			if osmoutils.Contains(poolDenoms, denom) {
 				poolsByDenom = append(poolsByDenom, pool)
 			}
 		}


### PR DESCRIPTION
Refer to [PR #6766](https://github.com/osmosis-labs/osmosis/pull/6766), get pool denoms info by `k.GetTotalPoolLiquidity` will lead to:
1. fetching pool module once again(one more io op) which already known as `k.poolModules` range iterator
2. filtering denom by `coins.AmountOf(denom).GT(osmomath.ZeroInt())` is odd, although there is no pool with zero amount token

## Testing and Verifying
This change is already covered by existing tests, such as *TestListPoolsByDenom*.