### PR TITLE
[DNM] Try using accum store instead of summing all locks

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -647,7 +647,8 @@ func (k Keeper) distributeInternal(
 
 		// This is a standard lock distribution flow that assumes that we have locks associated with the gauge.
 		denom := lockuptypes.NativeDenom(gauge.DistributeTo.Denom)
-		lockSum := lockuptypes.SumLocksByDenom(locks, denom)
+		// lockSum := lockuptypes.SumLocksByDenom(locks, denom)
+		lockSum := k.lk.GetPeriodLocksAccumulation(ctx, gauge.DistributeTo)
 
 		if lockSum.IsZero() {
 			return nil, nil


### PR DESCRIPTION
Try using the accum store instead of summing all locks.

If this is state compatible, we should merge via main. I'm checking this on a local node