### PR TITLE
feat(indexer): proper supply offset handling

### DIFF
--- a/ingest/indexer/domain/ingester.go
+++ b/ingest/indexer/domain/ingester.go
@@ -10,5 +10,5 @@ type PubSubClient interface {
 	PublishAsset(ctx context.Context, asset Asset) error
 	PublishPool(ctx context.Context, pool Pool) error
 	PublishTokenSupply(ctx context.Context, tokenSupply TokenSupply) error
-	PublishTokenSupplyOffset(ctx context.Context, tokenSupply TokenSupply) error
+	PublishTokenSupplyOffset(ctx context.Context, tokenSupply TokenSupplyOffset) error
 }

--- a/ingest/indexer/service/client/pubsub_client.go
+++ b/ingest/indexer/service/client/pubsub_client.go
@@ -18,7 +18,7 @@ type PubSubClient struct {
 }
 
 // NewPubSubCLient creates a new PubSubClient.
-func NewPubSubCLient(projectId string, topicId string) *PubSubClient {
+func NewPubSubCLient(projectId string, topicId string) indexerdomain.PubSubClient {
 	return &PubSubClient{
 		projectId: projectId,
 		topicId:   topicId,
@@ -82,8 +82,14 @@ func (p *PubSubClient) PublishPool(ctx context.Context, pool indexerdomain.Pool)
 	return p.publish(ctx, pool)
 }
 
+// PublishTokenSupply implements domain.PubSubClient.
 func (p *PubSubClient) PublishTokenSupply(ctx context.Context, tokenSupply indexerdomain.TokenSupply) error {
 	return p.publish(ctx, tokenSupply)
+}
+
+// PublishTokenSupplyOffset implements domain.PubSubClient.
+func (p *PubSubClient) PublishTokenSupplyOffset(ctx context.Context, tokenSupplyOffset indexerdomain.TokenSupplyOffset) error {
+	return p.publish(ctx, tokenSupplyOffset)
 }
 
 // marshal marshals a message to bytes.

--- a/ingest/indexer/service/client/pubsub_client.go
+++ b/ingest/indexer/service/client/pubsub_client.go
@@ -35,7 +35,6 @@ func NewPubSubCLient(projectId string, blockTopicId string, transactionTopicId s
 
 // publish publishes a message to the PubSub topic.
 func (p *PubSubClient) publish(ctx context.Context, message any, topicId string) error {
-
 	// Create PubSub client if it doesn't exist
 	if p.pubsubClient == nil {
 		client, err := pubsub.NewClient(ctx, p.projectId)

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -66,17 +66,14 @@ func (s *indexerStreamingService) ListenDeliverTx(ctx context.Context, req types
 }
 
 func (s *indexerStreamingService) ListenEndBlock(ctx context.Context, req types.RequestEndBlock, res types.ResponseEndBlock) error {
-
 	// If did not ingest initial data yet, ingest it now
 	if !s.coldStartManager.HasIngestedInitialData() {
-
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 		var err error
 
 		// Ingest the initial data
 		s.keepers.BankKeeper.IterateTotalSupply(sdkCtx, func(coin sdk.Coin) bool {
-
 			// Skip CL pool shares
 			if strings.Contains(coin.Denom, "cl/pool") {
 				return false

--- a/ingest/indexer/service/writelistener/bank_write_listener.go
+++ b/ingest/indexer/service/writelistener/bank_write_listener.go
@@ -52,13 +52,14 @@ func (s *bankWriteListener) OnWrite(storeKey storetypes.StoreKey, key []byte, va
 	// If the cold start manager has ingested initial data and the key is not empty and the key is a supply key.
 	if len(key) > 0 && bytes.Equal(banktypes.SupplyOffsetKey, key[:1]) {
 		denom := key[len(banktypes.SupplyOffsetKey):]
-		if err := s.publishSupply(denom, value); err != nil {
+		if err := s.publishSupplyOffset(denom, value); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// publishSupply publishes the updated supply to the pubsub client.
 func (s *bankWriteListener) publishSupply(denom, updatedSupplyBytes []byte) error {
 	// Track updated supplies.
 	var updatedSupply osmomath.Int
@@ -74,6 +75,29 @@ func (s *bankWriteListener) publishSupply(denom, updatedSupplyBytes []byte) erro
 	}
 
 	err = s.client.PublishTokenSupply(s.ctx, tokenSupply)
+	if err != nil {
+		return fmt.Errorf("unable to publish token supply %v", err)
+	}
+
+	return nil
+}
+
+// publishSupplyOffset publishes the updated supply offset to the pubsub client.
+func (s *bankWriteListener) publishSupplyOffset(denom, updatedSupplyOffsetBytes []byte) error {
+	// Track updated supplies.
+	var updatedSupplyOffset osmomath.Int
+	err := updatedSupplyOffset.Unmarshal(updatedSupplyOffsetBytes)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal supply value %v", err)
+	}
+
+	tokenSupplyOffset := indexerdomain.TokenSupplyOffset{
+		// Denom is the key without the supply offset prefix.
+		Denom:        string(denom[len(banktypes.SupplyOffsetKey):]),
+		SupplyOffset: updatedSupplyOffset,
+	}
+
+	err = s.client.PublishTokenSupplyOffset(s.ctx, tokenSupplyOffset)
 	if err != nil {
 		return fmt.Errorf("unable to publish token supply %v", err)
 	}

--- a/ingest/indexer/service/writelistener/bank_write_listener.go
+++ b/ingest/indexer/service/writelistener/bank_write_listener.go
@@ -10,7 +10,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/v25/ingest/indexer/domain"
 	indexerdomain "github.com/osmosis-labs/osmosis/v25/ingest/indexer/domain"
 )
 
@@ -23,10 +22,10 @@ type bankWriteListener struct {
 
 	client indexerdomain.Ingester
 
-	coldStartManager domain.ColdStartManager
+	coldStartManager indexerdomain.ColdStartManager
 }
 
-func NewBank(ctx context.Context, client indexerdomain.Ingester, coldStartManager domain.ColdStartManager) storetypes.WriteListener {
+func NewBank(ctx context.Context, client indexerdomain.Ingester, coldStartManager indexerdomain.ColdStartManager) storetypes.WriteListener {
 	return &bankWriteListener{
 		ctx:    ctx,
 		client: client,

--- a/ingest/sqs/service/sqs_streaming_service.go
+++ b/ingest/sqs/service/sqs_streaming_service.go
@@ -69,7 +69,6 @@ func (s *sqsStreamingService) ListenDeliverTx(ctx context.Context, req types.Req
 }
 
 func (s *sqsStreamingService) ListenEndBlock(ctx context.Context, req types.RequestEndBlock, res types.ResponseEndBlock) error {
-
 	// uCtx := sdk.UnwrapSDKContext(ctx)
 
 	// height := (uint64)(req.GetHeight())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This PR implements proper supply offset handling.

It adds a separate pub/sub API for the supply offsets, assuming that these would be transformed downstream in the indexer pipeline.

Note that supply offset is a pre-launch mystery. For regulatory reasons, we offset developer rewards using supply offsets.