### PR TITLE
fix: Remove Exit Fee from Create Pool cli

### DIFF
--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -257,7 +257,6 @@ The JSON [config-file] must specify the following parameters:
  "weights": [list weighted denoms],
  "initial-deposit": [list of denoms with initial deposit amount],
  "swap-fee": [spread factor in percentage],
- "exit-fee": [exit fee in percentage],
  "future-governor": [see options in pool parameters section above]
 }
 ```
@@ -275,7 +274,6 @@ The configuration json file contains the following parameters:
  "weights": "5ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4,5uosmo",
  "initial-deposit": "499404ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4,500000uosmo",
  "swap-fee": "0.003",
- "exit-fee": "0.00",
  "future-governor": ""
 }
 ```

--- a/x/gamm/client/cli/tx.go
+++ b/x/gamm/client/cli/tx.go
@@ -59,7 +59,6 @@ Sample pool JSON file contents for balancer:
 	"weights": "4uatom,4osmo,2uakt",
 	"initial-deposit": "100uatom,5osmo,20uakt",
 	"swap-fee": "0.01",
-	"exit-fee": "0.01",
 	"future-governor": "168h"
 }
 
@@ -67,7 +66,6 @@ For stableswap (demonstrating need for a 1:1000 scaling factor, see doc)
 {
 	"initial-deposit": "1000000uusdc,1000miliusdc",
 	"swap-fee": "0.01",
-	"exit-fee": "0.00",
 	"future-governor": "168h",
 	"scaling-factors": "1000,1"
 }
@@ -421,11 +419,6 @@ func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, fs *flag.FlagSet) (
 		return nil, err
 	}
 
-	exitFee, err := osmomath.NewDecFromStr(pool.ExitFee)
-	if err != nil {
-		return nil, err
-	}
-
 	var poolAssets []balancer.PoolAsset
 	for i := 0; i < len(poolAssetCoins); i++ {
 		if poolAssetCoins[i].Denom != deposit[i].Denom {
@@ -440,7 +433,7 @@ func NewBuildCreateBalancerPoolMsg(clientCtx client.Context, fs *flag.FlagSet) (
 
 	poolParams := &balancer.PoolParams{
 		SwapFee: spreadFactor,
-		ExitFee: exitFee,
+		ExitFee: osmomath.NewDec(0),
 	}
 
 	msg := &balancer.MsgCreateBalancerPool{
@@ -516,14 +509,9 @@ func NewBuildCreateStableswapPoolMsg(clientCtx client.Context, fs *flag.FlagSet)
 		return nil, err
 	}
 
-	exitFee, err := osmomath.NewDecFromStr(flags.ExitFee)
-	if err != nil {
-		return nil, err
-	}
-
 	poolParams := &stableswap.PoolParams{
 		SwapFee: spreadFactor,
-		ExitFee: exitFee,
+		ExitFee: osmomath.NewDec(0),
 	}
 
 	scalingFactors := []uint64{}

--- a/x/gamm/client/docs/create-balancer-pool.md
+++ b/x/gamm/client/docs/create-balancer-pool.md
@@ -17,6 +17,5 @@ pool.json
     "weights": "1eth,1regen,2btc",
     "initial-deposit": "100eth,100regen,100btc",
     "swap-fee": "0.001",
-    "exit-fee": "0.001"
 }
 ```

--- a/x/gamm/client/docs/create-lbp-pool.md
+++ b/x/gamm/client/docs/create-lbp-pool.md
@@ -39,7 +39,6 @@ pool.json
     "weights": "10akt,1atom",
     "initial-deposit": "1000akt,100atom",
     "swap-fee": "0.001",
-    "exit-fee": "0.001",
     "lbp-params": {
         "duration": "72h",
         "target-pool-weights": "1akt,1atom"
@@ -54,7 +53,6 @@ Start time included
     "weights": "10akt,1atom",
     "initial-deposit": "1000akt,100atom",
     "swap-fee": "0.001",
-    "exit-fee": "0.001",
     "lbp-params": {
         "duration": "72h",
         "target-pool-weights": "1akt,1atom",

--- a/x/gamm/client/docs/create-stableswap-pool.md
+++ b/x/gamm/client/docs/create-stableswap-pool.md
@@ -15,7 +15,6 @@ pool.json
 	"initial-deposit": "1000000uusdc,1000miliusdc",
     "scaling-factors": "1000,1",
 	"swap-fee": "0.005",
-	"exit-fee": "0.00",
 	"future-governor": "168h",
     "scaling-factor-controller": ""
 }


### PR DESCRIPTION
Closes: #5686

## What is the purpose of the change

Exit fee no longer is utilized, this PR removes exit fee from CLI command so person using CLI command does not need to think it is actually using it. More: #5686

Exit fee is still found in many other [places](https://github.com/search?q=repo%3Aosmosis-labs%2Fosmosis%20exit-fee&type=code) in the code and I am happy to clean up in all relevant places, but I would need a bit more guidance.

A few places were updated in [documentation](https://github.com/osmosis-labs/osmosis/tree/main/x/gamm/client/docs) to reflect this change as well.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

Where is the change documented?

Please let me know if I should document this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated guides for creating balancer, LBP, and stableswap pools to reflect the removal of the `exit-fee` parameter.
	- Clarified the explanation of the `scaling-factor-controller` field in the stableswap pool setup documentation.

- **Chores**
	- Removed the `exit-fee` parameter from the pool configuration across various pool types to simplify the configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->