### PR TITLE
More restrictive Circuit Breaker Auth

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -20,7 +20,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
 	authante "github.com/osmosis-labs/osmosis/v24/x/smart-account/ante"
-	authenticators "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
+	smartaccountkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
 
 	txfeeskeeper "github.com/osmosis-labs/osmosis/v24/x/txfees/keeper"
 	txfeestypes "github.com/osmosis-labs/osmosis/v24/x/txfees/types"
@@ -36,7 +36,7 @@ func NewAnteHandler(
 	wasmConfig wasmtypes.WasmConfig,
 	txCounterStoreKey storetypes.StoreKey,
 	accountKeeper ante.AccountKeeper,
-	authenticatorKeeper *authenticators.Keeper,
+	smartAccountKeeper *smartaccountkeeper.Keeper,
 	bankKeeper txfeestypes.BankKeeper,
 	txFeesKeeper *txfeeskeeper.Keeper,
 	spotPriceCalculator txfeestypes.SpotPriceCalculator,
@@ -71,7 +71,7 @@ func NewAnteHandler(
 		ante.NewValidateSigCountDecorator(accountKeeper),
 		// Both the signature verification and gas consumption functionality
 		// is enbedded in the authenticator decorator
-		authante.NewAuthenticatorDecorator(authenticatorKeeper, accountKeeper, signModeHandler),
+		authante.NewAuthenticatorDecorator(smartAccountKeeper, accountKeeper, signModeHandler),
 		ante.NewIncrementSequenceDecorator(accountKeeper),
 		ibcante.NewRedundantRelayDecorator(channelKeeper),
 		deductFeeDecorator,
@@ -92,7 +92,7 @@ func NewAnteHandler(
 		ante.NewValidateMemoDecorator(accountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(accountKeeper),
 		authante.NewCircuitBreakerDecorator(
-			authenticatorKeeper,
+			smartAccountKeeper,
 			authenticatorVerificationDecorator,
 			classicSignatureVerificationDecorator,
 		),

--- a/app/ante.go
+++ b/app/ante.go
@@ -19,7 +19,7 @@ import (
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
-	authante "github.com/osmosis-labs/osmosis/v24/x/smart-account/ante"
+	smartaccountante "github.com/osmosis-labs/osmosis/v24/x/smart-account/ante"
 	smartaccountkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
 
 	txfeeskeeper "github.com/osmosis-labs/osmosis/v24/x/txfees/keeper"
@@ -66,12 +66,12 @@ func NewAnteHandler(
 
 	// authenticatorVerificationDecorator is the new authenticator flow that's enbedded into the circuit breaker ante
 	authenticatorVerificationDecorator := sdk.ChainAnteDecorators(
-		authante.LimitFeePayerDecorator{},
-		authante.NewSetPubKeyDecorator(accountKeeper),
+		smartaccountante.LimitFeePayerDecorator{},
+		smartaccountante.NewSetPubKeyDecorator(accountKeeper),
 		ante.NewValidateSigCountDecorator(accountKeeper),
 		// Both the signature verification and gas consumption functionality
 		// is enbedded in the authenticator decorator
-		authante.NewAuthenticatorDecorator(smartAccountKeeper, accountKeeper, signModeHandler),
+		smartaccountante.NewAuthenticatorDecorator(smartAccountKeeper, accountKeeper, signModeHandler),
 		ante.NewIncrementSequenceDecorator(accountKeeper),
 		ibcante.NewRedundantRelayDecorator(channelKeeper),
 		deductFeeDecorator,
@@ -91,7 +91,7 @@ func NewAnteHandler(
 		ante.TxTimeoutHeightDecorator{},
 		ante.NewValidateMemoDecorator(accountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(accountKeeper),
-		authante.NewCircuitBreakerDecorator(
+		smartaccountante.NewCircuitBreakerDecorator(
 			smartAccountKeeper,
 			authenticatorVerificationDecorator,
 			classicSignatureVerificationDecorator,

--- a/app/app.go
+++ b/app/app.go
@@ -403,7 +403,7 @@ func NewOsmosisApp(
 		wasmConfig,
 		app.GetKey(wasmtypes.StoreKey),
 		app.AccountKeeper,
-		app.AuthenticatorKeeper,
+		app.SmartAccountKeeper,
 		app.BankKeeper,
 		app.TxFeesKeeper,
 		app.GAMMKeeper,
@@ -416,7 +416,7 @@ func NewOsmosisApp(
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetAnteHandler(anteHandler)
-	app.SetPostHandler(NewPostHandler(app.ProtoRevKeeper, app.AuthenticatorKeeper, app.AccountKeeper, encodingConfig.TxConfig.SignModeHandler()))
+	app.SetPostHandler(NewPostHandler(app.ProtoRevKeeper, app.SmartAccountKeeper, app.AccountKeeper, encodingConfig.TxConfig.SignModeHandler()))
 	app.SetEndBlocker(app.EndBlocker)
 
 	// Register snapshot extensions to enable state-sync for wasm.

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -79,8 +79,8 @@ import (
 	transfer "github.com/cosmos/ibc-go/v7/modules/apps/transfer"
 
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/authenticator"
-	authenticatorkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccountkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	_ "github.com/osmosis-labs/osmosis/v24/client/docs/statik"
 	owasm "github.com/osmosis-labs/osmosis/v24/wasmbinding"
@@ -172,7 +172,7 @@ type AppKeepers struct {
 	ValidatorSetPreferenceKeeper *valsetpref.Keeper
 	ConcentratedLiquidityKeeper  *concentratedliquidity.Keeper
 	CosmwasmPoolKeeper           *cosmwasmpool.Keeper
-	AuthenticatorKeeper          *authenticatorkeeper.Keeper
+	SmartAccountKeeper           *smartaccountkeeper.Keeper
 	AuthenticatorManager         *authenticator.AuthenticatorManager
 
 	// IBC modules
@@ -233,14 +233,16 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		authenticator.NewPartitionedAnyOfAuthenticator(appKeepers.AuthenticatorManager),
 		authenticator.NewPartitionedAllOfAuthenticator(appKeepers.AuthenticatorManager),
 	})
+	govModuleAddr := appKeepers.AccountKeeper.GetModuleAddress(govtypes.ModuleName)
 
-	authenticatorKeeper := authenticatorkeeper.NewKeeper(
+	smartAccountKeeper := smartaccountkeeper.NewKeeper(
 		appCodec,
-		appKeepers.keys[authenticatortypes.ManagerStoreKey],
-		appKeepers.GetSubspace(authenticatortypes.ModuleName),
+		appKeepers.keys[smartaccounttypes.ManagerStoreKey],
+		govModuleAddr,
+		appKeepers.GetSubspace(smartaccounttypes.ModuleName),
 		appKeepers.AuthenticatorManager,
 	)
-	appKeepers.AuthenticatorKeeper = &authenticatorKeeper
+	appKeepers.SmartAccountKeeper = &smartAccountKeeper
 
 	authzKeeper := authzkeeper.NewKeeper(
 		appKeepers.keys[authzkeeper.StoreKey],
@@ -779,7 +781,7 @@ func (appKeepers *AppKeepers) initParamsKeeper(appCodec codec.BinaryCodec, legac
 	paramsKeeper.Subspace(packetforwardtypes.ModuleName).WithKeyTable(packetforwardtypes.ParamKeyTable())
 	paramsKeeper.Subspace(cosmwasmpooltypes.ModuleName)
 	paramsKeeper.Subspace(ibchookstypes.ModuleName)
-	paramsKeeper.Subspace(authenticatortypes.ModuleName).WithKeyTable(authenticatortypes.ParamKeyTable())
+	paramsKeeper.Subspace(smartaccounttypes.ModuleName).WithKeyTable(smartaccounttypes.ParamKeyTable())
 	paramsKeeper.Subspace(txfeestypes.ModuleName)
 
 	return paramsKeeper
@@ -903,7 +905,7 @@ func KVStoreKeys() []string {
 		icqtypes.StoreKey,
 		packetforwardtypes.StoreKey,
 		cosmwasmpooltypes.StoreKey,
-		authenticatortypes.ManagerStoreKey,
-		authenticatortypes.AuthenticatorStoreKey,
+		smartaccounttypes.ManagerStoreKey,
+		smartaccounttypes.AuthenticatorStoreKey,
 	}
 }

--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -34,7 +34,7 @@ import (
 
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
-	authenticator "github.com/osmosis-labs/osmosis/v24/x/smart-account"
+	smartaccount "github.com/osmosis-labs/osmosis/v24/x/smart-account"
 
 	_ "github.com/osmosis-labs/osmosis/v24/client/docs/statik"
 	clclient "github.com/osmosis-labs/osmosis/v24/x/concentrated-liquidity/client"
@@ -132,5 +132,5 @@ var AppModuleBasics = []module.AppModuleBasic{
 	packetforward.AppModuleBasic{},
 	cosmwasmpoolmodule.AppModuleBasic{},
 	tendermint.AppModuleBasic{},
-	authenticator.AppModuleBasic{},
+	smartaccount.AppModuleBasic{},
 }

--- a/app/modules.go
+++ b/app/modules.go
@@ -65,8 +65,8 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils/partialord"
-	authenticator "github.com/osmosis-labs/osmosis/v24/x/smart-account"
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccount "github.com/osmosis-labs/osmosis/v24/x/smart-account"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	appparams "github.com/osmosis-labs/osmosis/v24/app/params"
 	_ "github.com/osmosis-labs/osmosis/v24/client/docs/statik"
@@ -135,7 +135,7 @@ var moduleAccountPermissions = map[string][]string{
 	valsetpreftypes.ModuleName:               {authtypes.Staking},
 	poolmanagertypes.ModuleName:              nil,
 	cosmwasmpooltypes.ModuleName:             nil,
-	authenticatortypes.ModuleName:            nil,
+	smartaccounttypes.ModuleName:             nil,
 }
 
 // appModules return modules to initialize module manager.
@@ -201,7 +201,7 @@ func appModules(
 		packetforward.NewAppModule(app.PacketForwardKeeper, app.GetSubspace(packetforwardtypes.ModuleName)),
 		cwpoolmodule.NewAppModule(appCodec, *app.CosmwasmPoolKeeper),
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
-		authenticator.NewAppModule(appCodec, *app.AuthenticatorKeeper),
+		smartaccount.NewAppModule(appCodec, *app.SmartAccountKeeper),
 	}
 }
 
@@ -269,7 +269,7 @@ func OrderInitGenesis(allModuleNames []string) []string {
 		protorevtypes.ModuleName,
 		twaptypes.ModuleName,
 		txfeestypes.ModuleName,
-		authenticatortypes.ModuleName,
+		smartaccounttypes.ModuleName,
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
 		paramstypes.ModuleName,

--- a/app/posthandler.go
+++ b/app/posthandler.go
@@ -6,7 +6,7 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
 	smartaccountkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
-	authpost "github.com/osmosis-labs/osmosis/v24/x/smart-account/post"
+	smartaccountpost "github.com/osmosis-labs/osmosis/v24/x/smart-account/post"
 
 	protorevkeeper "github.com/osmosis-labs/osmosis/v24/x/protorev/keeper"
 )
@@ -19,7 +19,7 @@ func NewPostHandler(
 ) sdk.PostHandler {
 	return sdk.ChainPostDecorators(
 		protorevkeeper.NewProtoRevDecorator(*protoRevKeeper),
-		authpost.NewAuthenticatorPostDecorator(
+		smartaccountpost.NewAuthenticatorPostDecorator(
 			smartAccountKeeper,
 			accountKeeper,
 			sigModeHandler,

--- a/app/posthandler.go
+++ b/app/posthandler.go
@@ -5,7 +5,7 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
-	authenticators "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
+	smartaccountkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
 	authpost "github.com/osmosis-labs/osmosis/v24/x/smart-account/post"
 
 	protorevkeeper "github.com/osmosis-labs/osmosis/v24/x/protorev/keeper"
@@ -13,14 +13,14 @@ import (
 
 func NewPostHandler(
 	protoRevKeeper *protorevkeeper.Keeper,
-	authenticatorKeeper *authenticators.Keeper,
+	smartAccountKeeper *smartaccountkeeper.Keeper,
 	accountKeeper *authkeeper.AccountKeeper,
 	sigModeHandler authsigning.SignModeHandler,
 ) sdk.PostHandler {
 	return sdk.ChainPostDecorators(
 		protorevkeeper.NewProtoRevDecorator(*protoRevKeeper),
 		authpost.NewAuthenticatorPostDecorator(
-			authenticatorKeeper,
+			smartAccountKeeper,
 			accountKeeper,
 			sigModeHandler,
 			// Add an empty handler here to enable a circuit breaker pattern

--- a/app/upgrades/v25/constants.go
+++ b/app/upgrades/v25/constants.go
@@ -5,7 +5,7 @@ import (
 
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v25 upgrade.
@@ -16,8 +16,8 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
 		Added: []string{
-			authenticatortypes.ManagerStoreKey,
-			authenticatortypes.AuthenticatorStoreKey,
+			smartaccounttypes.ManagerStoreKey,
+			smartaccounttypes.AuthenticatorStoreKey,
 		},
 		Deleted: []string{},
 	},

--- a/app/upgrades/v25/upgrades.go
+++ b/app/upgrades/v25/upgrades.go
@@ -26,10 +26,10 @@ func CreateUpgradeHandler(
 		keepers.TwapKeeper.DeleteDeprecatedHistoricalTWAPsIsPruning(ctx)
 
 		// Set the authenticator params in the store
-		authenticatorParams := keepers.AuthenticatorKeeper.GetParams(ctx)
+		authenticatorParams := keepers.SmartAccountKeeper.GetParams(ctx)
 		authenticatorParams.MaximumUnauthenticatedGas = 120_000
 		authenticatorParams.IsSmartAccountActive = false
-		keepers.AuthenticatorKeeper.SetParams(ctx, authenticatorParams)
+		keepers.SmartAccountKeeper.SetParams(ctx, authenticatorParams)
 
 		return migrations, nil
 	}

--- a/tests/osmosisibctesting/chain.go
+++ b/tests/osmosisibctesting/chain.go
@@ -12,7 +12,7 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 
@@ -302,7 +302,7 @@ func SignAuthenticatorMsg(
 		return nil, fmt.Errorf("expected authtx.ExtensionOptionsTxBuilder, got %T", baseTxBuilder)
 	}
 	if len(selectedAuthenticators) > 0 {
-		value, err := types.NewAnyWithValue(&authenticatortypes.TxExtension{
+		value, err := types.NewAnyWithValue(&smartaccounttypes.TxExtension{
 			SelectedAuthenticators: selectedAuthenticators,
 		})
 		if err != nil {
@@ -489,7 +489,7 @@ func SignAuthenticatorMsgWithCompoundSigs(
 		return nil, fmt.Errorf("expected authtx.ExtensionOptionsTxBuilder, got %T", baseTxBuilder)
 	}
 	if len(selectedAuthenticators) > 0 {
-		value, err := types.NewAnyWithValue(&authenticatortypes.TxExtension{
+		value, err := types.NewAnyWithValue(&smartaccounttypes.TxExtension{
 			SelectedAuthenticators: selectedAuthenticators,
 		})
 		if err != nil {

--- a/x/smart-account/ante/ante_test.go
+++ b/x/smart-account/ante/ante_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -77,7 +77,7 @@ func (s *AuthenticatorAnteSuite) SetupTest() {
 	}
 
 	s.AuthenticatorDecorator = ante.NewAuthenticatorDecorator(
-		s.OsmosisApp.AuthenticatorKeeper,
+		s.OsmosisApp.SmartAccountKeeper,
 		s.OsmosisApp.AccountKeeper,
 		s.EncodingConfig.TxConfig.SignModeHandler(),
 	)
@@ -139,7 +139,7 @@ func (s *AuthenticatorAnteSuite) TestSignatureVerificationWithAuthenticatorInSto
 	}
 	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
 
-	id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		"SignatureVerificationAuthenticator",
@@ -148,7 +148,7 @@ func (s *AuthenticatorAnteSuite) TestSignatureVerificationWithAuthenticatorInSto
 	s.Require().NoError(err)
 	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
-	id, err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
@@ -190,7 +190,7 @@ func (s *AuthenticatorAnteSuite) TestSignatureVerificationOutOfGas() {
 	}
 
 	// fee payer is authenticated
-	sigId, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	sigId, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
@@ -202,7 +202,7 @@ func (s *AuthenticatorAnteSuite) TestSignatureVerificationOutOfGas() {
 	alwaysHigher := testutils.TestingAuthenticator{Approve: testutils.Always, GasConsumption: 500_000}
 	s.OsmosisApp.AuthenticatorManager.RegisterAuthenticator(alwaysHigher)
 
-	excessGasId, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	excessGasId, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		alwaysHigher.Type(),
@@ -263,7 +263,7 @@ func (s *AuthenticatorAnteSuite) TestSpecificAuthenticator() {
 	}
 	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
 
-	sig1Id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	sig1Id, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
@@ -272,7 +272,7 @@ func (s *AuthenticatorAnteSuite) TestSpecificAuthenticator() {
 	s.Require().NoError(err)
 	s.Require().Equal(sig1Id, uint64(1), "Adding authenticator returning incorrect id")
 
-	sig2Id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	sig2Id, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
@@ -373,7 +373,7 @@ func GenTx(
 		return nil, fmt.Errorf("expected authtx.ExtensionOptionsTxBuilder, got %T", baseTxBuilder)
 	}
 	if len(selectedAuthenticators) > 0 {
-		value, err := types.NewAnyWithValue(&authenticatortypes.TxExtension{
+		value, err := types.NewAnyWithValue(&smartaccounttypes.TxExtension{
 			SelectedAuthenticators: selectedAuthenticators,
 		})
 		if err != nil {

--- a/x/smart-account/ante/circuit_breaker_test.go
+++ b/x/smart-account/ante/circuit_breaker_test.go
@@ -128,16 +128,16 @@ func (s *AuthenticatorCircuitBreakerAnteSuite) TestCircuitBreakerAnte() {
 
 	// Create a CircuitBreaker AnteDecorator
 	cbd := ante.NewCircuitBreakerDecorator(
-		s.OsmosisApp.AuthenticatorKeeper,
+		s.OsmosisApp.SmartAccountKeeper,
 		sdk.ChainAnteDecorators(mockTestAuthenticator),
 		sdk.ChainAnteDecorators(mockTestClassic),
 	)
 	anteHandler := sdk.ChainAnteDecorators(cbd)
 
 	// Deactivate smart accounts
-	params := s.OsmosisApp.AuthenticatorKeeper.GetParams(s.Ctx)
+	params := s.OsmosisApp.SmartAccountKeeper.GetParams(s.Ctx)
 	params.IsSmartAccountActive = false
-	s.OsmosisApp.AuthenticatorKeeper.SetParams(s.Ctx, params)
+	s.OsmosisApp.SmartAccountKeeper.SetParams(s.Ctx, params)
 
 	// Here we test when smart accounts are deactivated
 	ctx, err := anteHandler(s.Ctx, tx, false)
@@ -145,9 +145,9 @@ func (s *AuthenticatorCircuitBreakerAnteSuite) TestCircuitBreakerAnte() {
 	s.Require().Equal(int64(1), ctx.Priority(), "Should have disabled the full authentication flow")
 
 	// Reeactivate smart accounts
-	params = s.OsmosisApp.AuthenticatorKeeper.GetParams(ctx)
+	params = s.OsmosisApp.SmartAccountKeeper.GetParams(ctx)
 	params.IsSmartAccountActive = true
-	s.OsmosisApp.AuthenticatorKeeper.SetParams(ctx, params)
+	s.OsmosisApp.SmartAccountKeeper.SetParams(ctx, params)
 
 	// Here we test when smart accounts are active and there is not selected authenticator
 	ctx, err = anteHandler(ctx, tx, false)

--- a/x/smart-account/ante/limit_fee_payer_test.go
+++ b/x/smart-account/ante/limit_fee_payer_test.go
@@ -16,7 +16,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/ante"
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 )
 
 func (s *AuthenticatorAnteSuite) TestCustomFeePayerBlocked() {
@@ -36,7 +36,7 @@ func (s *AuthenticatorAnteSuite) TestCustomFeePayerBlocked() {
 	}
 	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
 
-	_, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	_, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		"SignatureVerificationAuthenticator",
@@ -44,7 +44,7 @@ func (s *AuthenticatorAnteSuite) TestCustomFeePayerBlocked() {
 	)
 	s.Require().NoError(err)
 
-	_, err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
@@ -141,7 +141,7 @@ func GenTxWithCustomFeePayer(
 		return nil, fmt.Errorf("expected authtx.ExtensionOptionsTxBuilder, got %T", baseTxBuilder)
 	}
 	if len(selectedAuthenticators) > 0 {
-		value, err := types.NewAnyWithValue(&authenticatortypes.TxExtension{
+		value, err := types.NewAnyWithValue(&smartaccounttypes.TxExtension{
 			SelectedAuthenticators: selectedAuthenticators,
 		})
 		if err != nil {

--- a/x/smart-account/authenticator/base_test.go
+++ b/x/smart-account/authenticator/base_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/authenticator"
 
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	"github.com/osmosis-labs/osmosis/v24/app"
 	"github.com/osmosis-labs/osmosis/v24/app/params"
@@ -132,7 +132,7 @@ func (s *BaseAuthenticatorSuite) GenSimpleTxWithSelectedAuthenticators(msgs []sd
 		return nil, fmt.Errorf("expected authtx.ExtensionOptionsTxBuilder, got %T", baseTxBuilder)
 	}
 	if len(selectedAuthenticators) > 0 {
-		value, err := types.NewAnyWithValue(&authenticatortypes.TxExtension{
+		value, err := types.NewAnyWithValue(&smartaccounttypes.TxExtension{
 			SelectedAuthenticators: selectedAuthenticators,
 		})
 		if err != nil {

--- a/x/smart-account/authenticator/composition_test.go
+++ b/x/smart-account/authenticator/composition_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/authenticator"
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/testutils"
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 )
 
 type AggregatedAuthenticatorsTest struct {
@@ -62,7 +62,7 @@ func (s *AggregatedAuthenticatorsTest) SetupTest() {
 		Confirm:        testutils.Always,
 	}
 	s.spyAuth = testutils.NewSpyAuthenticator(
-		s.OsmosisApp.GetKVStoreKey()[authenticatortypes.AuthenticatorStoreKey],
+		s.OsmosisApp.GetKVStoreKey()[smartaccounttypes.AuthenticatorStoreKey],
 	)
 
 	am.RegisterAuthenticator(s.AnyOfAuth)

--- a/x/smart-account/authenticator/spend_limits_test.go
+++ b/x/smart-account/authenticator/spend_limits_test.go
@@ -90,16 +90,16 @@ func (s *SpendLimitAuthenticatorTest) SetupTest() {
 	s.CosmwasmAuth = authenticator.NewCosmwasmAuthenticator(s.OsmosisApp.ContractKeeper, s.OsmosisApp.AccountKeeper, s.EncodingConfig.TxConfig.SignModeHandler(), s.OsmosisApp.AppCodec())
 
 	s.AlwaysPassAuth = testutils.TestingAuthenticator{Approve: testutils.Always, Confirm: testutils.Always, GasConsumption: 0}
-	s.OsmosisApp.AuthenticatorKeeper.AuthenticatorManager.RegisterAuthenticator(s.AlwaysPassAuth)
+	s.OsmosisApp.SmartAccountKeeper.AuthenticatorManager.RegisterAuthenticator(s.AlwaysPassAuth)
 
 	s.AuthenticatorAnteDecorator = ante.NewAuthenticatorDecorator(
-		s.OsmosisApp.AuthenticatorKeeper,
+		s.OsmosisApp.SmartAccountKeeper,
 		s.OsmosisApp.AccountKeeper,
 		s.EncodingConfig.TxConfig.SignModeHandler(),
 	)
 
 	s.AuthenticatorPostDecorator = post.NewAuthenticatorPostDecorator(
-		s.OsmosisApp.AuthenticatorKeeper,
+		s.OsmosisApp.SmartAccountKeeper,
 		s.OsmosisApp.AccountKeeper,
 		s.EncodingConfig.TxConfig.SignModeHandler(),
 		// Add an empty handler here to enable a circuit breaker pattern
@@ -157,7 +157,7 @@ func (s *SpendLimitAuthenticatorTest) TestSpendLimit() {
 	contractAddr := s.InstantiateContract(string(bz), codeId)
 
 	// add new authenticator
-	ak := s.OsmosisApp.AppKeepers.AuthenticatorKeeper
+	ak := s.OsmosisApp.AppKeepers.SmartAccountKeeper
 
 	authAcc := s.TestAccAddress[1]
 	authAccPriv := s.TestPrivKeys[1]

--- a/x/smart-account/integration_test.go
+++ b/x/smart-account/integration_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/osmosis-labs/osmosis/v24/app"
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -265,7 +265,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorState() {
 		Amount:      sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000_000_000_000)),
 	}
 
-	stateful := testutils.StatefulAuthenticator{KvStoreKey: s.app.GetKVStoreKey()[authenticatortypes.AuthenticatorStoreKey]}
+	stateful := testutils.StatefulAuthenticator{KvStoreKey: s.app.GetKVStoreKey()[smartaccounttypes.AuthenticatorStoreKey]}
 	s.app.AuthenticatorManager.RegisterAuthenticator(stateful)
 	_, err := s.app.SmartAccountKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), "Stateful", []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
@@ -291,7 +291,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorMultiMsg() {
 		Amount:      sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000)),
 	}
 
-	storeKey := s.app.GetKVStoreKey()[authenticatortypes.AuthenticatorStoreKey]
+	storeKey := s.app.GetKVStoreKey()[smartaccounttypes.AuthenticatorStoreKey]
 	maxAmount := testutils.MaxAmountAuthenticator{KvStoreKey: storeKey}
 	stateful := testutils.StatefulAuthenticator{KvStoreKey: storeKey}
 

--- a/x/smart-account/keeper/genesis_test.go
+++ b/x/smart-account/keeper/genesis_test.go
@@ -21,7 +21,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticatorWithId() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	err := s.App.AuthenticatorKeeper.AddAuthenticatorWithId(
+	err := s.App.SmartAccountKeeper.AddAuthenticatorWithId(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -30,7 +30,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticatorWithId() {
 	)
 	s.Require().NoError(err)
 
-	err = s.App.AuthenticatorKeeper.AddAuthenticatorWithId(
+	err = s.App.SmartAccountKeeper.AddAuthenticatorWithId(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -39,11 +39,11 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticatorWithId() {
 	)
 	s.Require().NoError(err)
 
-	authenticators, err := s.App.AuthenticatorKeeper.GetAuthenticatorDataForAccount(ctx, accAddress)
+	authenticators, err := s.App.SmartAccountKeeper.GetAuthenticatorDataForAccount(ctx, accAddress)
 	s.Require().NoError(err)
 	s.Require().Equal(len(authenticators), 2, "Getting authenticators returning incorrect data")
 
-	err = s.App.AuthenticatorKeeper.AddAuthenticatorWithId(
+	err = s.App.SmartAccountKeeper.AddAuthenticatorWithId(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -54,7 +54,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticatorWithId() {
 	s.Require().ErrorContains(err, "invalid secp256k1 public key size")
 
 	s.App.AuthenticatorManager.ResetAuthenticators()
-	err = s.App.AuthenticatorKeeper.AddAuthenticatorWithId(
+	err = s.App.SmartAccountKeeper.AddAuthenticatorWithId(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -78,7 +78,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAllAuthenticatorDataGenesis() {
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
 	for i := 1; i <= 5; i++ {
-		id, err := s.App.AuthenticatorKeeper.AddAuthenticator(
+		id, err := s.App.SmartAccountKeeper.AddAuthenticator(
 			ctx,
 			accAddress,
 			"SignatureVerificationAuthenticator",
@@ -88,7 +88,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAllAuthenticatorDataGenesis() {
 		s.Require().Equal(uint64(i), id)
 	}
 
-	authenticators, err := s.App.AuthenticatorKeeper.GetAllAuthenticatorData(ctx)
+	authenticators, err := s.App.SmartAccountKeeper.GetAllAuthenticatorData(ctx)
 	s.Require().NoError(err, "Error getting authenticator data")
 	s.Require().Equal(5, len(authenticators[0].Authenticators), "Getting authenticators returning incorrect data")
 	s.Require().Equal(accAddress.String(), authenticators[0].Address, "Authenticator Address is incorrect")

--- a/x/smart-account/keeper/keeper.go
+++ b/x/smart-account/keeper/keeper.go
@@ -27,9 +27,10 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 type Keeper struct {
-	storeKey   storetypes.StoreKey
-	cdc        codec.BinaryCodec
-	paramSpace paramtypes.Subspace
+	storeKey               storetypes.StoreKey
+	cdc                    codec.BinaryCodec
+	paramSpace             paramtypes.Subspace
+	CircuitBreakerGovernor sdk.AccAddress
 
 	AuthenticatorManager *authenticator.AuthenticatorManager
 }
@@ -37,6 +38,7 @@ type Keeper struct {
 func NewKeeper(
 	cdc codec.BinaryCodec,
 	managerStoreKey storetypes.StoreKey,
+	govModuleAddr sdk.AccAddress,
 	ps paramtypes.Subspace,
 	authenticatorManager *authenticator.AuthenticatorManager,
 ) Keeper {
@@ -46,10 +48,11 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		storeKey:             managerStoreKey,
-		cdc:                  cdc,
-		paramSpace:           ps,
-		AuthenticatorManager: authenticatorManager,
+		storeKey:               managerStoreKey,
+		cdc:                    cdc,
+		CircuitBreakerGovernor: govModuleAddr,
+		paramSpace:             ps,
+		AuthenticatorManager:   authenticatorManager,
 	}
 }
 

--- a/x/smart-account/keeper/keeper_test.go
+++ b/x/smart-account/keeper/keeper_test.go
@@ -47,7 +47,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticator() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	id, err := s.App.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -56,7 +56,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticator() {
 	s.Require().NoError(err, "Should successfully add a SignatureVerificationAuthenticator")
 	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
-	id, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"MessageFilterAuthenticator",
@@ -65,7 +65,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticator() {
 	s.Require().NoError(err, "Should successfully add a MessageFilterAuthenticator")
 	s.Require().Equal(id, uint64(2), "Adding authenticator returning incorrect id")
 
-	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -74,7 +74,7 @@ func (s *KeeperTestSuite) TestKeeper_AddAuthenticator() {
 	s.Require().Error(err, "Should have failed as OnAuthenticatorAdded fails")
 
 	s.App.AuthenticatorManager.ResetAuthenticators()
-	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"MessageFilterAuthenticator",
@@ -92,7 +92,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	_, err := s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err := s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -100,7 +100,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 	)
 	s.Require().NoError(err, "Should successfully add a SignatureVerificationAuthenticator")
 
-	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -108,7 +108,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 	)
 	s.Require().NoError(err, "Should successfully add a MessageFilterAuthenticator")
 
-	authenticators, err := s.App.AuthenticatorKeeper.GetAuthenticatorDataForAccount(ctx, accAddress)
+	authenticators, err := s.App.SmartAccountKeeper.GetAuthenticatorDataForAccount(ctx, accAddress)
 	s.Require().NoError(err)
 	s.Require().Equal(len(authenticators), 2, "Getting authenticators returning incorrect data")
 }
@@ -116,10 +116,10 @@ func (s *KeeperTestSuite) TestKeeper_GetAuthenticatorDataForAccount() {
 func (s *KeeperTestSuite) TestKeeper_GetAndSetAuthenticatorId() {
 	ctx := s.Ctx
 
-	authenticatorId := s.App.AuthenticatorKeeper.GetNextAuthenticatorId(ctx)
+	authenticatorId := s.App.SmartAccountKeeper.GetNextAuthenticatorId(ctx)
 	s.Require().Equal(uint64(1), authenticatorId, "Get authenticator id returned incorrect id")
 
-	authenticatorId = s.App.AuthenticatorKeeper.GetNextAuthenticatorId(ctx)
+	authenticatorId = s.App.SmartAccountKeeper.GetNextAuthenticatorId(ctx)
 	s.Require().Equal(uint64(1), authenticatorId, "Get authenticator id returned incorrect id")
 
 	// Set up account
@@ -128,7 +128,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAndSetAuthenticatorId() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	_, err := s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err := s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -136,10 +136,10 @@ func (s *KeeperTestSuite) TestKeeper_GetAndSetAuthenticatorId() {
 	)
 	s.Require().NoError(err, "Should successfully add a SignatureVerificationAuthenticator")
 
-	authenticatorId = s.App.AuthenticatorKeeper.GetNextAuthenticatorId(ctx)
+	authenticatorId = s.App.SmartAccountKeeper.GetNextAuthenticatorId(ctx)
 	s.Require().Equal(authenticatorId, uint64(2), "Get authenticator id returned incorrect id")
 
-	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -147,7 +147,7 @@ func (s *KeeperTestSuite) TestKeeper_GetAndSetAuthenticatorId() {
 	)
 	s.Require().NoError(err, "Should successfully add a MessageFilterAuthenticator")
 
-	authenticatorId = s.App.AuthenticatorKeeper.GetNextAuthenticatorId(ctx)
+	authenticatorId = s.App.SmartAccountKeeper.GetNextAuthenticatorId(ctx)
 	s.Require().Equal(authenticatorId, uint64(3), "Get authenticator id returned incorrect id")
 }
 
@@ -160,7 +160,7 @@ func (s *KeeperTestSuite) TestKeeper_GetSelectedAuthenticatorForAccount() {
 	priv := &secp256k1.PrivKey{Key: bz}
 	accAddress := sdk.AccAddress(priv.PubKey().Address())
 
-	_, err := s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err := s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"SignatureVerificationAuthenticator",
@@ -168,7 +168,7 @@ func (s *KeeperTestSuite) TestKeeper_GetSelectedAuthenticatorForAccount() {
 	)
 	s.Require().NoError(err, "Should successfully add a SignatureVerificationAuthenticator")
 
-	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"MessageFilterAuthenticator",
@@ -177,16 +177,16 @@ func (s *KeeperTestSuite) TestKeeper_GetSelectedAuthenticatorForAccount() {
 	s.Require().NoError(err, "Should successfully add a MessageFilterAuthenticator")
 
 	// Test getting a selected authenticator from the store
-	selectedAuthenticator, err := s.App.AuthenticatorKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2)
+	selectedAuthenticator, err := s.App.SmartAccountKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2)
 	s.Require().NoError(err)
 	s.Require().Equal(selectedAuthenticator.Authenticator.Type(), "MessageFilterAuthenticator", "Getting authenticators returning incorrect data")
 
-	selectedAuthenticator, err = s.App.AuthenticatorKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 1)
+	selectedAuthenticator, err = s.App.SmartAccountKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 1)
 	s.Require().NoError(err)
 	s.Require().Equal(selectedAuthenticator.Authenticator.Type(), "SignatureVerificationAuthenticator", "Getting authenticators returning incorrect data")
 	s.Require().Equal(selectedAuthenticator.Id, uint64(1), "Incorrect ID returned from store")
 
-	_, err = s.App.AuthenticatorKeeper.AddAuthenticator(
+	_, err = s.App.SmartAccountKeeper.AddAuthenticator(
 		ctx,
 		accAddress,
 		"MessageFilterAuthenticator",
@@ -198,13 +198,13 @@ func (s *KeeperTestSuite) TestKeeper_GetSelectedAuthenticatorForAccount() {
 	s.App.AuthenticatorManager.UnregisterAuthenticator(authenticator.MessageFilterAuthenticator{})
 
 	// Try to get an authenticator that has been removed from the store
-	selectedAuthenticator, err = s.App.AuthenticatorKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2)
+	selectedAuthenticator, err = s.App.SmartAccountKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2)
 	s.Require().Error(err)
 	s.Require().ErrorContains(err, "authenticator id 2 failed to initialize, authenticator type MessageFilterAuthenticator not registered in manager: internal logic error")
 
 	// Reset the authenticator manager to see how GetInitializedAuthenticatorForAccount behaves
 	s.App.AuthenticatorManager.ResetAuthenticators()
-	selectedAuthenticator, err = s.App.AuthenticatorKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2323)
+	selectedAuthenticator, err = s.App.SmartAccountKeeper.GetInitializedAuthenticatorForAccount(ctx, accAddress, 2323)
 	s.Require().Error(err)
 	s.Require().Equal(selectedAuthenticator.Id, uint64(0), "Incorrect ID returned from store")
 	s.Require().Equal(selectedAuthenticator.Authenticator, nil, "Returned authenticator from store but nothing registered in manager")

--- a/x/smart-account/keeper/msg_server.go
+++ b/x/smart-account/keeper/msg_server.go
@@ -3,12 +3,11 @@ package keeper
 import (
 	"context"
 	"fmt"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"strconv"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 )
 
@@ -97,18 +96,26 @@ func (m msgServer) SetActiveState(goCtx context.Context, msg *types.MsgSetActive
 	// `MsgSetActiveState` must have only one signer
 	signer := msg.GetSigners()[0]
 
-	// check if signer is authorized to set the active state
-	isAuthorized := false
-	params := m.Keeper.GetParams(ctx)
-
-	for _, controller := range params.CircuitBreakerControllers {
-		if controller == signer.String() {
-			isAuthorized = true
-			break
+	if msg.Active == true {
+		// Only the circuit breaker governor can set the active state of the authenticator to true
+		if !signer.Equals(m.Keeper.CircuitBreakerGovernor) {
+			return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "signer is not the circuit breaker governor")
 		}
-	}
-	if !isAuthorized {
-		return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "signer is not a circuit breaker controller")
+	} else {
+		// The circuit breaker can state can be set to false by any of the circuit breaker controllers
+		isAuthorized := false
+		params := m.Keeper.GetParams(ctx)
+
+		for _, controller := range params.CircuitBreakerControllers {
+			if controller == signer.String() {
+				isAuthorized = true
+				break
+			}
+		}
+		if !isAuthorized {
+			return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "signer is not a circuit breaker controller")
+
+		}
 	}
 
 	// Set the active state of the authenticator

--- a/x/smart-account/keeper/msg_server.go
+++ b/x/smart-account/keeper/msg_server.go
@@ -3,8 +3,9 @@ package keeper
 import (
 	"context"
 	"fmt"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"strconv"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/smart-account/keeper/msg_server.go
+++ b/x/smart-account/keeper/msg_server.go
@@ -96,7 +96,7 @@ func (m msgServer) SetActiveState(goCtx context.Context, msg *types.MsgSetActive
 	// `MsgSetActiveState` must have only one signer
 	signer := msg.GetSigners()[0]
 
-	if msg.Active == true {
+	if msg.Active {
 		// Only the circuit breaker governor can set the active state of the authenticator to true
 		if !signer.Equals(m.Keeper.CircuitBreakerGovernor) {
 			return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "signer is not the circuit breaker governor")
@@ -114,7 +114,6 @@ func (m msgServer) SetActiveState(goCtx context.Context, msg *types.MsgSetActive
 		}
 		if !isAuthorized {
 			return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "signer is not a circuit breaker controller")
-
 		}
 	}
 

--- a/x/smart-account/post/post.go
+++ b/x/smart-account/post/post.go
@@ -12,32 +12,32 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
-	authenticatorante "github.com/osmosis-labs/osmosis/v24/x/smart-account/ante"
+	smartaccountante "github.com/osmosis-labs/osmosis/v24/x/smart-account/ante"
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/authenticator"
-	authenticatorkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
+	smartaccountkeeper "github.com/osmosis-labs/osmosis/v24/x/smart-account/keeper"
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 )
 
 // AuthenticatorPostDecorator handles post-transaction tasks for smart accounts.
 type AuthenticatorPostDecorator struct {
-	authenticatorKeeper *authenticatorkeeper.Keeper
-	accountKeeper       *authkeeper.AccountKeeper
-	sigModeHandler      authsigning.SignModeHandler
-	next                sdk.PostHandler
+	smartAccountKeeper *smartaccountkeeper.Keeper
+	accountKeeper      *authkeeper.AccountKeeper
+	sigModeHandler     authsigning.SignModeHandler
+	next               sdk.PostHandler
 }
 
 // NewAuthenticatorPostDecorator creates a new AuthenticatorPostDecorator with necessary dependencies.
 func NewAuthenticatorPostDecorator(
-	authenticatorKeeper *authenticatorkeeper.Keeper,
+	smartAccountKeeper *smartaccountkeeper.Keeper,
 	accountKeeper *authkeeper.AccountKeeper,
 	sigModeHandler authsigning.SignModeHandler,
 	next sdk.PostHandler,
 ) AuthenticatorPostDecorator {
 	return AuthenticatorPostDecorator{
-		authenticatorKeeper: authenticatorKeeper,
-		accountKeeper:       accountKeeper,
-		sigModeHandler:      sigModeHandler,
-		next:                next,
+		smartAccountKeeper: smartAccountKeeper,
+		accountKeeper:      accountKeeper,
+		sigModeHandler:     sigModeHandler,
+		next:               next,
 	}
 }
 
@@ -54,7 +54,7 @@ func (ad AuthenticatorPostDecorator) PostHandle(
 	prevGasConsumed := ctx.GasMeter().GasConsumed()
 
 	// Ensure that the transaction is an authenticator transaction
-	active, txOptions := authenticatorante.IsCircuitBreakActive(ctx, tx, ad.authenticatorKeeper)
+	active, txOptions := smartaccountante.IsCircuitBreakActive(ctx, tx, ad.smartAccountKeeper)
 	if active {
 		return ad.next(ctx, tx, simulate, success)
 	}
@@ -78,7 +78,7 @@ func (ad AuthenticatorPostDecorator) PostHandle(
 		account := msg.GetSigners()[0]
 
 		selectedAuthenticatorId := int(selectedAuthenticatorsFromExtension[msgIndex])
-		selectedAuthenticator, err := ad.authenticatorKeeper.GetInitializedAuthenticatorForAccount(
+		selectedAuthenticator, err := ad.smartAccountKeeper.GetInitializedAuthenticatorForAccount(
 			ctx,
 			account,
 			selectedAuthenticatorId,

--- a/x/smart-account/post/post_test.go
+++ b/x/smart-account/post/post_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v24/app/params"
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/post"
 	"github.com/osmosis-labs/osmosis/v24/x/smart-account/testutils"
-	authenticatortypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v24/x/smart-account/types"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -75,7 +75,7 @@ func (s *AuthenticatorPostSuite) SetupTest() {
 	}
 
 	s.AuthenticatorPostDecorator = post.NewAuthenticatorPostDecorator(
-		s.OsmosisApp.AuthenticatorKeeper,
+		s.OsmosisApp.SmartAccountKeeper,
 		s.OsmosisApp.AccountKeeper,
 		s.EncodingConfig.TxConfig.SignModeHandler(),
 		// Add an empty handler here to enable a circuit breaker pattern
@@ -103,7 +103,7 @@ func (s *AuthenticatorPostSuite) TestAutenticatorPostHandlerSuccess() {
 	feeCoins := sdk.Coins{sdk.NewInt64Coin(osmoToken, 2500)}
 
 	// Add the authenticators for the accounts
-	id, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[0],
 		"SignatureVerificationAuthenticator",
@@ -112,7 +112,7 @@ func (s *AuthenticatorPostSuite) TestAutenticatorPostHandlerSuccess() {
 	s.Require().NoError(err)
 	s.Require().Equal(id, uint64(1), "Adding authenticator returning incorrect id")
 
-	id, err = s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(
+	id, err = s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(
 		s.Ctx,
 		s.TestAccAddress[1],
 		"SignatureVerificationAuthenticator",
@@ -177,7 +177,7 @@ func (s *AuthenticatorPostSuite) TestAutenticatorPostHandlerFailConfirmExecution
 		Confirm:        testutils.Never,
 	}
 	s.OsmosisApp.AuthenticatorManager.RegisterAuthenticator(approveAndBlock)
-	approveAndBlockId, err := s.OsmosisApp.AuthenticatorKeeper.AddAuthenticator(s.Ctx, s.TestAccAddress[0], approveAndBlock.Type(), []byte{})
+	approveAndBlockId, err := s.OsmosisApp.SmartAccountKeeper.AddAuthenticator(s.Ctx, s.TestAccAddress[0], approveAndBlock.Type(), []byte{})
 	s.Require().NoError(err, "Should have been able to add an authenticator")
 
 	// Create a test messages for signing
@@ -240,7 +240,7 @@ func GenTx(
 		return nil, fmt.Errorf("expected authtx.ExtensionOptionsTxBuilder, got %T", baseTxBuilder)
 	}
 	if len(selectedAuthenticators) > 0 {
-		value, err := types.NewAnyWithValue(&authenticatortypes.TxExtension{
+		value, err := types.NewAnyWithValue(&smartaccounttypes.TxExtension{
 			SelectedAuthenticators: selectedAuthenticators,
 		})
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

The circuit breaker can now be deactivated by any of the controllers, but only activated by gov. 

(drive by, rename authanticator to smartaccount when needed)

## Testing and Verifying
tests have been adapted to match this change

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A