### PR TITLE
Fix: Slow down action run time by reducing concurrent operations

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -27,7 +27,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: --exclude-loopback --verbose --no-progress './**/*.md' './**/*.html'
+          args: --exclude-loopback --verbose --no-progress --max-concurrency 1 './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
Closes: #7877 

## What is the purpose of the change

This pull request slows down "check broken links" action by reducing concurent requests to 1 ( default: 128 ).
After this change action will take around 10mins to complete for 1.5k links at the moment ( previously 30sec ) with no failed requests as per [testing](https://github.com/deividaspetraitis/osmosis/actions/runs/9112683030).

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? No
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? No

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [X] N/A
