### PR TITLE
feat(SQS): ingest cwPools only when modified rather than every block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -468,6 +468,9 @@ func getSQSServiceWriteListeners(app *OsmosisApp, appCodec codec.Codec, blockPoo
 	writeListeners[app.GetKey(cosmwasmpooltypes.StoreKey)] = []storetypes.WriteListener{
 		writelistener.NewCosmwasmPool(blockPoolUpdateTracker),
 	}
+	writeListeners[app.GetKey(banktypes.StoreKey)] = []storetypes.WriteListener{
+		writelistener.NewCosmwasmPoolBalance(blockPoolUpdateTracker),
+	}
 	return writeListeners
 }
 

--- a/ingest/sqs/domain/ingester.go
+++ b/ingest/sqs/domain/ingester.go
@@ -15,8 +15,8 @@ import (
 type Ingester interface {
 	// ProcessAllBlockData processes the block and ingests data into a sink.
 	// Returns error if the ingester fails to ingest data.
-	// Also runs a callback function that creates the initial cwPool address to cwPool object map.
-	ProcessAllBlockData(ctx sdk.Context, onCosmWasmPool func(cwPool poolmanagertypes.PoolI)) error
+	// Also returns cwpools, which is used to create the initial address to pool mapping.
+	ProcessAllBlockData(ctx sdk.Context) ([]poolmanagertypes.PoolI, error)
 
 	// ProcessChangedBlockData processes only the pools that were changed in the block.
 	ProcessChangedBlockData(ctx sdk.Context, changedPools BlockPools) error

--- a/ingest/sqs/domain/ingester.go
+++ b/ingest/sqs/domain/ingester.go
@@ -15,7 +15,8 @@ import (
 type Ingester interface {
 	// ProcessAllBlockData processes the block and ingests data into a sink.
 	// Returns error if the ingester fails to ingest data.
-	ProcessAllBlockData(ctx sdk.Context) error
+	// Also runs a callback function that creates the initial cwPool address to cwPool object map.
+	ProcessAllBlockData(ctx sdk.Context, onCosmWasmPool func(cwPool poolmanagertypes.PoolI)) error
 
 	// ProcessChangedBlockData processes only the pools that were changed in the block.
 	ProcessChangedBlockData(ctx sdk.Context, changedPools BlockPools) error

--- a/ingest/sqs/domain/mocks/sqs_ingester_mock.go
+++ b/ingest/sqs/domain/mocks/sqs_ingester_mock.go
@@ -4,6 +4,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v24/ingest/sqs/domain"
+
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v24/x/poolmanager/types"
 )
 
 var _ domain.Ingester = &SQSIngesterMock{}
@@ -26,7 +28,7 @@ type SQSIngesterMock struct {
 }
 
 // ProcessAllBlockData implements domain.Ingester.
-func (s *SQSIngesterMock) ProcessAllBlockData(ctx types.Context) error {
+func (s *SQSIngesterMock) ProcessAllBlockData(ctx types.Context, onCosmWasmPool func(pool poolmanagertypes.PoolI)) error {
 	if s.ProcessAllBlockDataPanicMsg != "" {
 		panic(s.ProcessAllBlockDataPanicMsg)
 	}

--- a/ingest/sqs/domain/mocks/sqs_ingester_mock.go
+++ b/ingest/sqs/domain/mocks/sqs_ingester_mock.go
@@ -28,13 +28,13 @@ type SQSIngesterMock struct {
 }
 
 // ProcessAllBlockData implements domain.Ingester.
-func (s *SQSIngesterMock) ProcessAllBlockData(ctx types.Context, onCosmWasmPool func(pool poolmanagertypes.PoolI)) error {
+func (s *SQSIngesterMock) ProcessAllBlockData(ctx types.Context) ([]poolmanagertypes.PoolI, error) {
 	if s.ProcessAllBlockDataPanicMsg != "" {
 		panic(s.ProcessAllBlockDataPanicMsg)
 	}
 
 	s.IsProcessAllBlockDataCalled = true
-	return s.AllBlockDataError
+	return s.LastChangedPoolsObserved.CosmWasmPools, s.AllBlockDataError
 }
 
 // ProcessChangedBlockData implements domain.Ingester.

--- a/ingest/sqs/domain/service.go
+++ b/ingest/sqs/domain/service.go
@@ -27,6 +27,9 @@ type BlockPoolUpdateTracker interface {
 	// TrackCosmWasm tracks the CosmWasm pool.
 	TrackCosmWasm(pool poolmanagertypes.PoolI)
 
+	// TrackCosmWasmPoolsAddressToPoolMap tracks the CosmWasm pools address to the pool object map.
+	TrackCosmWasmPoolsAddressToPoolMap(pool poolmanagertypes.PoolI)
+
 	// GetConcentratedPools returns the tracked concentrated pools.
 	GetConcentratedPools() []poolmanagertypes.PoolI
 
@@ -38,6 +41,9 @@ type BlockPoolUpdateTracker interface {
 
 	// GetCosmWasmPools returns the tracked CosmWasm pools.
 	GetCosmWasmPools() []poolmanagertypes.PoolI
+
+	// GetCosmWasmPoolsAddressToIDMap returns the tracked CosmWasm pools address to pool object map.
+	GetCosmWasmPoolsAddressToIDMap() map[string]poolmanagertypes.PoolI
 
 	// Reset clears the internal state.
 	Reset()

--- a/ingest/sqs/service/sqs_pool_tracker.go
+++ b/ingest/sqs/service/sqs_pool_tracker.go
@@ -7,19 +7,21 @@ import (
 
 // poolBlockUpdateTracker is a struct that tracks the pools that were updated in a block.
 type poolBlockUpdateTracker struct {
-	concentratedPools            map[uint64]poolmanagertypes.PoolI
-	concentratedPoolIDTickChange map[uint64]struct{}
-	cfmmPools                    map[uint64]poolmanagertypes.PoolI
-	cosmwasmPools                map[uint64]poolmanagertypes.PoolI
+	concentratedPools             map[uint64]poolmanagertypes.PoolI
+	concentratedPoolIDTickChange  map[uint64]struct{}
+	cfmmPools                     map[uint64]poolmanagertypes.PoolI
+	cosmwasmPools                 map[uint64]poolmanagertypes.PoolI
+	cosmwasmPoolsAddressToPoolMap map[string]poolmanagertypes.PoolI
 }
 
 // NewPoolTracker creates a new poolBlockUpdateTracker.
 func NewPoolTracker() domain.BlockPoolUpdateTracker {
 	return &poolBlockUpdateTracker{
-		concentratedPools:            map[uint64]poolmanagertypes.PoolI{},
-		concentratedPoolIDTickChange: map[uint64]struct{}{},
-		cfmmPools:                    map[uint64]poolmanagertypes.PoolI{},
-		cosmwasmPools:                map[uint64]poolmanagertypes.PoolI{},
+		concentratedPools:             map[uint64]poolmanagertypes.PoolI{},
+		concentratedPoolIDTickChange:  map[uint64]struct{}{},
+		cfmmPools:                     map[uint64]poolmanagertypes.PoolI{},
+		cosmwasmPools:                 map[uint64]poolmanagertypes.PoolI{},
+		cosmwasmPoolsAddressToPoolMap: map[string]poolmanagertypes.PoolI{},
 	}
 }
 
@@ -36,6 +38,11 @@ func (pt *poolBlockUpdateTracker) TrackCFMM(pool poolmanagertypes.PoolI) {
 // TrackCosmWasm implements PoolTracker.
 func (pt *poolBlockUpdateTracker) TrackCosmWasm(pool poolmanagertypes.PoolI) {
 	pt.cosmwasmPools[pool.GetId()] = pool
+}
+
+// TrackCosmWasmPoolsAddressToPoolMap implements PoolTracker.
+func (pt *poolBlockUpdateTracker) TrackCosmWasmPoolsAddressToPoolMap(pool poolmanagertypes.PoolI) {
+	pt.cosmwasmPoolsAddressToPoolMap[pool.GetAddress().String()] = pool
 }
 
 // TrackConcentratedPoolIDTickChange implements PoolTracker.
@@ -61,6 +68,11 @@ func (pt *poolBlockUpdateTracker) GetCFMMPools() []poolmanagertypes.PoolI {
 // GetCosmWasmPools implements PoolTracker.
 func (pt *poolBlockUpdateTracker) GetCosmWasmPools() []poolmanagertypes.PoolI {
 	return poolMapToSlice(pt.cosmwasmPools)
+}
+
+// GetCosmWasmPoolsAddressToIDMap implements PoolTracker.
+func (pt *poolBlockUpdateTracker) GetCosmWasmPoolsAddressToIDMap() map[string]poolmanagertypes.PoolI {
+	return pt.cosmwasmPoolsAddressToPoolMap
 }
 
 // Reset implements PoolTracker.

--- a/ingest/sqs/service/sqs_streaming_service.go
+++ b/ingest/sqs/service/sqs_streaming_service.go
@@ -171,7 +171,7 @@ func (s *sqsStreamingService) processBlock(ctx sdk.Context) error {
 			s.poolTracker.TrackCosmWasmPoolsAddressToPoolMap(cwPool)
 		})
 		if err != nil {
-			return fmt.Errorf("failed to process all block data: %w", err)
+			return err
 		}
 
 		// Successfully processed the block, no longer need to process full block data.

--- a/ingest/sqs/service/sqs_streaming_service.go
+++ b/ingest/sqs/service/sqs_streaming_service.go
@@ -167,7 +167,7 @@ func (s *sqsStreamingService) processBlock(ctx sdk.Context) error {
 		// Process the entire block if the node is caught up
 		cwPools, err := s.sqsIngester.ProcessAllBlockData(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to process all block data: %w", err)
+			return err
 		}
 
 		// Generate the initial cwPool address to pool mapping

--- a/ingest/sqs/service/sqs_streaming_service.go
+++ b/ingest/sqs/service/sqs_streaming_service.go
@@ -95,7 +95,7 @@ func (s *sqsStreamingService) processBlockRecoverError(ctx sdk.Context) (err err
 		s.poolTracker.Reset()
 
 		if r := recover(); r != nil {
-			// Due to panic, we set shouldProceessAllBlockData to true to reprocess the entire block.
+			// Due to panic, we set shouldProcessAllBlockData to true to reprocess the entire block.
 			// Be careful when changing this behavior.
 			s.shouldProcessAllBlockData = true
 
@@ -108,7 +108,7 @@ func (s *sqsStreamingService) processBlockRecoverError(ctx sdk.Context) (err err
 
 	// Process the block data.
 	if err := s.processBlock(ctx); err != nil {
-		// Due to error, we set shouldProceessAllBlockData to true to reprocess the entire block.
+		// Due to error, we set shouldProcessAllBlockData to true to reprocess the entire block.
 		// Be careful when changing this behavior.
 		s.shouldProcessAllBlockData = true
 
@@ -141,7 +141,7 @@ func (s *sqsStreamingService) Stream(wg *sync.WaitGroup) error {
 // It processes only the pools that were changed in the block in the following cases:
 // - The node is not in cold start and the previous block was processed successfully.
 //
-// An internal flag shouldProceessAllBlockData is used to determine if the block data should be processed in full.
+// An internal flag shouldProcessAllBlockData is used to determine if the block data should be processed in full.
 //
 // This method is a no-op in the following two cases:
 // - The node is syncing.

--- a/ingest/sqs/service/writelistener/cosmwasmpool_write_listener.go
+++ b/ingest/sqs/service/writelistener/cosmwasmpool_write_listener.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/osmosis-labs/osmosis/v24/ingest/sqs/domain"
 	cosmwasmpoolmodel "github.com/osmosis-labs/osmosis/v24/x/cosmwasmpool/model"
 	cosmwasmpooltypes "github.com/osmosis-labs/osmosis/v24/x/cosmwasmpool/types"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v24/x/poolmanager/types"
 )
 
 var _ storetypes.WriteListener = (*cosmwasmPoolWriteListener)(nil)
@@ -22,9 +26,11 @@ func NewCosmwasmPool(poolTracker domain.BlockPoolUpdateTracker) storetypes.Write
 	}
 }
 
-// OnWrite implements types.WriteListener.
+// OnWrite implements types.WriteListener
+//
+// NOTE: This only detects cwPools that have been created or migrated. It does not detect changes in balances (i.e. swaps / position creation / withdraws)
 func (s *cosmwasmPoolWriteListener) OnWrite(storeKey storetypes.StoreKey, key []byte, value []byte, delete bool) error {
-	// Track the changed pool.
+	// Track the cwPool that was just created/migrated
 	if len(key) > 0 && bytes.Equal(cosmwasmpooltypes.PoolsKey, key[:1]) {
 		var pool cosmwasmpoolmodel.CosmWasmPool
 		if err := pool.Unmarshal(value); err != nil {
@@ -32,6 +38,46 @@ func (s *cosmwasmPoolWriteListener) OnWrite(storeKey storetypes.StoreKey, key []
 		}
 
 		s.poolTracker.TrackCosmWasm(&pool)
+
+		// Create/modify the cwPool address to pool mapping
+		// This is used to check if a balance change is for a cwPool address, and if so, we can retrieve the pool from this mapping
+		var poolI poolmanagertypes.PoolI = &pool
+		s.poolTracker.TrackCosmWasmPoolsAddressToPoolMap(poolI)
+	}
+	return nil
+}
+
+type cosmwasmPoolBalanceWriteListener struct {
+	poolTracker domain.BlockPoolUpdateTracker
+}
+
+func NewCosmwasmPoolBalance(poolTracker domain.BlockPoolUpdateTracker) storetypes.WriteListener {
+	return &cosmwasmPoolBalanceWriteListener{
+		poolTracker: poolTracker,
+	}
+}
+
+// OnWrite implements types.WriteListener
+// Tracks balance changes for cwPools (i.e. swaps / position creation / withdraws)
+func (s *cosmwasmPoolBalanceWriteListener) OnWrite(storeKey storetypes.StoreKey, key []byte, value []byte, delete bool) error {
+	// Check if the key is a balance change for any address
+	if len(key) > 0 && key[0] == banktypes.BalancesPrefix[0] {
+		// The key is a balance change. Check if the address in question is a cwPool address
+
+		// We expect the key to be of the form:
+		// <prefix> (length 1)
+		// <address_length> (length 1)
+		// <address> (length address_length)
+		addressLength := key[1]
+		addressBytes := key[1+1 : 1+addressLength+1]
+		address := sdk.AccAddress(addressBytes)
+		addressStr := address.String()
+
+		cwPoolMap := s.poolTracker.GetCosmWasmPoolsAddressToIDMap()
+		if pool, ok := cwPoolMap[addressStr]; ok {
+			// The address is a cwPool address. Add the cwPool to the cwPool tracker
+			s.poolTracker.TrackCosmWasm(pool)
+		}
 	}
 	return nil
 }

--- a/ingest/sqs/service/writelistener/cosmwasmpool_write_listener_test.go
+++ b/ingest/sqs/service/writelistener/cosmwasmpool_write_listener_test.go
@@ -1,6 +1,9 @@
 package writelistener_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
 	"github.com/osmosis-labs/osmosis/v24/ingest/sqs/service"
 	"github.com/osmosis-labs/osmosis/v24/ingest/sqs/service/writelistener"
 	"github.com/osmosis-labs/osmosis/v24/x/cosmwasmpool/model"
@@ -10,7 +13,6 @@ import (
 // Tests that the cosmwasm write listener correctly tracks pool updates
 // It ignores error cases as they are simple and unlikely giving app wiring.
 func (s *WriteListenerTestSuite) TestWriteListener_CosmWasm() {
-
 	// Set up chain state once per test
 	s.Setup()
 
@@ -66,6 +68,80 @@ func (s *WriteListenerTestSuite) TestWriteListener_CosmWasm() {
 			cosmwasmPoolKVStore := s.App.GetKey(cosmwasmpooltypes.ModuleName)
 
 			err := cosmWasmPoolWriteListener.OnWrite(cosmwasmPoolKVStore, tc.key, tc.value, tc.isDelete)
+			s.Require().NoError(err)
+
+			// All non-cosmwasm pool updates should not be tracked.
+			s.Require().Empty(poolTracker.GetCFMMPools())
+			s.Require().Empty(poolTracker.GetConcentratedPools())
+
+			if tc.expectedPoolUpdate {
+				cosmWasmPools := poolTracker.GetCosmWasmPools()
+				s.Require().Len(cosmWasmPools, 1)
+
+				s.Require().Equal(&cosmWasmPoolModel.CosmWasmPool, cosmWasmPools[0])
+			} else {
+				cosmWasmPools := poolTracker.GetCosmWasmPools()
+				s.Require().Len(cosmWasmPools, 0)
+			}
+		})
+	}
+}
+
+func (s *WriteListenerTestSuite) TestWriteListener_CosmWasmBalance() {
+	// Set up chain state once per test
+	s.Setup()
+
+	cosmWasmPool := s.PrepareCosmWasmPool()
+
+	cosmWasmPoolModel, ok := cosmWasmPool.(*model.Pool)
+	s.Require().True(ok)
+
+	concentratedPoolModelBz, err := cosmWasmPoolModel.Marshal()
+	s.Require().NoError(err)
+
+	// Trigger cwPool write listener actions at pool creation
+	poolTracker := service.NewPoolTracker()
+	cosmWasmPoolWriteListener := writelistener.NewCosmwasmPool(poolTracker)
+	cosmwasmPoolKVStore := s.App.GetKey(cosmwasmpooltypes.ModuleName)
+	err = cosmWasmPoolWriteListener.OnWrite(cosmwasmPoolKVStore, cosmwasmpooltypes.FormatPoolsPrefix(cosmWasmPoolModel.PoolId), concentratedPoolModelBz, false)
+	s.Require().NoError(err)
+
+	// Reset pool tracker, so it will flush the pool changes tracker but keep the address to pool mapping
+	poolTracker.Reset()
+
+	testCases := []struct {
+		name string
+
+		key      []byte
+		value    []byte
+		isDelete bool
+
+		expectedPoolUpdate bool
+	}{
+		{
+			name: "balance write unrelated to cosmwasm pool, no-op",
+
+			key:   banktypes.CreateAccountBalancesPrefix(s.TestAccs[0]),
+			value: someValue, // value is not used for balance changes
+		},
+		{
+			name: "balance write to cosmwasm pool",
+
+			key:   banktypes.CreateAccountBalancesPrefix(sdk.MustAccAddressFromBech32(cosmWasmPoolModel.ContractAddress)),
+			value: someValue, // value is not used for balance changes
+
+			expectedPoolUpdate: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		s.Run(tc.name, func() {
+			cosmWasmPoolBalanceWriteListener := writelistener.NewCosmwasmPoolBalance(poolTracker)
+
+			bankKVStore := s.App.GetKey(banktypes.ModuleName)
+
+			err := cosmWasmPoolBalanceWriteListener.OnWrite(bankKVStore, tc.key, tc.value, tc.isDelete)
 			s.Require().NoError(err)
 
 			// All non-cosmwasm pool updates should not be tracked.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

As a workaround, we currently process every cwPool on every block. This was done because, the pool object chain side only changes when one of two things happen:
1. Pool is created
2. Pool is migrated

This is unlike all other pool types, where the pool object chain side is changed on every swap. We therefore do the following:

1. Ingest all cwPools on cold start, mapping the pool address to the pool object (which only changes in the two cases described above)
2. We listen to onWrite on the cosmwasmpool store, so that if one of the two cases described above occurs, we modify the pool address to pool struct mapping
3. We now also listen to onWrite on the bank store. We check each balance change address against the pool address to pool struct mapping. If the pool address has it's balance change, we add the stored pool struct (which doesn't change) to the change cwPools struct for this block, to be ingested by SQS

## Testing and Verifying

I set up a node against mainnet, and added prints to ensure that cwPools were now being detected as changed when swaps occur. 

I recommend this be tested in stage as well. I wasn't able to test against mainnet pool creations / pool migrations, but should theoretically work as described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced tracking and management of CosmWasm pools for improved data processing efficiency.
  - Introduced functionalities to track changes and balance updates in CosmWasm pools accurately.

- **Bug Fixes**
  - Corrected the detection of CW pool store updates, preventing unnecessary data processing per block.

- **Refactor**
  - Improved error handling and internal logic in block processing methods for enhanced stability and performance.

- **Tests**
  - Implemented new tests for balance write functionalities related to CosmWasm pools to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->