### PR TITLE
Remove CL all balances call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7555](https://github.com/osmosis-labs/osmosis/pull/7555) Refactor taker fees, distribute via a single module account, track once at epoch
 * [#7562](https://github.com/osmosis-labs/osmosis/pull/7562) Speedup Protorev estimation logic by removing unnecessary taker fee simulations.
 * [#7595](https://github.com/osmosis-labs/osmosis/pull/7595) Fix cosmwasm pool model code ID migration.
+* [#7619](https://github.com/osmosis-labs/osmosis/pull/7619) Slight speedup/gas improvement to CL GetTotalPoolLiquidity queries
 
 ### State Compatible
 

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -215,13 +215,10 @@ func (k Keeper) GetTotalPoolLiquidity(ctx sdk.Context, poolId uint64) (sdk.Coins
 		return nil, err
 	}
 
-	poolBalance := k.bankKeeper.GetAllBalances(ctx, pool.GetAddress())
+	token0Bal := k.bankKeeper.GetBalance(ctx, pool.GetAddress(), pool.GetToken0())
+	token1Bal := k.bankKeeper.GetBalance(ctx, pool.GetAddress(), pool.GetToken1())
 
-	// This is to ensure that malicious actor cannot send dust to
-	// a pool address.
-	filteredPoolBalance := osmoutils.FilterDenoms(poolBalance, []string{pool.GetToken0(), pool.GetToken1()})
-
-	return filteredPoolBalance, nil
+	return sdk.NewCoins(token0Bal, token1Bal), nil
 }
 
 // asPoolI takes a types.ConcentratedPoolExtension and attempts to convert it to a

--- a/x/concentrated-liquidity/types/expected_keepers.go
+++ b/x/concentrated-liquidity/types/expected_keepers.go
@@ -20,7 +20,6 @@ type AccountKeeper interface {
 // creating a x/concentrated-liquidity keeper.
 type BankKeeper interface {
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
-	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	GetDenomMetaData(ctx sdk.Context, denom string) (banktypes.Metadata, bool)
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	HasBalance(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin) bool


### PR DESCRIPTION
This PR removes the remaining AllBalances call from CL, and removes it from the expected keeper. Resolves a todo from: #7605 and will improve perf / lower Gas for CL TotalPoolLiquidity calls. 