### PR TITLE
chore(Makefile): add `setup-pre-commit` target to init git hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ help:
 	@echo "  make release               Show available release commands"
 	@echo "  make release-help          Show available release commands"
 	@echo "  make run-querygen          Generating GRPC queries, and queryproto logic"
+	@echo "  make setup-pre-commit      Set pre-commit git hook"
 	@echo "  make sqs                   Show available sqs commands"
 	@echo "  make test                  Show available test commands"
 	@echo ""
@@ -197,3 +198,9 @@ endif
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \
 	test test-all test-build test-cover test-unit test-race benchmark \
 	release release-dry-run release-snapshot
+
+setup-pre-commit:
+	@cp .git/hooks/pre-commit .git/hooks/pre-commit.bak 2>/dev/null || true
+	@echo "Installing pre-commit hook..."
+	@ln -sf ../../scripts/hooks/pre-commit.sh .git/hooks/pre-commit
+	@echo "Pre-commit hook installed successfully"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ help:
 	@echo "  make release               Show available release commands"
 	@echo "  make release-help          Show available release commands"
 	@echo "  make run-querygen          Generating GRPC queries, and queryproto logic"
-	@echo "  make setup-pre-commit      Set pre-commit git hook"
 	@echo "  make sqs                   Show available sqs commands"
 	@echo "  make test                  Show available test commands"
 	@echo ""
@@ -198,9 +197,3 @@ endif
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \
 	test test-all test-build test-cover test-unit test-race benchmark \
 	release release-dry-run release-snapshot
-
-setup-pre-commit:
-	@cp .git/hooks/pre-commit .git/hooks/pre-commit.bak 2>/dev/null || true
-	@echo "Installing pre-commit hook..."
-	@ln -sf ../../scripts/hooks/pre-commit.sh .git/hooks/pre-commit
-	@echo "Pre-commit hook installed successfully"

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # lint modified go files
-golangci-lint run --fix --new -c .golangci.yml
+golangci-lint run --fix --new --fast -c .golangci.yml

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# lint modified go files
+golangci-lint run --fix --new -c .golangci.yml

--- a/scripts/makefiles/lint.mk
+++ b/scripts/makefiles/lint.mk
@@ -8,12 +8,13 @@ lint-help:
 	@echo "  make lint-[command]"
 	@echo ""
 	@echo "Available Commands:"
-	@echo "  all          Run all linters"
-	@echo "  fix-typo     Run codespell to fix typos"
-	@echo "  format       Run linters with auto-fix"
-	@echo "  markdown     Run markdown linter with auto-fix"
-	@echo "  mdlint       Run markdown linter"
-	@echo "  typo         Run codespell to check typos"
+	@echo "  all                   Run all linters"
+	@echo "  fix-typo              Run codespell to fix typos"
+	@echo "  format                Run linters with auto-fix"
+	@echo "  markdown              Run markdown linter with auto-fix"
+	@echo "  mdlint                Run markdown linter"
+	@echo "  setup-pre-commit      Set pre-commit git hook"
+	@echo "  typo                  Run codespell to check typos"
 lint: lint-help
 
 lint-all:
@@ -38,3 +39,10 @@ lint-typo:
 
 lint-fix-typo:
 	@codespell -w
+
+lint-setup-pre-commit:
+	@cp .git/hooks/pre-commit .git/hooks/pre-commit.bak 2>/dev/null || true
+	@echo "Installing pre-commit hook..."
+	@ln -sf ../../scripts/hooks/pre-commit.sh .git/hooks/pre-commit
+	@echo "Pre-commit hook installed successfully"
+	


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
Similar to [cosmos/cosmos-sdk#19075](https://github.com/cosmos/cosmos-sdk/pull/19075)

We often forget to run lint or check the result of linting before we push the commits

This pr adds a git pre-commit hook for linting new changes code, this will prevent contributors from pushing their commits without linting, and reduce the times of re-run ci.

![image](https://github.com/osmosis-labs/osmosis/assets/150114626/e5c2660d-ccbf-4b78-9676-37611b99d72e)

## How to use
After you clone the repository, just simply run `make setup-pre-commit`

![image](https://github.com/osmosis-labs/osmosis/assets/150114626/1f015b7f-f09d-4ec4-b716-943d519514aa)

