### PR TITLE
protorev: Remove unneeded AllBalances call

### DIFF
--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -881,8 +881,8 @@ func (k Keeper) ComputeMaxInAmtGivenMaxTicksCrossed(
 	// Initialize swap state
 	// Utilize the total amount of tokenOutDenom in the pool as the specified amountOut, since we want
 	// the limitation to be the tick crossing, not the amountOut.
-	balances := k.bankKeeper.GetAllBalances(ctx, p.GetAddress())
-	swapState := newSwapState(balances.AmountOf(tokenOutDenom), p, swapStrategy)
+	balance := k.bankKeeper.GetBalance(ctx, p.GetAddress(), tokenOutDenom)
+	swapState := newSwapState(balance.Amount, p, swapStrategy)
 
 	nextInitTickIter := swapStrategy.InitializeNextTickIterator(cacheCtx, poolId, swapState.tick)
 	defer nextInitTickIter.Close()

--- a/x/concentrated-liquidity/types/expected_keepers.go
+++ b/x/concentrated-liquidity/types/expected_keepers.go
@@ -19,6 +19,7 @@ type AccountKeeper interface {
 // BankKeeper defines the banking contract that must be fulfilled when
 // creating a x/concentrated-liquidity keeper.
 type BankKeeper interface {
+	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	GetDenomMetaData(ctx sdk.Context, denom string) (banktypes.Metadata, bool)
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error


### PR DESCRIPTION
Minor protorev speedup, by removing an AllBalances call that happens after protorev has been determined to have non-zero minimum profit.

This is a 30ms speedup on a 2000 bloc syncs in IAVL v1 nfn, so very minor. Just came across it as I am going through the logic.