### PR TITLE
Delete TWAP deprecated pruning handler

### DIFF
--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -53,7 +53,7 @@ func CreateUpgradeHandler(
 		// Now that the TWAP keys are refactored, we can delete all time indexed TWAPs
 		// since we only need the pool indexed TWAPs. We set the is pruning store value to true
 		// and spread the pruning time across multiple blocks to avoid a single block taking too long.
-		keepers.TwapKeeper.SetDeprecatedHistoricalTWAPsIsPruning(ctx)
+		// keepers.TwapKeeper.SetDeprecatedHistoricalTWAPsIsPruning(ctx)
 
 		// Set the new min value for distribution for the incentives module.
 		// https://www.mintscan.io/osmosis/proposals/733

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -207,10 +207,10 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	s.App.EndBlocker(s.Ctx, abci.RequestEndBlock{})
 
 	// Since the prune limit was 1, 1 TWAP record indexed by time should be completely removed, leaving one more.
-	twapRecords, err = osmoutils.GatherValuesFromStorePrefix(store, []byte(HistoricalTWAPTimeIndexPrefix), types.ParseTwapFromBz)
-	s.Require().NoError(err)
-	s.Require().Len(twapRecords, 1)
-	s.Require().Equal(twapRecord2, twapRecords[0])
+	// twapRecords, err = osmoutils.GatherValuesFromStorePrefix(store, []byte(HistoricalTWAPTimeIndexPrefix), types.ParseTwapFromBz)
+	// s.Require().NoError(err)
+	// s.Require().Len(twapRecords, 1)
+	// s.Require().Equal(twapRecord2, twapRecords[0])
 
 	// TWAP records indexed by pool ID should be untouched.
 	twapRecords, err = s.App.TwapKeeper.GetAllHistoricalPoolIndexedTWAPsForPoolId(s.Ctx, twapRecord1.PoolId)

--- a/app/upgrades/v25/upgrades.go
+++ b/app/upgrades/v25/upgrades.go
@@ -23,6 +23,8 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 
+		keepers.TwapKeeper.DeleteDeprecatedHistoricalTWAPsIsPruning(ctx)
+
 		return migrations, nil
 	}
 }

--- a/x/twap/logic.go
+++ b/x/twap/logic.go
@@ -123,12 +123,6 @@ func (k Keeper) EndBlock(ctx sdk.Context) {
 			ctx.Logger().Error("Error pruning old twaps at the end block", err)
 		}
 	}
-
-	// If we still have more deprecated historical twaps to prune, then we prune up to the per block limit.
-	// TODO: Can remove this in the v25 upgrade or after.
-	if k.IsDeprecatedHistoricalTWAPsPruning(ctx) {
-		k.DeleteHistoricalTimeIndexedTWAPs(ctx)
-	}
 }
 
 // updateRecords updates all records for a given pool id.

--- a/x/twap/store.go
+++ b/x/twap/store.go
@@ -295,16 +295,10 @@ func (k Keeper) DeleteHistoricalTimeIndexedTWAPs(ctx sdk.Context) {
 	}
 }
 
-// IsDeprecatedHistoricalTWAPsPruning returns whether the deprecated historical twaps are being pruned.
-func (k Keeper) IsDeprecatedHistoricalTWAPsPruning(ctx sdk.Context) bool {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.DeprecatedHistoricalTWAPsIsPruningKey)
-	return bz != nil
-}
-
-// SetDeprecatedHistoricalTWAPsIsPruning sets the state entry that determines if we are still
+// DeleteDeprecatedHistoricalTWAPsIsPruning the state entry that determines if we are still
 // executing pruning logic in the end blocker.
-func (k Keeper) SetDeprecatedHistoricalTWAPsIsPruning(ctx sdk.Context) {
+// TODO: Remove this in v26
+func (k Keeper) DeleteDeprecatedHistoricalTWAPsIsPruning(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.DeprecatedHistoricalTWAPsIsPruningKey, sentinelExistsValue)
+	store.Delete(types.DeprecatedHistoricalTWAPsIsPruningKey)
 }

--- a/x/twap/types/keys.go
+++ b/x/twap/types/keys.go
@@ -26,7 +26,8 @@ const (
 )
 
 var (
-	PruningStateKey                       = []byte{0x01}
+	PruningStateKey = []byte{0x01}
+	// TODO: Delete in v26
 	DeprecatedHistoricalTWAPsIsPruningKey = []byte{0x02}
 	mostRecentTWAPsNoSeparator            = "recent_twap"
 	historicalTWAPPoolIndexNoSeparator    = "historical_pool_index"


### PR DESCRIPTION
Driveby delete the Deprecated isMigrationPruning variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the system to handle historical data more efficiently by modifying the pruning process.
- **Bug Fixes**
	- Fixed issues related to historical data management that could affect system performance.
- **Documentation**
	- Updated code comments to clarify future deprecations and modifications in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->