### PR TITLE
feat: dynamic recheck factor based on current base fee value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fee Market Parameter Updates
+* [#7285](https://github.com/osmosis-labs/osmosis/pull/7285) The following updates are applied:
+   * Dynamic recheck factor based on current base fee value. Under 0.01, the recheck factor is 3.
+    In face of continuous spam, will take ~19 blocks from base fee > spam cost, to mempool eviction.
+    Above 0.01, the recheck factor is 2.3. In face of continuous spam, will take ~15 blocks from base fee > spam cost, to mempool eviction.
+   * Reset interval set to 6000 which is approximately 8.5 hours.
+   * Default base fee is reduced by 2 to 0.005.
+   * Set target gas to .625 * block_gas_limt = 187.5 million
+
 ### State Breaking
 
 * [#7272](https://github.com/osmosis-labs/osmosis/pull/7272) Upgrade go 1.20 -> 1.21


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Updating recheck factor to be dynamic based on base fees:
At higher base fees, we apply a smaller re-check factor.
This is because the recheck factor forces the base fee to get at minimum
"recheck factor" times higher than the spam rate. This leads to slow recovery
and a bad UX for user transactions. We aim for spam to start getting evicted from the mempool
sooner to avoid more severe UX degradation for user transactions. Therefore,
we apply a smaller recheck factor at higher base fees.

- `.01` base fee threshold to set a divergence for recheck factor
- `2.3` for anything higher than the threshold. This differs from the original proposal of `2.25` to err on the side of caution. The resulting difference in terms of blocks is `1`.
- `3` for lower. This is because we do not observe issues at low base fees.

On the choice of threshold, see:
![image](https://github.com/osmosis-labs/osmosis/assets/34196718/9fc9f123-8402-4bd7-90c7-b396610bc0f1)

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A