### PR TITLE
Disable v16 and v17 upgrade tests

### DIFF
--- a/app/upgrades/v16/upgrades_test.go
+++ b/app/upgrades/v16/upgrades_test.go
@@ -1,7 +1,6 @@
 package v16_test
 
 import (
-	"fmt"
 	"testing"
 
 	cosmwasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -208,15 +207,16 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 		},
 	}
 
-	for _, tc := range testCases {
-		s.Run(fmt.Sprintf("Case %s", tc.name), func() {
-			s.SetupTest() // reset
+	_ = testCases
+	// for _, tc := range testCases {
+	// 	s.Run(fmt.Sprintf("Case %s", tc.name), func() {
+	// 		s.SetupTest() // reset
 
-			tc.pre_upgrade()
-			tc.upgrade()
-			tc.post_upgrade()
-		})
-	}
+	// 		tc.pre_upgrade()
+	// 		tc.upgrade()
+	// 		tc.post_upgrade()
+	// 	})
+	// }
 }
 
 func verifyProtorevUpdateSuccess(s *UpgradeTestSuite) {

--- a/app/upgrades/v17/upgrades_test.go
+++ b/app/upgrades/v17/upgrades_test.go
@@ -505,13 +505,13 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 			},
 		},
 	}
+	_ = testCases
+	// for _, tc := range testCases {
+	// 	s.Run(fmt.Sprintf("Case %s", tc.name), func() {
+	// 		s.SetupTest() // reset
 
-	for _, tc := range testCases {
-		s.Run(fmt.Sprintf("Case %s", tc.name), func() {
-			s.SetupTest() // reset
-
-			expectedCoinsUsedInUpgradeHandler, lastPoolID := tc.pre_upgrade(&s.App.AppKeepers)
-			tc.upgrade(&s.App.AppKeepers, expectedCoinsUsedInUpgradeHandler, lastPoolID)
-		})
-	}
+	// 		expectedCoinsUsedInUpgradeHandler, lastPoolID := tc.pre_upgrade(&s.App.AppKeepers)
+	// 		tc.upgrade(&s.App.AppKeepers, expectedCoinsUsedInUpgradeHandler, lastPoolID)
+	// 	})
+	// }
 }


### PR DESCRIPTION
Disables the v17 upgrade tests, which were taking 25s in CI, 6seconds locally.

Ditto for v16, at 4-6s in CI, like .8s locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Temporarily disabled execution of upgrade-related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->