### PR TITLE
perf(osmomath): make Exp2 use cheaper comparisons firstly

### DIFF
--- a/osmomath/exp2.go
+++ b/osmomath/exp2.go
@@ -45,11 +45,11 @@ var (
 // Note: our Python script plots show accuracy up to a factor of 10^22.
 // However, in Go tests we only test up to 10^18. Therefore, this is the guarantee.
 func Exp2(exponent BigDec) BigDec {
-	if exponent.Abs().GT(maxSupportedExponent) {
-		panic(fmt.Sprintf("integer exponent %s is too large, max (%s)", exponent, maxSupportedExponent))
-	}
 	if exponent.IsNegative() {
 		panic(fmt.Sprintf("negative exponent %s is not supported", exponent))
+	}
+	if exponent.Abs().GT(maxSupportedExponent) {
+		panic(fmt.Sprintf("integer exponent %s is too large, max (%s)", exponent, maxSupportedExponent))
 	}
 
 	integerExponent := exponent.TruncateDec()

--- a/osmomath/exp2_test.go
+++ b/osmomath/exp2_test.go
@@ -298,3 +298,34 @@ func TestExp2(t *testing.T) {
 		})
 	}
 }
+
+var negativeExponents = []osmomath.BigDec{
+	// These could be the results from subtractions or somehow snuck in.
+	osmomath.MustNewBigDecFromStr("-1"),
+	osmomath.MustNewBigDecFromStr("-2"),
+	osmomath.MustNewBigDecFromStr("-17"),
+	osmomath.MustNewBigDecFromStr("-19"),
+	osmomath.MustNewBigDecFromStr("-20"),
+	osmomath.MustNewBigDecFromStr("-39"),
+	osmomath.MustNewBigDecFromStr("-200"),
+	osmomath.MustNewBigDecFromStr("-2000"),
+	osmomath.MustNewBigDecFromStr("-5000"),
+	osmomath.MustNewBigDecFromStr("-5007"),
+	osmomath.MustNewBigDecFromStr("-9007"),
+}
+
+func BenchmarkExp2Negatives(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, exp := range negativeExponents {
+			func() {
+				defer func() {
+					_ = recover()
+				}()
+
+				_ = osmomath.Exp2(exp)
+			}()
+		}
+	}
+}


### PR DESCRIPTION
This change moves the cheaper big.Int.IsNegative() before big.Int.Abs().GT(maxSupportedExponent) to quickly throw away negative exponent values much faster than firstly converting to an absolute value then comparing against a large value. This change also includes a newly added benchmark that clearly exhibits the improvement.

```shell
$ benchstat before.txt after.txt
name             old time/op    new time/op    delta
Exp2Negatives-8    12.7µs ± 2%     9.7µs ± 3%  -23.04%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
Exp2Negatives-8    6.16kB ± 0%    4.35kB ± 0%  -29.35%  (p=0.000 n=9+10)

name             old allocs/op  new allocs/op  delta
Exp2Negatives-8       119 ± 0%        88 ± 0%  -26.05%  (p=0.000 n=10+10)
```

Fixes #7740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of the `Exp2` function by adjusting the order of exponent magnitude checks.
- **Tests**
	- Added benchmark tests for negative exponents in the `Exp2` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->