### PR TITLE
remove wasm store key from cosmwasm authenticator

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -540,7 +540,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 
 	// register CosmWasm authenticator
 	appKeepers.AuthenticatorManager.RegisterAuthenticator(
-		authenticator.NewCosmwasmAuthenticator(appKeepers.ContractKeeper, appKeepers.keys[wasmtypes.StoreKey], appKeepers.AccountKeeper, encodingConfig.TxConfig.SignModeHandler(), appCodec))
+		authenticator.NewCosmwasmAuthenticator(appKeepers.ContractKeeper, appKeepers.AccountKeeper, encodingConfig.TxConfig.SignModeHandler(), appCodec))
 
 	// set token factory contract keeper
 	appKeepers.TokenFactoryKeeper.SetContractKeeper(appKeepers.ContractKeeper)

--- a/x/authenticator/authenticator/cosmwasm.go
+++ b/x/authenticator/authenticator/cosmwasm.go
@@ -6,10 +6,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/store/prefix"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
@@ -20,7 +17,6 @@ import (
 
 type CosmwasmAuthenticator struct {
 	contractKeeper *keeper.PermissionedKeeper
-	wasmStoreKey   storetypes.StoreKey
 	ak             *authkeeper.AccountKeeper
 	cdc            codectypes.AnyUnpacker
 	sigModeHandler authsigning.SignModeHandler
@@ -31,10 +27,9 @@ type CosmwasmAuthenticator struct {
 
 var _ iface.Authenticator = &CosmwasmAuthenticator{}
 
-func NewCosmwasmAuthenticator(contractKeeper *keeper.PermissionedKeeper, wasmStoreKey storetypes.StoreKey, accountKeeper *authkeeper.AccountKeeper, sigModeHandler authsigning.SignModeHandler, cdc codectypes.AnyUnpacker) CosmwasmAuthenticator {
+func NewCosmwasmAuthenticator(contractKeeper *keeper.PermissionedKeeper, accountKeeper *authkeeper.AccountKeeper, sigModeHandler authsigning.SignModeHandler, cdc codectypes.AnyUnpacker) CosmwasmAuthenticator {
 	return CosmwasmAuthenticator{
 		contractKeeper: contractKeeper,
-		wasmStoreKey:   wasmStoreKey,
 		sigModeHandler: sigModeHandler,
 		ak:             accountKeeper,
 		cdc:            cdc,
@@ -242,9 +237,4 @@ func parseInitData(data []byte) (sdk.AccAddress, []byte, error) {
 	}
 
 	return contractAddr, initData.Params, nil
-}
-
-func (cwa CosmwasmAuthenticator) GetContractPrefixStore(ctx sdk.Context) storetypes.KVStore {
-	prefixStoreKey := wasmtypes.GetContractStorePrefix(cwa.contractAddr)
-	return prefix.NewStore(ctx.KVStore(cwa.wasmStoreKey), prefixStoreKey)
 }

--- a/x/authenticator/authenticator/cosmwasm_test.go
+++ b/x/authenticator/authenticator/cosmwasm_test.go
@@ -48,7 +48,7 @@ func (s *CosmwasmAuthenticatorTest) SetupTest() {
 	s.Ctx = s.Ctx.WithGasMeter(sdk.NewGasMeter(10_000_000))
 	s.EncodingConfig = app.MakeEncodingConfig()
 
-	s.CosmwasmAuth = authenticator.NewCosmwasmAuthenticator(s.OsmosisApp.ContractKeeper, s.OsmosisApp.GetKey(wasmtypes.StoreKey), s.OsmosisApp.AccountKeeper, s.EncodingConfig.TxConfig.SignModeHandler(), s.OsmosisApp.AppCodec())
+	s.CosmwasmAuth = authenticator.NewCosmwasmAuthenticator(s.OsmosisApp.ContractKeeper, s.OsmosisApp.AccountKeeper, s.EncodingConfig.TxConfig.SignModeHandler(), s.OsmosisApp.AppCodec())
 }
 
 func (s *CosmwasmAuthenticatorTest) TestOnAuthenticatorAdded() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Since transient store is removed, there is no need to copy over specific contract state anymore, hence wasm store key ref is not needed for `CosmwasmAuthenticator`