### PR TITLE
fix: e2e settings overrided

### DIFF
--- a/tests/e2e/configurer/base.go
+++ b/tests/e2e/configurer/base.go
@@ -85,7 +85,9 @@ func (bc *baseConfigurer) runValidators(chainConfig *chain.Config) error {
 	// Iterate over each node
 	for _, node := range chainConfig.NodeConfigs {
 		go func(n *chain.NodeConfig) {
-			defer wg.Done()       // Decrement the WaitGroup counter when the goroutine is done
+			defer wg.Done() // Decrement the WaitGroup counter when the goroutine is done
+			// TODO: After v24, either set this to true or remove the entire logic added in https://github.com/osmosis-labs/osmosis/pull/7784
+			// and just set --reject-config-defaults=true directly here https://github.com/osmosis-labs/osmosis/blob/b106139bcfe5605fb2fedd6237d9467497cf3ded/tests/e2e/containers/containers.go#L492-L493
 			errCh <- n.Run(false) // Run the node and send any error to the channel
 		}(node)
 	}

--- a/tests/e2e/configurer/base.go
+++ b/tests/e2e/configurer/base.go
@@ -85,8 +85,8 @@ func (bc *baseConfigurer) runValidators(chainConfig *chain.Config) error {
 	// Iterate over each node
 	for _, node := range chainConfig.NodeConfigs {
 		go func(n *chain.NodeConfig) {
-			defer wg.Done()  // Decrement the WaitGroup counter when the goroutine is done
-			errCh <- n.Run() // Run the node and send any error to the channel
+			defer wg.Done()       // Decrement the WaitGroup counter when the goroutine is done
+			errCh <- n.Run(false) // Run the node and send any error to the channel
 		}(node)
 	}
 

--- a/tests/e2e/configurer/chain/node.go
+++ b/tests/e2e/configurer/chain/node.go
@@ -46,13 +46,13 @@ func NewNodeConfig(t *testing.T, initNode *initialization.Node, initConfig *init
 // Run runs a node container for the given nodeIndex.
 // The node configuration must be already added to the chain config prior to calling this
 // method.
-func (n *NodeConfig) Run() error {
+func (n *NodeConfig) Run(rejectConfigDefaults bool) error {
 	maxRetries := 3
 	currentRetry := 0
 
 	for currentRetry < maxRetries {
 		n.t.Logf("starting node container: %s", n.Name)
-		resource, err := n.containerManager.RunNodeResource(n.chainId, n.Name, n.ConfigDir)
+		resource, err := n.containerManager.RunNodeResource(n.chainId, n.Name, n.ConfigDir, rejectConfigDefaults)
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -395,7 +395,7 @@ func (uc *UpgradeConfigurer) upgradeContainers(chainConfig *chain.Config, propHe
 	uc.containerManager.OsmosisTag = containers.CurrentBranchOsmoTag
 
 	for _, node := range chainConfig.NodeConfigs {
-		if err := node.Run(); err != nil {
+		if err := node.Run(true); err != nil {
 			return err
 		}
 	}

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -472,10 +472,15 @@ func (m *Manager) RunHermesResource(chainAID, osmoARelayerNodeName, osmoAValMnem
 
 // RunNodeResource runs a node container. Assigns containerName to the container.
 // Mounts the container on valConfigDir volume on the running host. Returns the container resource and error if any.
-func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir string) (*dockertest.Resource, error) {
+func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir string, rejectConfigDefaults bool) (*dockertest.Resource, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
+	}
+
+	cmd := []string{"start"}
+	if rejectConfigDefaults {
+		cmd = append(cmd, "--reject-config-defaults=true")
 	}
 
 	runOpts := &dockertest.RunOptions{
@@ -484,7 +489,7 @@ func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir st
 		Tag:        m.OsmosisTag,
 		NetworkID:  m.network.Network.ID,
 		User:       "root:root",
-		Cmd:        []string{"start", "--reject-config-defaults=true"},
+		Cmd:        cmd,
 		Mounts: []string{
 			fmt.Sprintf("%s/:/osmosis/.osmosisd", valCondifDir),
 			fmt.Sprintf("%s/scripts:/osmosis", pwd),

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -484,7 +484,7 @@ func (m *Manager) RunNodeResource(chainId string, containerName, valCondifDir st
 		Tag:        m.OsmosisTag,
 		NetworkID:  m.network.Network.ID,
 		User:       "root:root",
-		Cmd:        []string{"start"},
+		Cmd:        []string{"start", "--reject-config-defaults=true"},
 		Mounts: []string{
 			fmt.Sprintf("%s/:/osmosis/.osmosisd", valCondifDir),
 			fmt.Sprintf("%s/scripts:/osmosis", pwd),

--- a/tests/e2e/sync_test.go
+++ b/tests/e2e/sync_test.go
@@ -89,7 +89,7 @@ func (s *IntegrationTestSuite) StateSync() {
 	chainANode.WaitUntil(hasSnapshotsAvailable)
 
 	// start the state synchin node.
-	err = stateSynchingNode.Run()
+	err = stateSynchingNode.Run(true)
 	s.Require().NoError(err)
 
 	// ensure that the state syncing node cathes up to the running node.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We need to add the "--reject-config-defaults=true" flag to e2e because e2e relies on 300ms blocks. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Enhanced end-to-end testing for container management with new configuration arguments for more precise test conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->