### PR TITLE
Lower Epoch CPU usage

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -652,14 +652,17 @@ func (k Keeper) distributeInternal(
 		if lockSum.IsZero() {
 			return nil, nil
 		}
+		remainingEpochsAsInt := osmomath.NewInt(int64(remainEpochs))
+		// total_denom_lock_amount * remain_epochs
+		lockSumTimesRemainingEpochs := lockSum.Mul(remainingEpochsAsInt)
 
 		for _, lock := range locks {
 			distrCoins := sdk.Coins{}
-			ctx.Logger().Debug("distributeInternal, distribute to lock", "module", types.ModuleName, "gaugeId", gauge.Id, "lockId", lock.ID, "remainCons", remainCoins, "height", ctx.BlockHeight())
+			// ctx.Logger().Debug("distributeInternal, distribute to lock", "module", types.ModuleName, "gaugeId", gauge.Id, "lockId", lock.ID, "remainCons", remainCoins, "height", ctx.BlockHeight())
 			for _, coin := range remainCoins {
 				// distribution amount = gauge_size * denom_lock_amount / (total_denom_lock_amount * remain_epochs)
 				denomLockAmt := lock.Coins.AmountOfNoDenomValidation(denom)
-				amt := coin.Amount.Mul(denomLockAmt).Quo(lockSum.Mul(osmomath.NewInt(int64(remainEpochs))))
+				amt := coin.Amount.Mul(denomLockAmt).Quo(lockSumTimesRemainingEpochs)
 				if amt.IsPositive() {
 					newlyDistributedCoin := sdk.Coin{Denom: coin.Denom, Amount: amt}
 					distrCoins = distrCoins.Add(newlyDistributedCoin)

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -62,6 +62,7 @@ func (p PeriodLock) SingleCoin() (sdk.Coin, error) {
 	return p.Coins[0], nil
 }
 
+// TODO: Can we use sumtree instead here?
 func SumLocksByDenom(locks []PeriodLock, denom string) osmomath.Int {
 	sum := osmomath.NewInt(0)
 	// validate the denom once, so we can avoid the expensive validate check in the hot loop.
@@ -70,6 +71,7 @@ func SumLocksByDenom(locks []PeriodLock, denom string) osmomath.Int {
 		panic(fmt.Errorf("invalid denom used internally: %s, %v", denom, err))
 	}
 	for _, lock := range locks {
+		// TODO: Replace with Mutative Int Operations
 		sum = sum.Add(lock.Coins.AmountOfNoDenomValidation(denom))
 	}
 	return sum


### PR DESCRIPTION
Some state compatible speedups for lowering Epoch CPU usage!

- Removes an expensive log line for every single lock
- Removes two Heap allocations from the core loop taking CPU time here

Its not the easiest to gather quite what the speedup percentage for the whole system is, and not even for CPU time as a whole. It seems minor, e.g. I'd expect this to be shaving like 500ms off epoch, but could be more impactful. Very not simple to tell.