### PR TITLE
chore: push rc tags to docker

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -29,7 +29,7 @@ name: Push Docker Images
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-iavl-v1"
 
 env:
@@ -43,30 +43,24 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     if: ${{ !contains(github.ref_name, 'iavl') }}
     steps:
-      -
-        name: Check out the repo
+      - name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Find go version
+      - name: Find go version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-      -
-        name: Parse tag
+      - name: Parse tag
         id: tag
         run: |
           VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
@@ -78,8 +72,7 @@ jobs:
           echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
           echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
       # Distroless Docker image (default)
-      -
-        name: Build and push (distroless)
+      - name: Build and push (distroless)
         id: build_push_distroless
         uses: docker/build-push-action@v5
         with:
@@ -100,8 +93,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-distroless
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-distroless
       # Distroless nonroot Docker image
-      -
-        name: Build and push (nonroot)
+      - name: Build and push (nonroot)
         id: build_push_nonroot
         uses: docker/build-push-action@v5
         with:
@@ -119,8 +111,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-nonroot
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-nonroot
       # Alpine Docker image
-      -
-        name: Build and push (alpine)
+      - name: Build and push (alpine)
         id: build_push_alpine
         uses: docker/build-push-action@v5
         with:
@@ -137,8 +128,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-alpine
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine
-      -
-        if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
+      - if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
         name: Build and push (e2e-chain-init)
         uses: docker/build-push-action@v5
         with:
@@ -157,30 +147,24 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     if: ${{ contains(github.ref_name, 'iavl') }}
     steps:
-      -
-        name: Check out the repo
+      - name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Find go version
+      - name: Find go version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-      -
-        name: Parse tag
+      - name: Parse tag
         id: tag
         run: |
           VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
@@ -192,8 +176,7 @@ jobs:
           echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
           echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
       # Distroless Docker image (default)
-      -
-        name: Build and push (distroless)
+      - name: Build and push (distroless)
         id: build_push_distroless
         uses: docker/build-push-action@v5
         with:
@@ -212,8 +195,7 @@ jobs:
             # osmosis:X.Y.Z-iavl-v1-distroless
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-distroless
       # Distroless nonroot Docker image
-      -
-        name: Build and push (nonroot)
+      - name: Build and push (nonroot)
         id: build_push_nonroot
         uses: docker/build-push-action@v5
         with:
@@ -230,8 +212,7 @@ jobs:
             # osmosis:X.Y.Z-iavl-v1-nonroot
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-nonroot
       # Alpine Docker image
-      -
-        name: Build and push (alpine)
+      - name: Build and push (alpine)
         id: build_push_alpine
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We tend to get caught in a spot in between an upgrade where we are unable to set up the next upgrade handler until the docker tag is created for the upcoming version. RC tags being published to docker hub will allow this (we also use RC tags for testnet so seems like it makes sense to publish these here anyway)