### PR TITLE
fix: pool liquidity cap rounding edge case

### DIFF
--- a/ingest/sqs/pools/transformer/pool_transformer.go
+++ b/ingest/sqs/pools/transformer/pool_transformer.go
@@ -421,7 +421,10 @@ func (pi *poolTransformer) computeUSDCPoolLiquidityCapFromUOSMO(ctx sdk.Context,
 			// If truncation occurs, the real value is insignificant and we can ignore it.
 			poolLiquidityCapUSDC := poolLiquidityCapUSDCScaled.QuoMut(usdcPrecisionScalingFactor)
 
-			return poolLiquidityCapUSDC.Dec().TruncateInt(), noPoolLiquidityCapError
+			// Note, we round up so that pools that have non-zero liquidity get propagated to the router
+			// and reflect this context in the pool liquidity cap filtering. Otherwise, pools with zero liquidity get filtered out at the ingest level
+			// completely, breaking our edge case tests for supporting low liquidity routes.
+			return poolLiquidityCapUSDC.Dec().Ceil().TruncateInt(), noPoolLiquidityCapError
 		}
 	}
 

--- a/ingest/sqs/pools/transformer/pool_transformer_test.go
+++ b/ingest/sqs/pools/transformer/pool_transformer_test.go
@@ -856,5 +856,5 @@ func (s *PoolTransformerTestSuite) CreateDefaultQuoteDenomUOSMOPool() uint64 {
 
 // descaleQuoteDenomPrecisionAmount descales the amount with the quote denom precision scaling factor.
 func descaleQuoteDenomPrecisionAmount(amount osmomath.Int) osmomath.Int {
-	return osmomath.BigDecFromSDKInt(amount).QuoMut(poolstransformer.UsdcPrecisionScalingFactor).Dec().TruncateInt()
+	return osmomath.BigDecFromSDKInt(amount).QuoMut(poolstransformer.UsdcPrecisionScalingFactor).Dec().Ceil().TruncateInt()
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Our SQS integration test suite identified a regression. It stems from the fact that we would truncate the pool liquidity capitalization to zero.

Instead, we should reflect that there is at least some value in the pool by rounding pool liquidity cap up.

Tested against our suite that this change resolves the bug