### PR TITLE
refactor: avoid copying overhead in PeriodLocks

### DIFF
--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -295,7 +295,7 @@ func (k Keeper) GetFinishedGauges(ctx sdk.Context) []types.Gauge {
 // GetRewardsEst returns rewards estimation at a future specific time (by epoch)
 // If locks are nil, it returns the rewards between now and the end epoch associated with address.
 // If locks are not nil, it returns all the rewards for the given locks between now and end epoch.
-func (k Keeper) GetRewardsEst(ctx sdk.Context, addr sdk.AccAddress, locks []lockuptypes.PeriodLock, endEpoch int64) sdk.Coins {
+func (k Keeper) GetRewardsEst(ctx sdk.Context, addr sdk.AccAddress, locks []*lockuptypes.PeriodLock, endEpoch int64) sdk.Coins {
 	// if locks are nil, populate with all locks associated with the address
 	if len(locks) == 0 {
 		locks = k.lk.GetAccountPeriodLocks(ctx, addr)

--- a/x/incentives/keeper/gauge_test.go
+++ b/x/incentives/keeper/gauge_test.go
@@ -157,7 +157,7 @@ func (s *KeeperTestSuite) TestGaugeOperations() {
 		s.Require().Equal(gaugeID, gaugeIdsByDenom[0])
 
 		// check rewards estimation
-		rewardsEst := s.App.IncentivesKeeper.GetRewardsEst(s.Ctx, lockOwners[0], []lockuptypes.PeriodLock{}, 100)
+		rewardsEst := s.App.IncentivesKeeper.GetRewardsEst(s.Ctx, lockOwners[0], []*lockuptypes.PeriodLock{}, 100)
 		s.Require().Equal(expectedCoinsPerLock.String(), rewardsEst.String())
 
 		// check gauges
@@ -251,7 +251,7 @@ func (s *KeeperTestSuite) TestGaugeOperations() {
 			// check invalid gauge ID
 			_, err = s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, gaugeID+1000)
 			s.Require().Error(err)
-			rewardsEst = s.App.IncentivesKeeper.GetRewardsEst(s.Ctx, lockOwners[0], []lockuptypes.PeriodLock{}, 100)
+			rewardsEst = s.App.IncentivesKeeper.GetRewardsEst(s.Ctx, lockOwners[0], []*lockuptypes.PeriodLock{}, 100)
 			s.Require().Equal(sdk.Coins{}, rewardsEst)
 
 			// check gauge ids by denom
@@ -263,7 +263,7 @@ func (s *KeeperTestSuite) TestGaugeOperations() {
 			s.Require().Len(gauges, 0)
 
 			// check rewards estimation
-			rewardsEst = s.App.IncentivesKeeper.GetRewardsEst(s.Ctx, lockOwners[0], []lockuptypes.PeriodLock{}, 100)
+			rewardsEst = s.App.IncentivesKeeper.GetRewardsEst(s.Ctx, lockOwners[0], []*lockuptypes.PeriodLock{}, 100)
 			s.Require().Equal(sdk.Coins{}, rewardsEst)
 
 			// check gauge ids by denom

--- a/x/incentives/keeper/grpc_query.go
+++ b/x/incentives/keeper/grpc_query.go
@@ -157,13 +157,13 @@ func (q Querier) RewardsEst(goCtx context.Context, req *types.RewardsEstRequest)
 		ownerAddress = owner
 	}
 
-	locks := make([]lockuptypes.PeriodLock, 0, len(req.LockIds))
+	locks := make([]*lockuptypes.PeriodLock, 0, len(req.LockIds))
 	for _, lockId := range req.LockIds {
 		lock, err := q.Keeper.lk.GetLockByID(ctx, lockId)
 		if err != nil {
 			return nil, err
 		}
-		locks = append(locks, *lock)
+		locks = append(locks, lock)
 	}
 
 	return &types.RewardsEstResponse{Coins: q.Keeper.GetRewardsEst(ctx, ownerAddress, locks, req.EndEpoch)}, nil

--- a/x/incentives/keeper/iterator.go
+++ b/x/incentives/keeper/iterator.go
@@ -63,8 +63,8 @@ func (k Keeper) FinishedGaugesIterator(ctx sdk.Context) sdk.Iterator {
 }
 
 // FilterLocksByMinDuration returns locks whose lock duration is greater than the provided minimum duration.
-func FilterLocksByMinDuration(locks []lockuptypes.PeriodLock, minDuration time.Duration) []lockuptypes.PeriodLock {
-	filteredLocks := make([]lockuptypes.PeriodLock, 0, len(locks))
+func FilterLocksByMinDuration(locks []*lockuptypes.PeriodLock, minDuration time.Duration) []*lockuptypes.PeriodLock {
+	filteredLocks := make([]*lockuptypes.PeriodLock, 0, len(locks))
 	for _, lock := range locks {
 		if lock.Duration >= minDuration {
 			filteredLocks = append(filteredLocks, lock)

--- a/x/incentives/types/expected_keepers.go
+++ b/x/incentives/types/expected_keepers.go
@@ -26,9 +26,9 @@ type BankKeeper interface {
 
 // LockupKeeper defines the expected interface needed to retrieve locks.
 type LockupKeeper interface {
-	GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []lockuptypes.PeriodLock
+	GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []*lockuptypes.PeriodLock
 	GetPeriodLocksAccumulation(ctx sdk.Context, query lockuptypes.QueryCondition) osmomath.Int
-	GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []lockuptypes.PeriodLock
+	GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []*lockuptypes.PeriodLock
 	GetLockByID(ctx sdk.Context, lockID uint64) (*lockuptypes.PeriodLock, error)
 }
 

--- a/x/lockup/keeper/export_test.go
+++ b/x/lockup/keeper/export_test.go
@@ -18,7 +18,7 @@ func (k Keeper) GetLockRefs(ctx sdk.Context, key []byte) []uint64 {
 	return k.getLockRefs(ctx, key)
 }
 
-func (k Keeper) GetCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
+func (k Keeper) GetCoinsFromLocks(locks []*types.PeriodLock) sdk.Coins {
 	return k.getCoinsFromLocks(locks)
 }
 

--- a/x/lockup/keeper/genesis.go
+++ b/x/lockup/keeper/genesis.go
@@ -25,10 +25,13 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 
 // ExportGenesis returns the capability module's exported genesis.
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
-	locks, err := k.GetPeriodLocks(ctx)
+	locksPtr, err := k.GetPeriodLocks(ctx)
 	if err != nil {
 		panic(err)
 	}
+
+	locks := types.ConvertPointersToLocks(locksPtr)
+
 	params := k.GetParams(ctx)
 	return &types.GenesisState{
 		LastLockId:     k.GetLastLockID(ctx),

--- a/x/lockup/keeper/grpc_query.go
+++ b/x/lockup/keeper/grpc_query.go
@@ -111,7 +111,10 @@ func (q Querier) AccountLockedPastTime(goCtx context.Context, req *types.Account
 		return nil, err
 	}
 
-	return &types.AccountLockedPastTimeResponse{Locks: q.Keeper.GetAccountLockedPastTime(ctx, owner, req.Timestamp)}, nil
+	locksPtr := q.Keeper.GetAccountLockedPastTime(ctx, owner, req.Timestamp)
+	locks := types.ConvertPointersToLocks(locksPtr)
+
+	return &types.AccountLockedPastTimeResponse{Locks: locks}, nil
 }
 
 // AccountUnlockedBeforeTime returns locks of an account of which unlock time is before the provided timestamp.
@@ -130,7 +133,14 @@ func (q Querier) AccountUnlockedBeforeTime(goCtx context.Context, req *types.Acc
 		return nil, err
 	}
 
-	return &types.AccountUnlockedBeforeTimeResponse{Locks: q.Keeper.GetAccountUnlockedBeforeTime(ctx, owner, req.Timestamp)}, nil
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountUnlockedBeforeTime(ctx, owner, req.Timestamp)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
+	return &types.AccountUnlockedBeforeTimeResponse{Locks: locks}, nil
 }
 
 // AccountLockedPastTimeDenom returns the locks of an account whose unlock time is beyond provided timestamp, limited to locks with
@@ -150,7 +160,14 @@ func (q Querier) AccountLockedPastTimeDenom(goCtx context.Context, req *types.Ac
 		return nil, err
 	}
 
-	return &types.AccountLockedPastTimeDenomResponse{Locks: q.Keeper.GetAccountLockedPastTimeDenom(ctx, owner, req.Denom, req.Timestamp)}, nil
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountLockedPastTimeDenom(ctx, owner, req.Denom, req.Timestamp)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
+	return &types.AccountLockedPastTimeDenomResponse{Locks: locks}, nil
 }
 
 // LockedByID returns lock by lock ID.
@@ -238,7 +255,13 @@ func (q Querier) AccountLockedLongerDuration(goCtx context.Context, req *types.A
 		return nil, err
 	}
 
-	locks := q.Keeper.GetAccountLockedLongerDuration(ctx, owner, req.Duration)
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountLockedLongerDuration(ctx, owner, req.Duration)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
 	return &types.AccountLockedLongerDurationResponse{Locks: locks}, nil
 }
 
@@ -258,7 +281,13 @@ func (q Querier) AccountLockedLongerDurationDenom(goCtx context.Context, req *ty
 		return nil, err
 	}
 
-	locks := q.Keeper.GetAccountLockedLongerDurationDenom(ctx, owner, req.Denom, req.Duration)
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountLockedLongerDurationDenom(ctx, owner, req.Denom, req.Duration)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
 	return &types.AccountLockedLongerDurationDenomResponse{Locks: locks}, nil
 }
 
@@ -278,7 +307,13 @@ func (q Querier) AccountLockedDuration(goCtx context.Context, req *types.Account
 		return nil, err
 	}
 
-	locks := q.Keeper.GetAccountLockedDuration(ctx, owner, req.Duration)
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountLockedDuration(ctx, owner, req.Duration)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
 	return &types.AccountLockedDurationResponse{Locks: locks}, nil
 }
 
@@ -299,7 +334,14 @@ func (q Querier) AccountLockedPastTimeNotUnlockingOnly(goCtx context.Context, re
 		return nil, err
 	}
 
-	return &types.AccountLockedPastTimeNotUnlockingOnlyResponse{Locks: q.Keeper.GetAccountLockedPastTimeNotUnlockingOnly(ctx, owner, req.Timestamp)}, nil
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountLockedPastTimeNotUnlockingOnly(ctx, owner, req.Timestamp)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
+	return &types.AccountLockedPastTimeNotUnlockingOnlyResponse{Locks: locks}, nil
 }
 
 // AccountLockedLongerDurationNotUnlockingOnly returns locks of an account with longer duration
@@ -319,7 +361,14 @@ func (q Querier) AccountLockedLongerDurationNotUnlockingOnly(goCtx context.Conte
 		return nil, err
 	}
 
-	return &types.AccountLockedLongerDurationNotUnlockingOnlyResponse{Locks: q.Keeper.GetAccountLockedLongerDurationNotUnlockingOnly(ctx, owner, req.Duration)}, nil
+	// TODO: find a better way to abstract this or break APIs.
+	locksPtr := q.Keeper.GetAccountLockedLongerDurationNotUnlockingOnly(ctx, owner, req.Duration)
+	locks := make([]types.PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+
+	return &types.AccountLockedLongerDurationNotUnlockingOnlyResponse{Locks: locks}, nil
 }
 
 // LockedDenom returns the total amount of denom locked throughout all locks.

--- a/x/lockup/keeper/iterator.go
+++ b/x/lockup/keeper/iterator.go
@@ -179,8 +179,8 @@ func (k Keeper) AccountLockIteratorDurationDenom(ctx sdk.Context, isUnlocking bo
 }
 
 // getLocksFromIterator returns an array of single lock unit by period defined by the x/lockup module.
-func (k Keeper) getLocksFromIterator(ctx sdk.Context, iterator db.Iterator) []types.PeriodLock {
-	locks := []types.PeriodLock{}
+func (k Keeper) getLocksFromIterator(ctx sdk.Context, iterator db.Iterator) []*types.PeriodLock {
+	locks := []*types.PeriodLock{}
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		lockID := sdk.BigEndianToUint64(iterator.Value())
@@ -188,13 +188,13 @@ func (k Keeper) getLocksFromIterator(ctx sdk.Context, iterator db.Iterator) []ty
 		if err != nil {
 			panic(err)
 		}
-		locks = append(locks, *lock)
+		locks = append(locks, lock)
 	}
 	return locks
 }
 
 // unlockFromIterator gets locks from the iterator, then unlocks all matured locks. Returns locks unlocked and sum of coins unlocked.
-func (k Keeper) unlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]types.PeriodLock, sdk.Coins) {
+func (k Keeper) unlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]*types.PeriodLock, sdk.Coins) {
 	// Note: this function is only used for an account
 	// and this has no conflicts with synthetic lockups
 
@@ -212,7 +212,7 @@ func (k Keeper) unlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]typ
 }
 
 // beginUnlockFromIterator starts unlocking coins from NotUnlocking queue.
-func (k Keeper) beginUnlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]types.PeriodLock, error) {
+func (k Keeper) beginUnlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]*types.PeriodLock, error) {
 	// Note: this function is only used for an account
 	// and this has no conflicts with synthetic lockups
 

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -47,7 +47,7 @@ func (k Keeper) GetPeriodLocksAccumulation(ctx sdk.Context, query types.QueryCon
 }
 
 // BeginUnlockAllNotUnlockings begins unlock for all not unlocking locks of the given account.
-func (k Keeper) BeginUnlockAllNotUnlockings(ctx sdk.Context, account sdk.AccAddress) ([]types.PeriodLock, error) {
+func (k Keeper) BeginUnlockAllNotUnlockings(ctx sdk.Context, account sdk.AccAddress) ([]*types.PeriodLock, error) {
 	locks, err := k.beginUnlockFromIterator(ctx, k.AccountLockIterator(ctx, false, account))
 	return locks, err
 }
@@ -897,7 +897,7 @@ func (k Keeper) SplitLock(ctx sdk.Context, lock types.PeriodLock, coins sdk.Coin
 	return splitLock, err
 }
 
-func (k Keeper) getCoinsFromLocks(locks []types.PeriodLock) sdk.Coins {
+func (k Keeper) getCoinsFromLocks(locks []*types.PeriodLock) sdk.Coins {
 	coins := sdk.Coins{}
 	for _, lock := range locks {
 		coins = coins.Add(lock.Coins...)

--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -270,11 +270,11 @@ func (s *KeeperTestSuite) TestUnlock() {
 			s.Require().Equal(len(actualUnlockingCoins), 1)
 			s.Require().Equal(expectedUnlockingCoins[0].Amount, actualUnlockingCoins[0].Amount)
 
-			lock = lockupKeeper.GetAccountPeriodLocks(ctx, addr1)[0]
+			lock = *lockupKeeper.GetAccountPeriodLocks(ctx, addr1)[0]
 
 			// if it is partial unlocking, get the new partial lock id
 			if partialUnlocking {
-				lock = lockupKeeper.GetAccountPeriodLocks(ctx, addr1)[1]
+				lock = *lockupKeeper.GetAccountPeriodLocks(ctx, addr1)[1]
 			}
 
 			// check lock state

--- a/x/lockup/keeper/migration.go
+++ b/x/lockup/keeper/migration.go
@@ -52,7 +52,7 @@ func MergeLockupsForSimilarDurations(
 		// We make at most one lock per (addr, denom, base duration) triplet, which we keep adding coins to.
 		// We call this the new "normalized lock", and the value in the map is the new lock ID.
 		normals := make(map[string]uint64)
-		locksToNormalize := []types.PeriodLock{}
+		locksToNormalize := []*types.PeriodLock{}
 		for _, lock := range k.GetAccountPeriodLocks(ctx, addr) {
 			// ignore multilocks
 			if len(lock.Coins) > 1 {
@@ -129,7 +129,7 @@ func MergeLockupsForSimilarDurations(
 			}
 
 			k.deleteLock(ctx, lock.ID)
-			err = k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, lock)
+			err = k.deleteLockRefs(ctx, types.KeyPrefixNotUnlocking, *lock)
 			if err != nil {
 				panic(err)
 			}

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -127,7 +127,7 @@ func (server msgServer) BeginUnlockingAll(goCtx context.Context, msg *types.MsgB
 	}
 	for _, lock := range unlocks {
 		lock := lock
-		events = events.AppendEvent(createBeginUnlockEvent(&lock))
+		events = events.AppendEvent(createBeginUnlockEvent(lock))
 	}
 	ctx.EventManager().EmitEvents(events)
 

--- a/x/lockup/keeper/store.go
+++ b/x/lockup/keeper/store.go
@@ -120,7 +120,7 @@ func (k Keeper) GetAccountLockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.
 }
 
 // GetAccountLockedPastTime Returns the total locks of an account whose unlock time is beyond timestamp.
-func (k Keeper) GetAccountLockedPastTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
+func (k Keeper) GetAccountLockedPastTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []*types.PeriodLock {
 	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
 	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTime(ctx, addr, timestamp))
 	duration := time.Duration(0)
@@ -132,7 +132,7 @@ func (k Keeper) GetAccountLockedPastTime(ctx sdk.Context, addr sdk.AccAddress, t
 }
 
 // GetAccountLockedPastTimeNotUnlockingOnly Returns the total locks of an account whose unlock time is beyond timestamp.
-func (k Keeper) GetAccountLockedPastTimeNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
+func (k Keeper) GetAccountLockedPastTimeNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []*types.PeriodLock {
 	duration := time.Duration(0)
 	if timestamp.After(ctx.BlockTime()) {
 		duration = timestamp.Sub(ctx.BlockTime())
@@ -141,7 +141,7 @@ func (k Keeper) GetAccountLockedPastTimeNotUnlockingOnly(ctx sdk.Context, addr s
 }
 
 // GetAccountUnlockedBeforeTime Returns the total unlocks of an account whose unlock time is before timestamp.
-func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []types.PeriodLock {
+func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddress, timestamp time.Time) []*types.PeriodLock {
 	// unlockings finish before specific time + not started locks that can finish before the time if start now
 	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorBeforeTime(ctx, addr, timestamp))
 	if timestamp.Before(ctx.BlockTime()) {
@@ -153,7 +153,7 @@ func (k Keeper) GetAccountUnlockedBeforeTime(ctx sdk.Context, addr sdk.AccAddres
 }
 
 // GetAccountLockedPastTimeDenom is equal to GetAccountLockedPastTime but denom specific.
-func (k Keeper) GetAccountLockedPastTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, timestamp time.Time) []types.PeriodLock {
+func (k Keeper) GetAccountLockedPastTimeDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, timestamp time.Time) []*types.PeriodLock {
 	// unlockings finish after specific time + not started locks that will finish after the time even though it start now
 	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorAfterTimeDenom(ctx, addr, denom, timestamp))
 	duration := time.Duration(0)
@@ -165,12 +165,12 @@ func (k Keeper) GetAccountLockedPastTimeDenom(ctx sdk.Context, addr sdk.AccAddre
 }
 
 // GetAccountLockedDurationNotUnlockingOnly Returns account locked with specific duration within not unlockings.
-func (k Keeper) GetAccountLockedDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetAccountLockedDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []*types.PeriodLock {
 	return k.getLocksFromIterator(ctx, k.AccountLockIteratorDurationDenom(ctx, false, addr, denom, duration))
 }
 
 // GetAccountLockedLongerDuration Returns account locked with duration longer than specified.
-func (k Keeper) GetAccountLockedLongerDuration(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetAccountLockedLongerDuration(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []*types.PeriodLock {
 	// it does not matter started unlocking or not for duration query
 	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, true, addr, duration))
 	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
@@ -178,7 +178,7 @@ func (k Keeper) GetAccountLockedLongerDuration(ctx sdk.Context, addr sdk.AccAddr
 }
 
 // GetAccountLockedDuration returns locks with a specific duration for a given account.
-func (k Keeper) GetAccountLockedDuration(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetAccountLockedDuration(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []*types.PeriodLock {
 	// it does not matter started unlocking or not for duration query
 	unlockedLocks := k.getLocksFromIterator(ctx, k.AccountLockIteratorDuration(ctx, true, addr, duration))
 	lockedLocks := k.getLocksFromIterator(ctx, k.AccountLockIteratorDuration(ctx, false, addr, duration))
@@ -186,12 +186,12 @@ func (k Keeper) GetAccountLockedDuration(ctx sdk.Context, addr sdk.AccAddress, d
 }
 
 // GetAccountLockedLongerDurationNotUnlockingOnly Returns account locked with duration longer than specified
-func (k Keeper) GetAccountLockedLongerDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetAccountLockedLongerDurationNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, duration time.Duration) []*types.PeriodLock {
 	return k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDuration(ctx, false, addr, duration))
 }
 
 // GetAccountLockedLongerDurationDenom Returns account locked with duration longer than specified with specific denom.
-func (k Keeper) GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []*types.PeriodLock {
 	// it does not matter started unlocking or not for duration query
 	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, true, addr, denom, duration))
 	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, false, addr, denom, duration))
@@ -199,12 +199,12 @@ func (k Keeper) GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.Ac
 }
 
 // GetAccountLockedLongerDurationDenom Returns account locked with duration longer than specified with specific denom.
-func (k Keeper) GetAccountLockedLongerDurationDenomNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetAccountLockedLongerDurationDenomNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []*types.PeriodLock {
 	return k.getLocksFromIterator(ctx, k.AccountLockIteratorLongerDurationDenom(ctx, false, addr, denom, duration))
 }
 
 // GetLocksPastTimeDenom Returns the locks whose unlock time is beyond timestamp.
-func (k Keeper) GetLocksPastTimeDenom(ctx sdk.Context, denom string, timestamp time.Time) []types.PeriodLock {
+func (k Keeper) GetLocksPastTimeDenom(ctx sdk.Context, denom string, timestamp time.Time) []*types.PeriodLock {
 	// returns both unlocking started and not started assuming it started unlocking current time
 	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorAfterTimeDenom(ctx, denom, timestamp))
 	duration := time.Duration(0)
@@ -215,7 +215,7 @@ func (k Keeper) GetLocksPastTimeDenom(ctx sdk.Context, denom string, timestamp t
 	return combineLocks(notUnlockings, unlockings)
 }
 
-func (k Keeper) GetLocksDenom(ctx sdk.Context, denom string) []types.PeriodLock {
+func (k Keeper) GetLocksDenom(ctx sdk.Context, denom string) []*types.PeriodLock {
 	return k.GetLocksLongerThanDurationDenom(ctx, denom, time.Duration(0))
 }
 
@@ -230,7 +230,7 @@ func (k Keeper) GetLockedDenom(ctx sdk.Context, denom string, duration time.Dura
 }
 
 // GetLocksLongerThanDurationDenom Returns the locks whose unlock duration is longer than duration.
-func (k Keeper) GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []types.PeriodLock {
+func (k Keeper) GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []*types.PeriodLock {
 	// returns both unlocking started and not started
 	unlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, true, denom, duration))
 	notUnlockings := k.getLocksFromIterator(ctx, k.LockIteratorLongerThanDurationDenom(ctx, false, denom, duration))
@@ -269,14 +269,14 @@ func (k Keeper) GetLockRewardReceiver(ctx sdk.Context, lockID uint64) (string, e
 }
 
 // GetPeriodLocks Returns the period locks on pool.
-func (k Keeper) GetPeriodLocks(ctx sdk.Context) ([]types.PeriodLock, error) {
+func (k Keeper) GetPeriodLocks(ctx sdk.Context) ([]*types.PeriodLock, error) {
 	unlockings := k.getLocksFromIterator(ctx, k.LockIterator(ctx, true))
 	notUnlockings := k.getLocksFromIterator(ctx, k.LockIterator(ctx, false))
 	return combineLocks(notUnlockings, unlockings), nil
 }
 
 // GetAccountPeriodLocks Returns the period locks associated to an account.
-func (k Keeper) GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []types.PeriodLock {
+func (k Keeper) GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []*types.PeriodLock {
 	unlockings := k.getLocksFromIterator(ctx, k.AccountLockIterator(ctx, true, addr))
 	notUnlockings := k.getLocksFromIterator(ctx, k.AccountLockIterator(ctx, false, addr))
 	return combineLocks(notUnlockings, unlockings)

--- a/x/lockup/keeper/utils.go
+++ b/x/lockup/keeper/utils.go
@@ -107,6 +107,6 @@ func syntheticLockRefKeys(lock types.PeriodLock, synthLock types.SyntheticLock) 
 	return refKeys, nil
 }
 
-func combineLocks(pl1 []types.PeriodLock, pl2 []types.PeriodLock) []types.PeriodLock {
+func combineLocks(pl1 []*types.PeriodLock, pl2 []*types.PeriodLock) []*types.PeriodLock {
 	return append(pl1, pl2...)
 }

--- a/x/lockup/simulation/operations.go
+++ b/x/lockup/simulation/operations.go
@@ -47,7 +47,7 @@ func RandomMsgBeginUnlocking(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Cont
 	}, nil
 }
 
-var notUnlockingFilter = func(l types.PeriodLock) bool { return !l.IsUnlocking() }
+var notUnlockingFilter = func(l *types.PeriodLock) bool { return !l.IsUnlocking() }
 
 func accountHasLockConstraint(k keeper.Keeper, ctx sdk.Context) simtypes.SimAccountConstraint {
 	return func(acc legacysimulationtype.Account) bool {
@@ -55,7 +55,7 @@ func accountHasLockConstraint(k keeper.Keeper, ctx sdk.Context) simtypes.SimAcco
 	}
 }
 
-func randLock(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context, addr sdk.AccAddress) types.PeriodLock {
+func randLock(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Context, addr sdk.AccAddress) *types.PeriodLock {
 	locks := k.GetAccountPeriodLocks(ctx, addr)
 	notUnlockingLocks := osmoutils.Filter(notUnlockingFilter, locks)
 	return simtypes.RandSelect(sim, notUnlockingLocks...)

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -65,7 +65,7 @@ func (p PeriodLock) SingleCoin() (sdk.Coin, error) {
 
 // TODO: Can we use sumtree instead here?
 // Assumes that caller is passing in locks that contain denom
-func SumLocksByDenom(locks []PeriodLock, denom string) osmomath.Int {
+func SumLocksByDenom(locks []*PeriodLock, denom string) osmomath.Int {
 	sumBi := big.NewInt(0)
 	// validate the denom once, so we can avoid the expensive validate check in the hot loop.
 	err := sdk.ValidateDenom(denom)
@@ -98,4 +98,16 @@ func NativeDenom(denom string) string {
 
 func IsSyntheticDenom(denom string) bool {
 	return NativeDenom(denom) != denom
+}
+
+// Converts period lock pointers to structs.
+// This is done to avoid breaking query APIs and protos.
+// TODO: break query APIs to return pointers as oppossed to structs
+// and aboid this redundant convertsion.
+func ConvertPointersToLocks(locksPtr []*PeriodLock) []PeriodLock {
+	locks := make([]PeriodLock, 0, len(locksPtr))
+	for _, lock := range locksPtr {
+		locks = append(locks, *lock)
+	}
+	return locks
 }

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -102,7 +102,7 @@ func IsSyntheticDenom(denom string) bool {
 
 // Converts period lock pointers to structs.
 // This is done to avoid breaking query APIs and protos.
-// TODO: break query APIs to return pointers as oppossed to structs
+// TODO: break query APIs to return pointers as opposed to structs
 // and aboid this redundant convertsion.
 func ConvertPointersToLocks(locksPtr []*PeriodLock) []PeriodLock {
 	locks := make([]PeriodLock, 0, len(locksPtr))

--- a/x/superfluid/simulation/operations.go
+++ b/x/superfluid/simulation/operations.go
@@ -194,10 +194,10 @@ func RandomLockAndAccount(ctx sdk.Context, r *rand.Rand, lk types.LockupKeeper, 
 	lock := locks[r.Intn(len(locks))]
 	for _, acc := range accs {
 		if acc.Address.String() == lock.Owner {
-			return &lock, acc
+			return lock, acc
 		}
 	}
-	return &lock, simAccount
+	return lock, simAccount
 }
 
 func RandomAccountLock(ctx sdk.Context, r *rand.Rand, lk types.LockupKeeper, addr sdk.AccAddress) *lockuptypes.PeriodLock {
@@ -205,7 +205,7 @@ func RandomAccountLock(ctx sdk.Context, r *rand.Rand, lk types.LockupKeeper, add
 	if len(locks) == 0 {
 		return nil
 	}
-	return &locks[r.Intn(len(locks))]
+	return locks[r.Intn(len(locks))]
 }
 
 func RandomValidator(ctx sdk.Context, r *rand.Rand, sk types.StakingKeeper) *stakingtypes.Validator {

--- a/x/superfluid/types/expected_keepers.go
+++ b/x/superfluid/types/expected_keepers.go
@@ -19,12 +19,12 @@ import (
 
 // LockupKeeper defines the expected interface needed to retrieve locks.
 type LockupKeeper interface {
-	GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []lockuptypes.PeriodLock
-	GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []lockuptypes.PeriodLock
-	GetAccountLockedLongerDurationDenomNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []lockuptypes.PeriodLock
+	GetLocksLongerThanDurationDenom(ctx sdk.Context, denom string, duration time.Duration) []*lockuptypes.PeriodLock
+	GetAccountLockedLongerDurationDenom(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []*lockuptypes.PeriodLock
+	GetAccountLockedLongerDurationDenomNotUnlockingOnly(ctx sdk.Context, addr sdk.AccAddress, denom string, duration time.Duration) []*lockuptypes.PeriodLock
 	GetPeriodLocksAccumulation(ctx sdk.Context, query lockuptypes.QueryCondition) osmomath.Int
-	GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []lockuptypes.PeriodLock
-	GetPeriodLocks(ctx sdk.Context) ([]lockuptypes.PeriodLock, error)
+	GetAccountPeriodLocks(ctx sdk.Context, addr sdk.AccAddress) []*lockuptypes.PeriodLock
+	GetPeriodLocks(ctx sdk.Context) ([]*lockuptypes.PeriodLock, error)
 	GetLockByID(ctx sdk.Context, lockID uint64) (*lockuptypes.PeriodLock, error)
 	// Despite the name, BeginForceUnlock is really BeginUnlock
 	// TODO: Fix this in future code update

--- a/x/valset-pref/types/expected_interfaces.go
+++ b/x/valset-pref/types/expected_interfaces.go
@@ -37,5 +37,5 @@ type LockupKeeper interface {
 	GetSyntheticLockupByUnderlyingLockId(ctx sdk.Context, lockID uint64) (lockuptypes.SyntheticLock, bool, error)
 	ForceUnlock(ctx sdk.Context, lock lockuptypes.PeriodLock) error
 	BeginUnlock(ctx sdk.Context, lockID uint64, coins sdk.Coins) (uint64, error)
-	GetPeriodLocks(ctx sdk.Context) ([]lockuptypes.PeriodLock, error)
+	GetPeriodLocks(ctx sdk.Context) ([]*lockuptypes.PeriodLock, error)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Removes overhead from copying `PeriodLock` structs by using pointers instead.

Did a hack in queries to convert from pointers to structs to avoid API breakage.

## Testing and Verifying

Synched node through epoch.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A