### PR TITLE
Fix error on docker login secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,7 @@ jobs:
       -
         name: Login to DockerHub
         uses: docker/login-action@v3
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## What is the purpose of the change

Fix errors on the Docker login step (as shown in https://github.com/osmosis-labs/osmosis/actions/runs/8414076425/job/23037226970?pr=7824).

![image](https://github.com/osmosis-labs/osmosis/assets/6024049/740c3b01-f1e5-484c-b19c-36fcda33a525)

This is due to the fact that dependabot does not have access to GitHub secrets by default.

```yaml
-
        name: Login to DockerHub
        uses: docker/login-action@v3
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}   # EMPTY in depandabot
          password: ${{ secrets.DOCKERHUB_TOKEN }}      # EMPTY in depandabot
```

Normal run:
![image](https://github.com/osmosis-labs/osmosis/assets/6024049/e1bf737b-82f7-4436-92c9-8e8c94816813)

### Solution

Avoid docker login when PR is opened by a `depandabot` or `mergify`.

## Testing and Verifying

- Workflow should run without issues in this PR
- Workflow should run in the dependabot PR 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Improved CI workflow by skipping DockerHub login for specific GitHub bot actors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->