### PR TITLE
fix: eip 1559 fix for block-sdk

### DIFF
--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -135,7 +135,7 @@ func (e EipState) Clone() EipState {
 // deliverTxCode runs on every transaction in the feedecorator ante handler and sums the gas of each transaction
 func (e *EipState) deliverTxCode(ctx sdk.Context, tx sdk.FeeTx) {
 	if ctx.BlockHeight() != e.lastBlockHeight {
-		ctx.Logger().Error("Something is off here? ctx.BlockHeight() != e.lastBlockHeight", ctx.BlockHeight(), e.lastBlockHeight)
+		ctx.Logger().Error(fmt.Sprintf("Something is off here? ctx.BlockHeight() (%d) != e.lastBlockHeight (%d)", ctx.BlockHeight(), e.lastBlockHeight))
 	}
 	e.totalGasWantedThisBlock += int64(tx.GetGas())
 }
@@ -151,7 +151,10 @@ func (e *EipState) updateBaseFee(height int64) {
 	if height != e.lastBlockHeight {
 		fmt.Println("Something is off here? height != e.lastBlockHeight", height, e.lastBlockHeight)
 	}
-	e.lastBlockHeight = height
+
+	// N.B. we set the lastBlockHeight to height + 1 to avoid the case where block sdk submits a update proposal
+	// tx prior to the eip startBlock being called (which is a begin block call).
+	e.lastBlockHeight = height + 1
 
 	gasUsed := e.totalGasWantedThisBlock
 	gasDiff := gasUsed - TargetGas

--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -93,7 +93,7 @@ const (
 // EipState tracks the current base fee and totalGasWantedThisBlock
 // this structure is never written to state
 type EipState struct {
-	lastBlockHeight         int64
+	currentBlockHeight      int64
 	totalGasWantedThisBlock int64
 	BackupFilePath          string
 	CurBaseFee              osmomath.Dec `json:"cur_base_fee"`
@@ -103,7 +103,7 @@ type EipState struct {
 // DeliverTx (fee decorator AnteHandler) functions, it's also using when determining
 // if a transaction has enough gas to successfully execute
 var CurEipState = EipState{
-	lastBlockHeight:         0,
+	currentBlockHeight:      0,
 	totalGasWantedThisBlock: 0,
 	BackupFilePath:          "",
 	CurBaseFee:              sdk.NewDec(0),
@@ -112,7 +112,7 @@ var CurEipState = EipState{
 // startBlock is executed at the start of each block and is responsible for resetting the state
 // of the CurBaseFee when the node reaches the reset interval
 func (e *EipState) startBlock(height int64, logger log.Logger) {
-	e.lastBlockHeight = height
+	e.currentBlockHeight = height
 	e.totalGasWantedThisBlock = 0
 
 	if e.CurBaseFee.Equal(sdk.NewDec(0)) {
@@ -134,8 +134,8 @@ func (e EipState) Clone() EipState {
 
 // deliverTxCode runs on every transaction in the feedecorator ante handler and sums the gas of each transaction
 func (e *EipState) deliverTxCode(ctx sdk.Context, tx sdk.FeeTx) {
-	if ctx.BlockHeight() != e.lastBlockHeight {
-		ctx.Logger().Error(fmt.Sprintf("Something is off here? ctx.BlockHeight() (%d) != e.lastBlockHeight (%d)", ctx.BlockHeight(), e.lastBlockHeight))
+	if ctx.BlockHeight() != e.currentBlockHeight {
+		ctx.Logger().Error(fmt.Sprintf("Something is off here? ctx.BlockHeight() (%d) != e.currentBlockHeight (%d)", ctx.BlockHeight(), e.currentBlockHeight))
 	}
 	e.totalGasWantedThisBlock += int64(tx.GetGas())
 }
@@ -148,13 +148,13 @@ func (e *EipState) deliverTxCode(ctx sdk.Context, tx sdk.FeeTx) {
 //
 // updateBaseFee runs at the end of every block
 func (e *EipState) updateBaseFee(height int64) {
-	if height != e.lastBlockHeight {
-		fmt.Println("Something is off here? height != e.lastBlockHeight", height, e.lastBlockHeight)
+	if height != e.currentBlockHeight {
+		fmt.Println("Something is off here? height != e.currentBlockHeight", height, e.currentBlockHeight)
 	}
 
 	// N.B. we set the lastBlockHeight to height + 1 to avoid the case where block sdk submits a update proposal
 	// tx prior to the eip startBlock being called (which is a begin block call).
-	e.lastBlockHeight = height + 1
+	e.currentBlockHeight = height + 1
 
 	gasUsed := e.totalGasWantedThisBlock
 	gasDiff := gasUsed - TargetGas

--- a/x/txfees/keeper/mempool-1559/code_test.go
+++ b/x/txfees/keeper/mempool-1559/code_test.go
@@ -22,7 +22,7 @@ import (
 func TestUpdateBaseFee(t *testing.T) {
 	// Create an instance of eipState
 	eip := &EipState{
-		lastBlockHeight:         0,
+		currentBlockHeight:      0,
 		totalGasWantedThisBlock: 0,
 		CurBaseFee:              DefaultBaseFee.Clone(),
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We were seeing the following error recently in many of the blocks in the e2e test suite:

![Screenshot 2024-05-01 at 11 04 54 PM](https://github.com/osmosis-labs/osmosis/assets/40078083/ebf9684a-b96b-4b6e-9fc7-ab648f0f040a)

This error occurred any time an updateProposal call was made in which the partialProposalSize was greater than zero. The reason this error was occurring was because, in the EIP code, we set the e.lastBlockHeight in the EIP beginBlocker, however the block-sdk creates transactions prior to the beginBlocker being called, resulting in this error triggering.

We therefore set the block height in the end blocker instead of just the begin blocker. I left the begin blocker set, otherwise we might have an issue where the first block every time creates the error, and it is minimal additional overhead.

## Testing and Verifying

E2E no longer shows the error