### PR TITLE
fix(cwpool): add code id in query

### DIFF
--- a/x/cosmwasmpool/client/query_proto_wrap.go
+++ b/x/cosmwasmpool/client/query_proto_wrap.go
@@ -42,5 +42,5 @@ func (q Querier) ContractInfoByPoolId(ctx sdk.Context,
 		return nil, err
 	}
 
-	return &queryproto.ContractInfoByPoolIdResponse{ContractAddress: pool.GetContractAddress()}, nil
+	return &queryproto.ContractInfoByPoolIdResponse{ContractAddress: pool.GetContractAddress(), CodeId: pool.GetCodeId()}, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Noticed in unfork QA, we left out the codeID in the response of querying `ContractInfoByPoolId`
