### PR TITLE
Fix `init` command with correct Consensus Params

### DIFF
--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cometbft/cometbft/libs/cli"
 	tmos "github.com/cometbft/cometbft/libs/os"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
+	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -201,7 +202,11 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 					genDoc = *genDocFromFile
 				}
 
+				genDoc.Consensus = &genutiltypes.ConsensusGenesis{}
+				genDoc.Consensus.Params = cmttypes.DefaultConsensusParams()
+
 				genDoc.ChainID = chainID
+
 				genDoc.Consensus.Validators = nil
 				genDoc.AppState = appState
 				if err = genutil.ExportGenesisFile(&genDoc, genFilePath); err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Current `init` command fails with the following error

```
 ./osmosisd init my-node --chain-id=as
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x104eb6544]

goroutine 1 [running]:
github.com/osmosis-labs/osmosis/v25/cmd/osmosisd/cmd.InitCmd.func1(0x14001e21508, {0x14001a0d5c0, 0x1, 0x2?})
        github.com/osmosis-labs/osmosis/v25/cmd/osmosisd/cmd/init.go:205 +0xbf4
github.com/spf13/cobra.(*Command).execute(0x14001e21508, {0x14001a0d5a0, 0x2, 0x2})
        github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x14001628908)
        github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.8.0/command.go:1032
github.com/cosmos/cosmos-sdk/server/cmd.Execute(0x14001628908, {0x104ed5780, 0x8}, {0x14000fba8d0, 0x15})
        github.com/cosmos/cosmos-sdk@v0.50.6/server/cmd/execute.go:34 +0x154
main.main()
        github.com/osmosis-labs/osmosis/v25/cmd/osmosisd/main.go:16 +0x40
```

This PR fixes it so that we initialize the consensus params correctly. 
## Testing and Verifying
Verified the fix on my local machine via `osmosisd init`

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A