### PR TITLE
feat x/bridge: using MsgServer to access tokenfactory

### DIFF
--- a/x/bridge/keeper/assets.go
+++ b/x/bridge/keeper/assets.go
@@ -68,7 +68,7 @@ func (k Keeper) createAssets(ctx sdk.Context, assets []types.AssetWithStatus) er
 		if err != nil {
 			return errorsmod.Wrapf(
 				types.ErrTokenfactory,
-				"Can't execute a create denom message for asset %s: %s", asset.Asset.Name(), err,
+				"Can't execute a create denom message for %s: %s", asset.Asset.Name(), err,
 			)
 		}
 	}

--- a/x/bridge/keeper/assets.go
+++ b/x/bridge/keeper/assets.go
@@ -66,7 +66,10 @@ func (k Keeper) createAssets(ctx sdk.Context, assets []types.AssetWithStatus) er
 		// TODO: double-check if we need to handle the response
 		_, err := handler(ctx, msgCreateDenom)
 		if err != nil {
-			return errorsmod.Wrapf(types.ErrTokenfactory, "Can't execute a create denom message: %s", err)
+			return errorsmod.Wrapf(
+				types.ErrTokenfactory,
+				"Can't execute a create denom message for asset %s: %s", asset.Asset.Name(), err,
+			)
 		}
 	}
 

--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cometbft/cometbft/libs/log"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
@@ -12,21 +12,22 @@ import (
 )
 
 type Keeper struct {
-	storeKey   storetypes.StoreKey
+	// paramSpace stores module's params
 	paramSpace paramtypes.Subspace
-
-	accountKeeper      types.AccountKeeper
-	tokenFactoryKeeper types.TokenFactoryKeeper
-
+	// router is used to access tokenfactory methods
+	router *baseapp.MsgServiceRouter
+	// accountKeeper helps get the module's address
+	accountKeeper types.AccountKeeper
+	// govModuleAddr is used in UpdateParams method since it is
+	// the only addr that can update bridge module params
 	govModuleAddr string
 }
 
 // NewKeeper returns a new instance of the x/bridge keeper.
 func NewKeeper(
-	storeKey storetypes.StoreKey,
 	paramSpace paramtypes.Subspace,
+	router *baseapp.MsgServiceRouter,
 	accountKeeper types.AccountKeeper,
-	tokenFactoryKeeper types.TokenFactoryKeeper,
 	govModuleAddr string,
 ) Keeper {
 	// ensure bridge module account is set
@@ -39,11 +40,10 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		storeKey:           storeKey,
-		paramSpace:         paramSpace,
-		accountKeeper:      accountKeeper,
-		tokenFactoryKeeper: tokenFactoryKeeper,
-		govModuleAddr:      govModuleAddr,
+		paramSpace:    paramSpace,
+		router:        router,
+		accountKeeper: accountKeeper,
+		govModuleAddr: govModuleAddr,
 	}
 }
 

--- a/x/bridge/keeper/params.go
+++ b/x/bridge/keeper/params.go
@@ -28,7 +28,8 @@ func (k Keeper) UpdateParams(ctx sdk.Context, newParams types.Params) (UpdatePar
 	// create denoms for all new assets
 	err := k.createAssets(ctx, assetsToCreate)
 	if err != nil {
-		return UpdateParamsResult{}, err
+		return UpdateParamsResult{},
+			errorsmod.Wrapf(types.ErrCantCreateAsset, "Can't create new assets: %s", err)
 	}
 
 	// disable deleted assets
@@ -36,7 +37,7 @@ func (k Keeper) UpdateParams(ctx sdk.Context, newParams types.Params) (UpdatePar
 		_, err = k.ChangeAssetStatus(ctx, asset.Asset, types.AssetStatus_ASSET_STATUS_BLOCKED_BOTH)
 		if err != nil {
 			return UpdateParamsResult{},
-				errorsmod.Wrapf(types.ErrCantChangeAssetStatus, "Can't disable asset %v: %s", asset.Asset, err)
+				errorsmod.Wrapf(types.ErrCantChangeAssetStatus, "Can't disable asset %s: %s", asset.Asset.Name(), err)
 		}
 	}
 

--- a/x/bridge/keeper/transfers.go
+++ b/x/bridge/keeper/transfers.go
@@ -28,9 +28,14 @@ func (k Keeper) InboundTransfer(
 
 	moduleAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
 
+	denom, err := tokenfactorytypes.GetTokenDenom(moduleAddr.String(), asset.Name())
+	if err != nil {
+		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't create a tokenfacroty denom for %s", asset.Name())
+	}
+
 	msgMint := &tokenfactorytypes.MsgMint{
 		Sender:        moduleAddr.String(),
-		Amount:        sdk.NewCoin(asset.Name(), amount),
+		Amount:        sdk.NewCoin(denom, amount),
 		MintToAddress: destAddr,
 	}
 
@@ -41,7 +46,7 @@ func (k Keeper) InboundTransfer(
 
 	// ignore resp since it is empty in this method
 	// TODO: double-check if we need to handle the response
-	_, err := handler(ctx, msgMint)
+	_, err = handler(ctx, msgMint)
 	if err != nil {
 		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't execute a mint message: %s", err)
 	}
@@ -68,9 +73,14 @@ func (k Keeper) OutboundTransfer(
 
 	moduleAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
 
+	denom, err := tokenfactorytypes.GetTokenDenom(moduleAddr.String(), asset.Name())
+	if err != nil {
+		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't create a tokenfacroty denom for %s", asset.Name())
+	}
+
 	msgBurn := &tokenfactorytypes.MsgBurn{
 		Sender:          moduleAddr.String(),
-		Amount:          sdk.NewCoin(asset.Name(), amount),
+		Amount:          sdk.NewCoin(denom, amount),
 		BurnFromAddress: sourceAddr,
 	}
 
@@ -81,7 +91,7 @@ func (k Keeper) OutboundTransfer(
 
 	// ignore resp since it is empty in this method
 	// TODO: double-check if we need to handle the response
-	_, err := handler(ctx, msgBurn)
+	_, err = handler(ctx, msgBurn)
 	if err != nil {
 		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't execute a burn message: %s", err)
 	}

--- a/x/bridge/keeper/transfers.go
+++ b/x/bridge/keeper/transfers.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v23/x/bridge/types"
+	tokenfactorytypes "github.com/osmosis-labs/osmosis/v23/x/tokenfactory/types"
 )
 
 func (k Keeper) InboundTransfer(
@@ -27,12 +28,25 @@ func (k Keeper) InboundTransfer(
 
 	moduleAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
 
-	return k.tokenFactoryKeeper.Mint(
-		ctx,
-		moduleAddr.String(),
-		sdk.NewCoin(asset.Name(), amount),
-		destAddr,
-	)
+	msgMint := &tokenfactorytypes.MsgMint{
+		Sender:        moduleAddr.String(),
+		Amount:        sdk.NewCoin(asset.Name(), amount),
+		MintToAddress: destAddr,
+	}
+
+	handler := k.router.Handler(msgMint)
+	if handler == nil {
+		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't route a mint message")
+	}
+
+	// ignore resp since it is empty in this method
+	// TODO: double-check if we need to handle the response
+	_, err := handler(ctx, msgMint)
+	if err != nil {
+		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't execute a mint message: %s", err)
+	}
+
+	return nil
 }
 
 func (k Keeper) OutboundTransfer(
@@ -54,10 +68,23 @@ func (k Keeper) OutboundTransfer(
 
 	moduleAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
 
-	return k.tokenFactoryKeeper.Burn(
-		ctx,
-		moduleAddr.String(),
-		sdk.NewCoin(asset.Name(), amount),
-		sourceAddr,
-	)
+	msgBurn := &tokenfactorytypes.MsgBurn{
+		Sender:          moduleAddr.String(),
+		Amount:          sdk.NewCoin(asset.Name(), amount),
+		BurnFromAddress: sourceAddr,
+	}
+
+	handler := k.router.Handler(msgBurn)
+	if handler == nil {
+		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't route a burn message")
+	}
+
+	// ignore resp since it is empty in this method
+	// TODO: double-check if we need to handle the response
+	_, err := handler(ctx, msgBurn)
+	if err != nil {
+		return errorsmod.Wrapf(types.ErrTokenfactory, "Can't execute a burn message: %s", err)
+	}
+
+	return nil
 }

--- a/x/bridge/types/errors.go
+++ b/x/bridge/types/errors.go
@@ -16,5 +16,6 @@ var (
 	ErrInvalidSourceChain    = errorsmod.Register(ModuleName, 7, "invalid source chain")
 	ErrInvalidSigners        = errorsmod.Register(ModuleName, 8, "invalid signers")
 	ErrCantChangeAssetStatus = errorsmod.Register(ModuleName, 9, "can't change asset status")
-	ErrTokenfactory          = errorsmod.Register(ModuleName, 10, "tokenfactory error")
+	ErrCantCreateAsset       = errorsmod.Register(ModuleName, 10, "can't create asset")
+	ErrTokenfactory          = errorsmod.Register(ModuleName, 11, "tokenfactory error")
 )

--- a/x/bridge/types/errors.go
+++ b/x/bridge/types/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrInvalidSourceChain    = errorsmod.Register(ModuleName, 7, "invalid source chain")
 	ErrInvalidSigners        = errorsmod.Register(ModuleName, 8, "invalid signers")
 	ErrCantChangeAssetStatus = errorsmod.Register(ModuleName, 9, "can't change asset status")
+	ErrTokenfactory          = errorsmod.Register(ModuleName, 10, "tokenfactory error")
 )

--- a/x/bridge/types/expected_keepers.go
+++ b/x/bridge/types/expected_keepers.go
@@ -2,19 +2,10 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 type AccountKeeper interface {
-	// GetModuleAccount is used to create x/bridge module account
-	GetModuleAccount(ctx sdk.Context, moduleName string) authtypes.ModuleAccountI
 	// GetModuleAddress is used to get the module account
 	// to use it as the admin for denoms in x/tokenfactory.
 	GetModuleAddress(name string) sdk.AccAddress
-}
-
-type TokenFactoryKeeper interface {
-	CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string) (newTokenDenom string, err error)
-	Mint(ctx sdk.Context, sender string, amount sdk.Coin, mintTo string) error
-	Burn(ctx sdk.Context, sender string, amount sdk.Coin, burnFrom string) error
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/7643

## What is the purpose of the change

Modified x/bridge to use MsgServer to access tokenfactory

## Testing and Verifying

Tests are in process at https://github.com/osmosis-labs/osmosis/pull/7720. Now the module is not wired, so the change affects nothing.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Integrated a new handler for creating denominations.
- **Improvements**
	- Updated handling structures and improved error handling for inbound and outbound transfers.
- **Bug Fixes**
	- Added a specific error code for token factory-related errors.
- **Documentation**
	- Enhanced error messages for asset creation and disabling with specific asset names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->