### PR TITLE
fix: config overwrite ignores app.toml values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100),[#7172](https://github.com/osmosis-labs/osmosis/pull/7172) Lower CPU overheads of the Osmosis epoch.
 * [#7203](https://github.com/osmosis-labs/osmosis/pull/7203) Make a maximum number of pools of 100 billion.
 
+### Bug Fixes
+
+* [#7233](https://github.com/osmosis-labs/osmosis/pull/7233) fix: config overwrite ignores app.toml values 
+
 ## v21.1.5
 
 * [#7210](https://github.com/osmosis-labs/osmosis/pull/7210) Arb filter for new authz exec swap.

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -459,7 +459,6 @@ func overwriteConfigTomlValues(serverCtx *server.Context) error {
 		if timeoutCommitValue == fiveSecondsString {
 			serverCtx.Config.Consensus.TimeoutCommit = 4 * time.Second
 		}
-		tmcConfig = serverCtx.Config
 
 		defer func() {
 			if err := recover(); err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Previous PR that created config overwrite caused `app.toml` values being dropped when starting up `osmosisd`. This PR fixes the issue by creating a new viper copy that loads the `config.toml` values while preserving the original contents.

## Testing and Verifying

Tested locally

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A