### PR TITLE
chore: default timeout commit to 1.5s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+## v24.0.4
+
 * [#8142](https://github.com/osmosis-labs/osmosis/pull/8142) Add query for getting single authenticator and add stargate whitelist for the query.
+* [#8149](https://github.com/osmosis-labs/osmosis/pull/8149) Default timeoutCommit to 1.5s
 
 ## v24.0.3
 

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -119,7 +119,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.StateSync.TrustPeriod = 112 * time.Hour
 
 			// Consensus
-			config.Consensus.TimeoutCommit = 2 * time.Second
+			config.Consensus.TimeoutCommit = 1500 * time.Millisecond // 1.5s
 			// config.Consensus.PeerGossipSleepDuration = 10 * time.Millisecond
 
 			// Other

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -125,7 +125,7 @@ var (
 		{
 			Section: "consensus",
 			Key:     "timeout_commit",
-			Value:   "2s",
+			Value:   "1.5s",
 		},
 	}
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Moves default from 2s to 1.5s, targeting 2.5 second blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a query for retrieving individual authenticators.
	- Implemented a stargate whitelist for enhanced query management.

- **Bug Fixes**
	- Adjusted the default timeout for commit operations from 2 seconds to 1.5 seconds to improve system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->