### PR TITLE
chore: rename AuthenticatorStoreKey from smart-account module

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -237,7 +237,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 
 	smartAccountKeeper := smartaccountkeeper.NewKeeper(
 		appCodec,
-		appKeepers.keys[smartaccounttypes.ManagerStoreKey],
+		appKeepers.keys[smartaccounttypes.StoreKey],
 		govModuleAddr,
 		appKeepers.GetSubspace(smartaccounttypes.ModuleName),
 		appKeepers.AuthenticatorManager,
@@ -905,7 +905,6 @@ func KVStoreKeys() []string {
 		icqtypes.StoreKey,
 		packetforwardtypes.StoreKey,
 		cosmwasmpooltypes.StoreKey,
-		smartaccounttypes.ManagerStoreKey,
-		smartaccounttypes.AuthenticatorStoreKey,
+		smartaccounttypes.StoreKey,
 	}
 }

--- a/app/upgrades/v25/constants.go
+++ b/app/upgrades/v25/constants.go
@@ -16,8 +16,7 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
 		Added: []string{
-			smartaccounttypes.ManagerStoreKey,
-			smartaccounttypes.AuthenticatorStoreKey,
+			smartaccounttypes.StoreKey,
 		},
 		Deleted: []string{},
 	},

--- a/x/smart-account/authenticator/composition_test.go
+++ b/x/smart-account/authenticator/composition_test.go
@@ -62,7 +62,7 @@ func (s *AggregatedAuthenticatorsTest) SetupTest() {
 		Confirm:        testutils.Always,
 	}
 	s.spyAuth = testutils.NewSpyAuthenticator(
-		s.OsmosisApp.GetKVStoreKey()[smartaccounttypes.AuthenticatorStoreKey],
+		s.OsmosisApp.GetKVStoreKey()[smartaccounttypes.StoreKey],
 	)
 
 	am.RegisterAuthenticator(s.AnyOfAuth)

--- a/x/smart-account/integration_test.go
+++ b/x/smart-account/integration_test.go
@@ -265,7 +265,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorState() {
 		Amount:      sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000_000_000_000)),
 	}
 
-	stateful := testutils.StatefulAuthenticator{KvStoreKey: s.app.GetKVStoreKey()[smartaccounttypes.AuthenticatorStoreKey]}
+	stateful := testutils.StatefulAuthenticator{KvStoreKey: s.app.GetKVStoreKey()[smartaccounttypes.StoreKey]}
 	s.app.AuthenticatorManager.RegisterAuthenticator(stateful)
 	_, err := s.app.SmartAccountKeeper.AddAuthenticator(s.chainA.GetContext(), s.Account.GetAddress(), "Stateful", []byte{})
 	s.Require().NoError(err, "Failed to add authenticator")
@@ -291,7 +291,7 @@ func (s *AuthenticatorSuite) TestAuthenticatorMultiMsg() {
 		Amount:      sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000)),
 	}
 
-	storeKey := s.app.GetKVStoreKey()[smartaccounttypes.AuthenticatorStoreKey]
+	storeKey := s.app.GetKVStoreKey()[smartaccounttypes.StoreKey]
 	maxAmount := testutils.MaxAmountAuthenticator{KvStoreKey: storeKey}
 	stateful := testutils.StatefulAuthenticator{KvStoreKey: storeKey}
 

--- a/x/smart-account/keeper/keeper.go
+++ b/x/smart-account/keeper/keeper.go
@@ -37,7 +37,7 @@ type Keeper struct {
 
 func NewKeeper(
 	cdc codec.BinaryCodec,
-	managerStoreKey storetypes.StoreKey,
+	StoreKey storetypes.StoreKey,
 	govModuleAddr sdk.AccAddress,
 	ps paramtypes.Subspace,
 	authenticatorManager *authenticator.AuthenticatorManager,
@@ -48,7 +48,7 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		storeKey:               managerStoreKey,
+		storeKey:               StoreKey,
 		cdc:                    cdc,
 		CircuitBreakerGovernor: govModuleAddr,
 		paramSpace:             ps,

--- a/x/smart-account/types/keys.go
+++ b/x/smart-account/types/keys.go
@@ -9,11 +9,10 @@ import (
 
 const (
 	// ModuleName defines the module name
-	ModuleName = "authenticator"
+	ModuleName = "smartaccount"
 
 	// StoreKey defines the primary module store key
-	ManagerStoreKey       = ModuleName + "manager"
-	AuthenticatorStoreKey = ModuleName + "authenticator"
+	StoreKey = ModuleName
 
 	// RouterKey defines the module's message routing key
 	RouterKey = ModuleName


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #8095

## What is the purpose of the change

- removing an usused store key, that was left over from the transient store


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified key management in the smart-account module for enhanced maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->