### PR TITLE
fix: nil pointer issue on `osmosisd init` non mainnet chain id

### DIFF
--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -182,7 +182,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			// If this is not a mainnet node, or the genesis file download failed, generate a new genesis file
 			if genesisFileDownloadFailed || !isMainnet {
 				// If the chainID is not blank or genesis file download failed, generate a new genesis file
-				var genDoc *types.GenesisDoc
+				var genDoc types.GenesisDoc
 
 				appState, err := json.MarshalIndent(mbm.DefaultGenesis(cdc), "", " ")
 				if err != nil {
@@ -194,16 +194,17 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 						return err
 					}
 				} else {
-					genDoc, err = types.GenesisDocFromFile(genFilePath)
+					genDocFromFile, err := types.GenesisDocFromFile(genFilePath)
 					if err != nil {
 						return errors.Wrap(err, "Failed to read genesis doc from file")
 					}
+					genDoc = *genDocFromFile
 				}
 
 				genDoc.ChainID = chainID
 				genDoc.Validators = nil
 				genDoc.AppState = appState
-				if err = genutil.ExportGenesisFile(genDoc, genFilePath); err != nil {
+				if err = genutil.ExportGenesisFile(&genDoc, genFilePath); err != nil {
 					return errors.Wrap(err, "Failed to export genesis file")
 				}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

The following PR https://github.com/osmosis-labs/osmosis/pull/7795 panics when using a non mainnet chain ID. This fixes the pointer dereference issue.

## Testing and Verifying

Tested locally with init command that Paddy used to reproduce this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of genesis file generation logic for enhanced stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->