### PR TITLE
fix: e2e tests for smart accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 BUILDDIR ?= $(CURDIR)/build
 DOCKER := $(shell which docker)
-E2E_UPGRADE_VERSION := "v21"
+E2E_UPGRADE_VERSION := "v22"
 #SHELL := /bin/bash
 
 # Go version to be used in docker images

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 BUILDDIR ?= $(CURDIR)/build
 DOCKER := $(shell which docker)
-E2E_UPGRADE_VERSION := "v22"
+E2E_UPGRADE_VERSION := "v21"
 #SHELL := /bin/bash
 
 # Go version to be used in docker images

--- a/app/upgrades/v21/constants.go
+++ b/app/upgrades/v21/constants.go
@@ -6,6 +6,8 @@ import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+
+	authenticatortypes "github.com/osmosis-labs/osmosis/v21/x/authenticator/types"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v21 upgrade.
@@ -22,6 +24,8 @@ var Upgrade = upgrades.Upgrade{
 			// v47 modules
 			crisistypes.ModuleName,
 			consensustypes.ModuleName,
+			authenticatortypes.ManagerStoreKey,
+			authenticatortypes.AuthenticatorStoreKey,
 		},
 		Deleted: []string{},
 	},

--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -176,6 +176,10 @@ func CreateUpgradeHandler(
 		keepers.ProtoRevKeeper.SetCyclicArbProfitTrackerValue(ctx, allCyclicArbProfitsCoins)
 		keepers.ProtoRevKeeper.SetCyclicArbProfitTrackerStartHeight(ctx, ctx.BlockHeight())
 
+		authenticatorParams := keepers.AuthenticatorKeeper.GetParams(ctx)
+		authenticatorParams.MaximumUnauthenticatedGas = 50000
+		keepers.AuthenticatorKeeper.SetParams(ctx, authenticatorParams)
+
 		return migrations, nil
 	}
 }

--- a/app/upgrades/v22/contants.go
+++ b/app/upgrades/v22/contants.go
@@ -1,0 +1,26 @@
+package v22
+
+import (
+	"github.com/osmosis-labs/osmosis/v21/app/upgrades"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
+	authenticatortypes "github.com/osmosis-labs/osmosis/v21/x/authenticator/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v22 upgrade.
+const (
+	UpgradeName = "v22"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added: []string{
+			authenticatortypes.ManagerStoreKey,
+			authenticatortypes.AuthenticatorStoreKey,
+		},
+		Deleted: []string{},
+	},
+}

--- a/app/upgrades/v22/upgrades.go
+++ b/app/upgrades/v22/upgrades.go
@@ -1,0 +1,33 @@
+package v22
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/osmosis-labs/osmosis/v21/app/keepers"
+	"github.com/osmosis-labs/osmosis/v21/app/upgrades"
+
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bpm upgrades.BaseAppParamManager,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Run migrations before applying any other state changes.
+		// NOTE: DO NOT PUT ANY STATE CHANGES BEFORE RunMigrations().
+		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, err
+		}
+
+		authenticatorParams := keepers.AuthenticatorKeeper.GetParams(ctx)
+		authenticatorParams.MaximumUnauthenticatedGas = 50000
+		keepers.AuthenticatorKeeper.SetParams(ctx, authenticatorParams)
+
+		return migrations, nil
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

I took some time to debug the e2e tests on the `feat/smart-accounts` branch. Some points of note:

1. When running the e2e tests locally with the following command `make test-e2e-debug` the IBC tests & the UPGRADE tests must be set to run otherwise the environment is not setup correctly and the tests fail early. I'm assuming this is a separate/known issue with the e2e tests? @ValarDragon 
2. I have added the boilerplate v22 upgrade directory but this is not functional at present. In order to show the tests are passing I'm adding the authenticator module to our v21 upgrade code for now. When running the tests against the v22 upgrade code we run into the following error: @PaddyMc @ValarDragon @nicolaslara  I'm assuming this is a slight configuration issue?

```
failed to load latest version: version of store crisis mismatch root store's version; expected 150 got 0; new stores should be added using StoreUpgrades
```

## Testing and Verifying

```
// Ensure you have no previous containers running
// Worst case scenario run docker system prune -af

// build the image and run the tests
make e2e-docker-build-debug 
make test-e2e-debug
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A