### PR TITLE
[Smart Accounts] Emit authenticator id on add

### DIFF
--- a/x/authenticator/ante/ante_test.go
+++ b/x/authenticator/ante/ante_test.go
@@ -147,7 +147,7 @@ func (s *AutherticatorAnteSuite) TestSignatureVerificationWithAuthenticatorInSto
 		s.TestPrivKeys[0].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	tx, _ := GenTx(s.EncodingConfig.TxConfig, []sdk.Msg{
 		testMsg1,
@@ -189,7 +189,7 @@ func (s *AutherticatorAnteSuite) TestSignatureVerificationOutOfGas() {
 		s.TestPrivKeys[1].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	alwaysHigher := testutils.TestingAuthenticator{Approve: testutils.Always, GasConsumption: 500_000}
 	s.OsmosisApp.AuthenticatorManager.RegisterAuthenticator(alwaysHigher)
@@ -201,7 +201,7 @@ func (s *AutherticatorAnteSuite) TestSignatureVerificationOutOfGas() {
 		[]byte{},
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(2), "Adding authenticator returning incorrect id")
 
 	tx, _ := GenTx(s.EncodingConfig.TxConfig, []sdk.Msg{
 		testMsg1,
@@ -262,7 +262,7 @@ func (s *AutherticatorAnteSuite) TestSpecificAuthenticator() {
 		s.TestPrivKeys[0].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	id, err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
 		s.Ctx,
@@ -271,7 +271,7 @@ func (s *AutherticatorAnteSuite) TestSpecificAuthenticator() {
 		s.TestPrivKeys[1].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(2), "Adding authenticator returning incorrect id")
 
 	testCases := []struct {
 		name                  string

--- a/x/authenticator/ante/ante_test.go
+++ b/x/authenticator/ante/ante_test.go
@@ -140,13 +140,14 @@ func (s *AutherticatorAnteSuite) TestSignatureVerificationWithAuthenticatorInSto
 	}
 	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
 
-	err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		"SignatureVerificationAuthenticator",
 		s.TestPrivKeys[0].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
 
 	tx, _ := GenTx(s.EncodingConfig.TxConfig, []sdk.Msg{
 		testMsg1,
@@ -181,24 +182,26 @@ func (s *AutherticatorAnteSuite) TestSignatureVerificationOutOfGas() {
 	}
 
 	// fee payer is authenticated
-	err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		"SignatureVerificationAuthenticator",
 		s.TestPrivKeys[1].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
 
 	alwaysHigher := testutils.TestingAuthenticator{Approve: testutils.Always, GasConsumption: 500_000}
 	s.OsmosisApp.AuthenticatorManager.RegisterAuthenticator(alwaysHigher)
 
-	err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		alwaysHigher.Type(),
 		[]byte{},
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	tx, _ := GenTx(s.EncodingConfig.TxConfig, []sdk.Msg{
 		testMsg1,
@@ -252,21 +255,23 @@ func (s *AutherticatorAnteSuite) TestSpecificAuthenticator() {
 	}
 	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
 
-	err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
 		s.TestPrivKeys[0].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
 
-	err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
 		s.TestPrivKeys[1].PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	testCases := []struct {
 		name                  string

--- a/x/authenticator/authenticator/composition_test.go
+++ b/x/authenticator/authenticator/composition_test.go
@@ -560,7 +560,7 @@ func (s *AggregatedAuthenticatorsTest) TestNestedAuthenticatorCalls() {
 		data, err := tc.compositeAuth.buildInitData()
 		s.Require().NoError(err)
 
-		var auth iface.Authenticator
+		var auth authenticator.Authenticator
 		if tc.compositeAuth.isAllOf() {
 			auth, err = s.AllOfAuth.Initialize(data)
 			s.Require().NoError(err)
@@ -583,15 +583,15 @@ func (s *AggregatedAuthenticatorsTest) TestNestedAuthenticatorCalls() {
 		s.Require().NoError(err, "Should encode Any value successfully")
 
 		// mock the authentication request
-		authReq := iface.AuthenticationRequest{
+		authReq := authenticator.AuthenticationRequest{
 			AuthenticatorId:     tc.id,
 			Account:             s.TestAccAddress[0],
 			FeePayer:            s.TestAccAddress[0],
-			Msg:                 iface.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
+			Msg:                 authenticator.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
 			MsgIndex:            0,
 			Signature:           []byte{1, 1, 1, 1, 1},
-			SignModeTxData:      iface.SignModeData{Direct: []byte{1, 1, 1, 1, 1}},
-			SignatureData:       iface.SimplifiedSignatureData{Signers: []sdk.AccAddress{s.TestAccAddress[0]}, Signatures: [][]byte{{1, 1, 1, 1, 1}}},
+			SignModeTxData:      authenticator.SignModeData{Direct: []byte{1, 1, 1, 1, 1}},
+			SignatureData:       authenticator.SimplifiedSignatureData{Signers: []sdk.AccAddress{s.TestAccAddress[0]}, Signatures: [][]byte{{1, 1, 1, 1, 1}}},
 			Simulate:            false,
 			AuthenticatorParams: []byte{1, 1, 1, 1, 1},
 		}

--- a/x/authenticator/genesis.go
+++ b/x/authenticator/genesis.go
@@ -10,6 +10,13 @@ import (
 // InitGenesis initializes the module's state from a provided genesis state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	k.SetParams(ctx, genState.Params)
+
+	// if there is no NextAuthenticatorId set in genstate, go will set it to 0
+	// we need to set it to FirstAuthenticatorId in that case
+	if genState.NextAuthenticatorId == 0 {
+		genState.NextAuthenticatorId = keeper.FirstAuthenticatorId
+	}
+
 	k.SetNextAuthenticatorId(ctx, genState.NextAuthenticatorId)
 
 	for i := range genState.AuthenticatorData {

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -96,7 +96,7 @@ func (s *AuthenticatorSuite) TestKeyRotationStory() {
 	s.Require().NoError(err, "Failed to send bank tx using the first private key")
 
 	// Change account's authenticator
-	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(
+	sigVerAuthId, err := s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(),
 		s.Account.GetAddress(),
 		"SignatureVerificationAuthenticator",
@@ -113,7 +113,7 @@ func (s *AuthenticatorSuite) TestKeyRotationStory() {
 	s.Require().NoError(err, "Sending from the original PrivKey failed. This should succeed")
 
 	// Remove the account's authenticator
-	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), 0)
+	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), sigVerAuthId)
 	s.Require().NoError(err, "Failed to remove authenticator")
 
 	// Sending from the default PrivKey now works again
@@ -347,7 +347,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorGas() {
 
 	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), alwaysLow.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
-	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
+	acc2authId, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// Both account 0 and account 1 can send
@@ -357,7 +357,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorGas() {
 	s.Require().NoError(err)
 
 	// Remove account2's authenticator
-	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), account2.GetAddress(), 1)
+	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), account2.GetAddress(), acc2authId)
 	s.Require().NoError(err, "Failed to remove authenticator")
 
 	// Add two authenticators that are never high, and one always high.
@@ -461,7 +461,7 @@ func (s *AuthenticatorSuite) TestCompositeAuthenticatorAllOf() {
 	})
 
 	// Set the authenticator to our account
-	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), allOf.Type(), compositeData)
+	allOfAuthId, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), allOf.Type(), compositeData)
 	s.Require().NoError(err)
 
 	// Send from account 1 using the AllOf authenticator
@@ -489,7 +489,7 @@ func (s *AuthenticatorSuite) TestCompositeAuthenticatorAllOf() {
 	s.Require().Error(err, "Should be rejected because the message filter rejects the transaction")
 
 	// Remove the first AllOf authenticator
-	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), 0)
+	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), allOfAuthId)
 	s.Require().NoError(err, "Failed to remove authenticator")
 
 	initDataPrivKey2 := authenticator.SubAuthenticatorInitData{
@@ -617,17 +617,17 @@ func (s *AuthenticatorSuite) TestAuthenticatorAddRemove() {
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// Test authenticator that blocks removal
-	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, blockRemove.Type(), []byte{})
+	blockRemoveId, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, blockRemove.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
-	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), accountAddr, 1)
+	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), accountAddr, blockRemoveId)
 	s.Require().Error(err, "Authenticator should not be removed")
 	s.Require().ErrorContains(err, "authenticator could not be removed")
 
 	// Test authenticator that allows removal
-	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, allowRemove.Type(), []byte{})
+	allowRemoveId, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, allowRemove.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
-	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), accountAddr, 2)
+	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), accountAddr, allowRemoveId)
 	s.Require().NoError(err, "Failed to remove authenticator")
 }

--- a/x/authenticator/integration_test.go
+++ b/x/authenticator/integration_test.go
@@ -96,7 +96,7 @@ func (s *AuthenticatorSuite) TestKeyRotationStory() {
 	s.Require().NoError(err, "Failed to send bank tx using the first private key")
 
 	// Change account's authenticator
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(),
 		s.Account.GetAddress(),
 		"SignatureVerificationAuthenticator",
@@ -141,7 +141,7 @@ func (s *AuthenticatorSuite) TestCircuitBreaker() {
 	s.Require().NoError(err, "Failed to send bank tx using the first private key")
 
 	// Add signature verification authenticator
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(), s.Account.GetAddress(), "SignatureVerificationAuthenticator", s.PrivKeys[1].PubKey().Bytes())
 	s.Require().NoError(err, "Failed to add authenticator")
 
@@ -174,7 +174,7 @@ func (s *AuthenticatorSuite) TestMessageFilterStory() {
 	// Change account's authenticator
 	msgFilter := authenticator.NewMessageFilterAuthenticator(s.EncodingConfig)
 	s.app.AuthenticatorManager.RegisterAuthenticator(msgFilter)
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(), s.Account.GetAddress(),
 		"MessageFilterAuthenticator",
 		[]byte(fmt.Sprintf(`{"@type":"/cosmos.bank.v1beta1.MsgSend","amount": [{"denom": "%s", "amount": "50"}]}`, sdk.DefaultBondDenom)))
@@ -205,7 +205,7 @@ func (s *AuthenticatorSuite) TestKeyRotation() {
 	}
 
 	// Add a signature verification authenticator
-	err := s.app.AuthenticatorKeeper.AddAuthenticator(
+	_, err := s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(), s.Account.GetAddress(), "SignatureVerificationAuthenticator", s.PrivKeys[0].PubKey().Bytes())
 	s.Require().NoError(err, "Failed to add authenticator for key %d", 0)
 
@@ -222,11 +222,11 @@ func (s *AuthenticatorSuite) TestKeyRotation() {
 	s.Require().NoError(err, "Bank send with authenticator should pass 0")
 
 	// Add multiple keys
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(), s.Account.GetAddress(), "SignatureVerificationAuthenticator", s.PrivKeys[1].PubKey().Bytes())
 	s.Require().NoError(err, "Failed to add authenticator for key %d", 0)
 
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(
 		s.chainA.GetContext(), s.Account.GetAddress(), "SignatureVerificationAuthenticator", s.PrivKeys[2].PubKey().Bytes())
 	s.Require().NoError(err, "Failed to add authenticator for key %d", 0)
 
@@ -268,7 +268,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorState() {
 
 	stateful := testutils.StatefulAuthenticator{KvStoreKey: s.app.GetKVStoreKey()[authenticatortypes.AuthenticatorStoreKey]}
 	s.app.AuthenticatorManager.RegisterAuthenticator(stateful)
-	err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), "Stateful", []byte{})
+	_, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), "Stateful", []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	_, err = s.chainA.SendMsgsFromPrivKeysWithAuthenticator(pks{s.PrivKeys[0]}, pks{s.PrivKeys[1]}, []int32{0}, failSendMsg)
@@ -299,7 +299,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorMultiMsg() {
 	s.app.AuthenticatorManager.RegisterAuthenticator(maxAmount)
 	s.app.AuthenticatorManager.RegisterAuthenticator(stateful)
 
-	err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), "MaxAmountAuthenticator", []byte{})
+	_, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), "MaxAmountAuthenticator", []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	_, err = s.chainA.SendMsgsFromPrivKeysWithAuthenticator(pks{s.PrivKeys[0]}, pks{s.PrivKeys[1]}, []int32{0, 0}, successSendMsg, successSendMsg)
@@ -345,9 +345,9 @@ func (s *AuthenticatorSuite) TestAuthenticatorGas() {
 	s.app.AuthenticatorManager.RegisterAuthenticator(alwaysHigh)
 	s.app.AuthenticatorManager.RegisterAuthenticator(alwaysHigher)
 
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), alwaysLow.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), alwaysLow.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// Both account 0 and account 1 can send
@@ -362,11 +362,11 @@ func (s *AuthenticatorSuite) TestAuthenticatorGas() {
 
 	// Add two authenticators that are never high, and one always high.
 	// This allows account2 to execute but *only* after consuming >9k gas
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigher.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigher.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigher.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigher.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), account2.GetAddress(), alwaysHigh.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// This should fail, as authenticating the fee payer needs to be done with low gas
@@ -409,7 +409,7 @@ func (s *AuthenticatorSuite) TestCompositeAuthenticatorAnyOf() {
 	})
 
 	// Set the authenticator to our account
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), anyOf.Type(), compositeData)
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), anyOf.Type(), compositeData)
 	s.Require().NoError(err)
 
 	// Send from account 1 using the AnyOf authenticator
@@ -461,7 +461,7 @@ func (s *AuthenticatorSuite) TestCompositeAuthenticatorAllOf() {
 	})
 
 	// Set the authenticator to our account
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), allOf.Type(), compositeData)
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), allOf.Type(), compositeData)
 	s.Require().NoError(err)
 
 	// Send from account 1 using the AllOf authenticator
@@ -505,7 +505,7 @@ func (s *AuthenticatorSuite) TestCompositeAuthenticatorAllOf() {
 
 	// Set the authenticator to our account
 	partitionedAllOf := authenticator.NewPartitionedAllOfAuthenticator(s.app.AuthenticatorManager)
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), partitionedAllOf.Type(), compositeData)
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), partitionedAllOf.Type(), compositeData)
 	s.Require().NoError(err)
 
 	// We should provide only one signature (for the allOf authenticator) but the signature needs to be a compound
@@ -533,7 +533,7 @@ func (s *AuthenticatorSuite) TestSpendWithinLimit() {
 	s.app.AuthenticatorManager.RegisterAuthenticator(spendLimit)
 
 	initData := []byte(`{"allowed": 1000, "period": "day"}`)
-	err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), spendLimit.Type(), initData)
+	_, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), spendLimit.Type(), initData)
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	amountToSend := int64(500)
@@ -560,7 +560,7 @@ func (s *AuthenticatorSuite) TestSpendWithinLimit() {
 	})
 
 	// Add a SigVerificationAuthenticator to the account
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), anyOf.Type(), internalData)
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), anyOf.Type(), internalData)
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// sending 500 ok
@@ -608,16 +608,16 @@ func (s *AuthenticatorSuite) TestAuthenticatorAddRemove() {
 	accountAddr := sdk.AccAddress(s.PrivKeys[0].PubKey().Address())
 
 	// Test authenticator that blocks addition
-	err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, blockAdd.Type(), []byte{})
+	_, err := s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, blockAdd.Type(), []byte{})
 	s.Require().Error(err, "Authenticator should not be added")
 	s.Require().ErrorContains(err, "authenticator could not be added")
 
 	// Test authenticator that allows addition
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, allowAdd.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, allowAdd.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	// Test authenticator that blocks removal
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, blockRemove.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, blockRemove.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), accountAddr, 1)
@@ -625,7 +625,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorAddRemove() {
 	s.Require().ErrorContains(err, "authenticator could not be removed")
 
 	// Test authenticator that allows removal
-	err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, allowRemove.Type(), []byte{})
+	_, err = s.app.AuthenticatorKeeper.AddAuthenticator(s.chainA.GetContext(), accountAddr, allowRemove.Type(), []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
 
 	err = s.app.AuthenticatorKeeper.RemoveAuthenticator(s.chainA.GetContext(), accountAddr, 2)

--- a/x/authenticator/keeper/genesis_test.go
+++ b/x/authenticator/keeper/genesis_test.go
@@ -77,7 +77,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAllAuthenticatorDataGenesis() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	for i := 0; i < 5; i++ {
+	for i := 1; i <= 5; i++ {
 		id, err := s.App.AuthenticatorKeeper.AddAuthenticator(
 			ctx,
 			accAddress,

--- a/x/authenticator/keeper/genesis_test.go
+++ b/x/authenticator/keeper/genesis_test.go
@@ -78,13 +78,14 @@ func (s *KeeperTestSuite) TestKeeper_GetAllAuthenticatorDataGenesis() {
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
 	for i := 0; i < 5; i++ {
-		err := s.App.AuthenticatorKeeper.AddAuthenticator(
+		id, err := s.App.AuthenticatorKeeper.AddAuthenticator(
 			ctx,
 			accAddress,
 			"SignatureVerificationAuthenticator",
 			priv.PubKey().Bytes(),
 		)
 		s.Require().NoError(err)
+		s.Require().Equal(uint64(i), id)
 	}
 
 	authenticators, err := s.App.AuthenticatorKeeper.GetAllAuthenticatorData(ctx)

--- a/x/authenticator/keeper/keeper.go
+++ b/x/authenticator/keeper/keeper.go
@@ -161,13 +161,6 @@ func (k Keeper) SetNextAuthenticatorId(ctx sdk.Context, authenticatorId uint64) 
 	osmoutils.MustSet(store, types.KeyNextAccountAuthenticatorId(), &gogotypes.UInt64Value{Value: authenticatorId})
 }
 
-// GetNextAuthenticatorIdAndIncrement returns the next authenticator id and increments it.
-func (k Keeper) GetNextAuthenticatorIdAndIncrement(ctx sdk.Context) uint64 {
-	nextAuthenticatorId := k.GetNextAuthenticatorId(ctx)
-	k.SetNextAuthenticatorId(ctx, nextAuthenticatorId+1)
-	return nextAuthenticatorId
-}
-
 // AddAuthenticator adds an authenticator to an account, this function is used to add multiple
 // authenticators such as SignatureVerificationAuthenticators and AllOfAuthenticators
 func (k Keeper) AddAuthenticator(ctx sdk.Context, account sdk.AccAddress, authenticatorType string, data []byte) (uint64, error) {

--- a/x/authenticator/keeper/keeper_test.go
+++ b/x/authenticator/keeper/keeper_test.go
@@ -50,21 +50,23 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	err := s.App.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
 
-	err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	authenticators, err := s.App.AuthenticatorKeeper.GetAuthenticatorDataForAccount(ctx, accAddress)
 	s.Require().NoError(err)
@@ -83,27 +85,29 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorsForAccount() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	err := s.App.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
 
-	err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	authenticators, err := s.App.AuthenticatorKeeper.GetAuthenticatorsForAccount(ctx, accAddress)
 	s.Require().NoError(err)
 	s.Require().Equal(len(authenticators), 2, "Getting authenticators returning incorrect data")
 
-	err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",

--- a/x/authenticator/keeper/keeper_test.go
+++ b/x/authenticator/keeper/keeper_test.go
@@ -57,7 +57,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	id, err = s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
@@ -66,7 +66,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(2), "Adding authenticator returning incorrect id")
 
 	authenticators, err := s.App.AuthenticatorKeeper.GetAuthenticatorDataForAccount(ctx, accAddress)
 	s.Require().NoError(err)
@@ -92,7 +92,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorsForAccount() {
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(0), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
 	id, err = s.App.AuthenticatorKeeper.AddAuthenticator(
 		ctx,
@@ -101,7 +101,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorsForAccount() {
 		priv.PubKey().Bytes(),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
+	s.Require().Equal(id, uint64(2), "Adding authenticator returning incorrect id")
 
 	authenticators, err := s.App.AuthenticatorKeeper.GetAuthenticatorsForAccount(ctx, accAddress)
 	s.Require().NoError(err)

--- a/x/authenticator/keeper/msg_server.go
+++ b/x/authenticator/keeper/msg_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -46,17 +47,19 @@ func (m msgServer) AddAuthenticator(
 	}
 
 	// Finally, add the authenticator to the store.
-	err = m.Keeper.AddAuthenticator(ctx, sender, msg.Type, msg.Data)
+	id, err := m.Keeper.AddAuthenticator(ctx, sender, msg.Type, msg.Data)
 	if err != nil {
 		return nil, err
 	}
 
+	stringId := strconv.FormatUint(id, 10)
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
 			sdk.NewAttribute(types.AttributeKeyAuthenticatorType, msg.Type),
+			sdk.NewAttribute(types.AttributeKeyAuthenticatorId, stringId),
 		),
 	})
 

--- a/x/authenticator/keeper/msg_server_test.go
+++ b/x/authenticator/keeper/msg_server_test.go
@@ -35,7 +35,7 @@ func (s *KeeperTestSuite) TestMsgServer_AddAuthenticator() {
 	s.Require().NoError(err)
 	s.Require().True(resp.Success)
 
-	// assert event emited
+	// assert event emitted
 	s.Require().Equal(s.Ctx.EventManager().Events(), sdk.Events{
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/x/authenticator/keeper/msg_server_test.go
+++ b/x/authenticator/keeper/msg_server_test.go
@@ -34,6 +34,17 @@ func (s *KeeperTestSuite) TestMsgServer_AddAuthenticator() {
 	resp, err := msgServer.AddAuthenticator(sdk.WrapSDKContext(ctx), msg)
 	s.Require().NoError(err)
 	s.Require().True(resp.Success)
+
+	// assert event emited
+	s.Require().Equal(s.Ctx.EventManager().Events(), sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+			sdk.NewAttribute(types.AttributeKeyAuthenticatorType, msg.Type),
+			sdk.NewAttribute(types.AttributeKeyAuthenticatorId, "0"),
+		),
+	})
 }
 
 func (s *KeeperTestSuite) TestMsgServer_AddAuthenticatorFail() {

--- a/x/authenticator/keeper/msg_server_test.go
+++ b/x/authenticator/keeper/msg_server_test.go
@@ -42,7 +42,7 @@ func (s *KeeperTestSuite) TestMsgServer_AddAuthenticator() {
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
 			sdk.NewAttribute(types.AttributeKeyAuthenticatorType, msg.Type),
-			sdk.NewAttribute(types.AttributeKeyAuthenticatorId, "0"),
+			sdk.NewAttribute(types.AttributeKeyAuthenticatorId, "1"),
 		),
 	})
 }
@@ -94,7 +94,7 @@ func (s *KeeperTestSuite) TestMsgServer_RemoveAuthenticator() {
 	// Now attempt to remove it
 	removeMsg := &types.MsgRemoveAuthenticator{
 		Sender: accAddress.String(),
-		Id:     0,
+		Id:     1,
 	}
 
 	resp, err := msgServer.RemoveAuthenticator(sdk.WrapSDKContext(ctx), removeMsg)

--- a/x/authenticator/testutils/spy_authenticator.go
+++ b/x/authenticator/testutils/spy_authenticator.go
@@ -3,23 +3,23 @@ package testutils
 import (
 	"encoding/json"
 
-	"github.com/osmosis-labs/osmosis/v23/x/authenticator/iface"
-
 	errorsmod "cosmossdk.io/errors"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/osmosis-labs/osmosis/v23/x/authenticator/authenticator"
 )
 
-var _ iface.Authenticator = &SpyAuthenticator{}
+var _ authenticator.Authenticator = &SpyAuthenticator{}
 
 type SpyTrackRequest struct {
-	AuthenticatorId string         `json:"authenticator_id"`
-	Account         sdk.AccAddress `json:"account"`
-	Msg             iface.LocalAny `json:"msg"`
-	MsgIndex        uint64         `json:"msg_index"`
+	AuthenticatorId string                 `json:"authenticator_id"`
+	Account         sdk.AccAddress         `json:"account"`
+	Msg             authenticator.LocalAny `json:"msg"`
+	MsgIndex        uint64                 `json:"msg_index"`
 }
 
 type SpyAddRequest struct {
@@ -35,9 +35,9 @@ type SpyRemoveRequest struct {
 }
 
 type LatestCalls struct {
-	Authenticate           iface.AuthenticationRequest
+	Authenticate           authenticator.AuthenticationRequest
 	Track                  SpyTrackRequest
-	ConfirmExecution       iface.AuthenticationRequest
+	ConfirmExecution       authenticator.AuthenticationRequest
 	OnAuthenticatorAdded   SpyAddRequest
 	OnAuthenticatorRemoved SpyRemoveRequest
 }
@@ -64,7 +64,7 @@ func (s SpyAuthenticator) StaticGas() uint64 {
 	return 1000
 }
 
-func (s SpyAuthenticator) Initialize(data []byte) (iface.Authenticator, error) {
+func (s SpyAuthenticator) Initialize(data []byte) (authenticator.Authenticator, error) {
 	var spyData SpyAuthenticatorData
 	err := json.Unmarshal(data, &spyData)
 	if err != nil {
@@ -74,7 +74,7 @@ func (s SpyAuthenticator) Initialize(data []byte) (iface.Authenticator, error) {
 	return s, nil
 }
 
-func (s SpyAuthenticator) Authenticate(ctx sdk.Context, request iface.AuthenticationRequest) error {
+func (s SpyAuthenticator) Authenticate(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
 	s.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
 		calls.Authenticate = request
 		return calls
@@ -94,7 +94,7 @@ func (s SpyAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, feePaye
 		calls.Track = SpyTrackRequest{
 			AuthenticatorId: authenticatorId,
 			Account:         account,
-			Msg:             iface.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
+			Msg:             authenticator.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
 			MsgIndex:        msgIndex,
 		}
 		return calls
@@ -102,7 +102,7 @@ func (s SpyAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, feePaye
 	return nil
 }
 
-func (s SpyAuthenticator) ConfirmExecution(ctx sdk.Context, request iface.AuthenticationRequest) error {
+func (s SpyAuthenticator) ConfirmExecution(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
 	s.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
 		calls.ConfirmExecution = request
 		return calls

--- a/x/authenticator/types/keys.go
+++ b/x/authenticator/types/keys.go
@@ -22,6 +22,7 @@ const (
 
 	AttributeValueCategory        = ModuleName
 	AttributeKeyAuthenticatorType = "authenticator_type"
+	AttributeKeyAuthenticatorId   = "authenticator_id"
 )
 
 var (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

@JoseRFelix
> By the way, can we obtain the authenticator id right after a transaction succeeds, maybe by including it in the transaction event logs? At the moment, I need to retrieve the session information separately. It would enhance the user experience if we could store it in local storage as soon as the session is created, avoiding the wait time for a query 

## Testing and Verifying
- unit tested on `keeper.AddAuthenticator` returning the right incremental id
- unit tested on `msgServer.AddAuthenticator` ensuring that id is emitted as an event attribute
