### PR TITLE
perf: Move an overflow check out of hot loop

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	db "github.com/cometbft/cometbft-db"
@@ -724,10 +723,6 @@ func (k Keeper) distributeInternal(
 				// We should check overflow as we switch back to sdk.Int representation.
 				// However we know the final result will not be larger than the gauge size,
 				// which is bounded to an Int. So we can safely skip this.
-				err := checkBigInt(amtIntBi)
-				if err != nil {
-					continue
-				}
 
 				amtIntBi.Quo(amtIntBi, lockSumTimesRemainingEpochsBi)
 				if amtInt.Sign() == 1 {
@@ -760,18 +755,6 @@ func (k Keeper) distributeInternal(
 
 	err := k.updateGaugePostDistribute(ctx, gauge, totalDistrCoins)
 	return totalDistrCoins, err
-}
-
-// Max number of words a sdk.Int's big.Int can contain.
-// This is predicated on MaxBitLen being divisible by 64
-var maxWordLen = sdkmath.MaxBitLen / 64
-
-// check if a bigInt would overflow max sdk.Int. If it does, panic.
-func checkBigInt(bi *big.Int) error {
-	if len(bi.Bits()) > maxWordLen {
-		return fmt.Errorf("bigInt overflow")
-	}
-	return nil
 }
 
 // faster coins.AmountOf if we know that coins must contain the denom.

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -8,6 +8,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	sdkmath "cosmossdk.io/math"
+
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
@@ -65,12 +67,12 @@ func (p PeriodLock) SingleCoin() (sdk.Coin, error) {
 
 // TODO: Can we use sumtree instead here?
 // Assumes that caller is passing in locks that contain denom
-func SumLocksByDenom(locks []*PeriodLock, denom string) osmomath.Int {
+func SumLocksByDenom(locks []*PeriodLock, denom string) (osmomath.Int, error) {
 	sumBi := big.NewInt(0)
 	// validate the denom once, so we can avoid the expensive validate check in the hot loop.
 	err := sdk.ValidateDenom(denom)
 	if err != nil {
-		panic(fmt.Errorf("invalid denom used internally: %s, %v", denom, err))
+		return osmomath.Int{}, fmt.Errorf("invalid denom used internally: %s, %v", denom, err)
 	}
 	for _, lock := range locks {
 		var amt osmomath.Int
@@ -82,7 +84,25 @@ func SumLocksByDenom(locks []*PeriodLock, denom string) osmomath.Int {
 		}
 		sumBi.Add(sumBi, amt.BigIntMut())
 	}
-	return osmomath.NewIntFromBigInt(sumBi)
+
+	// handle overflow check here so we don't panic.
+	err = checkBigInt(sumBi)
+	if err != nil {
+		return sdk.ZeroInt(), err
+	}
+	return osmomath.NewIntFromBigInt(sumBi), nil
+}
+
+// Max number of words a sdk.Int's big.Int can contain.
+// This is predicated on MaxBitLen being divisible by 64
+var maxWordLen = sdkmath.MaxBitLen / 64
+
+// check if a bigInt would overflow max sdk.Int. If it does, panic.
+func checkBigInt(bi *big.Int) error {
+	if len(bi.Bits()) > maxWordLen {
+		return fmt.Errorf("bigInt overflow")
+	}
+	return nil
 }
 
 // quick fix for getting native denom from synthetic denom.

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -97,7 +97,7 @@ func SumLocksByDenom(locks []*PeriodLock, denom string) (osmomath.Int, error) {
 // This is predicated on MaxBitLen being divisible by 64
 var maxWordLen = sdkmath.MaxBitLen / 64
 
-// check if a bigInt would overflow max sdk.Int. If it does, panic.
+// check if a bigInt would overflow max sdk.Int. If it does, return an error.
 func checkBigInt(bi *big.Int) error {
 	if len(bi.Bits()) > maxWordLen {
 		return fmt.Errorf("bigInt overflow")

--- a/x/lockup/types/lock.go
+++ b/x/lockup/types/lock.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"math/big"
+	"math/bits"
 	"strings"
 	"time"
 
@@ -95,12 +96,14 @@ func SumLocksByDenom(locks []*PeriodLock, denom string) (osmomath.Int, error) {
 
 // Max number of words a sdk.Int's big.Int can contain.
 // This is predicated on MaxBitLen being divisible by 64
-var maxWordLen = sdkmath.MaxBitLen / 64
+var maxWordLen = sdkmath.MaxBitLen / bits.UintSize
 
 // check if a bigInt would overflow max sdk.Int. If it does, return an error.
 func checkBigInt(bi *big.Int) error {
 	if len(bi.Bits()) > maxWordLen {
-		return fmt.Errorf("bigInt overflow")
+		if bi.BitLen() > sdkmath.MaxBitLen {
+			return fmt.Errorf("bigInt overflow")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR moves the `err := checkBigInt(amtIntBi)` check from a hot loop, into one-time checking it on LockSum and noticing that it implies consistency that the hot loop is safe.

Nicely I noticed that we can also use len(bi.Bits()) instead of .BitLen() which saves a lot of CPU time. If we get this into the SDK, should save 1 full second off of Osmosis epoch, and speed up all math hot loops.