### PR TITLE
fix: update sqsdomain dep with taker fee key separator fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.4
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.10
 	github.com/osmosis-labs/sqs v0.0.0-20240109224414-786ae137f7c4
-	github.com/osmosis-labs/sqs/sqsdomain v0.0.0-20240109224414-786ae137f7c4
+	github.com/osmosis-labs/sqs/sqsdomain v0.0.0-20240115183431-296fc0a143ea
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/redis/go-redis/v9 v9.4.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.4
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.10
 	github.com/osmosis-labs/sqs v0.0.0-20240109224414-786ae137f7c4
-	github.com/osmosis-labs/sqs/sqsdomain v0.0.0-20240115183431-296fc0a143ea
+	github.com/osmosis-labs/sqs/sqsdomain v0.0.0-20240115211355-a4b77e29288d
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/redis/go-redis/v9 v9.4.0


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Updating SQS dependency with the most recent changes.
In particulate, it fixes the key separator issue that overlapped with tokenfactory denom key separator.



## Testing and Verifying

Tested on local node in testnet environment

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A