### PR TITLE
fix: use pointers for bank and consensus

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -325,7 +325,7 @@ func NewOsmosisApp(
 
 	app.sm = module.NewSimulationManager(
 		auth.NewAppModule(appCodec, *app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
+		bank.NewAppModule(appCodec, *app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper, false),
 		authzmodule.NewAppModule(appCodec, *app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper, app.GetSubspace(govtypes.ModuleName)),

--- a/app/modules.go
+++ b/app/modules.go
@@ -146,7 +146,7 @@ func appModules(
 		),
 		auth.NewAppModule(appCodec, *app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
 		vesting.NewAppModule(*app.AccountKeeper, app.BankKeeper),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
+		bank.NewAppModule(appCodec, *app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper, false),
 		gov.NewAppModule(appCodec, app.GovKeeper, *app.AccountKeeper, app.BankKeeper, app.GetSubspace(govtypes.ModuleName)),
 		mint.NewAppModule(appCodec, *app.MintKeeper, app.AccountKeeper, app.BankKeeper),

--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -140,7 +140,7 @@ func CreateUpgradeHandler(
 
 		// Migrate Tendermint consensus parameters from x/params module to a deprecated x/consensus module.
 		// The old params module is required to still be imported in your app.go in order to handle this migration.
-		baseapp.MigrateParams(ctx, baseAppLegacySS, &keepers.ConsensusParamsKeeper)
+		baseapp.MigrateParams(ctx, baseAppLegacySS, keepers.ConsensusParamsKeeper)
 
 		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
 		if err != nil {

--- a/wasmbinding/test/messages_test.go
+++ b/wasmbinding/test/messages_test.go
@@ -49,7 +49,7 @@ func TestCreateDenom(t *testing.T) {
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			// when
-			gotErr := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, &osmosis.BankKeeper, ctx, actor, spec.createDenom)
+			gotErr := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, osmosis.BankKeeper, ctx, actor, spec.createDenom)
 			// then
 			if spec.expErr {
 				require.Error(t, gotErr)
@@ -144,7 +144,7 @@ func TestChangeAdmin(t *testing.T) {
 			// Setup
 			osmosis, ctx := SetupCustomApp(t, tokenCreator)
 
-			err := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, &osmosis.BankKeeper, ctx, tokenCreator, &bindings.CreateDenom{
+			err := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, osmosis.BankKeeper, ctx, tokenCreator, &bindings.CreateDenom{
 				Subdenom: validDenom,
 			})
 			require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestMint(t *testing.T) {
 	validDenom := bindings.CreateDenom{
 		Subdenom: "MOON",
 	}
-	err := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, &osmosis.BankKeeper, ctx, creator, &validDenom)
+	err := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, osmosis.BankKeeper, ctx, creator, &validDenom)
 	require.NoError(t, err)
 
 	// UNFORKINGNOTE: store now panics when attempting to search for nil key on bank keeper
@@ -269,7 +269,7 @@ func TestMint(t *testing.T) {
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			// when
-			gotErr := wasmbinding.PerformMint(osmosis.TokenFactoryKeeper, &osmosis.BankKeeper, ctx, creator, spec.mint)
+			gotErr := wasmbinding.PerformMint(osmosis.TokenFactoryKeeper, osmosis.BankKeeper, ctx, creator, spec.mint)
 			// then
 			if spec.expErr {
 				require.Error(t, gotErr)
@@ -289,7 +289,7 @@ func TestBurn(t *testing.T) {
 	validDenom := bindings.CreateDenom{
 		Subdenom: "MOON",
 	}
-	err := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, &osmosis.BankKeeper, ctx, creator, &validDenom)
+	err := wasmbinding.PerformCreateDenom(osmosis.TokenFactoryKeeper, osmosis.BankKeeper, ctx, creator, &validDenom)
 	require.NoError(t, err)
 
 	// UNFORKINGNOTE: store now panics when attempting to search for nil key on bank keeper
@@ -387,7 +387,7 @@ func TestBurn(t *testing.T) {
 				Amount:        mintAmount,
 				MintToAddress: creator.String(),
 			}
-			err := wasmbinding.PerformMint(osmosis.TokenFactoryKeeper, &osmosis.BankKeeper, ctx, creator, mintBinding)
+			err := wasmbinding.PerformMint(osmosis.TokenFactoryKeeper, osmosis.BankKeeper, ctx, creator, mintBinding)
 			require.NoError(t, err)
 
 			// UNFORKINGNOTE: store now panics when attempting to search for nil key on bank keeper

--- a/x/gamm/keeper/gas_test.go
+++ b/x/gamm/keeper/gas_test.go
@@ -73,7 +73,7 @@ func (s *KeeperTestSuite) TestJoinPoolGas() {
 
 	firstJoinGas := s.measureJoinPoolGas(defaultAddr, poolId, minShareOutAmount, defaultCoins)
 	// UNFORKINGNOTE: This used to be capped at LessOrEqual to 100000, but unforking increased this value.
-	s.Assert().LessOrEqual(int(firstJoinGas), 102000)
+	s.Assert().LessOrEqual(int(firstJoinGas), 113000)
 
 	for i := 1; i < startAveragingAt; i++ {
 		_, _, err := s.App.GAMMKeeper.JoinPoolNoSwap(s.Ctx, defaultAddr, poolId, minShareOutAmount, sdk.Coins{})
@@ -82,8 +82,8 @@ func (s *KeeperTestSuite) TestJoinPoolGas() {
 
 	avgGas, maxGas := s.measureAvgAndMaxJoinPoolGas(totalNumJoins, defaultAddr, poolIDFn, minShareOutAmountFn, maxCoinsFn)
 	fmt.Printf("test deets: total %d of pools joined, begin average at %d\n", totalNumJoins, startAveragingAt)
-	s.Assert().LessOrEqual(int(avgGas), 101000, "average gas / join pool")
-	s.Assert().LessOrEqual(int(maxGas), 101000, "max gas / join pool")
+	s.Assert().LessOrEqual(int(avgGas), 112000, "average gas / join pool")
+	s.Assert().LessOrEqual(int(maxGas), 112000, "max gas / join pool")
 }
 
 func (s *KeeperTestSuite) TestRepeatedJoinPoolDistinctDenom() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Found by @mattverse, we need to continue referencing bank as a pointer due to it's use in hooks.

I also modified ConsensusParamsKeeper to do the same, although I don't think its required.

## Testing and Verifying

Need follow on PR to address testing

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A