### PR TITLE
feat: unblock ww pools

### DIFF
--- a/ingest/sqs/pools/ingester/pool_ingester.go
+++ b/ingest/sqs/pools/ingester/pool_ingester.go
@@ -13,12 +13,13 @@ import (
 	poolsredisrepo "github.com/osmosis-labs/sqs/sqsdomain/repository/redis/pools"
 	routerredisrepo "github.com/osmosis-labs/sqs/sqsdomain/repository/redis/router"
 
+	cosmwasmpooltypes "github.com/osmosis-labs/osmosis/v23/x/cosmwasmpool/types"
+
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v23/ingest/sqs/domain"
 
 	"github.com/osmosis-labs/osmosis/v23/x/concentrated-liquidity/client/queryproto"
 	concentratedtypes "github.com/osmosis-labs/osmosis/v23/x/concentrated-liquidity/types"
-	"github.com/osmosis-labs/osmosis/v23/x/cosmwasmpool/model"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v23/x/poolmanager/types"
 )
 
@@ -201,17 +202,6 @@ func (pi *poolIngester) processPoolState(ctx sdk.Context, tx repository.Tx) erro
 	}
 
 	for _, pool := range cosmWasmPools {
-		// The logic below is to skip mainnet WhiteWhale pools that were instantiated while
-		// borne
-		cwPool, ok := pool.(*model.Pool)
-		if !ok {
-			return errors.New("fail to cast cw pool")
-		}
-
-		// White whale pool code ID
-		if cwPool.CodeId == whiteWhalePoolCodeID {
-			continue
-		}
 
 		// Parse cosmwasm pool to the standard SQS types.
 		pool, err := pi.convertPool(ctx, pool, denomToRoutablePoolIDMap, denomPairToTakerFeeMap, tokenPrecisionMap)
@@ -330,6 +320,14 @@ func (pi *poolIngester) convertPool(
 	}()
 
 	balances := pi.bankKeeper.GetAllBalances(ctx, pool.GetAddress())
+	if pool.GetType() == poolmanagertypes.CosmWasm {
+		cwPool, ok := pool.(cosmwasmpooltypes.CosmWasmExtension)
+		if !ok {
+			return nil, fmt.Errorf("pool (%d) with type (%d) is not a CosmWasmExtension", pool.GetId(), pool.GetType())
+		}
+
+		balances = cwPool.GetTotalPoolLiquidity(ctx)
+	}
 
 	osmoPoolTVL := osmomath.ZeroInt()
 

--- a/ingest/sqs/pools/ingester/pool_ingester.go
+++ b/ingest/sqs/pools/ingester/pool_ingester.go
@@ -75,9 +75,6 @@ const (
 	atomDenom   = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
 	usdtDenom   = "ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C"
 	oneOSMO     = 1_000_000
-
-	// code ID of the broken WhiteWhale cosmwasm pools on mainnet.
-	whiteWhalePoolCodeID = uint64(503)
 )
 
 var (
@@ -202,7 +199,6 @@ func (pi *poolIngester) processPoolState(ctx sdk.Context, tx repository.Tx) erro
 	}
 
 	for _, pool := range cosmWasmPools {
-
 		// Parse cosmwasm pool to the standard SQS types.
 		pool, err := pi.convertPool(ctx, pool, denomToRoutablePoolIDMap, denomPairToTakerFeeMap, tokenPrecisionMap)
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

White whale pools are not picked up by the router due to being blackisted because of a recent breakage.

Now that the pools are migrated, we bring them back.

The pool balances are also not picked up due to reading bank balances as opposed to liquidity from the pool itself. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated pool ingestion logic to support `CosmWasm` pool types, enhancing compatibility and data processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->