### PR TITLE
fix: remove tokens from balances that are not in the pool

### DIFF
--- a/ingest/sqs/pools/ingester/pool_ingester.go
+++ b/ingest/sqs/pools/ingester/pool_ingester.go
@@ -316,6 +316,13 @@ func (pi *poolIngester) convertPool(
 	// Otherwise, the CosmWasmPool model panics.
 	pool = pool.AsSerializablePool()
 
+	if pool.GetId() == uint64(1) {
+		fmt.Println("here")
+	}
+
+	// filtered balances consisting only of the pool denom balances.
+	filteredBalances := sdk.NewCoins()
+
 	var errorInTVLStr string
 	for _, balance := range balances {
 		// Note that there are edge cases where gamm shares or some random
@@ -329,6 +336,9 @@ func (pi *poolIngester) convertPool(
 		if !exists {
 			continue
 		}
+
+		// update filtered balances only with pool tokens
+		filteredBalances = filteredBalances.Add(balance)
 
 		if balance.Denom == UOSMO {
 			osmoPoolTVL = osmoPoolTVL.Add(balance.Amount)
@@ -467,7 +477,7 @@ func (pi *poolIngester) convertPool(
 		SQSModel: sqsdomain.SQSPool{
 			TotalValueLockedUSDC:  osmoPoolTVL,
 			TotalValueLockedError: errorInTVLStr,
-			Balances:              balances,
+			Balances:              filteredBalances,
 			PoolDenoms:            denoms,
 			SpreadFactor:          spreadFactor,
 		},

--- a/ingest/sqs/pools/ingester/pool_ingester.go
+++ b/ingest/sqs/pools/ingester/pool_ingester.go
@@ -316,10 +316,6 @@ func (pi *poolIngester) convertPool(
 	// Otherwise, the CosmWasmPool model panics.
 	pool = pool.AsSerializablePool()
 
-	if pool.GetId() == uint64(1) {
-		fmt.Println("here")
-	}
-
 	// filtered balances consisting only of the pool denom balances.
 	filteredBalances := sdk.NewCoins()
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Pools sometimes have garbage tokens in balances. We need to filter them out for convenience in SQS.
