### PR TITLE
Update mempool 1559 params

### DIFF
--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -17,12 +17,12 @@ import (
 
 	 This logic does two things:
    - Maintaining data parsed from chain transaction execution and updating eipState accordingly.
-   - Resetting eipState to default every ResetInterval (1000) block height intervals to maintain consistency.
+   - Resetting eipState to default every ResetInterval (3000) block height intervals to maintain consistency.
 
    Additionally:
    - Periodically evaluating CheckTx and RecheckTx for compliance with these parameters.
 
-   Note: The reset interval is set to 2000 blocks, which is approximately 4 hours. Consider adjusting for a smaller time interval (e.g., 500 blocks = 1 hour) if necessary.
+   Note: The reset interval is set to 3000 blocks, which is approximately 6 hours. Consider adjusting for a smaller time interval (e.g., 500 blocks = 1 hour) if necessary.
 
    Challenges:
    - Transactions falling under their gas bounds are currently discarded by nodes. This behavior can be modified for CheckTx, rather than RecheckTx.
@@ -30,30 +30,33 @@ import (
    Global variables stored in memory:
    - DefaultBaseFee: Default base fee, initialized to 0.01.
    - MinBaseFee: Minimum base fee, initialized to 0.0025.
-   - MaxBaseFee: Maximum base fee, initialized to 10.
+   - MaxBaseFee: Maximum base fee, initialized to 5.
    - MaxBlockChangeRate: The maximum block change rate, initialized to 1/10.
 
    Global constants:
-   - TargetGas: Gas wanted per block, initialized to 70,000,000.
-   - ResetInterval: The interval at which eipState is reset, initialized to 1000 blocks.
+   - TargetGas: Gas wanted per block, initialized to 75,000,000.
+   - ResetInterval: The interval at which eipState is reset, initialized to 3000 blocks.
    - BackupFile: File for backup, set to "eip1559state.json".
-   - RecheckFeeConstant: A constant value for rechecking fees, initialized to 4.
+   - RecheckFeeConstant: A constant value for rechecking fees, initialized to 3.3.
 */
 
 var (
 	DefaultBaseFee = sdk.MustNewDecFromStr("0.01")
 	MinBaseFee     = sdk.MustNewDecFromStr("0.0025")
-	MaxBaseFee     = sdk.MustNewDecFromStr("10")
+	MaxBaseFee     = sdk.MustNewDecFromStr("5")
 
-	// Max increase per block is a factor of 15/14, max decrease is 9/10
+	// Max increase per block is a factor of 1.06, max decrease is 9/10
+	// If recovering at ~30M gas per block, decrease is .94
 	MaxBlockChangeRate = sdk.NewDec(1).Quo(sdk.NewDec(10))
-	TargetGas          = int64(70_000_000)
+	TargetGas          = int64(75_000_000)
 	// In face of continuous spam, will take ~21 blocks from base fee > spam cost, to mempool eviction
-	// ceil(log_{15/14}(RecheckFee mnConstant))
+	// ceil(log_{1.06}(RecheckFeeConstant))
 	// So potentially 2 minutes of impaired UX from 1559 nodes on top of time to get to base fee > spam.
-	RecheckFeeConstant = int64(4)
-	ResetInterval      = int64(2000)
+	RecheckFeeConstant = "3.3"
+	ResetInterval      = int64(3000)
 )
+
+var RecheckFeeDec = sdk.MustNewDecFromStr(RecheckFeeConstant)
 
 const (
 	BackupFilename = "eip1559state.json"
@@ -151,7 +154,7 @@ func (e *EipState) GetCurBaseFee() osmomath.Dec {
 // GetCurRecheckBaseFee returns a clone of the CurBaseFee / RecheckFeeConstant to account for
 // rechecked transactions in the feedecorator ante handler
 func (e *EipState) GetCurRecheckBaseFee() osmomath.Dec {
-	return e.CurBaseFee.Clone().Quo(sdk.NewDec(RecheckFeeConstant))
+	return e.CurBaseFee.Clone().Quo(RecheckFeeDec)
 }
 
 var rwMtx = sync.Mutex{}

--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -49,10 +49,10 @@ var (
 	// If recovering at ~30M gas per block, decrease is .94
 	MaxBlockChangeRate = sdk.NewDec(1).Quo(sdk.NewDec(10))
 	TargetGas          = int64(75_000_000)
-	// In face of continuous spam, will take ~21 blocks from base fee > spam cost, to mempool eviction
+	// In face of continuous spam, will take ~19 blocks from base fee > spam cost, to mempool eviction
 	// ceil(log_{1.06}(RecheckFeeConstant))
-	// So potentially 2 minutes of impaired UX from 1559 nodes on top of time to get to base fee > spam.
-	RecheckFeeConstant = "3.3"
+	// So potentially 1.8 minutes of impaired UX from 1559 nodes on top of time to get to base fee > spam.
+	RecheckFeeConstant = "3.0"
 	ResetInterval      = int64(3000)
 )
 


### PR DESCRIPTION
This PR updates mempool 1559 params to update a little slower. Its reasoned about, due to low gas usage txs on mainnet being observed to be around 30M gas, so were not lowering fast enough, and were spiking too fast.

As a comparable ETH block time (15s) is 2.5x slower than us, and they update at a maximum +- of 12.5%. Under spam we are currently updating at `(1 + (50/70)/10)**2.5 = 18.8%` upwards. We currently update at 0% usage for 15 seconds at -23%. However we do not see 0% usage, we instead see usage around 20-40M, so lets say 30M. That puts us at `(1 + (-40/70)/10)**2.5 = -13.7%` . 

So we see this asymmetrical upwards increase in our real settings. Lets assume that 30M is userflow/relayers, who are getting inputted Keplr's much higher gas numbers.

I suggest changing this target block gas param to 75M, which would then change 
- max update per block to: 6%
- max update over 15 seconds to: 15.6%
- max decrease per block (unchanged)
- expected decrease per block (30M): -14.4%

However, the spam / old txs are at a lower fee. They only gets evicted once base fee exceeds recheck_factor * spam_fee_rate. Currently this is set at 4 for high conservatism, especially around clients who haven't patched. Almost all clients in the ecosystem have patched, so we can reduce this. Also clients have standardized around using a fee much higher than base fee.

This PR changes it `3`. `3.3` gives the same guarantee to clients under max load with the above changes. (Follow the `log` line in the doc). 

The change to `3` will make max gas usage take 19 blocks to evict instead of 21. I believe we can get away with far lower to be honest, due to wallets over-estimating fee right now.

The effects of this are:
- I believe the recheck factor is what controls the height of the peaks. This reduction from 4->3, should cause a 25% reduction I hope, and probably better.
- Lowering the max rate of change will smoothen out the curves, and lower "edge effects" causing higher tops than we need.
- Raising target gas will help improve recovery time once we've past the over-filling point. 
- We may see periods of high block gas due to spam take a few more seconds to clear out