### PR TITLE
fix(e2e): twap records

### DIFF
--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -27,7 +27,7 @@ const (
 	previousVersionOsmoTag        = "23.0.0-rc1-alpine"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "23.0.0-rc1-temp"
+	previousVersionInitTag        = "v23.0.8-temp"
 	// Hermes repo/version for relayer
 	relayerRepository = "informalsystems/hermes"
 	relayerTag        = "1.5.1"

--- a/tests/e2e/initialization/config.go
+++ b/tests/e2e/initialization/config.go
@@ -487,7 +487,7 @@ func updateTWAPGenesis(appGenState map[string]json.RawMessage) func(twapGenState
 				twapRecord := twaptypes.TwapRecord{
 					PoolId:      balancerPool.Id,
 					Asset0Denom: denomPair.Denom0,
-					Asset1Denom: denomPair.Denom0,
+					Asset1Denom: denomPair.Denom1,
 					Height:      1,
 					Time:        time.Date(2023, 0o2, 1, 0, 0, 0, 0, time.UTC), // some time in the past.
 					// Note: truncation is acceptable as x/twap is guaranteed to work only on pools with spot prices > 10^-18.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

<img width="1437" alt="Screenshot 2024-03-23 at 12 06 52 AM" src="https://github.com/osmosis-labs/osmosis/assets/40078083/411e08b3-fc14-40a3-833f-74086e01fe05">

We were seeing the above error occur on both pre and post upgrade in e2e. Turns out we were initializing them incorrectly.

## Testing and Verifying

Tested locally, no longer see error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated end-to-end test configurations for better alignment with the current version.
	- Improved TWAP record initialization logic in tests for more accurate testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->