### PR TITLE
[fix]: Fix gauge CLI and `ValidateBasic` to work with uptimes

### DIFF
--- a/x/incentives/client/cli/tx.go
+++ b/x/incentives/client/cli/tx.go
@@ -112,6 +112,7 @@ func NewCreateGaugeCmd() *cobra.Command {
 			} else if poolId > 0 {
 				distributeTo = lockuptypes.QueryCondition{
 					LockQueryType: lockuptypes.NoLock,
+					Duration:      duration,
 				}
 			}
 

--- a/x/incentives/types/msgs.go
+++ b/x/incentives/types/msgs.go
@@ -72,10 +72,6 @@ func (m MsgCreateGauge) ValidateBasic() error {
 			return errors.New(`no lock gauge denom should be unset. It will be automatically set to the NoLockExternalGaugeDenom(<pool id>)
 			 format internally, allowing for querying the gauges by denom with this prefix`)
 		}
-
-		if m.DistributeTo.Duration != 0 {
-			return fmt.Errorf("'no lock' gauge must have duration set to 0, was (%d)", m.DistributeTo.Duration)
-		}
 	} else {
 		if m.PoolId != 0 {
 			return errors.New("pool id should not be set for duration distr condition")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR fixes a `create-gauge` CLI issue that initialized the `duration` field to `NoLock` gauges to 0. It also removes the `ValidateBasic` check that prevents nonzero durations from being set on `NoLock` guages, which somehow slipped through even though it was flagged in an earlier issue.

## Testing and Verifying

The changes will be manually QA'd on localosmosis/edgenet

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A