### PR TITLE
perf(osmoutils): use make([]T, size) hint in *SubDecCoinArrays

### DIFF
--- a/osmoutils/bench_test.go
+++ b/osmoutils/bench_test.go
@@ -1,0 +1,123 @@
+package osmoutils
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func decCoin(denom string, amount int64) sdk.DecCoin {
+	mInt := math.NewInt(amount)
+	return sdk.NewDecCoin(denom, mInt)
+}
+
+var subDecValues = []struct {
+	name string
+	a, b []sdk.DecCoins
+	want []sdk.DecCoins
+}{
+	{
+		name: "empty coins",
+		a:    []sdk.DecCoins{},
+		b:    []sdk.DecCoins{},
+		want: []sdk.DecCoins{},
+	},
+	{
+		name: "1 coin per set",
+		a:    []sdk.DecCoins{sdk.NewDecCoins(decCoin("osmo", 100))},
+		b:    []sdk.DecCoins{sdk.NewDecCoins(decCoin("osmo", 10))},
+		want: []sdk.DecCoins{sdk.NewDecCoins(decCoin("osmo", 90))},
+	},
+	{
+		name: "2 uniq coins",
+		a:    []sdk.DecCoins{sdk.NewDecCoins(decCoin("osmo", 100), decCoin("uosmo", 200))},
+		b:    []sdk.DecCoins{sdk.NewDecCoins(decCoin("osmo", 10), decCoin("uosmo", 20))},
+		want: []sdk.DecCoins{sdk.NewDecCoins(decCoin("osmo", 90), decCoin("uosmo", 180))},
+	},
+	{
+		name: "10 uniq coins",
+		a: []sdk.DecCoins{
+			sdk.NewDecCoins(
+				decCoin("osmo", 100), decCoin("uosmo", 200), decCoin("qck", 271), decCoin("tia", 2280),
+				decCoin("mosmo", 100), decCoin("posmo", 200), decCoin("uqck", 271), decCoin("utia", 2280),
+				decCoin("atom", 100), decCoin("uatom", 200),
+			),
+		},
+		b: []sdk.DecCoins{
+			sdk.NewDecCoins(
+				decCoin("osmo", 80), decCoin("uosmo", 200), decCoin("qck", 270), decCoin("tia", 1000),
+				decCoin("mosmo", 100), decCoin("posmo", 200), decCoin("uqck", 271), decCoin("utia", 2200),
+				decCoin("atom", 99), decCoin("uatom", 192),
+			),
+		},
+		want: []sdk.DecCoins{
+			sdk.NewDecCoins(
+				decCoin("osmo", 20), decCoin("uosmo", 0), decCoin("qck", 1), decCoin("tia", 1280),
+				decCoin("mosmo", 0), decCoin("posmo", 0), decCoin("uqck", 0), decCoin("utia", 80),
+				decCoin("atom", 1), decCoin("uatom", 8),
+			),
+		},
+	},
+}
+
+var sink any = nil
+
+func BenchmarkSafeSubDecCoinArrays(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, val := range subDecValues {
+			got, err := SafeSubDecCoinArrays(val.a, val.b)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if g, w := len(got), len(val.want); g != w {
+				b.Fatalf("Unequal lengths\n\tGot:  %d\n\twant: %d", g, w)
+			}
+			for j := range got {
+				gj := got[j]
+				wj := val.want[j]
+				if !gj.IsEqual(wj) {
+					b.Fatalf("#%d: unexpected result\n\tGot:  %v\n\tWant: %v", j, gj, wj)
+				}
+			}
+			sink = got
+		}
+	}
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+	sink = nil
+}
+
+func BenchmarkSubDecCoinArrays(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, val := range subDecValues {
+			got, err := SubDecCoinArrays(val.a, val.b)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if g, w := len(got), len(val.want); g != w {
+				b.Fatalf("Unequal lengths\n\tGot:  %d\n\twant: %d", g, w)
+			}
+			for j := range got {
+				gj := got[j]
+				wj := val.want[j]
+				if !gj.IsEqual(wj) {
+					b.Fatalf("#%d: unexpected result\n\tGot:  %v\n\tWant: %v", j, gj, wj)
+				}
+			}
+			sink = got
+		}
+	}
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+	sink = nil
+}

--- a/osmoutils/coin_helper.go
+++ b/osmoutils/coin_helper.go
@@ -14,9 +14,9 @@ func SubDecCoinArrays(decCoinsArrayA []sdk.DecCoins, decCoinsArrayB []sdk.DecCoi
 		return []sdk.DecCoins{}, fmt.Errorf("DecCoin arrays must be of equal length to be subtracted")
 	}
 
-	finalDecCoinArray := []sdk.DecCoins{}
+	finalDecCoinArray := make([]sdk.DecCoins, len(decCoinsArrayA))
 	for i := range decCoinsArrayA {
-		finalDecCoinArray = append(finalDecCoinArray, decCoinsArrayA[i].Sub(decCoinsArrayB[i]))
+		finalDecCoinArray[i] = decCoinsArrayA[i].Sub(decCoinsArrayB[i])
 	}
 
 	return finalDecCoinArray, nil
@@ -30,10 +30,10 @@ func SafeSubDecCoinArrays(decCoinsArrayA []sdk.DecCoins, decCoinsArrayB []sdk.De
 		return []sdk.DecCoins{}, fmt.Errorf("DecCoin arrays must be of equal length to be subtracted")
 	}
 
-	finalDecCoinArray := []sdk.DecCoins{}
+	finalDecCoinArray := make([]sdk.DecCoins, len(decCoinsArrayA))
 	for i := range decCoinsArrayA {
 		subResult, _ := decCoinsArrayA[i].SafeSub(decCoinsArrayB[i])
-		finalDecCoinArray = append(finalDecCoinArray, subResult)
+		finalDecCoinArray[i] = subResult
 	}
 
 	return finalDecCoinArray, nil


### PR DESCRIPTION
This change uses make([]T, size) when creating the slices that hold the final results from the subtractions, along with inserting values along with indices.

This results in these benchmarks

```shell
$ benchstat before.txt after.txt
name                    old time/op    new time/op    delta
SafeSubDecCoinArrays-8    4.23µs ± 6%    4.13µs ± 7%    ~     (p=0.243 n=9+10)
SubDecCoinArrays-8        4.09µs ± 4%    4.02µs ± 4%    ~     (p=0.052 n=10+10)

name                    old alloc/op   new alloc/op   delta
SafeSubDecCoinArrays-8    3.08kB ± 0%    3.06kB ± 0%  -0.78%  (p=0.000 n=10+10)
SubDecCoinArrays-8        3.08kB ± 0%    3.08kB ± 0%    ~     (all equal)

name                    old allocs/op  new allocs/op  delta
SafeSubDecCoinArrays-8      75.0 ± 0%      74.0 ± 0%  -1.33%  (p=0.000 n=10+10)
SubDecCoinArrays-8          75.0 ± 0%      75.0 ± 0%    ~     (all equal)
```

and this very simple change over time aids reduce RAM/CPU cycles given that Osmosis is very popular.

Fixes #7756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Performance Improvements**
	- Enhanced the efficiency of decimal coin array subtraction operations in the `osmoutils` package.
- **Tests**
	- Introduced benchmark tests for decimal coin array subtraction functions.
- **Refactor**
	- Optimized the initialization process of arrays in the `SubDecCoinArrays` and `SafeSubDecCoinArrays` functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->