### PR TITLE
chore: default TimeoutCommit to 2s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7527](https://github.com/osmosis-labs/osmosis/pull/7527) Add 30M gas limit to CW pool contract calls
 * [#7855](https://github.com/osmosis-labs/osmosis/pull/7855) Whitelist address parameter for setting fee tokens
 * [#7857](https://github.com/osmosis-labs/osmosis/pull/7857) SuperfluidDelegationsByValidatorDenom query now returns equivalent staked amount
+* [#7912](https://github.com/osmosis-labs/osmosis/pull/7912) Default timeoutCommit to 2s
 
 ### SDK
 

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -112,8 +112,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.StateSync.TrustPeriod = 112 * time.Hour
 
 			// The original default is 5s and is set in Cosmos SDK.
-			// We lower it to 3s for faster block times.
-			config.Consensus.TimeoutCommit = 3 * time.Second
+			// We lower it to 2s for faster block times.
+			config.Consensus.TimeoutCommit = 2 * time.Second
 
 			config.SetRoot(clientCtx.HomeDir)
 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -443,7 +443,7 @@ func overwriteConfigTomlValues(serverCtx *server.Context) error {
 		// It does not exist, so we update the default config.toml to update
 		// We modify the default config.toml to have faster block times
 		// It will be written by server.InterceptConfigsPreRunHandler
-		tmcConfig.Consensus.TimeoutCommit = 3 * time.Second
+		tmcConfig.Consensus.TimeoutCommit = 2 * time.Second
 	} else {
 		// config.toml exists
 
@@ -469,8 +469,8 @@ func overwriteConfigTomlValues(serverCtx *server.Context) error {
 		}
 
 		// The original default is 5s and is set in Cosmos SDK.
-		// We lower it to 3s for faster block times.
-		serverCtx.Config.Consensus.TimeoutCommit = 3 * time.Second
+		// We lower it to 2s for faster block times.
+		serverCtx.Config.Consensus.TimeoutCommit = 2 * time.Second
 
 		defer func() {
 			if err := recover(); err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #7907 

## What is the purpose of the change

Moves default from 3s to 2s, targeting 3 second blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Adjusted the default block time to enhance speed and efficiency in transactions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->