### PR TITLE
chore: custom v23 upgrade logic for testnet, introduce edgenet

### DIFF
--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -115,7 +115,7 @@ func migrateAllTestnetPools(ctx sdk.Context, concentratedKeeper concentratedliqu
 		}
 	}
 
-	// Set to pool ID zero becase all pools are migrated.
+	// Set to pool ID zero becuase all pools are migrated.
 	concentratedKeeper.SetIncentivePoolIDMigrationThreshold(ctx, 0)
 
 	return nil

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -1,6 +1,7 @@
 package v23
 
 import (
+	"errors"
 	"sort"
 	"time"
 
@@ -16,7 +17,15 @@ import (
 	concentratedtypes "github.com/osmosis-labs/osmosis/v23/x/concentrated-liquidity/types"
 )
 
-const mainnetChainID = "osmosis-1"
+const (
+	mainnetChainID = "osmosis-1"
+	// Edgenet is to function exactly the samas mainnet, and expected
+	// to be state-exported from mainnet state.
+	edgenetChainID = "edgenet"
+	// Testnet will have its own state. Contrary to mainnet, we would
+	// like to migrate all testnet pools at once.
+	testnetChainID = "osmo-test-5"
+)
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
@@ -44,13 +53,20 @@ func CreateUpgradeHandler(
 
 		keepers.ConcentratedLiquidityKeeper.SetIncentivePoolIDMigrationThreshold(ctx, lastPoolID)
 
+		chainID := ctx.ChainID()
 		// We only perform the migration on mainnet pools since we hard-coded the pool IDs to migrate
 		// in the types package. To ensure correctness, we will spin up a state-exported mainnet testnet
 		// with the same chain ID.
-		if ctx.ChainID() == mainnetChainID {
+		if chainID == mainnetChainID || chainID == edgenetChainID {
 			if err := migrateMainnetPools(ctx, *keepers.ConcentratedLiquidityKeeper); err != nil {
 				return nil, err
 			}
+		} else if chainID == testnetChainID {
+			if err := migrateAllTestnetPools(ctx, *keepers.ConcentratedLiquidityKeeper); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, errors.New("unsupported chain ID")
 		}
 
 		after := time.Now()
@@ -79,6 +95,28 @@ func migrateMainnetPools(ctx sdk.Context, concentratedKeeper concentratedliquidi
 			return err
 		}
 	}
+
+	return nil
+}
+
+// migrates all pools. This is only for testnet.
+// CONTRACT: called after setting the pool ID migration threshold since this overwrites the threshold to zero.
+func migrateAllTestnetPools(ctx sdk.Context, concentratedKeeper concentratedliquidity.Keeper) error {
+	// Get all pools
+	pools, err := concentratedKeeper.GetPools(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Migrate each pool
+	for _, pool := range pools {
+		if err := concentratedKeeper.MigrateAccumulatorToScalingFactor(ctx, pool.GetId()); err != nil {
+			return err
+		}
+	}
+
+	// Set to pool ID zero becase all pools are migrated.
+	concentratedKeeper.SetIncentivePoolIDMigrationThreshold(ctx, 0)
 
 	return nil
 }

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -115,7 +115,7 @@ func migrateAllTestnetPools(ctx sdk.Context, concentratedKeeper concentratedliqu
 		}
 	}
 
-	// Set to pool ID zero becuase all pools are migrated.
+	// Set to pool ID zero because all pools are migrated.
 	concentratedKeeper.SetIncentivePoolIDMigrationThreshold(ctx, 0)
 
 	return nil

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -25,6 +25,9 @@ const (
 	// Testnet will have its own state. Contrary to mainnet, we would
 	// like to migrate all testnet pools at once.
 	testnetChainID = "osmo-test-5"
+	// E2E chain IDs which we expect to migrate all pools similar to testnet.
+	e2eChaInIDA = "osmo-test-a"
+	e2eChaInIDB = "osmo-test-b"
 )
 
 func CreateUpgradeHandler(
@@ -61,7 +64,7 @@ func CreateUpgradeHandler(
 			if err := migrateMainnetPools(ctx, *keepers.ConcentratedLiquidityKeeper); err != nil {
 				return nil, err
 			}
-		} else if chainID == testnetChainID {
+		} else if chainID == testnetChainID || chainID == e2eChaInIDA || chainID == e2eChaInIDB {
 			if err := migrateAllTestnetPools(ctx, *keepers.ConcentratedLiquidityKeeper); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR introduces a custom testnet migration logic to migrate all pools.

Additionally, it allows for `edgenet` chain ID for our internal testnet. It is expected to work the same as mainnet
