### PR TITLE
(epoch speedup) Use accumulation store instead of iterating over all locks for total locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#6884](https://github.com/osmosis-labs/osmosis/pull/6914) Update ListPoolsByDenom function by using pool.GetPoolDenoms to filter denom directly
 * [#6959](https://github.com/osmosis-labs/osmosis/pull/6959) Increase high gas threshold to 2m from 1m
 * [#7068](https://github.com/osmosis-labs/osmosis/pull/7068) Add CI action that check for typo on new PRs (Thanks @codespell)
-* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100) Lower CPU overheads of the Osmosis epoch.
+* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100),[#7119](https://github.com/osmosis-labs/osmosis/pull/7119) Lower CPU overheads of the Osmosis epoch.
 * [#7106](https://github.com/osmosis-labs/osmosis/pull/7106) Halve the time of log2 calculation (speeds up TWAP code)
 
 

--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -647,7 +647,7 @@ func (k Keeper) distributeInternal(
 
 		// This is a standard lock distribution flow that assumes that we have locks associated with the gauge.
 		denom := lockuptypes.NativeDenom(gauge.DistributeTo.Denom)
-		lockSum := lockuptypes.SumLocksByDenom(locks, denom)
+		lockSum := k.lk.GetPeriodLocksAccumulation(ctx, gauge.DistributeTo)
 
 		if lockSum.IsZero() {
 			return nil, nil


### PR DESCRIPTION
This PR speeds up the epoch by using the accumulation store to get the total amount locked, rather than summing over the amount in each lock directly.

We did not do this in the past, because the accumulation store had errors due to a state migration early in osmosis history deleting them. These have all since been fixed.

This has been tested for state compatibility on v20 through syncing through a few epochs. Will continue running it so that it syncs through all blocks prior to hitting merge.

This PR trades off summing over N locks already in memory, with many heap allocations, to instead doing `log(num lock durations)` new DB reads.