### PR TITLE
fix: transmuter balance ingest not sorted

### DIFF
--- a/ingest/sqs/pools/transformer/pool_transformer.go
+++ b/ingest/sqs/pools/transformer/pool_transformer.go
@@ -217,6 +217,9 @@ func (pi *poolTransformer) convertPool(
 
 		balances = cwPool.GetTotalPoolLiquidity(ctx)
 
+		// Sort balances for consistency.
+		balances.Sort()
+
 		// This must never happen, but if it does, and there is no checks, the query will fail silently.
 		// We make sure to return an error here.
 		if pi.wasmKeeper == nil {

--- a/ingest/sqs/pools/transformer/pool_transformer.go
+++ b/ingest/sqs/pools/transformer/pool_transformer.go
@@ -217,7 +217,8 @@ func (pi *poolTransformer) convertPool(
 
 		balances = cwPool.GetTotalPoolLiquidity(ctx)
 
-		// Sort balances for consistency.
+		// Sort balances for consistency with `sdk.Coins` assumptions.
+		// For example, finding a denom by name using binary search requires coins to be sorted
 		balances.Sort()
 
 		// This must never happen, but if it does, and there is no checks, the query will fail silently.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Due to using a different method for extracting balances for a cw pool (from liquidity rather than bank) and alloyed having 3 assets, a binary search algorithm searching for denom from balances was breaking in SQS dowsntream, preventing the alloyed asset pool from being picked up.

This PR fixes the issue.

The change is committed to `v25.x` here: https://github.com/osmosis-labs/osmosis/pull/8368

## Testing and Verifying

Tested on node

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A