### PR TITLE
fix: return err if type not in manager

### DIFF
--- a/x/smart-account/authenticator/composite.go
+++ b/x/smart-account/authenticator/composite.go
@@ -56,6 +56,9 @@ func onSubAuthenticatorsAdded(ctx sdk.Context, account sdk.AccAddress, data []by
 	subAuthenticatorCount := 0
 	for id, initData := range initDatas {
 		authenticatorCode := am.GetAuthenticatorByType(initData.Type)
+		if authenticatorCode == nil {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "sub-authenticator failed to be added in function `OnAuthenticatorAdded` as type is not registered in manager")
+		}
 		subId := compositeId(baseId, id)
 		err := authenticatorCode.OnAuthenticatorAdded(ctx, account, initData.Config, subId)
 		if err != nil {
@@ -82,6 +85,9 @@ func onSubAuthenticatorsRemoved(ctx sdk.Context, account sdk.AccAddress, data []
 	baseId := authenticatorId
 	for id, initData := range initDatas {
 		authenticatorCode := am.GetAuthenticatorByType(initData.Type)
+		if authenticatorCode == nil {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "sub-authenticator failed to be removed in function `OnAuthenticatorRemoved` as type is not registered in manager")
+		}
 		subId := compositeId(baseId, id)
 		err := authenticatorCode.OnAuthenticatorRemoved(ctx, account, initData.Config, subId)
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Return an error is sub authenticator is not registered, this will avoid a recovered panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved error handling for unregistered sub-authenticators during addition or removal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->