### PR TITLE
fix: cw pool migration prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+* [#7590](https://github.com/osmosis-labs/osmosis/pull/7590) fix cwpool migration prop disallowing only one of code id or bytecode.
 * [#7582](https://github.com/osmosis-labs/osmosis/pull/7582) IAVL v1
 
 ## v23.0.0

--- a/x/cosmwasmpool/client/cli/tx.go
+++ b/x/cosmwasmpool/client/cli/tx.go
@@ -212,7 +212,7 @@ func parseMigratePoolContractsProposal(cmd *cobra.Command, args []string) (govty
 	}
 
 	wasm := []byte{}
-	// Only attempt to parse the bytecode of code ID is not
+	// Only attempt to parse the bytecode if code ID is not
 	// given (i.e. 0)
 	if newCodeId == 0 {
 		byteCodeFileName := args[2]

--- a/x/cosmwasmpool/client/cli/tx.go
+++ b/x/cosmwasmpool/client/cli/tx.go
@@ -211,9 +211,15 @@ func parseMigratePoolContractsProposal(cmd *cobra.Command, args []string) (govty
 		return nil, err
 	}
 
-	wasm, err := parseWasmByteCode(args[2])
-	if err != nil {
-		return nil, err
+	wasm := []byte{}
+	// Only attempt to parse the bytecode of code ID is not
+	// given (i.e. 0)
+	if newCodeId == 0 {
+		byteCodeFileName := args[2]
+		wasm, err = parseWasmByteCode(byteCodeFileName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// TODO: implement this later if needed.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The CLI logic did not allow providing only one of code ID and bytecode but the state-machine logic required only one to be set.

## Testing and Verifying

https://testnet.mintscan.io/osmosis-testnet/proposals/176