### PR TITLE
fix: inc flush-throttle-timeout overwrite to 80ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v25.0.3
 
+* [#8329](https://github.com/osmosis-labs/osmosis/pull/8329) Overwrite `flush_throttle_timeout` to 80ms instead of 10ms
+
+## v25.0.2
+
 ### Osmosis
 
 * [#8312](https://github.com/osmosis-labs/osmosis/pull/8312) Overwrite `flush_throttle_timeout` and `peer_gossip_sleep_duration` to 10ms and 50ms respectively
+* [#8308](https://github.com/osmosis-labs/osmosis/pull/8308) Remove IBC rate limit and wasm hook times from mempool checkTx's
 
 ### CometBFT
 
@@ -62,12 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#75](https://github.com/osmosis-labs/cometbft/pull/75) perf(p2p): 4% speedup to readMsg by removing one allocation
 * [#76](https://github.com/osmosis-labs/cometbft/pull/76) perf(consensus): Add LRU caches for blockstore operations used in gossip
 * [#77](https://github.com/osmosis-labs/cometbft/pull/77) perf(consensus): Make every gossip thread use its own randomness instance, reducing mutex contention
-
-## v25.0.2
-
-### Osmosis
-
-* [#8308](https://github.com/osmosis-labs/osmosis/pull/8308) Remove IBC rate limit and wasm hook times from mempool checkTx's
 
 ## v25.0.1
 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -139,7 +139,7 @@ var (
 		{
 			Section: "p2p",
 			Key:     "flush_throttle_timeout",
-			Value:   "100ms",
+			Value:   "80ms",
 		},
 		{
 			Section: "consensus",

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -139,7 +139,7 @@ var (
 		{
 			Section: "p2p",
 			Key:     "flush_throttle_timeout",
-			Value:   "10ms",
+			Value:   "100ms",
 		},
 		{
 			Section: "consensus",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

10ms was causing some validators to have issues, so we are increasing the default overwrite from 10ms to 80ms.