### PR TITLE
fix: prevent rand coin value from locking zero coins

### DIFF
--- a/x/lockup/keeper/migration_test.go
+++ b/x/lockup/keeper/migration_test.go
@@ -42,7 +42,7 @@ func (s *KeeperTestSuite) TestLockupMergeMigration() {
 			if rand.Intn(3) == 0 {
 				duration = baseDuration
 			}
-			amount := rand.Int63n(100000)
+			amount := rand.Int63n(99999) + 1 // ensure amount is never 0
 			add(addr, denom, baseDuration, amount)
 			s.LockTokens(addr, sdk.Coins{sdk.NewInt64Coin(denom, amount)}, duration)
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Rand value shouldn't be allowed to be zero. We aren't testing if we can or can't lock zero tokens here.