### PR TITLE
Remove iterator calls in two CL operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### State Breaking
 
 * [#7250](https://github.com/osmosis-labs/osmosis/pull/7250) Further filter spam gauges from epoch distribution.
+* [#7499](https://github.com/osmosis-labs/osmosis/pull/7499) Slight speed/gas improvements to CL CreatePosition and AddToPosition
 
 ## v23.0.0
 

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -94,10 +94,8 @@ func (k Keeper) CreatePosition(ctx sdk.Context, poolId uint64, owner sdk.AccAddr
 
 	// If this is the first position created in this pool, ensure that the position includes both asset0 and asset1
 	// in order to assign an initial spot price.
-	hasPositions, err := k.HasAnyPositionForPool(ctx, poolId)
-	if err != nil {
-		return CreatePositionData{}, err
-	}
+	// N.B. the pool is not mutated between fetching and this call.
+	hasPositions := k.PoolHasPosition(ctx, pool)
 
 	// Trigger before hook for CreatePosition prior to mutating state.
 	// If no contract is set, this will be a no-op.
@@ -307,6 +305,11 @@ func (k Keeper) WithdrawPosition(ctx sdk.Context, owner sdk.AccAddress, position
 			return osmomath.Int{}, osmomath.Int{}, err
 		}
 
+		// Note that here we currently use the iterator based definition to search
+		// for a remaining position in the pool. Since we have removed a position we need to
+		// search if there are more.
+		// Ideally in the future we could have a simple "num positions" counter to make this logic
+		// much faster.
 		anyPositionsRemainingInPool, err := k.HasAnyPositionForPool(ctx, position.PoolId)
 		if err != nil {
 			return osmomath.Int{}, osmomath.Int{}, err
@@ -417,11 +420,12 @@ func (k Keeper) addToPosition(ctx sdk.Context, owner sdk.AccAddress, positionId 
 		return 0, osmomath.Int{}, osmomath.Int{}, err
 	}
 
-	anyPositionsRemainingInPool, err := k.HasAnyPositionForPool(ctx, position.PoolId)
+	pool, err := k.GetConcentratedPoolById(ctx, position.PoolId)
 	if err != nil {
 		return 0, osmomath.Int{}, osmomath.Int{}, err
 	}
 
+	anyPositionsRemainingInPool := k.PoolHasPosition(ctx, pool)
 	if !anyPositionsRemainingInPool {
 		return 0, osmomath.Int{}, osmomath.Int{}, types.AddToLastPositionInPoolError{PoolId: position.PoolId, PositionId: position.PositionId}
 	}
@@ -429,10 +433,7 @@ func (k Keeper) addToPosition(ctx sdk.Context, owner sdk.AccAddress, positionId 
 	// Create new position with updated liquidity.
 	amount0Desired := amount0Withdrawn.Add(amount0Added)
 	amount1Desired := amount1Withdrawn.Add(amount1Added)
-	pool, err := k.GetConcentratedPoolById(ctx, position.PoolId)
-	if err != nil {
-		return 0, osmomath.Int{}, osmomath.Int{}, err
-	}
+
 	tokensProvided := sdk.NewCoins(sdk.NewCoin(pool.GetToken0(), amount0Desired), sdk.NewCoin(pool.GetToken1(), amount1Desired))
 	minimumAmount0 := amount0Withdrawn
 	minimumAmount1 := amount1Withdrawn


### PR DESCRIPTION
This removes one unneeded iterator call in CL CreatePosition It removes two unneeded iterator calls in CL addToPosition

This appears to be an approximately 10% speedup to both operations. (.2% impact to state machine processing time)

This is the same idea as #7258 and should be covered by existing tests. I left a code comment for why we can't do this same idea to WithdrawPosition.