### PR TITLE
feat: add arm support

### DIFF
--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -28,37 +28,44 @@ env:
   OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY: osmolabs/osmosis-e2e-init-chain
 
 jobs:
-  docker:
+  push-docker-images:
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
-      - name: Check out repo
+      -
+        name: Check out repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      -
+        name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Find go version
+      -
+        name: Find go version
         run: |
           GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-      - name: Create Docker Image Tag for release candidate
+      -
+        name: Create Docker Image Tag for release candidate
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           GITHUB_TAG=${{ github.ref_name }}
           echo "DOCKER_IMAGE_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
           echo "OSMOSIS_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-      - name: Create Docker Image Tag for vN.x branch
+      -
+        name: Create Docker Image Tag for vN.x branch
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)
           echo "DOCKER_IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
           echo "OSMOSIS_VERSION=${{ github.ref_name }}-$SHORT_SHA" >> $GITHUB_ENV
-      - name: Build and Push Docker Images
+      -
+        name: Build and Push Docker Images
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile
@@ -72,13 +79,78 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           tags: |
             ${{ env.OSMOSIS_DEV_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
-      - name: Build and Push E2E Init Docker Images
+      -
+        name: Build and Push E2E Init Docker Images
         uses: docker/build-push-action@v5
         with:
           file: tests/e2e/initialization/init.Dockerfile
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          build-args: |
+            E2E_SCRIPT_NAME=chain
+          tags: |
+            ${{ env.OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
+
+  push-docker-images-arm:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+      -
+        name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Find go version
+        run: |
+          GO_VERSION=$(cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+      -
+        name: Create Docker Image Tag for release candidate
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          GITHUB_TAG=${{ github.ref_name }}
+          echo "DOCKER_IMAGE_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
+          echo "OSMOSIS_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+      -
+        name: Create Docker Image Tag for vN.x branch
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)
+          echo "DOCKER_IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
+          echo "OSMOSIS_VERSION=${{ github.ref_name }}-$SHORT_SHA" >> $GITHUB_ENV
+      -
+        name: Build and Push Docker Images
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/arm64
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_ALPINE }}
+            GIT_VERSION=${{ env.OSMOSIS_VERSION }}
+            GIT_COMMIT=${{ github.sha }}
+          tags: |
+            ${{ env.OSMOSIS_DEV_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
+      -
+        name: Build and Push E2E Init Docker Images
+        uses: docker/build-push-action@v5
+        with:
+          file: tests/e2e/initialization/init.Dockerfile
+          context: .
+          push: true
+          platforms: linux/arm64
           build-args: |
             E2E_SCRIPT_NAME=chain
           tags: |


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces ARM support for development Docker images. We utilize `buildjet-2vcpu-ubuntu-2204-arm` for native ARM builds, eliminating the need for QEMU virtualization and resulting in faster build times. 
If this approach is validated, it can be extended to production images as well.

## Testing and Verifying

Manually verify this change after a push to `v24.x` branch.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A