### PR TITLE
e2e: use new image and extend blocks for upgrade

### DIFF
--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -54,8 +54,8 @@ func New(t *testing.T, containerManager *containers.Manager, id string, initVali
 			Id: id,
 		},
 		ValidatorInitConfigs:  initValidatorConfigs,
-		VotingPeriod:          numVal*config.PropVoteBlocks + config.PropBufferBlocks,
-		ExpeditedVotingPeriod: numVal*config.PropVoteBlocks + config.PropBufferBlocks - 3,
+		VotingPeriod:          numVal*config.PropVoteBlocks + config.PropBufferBlocksVotePeriod,
+		ExpeditedVotingPeriod: numVal*config.PropVoteBlocks + config.PropBufferBlocksVotePeriod - 3,
 		t:                     t,
 		containerManager:      containerManager,
 	}

--- a/tests/e2e/configurer/config/constants.go
+++ b/tests/e2e/configurer/config/constants.go
@@ -14,7 +14,9 @@ const (
 	// number of blocks it takes to vote for a single validator to vote for a proposal
 	PropVoteBlocks float32 = 1
 	// number of blocks used as a calculation buffer
-	PropBufferBlocks float32 = 8
+	PropBufferBlocks float32 = 30
+	// number of blocks used as a calculation buffer (used to set actual voting period)
+	PropBufferBlocksVotePeriod float32 = 8
 	// max retries for json unmarshalling
 	MaxRetries = 60
 )

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,7 +24,7 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis"
-	previousVersionOsmoTag        = "21.2.1-e2e-only"
+	previousVersionOsmoTag        = "v21.2.1-e2e-only"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
 	previousVersionInitTag        = "v21.1.5"

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,7 +24,7 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis"
-	previousVersionOsmoTag        = "21.1.5-alpine"
+	previousVersionOsmoTag        = "21.2.1-e2e-only"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
 	previousVersionInitTag        = "v21.1.5"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Two required changes:

1. Pre v21, our pre upgrade logic expected slow blocks, and post upgrade had fast blocks. Now, both pre and post upgrade have fast blocks. This logic requires the image to be built with the ignoreSequence tag, otherwise the tx spam causes the e2e suite to get caught up. I manually built a v21.2.1 image with the tag, uploaded to docker up, and changed here.

2. Because blocks are faster, the upgrade handler was not getting triggered due to miscalculation of how long 1 block was equal to. This sets the upgrade block height large enough to allow for a full gov cycle.