### PR TITLE
perf(all): use make([]T, 0, capacity) hint

### DIFF
--- a/x/concentrated-liquidity/client/cli/tx.go
+++ b/x/concentrated-liquidity/client/cli/tx.go
@@ -251,7 +251,7 @@ func parsePoolIdToTickSpacingRecords(cmd *cobra.Command) ([]types.PoolIdToTickSp
 		return nil, fmt.Errorf("poolIdToTickSpacingRecords must be a list of pairs of poolId and newTickSpacing")
 	}
 
-	poolIdToTickSpacingRecords := []types.PoolIdToTickSpacingRecord{}
+	poolIdToTickSpacingRecords := make([]types.PoolIdToTickSpacingRecord, 0, len(assets))
 	i := 0
 	for i < len(assets) {
 		poolId, err := strconv.Atoi(assets[i])
@@ -287,7 +287,7 @@ func parsePoolRecords(cmd *cobra.Command) ([]types.PoolRecord, error) {
 		return nil, fmt.Errorf("poolRecords must be a list of denom0, denom1, tickSpacing, and spreadFactor")
 	}
 
-	finalPoolRecords := []types.PoolRecord{}
+	finalPoolRecords := make([]types.PoolRecord, 0, len(poolRecords))
 	i := 0
 	for i < len(poolRecords) {
 		denom0 := poolRecords[i]

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -47,7 +47,7 @@ func (k Keeper) createUptimeAccumulators(ctx sdk.Context, poolId uint64) error {
 
 // getUptimeTrackerValues extracts the values of an array of uptime trackers
 func getUptimeTrackerValues(uptimeTrackers []model.UptimeTracker) []sdk.DecCoins {
-	trackerValues := []sdk.DecCoins{}
+	trackerValues := make([]sdk.DecCoins, 0, len(uptimeTrackers))
 	for _, uptimeTracker := range uptimeTrackers {
 		trackerValues = append(trackerValues, uptimeTracker.UptimeGrowthOutside)
 	}
@@ -79,7 +79,7 @@ func (k Keeper) GetUptimeAccumulatorValues(ctx sdk.Context, poolId uint64) ([]sd
 		return []sdk.DecCoins{}, err
 	}
 
-	uptimeValues := []sdk.DecCoins{}
+	uptimeValues := make([]sdk.DecCoins, 0, len(uptimeAccums))
 	for _, uptimeAccum := range uptimeAccums {
 		uptimeValues = append(uptimeValues, uptimeAccum.GetValue())
 	}
@@ -108,7 +108,7 @@ func (k Keeper) getInitialUptimeGrowthOppositeDirectionOfLastTraversalForTick(ct
 	}
 
 	// If currentTick < tick, we return len(SupportedUptimes) empty DecCoins
-	emptyUptimeValues := []sdk.DecCoins{}
+	emptyUptimeValues := make([]sdk.DecCoins, 0, len(types.SupportedUptimes))
 	for range types.SupportedUptimes {
 		emptyUptimeValues = append(emptyUptimeValues, emptyCoins)
 	}

--- a/x/cosmwasmpool/genesis.go
+++ b/x/cosmwasmpool/genesis.go
@@ -30,7 +30,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	if err != nil {
 		panic(err)
 	}
-	poolAnys := []*codectypes.Any{}
+	poolAnys := make([]*codectypes.Any, 0, len(pools))
 	for _, poolI := range pools {
 		cosmwasmPool, ok := poolI.(types.CosmWasmExtension)
 		if !ok {

--- a/x/downtime-detector/genesis.go
+++ b/x/downtime-detector/genesis.go
@@ -33,8 +33,9 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 }
 
 func (k *Keeper) getGenDowntimes(ctx sdk.Context) []types.GenesisDowntimeEntry {
-	downtimes := []types.GenesisDowntimeEntry{}
-	for _, downtime := range types.DowntimeToDuration.Keys() {
+	keys := types.DowntimeToDuration.Keys()
+	downtimes := make([]types.GenesisDowntimeEntry, 0, len(keys))
+	for _, downtime := range keys {
 		t, err := k.GetLastDowntimeOfLength(ctx, downtime)
 		if err != nil {
 			panic(err)

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -625,7 +625,7 @@ func swapAmountOutRoutes(fs *flag.FlagSet) ([]poolmanagertypes.SwapAmountOutRout
 		return nil, errors.New("swap route pool ids and denoms mismatch")
 	}
 
-	routes := []poolmanagertypes.SwapAmountOutRoute{}
+	routes := make([]poolmanagertypes.SwapAmountOutRoute, 0, len(swapRoutePoolIdsArray))
 	for index, poolIDStr := range swapRoutePoolIdsArray {
 		pID, err := strconv.Atoi(poolIDStr)
 		if err != nil {
@@ -722,7 +722,7 @@ func parseMigrationRecords(cmd *cobra.Command) ([]gammmigration.BalancerToConcen
 		return nil, errors.New("migration records should be a list of balancer pool id and concentrated pool id pairs")
 	}
 
-	replaceMigrations := []gammmigration.BalancerToConcentratedPoolLink{}
+	replaceMigrations := make([]gammmigration.BalancerToConcentratedPoolLink, 0, len(assets))
 	i := 0
 	for i < len(assets) {
 		balancerPoolId, err := strconv.Atoi(assets[i])
@@ -831,7 +831,7 @@ func parsePoolRecordsWithCFMMLink(cmd *cobra.Command) ([]types.PoolRecordWithCFM
 		return nil, fmt.Errorf("poolRecordswithCFMMLink must be a list of denom0, denom1, tickSpacing, exponentAtPriceOne, spreadFactor and balancerPoolId")
 	}
 
-	finalPoolRecords := []types.PoolRecordWithCFMMLink{}
+	finalPoolRecords := make([]types.PoolRecordWithCFMMLink, 0, len(poolRecordsWithCFMMLink))
 	i := 0
 	for i < len(poolRecordsWithCFMMLink) {
 		denom0 := poolRecordsWithCFMMLink[i]

--- a/x/gamm/keeper/genesis.go
+++ b/x/gamm/keeper/genesis.go
@@ -16,7 +16,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState, unpack
 
 	// Sums up the liquidity in all genesis state pools to find the total liquidity across all pools.
 	// Also adds each genesis state pool to the x/gamm module's state
-	liquidity := sdk.Coins{}
+	liquidity := make(sdk.Coins, 0, len(genState.Pools)*5)
 	for _, any := range genState.Pools {
 		var pool types.CFMMPoolI
 		err := unpacker.UnpackAny(any, &pool)
@@ -53,7 +53,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	if err != nil {
 		panic(err)
 	}
-	poolAnys := []*codectypes.Any{}
+	poolAnys := make([]*codectypes.Any, 0, len(pools))
 	for _, poolI := range pools {
 		any, err := codectypes.NewAnyWithValue(poolI)
 		if err != nil {

--- a/x/gamm/keeper/migrate.go
+++ b/x/gamm/keeper/migrate.go
@@ -287,7 +287,7 @@ func (k Keeper) UpdateMigrationRecords(ctx sdk.Context, records []gammmigration.
 		recordsMap[record.BalancerPoolId] = record
 	}
 
-	newRecords := []gammmigration.BalancerToConcentratedPoolLink{}
+	newRecords := make([]gammmigration.BalancerToConcentratedPoolLink, 0, len(recordsMap))
 
 	// Iterate through the map and add all the records to a new list
 	// if the clPoolId is 0, we remove the entire record

--- a/x/incentives/keeper/gauge.go
+++ b/x/incentives/keeper/gauge.go
@@ -289,7 +289,7 @@ func (k Keeper) GetGaugeByID(ctx sdk.Context, gaugeID uint64) (*types.Gauge, err
 
 // GetGaugeFromIDs returns multiple gauges from a gaugeIDs array.
 func (k Keeper) GetGaugeFromIDs(ctx sdk.Context, gaugeIDs []uint64) ([]types.Gauge, error) {
-	gauges := []types.Gauge{}
+	gauges := make([]types.Gauge, 0, len(gaugeIDs))
 	for _, gaugeID := range gaugeIDs {
 		gauge, err := k.GetGaugeByID(ctx, gaugeID)
 		if err != nil {
@@ -341,7 +341,7 @@ func (k Keeper) GetRewardsEst(ctx sdk.Context, addr sdk.AccAddress, locks []lock
 			denomSet[c.Denom] = true
 		}
 	}
-	gauges := []types.Gauge{}
+	gauges := make([]types.Gauge, 0, len(denomSet))
 	// initialize gauges to active and upcomings if not set
 	for s := range denomSet {
 		gaugeIDs := k.getAllGaugeIDsByDenom(ctx, s)

--- a/x/incentives/keeper/hooks.go
+++ b/x/incentives/keeper/hooks.go
@@ -52,7 +52,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 		// only distribute to active gauges that are for native denoms
 		// or non-perpetual and for synthetic denoms.
 		// We distribute to perpetual synthetic denoms elsewhere in superfluid.
-		distrGauges := []types.Gauge{}
+		distrGauges := make([]types.Gauge, 0, len(gauges))
 		for _, gauge := range gauges {
 			isSynthetic := lockuptypes.IsSyntheticDenom(gauge.DistributeTo.Denom)
 			if !(isSynthetic && gauge.IsPerpetual) {

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -615,7 +615,7 @@ func (k Keeper) InitializeAllLocks(ctx sdk.Context, locks []types.PeriodLock) er
 	// to avoid hitting the myriad of slowdowns in the SDK iterator creation process.
 	// We then save these once to the accumulation store at the end.
 	accumulationStoreEntries := make(map[string]map[time.Duration]osmomath.Int)
-	denoms := []string{}
+	denoms := make([]string, 0, len(locks))
 	for i, lock := range locks {
 		if i%25000 == 0 {
 			msg := fmt.Sprintf("Reset %d lock refs, cur lock ID %d", i, lock.ID)
@@ -679,7 +679,7 @@ func (k Keeper) InitializeAllSyntheticLocks(ctx sdk.Context, syntheticLocks []ty
 	// to avoid hitting the myriad of slowdowns in the SDK iterator creation process.
 	// We then save these once to the accumulation store at the end.
 	accumulationStoreEntries := make(map[string]map[time.Duration]osmomath.Int)
-	denoms := []string{}
+	denoms := make([]string, 0, len(syntheticLocks))
 	for i, synthLock := range syntheticLocks {
 		if i%25000 == 0 {
 			msg := fmt.Sprintf("Reset %d synthetic lock refs", i)

--- a/x/lockup/keeper/migration.go
+++ b/x/lockup/keeper/migration.go
@@ -51,9 +51,10 @@ func MergeLockupsForSimilarDurations(
 		addr := acc.GetAddress()
 		// We make at most one lock per (addr, denom, base duration) triplet, which we keep adding coins to.
 		// We call this the new "normalized lock", and the value in the map is the new lock ID.
-		normals := make(map[string]uint64)
-		locksToNormalize := []types.PeriodLock{}
-		for _, lock := range k.GetAccountPeriodLocks(ctx, addr) {
+		periodLocks := k.GetAccountPeriodLocks(ctx, addr)
+		normals := make(map[string]uint64, len(periodLocks))
+		locksToNormalize := make([]types.PeriodLock, 0, len(periodLocks))
+		for _, lock := range periodLocks {
 			// ignore multilocks
 			if len(lock.Coins) > 1 {
 				continue

--- a/x/lockup/keeper/synthetic_lock.go
+++ b/x/lockup/keeper/synthetic_lock.go
@@ -67,8 +67,8 @@ func (k Keeper) GetSyntheticLockupByUnderlyingLockId(ctx sdk.Context, lockID uin
 
 // GetAllSyntheticLockupsByAddr gets all the synthetic lockups from all the locks owned by the given address.
 func (k Keeper) GetAllSyntheticLockupsByAddr(ctx sdk.Context, owner sdk.AccAddress) []types.SyntheticLock {
-	synthLocks := []types.SyntheticLock{}
 	locks := k.GetAccountPeriodLocks(ctx, owner)
+	synthLocks := make([]types.SyntheticLock, 0, len(locks))
 	for _, lock := range locks {
 		synthLock, found, err := k.GetSyntheticLockupByUnderlyingLockId(ctx, lock.ID)
 		if err != nil {

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -97,7 +97,7 @@ func (k Keeper) distributeSuperfluidGauges(ctx sdk.Context) {
 	gauges := k.ik.GetActiveGauges(ctx)
 
 	// only distribute to active gauges that are for perpetual synthetic denoms
-	distrGauges := []incentivestypes.Gauge{}
+	distrGauges := make([]incentivestypes.Gauge, 0, len(gauges))
 	for _, gauge := range gauges {
 		// we filter superfluid gauges by using the distributeTo denom in the gauge.
 		// If the denom in the gauge is a synthetic denom, we append the gauge to the gauge list to distribute to.

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -496,7 +496,7 @@ func (q Querier) TotalDelegationByValidatorForDenom(goCtx context.Context, req *
 
 	var intermediaryAccount types.SuperfluidIntermediaryAccount
 
-	delegationsByValidator := []types.Delegations{}
+	delegationsByValidator := make([]types.Delegations, 0, len(intermediaryAccounts))
 	intermediaryAccounts := q.Keeper.GetAllIntermediaryAccounts(ctx)
 	for _, intermediaryAccount = range intermediaryAccounts {
 		if intermediaryAccount.Denom != req.Denom {

--- a/x/superfluid/keeper/intermediary_account.go
+++ b/x/superfluid/keeper/intermediary_account.go
@@ -54,7 +54,7 @@ func (k Keeper) GetIntermediaryAccount(ctx sdk.Context, address sdk.AccAddress) 
 
 func (k Keeper) GetIntermediaryAccountsForVal(ctx sdk.Context, valAddr sdk.ValAddress) []types.SuperfluidIntermediaryAccount {
 	accs := k.GetAllIntermediaryAccounts(ctx)
-	valAccs := []types.SuperfluidIntermediaryAccount{}
+	valAccs := make([]types.SuperfluidIntermediaryAccount, 0, len(accs))
 	for _, acc := range accs {
 		if acc.ValAddr != valAddr.String() { // only apply for slashed validator
 			continue

--- a/x/superfluid/keeper/msg_server.go
+++ b/x/superfluid/keeper/msg_server.go
@@ -150,7 +150,7 @@ func (server msgServer) UnPoolWhitelistedPool(goCtx context.Context, msg *types.
 	minimalDuration := time.Millisecond
 	unpoolLocks := server.keeper.lk.GetAccountLockedLongerDurationDenom(ctx, sender, lpShareDenom, minimalDuration)
 
-	allExitedLockIDs := []uint64{}
+	allExitedLockIDs := make([]uint64, 0, len(unpoolLocks))
 	for _, lock := range unpoolLocks {
 		exitedLockIDs, err := server.keeper.UnpoolAllowedPools(ctx, sender, msg.PoolId, lock.ID)
 		if err != nil {

--- a/x/twap/types/utils.go
+++ b/x/twap/types/utils.go
@@ -23,7 +23,7 @@ func GetAllUniqueDenomPairs(denoms []string) []DenomPair {
 	// get denoms in ascending order
 	sort.Strings(denoms)
 
-	denomPairs := []DenomPair{}
+	denomPairs := make([]DenomPair, 0, len(denoms))
 
 	for i := 0; i < len(denoms); i++ {
 		for j := i + 1; j < len(denoms); j++ {

--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -224,7 +224,7 @@ func (k Keeper) calculateDistributeAndTrackTakerFees(ctx sdk.Context, defaultFee
 func (k Keeper) swapNonNativeFeeToDenom(ctx sdk.Context, denomToSwapTo string, feeCollectorAddress sdk.AccAddress) sdk.Coin {
 	coinsToSwap := k.bankKeeper.GetAllBalances(ctx, feeCollectorAddress)
 	totalCoinOut := sdk.NewCoin(denomToSwapTo, osmomath.ZeroInt())
-	coinsNotSwapped := []string{}
+	coinsNotSwapped := make([]string, 0, len(coinsToSwap))
 
 	for _, coin := range coinsToSwap {
 		if coin.Denom == denomToSwapTo {

--- a/x/valset-pref/types/msgs.go
+++ b/x/valset-pref/types/msgs.go
@@ -35,7 +35,7 @@ func (m MsgSetValidatorSetPreference) ValidateBasic() error {
 	}
 
 	totalWeight := osmomath.ZeroDec()
-	validatorAddrs := []string{}
+	validatorAddrs := make([]string, 0, len(m.Preferences))
 	for _, validator := range m.Preferences {
 		_, err := sdk.ValAddressFromBech32(validator.ValOperAddress)
 		if err != nil {
@@ -221,7 +221,7 @@ func (m MsgRedelegateValidatorSet) ValidateBasic() error {
 	}
 
 	totalWeight := osmomath.NewDec(0)
-	validatorAddrs := []string{}
+	validatorAddrs := make([]string, 0, len(m.Preferences))
 	for _, validator := range m.Preferences {
 		_, err := sdk.ValAddressFromBech32(validator.ValOperAddress)
 		if err != nil {


### PR DESCRIPTION
This change uses the hint

    make([]T, 0, capacity)

which helps with performance as documented per
https://bencher.orijtech.com/perfclinic/sliceupdate/

It follows along with PR #7757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Optimized memory allocation by preallocating slices based on expected capacities across various modules, enhancing overall application performance.

- **Refactor**
	- Updated slice initialization strategies to improve efficiency in data handling and processing.

- **Chores**
	- Standardized slice initialization to use specific capacities where applicable, ensuring a more consistent and optimized memory usage pattern across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->