### PR TITLE
refactor(SQS): filter out duplicate pool ID routes

### DIFF
--- a/ingest/sqs/router/usecase/export_test.go
+++ b/ingest/sqs/router/usecase/export_test.go
@@ -48,3 +48,7 @@ func (r Router) GetSortedPoolIDs() []uint64 {
 	}
 	return sortedPoolIDs
 }
+
+func FilterDuplicatePoolIDRoutes(rankedRoutes []route.RouteImpl) []route.RouteImpl {
+	return filterDuplicatePoolIDRoutes(rankedRoutes)
+}

--- a/ingest/sqs/router/usecase/optimized_routes_test.go
+++ b/ingest/sqs/router/usecase/optimized_routes_test.go
@@ -614,7 +614,7 @@ func (s *RouterTestSuite) TestGetOptimalQuote() {
 
 			amountIn: osmomath.NewInt(100_000_000),
 
-			expectedRoutesCount: 2,
+			expectedRoutesCount: 1,
 		},
 		// This test validates that with a greater max routes value, SQS is able to find
 		// the path from umee to stOsmo


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Filters out duplicate pool ID routes that have been causing lower quality split quotes due to SQS not accounting for state updates.

Before:
![image](https://github.com/osmosis-labs/osmosis/assets/34196718/7954bbc8-6986-4337-a8ff-7ec7dffc6e55)

After:
![image](https://github.com/osmosis-labs/osmosis/assets/34196718/f1368d47-6497-46b5-9c98-5645945a08e4)

## Testing and Verifying

- Added unit test
- Manual test on dev node

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A