### PR TITLE
Revert "Stop double emitting events for CacheCtx.Write() (#7149) (#71…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### API
 
 * [#6991](https://github.com/osmosis-labs/osmosis/pull/6991) Fix: total liquidity poolmanager grpc gateway query
-* [#7149](https://github.com/osmosis-labs/osmosis/pull/7149) Fix double emitting CacheCtx events (e.g. Epoch, Superfluid, CL)
 
 ### Features
 

--- a/osmoutils/cache_ctx.go
+++ b/osmoutils/cache_ctx.go
@@ -38,6 +38,7 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	} else {
 		// no error, write the output of f
 		write()
+		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	}
 	return err
 }


### PR DESCRIPTION
This was unsafe for release, and is why we made `ApplyFuncIfNoErrorUnmetered`