### PR TITLE
chore: add nostrip compilr flag to attach debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ else ifeq (rocksdb,$(findstring rocksdb,$(OSMOSIS_BUILD_OPTIONS)))
 endif
 ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
   ldflags += -w -s
+  -gcflags "all=-N -l"
 endif
 ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,6 @@ else ifeq (rocksdb,$(findstring rocksdb,$(OSMOSIS_BUILD_OPTIONS)))
 endif
 ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
   ldflags += -w -s
-  -gcflags "all=-N -l"
 endif
 ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"

--- a/scripts/makefiles/build.mk
+++ b/scripts/makefiles/build.mk
@@ -48,7 +48,7 @@ build-dev-install: go.sum
 
 build-dev-build:
 	mkdir -p $(BUILDDIR)/
-	GOWORK=off go build $(GC_FLAGS) -mod=readonly -ldflags '$(DEBUG_LDFLAGS)' -trimpath -o $(BUILDDIR) ./...;
+	GOWORK=off go build $(GC_FLAGS) -mod=readonly -ldflags '$(DEBUG_LDFLAGS)' -gcflags "all=-N -l" -trimpath -o $(BUILDDIR) ./...;
 
 build-install-with-autocomplete: build-check-version go.sum
 	GOWORK=off go install -mod=readonly $(BUILD_FLAGS) $(GO_MODULE)/cmd/osmosisd


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This instructs the compiler to attach the debug symbols to a go binary. This is useful when profiling the system with external non-Go tools such as perf that offer visibility into kernel



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the build process for development environments to enhance debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->