### PR TITLE
fix(StargateQueries): use a sync pool when unmarshalling responses of protobuf objects 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#7181](https://github.com/osmosis-labs/osmosis/pull/7181) Improve errors for out of gas
 
+### Bug Fixes
+
+* [#7346](https://github.com/osmosis-labs/osmosis/pull/7346) Prevent heavy gRPC load from app hashing nodes
+
 ## v22.0.0
 
 ### Fee Market Parameter Updates

--- a/cmd/osmosisd/cmd/stargate-query.go
+++ b/cmd/osmosisd/cmd/stargate-query.go
@@ -78,7 +78,7 @@ Example:
 //nolint:staticcheck
 func GetStructAndFill(queryPath, module, structName string, structArguments ...string) (interface{}, error) {
 	const ParamRequest = "QueryParamsRequest"
-	_, err := wasmbinding.GetWhitelistedQuery(queryPath)
+	err := wasmbinding.IsWhitelistedQuery(queryPath)
 	if err != nil {
 		return nil, err
 	}

--- a/wasmbinding/export_test.go
+++ b/wasmbinding/export_test.go
@@ -2,6 +2,10 @@ package wasmbinding
 
 import "github.com/cosmos/cosmos-sdk/codec"
 
-func SetWhitelistedQuery(queryPath string, protoType codec.ProtoMarshaler) {
+func SetWhitelistedQuery[T any, PT protoTypeG[T]](queryPath string, protoType PT) {
 	setWhitelistedQuery(queryPath, protoType)
+}
+
+func GetWhitelistedQuery(queryPath string) (codec.ProtoMarshaler, error) {
+	return getWhitelistedQuery(queryPath)
 }

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -17,10 +17,13 @@ import (
 // StargateQuerier dispatches whitelisted stargate queries
 func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
 	return func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
-		protoResponseType, err := GetWhitelistedQuery(request.Path)
+		protoResponseType, err := getWhitelistedQuery(request.Path)
 		if err != nil {
 			return nil, err
 		}
+		// no matter what happens after this point, but we must return
+		// the response type to the pool.
+		defer returnStargateResponseToPool(request.Path, protoResponseType)
 
 		route := queryRouter.Route(request.Path)
 		if route == nil {

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -21,8 +21,9 @@ func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(
 		if err != nil {
 			return nil, err
 		}
-		// no matter what happens after this point, but we must return
-		// the response type to the pool.
+
+		// no matter what happens after this point, we must return
+		// the response type to prevent sync.Pool from leaking.
 		defer returnStargateResponseToPool(request.Path, protoResponseType)
 
 		route := queryRouter.Route(request.Path)

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -33,14 +33,15 @@ import (
 	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 )
 
-// stargateWhitelist keeps whitelist and its deterministic
+// stargateResponsePools keeps whitelist and its deterministic
 // response binding for stargate queries.
 // CONTRACT: since results of queries go into blocks, queries being added here should always be
 // deterministic or can cause non-determinism in the state machine.
 //
-// The query can be multi-thread, so we have to use
-// thread safe sync.Map.
-var stargateWhitelist sync.Map
+// The query is multi-threaded so we're using a sync.Pool
+// to manage the allocation and de-allocation of newly created
+// pb objects.
+var stargateResponsePools map[string]*sync.Pool
 
 // Note: When adding a migration here, we should also add it to the Async ICQ params in the upgrade.
 // In the future we may want to find a better way to keep these in sync
@@ -184,34 +185,48 @@ func init() {
 	setWhitelistedQuery("/osmosis.concentratedliquidity.v1beta1.Query/CFMMPoolIdLinkFromConcentratedPoolId", &concentratedliquidityquery.CFMMPoolIdLinkFromConcentratedPoolIdResponse{})
 }
 
-// GetWhitelistedQuery returns the whitelisted query at the provided path.
+// IsWhitelistedQuery returns if the query is not whitelisted.
+func IsWhitelistedQuery(queryPath string) error {
+	_, isWhitelisted := stargateResponsePools[queryPath]
+	if !isWhitelisted {
+		return wasmvmtypes.UnsupportedRequest{Kind: fmt.Sprintf("'%s' path is not allowed from the contract", queryPath)}
+	}
+	return nil
+}
+
+// getWhitelistedQuery returns the whitelisted query at the provided path.
 // If the query does not exist, or it was setup wrong by the chain, this returns an error.
-func GetWhitelistedQuery(queryPath string) (codec.ProtoMarshaler, error) {
-	protoResponseAny, isWhitelisted := stargateWhitelist.Load(queryPath)
+// CONTRACT: must call returnStargateResponseToPool in order to avoid pointless allocs.
+func getWhitelistedQuery(queryPath string) (codec.ProtoMarshaler, error) {
+	protoResponseAny, isWhitelisted := stargateResponsePools[queryPath]
 	if !isWhitelisted {
 		return nil, wasmvmtypes.UnsupportedRequest{Kind: fmt.Sprintf("'%s' path is not allowed from the contract", queryPath)}
 	}
-	protoResponseType, ok := protoResponseAny.(codec.ProtoMarshaler)
-	if !ok {
-		return nil, wasmvmtypes.Unknown{}
-	}
-	return protoResponseType, nil
+	return protoResponseAny.Get().(codec.ProtoMarshaler), nil
 }
 
-func setWhitelistedQuery(queryPath string, protoType codec.ProtoMarshaler) {
-	stargateWhitelist.Store(queryPath, protoType)
+type protoTypeG[T any] interface {
+	*T
+	codec.ProtoMarshaler
+}
+
+func setWhitelistedQuery[T any, PT protoTypeG[T]](queryPath string, _ PT) {
+	stargateResponsePools[queryPath] = &sync.Pool{
+		New: func() any {
+			return PT(new(T))
+		},
+	}
+}
+
+func returnStargateResponseToPool(queryPath string, pb codec.ProtoMarshaler) {
+	stargateResponsePools[queryPath].Put(pb)
 }
 
 func GetStargateWhitelistedPaths() (keys []string) {
 	// Iterate over the map and collect the keys
-	stargateWhitelist.Range(func(key, value interface{}) bool {
-		keyStr, ok := key.(string)
-		if !ok {
-			panic("key is not a string")
-		}
-		keys = append(keys, keyStr)
-		return true
-	})
-
+	keys = make([]string, 0, len(stargateResponsePools))
+	for k := range stargateResponsePools {
+		keys = append(keys, k)
+	}
 	return keys
 }

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -202,7 +202,11 @@ func getWhitelistedQuery(queryPath string) (codec.ProtoMarshaler, error) {
 	if !isWhitelisted {
 		return nil, wasmvmtypes.UnsupportedRequest{Kind: fmt.Sprintf("'%s' path is not allowed from the contract", queryPath)}
 	}
-	return protoResponseAny.Get().(codec.ProtoMarshaler), nil
+	protoMarshaler, ok := protoResponseAny.Get().(codec.ProtoMarshaler)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type to codec.ProtoMarshaler")
+	}
+	return protoMarshaler, nil
 }
 
 type protoTypeG[T any] interface {

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -41,7 +41,7 @@ import (
 // The query is multi-threaded so we're using a sync.Pool
 // to manage the allocation and de-allocation of newly created
 // pb objects.
-var stargateResponsePools map[string]*sync.Pool
+var stargateResponsePools = make(map[string]*sync.Pool)
 
 // Note: When adding a migration here, we should also add it to the Async ICQ params in the upgrade.
 // In the future we may want to find a better way to keep these in sync

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -222,6 +222,7 @@ func setWhitelistedQuery[T any, PT protoTypeG[T]](queryPath string, _ PT) {
 	}
 }
 
+// returnStargateResponseToPool returns the provided protoMarshaler to the appropriate pool based on it's query path.
 func returnStargateResponseToPool(queryPath string, pb codec.ProtoMarshaler) {
 	stargateResponsePools[queryPath].Put(pb)
 }

--- a/wasmbinding/stargate_whitelist.go
+++ b/wasmbinding/stargate_whitelist.go
@@ -214,6 +214,10 @@ type protoTypeG[T any] interface {
 	codec.ProtoMarshaler
 }
 
+// setWhitelistedQuery sets the whitelisted query at the provided path.
+// This method also creates a sync.Pool for the provided protoMarshaler.
+// We use generics so we can properly instantiate an object that the
+// queryPath expects as a response.
 func setWhitelistedQuery[T any, PT protoTypeG[T]](queryPath string, _ PT) {
 	stargateResponsePools[queryPath] = &sync.Pool{
 		New: func() any {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR uses a sync pool to unmarshal responses of protobuf objects in stargate queries.

We were previously utilizing pointers, which under heavy load can result in nondeterminism.

## Testing and Verifying

This code was backported to v21 and tested against mainnet.

Previously, we were able to app hash nodes within 10 minutes of spam. With this change, the node has been running for 1 hour with no issues.