### PR TITLE
fix(x/mint/simulation): use proper value of maxInt64

### DIFF
--- a/x/mint/simulation/genesis.go
+++ b/x/mint/simulation/genesis.go
@@ -3,6 +3,7 @@ package simulation
 // DONTCOVER
 
 import (
+	"math"
 	"math/rand"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -21,7 +22,7 @@ const (
 	mintingRewardsDistributionStartEpochKey = "minting_rewards_distribution_start_epoch"
 
 	epochIdentifier = "day"
-	maxInt64        = int(^uint(0) >> 1)
+	maxInt64        = int64(math.MaxInt64)
 )
 
 var (
@@ -143,21 +144,21 @@ func RandomizedGenState(simState *module.SimulationState) {
 }
 
 func genEpochProvisions(r *rand.Rand) osmomath.Dec {
-	return osmomath.NewDec(int64(r.Intn(maxInt64)))
+	return osmomath.NewDec(r.Int63n(maxInt64))
 }
 
 func genReductionFactor(r *rand.Rand) osmomath.Dec {
-	return osmomath.NewDecWithPrec(int64(r.Intn(10)), 1)
+	return osmomath.NewDecWithPrec(r.Int63n(10), 1)
 }
 
 func genReductionPeriodInEpochs(r *rand.Rand) int64 {
-	return int64(r.Intn(maxInt64))
+	return r.Int63n(maxInt64)
 }
 
 func genMintintRewardsDistributionStartEpoch(r *rand.Rand) int64 {
-	return int64(r.Intn(maxInt64))
+	return r.Int63n(maxInt64)
 }
 
 func genReductionStartedEpoch(r *rand.Rand) int64 {
-	return int64(r.Intn(maxInt64))
+	return r.Int63n(maxInt64)
 }

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -45,7 +45,7 @@ func TestRandomizedGenState(t *testing.T) {
 
 	const (
 		expectedEpochProvisionsStr      = "7913048388940673156"
-		expectedReductionFactorStr      = "0.6"
+		expectedReductionFactorStr      = "0.8"
 		expectedReductionPeriodInEpochs = int64(9171281239991390334)
 
 		expectedMintintRewardsDistributionStartEpoch = int64(14997548954463330)


### PR DESCRIPTION
This change infers maxInt64 correctly and non-superfluously, simply using math.MaxInt64 and typed as an int64; instead of how it was previously being inferred that posed a definite misinterpretation on 32-bit systems where it would have been maxInt32 instead. While here also used the correct way of generating int64 from math/rand.Int63n instead of int64(rand.Intn(n))

This work is a courtesy from the Quicksilver network as per PR https://github.com/quicksilver-zone/quicksilver/pull/1339.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved consistency and correctness in handling large integers by updating data types and random number generation methods.
	- Adjusted test scenario related to randomized genesis state generation by updating a value in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->