### PR TITLE
fix: v21 upgrade min dep ratio set

### DIFF
--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -159,6 +159,7 @@ func CreateUpgradeHandler(
 		// Set expedited proposal param:
 		govParams := keepers.GovKeeper.GetParams(ctx)
 		govParams.ExpeditedMinDeposit = sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(5000000000)))
+		govParams.MinInitialDepositRatio = "0.250000000000000000"
 		err = keepers.GovKeeper.SetParams(ctx, govParams)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The min deposit ratio needs to be manually set in the upgrade handler. This was found in v0.47 unfork testing.