### PR TITLE
fix: go mod update action targets branch it is called on

### DIFF
--- a/.github/workflows/go-mod-auto-bump.yml
+++ b/.github/workflows/go-mod-auto-bump.yml
@@ -1,9 +1,8 @@
-# This workflow is used in order to automatically update go.mod in case one of:
+# This workflow is manually triggered to update go.mod of:
 # * osmoutils
 # * osmomath
 # * x/ibc-hooks
 # * x/epochs
-# is updated.
 # It is triggerred by a manual workflow:
 # https://github.com/osmosis-labs/osmosis/actions/workflows/go-mod-auto-bump.yml
 
@@ -12,11 +11,11 @@ on:
   workflow_dispatch:
     inputs:
       target-branch:
-        description: 'Target Branch'
-        default: ''
+        description: "Target Branch"
+        default: ""
         required: true
 permissions:
-    contents: write
+  contents: write
 
 jobs:
   update_go_mod:
@@ -24,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with: 
+        with:
           fetch-depth: 0
 
       - name: Set GH config
@@ -36,24 +35,18 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.19.0'
+          go-version: ">=1.20.0"
       - name: Fetch branches and checkout target
         run: |
-         git fetch origin ${{ inputs.target-branch }}
-         git checkout ${{ inputs.target-branch }}
-         git fetch origin main
+          git fetch origin ${{ inputs.target-branch }}
+          git checkout ${{ inputs.target-branch }}
 
-      - name: Get latest commit on main branch
-        id: main_commit
-        run: |
-          echo "LATEST_MAIN_COMMIT=$(git rev-parse main)" >> $GITHUB_OUTPUT
-      
       - name: Run script
         run: |
           LATEST_TARGET_COMMIT=$(git rev-parse ${{ inputs.target-branch }})
-          bash ./scripts/update-go-mod.sh ${{ steps.main_commit.outputs.LATEST_MAIN_COMMIT }} $LATEST_TARGET_COMMIT
+          bash ./scripts/update-go-mod.sh $LATEST_TARGET_COMMIT
 
-      - name: Add Changes 
+      - name: Add Changes
         id: add_changes
         run: |
           git add .

--- a/scripts/update-go-mod.sh
+++ b/scripts/update-go-mod.sh
@@ -1,70 +1,35 @@
 #!/bin/bash
 
-# Script for checking `git diff` between two commits and updating osmoutils, osmomath, epochs or ibc-hooks if any were changed between two commits
+# Script for updating osmoutils, osmomath, epochs and ibc-hooks
 # Used by Go Mod Auto Version Update workflow
-# First argument: sha of a first commit
-# Second argument: sha of a second commit
+# Argument: sha of commit on target branch
 
-is_updated() {
-	if [ "${1}" != "" ]
-	then
-		return 1
-	fi
-	return 0
-}
+commit_after=$1
 
-commit_before=$1
-commit_after=$2
+# UPDATE OSMOUTILS
+go get github.com/osmosis-labs/osmosis/osmoutils@$commit_after
 
-changed_osmoutils=$(git diff --name-only $commit_before $commit_after | grep osmoutils)
-changed_osmomath=$(git diff --name-only $commit_before $commit_after | grep osmomath)
-changed_ibc_hooks=$(git diff --name-only $commit_before $commit_after | grep x/ibc-hooks)
-changed_epochs=$(git diff --name-only $commit_before $commit_after | grep x/epochs)
+# x/epochs depends on osmoutils
+cd x/epochs
+go get github.com/osmosis-labs/osmosis/osmoutils@$commit_after
+go mod tidy
 
-is_updated $changed_osmoutils
-update_osmoutils=$?
+# x/ibc-hooks depends on osmoutils
+cd ../ibc-hooks
+go get github.com/osmosis-labs/osmosis/osmoutils@$commit_after
+go mod tidy
 
-is_updated $changed_osmomath
-update_osmomath=$?
+# return to root
+cd ../..
 
-is_updated $changed_ibc_hooks
-update_ibc_hooks=$?
+# UPDATE OSMOMATH
+go get github.com/osmosis-labs/osmosis/osmomath@$commit_after
 
-is_updated $changed_epochs
-update_epochs=$?
+# UPDATE IBC HOOKS
+go get github.com/osmosis-labs/osmosis/x/ibc-hooks@$commit_after
 
-if [ $update_osmoutils -eq 1 ]
-then 
-	go get github.com/osmosis-labs/osmosis/osmoutils@$commit_after
-
-    # x/epochs depends on osmoutils
-    cd x/epochs
-    go get github.com/osmosis-labs/osmosis/osmoutils@$commit_after
-    go mod tidy
-
-    # x/ibc-hooks depends on osmoutils
-    cd ../ibc-hooks
-    go get github.com/osmosis-labs/osmosis/osmoutils@$commit_after
-    go mod tidy
-    
-    # return to root
-    cd ../..
-fi
-
-if [ $update_osmomath -eq 1 ]
-then 
-	go get github.com/osmosis-labs/osmosis/osmomath@$commit_after
-fi
-
-if [ $update_ibc_hooks -eq 1 ]
-then 
-	go get github.com/osmosis-labs/osmosis/x/ibc-hooks@$commit_after
-fi
-
-if [ $update_epochs -eq 1 ]
-then 
-	go get github.com/osmosis-labs/osmosis/x/epochs@$commit_after
-fi
+# UPDATE EPOCHS
+go get github.com/osmosis-labs/osmosis/x/epochs@$commit_after
 
 go mod tidy
 go work sync


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Right now, we have an action we manually trigger by putting in a branch, and github will update the osmosis related go mods of every occurrence of those dependencies. 

The issue is, even if this action is run on, say v21.x, it will use the dependencies from main.

What this change does is, it uses the dependencies on whatever branch the action is being called on, which is (in my opinion) the desired behavior.