### PR TITLE
fix: upgrades for in-place testnet

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -641,7 +641,7 @@ func InitOsmosisAppForTestnet(app *OsmosisApp, newValAddr bytes.HexBytes, newVal
 	if upgradeToTrigger != "" {
 		upgradePlan := upgradetypes.Plan{
 			Name:   upgradeToTrigger,
-			Height: app.LastBlockHeight(),
+			Height: app.LastBlockHeight() + 10,
 		}
 		err = app.UpgradeKeeper.ScheduleUpgrade(ctx, upgradePlan)
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When using the latest height for the upgrade, there is a panic right after the upgrade is applied due to having Comet votes for previous block from many validators.

As a result, we should run with modified state for a few blocks before actually applying the upgrade
