### PR TITLE
chore: reduce per block prune of TWAP from 1000 to 200

### DIFF
--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -12,10 +12,8 @@ import (
 )
 
 // NumRecordsToPrunePerBlock is the number of records to prune per block.
-// Two records are deleted per incentive record:
-// 1. by time index
-// 2. by pool index
-// Therefore, setting this to 200 means 100 complete incentive records are deleted per block.
+// One record indexed by pool ID is deleted per incentive record.
+// Therefore, setting this to 200 means 200 complete incentive records are deleted per block.
 // The choice is somewhat arbitrary
 // However, th intuition is that the number should be low enough to not make blocks take longer but
 // not too small where it would take all the way to the next epoch.

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -15,11 +15,11 @@ import (
 // Two records are deleted per incentive record:
 // 1. by time index
 // 2. by pool index
-// Therefore, setting this to 1000 means 500 complete incentive records are deleted per block.
+// Therefore, setting this to 200 means 100 complete incentive records are deleted per block.
 // The choice is somewhat arbitrary
 // However, th intuition is that the number should be low enough to not make blocks take longer but
 // not too small where it would take all the way to the next epoch.
-var NumRecordsToPrunePerBlock uint16 = 1000
+var NumRecordsToPrunePerBlock uint16 = 200
 
 type timeTooOldError struct {
 	Time time.Time


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We have been noticing more missed blocks directly after epoch, which is likely a result of us spreading the TWAP module pruning over the blocks after epoch rather than all at once at epoch time. This PR reduces the amount of records pruned per block from 1000 to 200. That translates to pruning 100 complete TWAP records instead of 500.