### PR TITLE
feat: precomputed order of magnitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7503](https://github.com/osmosis-labs/osmosis/pull/7503) Add IBC wasm light clients module
 * [#7689](https://github.com/osmosis-labs/osmosis/pull/7689) Make CL price estimations not cause state writes (speed and gas improvements)
 
+### Features
+
+* [#7250](https://github.com/osmosis-labs/osmosis/pull/7250) Introduces a look up table function for computing order of magnitude of an Int for better performance.
+
 ## v23.0.6-iavl-v1 (contains everything in v23.0.6)
 
 * [#558](https://github.com/osmosis-labs/cosmos-sdk/pull/558) Gracefully log when there is a pruning error instead of panic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* [#7250](https://github.com/osmosis-labs/osmosis/pull/7250) Introduces a look up table function for computing order of magnitude of an Int for better performance.
+* [#7742](https://github.com/osmosis-labs/osmosis/pull/7742) Introduces a look up table function for computing order of magnitude of an Int for better performance.
 
 ## v23.0.6-iavl-v1 (contains everything in v23.0.6)
 

--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -19,6 +19,16 @@ var (
 	// https://www.wolframalpha.com/input?i=2.718281828459045235360287471352662498&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
 	// nolint: unused
 	eulersNumber = MustNewBigDecFromStr("2.718281828459045235360287471352662498")
+
+	TenE9 = NewInt(1_000_000_000)
+	TenE8 = NewInt(100_000_000)
+	TenE7 = NewInt(10_000_000)
+	TenE6 = NewInt(1_000_000)
+	TenE5 = NewInt(100_000)
+	TenE4 = NewInt(10_000)
+	TenE3 = NewInt(1_000)
+	TenE2 = NewInt(100)
+	TenE1 = NewInt(10)
 )
 
 // Returns the internal "power precision".
@@ -202,4 +212,47 @@ func OrderOfMagnitude(num Dec) int {
 	}
 
 	return order
+}
+
+// GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
+// Uses look up table for precomputed order of magnitudes.
+// CONTRACT: amount must be positive or zero. Panics if not
+func GetPrecomputeOrderOfMagnitude(amount Int) int {
+	if amount.IsNegative() {
+		panic(fmt.Errorf("amount must be positive or zero, was (%s)", amount))
+	}
+
+	if amount.GT(TenE9) {
+		a := amount.Quo(TenE9)
+		return 9 + GetPrecomputeOrderOfMagnitude(a)
+	}
+	if amount.GTE(TenE9) {
+		return 9
+	}
+	if amount.GTE(TenE8) {
+		return 8
+	}
+	if amount.GTE(TenE7) {
+		return 7
+	}
+	if amount.GTE(TenE6) {
+		return 6
+	}
+	if amount.GTE(TenE5) {
+		return 5
+	}
+	if amount.GTE(TenE4) {
+		return 4
+	}
+	if amount.GTE(TenE3) {
+		return 3
+	}
+	if amount.GTE(TenE2) {
+		return 2
+	}
+	if amount.GTE(TenE1) {
+		return 1
+	}
+
+	return 0
 }

--- a/osmomath/math_test.go
+++ b/osmomath/math_test.go
@@ -241,3 +241,49 @@ func TestOrderOfMagnitudeWithoutLog(t *testing.T) {
 		})
 	}
 }
+
+// Tests the precomputed order of magnitude function
+// by comparing it to the OrderOfMagnitude version.
+func TestGetPrecomputeOrderOfMagnitude(t *testing.T) {
+
+	tests := map[string]struct {
+		amount Int
+	}{
+		"0 = 0": {
+			amount: ZeroInt(),
+		},
+		"1 = 0": {
+			amount: OneInt(),
+		},
+		"9.99 = 0": {
+			amount: NewInt(9),
+		},
+		"10^9 - 1": {
+			amount: TenE9.Sub(OneInt()),
+		},
+		"10^9": {
+			amount: TenE9,
+		},
+		"10^9 +1": {
+			amount: TenE9.Add(OneInt()),
+		},
+		"10^18 +1": {
+			amount: TenE9.Mul(TenE9).Add(OneInt()),
+		},
+		"10^15 +5": {
+			amount: TenE9.Mul(TenE6).Add(OneInt()),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// Test the function by comparing it to the OrderOfMagnitude function
+			actual := GetPrecomputeOrderOfMagnitude(tc.amount)
+			expected := OrderOfMagnitude(tc.amount.ToLegacyDec())
+
+			require.Equal(t, expected, actual)
+		})
+	}
+
+}

--- a/osmomath/order_of_magnitude_bench_test.go
+++ b/osmomath/order_of_magnitude_bench_test.go
@@ -1,0 +1,25 @@
+package osmomath
+
+import "testing"
+
+var (
+	testAmount = NewInt(1234567890323344555)
+)
+
+// go test -benchmem -run=^$ -bench ^BenchmarkGetPrecomputeOrderOfMagnitude$ github.com/osmosis-labs/osmosis/osmomath -count=6
+func BenchmarkGetPrecomputeOrderOfMagnitude(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		_ = GetPrecomputeOrderOfMagnitude(testAmount)
+	}
+}
+
+// go test -benchmem -run=^$ -benchmem -bench ^BenchmarkOrderOfMagnitude$ github.com/osmosis-labs/osmosis/osmomath -count=6 > old
+func BenchmarkOrderOfMagnitude(b *testing.B) {
+	// Create a test amount. Change this based on what you expect to be typical inputs for your application.
+	testAmount := NewInt(1234567890323344555) // You can adjust this value for different benchmark scenarios.
+
+	for i := 0; i < b.N; i++ {
+		_ = OrderOfMagnitude(testAmount.ToLegacyDec())
+	}
+}

--- a/osmomath/order_of_magnitude_bench_test.go
+++ b/osmomath/order_of_magnitude_bench_test.go
@@ -8,7 +8,6 @@ var (
 
 // go test -benchmem -run=^$ -bench ^BenchmarkGetPrecomputeOrderOfMagnitude$ github.com/osmosis-labs/osmosis/osmomath -count=6
 func BenchmarkGetPrecomputeOrderOfMagnitude(b *testing.B) {
-
 	for i := 0; i < b.N; i++ {
 		_ = GetPrecomputeOrderOfMagnitude(testAmount)
 	}
@@ -16,9 +15,6 @@ func BenchmarkGetPrecomputeOrderOfMagnitude(b *testing.B) {
 
 // go test -benchmem -run=^$ -benchmem -bench ^BenchmarkOrderOfMagnitude$ github.com/osmosis-labs/osmosis/osmomath -count=6 > old
 func BenchmarkOrderOfMagnitude(b *testing.B) {
-	// Create a test amount. Change this based on what you expect to be typical inputs for your application.
-	testAmount := NewInt(1234567890323344555) // You can adjust this value for different benchmark scenarios.
-
 	for i := 0; i < b.N; i++ {
 		_ = OrderOfMagnitude(testAmount.ToLegacyDec())
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

SQS frequently uses this function for getting order of magnitude of token in.

As a result, we optimize it here by implementing a look up table version

## Benchmarks

Precompute
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3527824	       371.8 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3109318	       328.9 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3569872	       349.1 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3276049	       352.9 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3739591	       322.9 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3297483	       324.7 ns/op	      96 B/op	       6 allocs/op
PASS
ok  	github.com/osmosis-labs/sqs/router/usecase	10.494s
```

Non-precompute
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkOrderOfMagnitude-8   	  229332	      5374 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  239371	      5549 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  257167	      5405 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  236186	      4932 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  233816	      5151 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  222508	      8797 ns/op	    1256 B/op	      22 allocs/op
PASS
ok  	github.com/osmosis-labs/sqs/router/usecase	12.149s
```

## Testing and Verifying

- Tested on sqs and added unit tests

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a look-up table function for computing the order of magnitude of an integer to enhance performance.
- **Tests**
	- Added tests to ensure the new order of magnitude computation works as expected.
	- Implemented benchmark tests for comparing performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->