### PR TITLE
Fix bank keeper wiring in tokenfactory keeper

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -285,6 +285,8 @@ func NewOsmosisApp(
 	// https://github.com/osmosis-labs/osmosis/issues/6580
 	app.SetupHooks()
 
+	app.TokenFactoryKeeper.SetBankKeeper(app.BankKeeper)
+
 	/****  Module Options ****/
 
 	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -721,7 +721,7 @@ func (appKeepers *AppKeepers) SetupHooks() {
 	// e.g. *app.StakingKeeper doesn't appear
 
 	// Recall that SetHooks is a mutative call.
-	appKeepers.BankKeeper.SetHooks(
+	appKeepers.BankKeeper.BaseSendKeeper = *appKeepers.BankKeeper.SetHooks(
 		banktypes.NewMultiBankHooks(
 			appKeepers.TokenFactoryKeeper.Hooks(),
 		),

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -78,6 +78,12 @@ func (k *Keeper) SetContractKeeper(contractKeeper types.ContractKeeper) {
 	k.contractKeeper = contractKeeper
 }
 
+// set the bank keeper
+// need this for setting the bank keeper with hooks registered
+func (k *Keeper) SetBankKeeper(bankKeeper types.BankKeeper) {
+	k.bankKeeper = bankKeeper
+}
+
 // CreateModuleAccount creates a module account with minting and burning capabilities
 // This account isn't intended to store any coins,
 // it purely mints and burns them on behalf of the admin of respective denoms,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The bug is occuring from how we are setting hooks / keepers in app.go. Basically from unforking v47, we were no longer taking bank keeper as pointer. (https://github.com/osmosis-labs/osmosis/blob/main/app/keepers/keepers.go#L135) Thus, setting up the hooks were actually not mutative. 

Don't think this is the right way to do it though, only for short term fix

## Testing and Verifying
Currently testing

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A