### PR TITLE
[Smart Account] Revert state of failed authenticator within anyOf

### DIFF
--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -109,7 +109,14 @@ func (aoa AnyOfAuthenticator) Track(ctx sdk.Context, account sdk.AccAddress, fee
 
 func (aoa AnyOfAuthenticator) ConfirmExecution(ctx sdk.Context, request AuthenticationRequest) error {
 	return subHandleRequest(ctx, request, aoa.SubAuthenticators, requireAnyPass, aoa.signatureAssignment, func(auth Authenticator, ctx sdk.Context, request AuthenticationRequest) error {
-		return auth.ConfirmExecution(ctx, request)
+		cacheCtx, write := ctx.CacheContext()
+		err := auth.ConfirmExecution(cacheCtx, request)
+		if err != nil {
+			return err
+		}
+
+		write()
+		return nil
 	})
 }
 

--- a/x/authenticator/authenticator/cosmwasm.go
+++ b/x/authenticator/authenticator/cosmwasm.go
@@ -91,10 +91,6 @@ func (cwa CosmwasmAuthenticator) Authenticate(ctx sdk.Context, request Authentic
 		return errorsmod.Wrapf(err, "failed to sudo")
 	}
 
-	if err != nil {
-		return errorsmod.Wrapf(err, "failed to unmarshal authentication result")
-	}
-
 	return nil
 }
 

--- a/x/authenticator/testutils/spy_authenticator.go
+++ b/x/authenticator/testutils/spy_authenticator.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"encoding/json"
-	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -127,8 +126,6 @@ func (s SpyAuthenticator) ConfirmExecution(ctx sdk.Context, request authenticato
 		calls.ConfirmExecution = request
 		return calls
 	})
-
-	fmt.Printf("spy %s has failure %v\n", s.Name, s.Failure)
 
 	if Has(s.Failure, CONFIRM_EXECUTION_FAIL) {
 		return errorsmod.Wrap(sdkerrors.ErrUnauthorized, "not authenticated")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Making sure that state of sub authenticators in `anyOf` that failed gets reverted even if `anyOf` it self is passed.
This make expectation of authenticator consistent that if the authenticator returns error, it shouldn't update the store in any case rather than depending on parent authenticator result.

## Testing and Verifying
- unit tested in `x/authenticator/authenticator/composite_test.go`