### PR TITLE
Remove wasm times from our antehandler checkTx + recheckTx stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+## v25.0.2
+
+### Osmosis
+
+* [#8308](https://github.com/osmosis-labs/osmosis/pull/8308) Remove IBC rate limit and wasm hook times from mempool checkTx's
+
 ## v25.0.1
 
 ### Osmosis
@@ -64,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#62](https://github.com/osmosis-labs/cometbft/pull/62) perf(consensus/blockstore): Remove validate basic call from LoadBlock
 * [#69](https://github.com/osmosis-labs/cometbft/pull/69) perf: Make mempool update async from block.Commit (#3008)
 * [#67](https://github.com/osmosis-labs/cometbft/pull/67) fix: TimeoutTicker returns wrong value/timeout pair when timeouts are…
+
+### IBC-go
+
+* Upgrade to v7.4.1 which fixes the significant mempool overhead caused by RedundantRelayDecorator
 
 ## v25.0.0
 

--- a/x/ibc-hooks/wasm_hook.go
+++ b/x/ibc-hooks/wasm_hook.go
@@ -298,6 +298,9 @@ func (h WasmHooks) OnAcknowledgementPacketOverride(im IBCMiddleware, ctx sdk.Con
 	if err != nil {
 		return err
 	}
+	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
+		return nil
+	}
 
 	if !h.ProperlyConfigured() {
 		// Not configured. Return from the underlying implementation

--- a/x/ibc-rate-limit/ibc_module.go
+++ b/x/ibc-rate-limit/ibc_module.go
@@ -157,6 +157,9 @@ func (im *IBCModule) OnAcknowledgementPacket(
 	acknowledgement []byte,
 	relayer sdk.AccAddress,
 ) error {
+	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
+		return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
+	}
 	var ack channeltypes.Acknowledgement
 	if err := json.Unmarshal(acknowledgement, &ack); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-20 transfer packet acknowledgement: %v", err)


### PR DESCRIPTION
These codepaths get called in checktx and rechecktx, causing notable overhead. This PR removes these.

We should get this into a patch release to significantly improve our spam resistance