### PR TITLE
Reduce sprintf overhead in code showing up during sync profiles

### DIFF
--- a/x/poolmanager/types/keys.go
+++ b/x/poolmanager/types/keys.go
@@ -45,8 +45,8 @@ var (
 // ModuleRouteToBytes serializes moduleRoute to bytes.
 func FormatModuleRouteKey(poolId uint64) []byte {
 	// Estimate the length of the string representation of poolId
-	// 7 is a safe upper bound, (9999999) pools, and is an 8 byte allocation (not bad)
-	length := 7
+	// 11 is a very safe upper bound, (99,999,999,999) pools, and is a 12 byte allocation
+	length := 11
 	result := make([]byte, 1, 1+length)
 	result[0] = SwapModuleRouterPrefix[0]
 	// Write poolId into the byte slice starting after the prefix

--- a/x/poolmanager/types/keys.go
+++ b/x/poolmanager/types/keys.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -43,7 +44,16 @@ var (
 
 // ModuleRouteToBytes serializes moduleRoute to bytes.
 func FormatModuleRouteKey(poolId uint64) []byte {
-	return []byte(fmt.Sprintf("%s%d", SwapModuleRouterPrefix, poolId))
+	// Estimate the length of the string representation of poolId
+	// 7 is a safe upper bound, (9999999) pools, and is an 8 byte allocation (not bad)
+	length := 7
+	result := make([]byte, 1, 1+length)
+	result[0] = SwapModuleRouterPrefix[0]
+	// Write poolId into the byte slice starting after the prefix
+	written := strconv.AppendUint(result[1:], poolId, 10)
+
+	// Slice result to the actual length used
+	return result[:1+len(written)]
 }
 
 // FormatDenomTradePairKey serializes denom trade pair to bytes.

--- a/x/poolmanager/types/keys_test.go
+++ b/x/poolmanager/types/keys_test.go
@@ -63,3 +63,24 @@ func TestParseDenomTradePairKey(t *testing.T) {
 		t.Errorf("Expected error, got nil")
 	}
 }
+
+func TestFormatModuleRouteKey(t *testing.T) {
+	cases := []struct {
+		id                 uint64
+		expectedSansPrefix string
+	}{0: {id: 0, expectedSansPrefix: "0"},
+		1: {id: 1, expectedSansPrefix: "1"},
+		2: {id: 12, expectedSansPrefix: "12"},
+		3: {id: 122, expectedSansPrefix: "122"},
+		4: {id: 4522, expectedSansPrefix: "4522"},
+		5: {id: 54522, expectedSansPrefix: "54522"},
+		6: {id: 654522, expectedSansPrefix: "654522"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("id=%d", tc.id), func(t *testing.T) {
+			key := types.FormatModuleRouteKey(tc.id)
+			require.Equal(t, types.SwapModuleRouterPrefix[0], key[0])
+			require.Equal(t, tc.expectedSansPrefix, string(key[1:]))
+		})
+	}
+}

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	time "time"
@@ -58,13 +59,17 @@ func FormatMostRecentTWAPKey(poolId uint64, denom1, denom2 string) []byte {
 
 // TODO: Replace historical management with ORM, we currently accept 2x write amplification right now.
 func FormatHistoricalTimeIndexTWAPKey(accumulatorWriteTime time.Time, poolId uint64, denom1, denom2 string) []byte {
+	var buffer bytes.Buffer
 	timeS := osmoutils.FormatTimeString(accumulatorWriteTime)
-	return []byte(fmt.Sprintf("%s%s%s%d%s%s%s%s", HistoricalTWAPTimeIndexPrefix, timeS, KeySeparator, poolId, KeySeparator, denom1, KeySeparator, denom2))
+	fmt.Fprintf(&buffer, "%s%s%s%d%s%s%s%s", HistoricalTWAPTimeIndexPrefix, timeS, KeySeparator, poolId, KeySeparator, denom1, KeySeparator, denom2)
+	return buffer.Bytes()
 }
 
 func FormatHistoricalPoolIndexTWAPKey(poolId uint64, denom1, denom2 string, accumulatorWriteTime time.Time) []byte {
+	var buffer bytes.Buffer
 	timeS := osmoutils.FormatTimeString(accumulatorWriteTime)
-	return []byte(fmt.Sprintf("%s%d%s%s%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2, KeySeparator, timeS))
+	fmt.Fprintf(&buffer, "%s%d%s%s%s%s%s%s", HistoricalTWAPPoolIndexPrefix, poolId, KeySeparator, denom1, KeySeparator, denom2, KeySeparator, timeS)
+	return buffer.Bytes()
 }
 
 func FormatHistoricalPoolIndexTimePrefix(poolId uint64, denom1, denom2 string) []byte {


### PR DESCRIPTION
Reduce some sprintf overheads

This is a pretty micro-optimization. It likely has more impact for txs than epoch. In epoch it shaves like 100ms (there are way better things to shave time on there)