### PR TITLE
Remove duplicated one minus spread factor calculations

### DIFF
--- a/x/concentrated-liquidity/swapstrategy/export_test.go
+++ b/x/concentrated-liquidity/swapstrategy/export_test.go
@@ -3,9 +3,12 @@ package swapstrategy
 import "github.com/osmosis-labs/osmosis/osmomath"
 
 func ComputeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget bool, amountIn, amountSpecifiedRemaining, spreadFactor osmomath.Dec) osmomath.Dec {
-	return computeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget, amountIn, amountSpecifiedRemaining, spreadFactor)
+	oneMinusSpreadFactorGetter := func() osmomath.Dec {
+		return osmomath.OneDec().Sub(spreadFactor)
+	}
+	return computeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget, amountIn, amountSpecifiedRemaining, spreadFactor, oneMinusSpreadFactorGetter)
 }
 
 func ComputeSpreadRewardChargeFromAmountIn(amountIn, spreadFactor osmomath.Dec) osmomath.Dec {
-	return computeSpreadRewardChargeFromAmountIn(amountIn, spreadFactor)
+	return computeSpreadRewardChargeFromAmountIn(amountIn, spreadFactor, oneDec.Sub(spreadFactor))
 }

--- a/x/concentrated-liquidity/swapstrategy/spread_rewards.go
+++ b/x/concentrated-liquidity/swapstrategy/spread_rewards.go
@@ -6,6 +6,8 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
+type oneMinusSpreadFactorGetter func() osmomath.Dec
+
 // computeSpreadRewardChargePerSwapStepOutGivenIn returns the total spread factor charge per swap step given the parameters.
 // Assumes swapping for token out given token in.
 //
@@ -22,7 +24,7 @@ import (
 //
 // If spread factor is negative, it panics.
 // If spread factor is 0, returns 0. Otherwise, computes and returns the spread factor charge per step.
-func computeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget bool, amountIn, amountSpecifiedRemaining, spreadFactor osmomath.Dec) osmomath.Dec {
+func computeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget bool, amountIn, amountSpecifiedRemaining, spreadFactor osmomath.Dec, oneMinSf oneMinusSpreadFactorGetter) osmomath.Dec {
 	if spreadFactor.IsZero() {
 		return osmomath.ZeroDec()
 	} else if spreadFactor.IsNegative() {
@@ -37,7 +39,7 @@ func computeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget bool, amoun
 		// 2) or sqrtPriceLimit is reached
 		// In both cases, we charge the spread factor on the amount in actually consumed before
 		// hitting the target.
-		spreadRewardChargeTotal = computeSpreadRewardChargeFromAmountIn(amountIn, spreadFactor)
+		spreadRewardChargeTotal = computeSpreadRewardChargeFromAmountIn(amountIn, spreadFactor, oneMinSf())
 	} else {
 		// Otherwise, the current tick had enough liquidity to fulfill the swap
 		// and we ran out of amount remaining before reaching either the next tick or the limit.
@@ -59,6 +61,6 @@ func computeSpreadRewardChargePerSwapStepOutGivenIn(hasReachedTarget bool, amoun
 // at precision end. This is necessary to ensure that the spread factor charge is always
 // rounded in favor of the pool.
 // TODO: Change this fn to take in 1 - spreadFactor as it should already have been computed.
-func computeSpreadRewardChargeFromAmountIn(amountIn osmomath.Dec, spreadFactor osmomath.Dec) osmomath.Dec {
-	return amountIn.MulRoundUp(spreadFactor).QuoRoundupMut(osmomath.OneDec().SubMut(spreadFactor))
+func computeSpreadRewardChargeFromAmountIn(amountIn osmomath.Dec, spreadFactor, oneMinusSpreadFactor osmomath.Dec) osmomath.Dec {
+	return amountIn.MulRoundUp(spreadFactor).QuoRoundupMut(oneMinusSpreadFactor)
 }


### PR DESCRIPTION
Remove duplicated one minus spread factor calculations.

Since there are only a small number of spread factors, we may consider just putting this in RAM eventually. In a subsequent (state breaking PR) I also want to cache `spreadfactor / (1 - spreadfactor)` and use that directly in computations.

I'm interested in feedback if this is worth the code complexity. This PR: https://github.com/cosmos/cosmos-sdk/pull/20034 will also help speedup the quo logic in this code. (It will 50% reduce the QuoRoundUpMut time seen in prod)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved consistency in spread factor calculations across various trading strategies.
- **Refactor**
	- Updated functions related to spread reward charges to include new parameters and logic enhancements, enhancing accuracy and performance in trading calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->