### PR TITLE
feat(SQS): custom quote query

### DIFF
--- a/ingest/sqs/domain/mvc/router.go
+++ b/ingest/sqs/domain/mvc/router.go
@@ -36,6 +36,10 @@ type RouterUsecase interface {
 	GetOptimalQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string) (domain.Quote, error)
 	// GetBestSingleRouteQuote returns the best single route quote for the given tokenIn and tokenOutDenom.
 	GetBestSingleRouteQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string) (domain.Quote, error)
+	// GetCustomQuote returns the custom quote for the given tokenIn, tokenOutDenom and poolIDs.
+	// It searches for the route that contains the specified poolIDs in the given order.
+	// If such route is not found it returns an error.
+	GetCustomQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, poolIDs []uint64) (domain.Quote, error)
 	// GetCandidateRoutes returns the candidate routes for the given tokenIn and tokenOutDenom.
 	GetCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (route.CandidateRoutes, error)
 	// StoreRoutes stores all router state in the files locally. Used for debugging.

--- a/ingest/sqs/router/delivery/http/router_handler.go
+++ b/ingest/sqs/router/delivery/http/router_handler.go
@@ -2,8 +2,11 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/labstack/echo"
 	"github.com/sirupsen/logrus"
@@ -41,6 +44,7 @@ func NewRouterHandler(e *echo.Echo, us mvc.RouterUsecase, logger log.Logger) {
 	e.GET("/quote", handler.GetOptimalQuote)
 	e.GET("/single-quote", handler.GetBestSingleRouteQuote)
 	e.GET("/routes", handler.GetCandidateRoutes)
+	e.GET("/custom-quote", handler.GetCustomQuote)
 	e.POST("/store-state", handler.StoreRouterStateInFiles)
 }
 
@@ -79,6 +83,37 @@ func (a *RouterHandler) GetBestSingleRouteQuote(c echo.Context) error {
 	}
 
 	quote, err := a.RUsecase.GetBestSingleRouteQuote(ctx, tokenIn, tokenOutDenom)
+	if err != nil {
+		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
+	}
+
+	quote.PrepareResult()
+
+	return c.JSON(http.StatusOK, quote)
+}
+
+// GetCustomQuote returns a direct custom quote. It ensures that the route contains all the pools
+// listed in the specific order, returns error if such route is not found.
+func (a *RouterHandler) GetCustomQuote(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	tokenOutDenom, tokenIn, err := getValidRoutingParameters(c)
+	if err != nil {
+		return err
+	}
+
+	poolIDsStr := c.QueryParam("poolIDs")
+	if len(poolIDsStr) == 0 {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: fmt.Sprintf("poolIDs is required")})
+	}
+
+	poolIDs, err := parseNumbers(poolIDsStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: err.Error()})
+	}
+
+	// Quote
+	quote, err := a.RUsecase.GetCustomQuote(ctx, tokenIn, tokenOutDenom, poolIDs)
 	if err != nil {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
@@ -173,4 +208,32 @@ func getValidTokenInTokenOutStr(c echo.Context) (tokenOutStr, tokenInStr string,
 	}
 
 	return tokenOutStr, tokenInStr, nil
+}
+
+// parseNumbers parses a comma-separated list of numbers into a slice of unit64.
+func parseNumbers(numbersParam string) ([]uint64, error) {
+	var numbers []uint64
+	numStrings := splitAndTrim(numbersParam, ",")
+
+	for _, numStr := range numStrings {
+		num, err := strconv.ParseUint(numStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		numbers = append(numbers, num)
+	}
+
+	return numbers, nil
+}
+
+// splitAndTrim splits a string by a separator and trims the resulting strings.
+func splitAndTrim(s, sep string) []string {
+	var result []string
+	for _, val := range strings.Split(s, sep) {
+		trimmed := strings.TrimSpace(val)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/ingest/sqs/router/usecase/optimized_routes_test.go
+++ b/ingest/sqs/router/usecase/optimized_routes_test.go
@@ -668,6 +668,55 @@ func (s *RouterTestSuite) TestGetBestSplitRoutesQuote_Mainnet_AKTUMEE() {
 	s.Require().Equal(uint64(1110), route.GetPools()[1].GetId())
 }
 
+// Validates custom quote for UOSMO to UION.
+// That is, with the given pool ID, we expect the quote to be routed through the route
+// that matches these pool IDs. Errors otherwise.
+func (s *RouterTestSuite) TestGetCustomQuote_Mainnet_UOSMOUION() {
+	config := defaultRouterConfig
+	config.MaxPoolsPerRoute = 5
+	config.MaxRoutes = 10
+
+	var (
+		amountIn = osmomath.NewInt(5000000)
+	)
+
+	router, tickMap, takerFeeMap := s.setupMainnetRouter(config)
+
+	// Setup router repository mock
+	routerRepositoryMock := mocks.RedisRouterRepositoryMock{
+		TakerFees: takerFeeMap,
+	}
+	routerusecase.WithRouterRepository(router, &routerRepositoryMock)
+
+	// Setup pools usecase mock.
+	poolsRepositoryMock := mocks.RedisPoolsRepositoryMock{
+		Pools:     router.GetSortedPools(),
+		TickModel: tickMap,
+	}
+	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil)
+	routerusecase.WithPoolsUsecase(router, poolsUsecase)
+
+	routerUsecase := routerusecase.NewRouterUsecase(time.Hour, &routerRepositoryMock, poolsUsecase, config, &log.NoOpLogger{})
+
+	// This pool ID is second best: https://app.osmosis.zone/pool/2
+	// The top one is https://app.osmosis.zone/pool/1110 which is not selected
+	// due to custom parameter.
+	const expectedPoolID = uint64(2)
+	poolIDs := []uint64{expectedPoolID}
+
+	quote, err := routerUsecase.GetCustomQuote(context.Background(), sdk.NewCoin(UOSMO, amountIn), UION, poolIDs)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(quote)
+
+	s.Require().Len(quote.GetRoute(), 1)
+	routePools := quote.GetRoute()[0].GetPools()
+	s.Require().Len(routePools, 1)
+
+	// Validate that the pool is pool 2
+	s.Require().Equal(expectedPoolID, routePools[0].GetId())
+}
+
 // Generates routes from mainnet state by:
 // - instrumenting pool repository mock with pools and ticks
 // - setting this mock on the pools use case


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

There are cases where it might be desired to specify a specific query path for quoting. This is especially useful for debugging.

As a result, such query is exposed.

It takes a list of pool IDs. If there is a route that mathes these pool IDs, such route is quotes. Otherwise, an error is returned.

Example:
```
curl "localhost:9092/custom-quote?tokenIn=5000000uosmo&tokenOutDenom=uion&poolIDs=2" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   305  100   305    0     0    309      0 --:--:-- --:--:-- --:--:--   309
{
  "amount_in": {
    "denom": "uosmo",
    "amount": "5000000"
  },
  "amount_out": "8714",
  "route": [
    {
      "pools": [
        {
          "id": 2,
          "type": 0,
          "balances": [],
          "spread_factor": "0.005000000000000000",
          "token_out_denom": "uion",
          "taker_fee": "0.001000000000000000"
        }
      ],
      "out_amount": "8714",
      "in_amount": "5000000"
    }
  ],
  "effective_fee": "0.006000000000000000"
}
```

## Testing and Verifying

Go test added with uion/uosmo

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A