### PR TITLE
fix: properly format info log

### DIFF
--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -296,7 +296,7 @@ func (k Keeper) swapNonNativeFeeToDenom(ctx sdk.Context, denomToSwapTo string, f
 		}
 	}
 	if len(coinsNotSwapped) > 0 {
-		ctx.Logger().Info("The following non-native tokens were not swapped (see debug logs for further details): %s", coinsNotSwapped)
+		ctx.Logger().Info(fmt.Sprintf("The following non-native tokens were not swapped (see debug logs for further details): %s", coinsNotSwapped))
 	}
 
 	return totalCoinOut


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

![Screenshot 2024-03-21 at 1 45 57 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/55aff8e5-618f-44d7-bb40-36cd98e1706e)

It's pretty silly, but you need to use Sprint to format the logger lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved log message formatting in the fee swapping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->