### PR TITLE
Fix non-deterministic spend limit test

### DIFF
--- a/x/smart-account/authenticator/spend_limits_test.go
+++ b/x/smart-account/authenticator/spend_limits_test.go
@@ -281,7 +281,7 @@ func (s *SpendLimitAuthenticatorTest) TestSpendLimit() {
 	s.Require().Contains(
 		err.Error(),
 		fmt.Sprintf(
-			"Current time %d.%d not within time limit None - %s.%s: execute wasm contract failed",
+			"Current time %d.%09d not within time limit None - %s.%s: execute wasm contract failed",
 			s.Ctx.BlockTime().Unix(), s.Ctx.BlockTime().Nanosecond(),
 			endTimeSecsStr, endTimeNanosStr,
 		),


### PR DESCRIPTION

## What is the purpose of the change

Fix non-deterministic spend limit test due to time formatting. Example here:

https://github.com/osmosis-labs/osmosis/actions/runs/8774269091/job/24075320765?pr=8118
https://github.com/osmosis-labs/osmosis/actions/runs/8773944616/job/24074635583?pr=7876


## Testing and Verifying

This change fix the test.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error message formatting in spend limit checks to include more precise time representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->