### PR TITLE
Update docs for TokenFactory CLI --help

### DIFF
--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -29,7 +29,7 @@ func GetTxCmd() *cobra.Command {
 func NewCreateDenomCmd() *cobra.Command {
 	return osmocli.BuildTxCli[*types.MsgCreateDenom](&osmocli.TxCliDesc{
 		Use:   "create-denom",
-		Short: "create a new denom from an account. (Costs osmo though!)",
+		Short: "create a new denom from an account.",
 	})
 }
 

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -29,7 +29,7 @@ func GetTxCmd() *cobra.Command {
 func NewCreateDenomCmd() *cobra.Command {
 	return osmocli.BuildTxCli[*types.MsgCreateDenom](&osmocli.TxCliDesc{
 		Use:   "create-denom",
-		Short: "create a new denom from an account.",
+		Short: "create a new denom from an account. (osmo to create tokens is charged through gas consumption)",
 	})
 }
 


### PR DESCRIPTION
Closes: #7942

## What is the purpose of the change

As per issue #7942 decription:

> when running osmosid tx tokenfactory the help documentation shows (Costs osmo though!), while since may 2023 this is not the case anymore (https://github.com/osmosis-labs/osmosis/pull/4983).

This MR simply updates docs by removing `(Costs osmo though!)` from the TokenFactory CLI help docs.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [X] N/A