### PR TITLE
fix: remove ctx.IsGenesis from cosmwasm authenticator

### DIFF
--- a/x/authenticator/authenticator/cosmwasm.go
+++ b/x/authenticator/authenticator/cosmwasm.go
@@ -3,6 +3,7 @@ package authenticator
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/CosmWasm/wasmd/x/wasm/keeper"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -150,7 +151,7 @@ func (cwa CosmwasmAuthenticator) Authenticate(ctx sdk.Context, account sdk.AccAd
 	}
 
 	// Retrieve and build the signer data struct
-	genesis := ctx.IsGenesis() || ctx.BlockHeight() == 0
+	genesis := ctx.BlockHeight() == 0
 	chainID := ctx.ChainID()
 	var accNum uint64
 	baseAccount := cwa.ak.GetAccount(ctx, account)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Removed deprecated code for IsGenesis()