### PR TITLE
[ci] Deprecate set-output from GitHub actions

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -28,7 +28,7 @@ jobs:
             .github/workflows/e2e-full.yml
       - name: Set output
         id: vars
-        run: echo "::set-output name=git_diff::$GIT_DIFF"
+        run: echo "git_diff=$GIT_DIFF" >> $GITHUB_OUTPUT
     outputs:
       git_diff: ${{ steps.vars.outputs.git_diff }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
             .github/workflows/test.yml
       - name: Set output
         id: vars
-        run: echo "::set-output name=git_diff::$GIT_DIFF"
+        run: echo "git_diff=$GIT_DIFF" >> $GITHUB_OUTPUT
     outputs:
       git_diff: ${{ steps.vars.outputs.git_diff }}
 


### PR DESCRIPTION
## What is the purpose of the change

Deprecate the use of `set-output` in favour of `GITHUB_OUTPUT` (docs: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs)

![image](https://github.com/osmosis-labs/osmosis/assets/6024049/22fbba33-b566-4dc0-b08f-bb097f726c27)

## Testing and Verifying

Modified workflow should run correctly in this PR

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated GitHub Actions workflows for enhanced integration and output handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->