### PR TITLE
perf: spread deprecated twap record pruning logic over multiple blocks

### DIFF
--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -38,8 +38,9 @@ func CreateUpgradeHandler(
 		}
 
 		// Now that the TWAP keys are refactored, we can delete all time indexed TWAPs
-		// since we only need the pool indexed TWAPs.
-		keepers.TwapKeeper.DeleteAllHistoricalTimeIndexedTWAPs(ctx)
+		// since we only need the pool indexed TWAPs. We set the is pruning store value to true
+		// and spread the pruning time across multiple blocks to avoid a single block taking too long.
+		keepers.TwapKeeper.SetDeprecatedHistoricalTWAPsIsPruning(ctx)
 
 		// Set the new min value for distribution for the incentives module.
 		// https://www.mintscan.io/osmosis/proposals/733

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -61,7 +61,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	}
 	twapRecord2 := twapRecord1
 	twapRecord2.Time = time.Date(2023, 0o2, 2, 0, 0, 0, 0, time.UTC)
-	twap.PruneLimitPerBlock = uint16(1)
+	twap.NumDeprecatedRecordsToPrunePerBlock = uint16(1)
 
 	// Set two records
 	poolIndexKey1 := types.FormatHistoricalPoolIndexTWAPKey(twapRecord1.PoolId, twapRecord1.Asset0Denom, twapRecord1.Asset1Denom, twapRecord1.Time)

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -123,6 +123,12 @@ func (k Keeper) EndBlock(ctx sdk.Context) {
 			ctx.Logger().Error("Error pruning old twaps at the end block", err)
 		}
 	}
+
+	// If we still have more deprecated historical twaps to prune, then we prune up to the per block limit.
+	// TODO: Can remove this in the v25 upgrade or after.
+	if k.IsDeprecatedHistoricalTWAPsPruning(ctx) {
+		k.DeleteHistoricalTimeIndexedTWAPs(ctx)
+	}
 }
 
 // updateRecords updates all records for a given pool id.

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -19,6 +19,8 @@ import (
 // not too small where it would take all the way to the next epoch.
 var NumRecordsToPrunePerBlock uint16 = 200
 
+var PruneLimitPerBlock uint16 = 200
+
 type timeTooOldError struct {
 	Time time.Time
 }
@@ -268,13 +270,11 @@ func (k Keeper) DeleteHistoricalTimeIndexedTWAPs(ctx sdk.Context) {
 	iter := sdk.KVStorePrefixIterator(store, []byte("historical_time_index"))
 	defer iter.Close()
 
-	pruneLimitPerBlock := 200
-
-	iterationCounter := 0
+	iterationCounter := uint16(0)
 	for iter.Valid() {
 		store.Delete(iter.Key())
 		iterationCounter++
-		if iterationCounter >= pruneLimitPerBlock {
+		if iterationCounter >= PruneLimitPerBlock {
 			ctx.Logger().Info("Deleted deprecated historical time indexed twaps", "count", iterationCounter)
 			return
 		}

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -275,6 +275,7 @@ func (k Keeper) DeleteHistoricalTimeIndexedTWAPs(ctx sdk.Context) {
 		store.Delete(iter.Key())
 		iterationCounter++
 		if iterationCounter >= pruneLimitPerBlock {
+			ctx.Logger().Info("Deleted deprecated historical time indexed twaps", "count", iterationCounter)
 			return
 		}
 		iter.Next()

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -26,9 +26,10 @@ const (
 )
 
 var (
-	PruningStateKey                    = []byte{0x01}
-	mostRecentTWAPsNoSeparator         = "recent_twap"
-	historicalTWAPPoolIndexNoSeparator = "historical_pool_index"
+	PruningStateKey                       = []byte{0x01}
+	DeprecatedHistoricalTWAPsIsPruningKey = []byte{0x02}
+	mostRecentTWAPsNoSeparator            = "recent_twap"
+	historicalTWAPPoolIndexNoSeparator    = "historical_pool_index"
 
 	// We do key management to let us easily meet the goals of (AKA minimal iteration):
 	// * Get most recent twap for a (pool id, asset 1, asset 2) with no iteration


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Upgrade currently takes 30s, this is partially due to the amount of time it takes to commit the large amount of deletes.

This instead spreads the deletes out at 200 per block until completion, starting at upgrade time.

## Testing and Verifying

I tested this with both changes of spreading pruning over multiple blocks and the upgrade was essentially instant.

![Screenshot 2024-03-19 at 2 26 17 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/c9767cce-9b76-457f-b99a-cd80a888ee9f)

I also modified the upgrade gotest to show that the incremental pruning works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a method to manage the pruning of outdated historical TWAP records, improving data handling efficiency.
- **Refactor**
	- Enhanced logic for deleting historical TWAP records with a new per block limit to ensure smoother operation and resource management.
- **Tests**
	- Updated tests to align with the new TWAP record handling and pruning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->