### PR TITLE
Delete some legacy code for delaying when lockup unbonds are possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Breaking
 
+* [#8030](https://github.com/osmosis-labs/osmosis/pull/8030) Delete legacy behavior where lockups could not unbond at very small block heights on a testnet.
+
 ### State Compatible
 
 * [#8006](https://github.com/osmosis-labs/osmosis/pull/8006) Speedup many BigDec operations

--- a/x/lockup/abci.go
+++ b/x/lockup/abci.go
@@ -14,13 +14,8 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 
 // Called every block to automatically unlock matured locks.
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) []abci.ValidatorUpdate {
-	// disable automatic withdraw before specific block height
-	// it is actually for testing with legacy
-	MinBlockHeightToBeginAutoWithdrawing := int64(6)
-	if ctx.BlockHeight() < MinBlockHeightToBeginAutoWithdrawing {
-		return []abci.ValidatorUpdate{}
-	}
-
+	// TODO: Change this logic to "know" when the next unbonding time is, and only unlock at that time.
+	// At each unbond, do an iterate to find the next unbonding time and wait until then.
 	// delete synthetic locks matured before lockup deletion
 	k.DeleteAllMaturedSyntheticLocks(ctx)
 


### PR DESCRIPTION
I have no idea why this was here. It could affect testnets, but will not affect mainnet. 

Also remark a TODO for improving the lockup speed logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the logic for unlocking matured locks to defer until the next unbonding time, enhancing the processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->