### PR TITLE
fix(valset): withdraw rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6814](https://github.com/osmosis-labs/osmosis/pull/6814) Add EstimateTradeBasedOnPriceImpact to stargate whitelist
 * [#6859](https://github.com/osmosis-labs/osmosis/pull/6859) Add hooks to core CL operations (position creation/withdrawal and swaps)
 * [#6937](https://github.com/osmosis-labs/osmosis/pull/6937) Update wasmd to v0.45.0 and wasmvm to v1.5.0
+* [#6949](https://github.com/osmosis-labs/osmosis/pull/6949) Valset withdraw rewards now considers all validators user is delegated to instead of valset
 
 ### Misc Improvements
 

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -467,14 +467,14 @@ func (k Keeper) getValTargetAndSource(ctx sdk.Context, valSource, valTarget stri
 	return validatorSource, validatorTarget, nil
 }
 
-// WithdrawDelegationRewards withdraws all the delegation rewards from the validator in the val-set.
+// WithdrawDelegationRewards withdraws all the delegation rewards from all validators the user is delegated to, disregarding the val-set.
 // If the valset does not exist, it withdraws from existing staking position.
 // Delegation reward is collected by the validator and in doing so, they can charge commission to the delegators.
 // Rewards are calculated per period, and is updated each time validator delegation changes. For ex: when a delegator
 // receives new delgation the rewards can be calculated by taking (total rewards before new delegation - the total current rewards).
 func (k Keeper) WithdrawDelegationRewards(ctx sdk.Context, delegatorAddr string) error {
-	// get the existingValSet if it exists, if not check existingStakingPosition and return it
-	existingSet, err := k.GetDelegationPreferences(ctx, delegatorAddr)
+	// Get all validators the user is delegated to, and create a set from it.
+	existingSet, err := k.GetValSetPreferencesWithDelegations(ctx, delegatorAddr)
 	if err != nil {
 		return types.NoValidatorSetOrExistingDelegationsError{DelegatorAddr: delegatorAddr}
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Withdraw rewards in valset was utilizing the valset as the source of truth, while the UI displays all pending rewards. This changes the withdraw rewards method to consider all validators the user is delegated to, instead of strictly the validator set pref.