### PR TITLE
[ci] Push iavl-v1 docker images on vX.Y.Z-iavl-v1 tags

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -29,7 +29,8 @@ name: Push Docker Images
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # ignore rc
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-iavl-v1"
 
 env:
   DOCKER_REPOSITORY: osmolabs/osmosis
@@ -38,27 +39,34 @@ env:
   RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
 
 jobs:
-  osmosisd-images:
+  push-docker-images:
     runs-on: buildjet-4vcpu-ubuntu-2204
+    if: ${{ !contains(github.ref_name, 'iavl') }}
     steps:
-      - name: Check out the repo
+      -
+        name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up QEMU
+      -
+        name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      -
+        name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Find go version
+      -
+        name: Find go version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-      - name: Parse tag
+      -
+        name: Parse tag
         id: tag
         run: |
           VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
@@ -70,7 +78,8 @@ jobs:
           echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
           echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
       # Distroless Docker image (default)
-      - name: Build and push (distroless)
+      -
+        name: Build and push (distroless)
         id: build_push_distroless
         uses: docker/build-push-action@v5
         with:
@@ -91,7 +100,8 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-distroless
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-distroless
       # Distroless nonroot Docker image
-      - name: Build and push (nonroot)
+      -
+        name: Build and push (nonroot)
         id: build_push_nonroot
         uses: docker/build-push-action@v5
         with:
@@ -109,7 +119,8 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-nonroot
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-nonroot
       # Alpine Docker image
-      - name: Build and push (alpine)
+      -
+        name: Build and push (alpine)
         id: build_push_alpine
         uses: docker/build-push-action@v5
         with:
@@ -126,7 +137,8 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine
-      - if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
+      -
+        if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
         name: Build and push (e2e-chain-init)
         uses: docker/build-push-action@v5
         with:
@@ -140,3 +152,98 @@ jobs:
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+
+  push-iavl-docker-images:
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    if: ${{ contains(github.ref_name, 'iavl') }}
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Find go version
+        run: |
+          GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+      -
+        name: Parse tag
+        id: tag
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
+          MAJOR_VERSION=$(echo $VERSION | cut -d '.' -f 1)
+          MINOR_VERSION=$(echo $VERSION | cut -d '.' -f 2)
+          PATCH_VERSION=$(echo $VERSION | cut -d '.' -f 3)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "MAJOR_VERSION=$MAJOR_VERSION" >> $GITHUB_ENV
+          echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
+          echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
+      # Distroless Docker image (default)
+      -
+        name: Build and push (distroless)
+        id: build_push_distroless
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_DISTROLESS }}
+            GIT_VERSION=${{ env.VERSION }}
+            GIT_COMMIT=${{ github.sha }}
+          tags: |
+            # osmosis:X.Y.Z-iavl-v1
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+            # osmosis:X.Y.Z-iavl-v1-distroless
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-distroless
+      # Distroless nonroot Docker image
+      -
+        name: Build and push (nonroot)
+        id: build_push_nonroot
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_NONROOT }}
+            GIT_VERSION=${{ env.VERSION }}
+            GIT_COMMIT=${{ github.sha }}
+          tags: |
+            # osmosis:X.Y.Z-iavl-v1-nonroot
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-nonroot
+      # Alpine Docker image
+      -
+        name: Build and push (alpine)
+        id: build_push_alpine
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_ALPINE }}
+            GIT_VERSION=${{ env.VERSION }}
+            GIT_COMMIT=${{ github.sha }}
+          tags: |
+            # osmosis:X.Y.Z-iavl-v1-alpine
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the CI for pushing Docker images to trigger when a `vX.Y.Z-iavl-v1` tag is pushed. To implement this, I added another job that specifically handles cases where `iavl-v1` is present in the tag. The execution of a particular job is determined by the presence of `iavl` in the tag.

```yaml
jobs:
  push-docker-images:
    runs-on: buildjet-4vcpu-ubuntu-2204
    if: ${{ !contains(github.ref_name, 'iavl') }}
    ...

push-iavl-docker-images:
    runs-on: buildjet-4vcpu-ubuntu-2204
    if: ${{ contains(github.ref_name, 'iavl') }}
    ...
```



## Testing and Verifying

Tested the workflow logic in another repository stubbing the docker push but just printing the tags.

Test push of `v111.222.333` tag:
https://github.com/niccoloraspa/test-ci/actions/runs/8341900968

Test push of `v111.222.333-iavl-v1` tag:
https://github.com/niccoloraspa/test-ci/actions/runs/8341910403

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A