### PR TITLE
[SmartAccounts] Deactivate smart accounts messages when smartaccounts is inactive

### DIFF
--- a/x/smart-account/keeper/msg_server.go
+++ b/x/smart-account/keeper/msg_server.go
@@ -32,6 +32,11 @@ func (m msgServer) AddAuthenticator(
 ) (*types.MsgAddAuthenticatorResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	isSmartAccountActive := m.GetIsSmartAccountActive(ctx)
+	if !isSmartAccountActive {
+		return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "smartaccount module is not active")
+	}
+
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid sender address")
@@ -61,6 +66,11 @@ func (m msgServer) AddAuthenticator(
 // RemoveAuthenticator removes an authenticator from the store. The message specifies a sender address and an index.
 func (m msgServer) RemoveAuthenticator(goCtx context.Context, msg *types.MsgRemoveAuthenticator) (*types.MsgRemoveAuthenticatorResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	isSmartAccountActive := m.GetIsSmartAccountActive(ctx)
+	if !isSmartAccountActive {
+		return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "smartaccount module is not active")
+	}
 
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {

--- a/x/smart-account/keeper/msg_server_test.go
+++ b/x/smart-account/keeper/msg_server_test.go
@@ -183,3 +183,30 @@ func (s *KeeperTestSuite) TestMsgServer_SetActiveState() {
 	params.IsSmartAccountActive = initialParams.IsSmartAccountActive
 	s.Require().Equal(params, initialParams)
 }
+
+func (s *KeeperTestSuite) TestMsgServer_SmartAccountsNotActive() {
+	msgServer := keeper.NewMsgServerImpl(*s.App.SmartAccountKeeper)
+	ctx := s.Ctx
+
+	s.App.SmartAccountKeeper.SetParams(s.Ctx, types.Params{IsSmartAccountActive: false})
+
+	// Create a test message
+	msg := &types.MsgAddAuthenticator{
+		Sender: "",
+		Type:   authenticator.SignatureVerification{}.Type(),
+		Data:   []byte(""),
+	}
+
+	_, err := msgServer.AddAuthenticator(sdk.WrapSDKContext(ctx), msg)
+	s.Require().Error(err)
+	s.Require().Equal(err.Error(), "smartaccount module is not active: unauthorized")
+
+	removeMsg := &types.MsgRemoveAuthenticator{
+		Sender: "",
+		Id:     1,
+	}
+
+	_, err = msgServer.RemoveAuthenticator(sdk.WrapSDKContext(ctx), removeMsg)
+	s.Require().Error(err)
+	s.Require().Equal(err.Error(), "smartaccount module is not active: unauthorized")
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Deactivate smart account messages if smart accounts is inactive

## Testing and Verifying

added a test. Existing tests should pass. 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A