### PR TITLE
fix(x/gamm): remove duplicate `query gamm pool` subcommand

### DIFF
--- a/x/gamm/client/cli/query.go
+++ b/x/gamm/client/cli/query.go
@@ -23,7 +23,6 @@ import (
 // GetQueryCmd returns the cli query commands for this module.
 func GetQueryCmd() *cobra.Command {
 	cmd := osmocli.QueryIndexCmd(types.ModuleName)
-	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdPool)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdSpotPrice)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdPool)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdPools)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This pr fixed the duplicate subcommand `osmosisd query gamm pool`


![image](https://github.com/osmosis-labs/osmosis/assets/150114626/61862f33-03fb-4677-a4ff-63f44f98be1d)


## Testing and Verifying

This change is already covered by existing tests, such as *TestQueryTestSuite*.