### PR TITLE
De-duplicate fetching intermediate accounts

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -799,7 +799,7 @@ func (k Keeper) Distribute(ctx sdk.Context, gauges []types.Gauge) (sdk.Coins, er
 
 	locksByDenomCache := make(map[string][]lockuptypes.PeriodLock)
 	totalDistributedCoins := sdk.NewCoins()
-	scratchSlice := make([]*lockuptypes.PeriodLock, 0, 10000)
+	scratchSlice := make([]*lockuptypes.PeriodLock, 0, 50000)
 
 	for _, gauge := range gauges {
 		var gaugeDistributedCoins sdk.Coins

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -61,6 +61,7 @@ func (k Keeper) AfterEpochStartBeginBlock(ctx sdk.Context) {
 }
 
 func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context, accs []types.SuperfluidIntermediaryAccount) {
+	bondDenom := k.sk.BondDenom(ctx)
 	for _, acc := range accs {
 		addr := acc.GetAccAddress()
 		valAddr, err := sdk.ValAddressFromBech32(acc.ValAddr)
@@ -84,7 +85,6 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context, accs []t
 		_ = osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
 			// Note! We only send the bond denom (osmo), to avoid attack vectors where people
 			// send many different denoms to the intermediary account, and make a resource exhaustion attack on end block.
-			bondDenom := k.sk.BondDenom(cacheCtx)
 			balance := k.bk.GetBalance(cacheCtx, addr, bondDenom)
 			if balance.IsZero() {
 				return nil

--- a/x/superfluid/keeper/epoch_test.go
+++ b/x/superfluid/keeper/epoch_test.go
@@ -215,7 +215,8 @@ func (s *KeeperTestSuite) TestMoveSuperfluidDelegationRewardToGauges() {
 			}
 
 			// move intermediary account delegation rewards to gauges
-			s.App.SuperfluidKeeper.MoveSuperfluidDelegationRewardToGauges(s.Ctx)
+			accs := s.App.SuperfluidKeeper.GetAllIntermediaryAccounts(s.Ctx)
+			s.App.SuperfluidKeeper.MoveSuperfluidDelegationRewardToGauges(s.Ctx, accs)
 
 			// check invariant is fine
 			reason, broken := keeper.AllInvariants(*s.App.SuperfluidKeeper)(s.Ctx)
@@ -292,7 +293,8 @@ func (s *KeeperTestSuite) TestDistributeSuperfluidGauges() {
 				}
 
 				// move intermediary account delegation rewards to gauges
-				s.App.SuperfluidKeeper.MoveSuperfluidDelegationRewardToGauges(s.Ctx)
+				accs := s.App.SuperfluidKeeper.GetAllIntermediaryAccounts(s.Ctx)
+				s.App.SuperfluidKeeper.MoveSuperfluidDelegationRewardToGauges(s.Ctx, accs)
 
 				// move gauges to active gauge by declaring epoch end
 				s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(time.Minute))

--- a/x/superfluid/keeper/hooks.go
+++ b/x/superfluid/keeper/hooks.go
@@ -115,5 +115,6 @@ func (h Hooks) AfterValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, in
 	if slashFactor.IsZero() {
 		return
 	}
-	h.k.RefreshIntermediaryDelegationAmounts(ctx)
+	accs := h.k.GetAllIntermediaryAccounts(ctx)
+	h.k.RefreshIntermediaryDelegationAmounts(ctx, accs)
 }

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -45,9 +45,8 @@ func (k Keeper) GetExpectedDelegationAmount(ctx sdk.Context, acc types.Superflui
 // RefreshIntermediaryDelegationAmounts refreshes the amount of delegation for all intermediary accounts.
 // This method includes minting new osmo if the refreshed delegation amount has increased, and
 // instantly undelegating and burning if the refreshed delegation has decreased.
-func (k Keeper) RefreshIntermediaryDelegationAmounts(ctx sdk.Context) {
+func (k Keeper) RefreshIntermediaryDelegationAmounts(ctx sdk.Context, accs []types.SuperfluidIntermediaryAccount) {
 	// iterate over all intermedairy accounts - every (denom, validator) pair
-	accs := k.GetAllIntermediaryAccounts(ctx)
 	for _, acc := range accs {
 		mAddr := acc.GetAccAddress()
 

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -975,7 +975,8 @@ func (s *KeeperTestSuite) TestRefreshIntermediaryDelegationAmounts() {
 				s.App.SuperfluidKeeper.SetOsmoEquivalentMultiplier(s.Ctx, 2, denom, multiplier)
 			}
 
-			s.App.SuperfluidKeeper.RefreshIntermediaryDelegationAmounts(s.Ctx)
+			accs := s.App.SuperfluidKeeper.GetAllIntermediaryAccounts(s.Ctx)
+			s.App.SuperfluidKeeper.RefreshIntermediaryDelegationAmounts(s.Ctx, accs)
 
 			originalMultiplier := osmomath.NewDec(20)
 			for interAccIndex, intermediaryAcc := range intermediaryAccs {
@@ -1022,7 +1023,8 @@ func (s *KeeperTestSuite) TestRefreshIntermediaryDelegationAmounts() {
 			}
 
 			// refresh intermediary account delegations
-			s.App.SuperfluidKeeper.RefreshIntermediaryDelegationAmounts(s.Ctx)
+			accs = s.App.SuperfluidKeeper.GetAllIntermediaryAccounts(s.Ctx)
+			s.App.SuperfluidKeeper.RefreshIntermediaryDelegationAmounts(s.Ctx, accs)
 
 			for _, intermediaryAcc := range intermediaryAccs {
 				// check unbonded amount is removed after refresh operation


### PR DESCRIPTION
State compatibly de-duplicate get intermediate account fetches. On its own, this isn't much of a savings (20ms with and w/o fast nodes -- not sure why theres cache hits in IAVL v1 and fast nodes off TBH). The hope is that this can be used with an additional filter to cheapen more expensive loops going on in both methods. The latter may not be state compatible, hence making two PR's.

This also removes getting the BondDenom from the core loop, saving another 60ms