### PR TITLE
feat: avoid clearing route cache every block; cache expiry; query for cached routes

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -522,7 +522,10 @@ route-update-height-interval = "{{ .SidecarQueryServerConfig.Router.RouteUpdateH
 
 # Whether to enable candidate route caching in Redis.
 route-cache-enabled = "{{ .SidecarQueryServerConfig.Router.RouteCacheEnabled }}"
-` + `
+
+# The number of seconds to cache routes for before expiry.
+route_cache_expiry_seconds = "{{ .SidecarQueryServerConfig.Router.RouteCacheExpirySeconds }}"
+
 ###############################################################################
 ###              		       Wasm Configuration    					    ###
 ###############################################################################

--- a/ingest/sqs/README.md
+++ b/ingest/sqs/README.md
@@ -256,7 +256,87 @@ curl "https://sqs.osmosis.zone/router/custom-quote?tokenIn=1000000uosmo&tokenOut
 }
 ```
 
-5. POST `/router/store-state`
+
+5. GET `/router/cached-routes?tokenIn=uosmo&tokenOutDenom=uion`
+
+Description: returns cached routes for the given tokenIn and tokenOutDenomn if cache
+is enabled. If not, returns error. Contrary to `/router/routes...` endpoint, does
+not attempt to compute routes if cache is not enabled.
+
+Parameters: none
+
+Parameters:
+- `tokenIn` the string representation of the denom of the token in
+- `tokenOutDenom` the string representing the denom of the token out
+
+
+Response example:
+```bash
+curl "https://sqs.osmosis.zone/cached-routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
+{
+  "Routes": [
+    {
+      "Pools": [
+        {
+          "ID": 1100,
+          "TokenOutDenom": "uion"
+        }
+      ]
+    },
+    {
+      "Pools": [
+        {
+          "ID": 2,
+          "TokenOutDenom": "uion"
+        }
+      ]
+    },
+    {
+      "Pools": [
+        {
+          "ID": 1013,
+          "TokenOutDenom": "uion"
+        }
+      ]
+    },
+    {
+      "Pools": [
+        {
+          "ID": 1092,
+          "TokenOutDenom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+        },
+        {
+          "ID": 476,
+          "TokenOutDenom": "uion"
+        }
+      ]
+    },
+    {
+      "Pools": [
+        {
+          "ID": 1108,
+          "TokenOutDenom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+        },
+        {
+          "ID": 26,
+          "TokenOutDenom": "uion"
+        }
+      ]
+    }
+  ],
+  "UniquePoolIDs": {
+    "1013": {},
+    "1092": {},
+    "1100": {},
+    "1108": {},
+    "2": {},
+    "26": {},
+    "476": {}
+  }
+}
+```
+
+6. POST `/router/store-state`
 
 Description: stores the current state of the router in a JSON file locally. Used for debugging purposes.
 This endpoint should be disabled in production.

--- a/ingest/sqs/domain/mvc/router.go
+++ b/ingest/sqs/domain/mvc/router.go
@@ -44,6 +44,10 @@ type RouterUsecase interface {
 	GetCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (route.CandidateRoutes, error)
 	// GetTakerFee returns the taker fee for all token pairs in a pool.
 	GetTakerFee(ctx context.Context, poolID uint64) ([]domain.TakerFeeForPair, error)
+	// GetCachedCandidateRoutes returns the candidate routes for the given tokenIn and tokenOutDenom from cache.
+	// It does not recompute the routes if they are not present in cache.
+	// Returns error if cache is disabled.
+	GetCachedCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (route.CandidateRoutes, error)
 	// StoreRoutes stores all router state in the files locally. Used for debugging.
 	StoreRouterStateFiles(ctx context.Context) error
 }

--- a/ingest/sqs/domain/router.go
+++ b/ingest/sqs/domain/router.go
@@ -87,6 +87,8 @@ type RouterConfig struct {
 	MinOSMOLiquidity          int  `mapstructure:"min_osmo_liquidity"`
 	RouteUpdateHeightInterval int  `mapstructure:"route_update_height_interval"`
 	RouteCacheEnabled         bool `mapstructure:"route_cache_enabled"`
+	// The number of seconds to cache routes for before expiry.
+	RouteCacheExpirySeconds uint64 `mapstructure:"route_cache_expiry_seconds"`
 }
 
 // DenomPair encapsulates a pair of denoms.

--- a/ingest/sqs/ingester.go
+++ b/ingest/sqs/ingester.go
@@ -37,11 +37,6 @@ func (i *sqsIngester) ProcessBlock(ctx sdk.Context) error {
 
 	goCtx := sdk.WrapSDKContext(ctx)
 
-	// Begin by flushing all previous writes
-	if err := tx.ClearAll(goCtx); err != nil {
-		return err
-	}
-
 	// Process block by reading and writing data and ingesting data into sinks
 	if err := i.poolsIngester.ProcessBlock(ctx, tx); err != nil {
 		return err

--- a/ingest/sqs/router/repository/redis/redis_router_repository.go
+++ b/ingest/sqs/router/repository/redis/redis_router_repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 
@@ -16,7 +17,8 @@ import (
 )
 
 type redisRouterRepo struct {
-	repositoryManager mvc.TxManager
+	repositoryManager        mvc.TxManager
+	routerCacheExpirySeconds uint64
 }
 
 const (
@@ -32,9 +34,10 @@ var (
 )
 
 // NewRedisRouterRepo will create an implementation of pools.Repository
-func NewRedisRouterRepo(repositoryManager mvc.TxManager) mvc.RouterRepository {
+func NewRedisRouterRepo(repositoryManager mvc.TxManager, routesCacheExpirySeconds uint64) mvc.RouterRepository {
 	return &redisRouterRepo{
-		repositoryManager: repositoryManager,
+		repositoryManager:        repositoryManager,
+		routerCacheExpirySeconds: routesCacheExpirySeconds,
 	}
 }
 
@@ -165,7 +168,9 @@ func (r *redisRouterRepo) SetRoutesTx(ctx context.Context, tx mvc.Tx, denom0, de
 		return err
 	}
 
-	cmd := pipeliner.HSet(ctx, routesPrefix, denom0+keySeparator+denom1, routesStr)
+	routeCacheExpiryDuration := time.Second * time.Duration(r.routerCacheExpirySeconds)
+
+	cmd := pipeliner.Set(ctx, getRoutesPrefixByDenoms(denom0, denom1), routesStr, routeCacheExpiryDuration)
 	if err := cmd.Err(); err != nil {
 		return err
 	}
@@ -207,7 +212,7 @@ func (r *redisRouterRepo) GetRoutes(ctx context.Context, denom0, denom1 string) 
 	}
 
 	// Create command to retrieve results.
-	getCmd := pipeliner.HGet(ctx, routesPrefix, denom0+keySeparator+denom1)
+	getCmd := pipeliner.Get(ctx, getRoutesPrefixByDenoms(denom0, denom1))
 
 	_, err = pipeliner.Exec(ctx)
 	if err != nil {
@@ -225,4 +230,8 @@ func (r *redisRouterRepo) GetRoutes(ctx context.Context, denom0, denom1 string) 
 	}
 
 	return routes, nil
+}
+
+func getRoutesPrefixByDenoms(denom0, denom1 string) string {
+	return routesPrefix + denom0 + keySeparator + denom1
 }

--- a/ingest/sqs/router/usecase/router_usecase.go
+++ b/ingest/sqs/router/usecase/router_usecase.go
@@ -207,6 +207,20 @@ func (r *routerUseCaseImpl) GetTakerFee(ctx context.Context, poolID uint64) ([]d
 	return result, nil
 }
 
+// GetCachedCandidateRoutes implements mvc.RouterUsecase.
+func (r *routerUseCaseImpl) GetCachedCandidateRoutes(ctx context.Context, tokenInDenom string, tokenOutDenom string) (route.CandidateRoutes, error) {
+	if !r.config.RouteCacheEnabled {
+		return route.CandidateRoutes{}, fmt.Errorf("route cache is disabled")
+	}
+
+	cachedCandidateRoutes, err := r.routerRepository.GetRoutes(ctx, tokenInDenom, tokenOutDenom)
+	if err != nil {
+		return route.CandidateRoutes{}, err
+	}
+
+	return cachedCandidateRoutes, nil
+}
+
 // initializeRouter initializes the router per configuration defined on the use case
 // Returns error if:
 // - there is an error retrieving pools from the store

--- a/ingest/sqs/sidecar_query_server.go
+++ b/ingest/sqs/sidecar_query_server.go
@@ -141,7 +141,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, routerConfig domain.RouterConfi
 	poolsHttpDelivery.NewPoolsHandler(e, poolsUseCase)
 
 	// Initialize router repository, usecase and HTTP handler
-	routerRepository := routerRedisRepository.NewRedisRouterRepo(redisTxManager)
+	routerRepository := routerRedisRepository.NewRedisRouterRepo(redisTxManager, routerConfig.RouteCacheExpirySeconds)
 	routerUsecase := routerUseCase.NewRouterUsecase(timeoutContext, routerRepository, poolsUseCase, routerConfig, logger)
 	routerHttpDelivery.NewRouterHandler(e, routerUsecase, logger)
 

--- a/ingest/sqs/sqs_config.go
+++ b/ingest/sqs/sqs_config.go
@@ -67,6 +67,7 @@ var DefaultConfig = Config{
 		MinOSMOLiquidity:          10000, // 10_000 OSMO
 		RouteUpdateHeightInterval: 0,
 		RouteCacheEnabled:         false,
+		RouteCacheExpirySeconds:   600, // 10 minutes
 	},
 }
 
@@ -111,6 +112,8 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 			RouteUpdateHeightInterval: osmoutils.ParseInt(opts, groupOptName, "route-update-height-interval"),
 
 			RouteCacheEnabled: osmoutils.ParseBool(opts, groupOptName, "route-cache-enabled", false),
+
+			RouteCacheExpirySeconds: uint64(osmoutils.ParseInt(opts, groupOptName, "route-cache-expiry-seconds")),
 		},
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR focuses on the following:
- stops clearing cache on every block. Instead, any updates will simply be overwritten. Additionally, routes are to be expired every 10 minutes and recomputed on demand.
- Now, routes are persisted across blocks and only recomputed when expired in Redis
- Adds the config to tweak the expiry
- Adds query for cached routes

Th infrastructure configuration is updated: https://github.com/osmosis-labs/osmosis/pull/7061

## Testing and Verifying

- Manually tested
- Ran pools comparison CI: https://github.com/osmosis-labs/infrastructure/actions/runs/7160319038/job/19494559775
- Load tested and saw no performance degradation but also no improvement. The improvement will come once I add the ability to persist optimal routes in subsequent PR. The goal of this is to minimize the number of CL poosl needed to be read from state. Json marshaling when reading pools from cache is the biggest bottleneck right now.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A