### PR TITLE
chore: move JoinPoolNoSwap error log to debug

### DIFF
--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -186,7 +186,7 @@ func (k Keeper) JoinPoolNoSwap(
 	}
 	// sanity check, don't return error as not worth halting the LP. We know its not too much.
 	if sharesOut.LT(shareOutAmount) {
-		ctx.Logger().Error(fmt.Sprintf("Expected to JoinPoolNoSwap >= %s shares, actually did %s shares",
+		ctx.Logger().Debug(fmt.Sprintf("Expected to JoinPoolNoSwap >= %s shares, actually did %s shares",
 			shareOutAmount, sharesOut))
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

![Screenshot 2024-02-20 at 10 27 02 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/2e98af4c-446e-4d24-a1ed-07dab4acafb9)

This log is spam and does not to notify all node operators of it's occurrence.