### PR TITLE
perf: remove cache e2e

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -62,13 +62,9 @@ jobs:
           load: true
           context: .
           tags: osmosis:debug
-          # Use experimental Cache backend API:
-          # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
-            BUILD_TAGS="netgo,ledger,muslc,excludeIncrement"
+            BUILD_TAGS="netgo,muslc,excludeIncrement"
       - name: Test e2e and Upgrade
         run: make test-e2e-ci-scheduled
       - name: Dump docker logs on failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,13 +138,9 @@ jobs:
           load: true
           context: .
           tags: osmosis:debug
-          # Use experimental Cache backend API:
-          # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             BASE_IMG_TAG=debug
-            BUILD_TAGS="netgo,ledger,muslc,excludeIncrement"
+            BUILD_TAGS="netgo,muslc,excludeIncrement"
       - name: Test e2e and Upgrade
         run: make test-e2e-ci
       - name: Dump docker logs on failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -X github.com/cosmos/cosmos-sdk/version.AppName="osmosisd" \
     -X github.com/cosmos/cosmos-sdk/version.Version=${GIT_VERSION} \
     -X github.com/cosmos/cosmos-sdk/version.Commit=${GIT_COMMIT} \
-    -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc \
+    -X github.com/cosmos/cosmos-sdk/version.BuildTags=${BUILD_TAGS} \
     -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
     -trimpath \
     -o /osmosis/build/osmosisd \

--- a/scripts/makefiles/e2e.mk
+++ b/scripts/makefiles/e2e.mk
@@ -22,7 +22,7 @@ e2e-build-script:
 	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ ./tests/e2e/initialization/$(E2E_SCRIPT_NAME)
 
 e2e-docker-build-debug:
-	@DOCKER_BUILDKIT=1 docker build --build-arg BUILD_TAGS="netgo,ledger,muslc,excludeIncrement" -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug --build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_ALPINE) -f Dockerfile .
+	@DOCKER_BUILDKIT=1 docker build --build-arg BUILD_TAGS="netgo,muslc,excludeIncrement" -t osmosis:${COMMIT} --build-arg BASE_IMG_TAG=debug --build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_ALPINE) -f Dockerfile .
 	@DOCKER_BUILDKIT=1 docker tag osmosis:${COMMIT} osmosis:debug
 
 e2e-docker-build-e2e-init-chain:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Ironically, cache was increasing our run times by almost 3 minutes. The cache needs to get reset on essentially every commit, so caching this doesn't make much sense in the first place (maybe cache the parts that don't change like wasmvm DL but that is another conversation).

This removes the cache.