### PR TITLE
fix: Allow single-quotes for arbitrage-min-gas-fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#8006](https://github.com/osmosis-labs/osmosis/pull/8006), [#8014](https://github.com/osmosis-labs/osmosis/pull/8014) Speedup many BigDec operations
 
+### Bug Fixes
+
+* [#8056](https://github.com/osmosis-labs/osmosis/pull/8056) fix: Allow single-quotes for arbitrage-min-gas-fee
+
 ## v24.0.1
 
 * [#7994](https://github.com/osmosis-labs/osmosis/pull/7994) Async pruning for IAVL v1

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -527,10 +527,13 @@ func overwriteAppTomlValues(serverCtx *server.Context) error {
 			}
 
 			// Find the opening and closing quotes
-			openQuoteIndex := strings.Index(fileContent[index:], "\"")
+			re := regexp.MustCompile(`["']`)
+			quoteCharacter := re.FindString(fileContent[index:])
+
+			openQuoteIndex := strings.Index(fileContent[index:], quoteCharacter)
 			openQuoteIndex += index
 
-			closingQuoteIndex := strings.Index(fileContent[openQuoteIndex+1:], "\"")
+			closingQuoteIndex := strings.Index(fileContent[openQuoteIndex+1:], quoteCharacter)
 			closingQuoteIndex += openQuoteIndex + 1
 
 			// Replace the old value with the new value


### PR DESCRIPTION
Closes: #8055

## What is the purpose of the change

There is mempool configuration in app.toml, which includes an arbitrage minimum gas fee value. During startup, Osmosis attempts to overwrite the app.toml values file. This is done with a direct string replacement - cutting based on where the nearest quotes are. Generally this works fine, if the TOML file has standard double quotes for regular strings. However, if the TOML file has been overwritten already with tooling that uses literal strings, then the file will consist of single-quotes instead, as follows:

```toml
[osmosis-mempool]
arbitrage-min-gas-fee = '.005'
```

Such configuration will fail to find double-quotes and use an index of -1 for the replacement cutting, resulting in an app.toml:

```toml
[osmosis-mempool]
0.1
arbitrage-min-gas-fee = '.005'
```

This results in a failure to restart the Osmosis binary, as the next startup tries to parse the broken TOML file.

This could be confusing, if later in the file double-quotes are actually still used, as Osmosis binary would do the replacement there instead. Such as:

```toml
[osmosis-mempool]
arbitrage-min-gas-fee = '.005'
max-gas-wanted-per-tx = "60000000"
```

Becoming:

```toml
[osmosis-mempool]
arbitrage-min-gas-fee = '.005'
max-gas-wanted-per-tx = "0.1"
```

This commit simply looks for whether a single-quote or a double-quote is the left-most matched character, before doing a replacement operation. This ensures that even TOML files with mixed quotes are handled properly.

This commit does not implement processing of multi-line strings with `"""` and `'''` boundaries.

## Testing and Verifying

This change is a ~trivial rework~ / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed a bug related to allowing single-quotes for `arbitrage-min-gas-fee`.
	- Enhanced flexibility in handling different quote types in the `overwriteAppTomlValues` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->