### PR TITLE
perf: Don't keep refetching params in epoch

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -29,6 +29,7 @@ var (
 // DistributionValueCache is a cache for when we calculate the minimum value
 // an underlying token must be to be distributed.
 type DistributionValueCache struct {
+	minDistrValue      sdk.Coin
 	denomToMinValueMap map[string]osmomath.Int
 }
 
@@ -624,7 +625,7 @@ func (k Keeper) distributeInternal(
 
 	// Retrieve the min value for distribution.
 	// If any distribution amount is valued less than what the param is set, it will be skipped.
-	minValueForDistr := k.GetParams(ctx).MinValueForDistribution
+	minValueForDistr := minDistrValueCache.minDistrValue
 
 	remainCoins := gauge.Coins.Sub(gauge.DistributedCoins...)
 
@@ -926,6 +927,7 @@ func (k Keeper) Distribute(ctx sdk.Context, gauges []types.Gauge) (sdk.Coins, er
 	// While this isn't precise as it doesn't account for price impact, it is good enough for the sole
 	// purpose of determining if we should distribute the token or not.
 	minDistrValueCache := &DistributionValueCache{
+		minDistrValue:      k.GetParams(ctx).MinValueForDistribution,
 		denomToMinValueMap: make(map[string]osmomath.Int),
 	}
 


### PR DESCRIPTION
Speeds up epoch by .5s by not repeatedly re-fetching the params.

This is state compatible even though its gas impacting, as it only affects begin block gas counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a minimum distribution value setting to enhance the distribution mechanism.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->