### PR TITLE
Pin alpine version in docker builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_TAGS="netgo,ledger,muslc"
 # Builder
 # --------------------------------------------------------
 
-FROM golang:${GO_VERSION}-alpine as builder
+FROM golang:${GO_VERSION}-alpine3.18 as builder
 
 ARG GIT_VERSION
 ARG GIT_COMMIT


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the alpine image usage in the builder step of the Dockerfile.

## Testing and Verifying

Run:

```bash
make docker-build-alpine
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A