### PR TITLE
Revert "perf: reduce supported uptimes (#7651)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7619](https://github.com/osmosis-labs/osmosis/pull/7619) Slight speedup/gas improvement to CL GetTotalPoolLiquidity queries
 * [#7622](https://github.com/osmosis-labs/osmosis/pull/7622) Create/remove tick events.
 * [#7623](https://github.com/osmosis-labs/osmosis/pull/7623) Add query for querying all before send hooks
-* [#7651](https://github.com/osmosis-labs/osmosis/pull/7651) Remove 1W and 2W supported uptimes for performance.
-* [#7625](https://github.com/osmosis-labs/osmosis/pull/7625) Remove duplicate CL accumulator update logic.
+* [#7622](https://github.com/osmosis-labs/osmosis/pull/7622) Remove duplicate CL accumulator update logic.
 * [#7665](https://github.com/osmosis-labs/osmosis/pull/7665) feat(x/protorev): Use Transient store to store swap backruns.
 * [#7685](https://github.com/osmosis-labs/osmosis/pull/7685) Speedup CL actions by only marshalling for CL hooks if they will be used.
 * [#7503](https://github.com/osmosis-labs/osmosis/pull/7503) Add IBC wasm light clients module

--- a/x/concentrated-liquidity/genesis_test.go
+++ b/x/concentrated-liquidity/genesis_test.go
@@ -84,8 +84,10 @@ var (
 		Options:               nil,
 	}
 
-	// four records because we have 4 supported uptimes
+	// five records because we have 5 supported uptimes
 	testUptimeAccumRecord = []accum.Record{
+		accumRecord,
+		accumRecord,
 		accumRecord,
 		accumRecord,
 		accumRecord,
@@ -236,6 +238,8 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(1000), osmomath.NewInt(100), osmomath.NewInt(50)),
 								accumRecordWithDefinedValues(accumRecord, hundredDec, osmomath.NewInt(100), osmomath.NewInt(50)),
 								accumRecordWithDefinedValues(accumRecord, tenDec, osmomath.NewInt(100), osmomath.NewInt(50)),
+								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(1), osmomath.NewInt(100), osmomath.NewInt(50)),
+								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(1), osmomath.NewInt(100), osmomath.NewInt(50)),
 							},
 						},
 					},
@@ -296,6 +300,8 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(1000), osmomath.NewInt(100), osmomath.NewInt(50)),
 						accumRecordWithDefinedValues(accumRecord, hundredDec, osmomath.NewInt(100), osmomath.NewInt(50)),
 						accumRecordWithDefinedValues(accumRecord, tenDec, osmomath.NewInt(100), osmomath.NewInt(50)),
+						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(1), osmomath.NewInt(100), osmomath.NewInt(50)),
+						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(1), osmomath.NewInt(100), osmomath.NewInt(50)),
 					},
 				},
 			},
@@ -381,6 +387,8 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9999), osmomath.NewInt(10), osmomath.NewInt(5)),
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(999), osmomath.NewInt(100), osmomath.NewInt(50)),
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(99), osmomath.NewInt(50), osmomath.NewInt(25)),
+								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9), osmomath.NewInt(50), osmomath.NewInt(25)),
+								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9), osmomath.NewInt(50), osmomath.NewInt(25)),
 							},
 						},
 					},
@@ -472,6 +480,8 @@ func (s *KeeperTestSuite) TestInitGenesis() {
 						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9999), osmomath.NewInt(10), osmomath.NewInt(5)),
 						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(999), osmomath.NewInt(100), osmomath.NewInt(50)),
 						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(99), osmomath.NewInt(50), osmomath.NewInt(25)),
+						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9), osmomath.NewInt(50), osmomath.NewInt(25)),
+						accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9), osmomath.NewInt(50), osmomath.NewInt(25)),
 					},
 				},
 			},
@@ -740,6 +750,8 @@ func (s *KeeperTestSuite) TestExportGenesis() {
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9999), osmomath.NewInt(10), osmomath.NewInt(5)),
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(999), osmomath.NewInt(100), osmomath.NewInt(50)),
 								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(99), osmomath.NewInt(50), osmomath.NewInt(25)),
+								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9), osmomath.NewInt(50), osmomath.NewInt(25)),
+								accumRecordWithDefinedValues(accumRecord, osmomath.NewDec(9), osmomath.NewInt(50), osmomath.NewInt(25)),
 							},
 						},
 					},

--- a/x/concentrated-liquidity/incentives_test.go
+++ b/x/concentrated-liquidity/incentives_test.go
@@ -1758,8 +1758,8 @@ func (s *KeeperTestSuite) TestInitOrUpdatePositionUptimeAccumulators() {
 func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 	ownerWithValidPosition := s.TestAccs[0]
 	uptimeHelper := getExpectedUptimes()
-	oneHour := time.Hour
 	oneDay := time.Hour * 24
+	twoWeeks := 14 * time.Hour * 24
 	defaultJoinTime := DefaultJoinTime
 
 	type positionParameters struct {
@@ -1803,47 +1803,6 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 	}{
 		// ---Cases for lowerTick < currentTick < upperTick---
 
-		"(lower < curr < upper) no uptime growth inside or outside range, 1H time in position": {
-			currentTick:                 1,
-			positionParams:              default0To2PosParam,
-			numPositions:                1,
-			timeInPosition:              oneHour,
-			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: sdk.Coins(nil),
-		},
-		"(lower < curr < upper) uptime growth outside range but not inside, 1H time in position": {
-			currentTick:              1,
-			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:           default0To2PosParam,
-			numPositions:             1,
-			timeInPosition:           oneHour,
-			// Since there was no growth inside the range, we expect no incentives to be claimed
-			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: sdk.Coins(nil),
-		},
-		"(lower < curr < upper) uptime growth inside range but not outside, 1H time in position": {
-			currentTick:             1,
-			addedUptimeGrowthInside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:          default0To2PosParam,
-			numPositions:            1,
-			timeInPosition:          oneHour,
-			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
-		},
-		"(lower < curr < upper) uptime growth both inside and outside range, 1H time in position": {
-			currentTick:              1,
-			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
-			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:           default0To2PosParam,
-			numPositions:             1,
-			timeInPosition:           oneHour,
-			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
-		},
 		"(lower < curr < upper) no uptime growth inside or outside range, 1D time in position": {
 			currentTick:                 1,
 			positionParams:              default0To2PosParam,
@@ -1871,7 +1830,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
 			// uptimes the position qualifies for.
 			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
-			expectedForfeitedIncentives: sdk.Coins(nil),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
 		"(lower < curr < upper) uptime growth both inside and outside range, 1D time in position": {
 			currentTick:              1,
@@ -1883,6 +1842,47 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
 			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
 			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
+		},
+		"(lower < curr < upper) no uptime growth inside or outside range, 2W time in position": {
+			currentTick:                 1,
+			positionParams:              default0To2PosParam,
+			numPositions:                1,
+			timeInPosition:              twoWeeks,
+			expectedIncentivesClaimed:   sdk.Coins(nil),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(lower < curr < upper) uptime growth outside range but not inside, 2W time in position": {
+			currentTick:              1,
+			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:           default0To2PosParam,
+			numPositions:             1,
+			timeInPosition:           twoWeeks,
+			// Since there was no growth inside the range, we expect no incentives to be claimed
+			expectedIncentivesClaimed:   sdk.Coins(nil),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(lower < curr < upper) uptime growth inside range but not outside, 2W time in position": {
+			currentTick:             1,
+			addedUptimeGrowthInside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:          default0To2PosParam,
+			numPositions:            1,
+			timeInPosition:          twoWeeks,
+			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
+			// uptimes the position qualifies for.
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(lower < curr < upper) uptime growth both inside and outside range, 2W time in position": {
+			currentTick:              1,
+			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
+			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:           default0To2PosParam,
+			numPositions:             1,
+			timeInPosition:           twoWeeks,
+			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
+			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 			expectedForfeitedIncentives: sdk.Coins(nil),
 		},
 		"(lower < curr < upper) no uptime growth inside or outside range, no time in position": {
@@ -1909,7 +1909,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:                1,
 			timeInPosition:              0,
 			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 		},
 		"(lower < curr < upper) uptime growth both inside and outside range, no time in position": {
 			currentTick:                 1,
@@ -1919,52 +1919,11 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:                1,
 			timeInPosition:              0,
 			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 		},
 
 		// ---Cases for currentTick < lowerTick < upperTick---
 
-		"(curr < lower < upper) no uptime growth inside or outside range, 1H time in position": {
-			currentTick:                 0,
-			positionParams:              default1To2PosParam,
-			numPositions:                1,
-			timeInPosition:              oneHour,
-			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: sdk.Coins(nil),
-		},
-		"(curr < lower < upper) uptime growth outside range but not inside, 1H time in position": {
-			currentTick:              0,
-			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:           default1To2PosParam,
-			numPositions:             1,
-			timeInPosition:           oneHour,
-			// Since there was no growth inside the range, we expect no incentives to be claimed
-			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: sdk.Coins(nil),
-		},
-		"(curr < lower < upper) uptime growth inside range but not outside, 1H time in position": {
-			currentTick:             0,
-			addedUptimeGrowthInside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:          default1To2PosParam,
-			numPositions:            1,
-			timeInPosition:          oneHour,
-			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
-		},
-		"(curr < lower < upper) uptime growth both inside and outside range, 1H time in position": {
-			currentTick:              0,
-			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
-			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:           default1To2PosParam,
-			numPositions:             1,
-			timeInPosition:           oneHour,
-			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
-		},
 		"(curr < lower < upper) no uptime growth inside or outside range, 1D time in position": {
 			currentTick:                 0,
 			positionParams:              default1To2PosParam,
@@ -1992,7 +1951,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
 			// uptimes the position qualifies for.
 			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
-			expectedForfeitedIncentives: sdk.Coins(nil),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
 		"(curr < lower < upper) uptime growth both inside and outside range, 1D time in position": {
 			currentTick:              0,
@@ -2004,6 +1963,47 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
 			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
 			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
+		},
+		"(curr < lower < upper) no uptime growth inside or outside range, 2W time in position": {
+			currentTick:                 0,
+			positionParams:              default1To2PosParam,
+			numPositions:                1,
+			timeInPosition:              twoWeeks,
+			expectedIncentivesClaimed:   sdk.Coins(nil),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(curr < lower < upper) uptime growth outside range but not inside, 2W time in position": {
+			currentTick:              0,
+			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:           default1To2PosParam,
+			numPositions:             1,
+			timeInPosition:           twoWeeks,
+			// Since there was no growth inside the range, we expect no incentives to be claimed
+			expectedIncentivesClaimed:   sdk.Coins(nil),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(curr < lower < upper) uptime growth inside range but not outside, 2W time in position": {
+			currentTick:             0,
+			addedUptimeGrowthInside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:          default1To2PosParam,
+			numPositions:            1,
+			timeInPosition:          twoWeeks,
+			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
+			// uptimes the position qualifies for.
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(curr < lower < upper) uptime growth both inside and outside range, 2W time in position": {
+			currentTick:              0,
+			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
+			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:           default1To2PosParam,
+			numPositions:             1,
+			timeInPosition:           twoWeeks,
+			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
+			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 			expectedForfeitedIncentives: sdk.Coins(nil),
 		},
 		"(curr < lower < upper) no uptime growth inside or outside range, no time in position": {
@@ -2030,7 +2030,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:                1,
 			timeInPosition:              0,
 			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 		},
 		"(curr < lower < upper) uptime growth both inside and outside range, no time in position": {
 			currentTick:                 0,
@@ -2040,52 +2040,11 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:                1,
 			timeInPosition:              0,
 			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 		},
 
 		// ---Cases for lowerTick < upperTick < currentTick---
 
-		"(lower < upper < curr) no uptime growth inside or outside range, 1H time in position": {
-			currentTick:                 3,
-			positionParams:              default1To2PosParam,
-			numPositions:                1,
-			timeInPosition:              oneHour,
-			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: sdk.Coins(nil),
-		},
-		"(lower < upper < curr) uptime growth outside range but not inside, 1H time in position": {
-			currentTick:              3,
-			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:           default1To2PosParam,
-			numPositions:             1,
-			timeInPosition:           oneHour,
-			// Since there was no growth inside the range, we expect no incentives to be claimed
-			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: sdk.Coins(nil),
-		},
-		"(lower < upper < curr) uptime growth inside range but not outside, 1H time in position": {
-			currentTick:             3,
-			addedUptimeGrowthInside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:          default1To2PosParam,
-			numPositions:            1,
-			timeInPosition:          oneHour,
-			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
-		},
-		"(lower < upper < curr) uptime growth both inside and outside range, 1H time in position": {
-			currentTick:              3,
-			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
-			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
-			positionParams:           default1To2PosParam,
-			numPositions:             1,
-			timeInPosition:           oneHour,
-			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
-		},
 		"(lower < upper < curr) no uptime growth inside or outside range, 1D time in position": {
 			currentTick:                 3,
 			positionParams:              default1To2PosParam,
@@ -2113,7 +2072,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
 			// uptimes the position qualifies for.
 			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
-			expectedForfeitedIncentives: sdk.Coins(nil),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
 		"(lower < upper < curr) uptime growth both inside and outside range, 1D time in position": {
 			currentTick:              3,
@@ -2123,8 +2082,49 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:             1,
 			timeInPosition:           oneDay,
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
-			// uptimes the position qualifies for.
+			// uptimes the position qualifies for. At the same time, growth outside does not affect the current position's incentive rewards.
 			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
+		},
+		"(lower < upper < curr) no uptime growth inside or outside range, 1W time in position": {
+			currentTick:                 3,
+			positionParams:              default1To2PosParam,
+			numPositions:                1,
+			timeInPosition:              twoWeeks,
+			expectedIncentivesClaimed:   sdk.Coins(nil),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(lower < upper < curr) uptime growth outside range but not inside, 1W time in position": {
+			currentTick:              3,
+			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:           default1To2PosParam,
+			numPositions:             1,
+			timeInPosition:           twoWeeks,
+			// Since there was no growth inside the range, we expect no incentives to be claimed
+			expectedIncentivesClaimed:   sdk.Coins(nil),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(lower < upper < curr) uptime growth inside range but not outside, 1W time in position": {
+			currentTick:             3,
+			addedUptimeGrowthInside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:          default1To2PosParam,
+			numPositions:            1,
+			timeInPosition:          twoWeeks,
+			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
+			// uptimes the position qualifies for.
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
+			expectedForfeitedIncentives: sdk.Coins(nil),
+		},
+		"(lower < upper < curr) uptime growth both inside and outside range, 1W time in position": {
+			currentTick:              3,
+			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
+			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
+			positionParams:           default1To2PosParam,
+			numPositions:             1,
+			timeInPosition:           twoWeeks,
+			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
+			// uptimes the position qualifies for.
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 			expectedForfeitedIncentives: sdk.Coins(nil),
 		},
 		"(lower < upper < curr) no uptime growth inside or outside range, no time in position": {
@@ -2151,7 +2151,7 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:                1,
 			timeInPosition:              0,
 			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 		},
 		"(lower < upper < curr) uptime growth both inside and outside range, no time in position": {
 			currentTick:                 3,
@@ -2161,68 +2161,72 @@ func (s *KeeperTestSuite) TestQueryAndCollectIncentives() {
 			numPositions:                1,
 			timeInPosition:              0,
 			expectedIncentivesClaimed:   sdk.Coins(nil),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier),
 		},
 
 		// Edge case tests
 
-		"(curr = lower) uptime growth both inside and outside range, 1H time in position": {
+		"(curr = lower) uptime growth both inside and outside range, 1D time in position": {
 			currentTick:              0,
 			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
 			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
 			positionParams:           default0To2PosParam,
 			numPositions:             1,
-			timeInPosition:           oneHour,
+			timeInPosition:           oneDay,
 			// We expect this case to behave like (lower < curr < upper)
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
-		"(curr = upper) uptime growth both inside and outside range, 1H time in position": {
+		"(curr = upper) uptime growth both inside and outside range, 1D time in position": {
 			currentTick:              2,
 			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
 			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
 			positionParams:           default1To2PosParam,
 			numPositions:             1,
-			timeInPosition:           oneHour,
+			timeInPosition:           oneDay,
 			// We expect this case to behave like (lower < upper < curr)
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
-		"other liquidity on uptime accums: (lower < curr < upper) uptime growth both inside and outside range, 1H time in position": {
+		"other liquidity on uptime accums: (lower < curr < upper) uptime growth both inside and outside range, 1D time in position": {
 			currentTick: 1,
 			existingAccumLiquidity: []osmomath.Dec{
 				osmomath.NewDec(99900123432),
 				osmomath.NewDec(18942),
 				osmomath.NewDec(0),
 				osmomath.NewDec(9981),
+				osmomath.NewDec(1),
+				osmomath.NewDec(778212931834),
 			},
 			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
 			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
 			positionParams:           default0To2PosParam,
 			numPositions:             1,
-			timeInPosition:           oneHour,
+			timeInPosition:           oneDay,
 			// Since there is no other existing liquidity, we expect all of the growth inside to accrue to be claimed for the
 			// uptimes the position qualifies for.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
-		"multiple positions in same range: (lower < curr < upper) uptime growth both inside and outside range, 1H time in position": {
+		"multiple positions in same range: (lower < curr < upper) uptime growth both inside and outside range, 1D time in position": {
 			currentTick: 1,
 			existingAccumLiquidity: []osmomath.Dec{
 				osmomath.NewDec(99900123432),
 				osmomath.NewDec(18942),
 				osmomath.NewDec(0),
 				osmomath.NewDec(9981),
+				osmomath.NewDec(1),
+				osmomath.NewDec(778212931834),
 			},
 			addedUptimeGrowthInside:  uptimeHelper.hundredTokensMultiDenom,
 			addedUptimeGrowthOutside: uptimeHelper.hundredTokensMultiDenom,
 			positionParams:           default0To2PosParam,
 			numPositions:             3,
-			timeInPosition:           oneHour,
+			timeInPosition:           oneDay,
 			// Since we introduced positionIDs, despite these position having the same range and pool, only
 			// the position ID being claimed will be considered for the claim.
-			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier),
-			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneHour, defaultMultiplier)...),
+			expectedIncentivesClaimed:   expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier),
+			expectedForfeitedIncentives: expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, defaultMultiplier).Sub(expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, defaultMultiplier)...),
 		},
 
 		// Error catching
@@ -2840,7 +2844,7 @@ func (s *KeeperTestSuite) TestQueryAndClaimAllIncentives() {
 			growthOutside:    uptimeHelper.twoHundredTokensMultiDenom,
 			numShares:        osmomath.OneDec(),
 
-			expectedError: types.NegativeDurationError{Duration: time.Hour * 648 * -1},
+			expectedError: types.NegativeDurationError{Duration: time.Hour * 336 * -1},
 		},
 	}
 
@@ -3369,8 +3373,8 @@ func (s *KeeperTestSuite) TestGetLargestAuthorizedAndSupportedUptimes() {
 			expectedAuthorized:     time.Nanosecond,
 		},
 		"Unordered authorized uptimes": {
-			preSetAuthorizedParams: []time.Duration{time.Hour, time.Nanosecond, time.Hour * 24},
-			expectedAuthorized:     time.Hour * 24,
+			preSetAuthorizedParams: []time.Duration{time.Hour * 24 * 7, time.Nanosecond, time.Hour * 24},
+			expectedAuthorized:     time.Hour * 24 * 7,
 		},
 		// note cannot have test case with empty authorized uptimes due to parameter validation.
 	}

--- a/x/concentrated-liquidity/keeper_test.go
+++ b/x/concentrated-liquidity/keeper_test.go
@@ -71,7 +71,7 @@ var (
 	InsufficientFundsError                         = fmt.Errorf("insufficient funds")
 	DefaultAuthorizedUptimes                       = []time.Duration{time.Nanosecond}
 	ThreeOrderedConsecutiveAuthorizedUptimes       = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24}
-	ThreeUnorderedNonConsecutiveAuthorizedUptimes  = []time.Duration{time.Nanosecond, time.Hour * 24, time.Minute}
+	ThreeUnorderedNonConsecutiveAuthorizedUptimes  = []time.Duration{time.Nanosecond, time.Hour * 24 * 7, time.Minute}
 	AllUptimesAuthorized                           = types.SupportedUptimes
 )
 

--- a/x/concentrated-liquidity/msg_server_test.go
+++ b/x/concentrated-liquidity/msg_server_test.go
@@ -338,7 +338,7 @@ func (s *KeeperTestSuite) TestCollectSpreadRewards_Events() {
 // when calling CollectIncentives.
 func (s *KeeperTestSuite) TestCollectIncentives_Events() {
 	uptimeHelper := getExpectedUptimes()
-	oneDay := time.Hour * 24
+	twoWeeks := time.Hour * 24 * 14
 	testcases := map[string]struct {
 		upperTick                           int64
 		lowerTick                           int64
@@ -414,7 +414,7 @@ func (s *KeeperTestSuite) TestCollectIncentives_Events() {
 
 			position, err := s.App.ConcentratedLiquidityKeeper.GetPosition(ctx, tc.positionIds[0])
 			s.Require().NoError(err)
-			ctx = ctx.WithBlockTime(position.JoinTime.Add(time.Hour))
+			ctx = ctx.WithBlockTime(position.JoinTime.Add(time.Hour * 24 * 7))
 			positionAge := ctx.BlockTime().Sub(position.JoinTime)
 
 			// Set up accrued incentives
@@ -426,7 +426,7 @@ func (s *KeeperTestSuite) TestCollectIncentives_Events() {
 			// The claim amount must be funded to the incentives address in order for the rewards to be sent to the user.
 			// The forfeited about must be funded to the incentives address in order for the forfeited rewards to be sent to the community pool.
 			incentivesToBeSentToUsers := expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, positionAge, numPositions)
-			incentivesToBeSentToCommunityPool := expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, oneDay, numPositions).Sub(incentivesToBeSentToUsers...)
+			incentivesToBeSentToCommunityPool := expectedIncentivesFromUptimeGrowth(uptimeHelper.hundredTokensMultiDenom, DefaultLiquidityAmt, twoWeeks, numPositions).Sub(incentivesToBeSentToUsers...)
 			totalAmountToFund := incentivesToBeSentToUsers.Add(incentivesToBeSentToCommunityPool...)
 			s.FundAcc(pool.GetIncentivesAddress(), totalAmountToFund)
 
@@ -645,8 +645,8 @@ func (s *KeeperTestSuite) TestTransferPositions_Events() {
 				s.AddToSpreadRewardAccumulator(pool.GetId(), sdk.NewDecCoin(ETH, osmomath.NewInt(10)))
 			}
 
-			// Move block time forward one hour to claim and forfeit part of the incentives.
-			s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(time.Hour))
+			// Move block time forward one day to claim and forfeit part of the incentives.
+			s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(time.Hour * 24))
 
 			if !tc.isLastPositionInPool {
 				// Setup a far out of range position that we do not touch, so when we transfer positions we do not transfer the last position in the pool.

--- a/x/concentrated-liquidity/types/constants.go
+++ b/x/concentrated-liquidity/types/constants.go
@@ -43,8 +43,8 @@ var (
 	MaxSqrtPriceBigDec = osmomath.BigDecFromDec(MaxSqrtPrice)
 	MinSqrtPriceBigDec = osmomath.BigDecFromDec(MinSqrtPrice)
 
-	// Supported uptimes preset to 1 ns, 1 min, 1 hr, 1D
-	SupportedUptimes        = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24}
+	// Supported uptimes preset to 1 ns, 1 min, 1 hr, 1D, 1W, 2W
+	SupportedUptimes        = []time.Duration{time.Nanosecond, time.Minute, time.Hour, time.Hour * 24, time.Hour * 24 * 7, time.Hour * 24 * 7 * 2}
 	AuthorizedTickSpacing   = []uint64{1, 10, 100, 1000}
 	AuthorizedSpreadFactors = []osmomath.Dec{
 		osmomath.ZeroDec(),

--- a/x/incentives/keeper/distribute_test.go
+++ b/x/incentives/keeper/distribute_test.go
@@ -624,13 +624,13 @@ func (s *KeeperTestSuite) TestDistribute_ExternalIncentives_NoLock() {
 		"non-perpetual, 2 coins, paid over 3 epochs": withNumEpochs(withGaugeCoins(defaultTest, defaultBothCoins), 3),
 
 		// We expect incentives with the set uptime to be created
-		"non-perpetual, 1 coin, paid over 1 epoch, authorized 1h uptime":   withAuthorizedUptime(defaultTest, time.Hour),
-		"non-perpetual, 2 coins, paid over 3 epochs, authorized 1d uptime": withAuthorizedUptime(withNumEpochs(withGaugeCoins(defaultTest, defaultBothCoins), 3), time.Hour*24),
+		"non-perpetual, 1 coin, paid over 1 epoch, authorized 1d uptime":   withAuthorizedUptime(defaultTest, time.Hour*24),
+		"non-perpetual, 2 coins, paid over 3 epochs, authorized 7d uptime": withAuthorizedUptime(withNumEpochs(withGaugeCoins(defaultTest, defaultBothCoins), 3), time.Hour*24*7),
 		"perpetual, 2 coins, authorized 1h uptime":                         withAuthorizedUptime(withIsPerpetual(withGaugeCoins(defaultTest, defaultBothCoins), true), time.Hour),
 
 		// We expect incentives to fall back to default uptime of 1ns
-		"non-perpetual, 1 coin, paid over 1 epoch, unauthorized 1h uptime":   withUnauthorizedUptime(defaultTest, time.Hour),
-		"non-perpetual, 2 coins, paid over 3 epochs, unauthorized 1d uptime": withUnauthorizedUptime(withNumEpochs(withGaugeCoins(defaultTest, defaultBothCoins), 3), time.Hour*24),
+		"non-perpetual, 1 coin, paid over 1 epoch, unauthorized 1d uptime":   withUnauthorizedUptime(defaultTest, time.Hour*24),
+		"non-perpetual, 2 coins, paid over 3 epochs, unauthorized 7d uptime": withUnauthorizedUptime(withNumEpochs(withGaugeCoins(defaultTest, defaultBothCoins), 3), time.Hour*24*7),
 		"perpetual, 2 coins, unauthorized 1h uptime":                         withUnauthorizedUptime(withIsPerpetual(withGaugeCoins(defaultTest, defaultBothCoins), true), time.Hour),
 
 		// 3h is not a valid uptime, so we expect this to fall back to 1ns


### PR DESCRIPTION
This reverts commit f4c546c2b184c9b7843e836655e1c7c388733c34.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Decided to revert and come back to another time, we have external incentives using the 2w duration ATM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced code efficiency by removing duplicate logic.
- **New Features**
	- Increased support for more uptime durations in concentrated liquidity calculations.
	- Expanded the range of supported uptimes to include 1 week and 2 weeks.
- **Tests**
	- Updated test scenarios to reflect new uptime duration units and expanded uptime support.
	- Adjusted incentive and reward calculation tests to use new time durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->