### PR TITLE
Lower the number of random tries we do on the sumtree.

### DIFF
--- a/osmoutils/sumtree/tree_test.go
+++ b/osmoutils/sumtree/tree_test.go
@@ -81,7 +81,7 @@ func (suite *TreeTestSuite) TestTreeInvariants() {
 	r := rand.New(rand.NewSource(seed))
 
 	// tested up to 2000
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 250; i++ {
 		// add a single element
 		key := make([]byte, r.Int()%20)
 		value := r.Uint64() % 100


### PR DESCRIPTION
Reduces the num pairs we test on save from 500 to 250. This results in a roughly 4x speedup in testing time. We expect this to save 15s off of CI testing time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Adjusted the iteration limit in `TestTreeInvariants` to enhance testing performance by reducing the range of elements processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->