### PR TITLE
Simplify authenticator manager

### DIFF
--- a/x/authenticator/authenticator/all_of.go
+++ b/x/authenticator/authenticator/all_of.go
@@ -58,16 +58,12 @@ func (aoa AllOfAuthenticator) Initialize(data []byte) (Authenticator, error) {
 	}
 
 	for _, initData := range initDatas {
-		for _, authenticatorCode := range aoa.am.GetRegisteredAuthenticators() {
-			if authenticatorCode.Type() == initData.AuthenticatorType {
-				instance, err := authenticatorCode.Initialize(initData.Data)
-				if err != nil {
-					return nil, errorsmod.Wrapf(err, "failed to initialize sub-authenticator (type = %s)", initData.AuthenticatorType)
-				}
-				aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
-				continue
-			}
+		authenticatorCode := aoa.am.GetAuthenticatorByType(initData.AuthenticatorType)
+		instance, err := authenticatorCode.Initialize(initData.Data)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "failed to initialize sub-authenticator (type = %s)", initData.AuthenticatorType)
 		}
+		aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
 	}
 
 	// If not all sub-authenticators are registered, return an error

--- a/x/authenticator/authenticator/any_of.go
+++ b/x/authenticator/authenticator/any_of.go
@@ -64,16 +64,12 @@ func (aoa AnyOfAuthenticator) Initialize(data []byte) (Authenticator, error) {
 
 	// Call Initialize on each sub-authenticator with its appropriate data using AuthenticatorManager
 	for _, initData := range initDatas {
-		for _, authenticatorCode := range aoa.am.GetRegisteredAuthenticators() {
-			if authenticatorCode.Type() == initData.AuthenticatorType {
-				instance, err := authenticatorCode.Initialize(initData.Data)
-				if err != nil {
-					return nil, errorsmod.Wrapf(err, "failed to initialize sub-authenticator (type = %s)", initData.AuthenticatorType)
-				}
-				aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
-				break
-			}
+		authenticatorCode := aoa.am.GetAuthenticatorByType(initData.AuthenticatorType)
+		instance, err := authenticatorCode.Initialize(initData.Data)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "failed to initialize sub-authenticator (type = %s)", initData.AuthenticatorType)
 		}
+		aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
 	}
 
 	// If not all sub-authenticators are registered, return an error

--- a/x/authenticator/authenticator/composite.go
+++ b/x/authenticator/authenticator/composite.go
@@ -106,18 +106,14 @@ func onSubAuthenticatorsAdded(ctx sdk.Context, account sdk.AccAddress, data []by
 	baseId := authenticatorId
 	subAuthenticatorCount := 0
 	for id, initData := range initDatas {
-		for _, authenticatorCode := range am.GetRegisteredAuthenticators() {
-			if authenticatorCode.Type() == initData.AuthenticatorType {
-				subId := compositeId(baseId, id)
-				err := authenticatorCode.OnAuthenticatorAdded(ctx, account, initData.Data, subId)
-				if err != nil {
-					return errorsmod.Wrapf(err, "sub-authenticator `OnAuthenticatorAdded` failed (sub-authenticator id = %s)", subId)
-				}
-
-				subAuthenticatorCount++
-				break
-			}
+		authenticatorCode := am.GetAuthenticatorByType(initData.AuthenticatorType)
+		subId := compositeId(baseId, id)
+		err := authenticatorCode.OnAuthenticatorAdded(ctx, account, initData.Data, subId)
+		if err != nil {
+			return errorsmod.Wrapf(err, "sub-authenticator `OnAuthenticatorAdded` failed (sub-authenticator id = %s)", subId)
 		}
+
+		subAuthenticatorCount++
 	}
 
 	// If not all sub-authenticators are registered, return an error
@@ -136,15 +132,11 @@ func onSubAuthenticatorsRemoved(ctx sdk.Context, account sdk.AccAddress, data []
 
 	baseId := authenticatorId
 	for id, initData := range initDatas {
-		for _, authenticatorCode := range am.GetRegisteredAuthenticators() {
-			if authenticatorCode.Type() == initData.AuthenticatorType {
-				subId := compositeId(baseId, id)
-				err := authenticatorCode.OnAuthenticatorRemoved(ctx, account, initData.Data, subId)
-				if err != nil {
-					return errorsmod.Wrapf(err, "sub-authenticator `OnAuthenticatorRemoved` failed (sub-authenticator id = %s)", subId)
-				}
-				break
-			}
+		authenticatorCode := am.GetAuthenticatorByType(initData.AuthenticatorType)
+		subId := compositeId(baseId, id)
+		err := authenticatorCode.OnAuthenticatorRemoved(ctx, account, initData.Data, subId)
+		if err != nil {
+			return errorsmod.Wrapf(err, "sub-authenticator `OnAuthenticatorRemoved` failed (sub-authenticator id = %s)", subId)
 		}
 	}
 	return nil

--- a/x/authenticator/authenticator/manager.go
+++ b/x/authenticator/authenticator/manager.go
@@ -1,19 +1,24 @@
 package authenticator
 
+import "sort"
+
 type AuthenticatorManager struct {
-	registeredAuthenticators []Authenticator
+	registeredAuthenticators map[string]Authenticator
+	orderedKeys              []string // slice to keep track of the keys in sorted order
 }
 
 // NewAuthenticatorManager creates a new AuthenticatorManager.
 func NewAuthenticatorManager() *AuthenticatorManager {
 	return &AuthenticatorManager{
-		registeredAuthenticators: []Authenticator{},
+		registeredAuthenticators: make(map[string]Authenticator),
+		orderedKeys:              []string{},
 	}
 }
 
-// ResetAuthenticators resets all registered authenticators.
+// ResetAuthenticators resets all registered authenticators.g
 func (am *AuthenticatorManager) ResetAuthenticators() {
-	am.registeredAuthenticators = []Authenticator{}
+	am.registeredAuthenticators = make(map[string]Authenticator)
+	am.orderedKeys = []string{}
 }
 
 // InitializeAuthenticators initializes authenticators. If already initialized, it will not overwrite.
@@ -21,45 +26,55 @@ func (am *AuthenticatorManager) InitializeAuthenticators(initialAuthenticators [
 	if len(am.registeredAuthenticators) > 0 {
 		return
 	}
-	am.registeredAuthenticators = initialAuthenticators
+	for _, authenticator := range initialAuthenticators {
+		am.registeredAuthenticators[authenticator.Type()] = authenticator
+		am.orderedKeys = append(am.orderedKeys, authenticator.Type())
+	}
+	sort.Strings(am.orderedKeys) // Ensure keys are sorted
 }
 
-// RegisterAuthenticator adds a new authenticator to the list of registered authenticators.
+// RegisterAuthenticator adds a new authenticator to the map of registered authenticators.
 func (am *AuthenticatorManager) RegisterAuthenticator(authenticator Authenticator) {
-	am.registeredAuthenticators = append(am.registeredAuthenticators, authenticator)
+	if _, exists := am.registeredAuthenticators[authenticator.Type()]; !exists {
+		am.orderedKeys = append(am.orderedKeys, authenticator.Type())
+		sort.Strings(am.orderedKeys) // Re-sort keys after addition
+	}
+	am.registeredAuthenticators[authenticator.Type()] = authenticator
 }
 
-// UnregisterAuthenticator removes an authenticator from the list of registered authenticators.
+// UnregisterAuthenticator removes an authenticator from the map of registered authenticators.
 func (am *AuthenticatorManager) UnregisterAuthenticator(authenticator Authenticator) {
-	for i, auth := range am.registeredAuthenticators {
-		if auth.Type() == authenticator.Type() {
-			am.registeredAuthenticators = append(am.registeredAuthenticators[:i], am.registeredAuthenticators[i+1:]...)
-			break
+	if _, exists := am.registeredAuthenticators[authenticator.Type()]; exists {
+		delete(am.registeredAuthenticators, authenticator.Type())
+		// Remove the key from orderedKeys
+		for i, key := range am.orderedKeys {
+			if key == authenticator.Type() {
+				am.orderedKeys = append(am.orderedKeys[:i], am.orderedKeys[i+1:]...)
+				break
+			}
 		}
 	}
 }
 
-// GetRegisteredAuthenticators returns the list of registered authenticators.
+// GetRegisteredAuthenticators returns the list of registered authenticators in sorted order.
 func (am *AuthenticatorManager) GetRegisteredAuthenticators() []Authenticator {
-	return am.registeredAuthenticators
+	var authenticators []Authenticator
+	for _, key := range am.orderedKeys {
+		authenticators = append(authenticators, am.registeredAuthenticators[key])
+	}
+	return authenticators
 }
 
 // IsAuthenticatorTypeRegistered checks if the authenticator type is registered.
 func (am *AuthenticatorManager) IsAuthenticatorTypeRegistered(authenticatorType string) bool {
-	for _, authenticator := range am.GetRegisteredAuthenticators() {
-		if authenticator.Type() == authenticatorType {
-			return true
-		}
-	}
-	return false
+	_, exists := am.registeredAuthenticators[authenticatorType]
+	return exists
 }
 
-// GetAuthenticatorByType returns the base implementation of the authenticator type
+// GetAuthenticatorByType returns the base implementation of the authenticator type.
 func (am *AuthenticatorManager) GetAuthenticatorByType(authenticatorType string) Authenticator {
-	for _, authenticator := range am.GetRegisteredAuthenticators() {
-		if authenticator.Type() == authenticatorType {
-			return authenticator
-		}
+	if authenticator, exists := am.registeredAuthenticators[authenticatorType]; exists {
+		return authenticator
 	}
 	return nil
 }

--- a/x/authenticator/keeper/keeper_test.go
+++ b/x/authenticator/keeper/keeper_test.go
@@ -195,12 +195,7 @@ func (s *KeeperTestSuite) TestKeeper_GetSelectedAuthenticatorForAccount() {
 	s.Require().NoError(err, "Should successfully add a MessageFilterAuthenticator")
 
 	// Remove a registered authenticator from the authenticator manager
-	ar := s.App.AuthenticatorManager.GetRegisteredAuthenticators()
-	for _, a := range ar {
-		if a.Type() == "MessageFilterAuthenticator" {
-			s.App.AuthenticatorManager.UnregisterAuthenticator(authenticator.MessageFilterAuthenticator{})
-		}
-	}
+	s.App.AuthenticatorManager.UnregisterAuthenticator(authenticator.MessageFilterAuthenticator{})
 
 	// Try to get an authenticator that has been removed from the store
 	selectedAuthenticator, err = s.App.AuthenticatorKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

We are unnecessarily iterating over authenticators in many places. This should be O(1).

This PR modifies the implementation of the authentication manager to keep the registered types in a map instead of a list

## Testing and Verifying
all tests should pass
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A