### PR TITLE
refactor: using coins.Denoms() from sdk instead of osmoutils

### DIFF
--- a/ingest/sqs/router/usecase/pools/routable_transmuter_pool.go
+++ b/ingest/sqs/router/usecase/pools/routable_transmuter_pool.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v21/ingest/sqs/domain"
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v21/x/cosmwasmpool/model"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v21/x/poolmanager/types"
@@ -30,7 +29,7 @@ func (r *routableTransmuterPoolImpl) GetId() uint64 {
 
 // GetPoolDenoms implements domain.RoutablePool.
 func (r *routableTransmuterPoolImpl) GetPoolDenoms() []string {
-	return osmoutils.CoinsDenoms(r.Balances)
+	return r.Balances.Denoms()
 }
 
 // GetType implements domain.RoutablePool.

--- a/osmoutils/coin_helper.go
+++ b/osmoutils/coin_helper.go
@@ -7,15 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// TODO: Get this into the SDK https://github.com/cosmos/cosmos-sdk/issues/12538
-func CoinsDenoms(coins sdk.Coins) []string {
-	denoms := make([]string, len(coins))
-	for i, coin := range coins {
-		denoms[i] = coin.Denom
-	}
-	return denoms
-}
-
 // MinCoins returns the minimum of each denom between both coins.
 // For now it assumes they have the same denoms.
 // TODO: Replace with method in SDK once we update our version

--- a/x/cosmwasmpool/model/pool.go
+++ b/x/cosmwasmpool/model/pool.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v21/x/cosmwasmpool/cosmwasm/msg"
 	"github.com/osmosis-labs/osmosis/v21/x/cosmwasmpool/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v21/x/poolmanager/types"
@@ -141,7 +140,7 @@ func (p *Pool) SetWasmKeeper(wasmKeeper types.WasmKeeper) {
 // GetPoolDenoms implements types.PoolI.
 func (p *Pool) GetPoolDenoms(ctx sdk.Context) []string {
 	poolLiquidity := p.GetTotalPoolLiquidity(ctx)
-	return osmoutils.CoinsDenoms(poolLiquidity)
+	return poolLiquidity.Denoms()
 }
 
 func (p Pool) AsSerializablePool() poolmanagertypes.PoolI {

--- a/x/gamm/keeper/pool.go
+++ b/x/gamm/keeper/pool.go
@@ -241,8 +241,7 @@ func (k Keeper) GetPoolDenoms(ctx sdk.Context, poolId uint64) ([]string, error) 
 		return nil, err
 	}
 
-	denoms := osmoutils.CoinsDenoms(pool.GetTotalPoolLiquidity(ctx))
-	return denoms, err
+	return pool.GetTotalPoolLiquidity(ctx).Denoms(), err
 }
 
 // setNextPoolId sets next pool Id.

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -11,7 +11,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v21/x/gamm/pool-models/internal/cfmm_common"
 	"github.com/osmosis-labs/osmosis/v21/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v21/x/poolmanager/types"
@@ -987,5 +986,5 @@ func (p *Pool) AsSerializablePool() poolmanagertypes.PoolI {
 // GetPoolDenoms implements types.CFMMPoolI.
 func (p *Pool) GetPoolDenoms(ctx sdk.Context) []string {
 	liquidity := p.GetTotalPoolLiquidity(ctx)
-	return osmoutils.CoinsDenoms(liquidity)
+	return liquidity.Denoms()
 }

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -10,7 +10,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v21/x/gamm/pool-models/internal/cfmm_common"
 	"github.com/osmosis-labs/osmosis/v21/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v21/x/poolmanager/types"
@@ -497,5 +496,5 @@ func (p *Pool) AsSerializablePool() poolmanagertypes.PoolI {
 // GetPoolDenoms implements types.CFMMPoolI.
 func (p *Pool) GetPoolDenoms(ctx sdk.Context) []string {
 	liquidity := p.GetTotalPoolLiquidity(ctx)
-	return osmoutils.CoinsDenoms(liquidity)
+	return liquidity.Denoms()
 }

--- a/x/gamm/simulation/sim_msgs.go
+++ b/x/gamm/simulation/sim_msgs.go
@@ -27,7 +27,7 @@ func RandomJoinPoolMsg(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context) (
 	if err != nil {
 		return nil, err
 	}
-	poolDenoms := osmoutils.CoinsDenoms(pool.GetTotalPoolLiquidity(ctx))
+	poolDenoms := pool.GetTotalPoolLiquidity(ctx).Denoms()
 
 	// get address that has all denoms from the randomly selected pool
 	sender, tokenIn, senderExists := sim.SelAddrWithDenoms(ctx, poolDenoms)

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v21/x/twap"
 	"github.com/osmosis-labs/osmosis/v21/x/twap/types"
 
@@ -58,7 +57,7 @@ func (s *TestSuite) TestAfterPoolCreatedHook() {
 					s.RunBasicSwap(poolId)
 				}
 
-				denoms := osmoutils.CoinsDenoms(tc.poolCoins)
+				denoms := tc.poolCoins.Denoms()
 				denomPairs := types.GetAllUniqueDenomPairs(denoms)
 				expectedRecords := []types.TwapRecord{}
 				for _, denomPair := range denomPairs {

--- a/x/twap/logic_test.go
+++ b/x/twap/logic_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 	gammtypes "github.com/osmosis-labs/osmosis/v21/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v21/x/poolmanager/types"
@@ -1323,7 +1322,7 @@ func (s *TestSuite) TestAfterCreatePool() {
 			s.Require().Equal(tc.poolId, poolId)
 			s.Require().NoError(err)
 
-			denoms := osmoutils.CoinsDenoms(tc.poolCoins)
+			denoms := tc.poolCoins.Denoms()
 			denomPairs := types.GetAllUniqueDenomPairs(denoms)
 			expectedRecords := []types.TwapRecord{}
 			for _, denomPair := range denomPairs {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Complete TODO of `CoinsDenoms`. I have replaced all reference using with `coins.Denoms()`

```go
// TODO: Get this into the SDK https://github.com/cosmos/cosmos-sdk/issues/12538
func CoinsDenoms(coins sdk.Coins) []string {
	denoms := make([]string, len(coins))
	for i, coin := range coins {
		denoms[i] = coin.Denom
	}
	return denoms
}
```