### PR TITLE
perf: isSmartAccountActive param cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8147](https://github.com/osmosis-labs/osmosis/pull/8147) Process unbonding locks once per minute, rather than every single block
 * [#8157](https://github.com/osmosis-labs/osmosis/pull/8157) Speedup protorev by not unmarshalling pools in cost-estimation phase
 * [#8177](https://github.com/osmosis-labs/osmosis/pull/8177) Change consensus params to match unbonding period
+* [#8189](https://github.com/osmosis-labs/osmosis/pull/8189) Perf: Use local cache for isSmartAccountActive param
 
 
 ### State Compatible

--- a/x/smart-account/ante/circuit_breaker.go
+++ b/x/smart-account/ante/circuit_breaker.go
@@ -54,9 +54,9 @@ func IsCircuitBreakActive(
 	tx sdk.Tx,
 	smartAccountKeeper *smartaccountkeeper.Keeper,
 ) (bool, smartaccounttypes.AuthenticatorTxOptions) {
-	authenticatorParams := smartAccountKeeper.GetParams(ctx)
+	isSmartAccountActive := smartAccountKeeper.GetIsSmartAccountActive(ctx)
 	// If the smart accounts are not active, the circuit breaker activates (i.e. return true).
-	if !authenticatorParams.IsSmartAccountActive {
+	if !isSmartAccountActive {
 		return true, nil
 	}
 

--- a/x/smart-account/keeper/keeper.go
+++ b/x/smart-account/keeper/keeper.go
@@ -27,10 +27,12 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 type Keeper struct {
-	storeKey               storetypes.StoreKey
-	cdc                    codec.BinaryCodec
-	paramSpace             paramtypes.Subspace
-	CircuitBreakerGovernor sdk.AccAddress
+	storeKey                storetypes.StoreKey
+	cdc                     codec.BinaryCodec
+	paramSpace              paramtypes.Subspace
+	CircuitBreakerGovernor  sdk.AccAddress
+	isSmartAccountActiveBz  []byte
+	isSmartAccountActiveVal bool
 
 	AuthenticatorManager *authenticator.AuthenticatorManager
 }

--- a/x/smart-account/keeper/params.go
+++ b/x/smart-account/keeper/params.go
@@ -20,6 +20,9 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
 }
 
+// GetIsSmartAccountActive returns the value of the isSmartAccountActive parameter.
+// If the value has not been set, it will return false.
+// If there is an error unmarshalling the value, it will return false.
 func (k Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
 	isSmartAccountActiveBz := k.paramSpace.GetRaw(ctx, types.KeyIsSmartAccountActive)
 	if !bytes.Equal(isSmartAccountActiveBz, k.isSmartAccountActiveBz) {

--- a/x/smart-account/keeper/params.go
+++ b/x/smart-account/keeper/params.go
@@ -33,6 +33,7 @@ func (k Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
 			isSmartAccountActiveValue = false
 		}
 		k.isSmartAccountActiveVal = isSmartAccountActiveValue
+		k.isSmartAccountActiveBz = isSmartAccountActiveBz
 	}
 	return k.isSmartAccountActiveVal
 }

--- a/x/smart-account/keeper/params.go
+++ b/x/smart-account/keeper/params.go
@@ -23,7 +23,7 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 // GetIsSmartAccountActive returns the value of the isSmartAccountActive parameter.
 // If the value has not been set, it will return false.
 // If there is an error unmarshalling the value, it will return false.
-func (k Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
+func (k *Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
 	isSmartAccountActiveBz := k.paramSpace.GetRaw(ctx, types.KeyIsSmartAccountActive)
 	if !bytes.Equal(isSmartAccountActiveBz, k.isSmartAccountActiveBz) {
 		var isSmartAccountActiveValue bool

--- a/x/smart-account/keeper/params.go
+++ b/x/smart-account/keeper/params.go
@@ -29,6 +29,7 @@ func (k Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
 		var isSmartAccountActiveValue bool
 		err := json.Unmarshal(isSmartAccountActiveBz, &isSmartAccountActiveValue)
 		if err != nil {
+			k.Logger(ctx).Error("failed to unmarshal isSmartAccountActive", "error", err)
 			isSmartAccountActiveValue = false
 		}
 		k.isSmartAccountActiveVal = isSmartAccountActiveValue

--- a/x/smart-account/keeper/params.go
+++ b/x/smart-account/keeper/params.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v25/x/smart-account/types"
-	smartaccounttypes "github.com/osmosis-labs/osmosis/v25/x/smart-account/types"
 )
 
 // GetParams get all parameters as types.Params
@@ -22,7 +21,7 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 }
 
 func (k Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
-	isSmartAccountActiveBz := k.paramSpace.GetRaw(ctx, smartaccounttypes.KeyIsSmartAccountActive)
+	isSmartAccountActiveBz := k.paramSpace.GetRaw(ctx, types.KeyIsSmartAccountActive)
 	if !bytes.Equal(isSmartAccountActiveBz, k.isSmartAccountActiveBz) {
 		var isSmartAccountActiveValue bool
 		err := json.Unmarshal(isSmartAccountActiveBz, &isSmartAccountActiveValue)

--- a/x/smart-account/keeper/params.go
+++ b/x/smart-account/keeper/params.go
@@ -1,9 +1,13 @@
 package keeper
 
 import (
+	"bytes"
+	"encoding/json"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/v25/x/smart-account/types"
+	smartaccounttypes "github.com/osmosis-labs/osmosis/v25/x/smart-account/types"
 )
 
 // GetParams get all parameters as types.Params
@@ -15,4 +19,17 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 // SetParams set the params
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
+}
+
+func (k Keeper) GetIsSmartAccountActive(ctx sdk.Context) bool {
+	isSmartAccountActiveBz := k.paramSpace.GetRaw(ctx, smartaccounttypes.KeyIsSmartAccountActive)
+	if !bytes.Equal(isSmartAccountActiveBz, k.isSmartAccountActiveBz) {
+		var isSmartAccountActiveValue bool
+		err := json.Unmarshal(isSmartAccountActiveBz, &isSmartAccountActiveValue)
+		if err != nil {
+			isSmartAccountActiveValue = false
+		}
+		k.isSmartAccountActiveVal = isSmartAccountActiveValue
+	}
+	return k.isSmartAccountActiveVal
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Inspired by https://github.com/osmosis-labs/osmosis/pull/8148

This param retrieval currently gets called 6 times for each tx. This requires unmarshalling all the params from the module, which is very wasteful.

## Testing and Verifying

All currently existing tests that test the circuit breaker should behave the same. I will also be setting breakpoints in my QA for v25 on this feature to ensure the behavior is as expected. 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A