### PR TITLE
test: gas charge for the Query method

### DIFF
--- a/x/cosmwasmpool/model/pool_test.go
+++ b/x/cosmwasmpool/model/pool_test.go
@@ -69,7 +69,7 @@ func (s *CosmWasmPoolSuite) TestSpotPrice() {
 
 	// Make sure that gas charge before and after is not dropped
 	gasConsumed = gasConsumed - gasChargeBefore - gasChargeAfter
-	s.Require().Greater(gasConsumed, 0)
+	s.Require().Greater(gasConsumed, uint64(0))
 
 	s.Require().Equal(expectedSpotPrice, actualSpotPrice)
 

--- a/x/cosmwasmpool/model/pool_test.go
+++ b/x/cosmwasmpool/model/pool_test.go
@@ -69,7 +69,7 @@ func (s *CosmWasmPoolSuite) TestSpotPrice() {
 
 	// Make sure that gas charge before and after is not dropped
 	gasConsumed = gasConsumed - gasChargeBefore - gasChargeAfter
-	s.Require().NotZero(gasConsumed)
+	s.Require().Greater(gasConsumed, 0)
 
 	s.Require().Equal(expectedSpotPrice, actualSpotPrice)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Expand test to make sure that gas charged before and after calling the relevant method is not dropped