### PR TITLE
Speedup CL spot price check and swap by removing an iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7106](https://github.com/osmosis-labs/osmosis/pull/7106) Halve the time of log2 calculation (speeds up TWAP code)
 * [#7093](https://github.com/osmosis-labs/osmosis/pull/7093),[#7100](https://github.com/osmosis-labs/osmosis/pull/7100),[#7172](https://github.com/osmosis-labs/osmosis/pull/7172) Lower CPU overheads of the Osmosis epoch.
 * [#7203](https://github.com/osmosis-labs/osmosis/pull/7203) Make a maximum number of pools of 100 billion.
+* [#7258](https://github.com/osmosis-labs/osmosis/pull/7258) Remove an iterator call in CL swaps and spot price calls.
 
 ### Bug Fixes
 

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -164,7 +164,7 @@ func (k Keeper) GetPoolDenoms(ctx sdk.Context, poolId uint64) ([]string, error) 
 	return denoms, nil
 }
 
-// Return if the Pool has a position. This is guaranteed to be equi-satisfiable to
+// Return true if the Pool has a position. This is guaranteed to be equi-satisfiable to
 // the current sqrt price being 0.
 // We also check that the current tick is 0, which is also guaranteed in this situation.
 // That derisks any edge-case where the sqrt price is 0 but the tick is not 0.

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -164,6 +164,17 @@ func (k Keeper) GetPoolDenoms(ctx sdk.Context, poolId uint64) ([]string, error) 
 	return denoms, nil
 }
 
+// Return if the Pool has a position. This is guaranteed to be equi-satisfiable to
+// the current sqrt price being 0.
+// We also check that the current tick is 0, which is also guaranteed in this situation.
+// That derisks any edge-case where the sqrt price is 0 but the tick is not 0.
+func (k Keeper) PoolHasPosition(ctx sdk.Context, pool types.ConcentratedPoolExtension) bool {
+	if pool.GetCurrentSqrtPrice().IsZero() && pool.GetCurrentTick() == 0 {
+		return false
+	}
+	return true
+}
+
 func (k Keeper) CalculateSpotPrice(
 	ctx sdk.Context,
 	poolId uint64,
@@ -175,10 +186,7 @@ func (k Keeper) CalculateSpotPrice(
 		return osmomath.BigDec{}, err
 	}
 
-	hasPositions, err := k.HasAnyPositionForPool(ctx, poolId)
-	if err != nil {
-		return osmomath.BigDec{}, err
-	}
+	hasPositions := k.PoolHasPosition(ctx, concentratedPool)
 
 	if !hasPositions {
 		return osmomath.BigDec{}, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -787,10 +787,7 @@ func (k Keeper) getPoolForSwap(ctx sdk.Context, poolId uint64) (types.Concentrat
 	if err != nil {
 		return p, err
 	}
-	hasPositionInPool, err := k.HasAnyPositionForPool(ctx, poolId)
-	if err != nil {
-		return p, err
-	}
+	hasPositionInPool := k.PoolHasPosition(ctx, p)
 	if !hasPositionInPool {
 		return p, types.NoSpotPriceWhenNoLiquidityError{PoolId: poolId}
 	}


### PR DESCRIPTION
Speedup the CL check for if a pool is initialized.

Right now we do a very expensive iterator call. This technically saves gas for user swaps, but this is really small (at not all commensurate with the CPU costs it induces)

More pressingly, this is a notable delay to block processing time, due to occurrence in:
- Protorev (iterators always hit IAVL right now)
- TWAP
- Swaps

Notice that SpotPrice is 0 iff there is no position in the pool. You can convince yourself of this by looking at:
- AddPosition: https://github.com/osmosis-labs/osmosis/blob/dev/speedup_cl_spotprice_and_swap/x/concentrated-liquidity/lp.go#L110-L116
- InitializeLogic: https://github.com/osmosis-labs/osmosis/blob/dev/speedup_cl_spotprice_and_swap/x/concentrated-liquidity/lp.go#L558
- Withdraw Position: https://github.com/osmosis-labs/osmosis/blob/dev/speedup_cl_spotprice_and_swap/x/concentrated-liquidity/lp.go#L310-L327
- UnitializePool: https://github.com/osmosis-labs/osmosis/blob/dev/speedup_cl_spotprice_and_swap/x/concentrated-liquidity/lp.go#L600