### PR TITLE
[ci] Run e2e when PR opened by bots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,13 @@ concurrency:
 
 jobs:
   get_diff:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - name: Check out repository code
+      -
+        name: Check out repository code
         uses: actions/checkout@v4
-      - name: Get git diff
+      -
+        name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -33,7 +35,8 @@ jobs:
             Makefile
             Dockerfile
             .github/workflows/test.yml
-      - name: Set output
+      -
+        name: Set output
         id: vars
         run: echo "::set-output name=git_diff::$GIT_DIFF"
     outputs:
@@ -41,18 +44,19 @@ jobs:
 
   go-split-test-files:
     needs: get_diff
-    if: needs.get_diff.outputs.git_diff
-    runs-on: ubuntu-latest
+    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot] }}
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - name: Check out repository
+      -
+        name: Check out repository
         uses: actions/checkout@v4
-      # Setup Golang based on the go.mod file.
-      # This is needed when the go version has changed and the code uses features from the new version.gi
-      - name: 🐿 Setup Golang
+      -
+        name: 🐿 Setup Golang
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Create a file with all core Cosmos SDK pkgs
+      -
+        name: Create a file with all core Cosmos SDK pkgs
         run: |
           go list \
             ./... \
@@ -62,47 +66,57 @@ jobs:
             ./x/epochs \
             | grep -E -v 'tests/simulator|e2e' \
             > pkgs.txt
-      - name: Split pkgs into 4 files
+      -
+        name: Split pkgs into 4 files
         run: |
           split -d -n l/4 pkgs.txt pkgs.txt.part.
-      - uses: actions/upload-artifact@v4
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-00"
           path: ./pkgs.txt.part.00
-      - uses: actions/upload-artifact@v4
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-01"
           path: ./pkgs.txt.part.01
-      - uses: actions/upload-artifact@v4
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-02"
           path: ./pkgs.txt.part.02
-      - uses: actions/upload-artifact@v4
+      -
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-03"
           path: ./pkgs.txt.part.03
 
   go:
     needs: [go-split-test-files, get_diff]
-    if: needs.get_diff.outputs.git_diff
-    runs-on: ubuntu-latest
+    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot] }}
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
         part: ["00", "01", "02", "03"]
     steps:
-      - name: Check out repository
+      -
+        name: Check out repository
         uses: actions/checkout@v4
-      - name: 🐿 Setup Golang
+      -
+        name: 🐿 Setup Golang
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Display go version
+      -
+        name: Display go version
         run: go version
-      - uses: actions/download-artifact@v4
+      -
+        uses: actions/download-artifact@v4
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
-      - name: Test & coverage report creation
+      -
+        name: Test & coverage report creation
         run: |
           VERSION=$(echo $(git describe --tags) | sed 's/^v//') || VERSION=${GITHUB_SHA}
           TESTS=$(cat pkgs.txt.part.${{ matrix.part }})
@@ -110,28 +124,34 @@ jobs:
 
   e2e:
     needs: get_diff
-    if: needs.get_diff.outputs.git_diff
+    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot] }}
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:
-      - name: Check out repository
+      -
+        name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up QEMU
+      -
+        name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      -
+        name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: 🐿 Setup Golang
+      -
+        name: 🐿 Setup Golang
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Build e2e image
+      -
+        name: Build e2e image
         uses: docker/build-push-action@v5
         with:
           load: true
@@ -140,18 +160,22 @@ jobs:
           build-args: |
             BASE_IMG_TAG=debug
             BUILD_TAGS="netgo,muslc,excludeIncrement"
-      - name: Test e2e and Upgrade
+      -
+        name: Test e2e and Upgrade
         run: make test-e2e-ci
-      - name: Dump docker logs on failure
+      -
+        name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
           dest: "./logs"
-      - name: Tar logs
+      -
+        name: Tar logs
         if: failure()
         run: |
           tar cvzf ./logs.tgz ./logs
-      - name: Upload logs to GitHub
+      -
+        name: Upload logs to GitHub
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
   go-split-test-files:
     needs: get_diff
-    if: needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]
+    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]' }}
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       -
@@ -93,7 +93,7 @@ jobs:
 
   go:
     needs: [go-split-test-files, get_diff]
-    if: needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]
+    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]' }}
     runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
 
   e2e:
     needs: get_diff
-    if: needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]
+    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]' }}
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
   go-split-test-files:
     needs: get_diff
-    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot] }}
+    if: needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       -
@@ -93,7 +93,7 @@ jobs:
 
   go:
     needs: [go-split-test-files, get_diff]
-    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot] }}
+    if: needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]
     runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
 
   e2e:
     needs: get_diff
-    if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot] }}
+    if: needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## What is the purpose of the change

This PR changes the e2e/go workflow trigger to always execute the workflow if a PR is opened or modified by `dependabot[bot]` or `mergify[bot]`, in addition to the existing git_diff checks.

I have also made other jobs run in `buildjet` to speed things up and improved formatting.

## Testing and Verifying

I will add a `backport` label to this PR to check if this workflow runs on the `mergify` backport.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
    - Enhanced GitHub Actions workflow configurations for improved CI/CD processes, focusing on optimizing test environments and artifact management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->