### PR TITLE
Speedup gamm balancer tests

### DIFF
--- a/x/gamm/keeper/gas_test.go
+++ b/x/gamm/keeper/gas_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v24/x/gamm/pool-models/balancer"
@@ -61,7 +62,7 @@ func (s *KeeperTestSuite) TestJoinPoolGas() {
 	minShareOutAmountFn := func(int) osmomath.Int { return minShareOutAmount }
 	maxCoinsFn := func(int) sdk.Coins { return defaultCoins }
 	startAveragingAt := 1000
-	totalNumJoins := 10000
+	totalNumJoins := 5000
 
 	// mint some assets to the accounts
 	s.FundAcc(defaultAddr, sdk.NewCoins(
@@ -86,6 +87,9 @@ func (s *KeeperTestSuite) TestJoinPoolGas() {
 	s.Assert().LessOrEqual(int(maxGas), 112000, "max gas / join pool")
 }
 
+var hundredInt = osmomath.NewInt(100)
+var tenInt = osmomath.NewInt(10)
+
 func (s *KeeperTestSuite) TestRepeatedJoinPoolDistinctDenom() {
 	// mint some usomo to account
 	s.FundAcc(defaultAddr, sdk.NewCoins(
@@ -107,22 +111,23 @@ func (s *KeeperTestSuite) TestRepeatedJoinPoolDistinctDenom() {
 	for i := 1; i <= denomNumber; i++ {
 		randToken := "randToken" + strconv.Itoa(i+1)
 		prevRandToken := "randToken" + strconv.Itoa(i)
-		coins := sdk.NewCoins(sdk.NewCoin(randToken, osmomath.NewInt(100)))
+		coins := sdk.NewCoins(sdk.NewCoin(randToken, hundredInt))
 
 		s.FundAcc(defaultAddr, coins)
 
 		poolAssets := []balancer.PoolAsset{
 			{
-				Weight: osmomath.NewInt(100),
-				Token:  sdk.NewCoin(prevRandToken, osmomath.NewInt(10)),
+				Weight: hundredInt,
+				Token:  sdk.NewCoin(prevRandToken, tenInt),
 			},
 			{
-				Weight: osmomath.NewInt(100),
-				Token:  sdk.NewCoin(randToken, osmomath.NewInt(10)),
+				Weight: hundredInt,
+				Token:  sdk.NewCoin(randToken, tenInt),
 			},
 		}
 		msg := balancer.NewMsgCreateBalancerPool(defaultAddr, defaultPoolParams, poolAssets, "")
 		_, err := s.App.PoolManagerKeeper.CreatePool(s.Ctx, msg)
+		s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(time.Millisecond))
 		s.Require().NoError(err)
 	}
 


### PR DESCRIPTION
This locally halves the time balancer tests take on my laptop. It takes 8s on CI. 
Old:
```
ok  	github.com/osmosis-labs/osmosis/v24/x/gamm/keeper	2.586s
```
New:
```
ok  	github.com/osmosis-labs/osmosis/v24/x/gamm/keeper	1.383s
```

This sped it up by doing two things. Noticing that we have two average gas tests that were (on my laptop) 75% of this time consumption. 
- Just reduced the number of samples needed for the first test. (10000 -> 5000)
- The second test creates many pools. The pool creation cost is dominated by some lockup incentives JSON marshal/unmarshal. We can reduce the size of each of these marshallings by just making every pool get created on a different block time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Optimized performance in certain tests by adjusting numerical parameters and introducing time adjustments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->