### PR TITLE
fix: total liquidity query

### DIFF
--- a/x/concentrated-liquidity/total_liquidity.go
+++ b/x/concentrated-liquidity/total_liquidity.go
@@ -1,8 +1,6 @@
 package concentrated_liquidity
 
 import (
-	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -57,7 +55,6 @@ func (k Keeper) IterateDenomLiquidity(ctx sdk.Context, cb func(sdk.Coin) bool) {
 
 	for ; iterator.Valid(); iterator.Next() {
 		var amount osmomath.Int
-		fmt.Println(iterator.Value())
 		if err := amount.Unmarshal(iterator.Value()); err != nil {
 			panic(err)
 		}

--- a/x/cosmwasmpool/pool_module.go
+++ b/x/cosmwasmpool/pool_module.go
@@ -412,7 +412,11 @@ func (k Keeper) GetTotalLiquidity(ctx sdk.Context) (sdk.Coins, error) {
 			}
 		}
 		totalPoolLiquidity := cosmwasmPool.GetTotalPoolLiquidity(ctx)
-		totalLiquidity = totalLiquidity.Add(totalPoolLiquidity...)
+		// We range over the coins and add them one at a time because GetTotalPoolLiquidity
+		// doesn't always return a sorted list of coins.
+		for _, coin := range totalPoolLiquidity {
+			totalLiquidity = totalLiquidity.Add(coin)
+		}
 	}
 	return totalLiquidity, nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

CW pools don't always return coins in a sorted list. When adding a non sorted list of coins, the method panics. This is a quick fix. Tested on private testnet and it works now.