### PR TITLE
chore: default TimeoutCommit to 3s (allow opt out of default overrides)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7745](https://github.com/osmosis-labs/osmosis/pull/7745) Add gauge id query to stargate whitelist
 * [#7747](https://github.com/osmosis-labs/osmosis/pull/7747) Remove redundant call to incentive collection in CL position withdrawal logic
 
+## v23.0.8-iavl-v1 & v23.0.8
+
+* [#7769](https://github.com/osmosis-labs/osmosis/pull/7769) Set and default timeout commit to 3s. Add flag to prevent custom overrides if not desired.
+
 ## v23.0.7-iavl-v1
 
 * [#7750](https://github.com/osmosis-labs/osmosis/pull/7750) IAVL bump to improve pruning

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -39,6 +39,9 @@ const (
 
 	// FlagSetEnv defines a flag to create environment file & save current home directory into it.
 	FlagSetEnv = "set-env"
+
+	// FlagRejectConfigDefaults defines a flag to reject some select defaults that override what is in the config file.
+	FlagRejectConfigDefaults = "reject-config-defaults"
 )
 
 type printInfo struct {
@@ -109,8 +112,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.StateSync.TrustPeriod = 112 * time.Hour
 
 			// The original default is 5s and is set in Cosmos SDK.
-			// We lower it to 4s for faster block times.
-			config.Consensus.TimeoutCommit = 4 * time.Second
+			// We lower it to 3s for faster block times.
+			config.Consensus.TimeoutCommit = 3 * time.Second
 
 			config.SetRoot(clientCtx.HomeDir)
 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -440,7 +440,7 @@ func overwriteConfigTomlValues(serverCtx *server.Context) error {
 		// It does not exist, so we update the default config.toml to update
 		// We modify the default config.toml to have faster block times
 		// It will be written by server.InterceptConfigsPreRunHandler
-		tmcConfig.Consensus.TimeoutCommit = 4 * time.Second
+		tmcConfig.Consensus.TimeoutCommit = 3 * time.Second
 	} else {
 		// config.toml exists
 
@@ -734,6 +734,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
 	wasm.AddModuleInitFlags(startCmd)
+	startCmd.Flags().Bool(FlagRejectConfigDefaults, false, "Reject some select recommended defaults from overriding the config.toml and app.toml")
 }
 
 // queryCommand adds transaction and account querying commands.

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -111,10 +111,9 @@ const (
 
 var (
 	//go:embed "osmosis-1-assetlist.json" "osmo-test-5-assetlist.json"
-	assetFS           embed.FS
-	mainnetId         = "osmosis-1"
-	testnetId         = "osmo-test-5"
-	fiveSecondsString = (5 * time.Second).String()
+	assetFS   embed.FS
+	mainnetId = "osmosis-1"
+	testnetId = "osmo-test-5"
 )
 
 func loadAssetList(initClientCtx client.Context, cmd *cobra.Command, basedenomToIBC, IBCtoBasedenom bool) (map[string]DenomUnitMap, map[string]string) {

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -741,7 +741,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
 	wasm.AddModuleInitFlags(startCmd)
-	startCmd.Flags().Bool(FlagRejectConfigDefaults, false, "Reject some select recommended defaults from overriding the config.toml and app.toml")
+	startCmd.Flags().Bool(FlagRejectConfigDefaults, false, "Reject some select recommended default values from being automatically set in the config.toml and app.toml")
 }
 
 // queryCommand adds transaction and account querying commands.

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -466,10 +466,8 @@ func overwriteConfigTomlValues(serverCtx *server.Context) error {
 		}
 
 		// The original default is 5s and is set in Cosmos SDK.
-		// We lower it to 4s for faster block times.
-		if timeoutCommitValue == fiveSecondsString {
-			serverCtx.Config.Consensus.TimeoutCommit = 4 * time.Second
-		}
+		// We lower it to 3s for faster block times.
+		serverCtx.Config.Consensus.TimeoutCommit = 3 * time.Second
 
 		defer func() {
 			if err := recover(); err != nil {

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -705,6 +705,9 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 
 				// overwrite config.toml and app.toml values, if rejectConfigDefaults is false
 				if !rejectConfigDefaults {
+					// Add ctx logger line to indicate that config.toml and app.toml values are being overwritten
+					serverCtx.Logger.Info("Overwriting config.toml and app.toml values with some recommended defaults. To prevent this, set the --reject-config-defaults flag to true.")
+
 					err := overwriteConfigTomlValues(serverCtx)
 					if err != nil {
 						return err

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -700,16 +700,20 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
 				serverCtx := server.GetServerContextFromCmd(cmd)
 
-				// overwrite config.toml values
-				err := overwriteConfigTomlValues(serverCtx)
-				if err != nil {
-					return err
-				}
+				// Get flag value for rejecting config defaults
+				rejectConfigDefaults := serverCtx.Viper.GetBool(FlagRejectConfigDefaults)
 
-				// overwrite app.toml values
-				err = overwriteAppTomlValues(serverCtx)
-				if err != nil {
-					return err
+				// overwrite config.toml and app.toml values, if rejectConfigDefaults is false
+				if !rejectConfigDefaults {
+					err := overwriteConfigTomlValues(serverCtx)
+					if err != nil {
+						return err
+					}
+
+					err = overwriteAppTomlValues(serverCtx)
+					if err != nil {
+						return err
+					}
 				}
 
 				return startRunE(cmd, args)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Sets and default the timeout commit to 3s.

Adds flag that allows node operators to opt out of custom overrides.

## Testing and Verifying

Logs show when no flag is provided, log does not show when flag is set to true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a feature to manage timeout commit settings, defaulting to 3 seconds for faster block times.
    - Added a flag to prevent overriding specific default configurations, enhancing user control over their settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->