### PR TITLE
Move some Balancer Dec operations to be mutative

### DIFF
--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -79,7 +79,7 @@ func Pow(base Dec, exp Dec) Dec {
 
 	fractionalPow := PowApprox(base, fractional, powPrecision)
 
-	return integerPow.Mul(fractionalPow)
+	return integerPow.MulMut(fractionalPow)
 }
 
 // Contract: 0 < base <= 2

--- a/x/gamm/pool-models/balancer/amm.go
+++ b/x/gamm/pool-models/balancer/amm.go
@@ -107,8 +107,8 @@ func solveConstantFunctionInvariant(
 
 	// amountY = balanceY * (1 - (y ^ weightRatio))
 	yToWeightRatio := osmomath.Pow(y, weightRatio)
-	paranthetical := osmomath.OneDec().Sub(yToWeightRatio)
-	amountY := tokenBalanceUnknownBefore.Mul(paranthetical)
+	paranthetical := oneDec.Sub(yToWeightRatio)
+	amountY := paranthetical.MulMut(tokenBalanceUnknownBefore)
 	return amountY
 }
 

--- a/x/gamm/pool-models/balancer/constants.go
+++ b/x/gamm/pool-models/balancer/constants.go
@@ -19,4 +19,5 @@ var (
 	GuaranteedWeightPrecision int64 = 1 << 30
 
 	PoolTypeName string = "Balancer"
+	oneDec              = osmomath.OneDec()
 )

--- a/x/gamm/pool-models/balancer/pool.go
+++ b/x/gamm/pool-models/balancer/pool.go
@@ -500,9 +500,9 @@ func (p Pool) CalcOutAmtGivenIn(
 		return sdk.Coin{}, err
 	}
 
-	tokenAmountInAfterFee := tokenIn.Amount.ToLegacyDec().Mul(osmomath.OneDec().Sub(spreadFactor))
+	tokenAmountInAfterFee := tokenIn.Amount.ToLegacyDec().MulMut(oneDec.Sub(spreadFactor))
 	poolTokenInBalance := poolAssetIn.Token.Amount.ToLegacyDec()
-	poolPostSwapInBalance := poolTokenInBalance.Add(tokenAmountInAfterFee)
+	poolPostSwapInBalance := tokenAmountInAfterFee.AddMut(poolTokenInBalance)
 
 	// deduct spread factor on the tokensIn
 	// delta balanceOut is positive(tokens inside the pool decreases)


### PR DESCRIPTION
Make some more balancer Dec operations mutative.

This PR should only:
- make oneDec be a constant not created every time
- use mutative operations on internally allocated Decimals

I expect this to be an ~.05% speedup, so pretty small right now