### PR TITLE
More stableswap mutative operations

### DIFF
--- a/osmomath/binary_search.go
+++ b/osmomath/binary_search.go
@@ -279,7 +279,8 @@ func BinarySearchBigDec(f func(BigDec) BigDec,
 
 	curIteration := 0
 	for ; curIteration < maxIterations; curIteration += 1 {
-		curEstimate = lowerbound.Add(upperbound).Quo(NewBigDec(2))
+		// TODO: Try replacing this with RSH
+		curEstimate = lowerbound.Add(upperbound).QuoRaw(2)
 		curOutput = f(curEstimate)
 
 		// fmt.Println("binary search, input, target output, cur output", curEstimate, targetOutput, curOutput)

--- a/x/gamm/pool-models/stableswap/amm.go
+++ b/x/gamm/pool-models/stableswap/amm.go
@@ -72,8 +72,8 @@ func iterKCalculator(x0, w, yf osmomath.BigDec) func(osmomath.BigDec) osmomath.B
 		// horners method
 		// ax^3 + bx^2 + cx = x(c + x(b + ax))
 		res := cubicCoeff.Mul(xOut)
-		res = res.Add(quadraticCoeff).Mul(xOut)
-		res = res.Add(linearCoeff).Mul(xOut)
+		res = res.AddMut(quadraticCoeff).MulMut(xOut)
+		res = res.AddMut(linearCoeff).MulMut(xOut)
 		return res
 	}
 }


### PR DESCRIPTION
Make more components of the stableswap math faster / less heap intensive. 

Pretty low magnitude win right now. (At best 5 seconds in a 20000 block sync, likely lower)