### PR TITLE
(SQS) Return 501 upon node not being synced

### DIFF
--- a/ingest/sqs/system/delivery/http/system_http_handler.go
+++ b/ingest/sqs/system/delivery/http/system_http_handler.go
@@ -86,12 +86,10 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 		}
 	}
 
-	// Compare latestHeight with latest_block_height from the status endpoint
-	nodeStatus := "synced"
-
 	// allow 10 blocks of difference before claiming node is not synced
+	// If the node is not synced, return HTTP 501
 	if fmt.Sprint(int64(latestHeight)+10) < statusResponse.Result.SyncInfo.LatestBlockHeight {
-		nodeStatus = "not_synced"
+		return echo.NewHTTPError(http.StatusNotImplemented, "Node is not synced")
 	}
 
 	// Check Redis status
@@ -109,6 +107,5 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{
 		"grpc_gateway_status": grpcStatus,
 		"redis_status":        redisStatus,
-		"node_status":         nodeStatus,
 	})
 }

--- a/ingest/sqs/system/delivery/http/system_http_handler.go
+++ b/ingest/sqs/system/delivery/http/system_http_handler.go
@@ -37,9 +37,6 @@ func NewSystemHandler(e *echo.Echo, redisAddress, grpcAddress string, logger log
 	e.GET("/debug/pprof/*", echo.WrapHandler(http.DefaultServeMux))
 	e.GET("/healthcheck", handler.GetHealthStatus)
 	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
-
-	// // Register pprof handlers on "/debug/pprof"
-	// e.GET("/debug/pprof/*", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
 }
 
 // GetHealthStatus handles health check requests for both GRPC gateway and Redis
@@ -47,12 +44,11 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	// Check GRPC Gateway status
-	grpcStatus := "running"
 	url := h.grpcAddress + "/status"
 	resp, err := http.Get(url)
-	if err != nil {
-		grpcStatus = "down"
+	if err != nil || resp == nil || resp.StatusCode != http.StatusOK {
 		h.logger.Error("Error checking GRPC gateway status", zap.Error(err))
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Error connecting to the Osmosis chain via GRPC gateway")
 	} else {
 		defer resp.Body.Close()
 	}
@@ -60,7 +56,7 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 	// Check the latest height from chain info use case
 	latestHeight, err := h.CIUsecase.GetLatestHeight(ctx)
 	if err != nil {
-		return err
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get latest height from Redis")
 	}
 
 	// Parse the response from the GRPC Gateway status endpoint
@@ -87,25 +83,25 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 	}
 
 	// allow 10 blocks of difference before claiming node is not synced
-	// If the node is not synced, return HTTP 501
+	// If the node is not synced, return HTTP 503
 	if fmt.Sprint(int64(latestHeight)+10) < statusResponse.Result.SyncInfo.LatestBlockHeight {
-		return echo.NewHTTPError(http.StatusNotImplemented, "Node is not synced")
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Node is not synced")
 	}
 
 	// Check Redis status
-	redisStatus := "running"
 	rdb := redis.NewClient(&redis.Options{
 		Addr: h.redisAddress,
 	})
 
 	if _, err := rdb.Ping().Result(); err != nil {
-		redisStatus = "down"
 		h.logger.Error("Error connecting to Redis", zap.Error(err))
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Error connecting to Redis", err)
 	}
 
 	// Return combined status
 	return c.JSON(http.StatusOK, map[string]string{
-		"grpc_gateway_status": grpcStatus,
-		"redis_status":        redisStatus,
+		"grpc_gateway_status": "running",
+		"redis_status":        "running",
+		"chain_latest_height": fmt.Sprint(latestHeight),
 	})
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Changes to return 501 upon node not being synced for `GetHealthStatus` Endpoint so that load balancers can properly remove unsynchronized nodes from rotation.

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.



## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A