### PR TITLE
Stop double emitting events for CacheCtx.Write()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### API
 
 * [#6991](https://github.com/osmosis-labs/osmosis/pull/6991) Fix: total liquidity poolmanager grpc gateway query
+* [#7149](https://github.com/osmosis-labs/osmosis/pull/7149) Fix double emitting CacheCtx events (e.g. Epoch, Superfluid, CL)
 
 ### Features
 * [#6804](https://github.com/osmosis-labs/osmosis/pull/6993) feat(math): add mutative api for BigDec.BigInt()

--- a/osmoutils/cache_ctx.go
+++ b/osmoutils/cache_ctx.go
@@ -38,7 +38,6 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	} else {
 		// no error, write the output of f
 		write()
-		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	}
 	return err
 }


### PR DESCRIPTION
As of SDK unfork, we are double emitting events in CacheCtx.Write() for ApplyFuncIfNoError(). We fixed that the SDK didn't write these events in SDK v0.45. (We couldn't do it in the SDK, as that behavior would interfere with IBC. We tried!)

So we now remove our workaround here.

This is state compatible as it only affects events. 