### PR TITLE
Don't check for expired locks every single blcok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8125](https://github.com/osmosis-labs/osmosis/pull/8125) When using smart accounts, fees are deducted directly after the feePayer is authenticated. Regardless of the authentication of other signers
 * [#8136](https://github.com/osmosis-labs/osmosis/pull/8136) Don't allow gauge creation/addition with rewards that have no protorev route (i.e. no way to determine if rewards meet minimum epoch value distribution requirements)
 * [#8144](https://github.com/osmosis-labs/osmosis/pull/8144) IBC wasm clients can now make stargate queries and support abort.
+* [#8147](https://github.com/osmosis-labs/osmosis/pull/8147) Process unbonding locks once per minute, rather than every single block.
 
 ### State Compatible
 

--- a/x/lockup/abci.go
+++ b/x/lockup/abci.go
@@ -14,13 +14,15 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 
 // Called every block to automatically unlock matured locks.
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) []abci.ValidatorUpdate {
-	// TODO: Change this logic to "know" when the next unbonding time is, and only unlock at that time.
-	// At each unbond, do an iterate to find the next unbonding time and wait until then.
-	// delete synthetic locks matured before lockup deletion
-	k.DeleteAllMaturedSyntheticLocks(ctx)
+	if ctx.BlockHeight()%30 == 0 {
+		// TODO: Change this logic to "know" when the next unbonding time is, and only unlock at that time.
+		// At each unbond, do an iterate to find the next unbonding time and wait until then.
+		// delete synthetic locks matured before lockup deletion
+		k.DeleteAllMaturedSyntheticLocks(ctx)
 
-	// withdraw and delete locks
-	k.WithdrawAllMaturedLocks(ctx)
+		// withdraw and delete locks
+		k.WithdrawAllMaturedLocks(ctx)
+	}
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
We are running somewhat expensive iterators every block. This PR makes it now once every 30 blocks, reducing the average case load of a block. 

I am a bit surprised no tests broke though,.