### PR TITLE
Lower fractional exp iteration limit

### DIFF
--- a/osmomath/math.go
+++ b/osmomath/math.go
@@ -8,7 +8,7 @@ import (
 // TODO: Analyze choice here.
 var powPrecision, _ = NewDecFromStr("0.00000001")
 
-const powIterationLimit = 150_000
+const powIterationLimit = 100_000
 
 var (
 	one_half Dec = MustNewDecFromStr("0.5")


### PR DESCRIPTION
Simple PR to lower the cost of some unmetered code.

The failure mode for this, is some balancer non 50-50 pools in edge cases will have to use higher min swap amounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the iteration behavior by modifying the iteration limit constant for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->