### PR TITLE
chore: Create CI for bumping sdk version via GA

### DIFF
--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -44,7 +44,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "auto: update osmosis-labs/cosmos-sdk to $VERSION"
+          title: "auto: update osmosis-labs/cosmos-sdk to $${{ github.event.inputs.version }}"
           commit-message: "auto: update osmosis-labs/cosmos-sdk to $VERSION"
           body: |
             **Automated pull request**

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -10,7 +10,7 @@ on:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
         default: 'main' # Default branch
-        
+
 jobs:
   update-sdk-version-and-create-pr:
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           echo "Using version: $VERSION"
-          MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod"
+          MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod"
           for modfile in $MODFILES; do
             if [ -e "$modfile" ]; then
               sed -i "s|github.com/osmosis-labs/cosmos-sdk v[0-9a-zA-Z.\-]*|github.com/osmosis-labs/cosmos-sdk $VERSION|g" $modfile

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -44,7 +44,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "auto: update osmosis-labs/cosmos-sdk to $${{ github.event.inputs.version }}"
+          title: "auto: update osmosis-labs/cosmos-sdk to ${{ github.event.inputs.version }}"
           commit-message: "auto: update osmosis-labs/cosmos-sdk to $VERSION"
           body: |
             **Automated pull request**
@@ -55,4 +55,4 @@ jobs:
           delete-branch: true
           assignees: ${{ github.actor }}
           draft: true
-          labels: "T:auto,T:code-hygiene,V:state/compatible,no_backport,A:no-changelog"
+          labels: "T:auto,A:no-changelog"

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -54,5 +54,4 @@ jobs:
           branch-suffix: random
           delete-branch: true
           assignees: ${{ github.actor }}
-          draft: true
           labels: "T:auto,A:no-changelog"

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -3,14 +3,17 @@ name: Update Cosmos SDK Version
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'SDK version to use'
+        required: true
       branch:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
         default: 'main' # Default branch
+
   pull_request:
     branches: 
       - main # or any other branches you want to include
-    
 
 jobs:
   update-sdk-version-and-create-pr:
@@ -31,7 +34,7 @@ jobs:
           MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod"
           for modfile in $MODFILES; do
             if [ -e "$modfile" ]; then
-              sed -i "s|github.com/cosmos/cosmos-sdk v[0-9a-z.\-]*|github.com/osmosis-labs/cosmos-sdk $VERSION|g" $modfile
+              sed -i "s|github.com/osmosis-labs/cosmos-sdk v[0-9a-zA-Z.\-]*|github.com/osmosis-labs/cosmos-sdk $VERSION|g" $modfile
               cd `dirname $modfile`
               go mod tidy
               cd - > /dev/null
@@ -51,7 +54,7 @@ jobs:
             **Automated pull request**
 
             Updating osmosis-labs/cosmos-sdk dependency to the specified version $VERSION.
-          base: main
+          base: ${{ github.event.inputs.branch }}
           branch-suffix: random
           delete-branch: true
           assignees: ${{ github.actor }}

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
-        default: 'main' # Default branch
+        default: 'osmo/v0.47.5' # Default branch
 
 jobs:
   update-sdk-version-and-create-pr:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.17' # Specify your Go version here
+          go-version: '^1.20' 
 
       - name: Fetch Latest Commit Hash
         id: fetch-commit
@@ -60,7 +60,7 @@ jobs:
             **Automated pull request**
 
             Updating osmosis-labs/cosmos-sdk dependency to the latest commit on branch ${{ github.event.inputs.branch }}.
-          base: main # Specify the base branch for the PR
+          base: main
           branch-suffix: random
           delete-branch: true
           assignees: ${{ github.actor }}

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -7,9 +7,9 @@ on:
         description: 'SDK version to use'
         required: true
       branch:
-        description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
+        description: 'Branch to update sdk version'
         required: true
-        default: 'main' # Default branch
+        default: 'main'
 
 jobs:
   update-sdk-version-and-create-pr:
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.20' # Specify your Go version here
+          go-version: '^1.20' 
 
       - name: Update SDK Version in Go Mod Files
         run: |
@@ -45,11 +45,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "auto: update osmosis-labs/cosmos-sdk to ${{ github.event.inputs.version }}"
-          commit-message: "auto: update osmosis-labs/cosmos-sdk to $VERSION"
+          commit-message: "auto: update osmosis-labs/cosmos-sdk to ${{ github.event.inputs.version }}"
           body: |
             **Automated pull request**
 
-            Updating osmosis-labs/cosmos-sdk dependency to the specified version $VERSION.
+            Updating osmosis-labs/cosmos-sdk dependency to the specified version ${{ github.event.inputs.version }}.
           base: ${{ github.event.inputs.branch }}
           branch-suffix: random
           delete-branch: true

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -1,0 +1,68 @@
+name: Update SDK Version with Commit Hash and Create PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
+        required: true
+        default: 'main' # Default branch
+
+jobs:
+  update-sdk-version-and-create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17' # Specify your Go version here
+
+      - name: Fetch Latest Commit Hash
+        id: fetch-commit
+        run: |
+          BRANCH=${{ github.event.inputs.branch }}
+          COMMIT_HASH=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                               -H "Accept: application/vnd.github.v3+json" \
+                               "https://api.github.com/repos/osmosis-labs/cosmos-sdk/commits/$BRANCH" \
+                               | jq -r '.sha')
+          echo "Latest commit hash in $BRANCH branch is $COMMIT_HASH"
+          echo "::set-output name=commit_hash::$COMMIT_HASH"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update SDK Version in Go Mod Files
+        run: |
+          VERSION=$(echo "v0.0.0-$(date +%Y%m%d%H%M%S)-${{ steps.fetch-commit.outputs.commit_hash }}")
+          echo "Formatted version: $VERSION"
+          MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod"
+          for modfile in $MODFILES; do
+            if [ -e "$modfile" ]; then
+              sed -i "s|github.com/osmosis-labs/cosmos-sdk v[0-9a-z.\-]*|github.com/osmosis-labs/cosmos-sdk $VERSION|g" $modfile
+              cd `dirname $modfile`
+              go mod tidy
+              cd - > /dev/null
+            else
+              echo "File $modfile does not exist"
+            fi
+          done
+        shell: bash
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "auto: update osmosis-labs/cosmos-sdk to latest commit on branch ${{ github.event.inputs.branch }}"
+          commit-message: "auto: update osmosis-labs/cosmos-sdk dependency"
+          body: |
+            **Automated pull request**
+
+            Updating osmosis-labs/cosmos-sdk dependency to the latest commit on branch ${{ github.event.inputs.branch }}.
+          base: main # Specify the base branch for the PR
+          branch-suffix: random
+          delete-branch: true
+          assignees: ${{ github.actor }}
+          draft: true
+          labels: "T:auto,T:code-hygiene,V:state/compatible/no_backport,A:no-changelog"

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -1,3 +1,5 @@
+name: Update Cosmos SDK Version
+
 on:
   workflow_dispatch:
     inputs:
@@ -5,9 +7,10 @@ on:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
         default: 'main' # Default branch
-  pull_request:
-    branches: 
-      - main # or any other branches you want to include
+      version:
+        description: 'Version tag to use for osmosis-labs/cosmos-sdk'
+        required: true
+        default: 'v0.47.5-v24-osmo-4' # Default version
 
 jobs:
   update-sdk-version-and-create-pr:
@@ -19,42 +22,16 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.17' # Specify your Go version here
-
-      - name: Determine Branch for Latest Commit
-        id: get-branch
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "::set-output name=branch::${{ github.event.inputs.branch }}"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # For testing purposes, using a hard-coded branch name when triggered by a pull request
-            echo "::set-output name=branch::osmo/v0.47.5"
-          else
-            echo "::set-output name=branch::main"
-          fi
-
-
-      - name: Fetch Latest Commit Hash
-        id: fetch-commit
-        run: |
-          BRANCH=${{ steps.get-branch.outputs.branch }}
-          COMMIT_HASH=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                               -H "Accept: application/vnd.github.v3+json" \
-                               "https://api.github.com/repos/osmosis-labs/cosmos-sdk/commits/$BRANCH" \
-                               | jq -r '.sha')
-          echo "Latest commit hash in $BRANCH branch is $COMMIT_HASH"
-          echo "::set-output name=commit_hash::$COMMIT_HASH"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          go-version: '^1.20' # Specify your Go version here
 
       - name: Update SDK Version in Go Mod Files
         run: |
-          VERSION=$(echo "v0.0.0-$(date +%Y%m%d%H%M%S)-${{ steps.fetch-commit.outputs.commit_hash }}")
-          echo "Formatted version: $VERSION"
+          VERSION="${{ github.event.inputs.version }}"
+          echo "Using version: $VERSION"
           MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod"
           for modfile in $MODFILES; do
             if [ -e "$modfile" ]; then
-              sed -i "s|github.com/osmosis-labs/cosmos-sdk v[0-9a-z.\-]*|github.com/osmosis-labs/cosmos-sdk $VERSION|g" $modfile
+              sed -i "s|github.com/cosmos/cosmos-sdk v[0-9a-z.\-]*|github.com/osmosis-labs/cosmos-sdk $VERSION|g" $modfile
               cd `dirname $modfile`
               go mod tidy
               cd - > /dev/null
@@ -68,15 +45,15 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "auto: update osmosis-labs/cosmos-sdk to latest commit on branch ${{ github.event.inputs.branch }}"
-          commit-message: "auto: update osmosis-labs/cosmos-sdk dependency"
+          title: "auto: update osmosis-labs/cosmos-sdk to $VERSION"
+          commit-message: "auto: update osmosis-labs/cosmos-sdk to $VERSION"
           body: |
             **Automated pull request**
 
-            Updating osmosis-labs/cosmos-sdk dependency to the latest commit on branch ${{ github.event.inputs.branch }}.
+            Updating osmosis-labs/cosmos-sdk dependency to the specified version $VERSION.
           base: main
           branch-suffix: random
           delete-branch: true
           assignees: ${{ github.actor }}
           draft: true
-          labels: "T:auto,T:code-hygiene,V:state/compatible/no_backport,A:no-changelog"
+          labels: "T:auto,T:code-hygiene,V:state/compatible,no_backport,A:no-changelog"

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -11,6 +11,9 @@ on:
         description: 'Version tag to use for osmosis-labs/cosmos-sdk'
         required: true
         default: 'v0.47.5-v24-osmo-4' # Default version
+  pull_request:
+    branches: 
+      - main # or any other branches you want to include
 
 jobs:
   update-sdk-version-and-create-pr:

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -10,11 +10,7 @@ on:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
         default: 'main' # Default branch
-
-  pull_request:
-    branches: 
-      - main # or any other branches you want to include
-
+        
 jobs:
   update-sdk-version-and-create-pr:
     runs-on: ubuntu-latest
@@ -29,7 +25,7 @@ jobs:
 
       - name: Update SDK Version in Go Mod Files
         run: |
-          VERSION="v0.47.5-v24-osmo-4"
+          VERSION="${{ github.event.inputs.version }}"
           echo "Using version: $VERSION"
           MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod"
           for modfile in $MODFILES; do

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -1,12 +1,13 @@
-name: Update SDK Version with Commit Hash and Create PR
-
 on:
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
-        default: 'osmo/v0.47.5' # Default branch
+        default: 'main' # Default branch
+  pull_request:
+    branches: 
+      - main # or any other branches you want to include
 
 jobs:
   update-sdk-version-and-create-pr:
@@ -18,12 +19,23 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.20' 
+          go-version: '^1.17' # Specify your Go version here
+
+      - name: Determine Branch for Latest Commit
+        id: get-branch
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::set-output name=branch::${{ github.event.inputs.branch }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::set-output name=branch::${{ github.event.pull_request.head.ref }}"
+          else
+            echo "::set-output name=branch::main"
+          fi
 
       - name: Fetch Latest Commit Hash
         id: fetch-commit
         run: |
-          BRANCH=${{ github.event.inputs.branch }}
+          BRANCH=${{ steps.get-branch.outputs.branch }}
           COMMIT_HASH=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                                -H "Accept: application/vnd.github.v3+json" \
                                "https://api.github.com/repos/osmosis-labs/cosmos-sdk/commits/$BRANCH" \
@@ -49,7 +61,6 @@ jobs:
             fi
           done
         shell: bash
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -27,10 +27,12 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "::set-output name=branch::${{ github.event.inputs.branch }}"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "::set-output name=branch::${{ github.event.pull_request.head.ref }}"
+            # For testing purposes, using a hard-coded branch name when triggered by a pull request
+            echo "::set-output name=branch::osmo/v0.47.5"
           else
             echo "::set-output name=branch::main"
           fi
+
 
       - name: Fetch Latest Commit Hash
         id: fetch-commit
@@ -61,6 +63,7 @@ jobs:
             fi
           done
         shell: bash
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -7,13 +7,10 @@ on:
         description: 'Branch name in osmosis-labs/cosmos-sdk to fetch the latest commit from'
         required: true
         default: 'main' # Default branch
-      version:
-        description: 'Version tag to use for osmosis-labs/cosmos-sdk'
-        required: true
-        default: 'v0.47.5-v24-osmo-4' # Default version
   pull_request:
     branches: 
       - main # or any other branches you want to include
+    
 
 jobs:
   update-sdk-version-and-create-pr:
@@ -29,7 +26,7 @@ jobs:
 
       - name: Update SDK Version in Go Mod Files
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="v0.47.5-v24-osmo-4"
           echo "Using version: $VERSION"
           MODFILES="./go.mod ./osmoutils/go.mod ./osmomath/go.mod ./x/epochs/go.mod ./x/ibc-hooks/go.mod ./tests/cl-genesis-positions/go.mod ./tests/cl-go-client/go.mod"
           for modfile in $MODFILES; do


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Bumping sdk version has always been a painful process, this PR adds a github action that bumps all the sdk versions in all the different go.mods in our repo 

## Testing and Verifying

A successful run on this CI can be seen in https://github.com/mattverse/osmosis/actions/runs/8872042264, https://github.com/mattverse/osmosis/pull/20.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Actions workflow to automate the updating of the Cosmos SDK version across Go mod files, enhancing efficiency and accuracy in dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->