### PR TITLE
fix: move log out of loop

### DIFF
--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -294,10 +294,11 @@ func (k Keeper) swapNonNativeFeeToDenom(ctx sdk.Context, denomToSwapTo string, f
 				},
 			})
 		}
-		if len(coinsNotSwapped) > 0 {
-			ctx.Logger().Info("The following non-native tokens were not swapped (see debug logs for further details): %s", coinsNotSwapped)
-		}
 	}
+	if len(coinsNotSwapped) > 0 {
+		ctx.Logger().Info("The following non-native tokens were not swapped (see debug logs for further details): %s", coinsNotSwapped)
+	}
+
 	return totalCoinOut
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

NOTE: I already made this change on the backports (https://github.com/osmosis-labs/osmosis/pull/7713 and https://github.com/osmosis-labs/osmosis/pull/7714).

I meant to add this log outside of the for loop, and only log the total of all coins not swapped a single time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved logging efficiency in fee processing by consolidating log entries for non-native tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->