### PR TITLE
additional context for fee on 'create-pool'

### DIFF
--- a/x/gamm/README.md
+++ b/x/gamm/README.md
@@ -281,7 +281,8 @@ The configuration json file contains the following parameters:
 :::
 
 ::: warning
-There is now a 100 OSMO fee for creating pools.
+There is now a 100 OSMO fee for creating pools. 
+This is separate from tx fees and is spent from the creating wallet automatically.
 :::
 
 ### Join pool


### PR DESCRIPTION
Added clarity around the fee when creating pool. [Some are mistakenly specifying '--fees 100000000uusdc' here.]
Equivalent change to docs site to immediately follow. [link below]

## What is the purpose of the change

Streamline pool creation.

## Testing and Verifying

Added a line describing that it is automated.

## Documentation and Release Note

  - [ no ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ no ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ `osmosis/tree/main/x/gamm#create-pool/README.md` ] Specification
  - [ `https://github.com/osmosis-labs/docs/blob/main/docs/overview/integrate/pool-setup.md` ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A