### PR TITLE
Raise mempool config gas per tx's defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7253](https://github.com/osmosis-labs/osmosis/pull/7253) Extended app hash logs (includes module hashes for easier debugging)
 * [#7258](https://github.com/osmosis-labs/osmosis/pull/7258) Remove an iterator call in CL swaps and spot price calls.
 * [#7282](https://github.com/osmosis-labs/osmosis/pull/7282) Update sdk fork to no longer utilize reverse denom mapping, reducing gas costs.
+* [#7291](https://github.com/osmosis-labs/osmosis/pull/7291) Raise mempool config's default max gas per tx configs.
 
 ### Bug Fixes
 

--- a/x/txfees/types/options.go
+++ b/x/txfees/types/options.go
@@ -21,8 +21,8 @@ var DefaultMinGasPriceForArbitrageTx = osmomath.ZeroDec()
 
 var (
 	DefaultMinGasPriceForHighGasTx = osmomath.ZeroDec()
-	DefaultMaxGasWantedPerTx       = uint64(25 * 1000 * 1000)
-	DefaultHighGasTxThreshold      = uint64(2 * 1000 * 1000)
+	DefaultMaxGasWantedPerTx       = uint64(30 * 1000 * 1000)
+	DefaultHighGasTxThreshold      = uint64(2.5 * 1000 * 1000)
 	DefaultMempool1559Enabled      = true
 )
 


### PR DESCRIPTION
With the raise of block gas to 300M, these can be relaxed, and will solve some integrator pain.