### PR TITLE
chore: downgrade toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/osmosis-labs/osmosis/v25
 
 go 1.21.4
 
-toolchain go1.22.0
+toolchain go1.21.6
 
 require (
 	cosmossdk.io/api v0.3.1


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

I think we accidentally bumped to 1.22 on the toolchain. We had agreed to stay on 1.21 for now