### PR TITLE
fix: set-output deprecated

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -31,9 +31,12 @@ jobs:
             .github/workflows/test.yml
       - name: Set output
         id: vars
-        run: echo "::set-output name=git_diff::$GIT_DIFF"
+        run: echo "$GIT_DIFF" > git_diff.txt
+      - name: Get output
+        id: get_output
+        run: echo "::set-output name=git_diff::$(cat git_diff.txt)"
     outputs:
-      git_diff: ${{ steps.vars.outputs.git_diff }}
+      git_diff: ${{ steps.get_output.outputs.git_diff }}
 
   e2e:
     needs: get_diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,12 @@ jobs:
             .github/workflows/test.yml
       - name: Set output
         id: vars
-        run: echo "::set-output name=git_diff::$GIT_DIFF"
+        run: echo "$GIT_DIFF" > git_diff.txt
+      - name: Get output
+        id: get_output
+        run: echo "::set-output name=git_diff::$(cat git_diff.txt)"
     outputs:
-      git_diff: ${{ steps.vars.outputs.git_diff }}
+      git_diff: ${{ steps.get_output.outputs.git_diff }}
 
   go-split-test-files:
     needs: get_diff


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

set-output is deprecated and will be disabled in the future.