### PR TITLE
Speedup PowApprox using faster methods with rounding differences in core loop

### DIFF
--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -150,7 +150,7 @@ func PowApprox(originalBase Dec, exp Dec, precision Dec) Dec {
 		// On this line, bigK == i-1.
 		c, cneg := AbsDifferenceWithSign(a, bigK)
 		// On this line, bigK == i.
-		bigK.SetInt64(i)
+		bigK.AddMut(one)
 		LegacyMultiMulMut(term, c, x).QuoInt64Mut(i)
 
 		// a is mutated on absDifferenceWithSign, reset

--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -148,7 +148,7 @@ func PowApprox(originalBase Dec, exp Dec, precision Dec) Dec {
 		c, cneg := AbsDifferenceWithSign(a, bigK)
 		// On this line, bigK == i.
 		bigK.SetInt64(i)
-		term.MulMut(c).MulMut(x).QuoMut(bigK)
+		term.MulMut(c).MulMut(x).QuoInt64Mut(i)
 
 		// a is mutated on absDifferenceWithSign, reset
 		a.Set(exp)


### PR DESCRIPTION
This is subtly state breaking, but helps speed up a very slow edge case query. And speeds up every invokation of this logic (which is non 50-50 balancer pools)

This can change rounding behavior of the final PowApprox result from `+1 ULP` to `-1 ULP` (or vice versa) due to very subtle rounding changes.

We only rely on this result being accurate to `1 ULP` anyway though, and not on rounding direction. This is left unchanged.

This should cause no issues in production, for any balancer pool with non-zero spread factor. For a pool with zero spread factor, there could be a one time rounding error change, which could lead to a slight LP loss that I believe should at most be on the order of `0.0001%`. However there is only one non-50/50 balancer pool on mainnet with a zero spread factor.

Benchmark improvement (Note: There are slower allowed queries in this)
OLD:
```
pkg: github.com/osmosis-labs/osmosis/osmomath
cpu: 13th Gen Intel(R) Core(TM) i7-1355U
BenchmarkSlowPowCases-12    	      18	  59050529 ns/op	 3763835 B/op	  168195 allocs/op
```
NEW:
```
BenchmarkSlowPowCases-12    	      38	  39404833 ns/op	 1000578 B/op	  125014 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved precision in mathematical calculations by adjusting the method used for `term` calculation in `PowApprox` function.
- **New Features**
	- Introduced new functions for complex calculations involving precision adjustments.
- **Tests**
	- Added tests for the new legacy multiplication operation to ensure accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->