### PR TITLE
Speedup go test Reset logic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -387,10 +387,7 @@ func NewOsmosisApp(
 
 	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.mm.Modules))
 
-	reflectionSvc, err := runtimeservices.NewReflectionService()
-	if err != nil {
-		panic(err)
-	}
+	reflectionSvc := getReflectionService()
 	reflectionv1.RegisterReflectionServiceServer(app.GRPCQueryRouter(), reflectionSvc)
 
 	app.sm.RegisterStoreDecoders()
@@ -471,6 +468,21 @@ func getSQSServiceWriteListeners(app *OsmosisApp, appCodec codec.Codec, blockPoo
 		writelistener.NewCosmwasmPool(blockPoolUpdateTracker),
 	}
 	return writeListeners
+}
+
+// we cache the reflectionService to save us time within tests.
+var cachedReflectionService *runtimeservices.ReflectionService = nil
+
+func getReflectionService() *runtimeservices.ReflectionService {
+	if cachedReflectionService != nil {
+		return cachedReflectionService
+	}
+	reflectionSvc, err := runtimeservices.NewReflectionService()
+	if err != nil {
+		panic(err)
+	}
+	cachedReflectionService = reflectionSvc
+	return reflectionSvc
 }
 
 // InitOsmosisAppForTestnet is broken down into two sections:

--- a/app/apptesting/concentrated_liquidity.go
+++ b/app/apptesting/concentrated_liquidity.go
@@ -912,9 +912,8 @@ func (s *KeeperTestHelper) SetupConcentratedLiquidityDenomsAndPoolCreation() {
 	defaultParams.IsPermissionlessPoolCreationEnabled = true
 	s.App.ConcentratedLiquidityKeeper.SetParams(s.Ctx, defaultParams)
 
-	poolManagerParams := s.App.PoolManagerKeeper.GetParams(s.Ctx)
-	poolManagerParams.AuthorizedQuoteDenoms = append(poolmanagertypes.DefaultParams().AuthorizedQuoteDenoms, ETH, USDC, BAR, BAZ, FOO, UOSMO, STAKE, WBTC)
-	s.App.PoolManagerKeeper.SetParams(s.Ctx, poolManagerParams)
+	authorizedQuoteDenoms := append(poolmanagertypes.DefaultParams().AuthorizedQuoteDenoms, ETH, USDC, BAR, BAZ, FOO, UOSMO, STAKE, WBTC)
+	s.App.PoolManagerKeeper.SetParam(s.Ctx, poolmanagertypes.KeyAuthorizedQuoteDenoms, authorizedQuoteDenoms)
 }
 
 func (s *ConcentratedKeeperTestHelper) SetupTest() {

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -206,20 +206,7 @@ func (s *KeeperTestHelper) SetupWithLevelDb() func() {
 }
 
 func (s *KeeperTestHelper) setupGeneral() {
-	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "osmosis-1", Time: defaultTestStartTime})
-	if s.withCaching {
-		s.Ctx, _ = s.Ctx.CacheContext()
-	}
-	s.QueryHelper = &baseapp.QueryServiceTestHelper{
-		GRPCQueryRouter: s.App.GRPCQueryRouter(),
-		Ctx:             s.Ctx,
-	}
-
-	s.SetEpochStartTime()
-	s.TestAccs = []sdk.AccAddress{}
-	s.TestAccs = append(s.TestAccs, baseTestAccts...)
-	s.SetupConcentratedLiquidityDenomsAndPoolCreation()
-	s.hasUsedAbci = false
+	s.setupGeneralCustomChainId("osmosis-1")
 }
 
 func (s *KeeperTestHelper) setupGeneralCustomChainId(chainId string) {

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -15,8 +15,29 @@ import (
 // object provided to it during init.
 type GenesisState map[string]json.RawMessage
 
+// CloneGenesisState creates a deep clone of the provided GenesisState.
+func cloneGenesisState(original GenesisState) GenesisState {
+	clone := make(GenesisState, len(original))
+	for key, value := range original {
+		// Make a copy of the json.RawMessage (which is a []byte slice).
+		copiedValue := make(json.RawMessage, len(value))
+		copy(copiedValue, value)
+		if len(copiedValue) == 0 {
+			// If the value is empty, set it to nil.
+			copiedValue = nil
+		}
+		clone[key] = copiedValue
+	}
+	return clone
+}
+
+var defaultGenesisState GenesisState = nil
+
 // NewDefaultGenesisState generates the default state for the application.
 func NewDefaultGenesisState() GenesisState {
+	if defaultGenesisState != nil {
+		return cloneGenesisState(defaultGenesisState)
+	}
 	encCfg := MakeEncodingConfig()
 	gen := ModuleBasics.DefaultGenesis(encCfg.Marshaler)
 
@@ -28,5 +49,6 @@ func NewDefaultGenesisState() GenesisState {
 		},
 	}
 	gen[wasmtypes.ModuleName] = encCfg.Marshaler.MustMarshalJSON(&wasmGen)
+	defaultGenesisState = cloneGenesisState(gen)
 	return gen
 }


### PR DESCRIPTION
cref #3957 slight speedup to go tests.

I tested locally for CL, that this dropped testing that single package time locally from 25.2 seconds to 22.9 seconds. This should help speedup every go test in the repo. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the initialization process by introducing deep cloning and caching for the default genesis state.
	- Refactored the initialization of `reflectionSvc` to use a cached instance for improved efficiency.
	- Added a new function `getReflectionService()` to handle the creation and caching of `reflectionSvc`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->