### PR TITLE
perf: avoid copy of period locks in epoch

### DIFF
--- a/x/incentives/keeper/iterator.go
+++ b/x/incentives/keeper/iterator.go
@@ -63,11 +63,11 @@ func (k Keeper) FinishedGaugesIterator(ctx sdk.Context) sdk.Iterator {
 }
 
 // FilterLocksByMinDuration returns locks whose lock duration is greater than the provided minimum duration.
-func FilterLocksByMinDuration(locks []lockuptypes.PeriodLock, minDuration time.Duration) []lockuptypes.PeriodLock {
-	filteredLocks := make([]lockuptypes.PeriodLock, 0, len(locks))
-	for _, lock := range locks {
-		if lock.Duration >= minDuration {
-			filteredLocks = append(filteredLocks, lock)
+func FilterLocksByMinDuration(locks []lockuptypes.PeriodLock, minDuration time.Duration) []*lockuptypes.PeriodLock {
+	filteredLocks := make([]*lockuptypes.PeriodLock, 0, len(locks))
+	for i := range locks {
+		if locks[i].Duration >= minDuration {
+			filteredLocks = append(filteredLocks, &locks[i])
 		}
 	}
 	return filteredLocks

--- a/x/incentives/keeper/iterator_test.go
+++ b/x/incentives/keeper/iterator_test.go
@@ -1,0 +1,37 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v21/x/incentives/keeper"
+	lockuptypes "github.com/osmosis-labs/osmosis/v21/x/lockup/types"
+)
+
+// This test validates that the FilterLocksByMinDuration function
+// copies the correct locks when filtering.
+// It helps to ensure that we do not use a wrong pointer by referencing
+// a loop variable.
+func TestFilterLocksByMinDuration(t *testing.T) {
+	const (
+		numLocks    = 3
+		minDuration = 2
+	)
+
+	locks := make([]lockuptypes.PeriodLock, numLocks)
+	for i := 0; i < numLocks; i++ {
+		locks[i] = lockuptypes.PeriodLock{
+			ID:       uint64(i + 1),
+			Duration: minDuration,
+		}
+	}
+
+	filteredLocks := keeper.FilterLocksByMinDuration(locks, minDuration)
+
+	require.Equal(t, len(locks), len(filteredLocks))
+
+	for i := 0; i < len(locks); i++ {
+		require.Equal(t, locks[i].ID, filteredLocks[i].ID)
+	}
+}

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -65,7 +65,7 @@ func (p PeriodLock) SingleCoin() (sdk.Coin, error) {
 
 // TODO: Can we use sumtree instead here?
 // Assumes that caller is passing in locks that contain denom
-func SumLocksByDenom(locks []PeriodLock, denom string) osmomath.Int {
+func SumLocksByDenom(locks []*PeriodLock, denom string) osmomath.Int {
 	sumBi := big.NewInt(0)
 	// validate the denom once, so we can avoid the expensive validate check in the hot loop.
 	err := sdk.ValidateDenom(denom)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This speeds up epoch by avoiding copying stemming from period locks

New:
![image](https://github.com/osmosis-labs/osmosis/assets/34196718/39ed1082-223b-4bea-8fbf-1b5069abea04)


Old:
![image](https://github.com/osmosis-labs/osmosis/assets/34196718/dd83c728-2b91-4ea5-a0db-e0a24c70c4b9)


## Testing and Verifying

Synched over epoch + 150 blocks.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A