### PR TITLE
chore: update gov metadata length from 256 to 10200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * [#7233](https://github.com/osmosis-labs/osmosis/pull/7233) fix: config overwrite ignores app.toml values 
+* [#7243](https://github.com/osmosis-labs/osmosis/pull/7243) fix: chore: update gov metadata length from 256 to 10200
 
 ## v21.1.5
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -540,6 +540,8 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		AddRoute(incentivestypes.RouterKey, incentiveskeeper.NewIncentivesProposalHandler(*appKeepers.IncentivesKeeper))
 
 	govConfig := govtypes.DefaultConfig()
+	// Set the maximum metadata length for government-related configurations to 10,200, deviating from the default value of 256.
+	govConfig.MaxMetadataLen = 10200
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, appKeepers.keys[govtypes.StoreKey],
 		appKeepers.AccountKeeper, appKeepers.BankKeeper, appKeepers.SuperfluidKeeper, bApp.MsgServiceRouter(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Update the metadata length to 10200, to enable longer summaries and titles for gov proposals

see:
https://github.com/osmosis-labs/cosmos-sdk/blob/osmo/v0.47.5/x/gov/keeper/proposal.go#L17-L32

&&

https://github.com/osmosis-labs/cosmos-sdk/blob/osmo/v0.47.5/x/gov/keeper/keeper.go#L222-L229

## Testing and Verifying

- start a node and submit a gov transaction with longer metadata

```bash
BASE64_METADATA=$(echo -n '{
	"authors": [""],
	"details": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
	"proposal_forum_url": "",
	"vote_option_context": ""
}' | base64 -w 0)

echo '{
  "messages": [
    {
      "@type": "/cosmos.bank.v1beta1.MsgSend",
      "from_address": "'"$GOVMODULEACC"'",
      "to_address": "'$ADDRESS1'",
      "amount": [{"denom": "uosmo", "amount": "1000000"}]
    }
  ],
  "metadata": "'"$BASE64_METADATA"'",
  "deposit": "3000000000uosmo",
  "title": "My Latest pro proposal",
  "summary": "A short summary of my proposal",
  "expedited": true
}' > proposal.json

# submit-proposal: Submit a proposal along with some messages, metadata and deposit
tx_result=$(osmosisd tx gov submit-proposal proposal.json $OPTS $SENDER -y --output json | jq .txhash)
echo $tx_result 
```

## Documentation and Release Note

  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A