### PR TITLE
Minor state compatible speedups to txfees

### DIFF
--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -142,8 +142,10 @@ func (k Keeper) IsSufficientFee(ctx sdk.Context, minBaseGasPrice osmomath.Dec, g
 
 	// Determine the required fees by multiplying the required minimum gas
 	// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+	// note we mutate this one line below, to avoid extra heap allocations.
 	glDec := osmomath.NewDec(int64(gasRequested))
-	requiredBaseFee := sdk.NewCoin(baseDenom, minBaseGasPrice.Mul(glDec).Ceil().RoundInt())
+	baseFeeAmt := glDec.MulMut(minBaseGasPrice).Ceil().RoundInt()
+	requiredBaseFee := sdk.Coin{Denom: baseDenom, Amount: baseFeeAmt}
 
 	convertedFee, err := k.ConvertToBaseToken(ctx, feeCoin)
 	if err != nil {

--- a/x/txfees/keeper/feetokens.go
+++ b/x/txfees/keeper/feetokens.go
@@ -35,7 +35,7 @@ func (k Keeper) ConvertToBaseToken(ctx sdk.Context, inputFee sdk.Coin) (sdk.Coin
 	// Note: spotPrice truncation is done here for maintaining state-compatibility with v19.x
 	// It should be changed to support full spot price precision before
 	// https://github.com/osmosis-labs/osmosis/issues/6064 is complete
-	return sdk.NewCoin(baseDenom, spotPrice.Dec().MulInt(inputFee.Amount).RoundInt()), nil
+	return sdk.NewCoin(baseDenom, spotPrice.Dec().MulIntMut(inputFee.Amount).RoundInt()), nil
 }
 
 // CalcFeeSpotPrice converts the provided tx fees into their equivalent value in the base denomination.


### PR DESCRIPTION
Pretty minor speedups to txfees. This is taking a pretty small amount of time in profiles, but driveby noticed it, hence PR'ing slight improvements. THere are better improvements via reducing the number of math ops in a state breaking change, which we should eventually do.

Also made some slight speedups to relevant ops in upstream SDK, which we should get on next math version bump. (https://github.com/cosmos/cosmos-sdk/pull/19467, https://github.com/cosmos/cosmos-sdk/pull/19466)