### PR TITLE
CI: shaves off .5s from ibc tests locally

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -331,5 +331,5 @@ func (app *OsmosisApp) GetPoolManagerKeeper() simtypes.PoolManagerKeeper {
 }
 
 func (app *OsmosisApp) GetTxConfig() client.TxConfig {
-	return MakeEncodingConfig().TxConfig
+	return GetEncodingConfig().TxConfig
 }


### PR DESCRIPTION
Shaves down ibctests time by .5s locally for me. (takes 25s locally. CI takes 100 seconds)

The bulk of this bottleneck is really things that should be getting cached, but we don't have the ability to edit ibctesting too easily. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the method for transaction configuration retrieval to enhance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->