### PR TITLE
[performance]: Better key formatting in taker fee

### DIFF
--- a/x/poolmanager/taker_fee.go
+++ b/x/poolmanager/taker_fee.go
@@ -24,14 +24,15 @@ func (k Keeper) GetDefaultTakerFee(ctx sdk.Context) sdk.Dec {
 // it is deleted from state.
 func (k Keeper) SetDenomPairTakerFee(ctx sdk.Context, denom0, denom1 string, takerFee osmomath.Dec) {
 	store := ctx.KVStore(k.storeKey)
+	key := types.FormatDenomTradePairKey(denom0, denom1)
 	// if given taker fee is equal to the default taker fee,
 	// delete whatever we have in current state to use default taker fee.
 	// TODO: This logic is actually wrong imo, where it can be valid to set an override over the default.
 	if takerFee.Equal(k.GetDefaultTakerFee(ctx)) {
-		store.Delete(types.FormatDenomTradePairKey(denom0, denom1))
+		store.Delete(key)
 		return
 	} else {
-		osmoutils.MustSetDec(store, types.FormatDenomTradePairKey(denom0, denom1), takerFee)
+		osmoutils.MustSetDec(store, key, takerFee)
 	}
 }
 

--- a/x/poolmanager/types/keys.go
+++ b/x/poolmanager/types/keys.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	"bytes"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -67,9 +67,13 @@ func FormatModuleRouteKey(poolId uint64) []byte {
 // FormatDenomTradePairKey serializes denom trade pair to bytes.
 // Denom trade pair is automatically sorted lexicographically.
 func FormatDenomTradePairKey(denom0, denom1 string) []byte {
-	denoms := []string{denom0, denom1}
-	sort.Strings(denoms)
-	return []byte(fmt.Sprintf("%s%s%s%s%s", DenomTradePairPrefix, KeySeparator, denoms[0], KeySeparator, denoms[1]))
+	denomA, denomB := denom0, denom1
+	if denom0 > denom1 {
+		denomA, denomB = denom1, denom0
+	}
+	var buffer bytes.Buffer
+	fmt.Fprintf(&buffer, "%s%s%s%s%s", DenomTradePairPrefix, KeySeparator, denomA, KeySeparator, denomB)
+	return buffer.Bytes()
 }
 
 // ParseModuleRouteFromBz parses the raw bytes into ModuleRoute.


### PR DESCRIPTION
A driveby fix for improving the key formatting of taker fee keys. I was surprised to see this was taking .1% of state machine exec time. (Mostly due to too many calls w/ protorev, but still shocking regardless)

This just lowers the heap allocs here.