### PR TITLE
fix: remove all vals from testnet state

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -473,6 +473,20 @@ func InitOsmosisAppForTestnet(app *OsmosisApp, newValAddr bytes.HexBytes, newVal
 	}
 	iterator.Close()
 
+	// Remove all validators from validators store
+	iterator = sdk.KVStorePrefixIterator(stakingStore, stakingtypes.ValidatorsKey)
+	for ; iterator.Valid(); iterator.Next() {
+		stakingStore.Delete(iterator.Key())
+	}
+	iterator.Close()
+
+	// Remove all validators from unbonding queue
+	iterator = sdk.KVStorePrefixIterator(stakingStore, stakingtypes.ValidatorQueueKey)
+	for ; iterator.Valid(); iterator.Next() {
+		stakingStore.Delete(iterator.Key())
+	}
+	iterator.Close()
+
 	// Add our validator to power and last validators store
 	app.StakingKeeper.SetValidator(ctx, newVal)
 	err = app.StakingKeeper.SetValidatorByConsAddr(ctx, newVal)
@@ -534,6 +548,8 @@ func InitOsmosisAppForTestnet(app *OsmosisApp, newValAddr bytes.HexBytes, newVal
 	dayEpochInfo.Duration = time.Hour * 6
 	// Prevents epochs from running back to back
 	dayEpochInfo.CurrentEpochStartTime = time.Now().UTC()
+	// If you want epoch to run a minute after starting the chain, uncomment the line below and comment the line above
+	// dayEpochInfo.CurrentEpochStartTime = time.Now().UTC().Add(-dayEpochInfo.Duration).Add(time.Minute)
 	dayEpochInfo.CurrentEpochStartHeight = app.LastBlockHeight()
 	app.EpochsKeeper.DeleteEpochInfo(ctx, "day")
 	err = app.EpochsKeeper.AddEpochInfo(ctx, dayEpochInfo)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Noticed in testing that after epoch, the old validators would repopulate. The chain still ran because our validator has majority power, but caused longer blocks due to waiting for validators to time out. This removes the last two store entries for validators that were missed.

## Testing and Verifying

Tested in v23 testing.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A