### PR TITLE
fix(e2e): use osmolabs relayer image, remove unnecessary deposit calls

### DIFF
--- a/tests/e2e/configurer/chain/chain.go
+++ b/tests/e2e/configurer/chain/chain.go
@@ -281,8 +281,6 @@ func (c *Config) getNodeAtIndex(nodeIndex int) (*NodeConfig, error) {
 func (c *Config) SubmitCreateConcentratedPoolProposal(chainANode *NodeConfig, isLegacy bool) (uint64, error) {
 	propNumber := chainANode.SubmitCreateConcentratedPoolProposal(false, isLegacy)
 
-	chainANode.DepositProposal(propNumber, true)
-
 	AllValsVoteOnProposal(c, propNumber)
 
 	require.Eventually(c.t, func() bool {

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -392,18 +392,6 @@ func (n *NodeConfig) SubmitTickSpacingReductionProposal(poolTickSpacingRecords s
 	return n.SubmitProposal(cmd, isExpedited, "tick spacing reduction proposal", isLegacy)
 }
 
-func (n *NodeConfig) DepositProposal(proposalNumber int, isExpedited bool) {
-	n.LogActionF("depositing on proposal: %d", proposalNumber)
-	deposit := sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.MinDepositValue)).String()
-	if isExpedited {
-		deposit = sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.MinExpeditedDepositValue)).String()
-	}
-	cmd := []string{"osmosisd", "tx", "gov", "deposit", fmt.Sprintf("%d", proposalNumber), deposit, "--from=val"}
-	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
-	require.NoError(n.t, err)
-	n.LogActionF("successfully deposited on proposal %d", proposalNumber)
-}
-
 func (n *NodeConfig) VoteYesProposal(from string, proposalNumber int) {
 	n.LogActionF("voting yes on proposal: %d", proposalNumber)
 	cmd := []string{"osmosisd", "tx", "gov", "vote", fmt.Sprintf("%d", proposalNumber), "yes", fmt.Sprintf("--from=%s", from)}
@@ -733,7 +721,6 @@ func (n *NodeConfig) SendIBCNoMutex(srcChain, dstChain *Config, recipient string
 
 func (n *NodeConfig) EnableSuperfluidAsset(srcChain *Config, denom string, isLegacy bool) {
 	propNumber := n.SubmitSuperfluidProposal(denom, isLegacy)
-	n.DepositProposal(propNumber, false)
 
 	AllValsVoteOnProposal(srcChain, propNumber)
 }

--- a/tests/e2e/configurer/upgrade.go
+++ b/tests/e2e/configurer/upgrade.go
@@ -366,8 +366,6 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 		chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
 		propNumber := node.SubmitUpgradeProposal(uc.upgradeVersion, chainConfig.UpgradePropHeight, sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(config.InitialMinDeposit)), true)
 
-		node.DepositProposal(propNumber, false)
-
 		chain.AllValsVoteOnProposal(chainConfig, propNumber)
 	}
 

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -29,7 +29,7 @@ const (
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
 	previousVersionInitTag        = "v23.0.8-temp"
 	// Hermes repo/version for relayer
-	relayerRepository = "informalsystems/hermes"
+	relayerRepository = "osmolabs/relayer"
 	relayerTag        = "1.5.1"
 )
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This clones the image from informalsystems and hosts it on our own docker hub repo. I believe this was causing rate limits to occur (we were always pulling from informal's repo rather than our own).

We also had some unnecessary deposit calls, which are removed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified proposal submission and handling process in testing configurations.
- **Chores**
	- Updated the relayer repository source in container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->