### PR TITLE
fix: SuperfluidDelegationsByValidatorDenom does not return equivalent staked amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7785](https://github.com/osmosis-labs/osmosis/pull/7785) Remove reward claiming during position transfers
 * [#7839](https://github.com/osmosis-labs/osmosis/pull/7839) Add ICA controller
 * [#7527](https://github.com/osmosis-labs/osmosis/pull/7527) Add 30M gas limit to CW pool contract calls
+* [#7857](https://github.com/osmosis-labs/osmosis/pull/7857) SuperfluidDelegationsByValidatorDenom query now returns equivalent staked amount
 
 ### SDK
 

--- a/x/superfluid/keeper/grpc_query.go
+++ b/x/superfluid/keeper/grpc_query.go
@@ -263,11 +263,9 @@ func (q Querier) SuperfluidDelegationsByDelegator(goCtx context.Context, req *ty
 		if err != nil {
 			return nil, err
 		}
+
 		coin := sdk.NewCoin(appparams.BaseCoinUnit, equivalentAmount)
 
-		if err != nil {
-			return nil, err
-		}
 		res.SuperfluidDelegationRecords = append(res.SuperfluidDelegationRecords,
 			types.SuperfluidDelegationRecord{
 				DelegatorAddress:       req.DelegatorAddress,
@@ -428,11 +426,21 @@ func (q Querier) SuperfluidDelegationsByValidatorDenom(goCtx context.Context, re
 
 	for _, lock := range periodLocks {
 		lockedCoins := sdk.NewCoin(req.Denom, lock.GetCoins().AmountOf(req.Denom))
+		baseDenom := lock.Coins.GetDenomByIndex(0)
+
+		equivalentAmount, err := q.Keeper.GetSuperfluidOSMOTokens(ctx, baseDenom, lockedCoins.Amount)
+		if err != nil {
+			return nil, err
+		}
+
+		coin := sdk.NewCoin(appparams.BaseCoinUnit, equivalentAmount)
+
 		res.SuperfluidDelegationRecords = append(res.SuperfluidDelegationRecords,
 			types.SuperfluidDelegationRecord{
-				DelegatorAddress: lock.GetOwner(),
-				ValidatorAddress: req.ValidatorAddress,
-				DelegationAmount: lockedCoins,
+				DelegatorAddress:       lock.GetOwner(),
+				ValidatorAddress:       req.ValidatorAddress,
+				DelegationAmount:       lockedCoins,
+				EquivalentStakedAmount: &coin,
 			},
 		)
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #7842

## What is the purpose of the change

Fixes query to return equivalent staked amount.

## Testing and Verifying

Tested against mainnet and got values instead of null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `SuperfluidDelegationsByValidatorDenom` query to return the equivalent staked amount, improving clarity and usability for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->