### PR TITLE
Remove one multiplication from sqrt

### DIFF
--- a/osmomath/sqrt.go
+++ b/osmomath/sqrt.go
@@ -53,6 +53,10 @@ func MonotonicSqrtMut(d Dec) (Dec, error) {
 }
 
 func MonotonicSqrtBigDec(d BigDec) (BigDec, error) {
+	return MonotonicSqrtBigDecMut(d.Clone())
+}
+
+func MonotonicSqrtBigDecMut(d BigDec) (BigDec, error) {
 	if d.IsNegative() {
 		return d, errors.New("cannot take square root of negative number")
 	}
@@ -66,7 +70,7 @@ func MonotonicSqrtBigDec(d BigDec) (BigDec, error) {
 	//
 	// We can than interpret sqrt(10^18 * v) as our resulting decimal and return it.
 	// monotonicity is guaranteed by correctness of integer square root.
-	dBi := d.BigInt()
+	dBi := d.BigIntMut()
 	r := big.NewInt(0).Mul(dBi, tenTo36)
 	r.Sqrt(r)
 	// However this square root r is s.t. r^2 <= d. We want to flip this to be r^2 >= d.
@@ -78,9 +82,9 @@ func MonotonicSqrtBigDec(d BigDec) (BigDec, error) {
 	if check.Cmp(shiftedD) == -1 {
 		r.Add(r, oneBigInt)
 	}
-	root := NewBigDecFromBigIntMutWithPrec(r, 36)
+	dBi.Set(r)
 
-	return root, nil
+	return d, nil
 }
 
 // MustMonotonicSqrt returns the output of MonotonicSqrt, panicking on error.

--- a/osmomath/sqrt.go
+++ b/osmomath/sqrt.go
@@ -18,6 +18,10 @@ var oneBigInt = big.NewInt(1)
 // the returned root r, will be such that r^2 >= d
 // This function is monotonic, i.e. if d1 >= d2, then sqrt(d1) >= sqrt(d2)
 func MonotonicSqrt(d Dec) (Dec, error) {
+	return MonotonicSqrtMut(d.Clone())
+}
+
+func MonotonicSqrtMut(d Dec) (Dec, error) {
 	if d.IsNegative() {
 		return d, errors.New("cannot take square root of negative number")
 	}
@@ -31,7 +35,7 @@ func MonotonicSqrt(d Dec) (Dec, error) {
 	//
 	// We can than interpret sqrt(10^18 * v) as our resulting decimal and return it.
 	// monotonicity is guaranteed by correctness of integer square root.
-	dBi := d.BigInt()
+	dBi := d.BigIntMut()
 	r := big.NewInt(0).Mul(dBi, tenTo18)
 	r.Sqrt(r)
 	// However this square root r is s.t. r^2 <= d. We want to flip this to be r^2 >= d.
@@ -43,9 +47,9 @@ func MonotonicSqrt(d Dec) (Dec, error) {
 	if check.Cmp(shiftedD) == -1 {
 		r.Add(r, oneBigInt)
 	}
-	root := NewDecFromBigIntWithPrec(r, 18)
 
-	return root, nil
+	dBi.Set(r)
+	return d, nil
 }
 
 func MonotonicSqrtBigDec(d BigDec) (BigDec, error) {

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -561,7 +561,7 @@ func (k Keeper) initializeInitialPositionForPool(ctx sdk.Context, pool types.Con
 	// Calculate the spot price and sqrt price from the amount provided
 	initialSpotPrice := amount1Desired.ToLegacyDec().Quo(amount0Desired.ToLegacyDec())
 	// TODO: any concerns with this being an osmomath.Dec?
-	initialCurSqrtPrice, err := osmomath.MonotonicSqrt(initialSpotPrice)
+	initialCurSqrtPrice, err := osmomath.MonotonicSqrtMut(initialSpotPrice)
 	if err != nil {
 		return err
 	}

--- a/x/concentrated-liquidity/math/tick.go
+++ b/x/concentrated-liquidity/math/tick.go
@@ -44,7 +44,7 @@ func TickToSqrtPrice(tickIndex int64) (osmomath.BigDec, error) {
 		// As a result, there is no data loss.
 		price := priceBigDec.Dec()
 
-		sqrtPrice, err := osmomath.MonotonicSqrt(price)
+		sqrtPrice, err := osmomath.MonotonicSqrtMut(price)
 		if err != nil {
 			return osmomath.BigDec{}, err
 		}

--- a/x/concentrated-liquidity/swapstrategy/swap_strategy.go
+++ b/x/concentrated-liquidity/swapstrategy/swap_strategy.go
@@ -139,7 +139,7 @@ func GetSqrtPriceLimit(priceLimit osmomath.BigDec, zeroForOne bool) (osmomath.Bi
 	if priceLimit.GTE(types.MinSpotPriceBigDec) {
 		// Truncation is fine since previous Osmosis version only supported
 		// 18 decimal price ranges.
-		sqrtPriceLimit, err := osmomath.MonotonicSqrt(priceLimit.Dec())
+		sqrtPriceLimit, err := osmomath.MonotonicSqrtMut(priceLimit.Dec())
 		if err != nil {
 			return osmomath.BigDec{}, err
 		}


### PR DESCRIPTION
Remove one multiplication from the sqrt calls. This is a 3-4% speedup to MonotonicSqrt

We have bigger speedups to go for afterwards, just noticed this as a driveby.

See the Bytes & heap allocations here (time is dominated by system noise):
OLD
```
BenchmarkMonotonicSqrt-12           1152           1257251 ns/op          287502 B/op       5170 allocs/op
```
NEW
BenchmarkMonotonicSqrt-12           1006           1081692 ns/op          258538 B/op       4544 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the square root calculation method for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->