### PR TITLE
perf!: Don't try doing superfluid distributions to jailed validators

### DIFF
--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -30,6 +30,8 @@ func (k Keeper) AfterEpochStartBeginBlock(ctx sdk.Context) {
 	accs := k.GetAllDistrIntermediaryAccounts(ctx)
 	// Move delegation rewards to perpetual gauge
 	ctx.Logger().Info("Move delegation rewards to gauges")
+	// TODO: Evaluate what happens when val becomes jailed. Expected:
+	// Reward stays in the gauge and never distributes, which is fine.
 	k.MoveSuperfluidDelegationRewardToGauges(ctx, accs)
 
 	ctx.Logger().Info("Distribute Superfluid gauges")
@@ -57,6 +59,8 @@ func (k Keeper) AfterEpochStartBeginBlock(ctx sdk.Context) {
 	// Refresh intermediary accounts' delegation amounts,
 	// making staking rewards follow the updated multiplier numbers.
 	ctx.Logger().Info("Refresh all superfluid delegation amounts")
+	// TODO: Evaluate what happens when val becomes jailed. Expected:
+	// Reward stays in the gauge and never distributes, which is fine.
 	k.RefreshIntermediaryDelegationAmounts(ctx, accs)
 }
 

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -70,6 +70,7 @@ func (k Keeper) RefreshIntermediaryDelegationAmounts(ctx sdk.Context, accs []typ
 			k.Logger(ctx).Debug(fmt.Sprintf("Existing delegation not found for %s with %s during superfluid refresh."+
 				" It may have been previously bonded, but now unbonded.", mAddr.String(), acc.ValAddr))
 		} else {
+			// TODO: Evaluate if we can compute TokensFromShares off a single Validator instance.
 			currentAmount = validator.TokensFromShares(delegation.Shares).RoundInt()
 		}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Speedup superfluid distribution by not doing staking operations on jailed validators. Estimated impact is 10s reduction of epoch time.

TODO: Need to immediately remove all SF staking after jailing, and test that upon unjailing its correctly re-included. Ideally we do this by making these account intermediary connections be stored separately in state.

## Testing and Verifying

TODO: Test this. This will likely block this PR from getting through to completion

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A