### PR TITLE
Remove SetupTest from the randomized TWAP hotloop

### DIFF
--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -861,8 +861,6 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 		weightB := osmomath.NewInt(int64(sdkrand.RandIntBetween(r, 1, 1000)))
 
 		s.Run(fmt.Sprintf("elapsedTimeMs=%d, weightA=%d, tokenASupply=%d, weightB=%d, tokenBSupply=%d", elapsedTimeMs, weightA, tokenASupply, weightB, tokenBSupply), func() {
-			s.SetupTest()
-
 			ctx := s.Ctx
 			app := s.App
 
@@ -877,7 +875,7 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 				},
 			}
 
-			s.PrepareCustomBalancerPool(assets, balancer.PoolParams{
+			poolId := s.PrepareCustomBalancerPool(assets, balancer.PoolParams{
 				SwapFee: osmomath.ZeroDec(),
 				ExitFee: osmomath.ZeroDec(),
 			})
@@ -890,10 +888,10 @@ func (s *TestSuite) TestGeometricTwapToNow_BalancerPool_Randomized() {
 
 			ctx = ctx.WithBlockTime(newTime)
 
-			spotPrice, err := app.GAMMKeeper.CalculateSpotPrice(ctx, 1, denom1, denom0)
+			spotPrice, err := app.GAMMKeeper.CalculateSpotPrice(ctx, poolId, denom1, denom0)
 			s.Require().NoError(err)
 
-			twap, err := app.TwapKeeper.GetGeometricTwapToNow(ctx, 1, denom0, denom1, oldTime)
+			twap, err := app.TwapKeeper.GetGeometricTwapToNow(ctx, poolId, denom0, denom1, oldTime)
 			s.Require().NoError(err)
 
 			osmomath.ErrTolerance{

--- a/x/twap/api_test.go
+++ b/x/twap/api_test.go
@@ -357,13 +357,14 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 			expectSpErr:  baseTime,
 		},
 	}
+	counter := uint64(0)
 	for name, test := range tests {
+		curPoolId := counter
 		s.Run(name, func() {
-			s.SetupTest()
-			s.preSetRecords(test.recordsToSet)
+			s.preSetRecordsWithPoolId(curPoolId, test.recordsToSet)
 			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
 
-			twap, err := s.twapkeeper.GetArithmeticTwap(s.Ctx, test.input.poolId,
+			twap, err := s.twapkeeper.GetArithmeticTwap(s.Ctx, curPoolId,
 				test.input.baseAssetDenom, test.input.quoteAssetDenom,
 				test.input.startTime, test.input.endTime)
 
@@ -376,6 +377,7 @@ func (s *TestSuite) TestGetArithmeticTwap() {
 			s.Require().NoError(err)
 			s.Require().Equal(test.expTwap, twap)
 		})
+		counter++
 	}
 }
 
@@ -577,16 +579,17 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 		},
 	}
 
+	counter := uint64(0)
 	for name, test := range tests {
+		curPoolId := counter // Capture the current value of the counter for use within the goroutine
 		s.Run(name, func() {
-			s.SetupTest()
-			s.preSetRecords(test.recordsToSet)
+			s.preSetRecordsWithPoolId(curPoolId, test.recordsToSet)
 			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
 
 			var twap osmomath.Dec
 			var err error
 
-			twap, err = s.twapkeeper.GetArithmeticTwap(s.Ctx, test.input.poolId,
+			twap, err = s.twapkeeper.GetArithmeticTwap(s.Ctx, curPoolId,
 				test.input.baseAssetDenom, test.input.quoteAssetDenom,
 				test.input.startTime, test.input.endTime)
 
@@ -598,6 +601,7 @@ func (s *TestSuite) TestGetArithmeticTwap_PruningRecordKeepPeriod() {
 			s.Require().NoError(err)
 			s.Require().Equal(test.expTwap, twap)
 		})
+		counter++
 	}
 }
 
@@ -757,17 +761,18 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 			expectedError: errSpotPrice,
 		},
 	}
+	counter := uint64(0)
 	for name, test := range tests {
+		curPoolId := counter
 		s.Run(name, func() {
-			s.SetupTest()
-			s.preSetRecords(test.recordsToSet)
+			s.preSetRecordsWithPoolId(curPoolId, test.recordsToSet)
 			s.Ctx = s.Ctx.WithBlockTime(test.ctxTime)
 
 			var twap osmomath.Dec
 			var err error
 
 			// test the values of `GetArithmeticTwapToNow` if bool in test field is true
-			twap, err = s.twapkeeper.GetArithmeticTwapToNow(s.Ctx, test.input.poolId,
+			twap, err = s.twapkeeper.GetArithmeticTwapToNow(s.Ctx, curPoolId,
 				test.input.baseAssetDenom, test.input.quoteAssetDenom,
 				test.input.startTime)
 
@@ -779,6 +784,7 @@ func (s *TestSuite) TestGetArithmeticTwapToNow() {
 			s.Require().NoError(err)
 			s.Require().Equal(test.expTwap, twap)
 		})
+		counter++
 	}
 }
 

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -324,6 +324,15 @@ func (s *TestSuite) preSetRecords(records []types.TwapRecord) {
 	}
 }
 
+// preSetRecords pre sets records on the twap keeper to the
+// given records. The records are updated to use the provided pool ID
+func (s *TestSuite) preSetRecordsWithPoolId(poolId uint64, records []types.TwapRecord) {
+	for _, record := range records {
+		record.PoolId = poolId
+		s.twapkeeper.StoreNewRecord(s.Ctx, record)
+	}
+}
+
 // getAllHistoricalRecordsForPool returns all historical records for a given pool.
 func (s *TestSuite) getAllHistoricalRecordsForPool(poolId uint64) []types.TwapRecord {
 	allRecords, err := s.twapkeeper.GetAllHistoricalPoolIndexedTWAPs(s.Ctx)

--- a/x/twap/listeners_test.go
+++ b/x/twap/listeners_test.go
@@ -342,7 +342,6 @@ func (s *TestSuite) TestPoolStateChange() {
 	}
 
 	for name, tc := range tests {
-		s.SetupTest()
 		s.Run(name, func() {
 			poolId := s.PrepareBalancerPoolWithCoins(tc.poolCoins...)
 


### PR DESCRIPTION
~almost halves TWAP setup time locally by removing SetupTest from a hot loop.

This takes 20.5s on CI.

Local times:
Old: `ok  	github.com/osmosis-labs/osmosis/v24/x/twap	2.474s`
New: `ok  	github.com/osmosis-labs/osmosis/v24/x/twap	1.466s`

Almost the entirety of the remaining time should be solved by #7918 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the testing process for calculating TWAP (Time Weighted Average Price) in Balancer Pools by introducing dynamic pool ID handling.
- **Tests**
	- Added a new method to pre-set records with a specified pool ID in the test suite.
	- Updated test function in listeners_test.go by removing unnecessary setup call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->