### PR TITLE
perf: Remove unneeded balance fetch in superfluid distribution

### DIFF
--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -74,7 +74,8 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context, accs []t
 		_ = osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
 			_, err := k.ck.WithdrawDelegationRewards(cacheCtx, addr, valAddr)
 			if errors.Is(err, distributiontypes.ErrEmptyDelegationDistInfo) {
-				ctx.Logger().Debug("no swaps occurred in this pool between last epoch and this epoch")
+				ctx.Logger().Debug("no delegations for this (pool, validator) pair, skipping...")
+				// TODO: Remove this account from IntermediaryAccounts that we iterate over
 				return nil
 			} else if err != nil {
 				return err

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -75,14 +75,12 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context, accs []t
 			_, err := k.ck.WithdrawDelegationRewards(cacheCtx, addr, valAddr)
 			if errors.Is(err, distributiontypes.ErrEmptyDelegationDistInfo) {
 				ctx.Logger().Debug("no swaps occurred in this pool between last epoch and this epoch")
+				return nil
 			} else if err != nil {
 				return err
 			}
-			return err
-		})
 
-		// Send delegation rewards to gauges
-		_ = osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
+			// Send delegation rewards to gauges
 			// Note! We only send the bond denom (osmo), to avoid attack vectors where people
 			// send many different denoms to the intermediary account, and make a resource exhaustion attack on end block.
 			balance := k.bk.GetBalance(cacheCtx, addr, bondDenom)


### PR DESCRIPTION
This PR removes an unneeded balance fetch if there is no delegation for a superfluid intermediary account. Its not-obvious to be fully sure of time savings, but it currently appears that removing this second ApplyFuncIfNoError, and skipping the balance check should be saving us ~700ms in IAVL v1 no fast nodes, and 150ms in IAVL v0. (This data should be in the parent CacheCtx, as its sent tokens in withdraw delegation rewards for pools with superfluid delegations. So any time spent in IAVL in this Get Balance call should be what we save. This isn't true if there's simply too few rewards to distribute, but I'd hope that distribution errors in such cases, and so isn't what we see.)

This is not state compatible due to edge cases.