### PR TITLE
fix: expose get authenticator to cli

### DIFF
--- a/x/smart-account/client/cli/query.go
+++ b/x/smart-account/client/cli/query.go
@@ -10,6 +10,7 @@ import (
 func GetQueryCmd() *cobra.Command {
 	cmd := osmocli.QueryIndexCmd(types.ModuleName)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdAuthenticators)
+	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdAuthenticator)
 	osmocli.AddQueryCmd(cmd, types.NewQueryClient, GetCmdParams)
 
 	return cmd
@@ -18,16 +19,25 @@ func GetQueryCmd() *cobra.Command {
 func GetCmdAuthenticators() (*osmocli.QueryDescriptor, *types.GetAuthenticatorsRequest) {
 	return &osmocli.QueryDescriptor{
 		Use:   "authenticators",
-		Short: "Query authenticators",
+		Short: "Query authenticators by account",
 		Long: `{{.Short}}{{.ExampleHeader}}
-{{.CommandPrefix}} osmo1asdadasd`,
+{{.CommandPrefix}} osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj`,
 	}, &types.GetAuthenticatorsRequest{}
+}
+
+func GetCmdAuthenticator() (*osmocli.QueryDescriptor, *types.GetAuthenticatorRequest) {
+	return &osmocli.QueryDescriptor{
+		Use:   "authenticator",
+		Short: "Query authenticator by account and id",
+		Long: `{{.Short}}{{.ExampleHeader}}
+{{.CommandPrefix}} osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj 17`,
+	}, &types.GetAuthenticatorRequest{}
 }
 
 func GetCmdParams() (*osmocli.QueryDescriptor, *types.QueryParamsRequest) {
 	return &osmocli.QueryDescriptor{
 		Use:   "params",
-		Short: "Query params",
+		Short: "Query smartaccount params",
 		Long: `{{.Short}}{{.ExampleHeader}}
 {{.CommandPrefix}} params`,
 	}, &types.QueryParamsRequest{}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Exposing the cli command for getting a specific authenticator

### How to test

```
- make install
- osmosisd q smartaccount authenticator osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj 14 --output json --node http://164.92.247.225:26657 | jq
```