### PR TITLE
fix(SQS): healtcheck returning 200 due to time update not present

### DIFF
--- a/ingest/sqs/chain_info/usecase/chain_info_usecase.go
+++ b/ingest/sqs/chain_info/usecase/chain_info_usecase.go
@@ -52,6 +52,8 @@ func (p *chainInfoUseCase) GetLatestHeight(ctx context.Context) (uint64, error) 
 			if err := p.chainInfoRepository.StoreLatestHeightRetrievalTime(ctx, currentTimeUTC); err != nil {
 				return 0, err
 			}
+
+			return latestHeight, nil
 		}
 
 		return 0, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Was caught in chaos testing with @gzukel .

Erroring in the case where there is no last update time present would cause instabilities with the healthcheck.

Returning the latest observed height in such a case should make the healthcheck more robust

## Testing and Verifying

Tested by chaos testing

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A