### PR TITLE
fix: add build tag to CI job

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -68,6 +68,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
+            BUILD_TAGS="netgo,ledger,muslc,excludeIncrement"
       - name: Test e2e and Upgrade
         run: make test-e2e-ci-scheduled
       - name: Dump docker logs on failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
+            BUILD_TAGS="netgo,ledger,muslc,excludeIncrement"
       - name: Test e2e and Upgrade
         run: make test-e2e-ci
       - name: Dump docker logs on failure


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

I didn't notice this on main, but the v21.x branch was building without the excludeIncrement tag in CI. I looked into it and this is because the Build e2e image step isn't explicit with this. I already patched this on v21.x via my last backport, but thought this should probably be on main too.