### PR TITLE
chore: add v25.x backport tag to mergify github action

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -175,3 +175,11 @@ pull_request_rules:
       backport:
         branches:
           - v24.x
+  - name: backport patches to v25.x branch
+    conditions:
+      - base=main
+      - label=A:backport/v25.x
+    actions:
+      backport:
+        branches:
+          - v25.x


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Adding v25.x backport label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a rule to automatically backport patches to the `v25.x` branch, enhancing the update process for users on this version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->