### PR TITLE
feat(SQS): prometheus metrics for latency and rps

### DIFF
--- a/ingest/sqs/middleware/middleware.go
+++ b/ingest/sqs/middleware/middleware.go
@@ -1,6 +1,9 @@
 package middleware
 
 import (
+	"net/url"
+	"time"
+
 	"github.com/labstack/echo"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -11,17 +14,29 @@ type GoMiddleware struct {
 }
 
 var (
+	// total number of requests counter
 	requestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "sqs_requests_total",
 			Help: "Total number of requests.",
 		},
-		[]string{"method"},
+		[]string{"method", "endpoint"},
+	)
+
+	// request latency histogram
+	requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sqs_request_duration_seconds",
+			Help:    "Histogram of request latencies.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "endpoint"},
 	)
 )
 
 func init() {
 	prometheus.MustRegister(requestsTotal)
+	prometheus.MustRegister(requestLatency)
 }
 
 // CORS will handle the CORS middleware
@@ -37,10 +52,30 @@ func InitMiddleware() *GoMiddleware {
 	return &GoMiddleware{}
 }
 
+// InstrumentMiddleware will handle the instrumentation middleware
 func (m *GoMiddleware) InstrumentMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
+
+		start := time.Now()
+
+		parsedURL, err := url.Parse(c.Request().RequestURI)
+		if err != nil {
+			return err
+		}
+
+		requestMethod := c.Request().Method
+		requestPath := parsedURL.Path
+
 		// Increment the request counter
-		requestsTotal.WithLabelValues(c.Request().Method).Inc()
-		return next(c)
+		requestsTotal.WithLabelValues(requestMethod, requestPath).Inc()
+
+		err = next(c)
+
+		duration := time.Since(start).Seconds()
+
+		// Observe the duration with the histogram
+		requestLatency.WithLabelValues(requestMethod, requestPath).Observe(duration)
+
+		return err
 	}
 }

--- a/ingest/sqs/middleware/middleware.go
+++ b/ingest/sqs/middleware/middleware.go
@@ -55,7 +55,6 @@ func InitMiddleware() *GoMiddleware {
 // InstrumentMiddleware will handle the instrumentation middleware
 func (m *GoMiddleware) InstrumentMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-
 		start := time.Now()
 
 		parsedURL, err := url.Parse(c.Request().RequestURI)

--- a/ingest/sqs/router/delivery/http/router_handler.go
+++ b/ingest/sqs/router/delivery/http/router_handler.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
-	"time"
 
 	"github.com/labstack/echo"
 	"github.com/sirupsen/logrus"
-	"go.uber.org/zap"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -49,8 +47,6 @@ func NewRouterHandler(e *echo.Echo, us mvc.RouterUsecase, logger log.Logger) {
 // GetOptimalQuote will determine the optimal quote for a given tokenIn and tokenOutDenom
 // Return the optimal quote.
 func (a *RouterHandler) GetOptimalQuote(c echo.Context) error {
-	start := time.Now()
-
 	ctx := c.Request().Context()
 
 	tokenOutDenom, tokenIn, err := getValidRoutingParameters(c)
@@ -69,8 +65,6 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-
-	a.logger.Info("GetOptimalQuote", zap.Duration("duration", time.Since(start)))
 
 	return nil
 }
@@ -96,8 +90,6 @@ func (a *RouterHandler) GetBestSingleRouteQuote(c echo.Context) error {
 
 // GetCandidateRoutes returns the candidate routes for a given tokenIn and tokenOutDenom
 func (a *RouterHandler) GetCandidateRoutes(c echo.Context) error {
-	start := time.Now()
-
 	ctx := c.Request().Context()
 
 	tokenOutDenom, tokenIn, err := getValidTokenInTokenOutStr(c)
@@ -113,8 +105,6 @@ func (a *RouterHandler) GetCandidateRoutes(c echo.Context) error {
 	if err := c.JSON(http.StatusOK, routes); err != nil {
 		return err
 	}
-
-	a.logger.Info("GetCandidateRoutes", zap.Duration("duration", time.Since(start)))
 	return nil
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Implements a prometheus counter and a histogram that allows computing all of the values listed here in Grafana:
https://app.clickup.com/37420681/v/dc/13nzm9-25273/13nzm9-51693

From the histogram, we can get the average request time and RPS.

By having labels, we can plot counters for each endpoint.

Removing latency logs since we don't need them anymore (replaced by metrics)

## Testing and Verifying

Tested on node.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A