### PR TITLE
Speedup SumLocksByDenom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Misc Improvements
 * [#7106](https://github.com/osmosis-labs/osmosis/pull/7106) Halve the time of log2 calculation (speeds up TWAP code)
-* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100) Lower CPU overheads of the Osmosis epoch.
+* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100),[#7172](https://github.com/osmosis-labs/osmosis/pull/7093) Lower CPU overheads of the Osmosis epoch.
 
 ## v21.0.0
 

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
@@ -64,17 +65,16 @@ func (p PeriodLock) SingleCoin() (sdk.Coin, error) {
 
 // TODO: Can we use sumtree instead here?
 func SumLocksByDenom(locks []PeriodLock, denom string) osmomath.Int {
-	sum := osmomath.NewInt(0)
+	sumBi := big.NewInt(0)
 	// validate the denom once, so we can avoid the expensive validate check in the hot loop.
 	err := sdk.ValidateDenom(denom)
 	if err != nil {
 		panic(fmt.Errorf("invalid denom used internally: %s, %v", denom, err))
 	}
 	for _, lock := range locks {
-		// TODO: Replace with Mutative Int Operations
-		sum = sum.Add(lock.Coins.AmountOfNoDenomValidation(denom))
+		sumBi.Add(sumBi, lock.Coins.AmountOfNoDenomValidation(denom).BigIntMut())
 	}
-	return sum
+	return osmomath.NewIntFromBigInt(sumBi)
 }
 
 // quick fix for getting native denom from synthetic denom.


### PR DESCRIPTION
State compatible speedups to SumLocksByDenom code.

I expect this to reduce epoch CPU time by 4 seconds. (maybe a bit more with garbage collector reductions)

This entire for loop should later get eliminated with #7119, but that can come later / after being more certain around state compat.