### PR TITLE
Support CL pools in TX Fee module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7233](https://github.com/osmosis-labs/osmosis/pull/7233) fix: config overwrite ignores app.toml values 
 * [#7243](https://github.com/osmosis-labs/osmosis/pull/7243) fix: chore: update gov metadata length from 256 to 10200
 * [#7246](https://github.com/osmosis-labs/osmosis/pull/7246) fix: config overwrite fails with exit code 1 if wrong permissions
+* [#7267](https://github.com/osmosis-labs/osmosis/pull/7267) fix: support CL pools in tx fee module
 
 ## v21.1.5
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -400,7 +400,6 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.BankKeeper,
 		appKeepers.keys[txfeestypes.StoreKey],
 		appKeepers.PoolManagerKeeper,
-		appKeepers.GAMMKeeper,
 		appKeepers.ProtoRevKeeper,
 		appKeepers.DistrKeeper,
 		dataDir,

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -53,7 +53,7 @@ func (k Keeper) CalcFeeSpotPrice(ctx sdk.Context, inputDenom string) (osmomath.B
 		return osmomath.BigDec{}, err
 	}
 
-	spotPrice, err := k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
+	spotPrice, err := k.poolManager.RouteCalculateSpotPrice(ctx, feeToken.PoolID, baseDenom, feeToken.Denom)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
@@ -105,7 +105,7 @@ func (k Keeper) ValidateFeeToken(ctx sdk.Context, feeToken types.FeeToken) error
 	// - feeToken.Denom exists
 	// - feeToken.PoolID exists
 	// - feeToken.PoolID has both feeToken.Denom and baseDenom
-	_, err = k.spotPriceCalculator.CalculateSpotPrice(ctx, feeToken.PoolID, feeToken.Denom, baseDenom)
+	_, err = k.poolManager.RouteCalculateSpotPrice(ctx, feeToken.PoolID, feeToken.Denom, baseDenom)
 
 	return err
 }

--- a/x/txfees/keeper/keeper.go
+++ b/x/txfees/keeper/keeper.go
@@ -16,13 +16,12 @@ import (
 type Keeper struct {
 	storeKey storetypes.StoreKey
 
-	accountKeeper       types.AccountKeeper
-	bankKeeper          types.BankKeeper
-	poolManager         types.PoolManager
-	spotPriceCalculator types.SpotPriceCalculator
-	protorevKeeper      types.ProtorevKeeper
-	distributionKeeper  types.DistributionKeeper
-	dataDir             string
+	accountKeeper      types.AccountKeeper
+	bankKeeper         types.BankKeeper
+	poolManager        types.PoolManager
+	protorevKeeper     types.ProtorevKeeper
+	distributionKeeper types.DistributionKeeper
+	dataDir            string
 }
 
 var _ types.TxFeesKeeper = (*Keeper)(nil)
@@ -32,20 +31,18 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	storeKey storetypes.StoreKey,
 	poolManager types.PoolManager,
-	spotPriceCalculator types.SpotPriceCalculator,
 	protorevKeeper types.ProtorevKeeper,
 	distributionKeeper types.DistributionKeeper,
 	dataDir string,
 ) Keeper {
 	return Keeper{
-		accountKeeper:       accountKeeper,
-		bankKeeper:          bankKeeper,
-		storeKey:            storeKey,
-		poolManager:         poolManager,
-		spotPriceCalculator: spotPriceCalculator,
-		protorevKeeper:      protorevKeeper,
-		distributionKeeper:  distributionKeeper,
-		dataDir:             dataDir,
+		accountKeeper:      accountKeeper,
+		bankKeeper:         bankKeeper,
+		storeKey:           storeKey,
+		poolManager:        poolManager,
+		protorevKeeper:     protorevKeeper,
+		distributionKeeper: distributionKeeper,
+		dataDir:            dataDir,
 	}
 }
 

--- a/x/txfees/types/expected_keepers.go
+++ b/x/txfees/types/expected_keepers.go
@@ -42,6 +42,13 @@ type PoolManager interface {
 	) (osmomath.Int, error)
 
 	GetParams(ctx sdk.Context) (params poolmanagertypes.Params)
+
+	RouteCalculateSpotPrice(
+		ctx sdk.Context,
+		poolId uint64,
+		quoteAssetDenom string,
+		baseAssetDenom string,
+	) (price osmomath.BigDec, err error)
 }
 
 // AccountKeeper defines the contract needed for AccountKeeper related APIs.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #https://github.com/osmosis-labs/osmosis/issues/6783

## What is the purpose of the change

Previously CL pools were not supported in tx fee module, as we were calculated sp via gamm keeper. 
This PR changes it to use pool manager keeper instead for sp calculation

## Testing and Verifying

This change added tests and can be verified as follows:

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A