### PR TITLE
Add maximum pool ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Misc Improvements
 * [#7106](https://github.com/osmosis-labs/osmosis/pull/7106) Halve the time of log2 calculation (speeds up TWAP code)
-* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100),[#7172](https://github.com/osmosis-labs/osmosis/pull/7093) Lower CPU overheads of the Osmosis epoch.
+* [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100),[#7172](https://github.com/osmosis-labs/osmosis/pull/7172) Lower CPU overheads of the Osmosis epoch.
+* [#7203](https://github.com/osmosis-labs/osmosis/pull/7203) Make a maximum number of pools of 100 billion.
 
 ## v21.0.0
 

--- a/x/poolmanager/create_pool.go
+++ b/x/poolmanager/create_pool.go
@@ -99,6 +99,9 @@ func (k Keeper) createPoolZeroLiquidityNoCreationFee(ctx sdk.Context, msg types.
 
 	// Get the next pool ID and increment the pool ID counter.
 	poolId := k.getNextPoolIdAndIncrement(ctx)
+	if poolId >= types.MaxPoolId {
+		return nil, fmt.Errorf("next pool ID %d is greater than max pool ID %d", poolId, types.MaxPoolId)
+	}
 
 	poolType := msg.GetPoolType()
 

--- a/x/poolmanager/types/pool.go
+++ b/x/poolmanager/types/pool.go
@@ -8,6 +8,8 @@ import (
 	"github.com/osmosis-labs/osmosis/osmoutils"
 )
 
+var MaxPoolId uint64 = 99_999_999_999
+
 // PoolI defines an interface for pools that hold tokens.
 type PoolI interface {
 	proto.Message


### PR DESCRIPTION
makes a maximum pool ID of 100 billion - 1

This lets us make allocations for certain keys more efficient, that legacy use string formatting instead of uint64 representation.

At $1 to create a pool, this costs too much to ever be an issue. Let alone the $10 to $100 range governance currently seems to be in the mind of.