### PR TITLE
perf: Lower timeout commit to 600ms

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -144,7 +144,7 @@ var (
 		{
 			Section: "consensus",
 			Key:     "timeout_commit",
-			Value:   "1s",
+			Value:   "600ms",
 		},
 		{
 			Section: "consensus",


### PR DESCRIPTION
Lower blocktime by another 400ms. Keeping it at 600ms feels more than enough, as thats more than enough for 2 global internet round trips. Furthermore Comet improvements should lower risk of overheads here as well