### PR TITLE
Significantly speedup protorev tests. 

### DIFF
--- a/x/protorev/keeper/developer_fees_test.go
+++ b/x/protorev/keeper/developer_fees_test.go
@@ -128,7 +128,7 @@ func (suite *KeeperTestSuite) TestDistributeProfit() {
 
 	for _, tc := range cases {
 		suite.Run(tc.description, func() {
-			suite.SetupTest()
+			suite.SetupNoPools()
 
 			commAccount := suite.App.AppKeepers.AccountKeeper.GetModuleAddress(distributiontypes.ModuleName)
 			commBalanceBefore := suite.App.AppKeepers.BankKeeper.GetBalance(suite.Ctx, commAccount, tc.denom)

--- a/x/protorev/keeper/epoch_hook_test.go
+++ b/x/protorev/keeper/epoch_hook_test.go
@@ -18,7 +18,7 @@ func BenchmarkEpochHook(b *testing.B) {
 	// Setup the test suite
 	s := new(KeeperTestSuite)
 	s.SetT(&testing.T{})
-	s.SetupTest()
+	s.SetupPoolsTest()
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
@@ -37,6 +37,7 @@ func BenchmarkEpochHook(b *testing.B) {
 // again to only include the pools that have the highest liquidity. The pools are then checked to see if the pool IDs are correctly set in the
 // DenomPairToPool stores.
 func (s *KeeperTestSuite) TestEpochHook() {
+	s.SetupPoolsTest()
 	// All of the pools initialized in the setup function are available in keeper_test.go
 	// akash <-> types.OsmosisDenomination
 	// juno <-> types.OsmosisDenomination
@@ -172,7 +173,7 @@ func (s *KeeperTestSuite) TestUpdateHighestLiquidityPools() {
 		s.Run(tc.name, func() {
 			// SetupTest creates all the pools used in the ProtoRev test suite,
 			// including the pools with "epoch" prefixed denoms used in this test
-			s.SetupTest()
+			s.SetupPoolsTest()
 
 			err := s.App.ProtoRevKeeper.UpdateHighestLiquidityPools(s.Ctx, tc.inputBaseDenomPools)
 			s.Require().NoError(err)

--- a/x/protorev/keeper/grpc_query_test.go
+++ b/x/protorev/keeper/grpc_query_test.go
@@ -12,8 +12,6 @@ import (
 
 // TestParams tests the query for params
 func (s *KeeperTestSuite) TestParams() {
-	// TODO: Move query server to normal
-	s.SetupPoolsTest()
 	ctx := sdk.WrapSDKContext(s.Ctx)
 	expectedParams := s.App.ProtoRevKeeper.GetParams(s.Ctx)
 
@@ -266,7 +264,6 @@ func (s *KeeperTestSuite) TestGetProtoRevTokenPairArbRoutes() {
 
 // TestGetProtoRevAdminAccount tests the query to retrieve the admin account
 func (s *KeeperTestSuite) TestGetProtoRevAdminAccount() {
-	s.SetupPoolsTest()
 	req := &types.QueryGetProtoRevAdminAccountRequest{}
 	res, err := s.queryClient.GetProtoRevAdminAccount(sdk.WrapSDKContext(s.Ctx), req)
 	s.Require().NoError(err)
@@ -275,7 +272,6 @@ func (s *KeeperTestSuite) TestGetProtoRevAdminAccount() {
 
 // TestGetProtoRevDeveloperAccount tests the query to retrieve the developer account
 func (s *KeeperTestSuite) TestGetProtoRevDeveloperAccount() {
-	s.SetupPoolsTest()
 	// By default it should be empty
 	req := &types.QueryGetProtoRevDeveloperAccountRequest{}
 	res, err := s.queryClient.GetProtoRevDeveloperAccount(sdk.WrapSDKContext(s.Ctx), req)
@@ -294,7 +290,6 @@ func (s *KeeperTestSuite) TestGetProtoRevDeveloperAccount() {
 
 // TestGetProtoRevInfoByPoolType tests the query to retrieve the pool info
 func (s *KeeperTestSuite) TestGetProtoRevInfoByPoolType() {
-	s.SetupPoolsTest()
 	// Set the pool weights
 	poolInfo := types.InfoByPoolType{
 		Stable:       types.StablePoolInfo{Weight: 1},
@@ -314,7 +309,6 @@ func (s *KeeperTestSuite) TestGetProtoRevInfoByPoolType() {
 
 // TestGetProtoRevMaxPoolPointsPerTx tests the query to retrieve the max pool points per tx
 func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerTx() {
-	s.SetupPoolsTest()
 	// Set the max pool points per tx
 	maxPoolPointsPerTx := types.MaxPoolPointsPerTx - 1
 	err := s.App.AppKeepers.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, maxPoolPointsPerTx)
@@ -328,7 +322,6 @@ func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerTx() {
 
 // TestGetProtoRevMaxPoolPointsPerBlock tests the query to retrieve the max pool points per block
 func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerBlock() {
-	s.SetupPoolsTest()
 	// Set the max pool points per block
 	maxPoolPointsPerBlock := types.MaxPoolPointsPerBlock - 1
 	err := s.App.AppKeepers.ProtoRevKeeper.SetMaxPointsPerBlock(s.Ctx, maxPoolPointsPerBlock)
@@ -342,7 +335,6 @@ func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerBlock() {
 
 // TestGetProtoRevBaseDenoms tests the query to retrieve the base denoms
 func (s *KeeperTestSuite) TestGetProtoRevBaseDenoms() {
-	s.SetupPoolsTest()
 	// base denoms already set in setup
 	baseDenoms, err := s.App.AppKeepers.ProtoRevKeeper.GetAllBaseDenoms(s.Ctx)
 	s.Require().NoError(err)
@@ -355,7 +347,6 @@ func (s *KeeperTestSuite) TestGetProtoRevBaseDenoms() {
 
 // TestGetProtoRevEnabled tests the query to retrieve the enabled status of protorev
 func (s *KeeperTestSuite) TestGetProtoRevEnabledQuery() {
-	s.SetupPoolsTest()
 	// Set the enabled status
 	enabled := false
 	s.App.AppKeepers.ProtoRevKeeper.SetProtoRevEnabled(s.Ctx, enabled)
@@ -399,7 +390,6 @@ func (s *KeeperTestSuite) TestGetProtoRevPool() {
 
 // TestGetAllProtocolRevenue tests the query for all protocol revenue profits
 func (s *KeeperTestSuite) TestGetAllProtocolRevenueGRPCQuery() {
-	s.SetupPoolsTest()
 	baseDenom, err := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
 	s.Require().NoError(err)
 	communityPoolDenom := "Akash"

--- a/x/protorev/keeper/grpc_query_test.go
+++ b/x/protorev/keeper/grpc_query_test.go
@@ -12,6 +12,8 @@ import (
 
 // TestParams tests the query for params
 func (s *KeeperTestSuite) TestParams() {
+	// TODO: Move query server to normal
+	s.SetupPoolsTest()
 	ctx := sdk.WrapSDKContext(s.Ctx)
 	expectedParams := s.App.ProtoRevKeeper.GetParams(s.Ctx)
 
@@ -22,6 +24,7 @@ func (s *KeeperTestSuite) TestParams() {
 
 // TestGetProtoRevNumberOfTrades tests the query for number of trades
 func (s *KeeperTestSuite) TestGetProtoRevNumberOfTrades() {
+	s.SetupPoolsTest()
 	// Initially should throw an error
 	_, err := s.queryClient.GetProtoRevNumberOfTrades(sdk.WrapSDKContext(s.Ctx), &types.QueryGetProtoRevNumberOfTradesRequest{})
 	s.Require().Error(err)
@@ -52,6 +55,7 @@ func (s *KeeperTestSuite) TestGetProtoRevNumberOfTrades() {
 
 // TestGetProtoRevProfitsByDenom tests the query for profits by denom
 func (s *KeeperTestSuite) TestGetProtoRevProfitsByDenom() {
+	s.SetupPoolsTest()
 	req := &types.QueryGetProtoRevProfitsByDenomRequest{
 		Denom: types.OsmosisDenomination,
 	}
@@ -87,6 +91,7 @@ func (s *KeeperTestSuite) TestGetProtoRevProfitsByDenom() {
 
 // TestGetProtoRevAllProfits tests the query for all profits
 func (s *KeeperTestSuite) TestGetProtoRevAllProfits() {
+	s.SetupPoolsTest()
 	req := &types.QueryGetProtoRevAllProfitsRequest{}
 	res, err := s.queryClient.GetProtoRevAllProfits(sdk.WrapSDKContext(s.Ctx), req)
 	s.Require().NoError(err)
@@ -121,6 +126,7 @@ func (s *KeeperTestSuite) TestGetProtoRevAllProfits() {
 
 // TestGetProtoRevStatisticsByRoute tests the query for statistics by route
 func (s *KeeperTestSuite) TestGetProtoRevStatisticsByRoute() {
+	s.SetupPoolsTest()
 	// Request with no trades should return an error
 	req := &types.QueryGetProtoRevStatisticsByRouteRequest{
 		Route: []uint64{1, 2, 3},
@@ -171,6 +177,7 @@ func (s *KeeperTestSuite) TestGetProtoRevStatisticsByRoute() {
 
 // TestGetProtoRevAllRouteStatistics tests the query for all route statistics
 func (s *KeeperTestSuite) TestGetProtoRevAllRouteStatistics() {
+	s.SetupPoolsTest()
 	req := &types.QueryGetProtoRevAllRouteStatisticsRequest{}
 
 	res, err := s.queryClient.GetProtoRevAllRouteStatistics(sdk.WrapSDKContext(s.Ctx), req)
@@ -246,6 +253,7 @@ func (s *KeeperTestSuite) TestGetProtoRevAllRouteStatistics() {
 
 // TestGetProtoRevTokenPairArbRoutes tests the query to retrieve all token pair arb routes
 func (s *KeeperTestSuite) TestGetProtoRevTokenPairArbRoutes() {
+	s.SetupPoolsTest()
 	req := &types.QueryGetProtoRevTokenPairArbRoutesRequest{}
 	res, err := s.queryClient.GetProtoRevTokenPairArbRoutes(sdk.WrapSDKContext(s.Ctx), req)
 	s.Require().NoError(err)
@@ -258,6 +266,7 @@ func (s *KeeperTestSuite) TestGetProtoRevTokenPairArbRoutes() {
 
 // TestGetProtoRevAdminAccount tests the query to retrieve the admin account
 func (s *KeeperTestSuite) TestGetProtoRevAdminAccount() {
+	s.SetupPoolsTest()
 	req := &types.QueryGetProtoRevAdminAccountRequest{}
 	res, err := s.queryClient.GetProtoRevAdminAccount(sdk.WrapSDKContext(s.Ctx), req)
 	s.Require().NoError(err)
@@ -266,6 +275,7 @@ func (s *KeeperTestSuite) TestGetProtoRevAdminAccount() {
 
 // TestGetProtoRevDeveloperAccount tests the query to retrieve the developer account
 func (s *KeeperTestSuite) TestGetProtoRevDeveloperAccount() {
+	s.SetupPoolsTest()
 	// By default it should be empty
 	req := &types.QueryGetProtoRevDeveloperAccountRequest{}
 	res, err := s.queryClient.GetProtoRevDeveloperAccount(sdk.WrapSDKContext(s.Ctx), req)
@@ -284,6 +294,7 @@ func (s *KeeperTestSuite) TestGetProtoRevDeveloperAccount() {
 
 // TestGetProtoRevInfoByPoolType tests the query to retrieve the pool info
 func (s *KeeperTestSuite) TestGetProtoRevInfoByPoolType() {
+	s.SetupPoolsTest()
 	// Set the pool weights
 	poolInfo := types.InfoByPoolType{
 		Stable:       types.StablePoolInfo{Weight: 1},
@@ -303,6 +314,7 @@ func (s *KeeperTestSuite) TestGetProtoRevInfoByPoolType() {
 
 // TestGetProtoRevMaxPoolPointsPerTx tests the query to retrieve the max pool points per tx
 func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerTx() {
+	s.SetupPoolsTest()
 	// Set the max pool points per tx
 	maxPoolPointsPerTx := types.MaxPoolPointsPerTx - 1
 	err := s.App.AppKeepers.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, maxPoolPointsPerTx)
@@ -316,6 +328,7 @@ func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerTx() {
 
 // TestGetProtoRevMaxPoolPointsPerBlock tests the query to retrieve the max pool points per block
 func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerBlock() {
+	s.SetupPoolsTest()
 	// Set the max pool points per block
 	maxPoolPointsPerBlock := types.MaxPoolPointsPerBlock - 1
 	err := s.App.AppKeepers.ProtoRevKeeper.SetMaxPointsPerBlock(s.Ctx, maxPoolPointsPerBlock)
@@ -329,6 +342,7 @@ func (s *KeeperTestSuite) TestGetProtoRevMaxPoolPointsPerBlock() {
 
 // TestGetProtoRevBaseDenoms tests the query to retrieve the base denoms
 func (s *KeeperTestSuite) TestGetProtoRevBaseDenoms() {
+	s.SetupPoolsTest()
 	// base denoms already set in setup
 	baseDenoms, err := s.App.AppKeepers.ProtoRevKeeper.GetAllBaseDenoms(s.Ctx)
 	s.Require().NoError(err)
@@ -341,6 +355,7 @@ func (s *KeeperTestSuite) TestGetProtoRevBaseDenoms() {
 
 // TestGetProtoRevEnabled tests the query to retrieve the enabled status of protorev
 func (s *KeeperTestSuite) TestGetProtoRevEnabledQuery() {
+	s.SetupPoolsTest()
 	// Set the enabled status
 	enabled := false
 	s.App.AppKeepers.ProtoRevKeeper.SetProtoRevEnabled(s.Ctx, enabled)
@@ -361,6 +376,7 @@ func (s *KeeperTestSuite) TestGetProtoRevEnabledQuery() {
 
 // TestGetProtoRevPool tests the query for getting the highest liquidity pool stored
 func (s *KeeperTestSuite) TestGetProtoRevPool() {
+	s.SetupPoolsTest()
 	// Request without setting pool for the base denom and other denom should return an error
 	req := &types.QueryGetProtoRevPoolRequest{
 		BaseDenom:  "uosmo",
@@ -383,6 +399,7 @@ func (s *KeeperTestSuite) TestGetProtoRevPool() {
 
 // TestGetAllProtocolRevenue tests the query for all protocol revenue profits
 func (s *KeeperTestSuite) TestGetAllProtocolRevenueGRPCQuery() {
+	s.SetupPoolsTest()
 	baseDenom, err := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
 	s.Require().NoError(err)
 	communityPoolDenom := "Akash"

--- a/x/protorev/keeper/hooks_test.go
+++ b/x/protorev/keeper/hooks_test.go
@@ -130,7 +130,7 @@ func (s *KeeperTestSuite) TestSwapping() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 			tc.param.executeSwap()
 
 			routes, err := s.App.ProtoRevKeeper.GetSwapsToBackrun(s.Ctx)
@@ -235,7 +235,7 @@ func (s *KeeperTestSuite) TestLiquidityChanging() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 			tc.param.executeLiquidityProviding()
 
 			routes, err := s.App.ProtoRevKeeper.GetSwapsToBackrun(s.Ctx)
@@ -379,7 +379,7 @@ func (s *KeeperTestSuite) TestPoolCreation() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 			poolId := tc.param.executePoolCreation()
 			setPoolId, err := s.App.ProtoRevKeeper.GetPoolForDenomPair(s.Ctx, types.OsmosisDenomination, tc.param.matchDenom)
 
@@ -452,7 +452,7 @@ func (s *KeeperTestSuite) TestStoreSwap() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 
 			// Run any state preparation
 			tc.param.prepareState()
@@ -545,7 +545,7 @@ func (s *KeeperTestSuite) TestGetComparablePoolLiquidity() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 
 			// Create the pool
 			poolId := tc.param.executePoolCreation()
@@ -620,7 +620,7 @@ func (s *KeeperTestSuite) TestStoreJoinExitPoolSwaps() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 
 			// All pools are already created in the setup
 			s.App.ProtoRevKeeper.StoreJoinExitPoolSwaps(s.Ctx, s.TestAccs[0], tc.param.poolId, tc.param.denom, tc.param.isJoin)
@@ -832,7 +832,7 @@ func (s *KeeperTestSuite) TestCompareAndStorePool() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 
 			// Run any state preparation and get the pool id to compare to the stored pool
 			expectedStoredPoolId, comparePoolId := tc.param.prepareStateAndGetPoolIdToCompare()
@@ -879,7 +879,7 @@ func (s *KeeperTestSuite) TestAfterEpochEnd() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupPoolsTest()
 
 			// Set base denoms
 			baseDenoms := []types.BaseDenom{

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -58,7 +58,10 @@ func TestKeeperTestSuite(t *testing.T) {
 func (s *KeeperTestSuite) SetupNoPools() {
 	s.Setup()
 	s.setupParams()
-	s.Commit()
+
+	queryHelper := baseapp.NewQueryServerTestHelper(s.Ctx, s.App.InterfaceRegistry())
+	types.RegisterQueryServer(queryHelper, protorevkeeper.NewQuerier(*s.App.AppKeepers.ProtoRevKeeper))
+	s.queryClient = types.NewQueryClient(queryHelper)
 }
 
 func (s *KeeperTestSuite) SetupTest() {

--- a/x/protorev/keeper/keeper_test.go
+++ b/x/protorev/keeper/keeper_test.go
@@ -55,49 +55,21 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
-func (s *KeeperTestSuite) SetupTest() {
+func (s *KeeperTestSuite) SetupNoPools() {
 	s.Setup()
+	s.setupParams()
+	s.Commit()
+}
 
-	// Genesis on init should be the same as the default genesis
-	exportDefaultGenesis := s.App.ProtoRevKeeper.ExportGenesis(s.Ctx)
-	s.Require().Equal(exportDefaultGenesis, types.DefaultGenesis())
+func (s *KeeperTestSuite) SetupTest() {
+	s.SetupNoPools()
+}
 
-	// Init module state for testing (params may differ from default params)
-	s.App.ProtoRevKeeper.SetProtoRevEnabled(s.Ctx, true)
-	s.App.ProtoRevKeeper.SetDaysSinceModuleGenesis(s.Ctx, 0)
-	s.App.ProtoRevKeeper.SetLatestBlockHeight(s.Ctx, uint64(s.Ctx.BlockHeight()))
-	s.App.ProtoRevKeeper.SetPointCountForBlock(s.Ctx, 0)
+func (s *KeeperTestSuite) SetupPoolsTest() {
+	s.Setup()
+	s.setupParams()
 
-	// Configure max pool points per block. This roughly correlates to the ms of execution time protorev will
-	// take per block
-	if err := s.App.ProtoRevKeeper.SetMaxPointsPerBlock(s.Ctx, 100); err != nil {
-		panic(err)
-	}
-	// Configure max pool points per tx. This roughly correlates to the ms of execution time protorev will take
-	// per tx
-	if err := s.App.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, 18); err != nil {
-		panic(err)
-	}
-
-	// Configure the initial base denoms used for cyclic route building
-	baseDenomPriorities := []types.BaseDenom{
-		{
-			Denom:    types.OsmosisDenomination,
-			StepSize: osmomath.NewInt(1_000_000),
-		},
-		{
-			Denom:    "Atom",
-			StepSize: osmomath.NewInt(1_000_000),
-		},
-		{
-			Denom:    "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-			StepSize: osmomath.NewInt(1_000_000),
-		},
-	}
-	err := s.App.ProtoRevKeeper.SetBaseDenoms(s.Ctx, baseDenomPriorities)
-	s.Require().NoError(err)
-
-	encodingConfig := osmosisapp.MakeEncodingConfig()
+	encodingConfig := osmosisapp.GetEncodingConfig()
 	s.clientCtx = client.Context{}.
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithTxConfig(encodingConfig.TxConfig).
@@ -139,7 +111,6 @@ func (s *KeeperTestSuite) SetupTest() {
 		sdk.NewCoin("stake", osmomath.NewInt(9000000000000000000)),
 	)
 	s.fundAllAccountsWith()
-	s.Commit()
 
 	// Init pools
 	s.setUpPools()
@@ -149,14 +120,55 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.setUpTokenPairRoutes()
 	s.Commit()
 
-	// Set the Admin Account
-	s.adminAccount = apptesting.CreateRandomAccounts(1)[0]
-	err = protorev.HandleSetProtoRevAdminAccount(s.Ctx, *s.App.ProtoRevKeeper, &types.SetProtoRevAdminAccountProposal{Account: s.adminAccount.String()})
-	s.Require().NoError(err)
-
 	queryHelper := baseapp.NewQueryServerTestHelper(s.Ctx, s.App.InterfaceRegistry())
 	types.RegisterQueryServer(queryHelper, protorevkeeper.NewQuerier(*s.App.AppKeepers.ProtoRevKeeper))
 	s.queryClient = types.NewQueryClient(queryHelper)
+}
+
+func (s *KeeperTestSuite) setupParams() {
+	// Genesis on init should be the same as the default genesis
+	exportDefaultGenesis := s.App.ProtoRevKeeper.ExportGenesis(s.Ctx)
+	s.Require().Equal(exportDefaultGenesis, types.DefaultGenesis())
+
+	// Init module state for testing (params may differ from default params)
+	s.App.ProtoRevKeeper.SetProtoRevEnabled(s.Ctx, true)
+	s.App.ProtoRevKeeper.SetDaysSinceModuleGenesis(s.Ctx, 0)
+	s.App.ProtoRevKeeper.SetLatestBlockHeight(s.Ctx, uint64(s.Ctx.BlockHeight()))
+	s.App.ProtoRevKeeper.SetPointCountForBlock(s.Ctx, 0)
+
+	// Configure max pool points per block. This roughly correlates to the ms of execution time protorev will
+	// take per block
+	if err := s.App.ProtoRevKeeper.SetMaxPointsPerBlock(s.Ctx, 100); err != nil {
+		panic(err)
+	}
+	// Configure max pool points per tx. This roughly correlates to the ms of execution time protorev will take
+	// per tx
+	if err := s.App.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, 18); err != nil {
+		panic(err)
+	}
+
+	// Set the Admin Account
+	s.adminAccount = apptesting.CreateRandomAccounts(1)[0]
+	err := protorev.HandleSetProtoRevAdminAccount(s.Ctx, *s.App.ProtoRevKeeper, &types.SetProtoRevAdminAccountProposal{Account: s.adminAccount.String()})
+	s.Require().NoError(err)
+
+	// Configure the initial base denoms used for cyclic route building
+	baseDenomPriorities := []types.BaseDenom{
+		{
+			Denom:    types.OsmosisDenomination,
+			StepSize: osmomath.NewInt(1_000_000),
+		},
+		{
+			Denom:    "Atom",
+			StepSize: osmomath.NewInt(1_000_000),
+		},
+		{
+			Denom:    "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+			StepSize: osmomath.NewInt(1_000_000),
+		},
+	}
+	err = s.App.ProtoRevKeeper.SetBaseDenoms(s.Ctx, baseDenomPriorities)
+	s.Require().NoError(err)
 }
 
 // setUpPools sets up the pools needed for testing

--- a/x/protorev/keeper/posthandler_test.go
+++ b/x/protorev/keeper/posthandler_test.go
@@ -74,6 +74,7 @@ func BenchmarkFourHopHotRouteArb(b *testing.B) {
 }
 
 func (s *KeeperTestSuite) TestPostHandle() {
+	s.SetupPoolsTest()
 	type param struct {
 		trades              []types.Trade
 		expectedNumOfTrades osmomath.Int
@@ -706,7 +707,7 @@ func setUpBenchmarkSuite(msgs []sdk.Msg) (*KeeperTestSuite, authsigning.Tx, sdk.
 	// Create a new test suite
 	s := new(KeeperTestSuite)
 	s.SetT(&testing.T{})
-	s.SetupTest()
+	s.SetupPoolsTest()
 
 	// Set up the app to the correct state to run the test
 	s.Ctx = s.Ctx.WithGasMeter(sdk.NewInfiniteGasMeter())

--- a/x/protorev/keeper/protorev_test.go
+++ b/x/protorev/keeper/protorev_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestGetTokenPairArbRoutes tests the GetTokenPairArbRoutes function.
 func (s *KeeperTestSuite) TestGetTokenPairArbRoutes() {
+	s.SetupPoolsTest()
 	// Tests that we can properly retrieve all of the routes that were set up
 	for _, tokenPair := range s.tokenPairArbRoutes {
 		tokenPairArbRoutes, err := s.App.ProtoRevKeeper.GetTokenPairArbRoutes(s.Ctx, tokenPair.TokenIn, tokenPair.TokenOut)
@@ -25,6 +26,7 @@ func (s *KeeperTestSuite) TestGetTokenPairArbRoutes() {
 
 // TestGetAllTokenPairArbRoutes tests the GetAllTokenPairArbRoutes function.
 func (s *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
+	s.SetupPoolsTest()
 	// Tests that we can properly retrieve all of the routes that were set up
 	tokenPairArbRoutes, err := s.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(s.Ctx)
 
@@ -38,6 +40,7 @@ func (s *KeeperTestSuite) TestGetAllTokenPairArbRoutes() {
 
 // TestDeleteAllTokenPairArbRoutes tests the DeleteAllTokenPairArbRoutes function.
 func (s *KeeperTestSuite) TestDeleteAllTokenPairArbRoutes() {
+	s.SetupPoolsTest()
 	// Tests that we can properly retrieve all of the routes that were set up
 	tokenPairArbRoutes, err := s.App.ProtoRevKeeper.GetAllTokenPairArbRoutes(s.Ctx)
 
@@ -320,6 +323,7 @@ func (s *KeeperTestSuite) TestGetInfoByPoolType() {
 }
 
 func (s *KeeperTestSuite) TestGetAllProtocolRevenue() {
+	s.SetupPoolsTest()
 	baseDenom, err := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
 	s.Require().NoError(err)
 	communityPoolDenom := "Akash"

--- a/x/protorev/keeper/rebalance_test.go
+++ b/x/protorev/keeper/rebalance_test.go
@@ -231,6 +231,7 @@ var cwPoolRoute = poolmanagertypes.SwapAmountInRoutes{
 }
 
 func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
+	s.SetupPoolsTest()
 	type param struct {
 		route           poolmanagertypes.SwapAmountInRoutes
 		expectedAmtIn   osmomath.Int
@@ -418,6 +419,7 @@ func (s *KeeperTestSuite) TestFindMaxProfitRoute() {
 }
 
 func (s *KeeperTestSuite) TestExecuteTrade() {
+	s.SetupPoolsTest()
 	type param struct {
 		route          poolmanagertypes.SwapAmountInRoutes
 		inputCoin      sdk.Coin
@@ -580,6 +582,7 @@ func (s *KeeperTestSuite) TestExecuteTrade() {
 }
 
 func (s *KeeperTestSuite) TestIterateRoutes() {
+	s.SetupPoolsTest()
 	type paramm struct {
 		routes                     []poolmanagertypes.SwapAmountInRoutes
 		expectedMaxProfitAmount    osmomath.Int
@@ -688,6 +691,7 @@ func (s *KeeperTestSuite) TestIterateRoutes() {
 
 // Test logic that compares proftability of routes with different assets
 func (s *KeeperTestSuite) TestConvertProfits() {
+	s.SetupPoolsTest()
 	type param struct {
 		inputCoin           sdk.Coin
 		profit              osmomath.Int
@@ -788,8 +792,6 @@ func (s *KeeperTestSuite) TestRemainingPoolPointsForTx() {
 
 	for _, tc := range cases {
 		s.Run(tc.description, func() {
-			s.SetupTest()
-
 			err := s.App.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, tc.maxRoutesPerTx)
 			s.Require().NoError(err)
 
@@ -806,6 +808,7 @@ func (s *KeeperTestSuite) TestRemainingPoolPointsForTx() {
 }
 
 func (s *KeeperTestSuite) TestUpdateSearchRangeIfNeeded() {
+	s.SetupPoolsTest()
 	s.Run("Extended search on stable pools", func() {
 		route := keeper.RouteMetaData{
 			Route:    extendedRangeRoute,

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -130,7 +130,6 @@ func (s *KeeperTestSuite) TestBuildRoutes() {
 
 // TestBuildHighestLiquidityRoute tests the BuildHighestLiquidityRoute function
 func (s *KeeperTestSuite) TestBuildHighestLiquidityRoute() {
-	// TODO:
 	s.SetupPoolsTest()
 	cases := []struct {
 		description              string

--- a/x/protorev/keeper/routes_test.go
+++ b/x/protorev/keeper/routes_test.go
@@ -14,6 +14,7 @@ type TestRoute struct {
 
 // TestBuildRoutes tests the BuildRoutes function
 func (s *KeeperTestSuite) TestBuildRoutes() {
+	s.SetupPoolsTest()
 	cases := []struct {
 		description    string
 		inputDenom     string
@@ -129,6 +130,8 @@ func (s *KeeperTestSuite) TestBuildRoutes() {
 
 // TestBuildHighestLiquidityRoute tests the BuildHighestLiquidityRoute function
 func (s *KeeperTestSuite) TestBuildHighestLiquidityRoute() {
+	// TODO:
+	s.SetupPoolsTest()
 	cases := []struct {
 		description              string
 		swapDenom                string
@@ -243,6 +246,7 @@ func (s *KeeperTestSuite) TestBuildHighestLiquidityRoute() {
 
 // TestBuildTwoPoolRoute tests the BuildTwoPoolRoute function
 func (s *KeeperTestSuite) TestBuildTwoPoolRoute() {
+	s.SetupPoolsTest()
 	cases := []struct {
 		description   string
 		swapDenom     types.BaseDenom
@@ -336,6 +340,7 @@ func (s *KeeperTestSuite) TestBuildTwoPoolRoute() {
 
 // TestBuildHotRoutes tests the BuildHotRoutes function
 func (s *KeeperTestSuite) TestBuildHotRoutes() {
+	s.SetupPoolsTest()
 	cases := []struct {
 		description             string
 		swapIn                  string
@@ -416,6 +421,7 @@ func (s *KeeperTestSuite) TestBuildHotRoutes() {
 
 // TestCalculateRoutePoolPoints tests the CalculateRoutePoolPoints function
 func (s *KeeperTestSuite) TestCalculateRoutePoolPoints() {
+	s.SetupPoolsTest()
 	cases := []struct {
 		description             string
 		route                   poolmanagertypes.SwapAmountInRoutes
@@ -466,12 +472,10 @@ func (s *KeeperTestSuite) TestCalculateRoutePoolPoints() {
 		},
 	}
 
+	s.Require().NoError(s.App.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, 25))
+	s.Require().NoError(s.App.ProtoRevKeeper.SetMaxPointsPerBlock(s.Ctx, 100))
 	for _, tc := range cases {
 		s.Run(tc.description, func() {
-			s.SetupTest()
-			s.Require().NoError(s.App.ProtoRevKeeper.SetMaxPointsPerTx(s.Ctx, 25))
-			s.Require().NoError(s.App.ProtoRevKeeper.SetMaxPointsPerBlock(s.Ctx, 100))
-
 			routePoolPoints, err := s.App.ProtoRevKeeper.CalculateRoutePoolPoints(s.Ctx, tc.route)
 			if tc.expectedPass {
 				s.Require().NoError(err)


### PR DESCRIPTION
It no longer sets up all pools in every test.

Instead tests that need pool setups have to call a separate function

Locally takes my laptop from 27 seconds to 12 seconds, we will see what happens on CI. (Was 65s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
    - Enhanced testing infrastructure for more accurate simulation of pool setups.
- **Refactor**
    - Improved setup procedures for testing, focusing on more detailed pool configurations.
- **Chores**
    - Streamlined test setup processes to better reflect real-world scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->