### PR TITLE
Support multiple sqs instances

### DIFF
--- a/ingest/sqs/ingester.go
+++ b/ingest/sqs/ingester.go
@@ -114,5 +114,4 @@ func (i *sqsIngester) ProcessChangedBlockData(ctx sdk.Context, changedPools doma
 	}
 
 	return nil
-
 }


### PR DESCRIPTION
## What is the purpose of the change

The changes in this ticket will allow supporting multiple sqs instances, with a comma delimited hostname:port in app.toml, e.g. grpc-ingest-address = "localhost:50051,localhost:50052"

This will make scaling up sqs much easier, without always having to have a corresponding osmosis node for each sqs instance.

## Testing and Verifying

Tested in local dev environment with two instances of sqs running.
