### PR TITLE
[Bug Fix] Fix Arb Tx Filter Out Of Index Error On Non Affiliated Swap Msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6840](https://github.com/osmosis-labs/osmosis/pull/6840) fix: change TypeMsgUnbondConvertAndStake value to "unbond_convert_and_stake" and improve error message when epoch currentEpochStartHeight less than zero
 * [#6769](https://github.com/osmosis-labs/osmosis/pull/6769) fix: improve dust handling in EstimateTradeBasedOnPriceImpact
 * [#6841](https://github.com/osmosis-labs/osmosis/pull/6841) fix: fix receive_ack response field and imporove error message of InvalidCrosschainSwapsContract and NoDenomTrace
+* [#6903](https://github.com/osmosis-labs/osmosis/pull/6903) fix: fix mempool arb tx filter out of index error on non affiliated swap msgs
 
 ## v20.0.0
 

--- a/x/txfees/keeper/txfee_filters/arb_tx.go
+++ b/x/txfees/keeper/txfee_filters/arb_tx.go
@@ -108,6 +108,11 @@ func isArbTxLooseAuthz(msg sdk.Msg, swapInDenom string, lpTypesSeen map[gammtype
 			return swapInDenom, false
 		}
 
+		// If there are no routes, it's not an affiliate swap message
+		if len(affiliateSwapMsg.Routes) == 0 {
+			return swapInDenom, false
+		}
+
 		// Otherwise, we have an affiliate swap message, so we check if it's an arb
 		affiliateSwapMsg.TokenIn = tokenIn.Denom
 		swapInDenom, isArb := isArbTxLooseSwapMsg(affiliateSwapMsg, swapInDenom)

--- a/x/txfees/keeper/txfee_filters/arb_tx_test.go
+++ b/x/txfees/keeper/txfee_filters/arb_tx_test.go
@@ -64,3 +64,21 @@ func (suite *KeeperTestSuite) TestIsArbTxLooseAuthz_AffiliateSwapMsg() {
 	_, isArb := txfee_filters.IsArbTxLooseAuthz(executeMsg, executeMsg.Funds[0].Denom, map[types.LiquidityChangeType]bool{})
 	suite.Require().True(isArb)
 }
+
+// Tests that the arb filter is disabled on non affiliate swap msgs.
+func (suite *KeeperTestSuite) TestIsArbTxLooseAuthz_NonAffiliateSwapMsg() {
+	jsonData := `{
+		"arbitrary": {
+			"key": {}
+		}
+	}`
+	executeMsg := &wasmtypes.MsgExecuteContract{
+		Contract: "osmo1etpha3a65tds0hmn3wfjeag6wgxgrkuwg2zh94cf5hapz7mz04dq6c25s5",
+		Sender:   "osmo1dldrxz5p8uezxz3qstpv92de7wgfp7hvr72dcm",
+		Funds:    sdk.NewCoins(sdk.NewCoin("ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4", sdk.NewInt(217084399))),
+		Msg:      []byte(jsonData),
+	}
+
+	_, isArb := txfee_filters.IsArbTxLooseAuthz(executeMsg, executeMsg.Funds[0].Denom, map[types.LiquidityChangeType]bool{})
+	suite.Require().False(isArb)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6905

## What is the purpose of the change

- Fixes a bug that would panic in the arb filter on contract calls that were not affiliated swaps.

## Testing and Verifying

This change added tests and can be verified as follows:
- Added a test in the first commit of the PR that submits a non affiliated swap to isArbTxLooseAuthz which panics with the out of index error
- The second commit adds the check that the len is not 0 to continue, which passes the test

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A