### PR TITLE
fix: cosmwasm pool model code ID migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7509](https://github.com/osmosis-labs/osmosis/pull/7509) Distributing ProtoRev profits to the community pool and burn address
 * [#7550](https://github.com/osmosis-labs/osmosis/pull/7550) Speedup small CL swaps, by only fetching CL uptime accumulators if there is a tick crossing.
 * [#7562](https://github.com/osmosis-labs/osmosis/pull/7562) Speedup Protorev estimation logic by removing unnecessary taker fee simulations.
-* [#7562](https://github.com/osmosis-labs/osmosis/pull/7562) Fix cosmwasm pool model code ID migration.
+* [#7595](https://github.com/osmosis-labs/osmosis/pull/7595) Fix cosmwasm pool model code ID migration.
 
 ### State Compatible
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7509](https://github.com/osmosis-labs/osmosis/pull/7509) Distributing ProtoRev profits to the community pool and burn address
 * [#7550](https://github.com/osmosis-labs/osmosis/pull/7550) Speedup small CL swaps, by only fetching CL uptime accumulators if there is a tick crossing.
 * [#7562](https://github.com/osmosis-labs/osmosis/pull/7562) Speedup Protorev estimation logic by removing unnecessary taker fee simulations.
+* [#7562](https://github.com/osmosis-labs/osmosis/pull/7562) Fix cosmwasm pool model code ID migration.
 
 ### State Compatible
 

--- a/x/cosmwasmpool/gov.go
+++ b/x/cosmwasmpool/gov.go
@@ -122,6 +122,10 @@ func (k Keeper) migrateCosmwasmPools(ctx sdk.Context, poolIds []uint64, newCodeI
 		if err != nil {
 			return err
 		}
+
+		// Update code ID to the updated one in state
+		cwPool.SetCodeId(newCodeId)
+		k.SetPool(ctx, cwPool)
 	}
 
 	// Whitelist new code id. No-op if already whitelisted.

--- a/x/cosmwasmpool/model/pool.pb.go
+++ b/x/cosmwasmpool/model/pool.pb.go
@@ -48,6 +48,7 @@ type CosmWasmPool struct {
 	InstantiateMsg  []byte `protobuf:"bytes,4,opt,name=instantiate_msg,json=instantiateMsg,proto3" json:"instantiate_msg,omitempty" yaml:"instantiate_msg"`
 }
 
+
 func (m *CosmWasmPool) Reset()      { *m = CosmWasmPool{} }
 func (*CosmWasmPool) ProtoMessage() {}
 func (*CosmWasmPool) Descriptor() ([]byte, []int) {

--- a/x/cosmwasmpool/model/pool.pb.go
+++ b/x/cosmwasmpool/model/pool.pb.go
@@ -48,7 +48,6 @@ type CosmWasmPool struct {
 	InstantiateMsg  []byte `protobuf:"bytes,4,opt,name=instantiate_msg,json=instantiateMsg,proto3" json:"instantiate_msg,omitempty" yaml:"instantiate_msg"`
 }
 
-
 func (m *CosmWasmPool) Reset()      { *m = CosmWasmPool{} }
 func (*CosmWasmPool) ProtoMessage() {}
 func (*CosmWasmPool) Descriptor() ([]byte, []int) {

--- a/x/cosmwasmpool/model/store_model.go
+++ b/x/cosmwasmpool/model/store_model.go
@@ -103,6 +103,6 @@ func (p *CosmWasmPool) GetPoolDenoms(ctx sdk.Context) []string {
 }
 
 // SetCodeId implements types.CosmWasmExtension.
-func (cp *CosmWasmPool) SetCodeId(codeId uint64) {
-	cp.CodeId = codeId
+func (p *CosmWasmPool) SetCodeId(codeId uint64) {
+	p.CodeId = codeId
 }

--- a/x/cosmwasmpool/model/store_model.go
+++ b/x/cosmwasmpool/model/store_model.go
@@ -101,3 +101,8 @@ func (p CosmWasmPool) SetWasmKeeper(wasmKeeper types.WasmKeeper) {
 func (p *CosmWasmPool) GetPoolDenoms(ctx sdk.Context) []string {
 	panic("CosmWasmPool.GetPoolDenoms not implemented")
 }
+
+// SetCodeId implements types.CosmWasmExtension.
+func (cp *CosmWasmPool) SetCodeId(codeId uint64) {
+	cp.CodeId = codeId
+}

--- a/x/cosmwasmpool/types/pool.go
+++ b/x/cosmwasmpool/types/pool.go
@@ -23,4 +23,6 @@ type CosmWasmExtension interface {
 	SetWasmKeeper(wasmKeeper WasmKeeper)
 
 	GetTotalPoolLiquidity(ctx sdk.Context) sdk.Coins
+
+	SetCodeId(codeId uint64)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Found when testing white whale pool migration on testnet.


We did not update the cw pool model in the state machine.

There should be no serious impact but if pools are migrated using this method today, we would have to maintain old code IDs in the whitelist until the state is fixed via the upgrade handler

## Testing and Verifying

- Unit tests
- Testnet

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A