### PR TITLE
x/incentives: Lower Epoch allocation overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6890](https://github.com/osmosis-labs/osmosis/pull/6890) Enable arb filter for affiliate swap contract
 * [#6884](https://github.com/osmosis-labs/osmosis/pull/6914) Update ListPoolsByDenom function by using pool.GetPoolDenoms to filter denom directly
 * [#6959](https://github.com/osmosis-labs/osmosis/pull/6959) Increase high gas threshold to 2m from 1m
+* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100) Lower CPU overheads of the Osmosis epoch.
 
 ### API Breaks
 

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -652,13 +652,14 @@ func (k Keeper) distributeInternal(
 		if lockSum.IsZero() {
 			return nil, nil
 		}
-		remainingEpochsAsInt := osmomath.NewInt(int64(remainEpochs))
 		// total_denom_lock_amount * remain_epochs
-		lockSumTimesRemainingEpochs := lockSum.Mul(remainingEpochsAsInt)
+		lockSumTimesRemainingEpochs := lockSum.MulRaw(int64(remainEpochs))
 
 		for _, lock := range locks {
 			distrCoins := sdk.Coins{}
+			// too expensive + verbose even in debug mode.
 			// ctx.Logger().Debug("distributeInternal, distribute to lock", "module", types.ModuleName, "gaugeId", gauge.Id, "lockId", lock.ID, "remainCons", remainCoins, "height", ctx.BlockHeight())
+
 			for _, coin := range remainCoins {
 				// distribution amount = gauge_size * denom_lock_amount / (total_denom_lock_amount * remain_epochs)
 				denomLockAmt := lock.Coins.AmountOfNoDenomValidation(denom)

--- a/x/incentives/keeper/iterator.go
+++ b/x/incentives/keeper/iterator.go
@@ -64,7 +64,7 @@ func (k Keeper) FinishedGaugesIterator(ctx sdk.Context) sdk.Iterator {
 
 // FilterLocksByMinDuration returns locks whose lock duration is greater than the provided minimum duration.
 func FilterLocksByMinDuration(locks []lockuptypes.PeriodLock, minDuration time.Duration) []lockuptypes.PeriodLock {
-	filteredLocks := make([]lockuptypes.PeriodLock, 0, len(locks)/2)
+	filteredLocks := make([]lockuptypes.PeriodLock, 0, len(locks))
 	for _, lock := range locks {
 		if lock.Duration >= minDuration {
 			filteredLocks = append(filteredLocks, lock)


### PR DESCRIPTION
The IAVL v2 benchmarks were showing Memory allocation as a significant chunk of the CPU time. (NOTE: CacheKV and DB overheads that are mainly applying to us in production are not shown in these benchmarks)

So looking at golang code, the capacity of a large slice grows by a factor of `1.25` every grow. So in the case where this is full / near full (most of the time), this would grow 3 or 4 times. `1.25**3 = 1.95`, which involves expensive memcopies on top of extra allocations.

Hence this speeds up the relevant logic.

From the IAVL v2 benchmarks, this is ~30% of the CPU time of the Distribute function!