### PR TITLE
Feat/add more buildjet runners

### DIFF
--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -34,22 +34,23 @@ on:
       - "v[0-9]+.x"
 
 env:
-  GENESIS_URL: https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
+  GENESIS_URL: https://osmosis.fra1.cdn.digitaloceanspaces.com/osmosis-1/genesis.json
   ADDRBOOK_URL: https://rpc.osmosis.zone/addrbook
   SNAPSHOT_BUCKET: https://snapshots.osmosis.zone
   RPC_ENDPOINT: https://rpc.osmosis.zone
   LCD_ENDPOINT: https://lcd.osmosis.zone
-  DELTA_HALT_HEIGHT: 50
+  DELTA_TARGET_HEIGHT: 50
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+
+  # Compare current mainnet osmosis major version with the major version of github branch
+  # Skip the next job if the current github major is greater than the current mainnet major
   compare_versions:
-    # Compare current mainnet osmosis major version with the major version of github branch
-    # Skip the next job if the current github major is greater than the current mainnet major
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       should_i_run: ${{ steps.compare_versions.outputs.should_i_run }}
       mainnet_major_version: ${{ steps.mainnet_version.outputs.mainnet_major_version }}
@@ -58,9 +59,8 @@ jobs:
         name: Get mainnet major version
         id: mainnet_version
         run: |
-          # Find current major version via rpc.osmosis.zone/abci_info
           RPC_ABCI_INFO=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" ${{ env.RPC_ENDPOINT }}/abci_info)
-          MAINNET_MAJOR_VERSION=$(echo $RPC_ABCI_INFO | dasel --plain -r json  'result.response.version' | cut -f 1 -d '.')
+          MAINNET_MAJOR_VERSION=$(echo $RPC_ABCI_INFO | jq -r '.result.response.version' | cut -f 1 -d '.')
 
           echo "MAINNET_MAJOR_VERSION=$MAINNET_MAJOR_VERSION" >> $GITHUB_ENV
           echo "mainnet_major_version=$MAINNET_MAJOR_VERSION" >> $GITHUB_OUTPUT
@@ -82,19 +82,23 @@ jobs:
           fi
 
   check_state_compatibility:
-    # DO NOT CHANGE THIS: please read the note above
-    if: ${{ github.event.pull_request.head.repo.full_name == 'osmosis-labs/osmosis' && needs.compare_versions.outputs.should_i_run == 'true' }}
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: compare_versions
-    runs-on: self-hosted
+    timeout-minutes: 20
+    if: ${{ needs.compare_versions.outputs.should_i_run == 'true'}}
     steps:
       -
-        name: Checkout branch
+        name: Get chain major version
+        run: |
+          echo "MAINNET_MAJOR_VERSION=${{ needs.compare_versions.outputs.mainnet_major_version }}" >> $GITHUB_ENV
+      -
+        name: Checkout ref
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
         name: 🐿 Setup Golang
-        uses: actions/setup-go@v5
+        uses: buildjet/setup-go@v5
         with:
           go-version-file: go.mod
       -
@@ -104,18 +108,8 @@ jobs:
           build/osmosisd version
       -
         name: 🧪 Initialize Osmosis Node
-        run: |
-          rm -rf $HOME/.osmosisd/ || true
-          build/osmosisd init runner -o
-
-          # Download genesis file if not present
-          mkdir -p /mnt/data/genesis/osmosis-1/
-          if [ ! -f "/mnt/data/genesis/osmosis-1/genesis.json" ]; then
-            wget -q -O /mnt/data/genesis/osmosis-1/genesis.json ${{ env.GENESIS_URL }}
-          fi
-
-          # Copy genesis to config folder
-          cp /mnt/data/genesis/osmosis-1/genesis.json $HOME/.osmosisd/config/genesis.json
+        run:  |
+          build/osmosisd init runner -o --home ${{ runner.temp }}/.osmosisd/
       -
         name: ⏬ Download last pre-epoch snapshot
         run: |
@@ -127,25 +121,28 @@ jobs:
           SNAPSHOT_URL=$(echo $SNAPSHOT_INFO | jq -r '.[] | select(.type == "pre-epoch").url')
           SNAPSHOT_ID=$(echo $SNAPSHOT_INFO |  jq -r '.[] | select(.type == "pre-epoch").filename' | cut -f 1 -d '.')
 
-          # Download snapshot if not already present
-          mkdir -p /mnt/data/snapshots/$REPO_MAJOR_VERSION/
-          if [ ! -d "/mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID" ]; then
-              rm -rf /mnt/data/snapshots/$REPO_MAJOR_VERSION/*
-              mkdir /mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID
-              wget -q -O - $SNAPSHOT_URL | lz4 -d | tar -C /mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID -xvf -
-          fi
+          # Download snapshot
+          sudo apt install lz4 -y
+          wget -q -O - $SNAPSHOT_URL | lz4 -d | tar -C ${{ runner.temp }}/.osmosisd/ -xvf -
+      -
+        name: ⏬ Download genesis and addrbook
+        run:  |
+          CONFIG_FOLDER=${{ runner.temp }}/.osmosisd/config
 
-          # Copy snapshot in Data folder
-          cp -R /mnt/data/snapshots/$REPO_MAJOR_VERSION/$SNAPSHOT_ID/* $HOME/.osmosisd/
+          # Download genesis
+          wget -O $CONFIG_FOLDER/genesis.json ${{ env.GENESIS_URL }}
+
+          # Download addrbook
+          wget -O $CONFIG_FOLDER/addrbook.json ${{ env.ADDRBOOK_URL }}
       -
         name: 🧪 Configure Osmosis Node
         run: |
-          CONFIG_FOLDER=$HOME/.osmosisd/config
+          CONFIG_FOLDER=${{ runner.temp }}/.osmosisd/config
           REPO_MAJOR_VERSION=$(echo ${{ github.base_ref }} | tr -dc '0-9')
 
           if [ $REPO_MAJOR_VERSION == $MAINNET_MAJOR_VERSION ]; then
             # I'm in the latest major, fetch the epoch info from the lcd endpoint
-            LAST_EPOCH_BLOCK_HEIGHT=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 ${{ env.LCD_ENDPOINT }}/osmosis/epochs/v1beta1/epochs | dasel --plain -r json 'epochs.(identifier=day).current_epoch_start_height')
+            LAST_EPOCH_BLOCK_HEIGHT=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 ${{ env.LCD_ENDPOINT }}/osmosis/epochs/v1beta1/epochs | jq -r '.epochs[] | select(.identifier=="day").current_epoch_start_height')
           else
             # I'm in a previous major, calculate the epoch height from the snapshot height
             # (Snapshot is taken 100 blocks before epoch)
@@ -156,28 +153,61 @@ jobs:
             LAST_EPOCH_BLOCK_HEIGHT=$(($SNAPSHOT_BLOCK_HEIGHT + 100))
           fi
 
-          HALT_HEIGHT=$(($LAST_EPOCH_BLOCK_HEIGHT + ${{ env.DELTA_HALT_HEIGHT }}))
+          TARGET_HEIGHT=$(($LAST_EPOCH_BLOCK_HEIGHT + ${{ env.DELTA_TARGET_HEIGHT }}))
+          echo "TARGET_HEIGHT=$TARGET_HEIGHT" >> $GITHUB_ENV
 
           echo "Osmosis repo version: $REPO_MAJOR_VERSION"
           echo "Last Epoch Height: $LAST_EPOCH_BLOCK_HEIGHT"
-          echo "Halt Height: $HALT_HEIGHT"
+          echo "Target Height: $TARGET_HEIGHT"
 
-          # Edit config.toml
-          dasel put string -f $CONFIG_FOLDER/config.toml '.tx_index.indexer' null
-          dasel put string -f $CONFIG_FOLDER/config.toml '.p2p.persistent_peers' '37c195e518c001099f956202d34af029b04f2c97@p2p.archive.osmosis.zone:26656'
-          dasel put string -f $CONFIG_FOLDER/config.toml 'seeds' ''
+          # Edit config.toml for necessary configurations
+          sed -i 's/^indexer =.*/indexer = "null"/' $CONFIG_FOLDER/config.toml
+          sed -i 's/^persistent_peers =.*/persistent_peers = "37c195e518c001099f956202d34af029b04f2c97@p2p.archive.osmosis.zone:26656"/' $CONFIG_FOLDER/config.toml
+          sed -i '/^seeds =/c\seeds = ""' $CONFIG_FOLDER/config.toml
 
-          # Edit app.toml
-          dasel put string -f $CONFIG_FOLDER/app.toml '.halt-height' $HALT_HEIGHT
-          dasel put string -f $CONFIG_FOLDER/app.toml '.pruning' everything
-          dasel put string -f $CONFIG_FOLDER/app.toml '.state-sync.snapshot-interval' 0
-
-          # Download addrbook
-          wget -q -O $CONFIG_FOLDER/addrbook.json ${{ env.ADDRBOOK_URL }}
+          # Edit app.toml for pruning, and snapshot onfigurations
+          sed -i '/^pruning =/c\pruning = "everything"' $CONFIG_FOLDER/app.toml
+          sed -i '/^snapshot-interval =/c\snapshot-interval = 0' $CONFIG_FOLDER/app.toml
       -
-        name: 🧪 Start Osmosis Node
-        run: build/osmosisd start
+        name: 🧪 Start Osmosis Node in the background
+        run: |
+          mkdir ${{ runner.temp }}/logs
+
+          build/osmosisd start \
+            --home ${{ runner.temp }}/.osmosisd > ${{ runner.temp }}/logs/osmosis.log 2>&1 &
+          echo $! > ${{ runner.temp }}/osmosis_pid.txt
       -
-        name: 🧹 Clean up Osmosis Home
-        if: always()
-        run: rm -rf $HOME/.osmosisd/ || true
+        name: ⏳ Wait for Chain to start
+        run: |
+          echo -n "Waiting for chain to start"
+
+          until $(curl --output /dev/null --silent --head --fail http://localhost:26657/status) && [ $(curl -s http://localhost:26657/status | jq -r '.result.sync_info.latest_block_height') -ne 0 ]; do
+            printf '.'
+            sleep 1
+            if ! ps -p $(cat ${{ runner.temp }}/osmosis_pid.txt) > /dev/null; then
+              echo "Osmosis process is no longer running. Exiting."
+              exit 1
+            fi
+          done
+      -
+        name: ⏳ Wait for Chain to reach target height
+        run: |
+          until $(curl --output /dev/null --silent --head --fail http://localhost:26657/status) && [ $(curl -s http://localhost:26657/status | jq -r '.result.sync_info.latest_block_height') -ge $TARGET_HEIGHT ]; do
+
+            if ! ps -p $(cat ${{ runner.temp }}/osmosis_pid.txt) > /dev/null; then
+              echo "Osmosis process is no longer running. Exiting."
+              exit 1
+            fi
+
+            CURRENT_HEIGHT=$(curl -s --retry 5 --retry-delay 5 --connect-timeout 30 -H "Accept: application/json" http://localhost:26657/status | jq -r '.result.sync_info.latest_block_height')
+            echo "Current block height is $CURRENT_HEIGHT. Waiting for it to reach $TARGET_HEIGHT..."
+
+            sleep 1
+          done
+      -
+        name: 📤 Upload Upgrade Logs as Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs
+          path: ${{ runner.temp }}/logs

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -23,42 +23,49 @@ on:
       - v[0-9]+.x
 
 env:
-  RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.18
   OSMOSIS_DEV_IMAGE_REPOSITORY: osmolabs/osmosis-dev
   OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY: osmolabs/osmosis-e2e-init-chain
 
 jobs:
   docker:
-    runs-on: self-hosted
+    runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
-      - name: Check out repo
+      - 
+        name: Check out repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Docker Buildx
+      - 
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      - 
+        name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Find go version
+      - 
+        name: Find go version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-      - name: Create Docker Image Tag for release candidate
+      - 
+        name: Create Docker Image Tag for release candidate
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           GITHUB_TAG=${{ github.ref_name }}
           echo "DOCKER_IMAGE_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
           echo "OSMOSIS_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-      - name: Create Docker Image Tag for vN.x branch
+      - 
+        name: Create Docker Image Tag for vN.x branch
         if: "!startsWith(github.ref, 'refs/tags/v')"
         run: |
           SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)
           echo "DOCKER_IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
           echo "OSMOSIS_VERSION=${{ github.ref_name }}-$SHORT_SHA" >> $GITHUB_ENV
-      - name: Build and Push Docker Images
+      - 
+        name: Build and Push Docker Images
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile
@@ -72,7 +79,8 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           tags: |
             ${{ env.OSMOSIS_DEV_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
-      - name: Build and Push E2E Init Docker Images
+      - 
+        name: Build and Push E2E Init Docker Images
         uses: docker/build-push-action@v5
         with:
           file: tests/e2e/initialization/init.Dockerfile

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -23,7 +23,7 @@ on:
       - v[0-9]+.x
 
 env:
-  RUNNER_BASE_IMAGE_ALPINE: alpine:3.18
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
   OSMOSIS_DEV_IMAGE_REPOSITORY: osmolabs/osmosis-dev
   OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY: osmolabs/osmosis-e2e-init-chain
 

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -36,16 +36,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - 
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - 
+      -
         name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - 
+      -
         name: Find go version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -41,18 +41,18 @@ jobs:
   osmosisd-images:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - 
+      -
         name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - 
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - 
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - 
+      -
         name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -60,7 +60,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Find go version
-        id: find_go_version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
@@ -77,7 +76,7 @@ jobs:
           echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
           echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
       # Distroless Docker image (default)
-      - 
+      -
         name: Build and push (distroless)
         id: build_push_distroless
         uses: docker/build-push-action@v5
@@ -99,7 +98,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-distroless
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-distroless
       # Distroless nonroot Docker image
-      - 
+      -
         name: Build and push (nonroot)
         id: build_push_nonroot
         uses: docker/build-push-action@v5
@@ -118,7 +117,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-nonroot
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-nonroot
       # Alpine Docker image
-      - 
+      -
         name: Build and push (alpine)
         id: build_push_alpine
         uses: docker/build-push-action@v5
@@ -136,7 +135,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine
-      - 
+      -
         if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
         name: Build and push (e2e-chain-init)
         uses: docker/build-push-action@v5

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   osmosisd-images:
-    runs-on: self-hosted
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - 
         name: Check out the repo


### PR DESCRIPTION
## What is the purpose of the change

This PR eliminates the remaining workflows that utilize self-hosted runners by transitioning them to BuildJet.

A few adjustments are required in the process:

- Discontinue the use of the internal cache.
- Install the necessary packages.
- Transition from actions/setup to buildjet/setup.
- Enhance the formatting of the workflows.
- Use `jq` and `sed` over `dasel` 

## Testing and Verifying

Tested in: https://github.com/osmosis-labs/infrastructure/actions/runs/7902076978

The workflow can be triggered manually from: https://github.com/osmosis-labs/infrastructure/actions/workflows/state-compatibility.yaml

![image](https://github.com/osmosis-labs/osmosis/assets/6024049/0d8dbadc-00e1-452f-b48a-22f19f0fe381)


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A