### PR TITLE
Add buildjet runners

### DIFF
--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -34,7 +34,6 @@ on:
       - "v[0-9]+.x"
 
 env:
-  GOLANG_VERSION: 1.18
   GENESIS_URL: https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
   ADDRBOOK_URL: https://rpc.osmosis.zone/addrbook
   SNAPSHOT_BUCKET: https://snapshots.osmosis.zone

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -62,8 +62,6 @@ jobs:
           build-args: |
             BASE_IMG_TAG=debug
             BUILD_TAGS="netgo,muslc,excludeIncrement"
-          cache-from: type=registry,ref=osmosis:debug
-          cache-to: type=inline
       -
         name: Test e2e and Upgrade
         run: make test-e2e-ci-scheduled

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-env:
-  GO_VERSION: "1.20.5"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -16,9 +13,11 @@ jobs:
   get_diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository code
         uses: actions/checkout@v4
-      - name: Get git diff
+      -
+        name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -28,8 +27,9 @@ jobs:
             **/**.sum
             Makefile
             Dockerfile
-            .github/workflows/test.yml
-      - name: Set output
+            .github/workflows/e2e-full.yml
+      -
+        name: Set output
         id: vars
         run: echo "::set-output name=git_diff::$GIT_DIFF"
     outputs:
@@ -41,22 +41,19 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:
-      - name: Clean up Pre-Existing E2E Docker containers
-        run: |
-          # Remove containers with names starting with "osmo-test-"
-          docker ps -aqf "name=osmo-test-*" | xargs -r docker rm -f
-
-          # Remove containers with names starting with "hermes-relayer"
-          docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
-      - name: Check out repository code
+      -
+        name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up QEMU
+      -
+        name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build e2e image
+      -
+        name: Build e2e image
         uses: docker/build-push-action@v5
         with:
           load: true
@@ -65,29 +62,27 @@ jobs:
           build-args: |
             BASE_IMG_TAG=debug
             BUILD_TAGS="netgo,muslc,excludeIncrement"
-      - name: Test e2e and Upgrade
+          cache-from: type=registry,ref=osmosis:debug
+          cache-to: type=inline
+      -
+        name: Test e2e and Upgrade
         run: make test-e2e-ci-scheduled
-      - name: Dump docker logs on failure
+      -
+        name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
           dest: "./logs"
-      - name: Tar logs
+      -
+        name: Tar logs
         if: failure()
-        run: tar cvzf ./logs.tgz ./logs
-      - name: Upload logs to GitHub
-        uses: actions/upload-artifact@v3
+        run: |
+          tar cvzf ./logs.tgz ./logs
+      -
+        name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v4
         with:
           name: logs.tgz
           path: ./logs.tgz
-        if: failure()
-      - name: 🧹 Clean up Osmosis Home
-        if: always()
-        run: rm -rf $HOME/.osmosisd/ || true
-      - name: Clean up E2E Docker containers
-        run: |
-          # Remove containers with names starting with "osmo-test-"
-          docker ps -aqf "name=osmo-test-*" | xargs -r docker rm -f
-
-          # Remove containers with names starting with "hermes-relayer"
-          docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
+  

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -38,7 +38,7 @@ jobs:
   e2e:
     needs: get_diff
     if: needs.get_diff.outputs.git_diff
-    runs-on: self-hosted
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:
       - name: Clean up Pre-Existing E2E Docker containers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release:
     name: Create release
-    runs-on: self-hosted
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       -
         name: Check out repository code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
         name: Display go version
         run: go version
       -
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,6 @@ on:
       - "v[0-9]**"
   workflow_dispatch:
 
-env:
-  GO_VERSION: "1.20.5"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -22,9 +19,11 @@ jobs:
   get_diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository code
         uses: actions/checkout@v4
-      - name: Get git diff
+      -
+        name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -35,7 +34,8 @@ jobs:
             Makefile
             Dockerfile
             .github/workflows/test.yml
-      - name: Set output
+      -
+        name: Set output
         id: vars
         run: echo "::set-output name=git_diff::$GIT_DIFF"
     outputs:
@@ -46,29 +46,46 @@ jobs:
     if: needs.get_diff.outputs.git_diff
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository
         uses: actions/checkout@v4
-      - name: 🐿 Setup Golang
+      -
+        name: 🐿 Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: ${{env.GO_VERSION}}
-      - name: Create a file with all core Cosmos SDK pkgs
-        run: go list ./... ./osmomath/... ./osmoutils/... ./x/ibc-hooks/... ./x/epochs | grep -E -v 'tests/simulator|e2e' > pkgs.txt
-      - name: Split pkgs into 4 files
-        run: split -d -n l/4 pkgs.txt pkgs.txt.part.
-      - uses: actions/upload-artifact@v3
+          go-version-file: go.mod
+      -
+        name: Create a file with all core Cosmos SDK pkgs
+        run: |
+          go list \
+            ./... \
+            ./osmomath/... \
+            ./osmoutils/... \
+            ./x/ibc-hooks/...\
+            ./x/epochs \
+            | grep -E -v 'tests/simulator|e2e' \
+            > pkgs.txt
+      -
+        name: Split pkgs into 4 files
+        run: |
+          split -d -n l/4 pkgs.txt pkgs.txt.part.
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-00"
           path: ./pkgs.txt.part.00
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-01"
           path: ./pkgs.txt.part.01
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-02"
           path: ./pkgs.txt.part.02
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-03"
           path: ./pkgs.txt.part.03
@@ -82,57 +99,47 @@ jobs:
       matrix:
         part: ["00", "01", "02", "03"]
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository
         uses: actions/checkout@v4
-      - name: 🐿 Setup Golang
+      -
+        name: 🐿 Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: ${{env.GO_VERSION}}
-      - name: Display go version
+          go-version-file: go.mod
+      -
+        name: Display go version
         run: go version
-      - uses: actions/download-artifact@v3
+      -
+        uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
-      - name: Test & coverage report creation
+      -
+        name: Test & coverage report creation
         run: |
           VERSION=$(echo $(git describe --tags) | sed 's/^v//') || VERSION=${GITHUB_SHA}
           TESTS=$(cat pkgs.txt.part.${{ matrix.part }})
-
           VERSION=$VERSION SKIP_WASM_WSL_TESTS="false" go test -race -mod=readonly -tags='ledger test_ledger_mock norace' $TESTS
 
   e2e:
     needs: get_diff
     if: needs.get_diff.outputs.git_diff
-    runs-on: self-hosted
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:
-      - name: Clean up Pre-Existing E2E Docker containers
-        run: |
-          # Remove containers with names starting with "osmo-test-"
-          docker ps -aqf "name=osmo-test-*" | xargs -r docker rm -f
-
-          # Remove containers with names starting with "hermes-relayer"
-          docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
-
-          # Get a list of all networks
-          NETWORKS=$(docker network ls --filter "name=osmosis-testnet" --format "{{.ID}}")
-
-          # Remove all the disconnected networks
-          for NETWORK in $NETWORKS; do
-              echo "Pruning $NETWORK..."
-              docker network rm $NETWORK
-          done
-
-          echo "Done pruning osmosis-testnet networks."
-      - name: Check out repository code
+      -
+        name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up QEMU
+      -
+        name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build e2e image
+      -
+        name: Build e2e image
         uses: docker/build-push-action@v5
         with:
           load: true
@@ -141,40 +148,26 @@ jobs:
           build-args: |
             BASE_IMG_TAG=debug
             BUILD_TAGS="netgo,muslc,excludeIncrement"
-      - name: Test e2e and Upgrade
+          cache-from: type=registry,ref=osmosis:debug
+          cache-to: type=inline
+      -
+        name: Test e2e and Upgrade
         run: make test-e2e-ci
-      - name: Dump docker logs on failure
+      -
+        name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
           dest: "./logs"
-      - name: Tar logs
+      -
+        name: Tar logs
         if: failure()
-        run: tar cvzf ./logs.tgz ./logs
-      - name: Upload logs to GitHub
-        uses: actions/upload-artifact@v3
+        run: |
+          tar cvzf ./logs.tgz ./logs
+      -
+        name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v4
         with:
           name: logs.tgz
           path: ./logs.tgz
-        if: failure()
-      - name: 🧹 Clean up Osmosis Home
-        if: always()
-        run: rm -rf $HOME/.osmosisd/ || true
-      - name: Clean up E2E Docker containers
-        run: |
-          # Remove containers with names starting with "osmo-test-"
-          docker ps -aqf "name=osmo-test-*" | xargs -r docker rm -f
-
-          # Remove containers with names starting with "hermes-relayer"
-          docker ps -aqf "name=hermes-relayer*" | xargs -r docker rm -f
-
-          # Get a list of all networks
-          NETWORKS=$(docker network ls --filter "name=osmosis-testnet" --format "{{.ID}}")
-
-          # Remove all the disconnected networks
-          for NETWORK in $NETWORKS; do
-              echo "Pruning $NETWORK..."
-              docker network rm $NETWORK
-          done
-
-          echo "Done pruning osmosis-testnet networks."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,8 +148,6 @@ jobs:
           build-args: |
             BASE_IMG_TAG=debug
             BUILD_TAGS="netgo,muslc,excludeIncrement"
-          cache-from: type=registry,ref=osmosis:debug
-          cache-to: type=inline
       -
         name: Test e2e and Upgrade
         run: make test-e2e-ci


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to enhance our CI/CD pipeline by transitioning from `self-hosted` runners to `buildjet` runners.

It also add the following minor improvements include:

- **Dynamic GO Version Configuration**: Eliminate the hardcoding of the `GO_VERSION` variable. Previously configured as:
```yaml
- name: 🐿 Setup Golang
  uses: actions/setup-go@v5
  with:
    go-version: ${{env.GO_VERSION}}
```
Now, the Go version is dynamically determined from the `go.mod` file, ensuring consistency with our project's requirements:
```yaml
- name: 🐿 Setup Golang
  uses: actions/setup-go@v5
  with:
    go-version-file: go.mod
```
- **Action Updates**: Upgraded certain actions to their latest versions.

Additionally, this PR changes the formatting to improve readability

## Testing and Verifying

This has been tested in https://github.com/osmosis-labs/test-buildjet 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A