### PR TITLE
fix: update all migrated whitewhale contracts to code id 641

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#7951](https://github.com/osmosis-labs/osmosis/pull/7951) Only migrate selected cl incentives
 * [#7938](https://github.com/osmosis-labs/osmosis/pull/7938) Add missing swap events for missing swap event for cw pools.
 * [#7957](https://github.com/osmosis-labs/osmosis/pull/7957) Update to the latest version of ibc-go
+* [#7966](https://github.com/osmosis-labs/osmosis/pull/7966) Update all governance migrated white whale pools to code id 641
 
 ### SDK
 

--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -75,7 +75,7 @@ func CreateUpgradeHandler(
 		// However, there was a problem in the migration logic where the CosmWasmpool state CodeId did not get updated.
 		// As a result, the CodeID for the contract that is tracked in x/wasmd was migrated correctly. However, the code ID that we track in the x/cosmwasmpool state did not.
 		// Therefore, we should perform a migration for each of the hardcoded white whale pools.
-		poolIds := []uint64{1463, 1462, 1461}
+		poolIds := []uint64{1584, 1575, 1514, 1463, 1462, 1461}
 		for _, poolId := range poolIds {
 			pool, err := keepers.CosmwasmPoolKeeper.GetPool(ctx, poolId)
 			if err != nil {
@@ -89,13 +89,13 @@ func CreateUpgradeHandler(
 					ActualPool: pool,
 				}
 			}
-			if cwPool.GetCodeId() != 503 {
+			if cwPool.GetCodeId() != 503 && cwPool.GetCodeId() != 572 {
 				ctx.Logger().Error("Pool has incorrect code id", "poolId", poolId, "codeId", cwPool.GetCodeId())
 				return nil, cwpooltypes.InvalidPoolTypeError{
 					ActualPool: pool,
 				}
 			}
-			cwPool.SetCodeId(572)
+			cwPool.SetCodeId(641)
 			keepers.CosmwasmPoolKeeper.SetPool(ctx, cwPool)
 		}
 

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -255,7 +255,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	//
 
 	// Test that the white whale pools have been updated
-	s.requirePoolsHaveCodeId(whiteWhalePoolIds, 572)
+	s.requirePoolsHaveCodeId(whiteWhalePoolIds, 641)
 
 	// TXFEES Tests
 	//


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Since whitewhale have migrated their contracts twice, we need to upgrade all code ids for whitewhale contracts to code id 641

## Testing and Verifying

test using an `in-place-testnet`

what it looked like before
```
osmosisd q poolmanager pool 1584 --node https://rpc.osmosis.zone:443
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "572"
  contract_address: osmo1w2sdnptx8jt4vuugcauv6tj3c2syjay5rx2mxalngn7m2cywllsq6xt64k
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xbmtqY2s3Nzc0c2Vtc2xxazZmOG4wNThtNGd3Y3c1c3BxdHphMGhyamY4ZTJrc2huNHg2c3ZqcmMwbSJ9
  pool_id: "1584"

osmosisd q poolmanager pool 1575 --node https://rpc.osmosis.zone:443
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "572"
  contract_address: osmo1hnlw8ajwhgg7rsyke2t34uknp4jjcmm23zeygsu7n8cwjqnt2jsqju3nz4
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xM2M1azJ3eHEzY3g1eGFucW5xamR5cnd2Z3cwcXM4ZWE3azhjOWR6ZGRkbHRoZzU1c3VocXB2am5xNyJ9
  pool_id: "1575"

osmosisd q poolmanager pool 1514 --node https://rpc.osmosis.zone:443
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "572"
  contract_address: osmo1g883rt8ytjlhawxey39m3w90nyaxg2vfmlfh6jvnv9ec3py2hgxq9qdz53
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xNjkydGx1d3p6bW54NTZ0bTV2N3Iwbjh2NWZnMzJucmQ5bnV1a3A5ano0NThhcDd3bWNsczljejIwbSJ9
  pool_id: "1514"

osmosisd q poolmanager pool 1463 --node https://rpc.osmosis.zone:443
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "503"
  contract_address: osmo184utpa0q2x5d79ctpewwvskea50x7tr3fkgj7ge2r0uavhqexququsj3xq
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xOHIzNWx1eXlmcXA3anRlcjZqYzkzdnpoZnQ1empndnNndDJ0Z3g3NnFlejJscGpwemZ4cXd4NHluayJ9
  pool_id: "1463"

osmosisd q poolmanager pool 1462 --node https://rpc.osmosis.zone:443
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "503"
  contract_address: osmo1suf8z9ypyv3kk4egr7plde00dfetw7rcm4m9ecut7x3720z8l46q23663a
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xdzhlMnd5emhyZzN5NWdoZTl5ZzB4bjB1NzU0OGU2Mjd6czd4YWhmdm41bDYzcnkyeDh6c3RhcmF4cyJ9
  pool_id: "1462"

osmosisd q poolmanager pool 1461 --node https://rpc.osmosis.zone:443
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "503"
  contract_address: osmo14zdnsp658g6tf7s5863ygeuj9ce5g00szud3tup6sqpwhuxmdwusc2eq7v
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xNjkydGx1d3p6bW54NTZ0bTV2N3Iwbjh2NWZnMzJucmQ5bnV1a3A5ano0NThhcDd3bWNsczljejIwbSJ9
  pool_id: "1461"
```

what it looks like after
```
osmosisd q poolmanager pool 1461                                    
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "641"
  contract_address: osmo14zdnsp658g6tf7s5863ygeuj9ce5g00szud3tup6sqpwhuxmdwusc2eq7v
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xNjkydGx1d3p6bW54NTZ0bTV2N3Iwbjh2NWZnMzJucmQ5bnV1a3A5ano0NThhcDd3bWNsczljejIwbSJ9
  pool_id: "1461"

osmosisd q poolmanager pool 1462                                    
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "641"
  contract_address: osmo1suf8z9ypyv3kk4egr7plde00dfetw7rcm4m9ecut7x3720z8l46q23663a
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xdzhlMnd5emhyZzN5NWdoZTl5ZzB4bjB1NzU0OGU2Mjd6czd4YWhmdm41bDYzcnkyeDh6c3RhcmF4cyJ9
  pool_id: "1462"

osmosisd q poolmanager pool 1514                                    
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "641"
  contract_address: osmo1g883rt8ytjlhawxey39m3w90nyaxg2vfmlfh6jvnv9ec3py2hgxq9qdz53
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xNjkydGx1d3p6bW54NTZ0bTV2N3Iwbjh2NWZnMzJucmQ5bnV1a3A5ano0NThhcDd3bWNsczljejIwbSJ9
  pool_id: "1514"

osmosisd q poolmanager pool 1575                                    
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "641"
  contract_address: osmo1hnlw8ajwhgg7rsyke2t34uknp4jjcmm23zeygsu7n8cwjqnt2jsqju3nz4
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xM2M1azJ3eHEzY3g1eGFucW5xamR5cnd2Z3cwcXM4ZWE3azhjOWR6ZGRkbHRoZzU1c3VocXB2am5xNyJ9
  pool_id: "1575"

osmosisd q poolmanager pool 1584                                    
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "641"
  contract_address: osmo1w2sdnptx8jt4vuugcauv6tj3c2syjay5rx2mxalngn7m2cywllsq6xt64k
  instantiate_msg: eyJ3aGl0ZV93aGFsZV9wb29sIjogIm9zbW8xbmtqY2s3Nzc0c2Vtc2xxazZmOG4wNThtNGd3Y3c1c3BxdHphMGhyamY4ZTJrc2huNHg2c3ZqcmMwbSJ9
  pool_id: "1584"
```

Or unit test by:

- `cd app/upgrades/v24`
- `go test ./... -cover`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the upgrade handler to support a wider range of pool IDs and introduced a new code ID comparison logic for migrations.
- **Tests**
	- Updated tests to reflect the new code ID values for specific pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->