### PR TITLE
Make a protorev error a constant

### DIFF
--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -191,7 +191,7 @@ func (k Keeper) BuildTwoPoolRoute(
 	}
 
 	if pool1 == pool2 {
-		return RouteMetaData{}, fmt.Errorf("cannot be trading on the same pool twice")
+		return RouteMetaData{}, types.ErrRouteDoubleContainsPool
 	}
 
 	newRoute := poolmanagertypes.SwapAmountInRoutes{

--- a/x/protorev/types/errors.go
+++ b/x/protorev/types/errors.go
@@ -10,3 +10,5 @@ type NoPoolForDenomPairError struct {
 func (e NoPoolForDenomPairError) Error() string {
 	return fmt.Sprintf("highest liquidity pool between base %s and match denom %s not found", e.BaseDenom, e.MatchDenom)
 }
+
+var ErrRouteDoubleContainsPool = fmt.Errorf("cannot be trading on the same pool twice")


### PR DESCRIPTION
Make this protorev error constant-interned.

This is a .03% speedup over last benchmark, taking a cumulative of .12s. 