### PR TITLE
feat: tick init/deinit for CL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#7590](https://github.com/osmosis-labs/osmosis/pull/7590) fix cwpool migration prop disallowing only one of code id or bytecode.
 * [#7582](https://github.com/osmosis-labs/osmosis/pull/7582) IAVL v1
+* [#7622](https://github.com/osmosis-labs/osmosis/pull/7622) Create/remove tick events.
 
 ## v23.0.0
 

--- a/x/concentrated-liquidity/tick.go
+++ b/x/concentrated-liquidity/tick.go
@@ -153,7 +153,21 @@ func (k Keeper) makeInitialTickInfo(ctx sdk.Context, poolId uint64, tickIndex in
 		initialUptimeTrackers = append(initialUptimeTrackers, model.UptimeTracker{UptimeGrowthOutside: uptimeTrackerValue})
 	}
 
-	return model.TickInfo{LiquidityGross: osmomath.ZeroDec(), LiquidityNet: osmomath.ZeroDec(), SpreadRewardGrowthOppositeDirectionOfLastTraversal: initialSpreadRewardGrowthOppositeDirectionOfLastTraversal, UptimeTrackers: model.UptimeTrackers{List: initialUptimeTrackers}}, nil
+	uptimeTrackers := model.UptimeTrackers{List: initialUptimeTrackers}
+
+	// Emit init tick event
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.TypeEvtInitTick,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+			sdk.NewAttribute(types.AttributeKeyTickIndex, strconv.FormatInt(tickIndex, 10)),
+			sdk.NewAttribute(types.AttributeKeySpreadRewardGrowthOppositeDirectionOfLastTraversal, initialSpreadRewardGrowthOppositeDirectionOfLastTraversal.String()),
+			sdk.NewAttribute(types.AttributeKeyUptimeGrowthOppositeDirectionOfLastTraversal, uptimeTrackers.String()),
+		),
+	})
+
+	return model.TickInfo{LiquidityGross: osmomath.ZeroDec(), LiquidityNet: osmomath.ZeroDec(), SpreadRewardGrowthOppositeDirectionOfLastTraversal: initialSpreadRewardGrowthOppositeDirectionOfLastTraversal, UptimeTrackers: uptimeTrackers}, nil
 }
 
 func (k Keeper) SetTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64, tickInfo *model.TickInfo) {
@@ -167,6 +181,16 @@ func (k Keeper) RemoveTickInfo(ctx sdk.Context, poolId uint64, tickIndex int64) 
 	store := ctx.KVStore(k.storeKey)
 	key := types.KeyTick(poolId, tickIndex)
 	store.Delete(key)
+
+	// Emit remove tick event
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.TypeEvtRemoveTick,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(poolId, 10)),
+			sdk.NewAttribute(types.AttributeKeyTickIndex, strconv.FormatInt(tickIndex, 10)),
+		),
+	})
 }
 
 func (k Keeper) GetAllInitializedTicksForPool(ctx sdk.Context, poolId uint64) ([]genesis.FullTick, error) {

--- a/x/concentrated-liquidity/types/events.go
+++ b/x/concentrated-liquidity/types/events.go
@@ -13,6 +13,8 @@ const (
 	TypeEvtMoveRewards               = "move_rewards"
 	TypeEvtCrossTick                 = "cross_tick"
 	TypeEvtTransferPositions         = "transfer_positions"
+	TypeEvtInitTick                  = "init_tick"
+	TypeEvtRemoveTick                = "remove_tick"
 
 	AttributeValueCategory                                         = ModuleName
 	AttributeKeyPositionId                                         = "position_id"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Adding events for initializing and deinitializing ticks. This is needed by Numia for computing the APRs.

As a drive-by change, I noticed that we recomputed the spread rewards accumulators and removed the duplicate logic.

## Testing and Verifying

- Will run this change on a node since the beginning of v23.x once backported

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented? 
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A