### PR TITLE
fix: e2e init genesis default values for uptime incentives

### DIFF
--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -390,9 +390,8 @@ func updateIncentivesGenesis(incentivesGenState *incentivestypes.GenesisState) {
 		time.Second * 120,
 		time.Second * 240,
 	}
-	incentivesGenState.Params = incentivestypes.Params{
-		DistrEpochIdentifier: "day",
-	}
+	incentivesGenState = incentivestypes.DefaultGenesis()
+	incentivesGenState.Params.DistrEpochIdentifier = "day"
 }
 
 func updateMintGenesis(mintGenState *minttypes.GenesisState) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When testing v23 > v24 e2e, I saw that v23 initialization was panicking due to a zero time value for InternalUptime. This starts by setting all defaults, and then overrides the one param required. 

## Testing and Verifying

Built image locally, tested and it works.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A