### PR TITLE
fix(SQS): healthcheck false positive when node is stuck

### DIFF
--- a/ingest/sqs/chain_info/repository/redis/redis_chain_info_repository.go
+++ b/ingest/sqs/chain_info/repository/redis/redis_chain_info_repository.go
@@ -53,6 +53,12 @@ func (r *chainInfoRepo) StoreLatestHeight(ctx context.Context, tx mvc.Tx, height
 }
 
 // GetLatestHeight retrieves the latest blockchain height from Redis
+//
+// N.B. sometimes the node gets stuck and does not make progress.
+// However, it returns 200 OK for the status endpoint and claims to be not catching up.
+// This has caused the healthcheck to pass with false positives in production.
+// As a result, we need to keep track of the last seen height that chain ingester pushes into
+// the Redis repository.
 func (r *chainInfoRepo) GetLatestHeight(ctx context.Context) (uint64, error) {
 	tx := r.repositoryManager.StartTx()
 	redisTx, err := tx.AsRedisTx()

--- a/ingest/sqs/chain_info/repository/redis/redis_chain_info_repository.go
+++ b/ingest/sqs/chain_info/repository/redis/redis_chain_info_repository.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/osmosis-labs/osmosis/v21/ingest/sqs/domain/json"
 	"github.com/osmosis-labs/osmosis/v21/ingest/sqs/domain/mvc"
 )
 
@@ -20,9 +19,8 @@ type TimeWrapper struct {
 }
 
 const (
-	latestHeightKey     = "latestHeight"
-	latestHeightField   = "height"
-	latestHeightTimeKey = "timeLatestHeight"
+	latestHeightKey   = "latestHeight"
+	latestHeightField = "height"
 )
 
 // NewChainInfoRepo creates a new repository for chain information
@@ -81,69 +79,4 @@ func (r *chainInfoRepo) GetLatestHeight(ctx context.Context) (uint64, error) {
 	}
 
 	return height, nil
-}
-
-// GetLatestHeightRetrievalTime implements mvc.ChainInfoRepository.
-func (r *chainInfoRepo) GetLatestHeightRetrievalTime(ctx context.Context) (time.Time, error) {
-	tx := r.repositoryManager.StartTx()
-	redisTx, err := tx.AsRedisTx()
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	pipeliner, err := redisTx.GetPipeliner(ctx)
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	cmd := pipeliner.Get(ctx, latestHeightTimeKey)
-
-	if err := tx.Exec(ctx); err != nil {
-		return time.Time{}, err
-	}
-
-	heightStr := cmd.Val()
-
-	var timeWrapper TimeWrapper
-	if err := json.Unmarshal([]byte(heightStr), &timeWrapper); err != nil {
-		return time.Time{}, err
-	}
-
-	return timeWrapper.Time, nil
-}
-
-// StoreLatestHeightRetrievalTime implements mvc.ChainInfoRepository.
-func (r *chainInfoRepo) StoreLatestHeightRetrievalTime(ctx context.Context, time time.Time) error {
-	tx := r.repositoryManager.StartTx()
-	redisTx, err := tx.AsRedisTx()
-	if err != nil {
-		return err
-	}
-
-	pipeliner, err := redisTx.GetPipeliner(ctx)
-	if err != nil {
-		return err
-	}
-
-	timeWrapper := TimeWrapper{
-		Time: time.UTC(), // always in UTC
-	}
-
-	bz, err := json.Marshal(timeWrapper)
-	if err != nil {
-		return err
-	}
-
-	cmd := pipeliner.Set(ctx, latestHeightTimeKey, bz, 0)
-
-	if err := tx.Exec(ctx); err != nil {
-		return err
-	}
-
-	err = cmd.Err()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/ingest/sqs/chain_info/usecase/chain_info_usecase.go
+++ b/ingest/sqs/chain_info/usecase/chain_info_usecase.go
@@ -40,6 +40,15 @@ func NewChainInfoUsecase(timeout time.Duration, chainInfoRepository mvc.ChainInf
 	}
 }
 
+// GetLatestHeight retrieves the latest blockchain height
+//
+// Despite being a getter, this method also validates that the height is updated within a reasonable time frame.
+//
+// Sometimes the node gets stuck and does not make progress.
+// However, it returns 200 OK for the status endpoint and claims to be not catching up.
+// This has caused the healthcheck to pass with false positives in production.
+// As a result, we need to keep track of the last seen height and time. Chain ingester pushes
+// the latest height into Redis. This method checks that the height is updated within a reasonable time frame.
 func (p *chainInfoUseCase) GetLatestHeight(ctx context.Context) (uint64, error) {
 	ctx, cancel := context.WithTimeout(ctx, p.contextTimeout)
 	defer cancel()

--- a/ingest/sqs/chain_info/usecase/chain_info_usecase.go
+++ b/ingest/sqs/chain_info/usecase/chain_info_usecase.go
@@ -16,7 +16,7 @@ type chainInfoUseCase struct {
 
 	// N.B. sometimes the node gets stuck and does not make progress.
 	// However, it returns 200 OK for the status endpoint and claims to be not catching up.
-	// This has caused the healthcheck to pass with false positive a number of times in production.
+	// This has caused the healthcheck to pass with false positives in production.
 	// As a result, we need to keep track of the last seen height and time to ensure that the height is
 	// updated within a reasonable time frame.
 	lastSeenMx            sync.Mutex

--- a/ingest/sqs/chain_info/usecase/chain_info_usecase.go
+++ b/ingest/sqs/chain_info/usecase/chain_info_usecase.go
@@ -2,9 +2,8 @@ package usecase
 
 import (
 	"context"
+	"sync"
 	"time"
-
-	"github.com/go-redis/redis"
 
 	"github.com/osmosis-labs/osmosis/v21/ingest/sqs/domain"
 	"github.com/osmosis-labs/osmosis/v21/ingest/sqs/domain/mvc"
@@ -14,6 +13,15 @@ type chainInfoUseCase struct {
 	contextTimeout         time.Duration
 	chainInfoRepository    mvc.ChainInfoRepository
 	redisRepositoryManager mvc.TxManager
+
+	// N.B. sometimes the node get stuck and does not make progress.
+	// However, it returns 200 OK for the status endpoint and claims to be not catching up.
+	// This has caused the healthcheck to pass with false positive a number of times in production.
+	// As a result, we need to keep track of the last seen height and time to ensure that the height is
+	// updated within a reasonable time frame.
+	lastSeenMx            sync.Mutex
+	lastSeenUpdatedHeight uint64
+	lastSeenUpdatedTime   time.Time
 }
 
 // The max number of seconds allowed for there to be no updates
@@ -27,6 +35,8 @@ func NewChainInfoUsecase(timeout time.Duration, chainInfoRepository mvc.ChainInf
 		contextTimeout:         timeout,
 		chainInfoRepository:    chainInfoRepository,
 		redisRepositoryManager: redisRepositoryManager,
+
+		lastSeenMx: sync.Mutex{},
 	}
 }
 
@@ -39,31 +49,18 @@ func (p *chainInfoUseCase) GetLatestHeight(ctx context.Context) (uint64, error) 
 		return 0, err
 	}
 
-	// Current UTC time
+	p.lastSeenMx.Lock()
+	defer p.lastSeenMx.Unlock()
+
 	currentTimeUTC := time.Now().UTC()
 
-	latestHeightRetrievalTime, err := p.chainInfoRepository.GetLatestHeightRetrievalTime(ctx)
-	if err != nil {
-		// If there is no entry, then we can assume that the height has never been retrieved,
-		// so we store the current time.
-		// TODO: clean up this error handling
-		if err.Error() == redis.Nil.Error() {
-			// Store the latest height retrieval time
-			if err := p.chainInfoRepository.StoreLatestHeightRetrievalTime(ctx, currentTimeUTC); err != nil {
-				return 0, err
-			}
-
-			return latestHeight, nil
-		}
-
-		return 0, err
-	}
-
 	// Time since last height retrieval
-	timeDeltaSecs := int(currentTimeUTC.Sub(latestHeightRetrievalTime).Seconds())
+	timeDeltaSecs := int(currentTimeUTC.Sub(p.lastSeenUpdatedTime).Seconds())
+
+	isHeightUpdated := latestHeight > p.lastSeenUpdatedHeight
 
 	// Validate that it does not exceed the max allowed time delta
-	if timeDeltaSecs > MaxAllowedHeightUpdateTimeDeltaSecs {
+	if !isHeightUpdated && timeDeltaSecs > MaxAllowedHeightUpdateTimeDeltaSecs {
 		return 0, domain.StaleHeightError{
 			StoredHeight:            latestHeight,
 			TimeSinceLastUpdate:     timeDeltaSecs,
@@ -71,10 +68,9 @@ func (p *chainInfoUseCase) GetLatestHeight(ctx context.Context) (uint64, error) 
 		}
 	}
 
-	// Store the latest height retrieval time
-	if err := p.chainInfoRepository.StoreLatestHeightRetrievalTime(ctx, currentTimeUTC); err != nil {
-		return 0, err
-	}
+	// Update the last seen height and time
+	p.lastSeenUpdatedHeight = latestHeight
+	p.lastSeenUpdatedTime = currentTimeUTC
 
 	return latestHeight, nil
 }

--- a/ingest/sqs/chain_info/usecase/chain_info_usecase.go
+++ b/ingest/sqs/chain_info/usecase/chain_info_usecase.go
@@ -14,7 +14,7 @@ type chainInfoUseCase struct {
 	chainInfoRepository    mvc.ChainInfoRepository
 	redisRepositoryManager mvc.TxManager
 
-	// N.B. sometimes the node get stuck and does not make progress.
+	// N.B. sometimes the node gets stuck and does not make progress.
 	// However, it returns 200 OK for the status endpoint and claims to be not catching up.
 	// This has caused the healthcheck to pass with false positive a number of times in production.
 	// As a result, we need to keep track of the last seen height and time to ensure that the height is

--- a/ingest/sqs/domain/mvc/chainInfo.go
+++ b/ingest/sqs/domain/mvc/chainInfo.go
@@ -14,5 +14,14 @@ type ChainInfoRepository interface {
 }
 
 type ChainInfoUsecase interface {
+	// GetLatestHeight retrieves the latest blockchain height
+	//
+	// Despite being a getter, this method also validates that the height is updated within a reasonable time frame.
+	//
+	// Sometimes the node gets stuck and does not make progress.
+	// However, it returns 200 OK for the status endpoint and claims to be not catching up.
+	// This has caused the healthcheck to pass with false positives in production.
+	// As a result, we need to keep track of the last seen height and time. Chain ingester pushes
+	// the latest height into Redis. This method checks that the height is updated within a reasonable time frame.
 	GetLatestHeight(ctx context.Context) (uint64, error)
 }

--- a/ingest/sqs/domain/mvc/chainInfo.go
+++ b/ingest/sqs/domain/mvc/chainInfo.go
@@ -2,7 +2,6 @@ package mvc
 
 import (
 	"context"
-	"time"
 )
 
 // ChainInfoRepository represents the contract for a repository handling chain information
@@ -12,12 +11,6 @@ type ChainInfoRepository interface {
 
 	// GetLatestHeight retrieves the latest blockchain height
 	GetLatestHeight(ctx context.Context) (uint64, error)
-
-	// GetLatestHeightRetrievalTime retrieves the latest blockchain height retrieval time.
-	GetLatestHeightRetrievalTime(ctx context.Context) (time.Time, error)
-
-	// StoreLatestHeightRetrievalTime stores the latest blockchain height retrieval time.
-	StoreLatestHeightRetrievalTime(ctx context.Context, time time.Time) error
 }
 
 type ChainInfoUsecase interface {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Sometimes the node gets stuck and does not make progress.
However, it returns 200 OK for the status endpoint and claims to be not catching up.
This has caused the healthcheck to pass with false positives in production.
As a result, we need to keep track of the last seen height and time to ensure that the height is
updated within a reasonable time frame.

## Testing and Verifying

Will test in stage

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A