### PR TITLE
Update the eip1559 constants

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1458,8 +1458,6 @@ github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:Ylmch
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.7-0.20231108202153-af031b1367bb h1:d4JXafqN5tqmM5gQ56nMGsOccLI9M+zp3KgI3vFU8vk=
 github.com/osmosis-labs/osmosis/osmomath v0.0.7-0.20231108202153-af031b1367bb/go.mod h1:I8CSvdOyPJREATq1Kb4mFPiDVrl2jxCRd4W3NVQFom8=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.7-0.20231110043608-da030c5b18ac h1:60A8/hLeNPpEJ4QPoJbpN0BgJEjMzcAy+0lByxGIlaE=
-github.com/osmosis-labs/osmosis/osmoutils v0.0.7-0.20231110043608-da030c5b18ac/go.mod h1:5vLzE4XFr/qa5bXq6zSFncM3jUwTMOW9hMjVRSlTQAc=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.7-0.20231113053702-9d3cce854a9d h1:HU/Ti1vae94c2u+AGqCKnVM2YOboewjTfxbMhu1T2rY=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.7-0.20231113053702-9d3cce854a9d/go.mod h1:5vLzE4XFr/qa5bXq6zSFncM3jUwTMOW9hMjVRSlTQAc=
 github.com/osmosis-labs/osmosis/x/epochs v0.0.3-0.20231108202153-af031b1367bb h1:Gz4FoT0QgrqbYUt+fj+pl7kpcmv/Jd4VAKWOq3Bjpow=

--- a/proto/osmosis/poolmanager/v1beta1/query.yml
+++ b/proto/osmosis/poolmanager/v1beta1/query.yml
@@ -88,3 +88,8 @@ queries:
       query_func: "k.GetTradingPairTakerFee"
     cli:
       cmd: "TradingPairTakerFee"
+  ListPoolsByDenom:
+    proto_wrapper:
+      query_func: "k.ListPoolsByDenom"
+    cli:
+      cmd: "ListPoolsByDenom"

--- a/x/poolmanager/client/grpc/grpc_query.go
+++ b/x/poolmanager/client/grpc/grpc_query.go
@@ -71,6 +71,16 @@ func (q Querier) SpotPrice(grpcCtx context.Context,
 	return q.Q.SpotPrice(ctx, *req)
 }
 
+func (q Querier) ListPoolsByDenom(grpcCtx context.Context,
+	req *queryproto.ListPoolsByDenomRequest,
+) (*queryproto.ListPoolsByDenomResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+	ctx := sdk.UnwrapSDKContext(grpcCtx)
+	return q.Q.ListPoolsByDenom(ctx, *req)
+}
+
 func (q Querier) Pool(grpcCtx context.Context,
 	req *queryproto.PoolRequest,
 ) (*queryproto.PoolResponse, error) {

--- a/x/poolmanager/client/grpc/grpc_query.go
+++ b/x/poolmanager/client/grpc/grpc_query.go
@@ -71,16 +71,6 @@ func (q Querier) SpotPrice(grpcCtx context.Context,
 	return q.Q.SpotPrice(ctx, *req)
 }
 
-func (q Querier) ListPoolsByDenom(grpcCtx context.Context,
-	req *queryproto.ListPoolsByDenomRequest,
-) (*queryproto.ListPoolsByDenomResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
-	}
-	ctx := sdk.UnwrapSDKContext(grpcCtx)
-	return q.Q.ListPoolsByDenom(ctx, *req)
-}
-
 func (q Querier) Pool(grpcCtx context.Context,
 	req *queryproto.PoolRequest,
 ) (*queryproto.PoolResponse, error) {
@@ -109,6 +99,16 @@ func (q Querier) NumPools(grpcCtx context.Context,
 	}
 	ctx := sdk.UnwrapSDKContext(grpcCtx)
 	return q.Q.NumPools(ctx, *req)
+}
+
+func (q Querier) ListPoolsByDenom(grpcCtx context.Context,
+	req *queryproto.ListPoolsByDenomRequest,
+) (*queryproto.ListPoolsByDenomResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+	ctx := sdk.UnwrapSDKContext(grpcCtx)
+	return q.Q.ListPoolsByDenom(ctx, *req)
 }
 
 func (q Querier) EstimateTradeBasedOnPriceImpact(grpcCtx context.Context,

--- a/x/poolmanager/client/grpc/grpc_query.go
+++ b/x/poolmanager/client/grpc/grpc_query.go
@@ -71,16 +71,6 @@ func (q Querier) SpotPrice(grpcCtx context.Context,
 	return q.Q.SpotPrice(ctx, *req)
 }
 
-func (q Querier) ListPoolsByDenom(grpcCtx context.Context,
-	req *queryproto.ListPoolsByDenomRequest,
-) (*queryproto.ListPoolsByDenomResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
-	}
-	ctx := sdk.UnwrapSDKContext(grpcCtx)
-	return q.Q.ListPoolsByDenom(ctx, *req)
-}
-
 func (q Querier) Pool(grpcCtx context.Context,
 	req *queryproto.PoolRequest,
 ) (*queryproto.PoolResponse, error) {

--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -22,13 +22,13 @@ import (
    Additionally:
    - Periodically evaluating CheckTx and RecheckTx for compliance with these parameters.
 
-   Note: The reset interval is set to 1000 blocks, which is approximately 2 hours. Consider adjusting for a smaller time interval (e.g., 500 blocks = 1 hour) if necessary.
+   Note: The reset interval is set to 2000 blocks, which is approximately 4 hours. Consider adjusting for a smaller time interval (e.g., 500 blocks = 1 hour) if necessary.
 
    Challenges:
    - Transactions falling under their gas bounds are currently discarded by nodes. This behavior can be modified for CheckTx, rather than RecheckTx.
 
    Global variables stored in memory:
-   - DefaultBaseFee: Default base fee, initialized to 0.0025.
+   - DefaultBaseFee: Default base fee, initialized to 0.01.
    - MinBaseFee: Minimum base fee, initialized to 0.0025.
    - MaxBaseFee: Maximum base fee, initialized to 10.
    - MaxBlockChangeRate: The maximum block change rate, initialized to 1/10.
@@ -49,7 +49,7 @@ var (
 	MaxBlockChangeRate = sdk.NewDec(1).Quo(sdk.NewDec(10))
 	TargetGas          = int64(70_000_000)
 	// In face of continuous spam, will take ~21 blocks from base fee > spam cost, to mempool eviction
-	// ceil(log_{15/14}(RecheckFeeConstant))
+	// ceil(log_{15/14}(RecheckFee mnConstant))
 	// So potentially 2 minutes of impaired UX from 1559 nodes on top of time to get to base fee > spam.
 	RecheckFeeConstant = int64(4)
 	ResetInterval      = int64(2000)

--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -41,7 +41,7 @@ import (
 */
 
 var (
-	DefaultBaseFee = sdk.MustNewDecFromStr("0.0025")
+	DefaultBaseFee = sdk.MustNewDecFromStr("0.01")
 	MinBaseFee     = sdk.MustNewDecFromStr("0.0025")
 	MaxBaseFee     = sdk.MustNewDecFromStr("10")
 
@@ -52,7 +52,7 @@ var (
 	// ceil(log_{15/14}(RecheckFeeConstant))
 	// So potentially 2 minutes of impaired UX from 1559 nodes on top of time to get to base fee > spam.
 	RecheckFeeConstant = int64(4)
-	ResetInterval      = int64(1000)
+	ResetInterval      = int64(2000)
 )
 
 const (


### PR DESCRIPTION
Update the EIP-1559 constants to ease resets.

The last spamming that affected users seems to me to have had 4 root causes of issue:
- The reset interval happened right after epoch, resulting in 7 extra minutes of pain. (Every 1000 blocks) Make this 50% less likely by making it every 2000 blocks
- The value reset to .0025, requiring 4 minutes to get back to old value
- Keplr fee settings were too low (other integrators were set. The keplr chain registry bot was not updated to latest integrator suggested numbers)
- Large time with only non-1559 validator proposals

So (3) should get independently fixed, which should've been the root cause of most user pain outside of (4).
(4) should be fixed by increasing number of 1559 nodes, and lowering block times.

This PR lowers the probability of resets, and makes resets cause 2 minutes fewer of damage.