### PR TITLE
refactor: auto-set timeout-commit to 4s for faster block times

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,18 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch file",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "cmd/osmosisd/main.go",
+            "args": [
+                "init",
+                "test",
+            ],
+        },
+        
+        {
             // Note: Osmosisd must already be running
             // Binary must be built with debug flags.
             // See CONTRIBUTING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Config
 
-* [#7180](https://github.com/osmosis-labs/osmosis/pull/7180) Change `consensus.timeout-commit` from 5s to 4s. Overwrites the existing value on start-up. Default is set to 4s.
+* [#7180](https://github.com/osmosis-labs/osmosis/pull/7180) Change `consensus.timeout-commit` from 5s to 4s in `config.toml`. Overwrites the existing value on start-up. Default is set to 4s.
 
 ### API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Config
+
+* [#7180](https://github.com/osmosis-labs/osmosis/pull/7180) Change `consensus.timeout-commit` from 5s to 4s. Overwrites the existing value on start-up. Default is set to 4s.
+
 ### API
 
 * [#6991](https://github.com/osmosis-labs/osmosis/pull/6991) Fix: total liquidity poolmanager grpc gateway query

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -108,6 +108,10 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.Mempool.Size = 10000
 			config.StateSync.TrustPeriod = 112 * time.Hour
 
+			// The original default is 5s and is set in Cosmos SDK.
+			// We lower it to 4s for faster block times.
+			config.Consensus.TimeoutCommit = 4 * time.Second
+
 			config.SetRoot(clientCtx.HomeDir)
 
 			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	rosettaCmd "cosmossdk.io/tools/rosetta/cmd"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
@@ -58,8 +60,6 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
 	"github.com/joho/godotenv"
-
-	"github.com/cosmos/cosmos-sdk/client/config"
 
 	osmosis "github.com/osmosis-labs/osmosis/v21/app"
 )
@@ -301,6 +301,22 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 				return err
 			}
 
+			serverCtx := server.GetServerContextFromCmd(cmd)
+
+			// configure the viper instance to parse home flags
+			if err := serverCtx.Viper.BindPFlags(cmd.Flags()); err != nil {
+				return err
+			}
+			if err := serverCtx.Viper.BindPFlags(cmd.PersistentFlags()); err != nil {
+				return err
+			}
+
+			// overwrite config.toml values
+			cometConfig, err := overwriteConfigTomlValues(serverCtx)
+			if err != nil {
+				return err
+			}
+
 			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
 			if err != nil {
 				return err
@@ -389,7 +405,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 					}
 				})
 			}
-			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmcfg.DefaultConfig())
+			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, cometConfig)
 		},
 		SilenceUsage: true,
 	}
@@ -399,6 +415,52 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	initRootCmd(rootCmd, encodingConfig)
 
 	return rootCmd, encodingConfig
+}
+
+// overwrites config.toml values if it exists, otherwise it writes the default config.toml
+func overwriteConfigTomlValues(serverCtx *server.Context) (*tmcfg.Config, error) {
+	// Get paths to config.toml and config parent directory
+	rootDir := serverCtx.Viper.GetString(flags.FlagHome)
+	configParentDirPath := filepath.Join(rootDir, "config")
+	configFilePath := filepath.Join(configParentDirPath, "config.toml")
+
+	// Initialize default config
+	tmcConfig := tmcfg.DefaultConfig()
+
+	_, err := os.Stat(configFilePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read in %s: %w", configFilePath, err)
+		}
+
+		// If does not exist, write default config.toml to update
+
+		// We modify the default config.toml to have faster block times
+		// It will be written by server.InterceptConfigsPreRunHandler
+		tmcConfig.Consensus.TimeoutCommit = 4 * time.Second
+	} else {
+		// config.toml exists
+
+		serverCtx.Viper.SetConfigType("toml")
+		serverCtx.Viper.SetConfigName("config")
+		serverCtx.Viper.AddConfigPath(configParentDirPath)
+
+		// We read it in and modify the consensus timeout commit
+		// and write it back.
+		if err := serverCtx.Viper.ReadInConfig(); err != nil {
+			return nil, fmt.Errorf("failed to read in %s: %w", configFilePath, err)
+		}
+
+		// The original default is 5s and is set in Cosmos SDK.
+		// We lower it to 4s for faster block times.
+		serverCtx.Config.Consensus.TimeoutCommit = 4 * time.Second
+
+		// It will be re-read in server.InterceptConfigsPreRunHandler
+		tmcfg.WriteConfigFile(configFilePath, serverCtx.Config)
+
+		tmcConfig = serverCtx.Config
+	}
+	return tmcConfig, nil
 }
 
 func getHomeEnvironment() string {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Faster block times are desired. As a result, we lower the commit timeout from 5s to 4s.

Additionally, we overwrite the existing config.toml values when the binary is used.

While working on this, found unrelated bug during `osmosisd init`: https://github.com/osmosis-labs/osmosis/issues/7179

## Testing and Verifying

Tested:
`osmosisd init test`
`osmosisd start`
`osmosisd init test --home=custom`
`osmosisd start test --home=custom`

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A