### PR TITLE
feat: rename ingester to publisher, added block publishing code

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -581,7 +581,7 @@ func getSQSServiceWriteListeners(app *OsmosisApp, appCodec codec.Codec, blockPoo
 }
 
 // getIndexerServiceWriteListeners returns the write listeners for the app that are specific to the indexer service.
-func getIndexerServiceWriteListeners(ctx context.Context, app *OsmosisApp, client indexerdomain.Ingester, coldStartManager indexerdomain.ColdStartManager) map[storetypes.StoreKey][]storetypes.WriteListener {
+func getIndexerServiceWriteListeners(ctx context.Context, app *OsmosisApp, client indexerdomain.Publisher, coldStartManager indexerdomain.ColdStartManager) map[storetypes.StoreKey][]storetypes.WriteListener {
 	writeListeners := make(map[storetypes.StoreKey][]storetypes.WriteListener)
 
 	// Add write listeners for the bank module.

--- a/ingest/indexer/domain/publisher.go
+++ b/ingest/indexer/domain/publisher.go
@@ -10,8 +10,8 @@ type TokenSupplyPublisher interface {
 	PublishTokenSupplyOffset(ctx context.Context, tokenSupplyOffset TokenSupplyOffset) error
 }
 
-// Ingester is an interface for ingesting & publishing various types of data.
-type Ingester interface {
+// Publisher is an interface for publishing various types of data.
+type Publisher interface {
 	TokenSupplyPublisher
 
 	PublishBlock(ctx context.Context, block Block) error

--- a/ingest/indexer/domain/token_supply.go
+++ b/ingest/indexer/domain/token_supply.go
@@ -3,11 +3,11 @@ package domain
 import "github.com/osmosis-labs/osmosis/osmomath"
 
 type TokenSupply struct {
-	Denom  string
-	Supply osmomath.Int
+	Denom  string       `json:"denom"`
+	Supply osmomath.Int `json:"supply"`
 }
 
 type TokenSupplyOffset struct {
-	Denom        string
-	SupplyOffset osmomath.Int
+	Denom        string       `json:"denom"`
+	SupplyOffset osmomath.Int `json:"supply_offset"`
 }

--- a/ingest/indexer/indexer_config.go
+++ b/ingest/indexer/indexer_config.go
@@ -55,5 +55,5 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 // Initialize initializes the indexer by creating a new PubSubClient and returning a new IndexerIngester.
 func (c Config) Initialize() domain.Publisher {
 	pubSubClient := service.NewPubSubCLient(c.GCPProjectId, c.BlockTopicId, c.TransactionTopicId, c.PoolTopicId, c.TokenSupplyTopicId, c.TokenSupplyOffsetTopicId)
-	return NewIndexerIngester(*pubSubClient)
+	return NewIndexerPublisher(*pubSubClient)
 }

--- a/ingest/indexer/indexer_config.go
+++ b/ingest/indexer/indexer_config.go
@@ -53,7 +53,7 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 }
 
 // Initialize initializes the indexer by creating a new PubSubClient and returning a new IndexerIngester.
-func (c Config) Initialize() domain.Ingester {
+func (c Config) Initialize() domain.Publisher {
 	pubSubClient := service.NewPubSubCLient(c.GCPProjectId, c.BlockTopicId, c.TransactionTopicId, c.PoolTopicId, c.TokenSupplyTopicId, c.TokenSupplyOffsetTopicId)
 	return NewIndexerIngester(*pubSubClient)
 }

--- a/ingest/indexer/ingester.go
+++ b/ingest/indexer/ingester.go
@@ -13,7 +13,7 @@ type indexerIngester struct {
 }
 
 // NewIndexerIngester creates a new indexer ingester.
-func NewIndexerIngester(pubsubClient service.PubSubClient) domain.Ingester {
+func NewIndexerIngester(pubsubClient service.PubSubClient) domain.Publisher {
 	return &indexerIngester{
 		pubsubClient: pubsubClient,
 	}

--- a/ingest/indexer/publisher.go
+++ b/ingest/indexer/publisher.go
@@ -8,19 +8,19 @@ import (
 )
 
 // indexerIngester is an implementation of domain.Ingester.
-type indexerIngester struct {
+type indexerPublisher struct {
 	pubsubClient service.PubSubClient
 }
 
 // NewIndexerIngester creates a new indexer ingester.
-func NewIndexerIngester(pubsubClient service.PubSubClient) domain.Publisher {
-	return &indexerIngester{
+func NewIndexerPublisher(pubsubClient service.PubSubClient) domain.Publisher {
+	return &indexerPublisher{
 		pubsubClient: pubsubClient,
 	}
 }
 
 // PublishBlock implements domain.Ingester.
-func (i *indexerIngester) PublishBlock(ctx context.Context, block domain.Block) error {
+func (i *indexerPublisher) PublishBlock(ctx context.Context, block domain.Block) error {
 	err := i.pubsubClient.PublishBlock(ctx, block)
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func (i *indexerIngester) PublishBlock(ctx context.Context, block domain.Block) 
 }
 
 // PublishTransaction implements domain.Ingester.
-func (i *indexerIngester) PublishTransaction(ctx context.Context, txn domain.Transaction) error {
+func (i *indexerPublisher) PublishTransaction(ctx context.Context, txn domain.Transaction) error {
 	err := i.pubsubClient.PublishTransaction(ctx, txn)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func (i *indexerIngester) PublishTransaction(ctx context.Context, txn domain.Tra
 }
 
 // PublishPool implements domain.Ingester.
-func (i *indexerIngester) PublishPool(ctx context.Context, pool domain.Pool) error {
+func (i *indexerPublisher) PublishPool(ctx context.Context, pool domain.Pool) error {
 	err := i.pubsubClient.PublishPool(ctx, pool)
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func (i *indexerIngester) PublishPool(ctx context.Context, pool domain.Pool) err
 }
 
 // PublishTokenSupply implements domain.Ingester.
-func (i *indexerIngester) PublishTokenSupply(ctx context.Context, tokenSupply domain.TokenSupply) error {
+func (i *indexerPublisher) PublishTokenSupply(ctx context.Context, tokenSupply domain.TokenSupply) error {
 	err := i.pubsubClient.PublishTokenSupply(ctx, tokenSupply)
 	if err != nil {
 		return err
@@ -56,7 +56,7 @@ func (i *indexerIngester) PublishTokenSupply(ctx context.Context, tokenSupply do
 }
 
 // PublishTokenSupplyOffset implements domain.Ingester.
-func (i *indexerIngester) PublishTokenSupplyOffset(ctx context.Context, tokenSupplyOffset domain.TokenSupplyOffset) error {
+func (i *indexerPublisher) PublishTokenSupplyOffset(ctx context.Context, tokenSupplyOffset domain.TokenSupplyOffset) error {
 	err := i.pubsubClient.PublishTokenSupplyOffset(ctx, tokenSupplyOffset)
 	if err != nil {
 		return err

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -22,7 +22,7 @@ type indexerStreamingService struct {
 	// manages tracking of whether the node is code started
 	coldStartManager domain.ColdStartManager
 
-	client domain.Ingester
+	client domain.Publisher
 
 	keepers domain.Keepers
 }
@@ -32,7 +32,7 @@ type indexerStreamingService struct {
 // sqsIngester is an ingester that ingests the block data into SQS.
 // poolTracker is a tracker that tracks the pools that were changed in the block.
 // nodeStatusChecker is a checker that checks if the node is syncing.
-func New(writeListeners map[storetypes.StoreKey][]storetypes.WriteListener, coldStartManager domain.ColdStartManager, client domain.Ingester, keepers domain.Keepers) baseapp.StreamingService {
+func New(writeListeners map[storetypes.StoreKey][]storetypes.WriteListener, coldStartManager domain.ColdStartManager, client domain.Publisher, keepers domain.Keepers) baseapp.StreamingService {
 	return &indexerStreamingService{
 
 		writeListeners: writeListeners,
@@ -65,9 +65,34 @@ func (s *indexerStreamingService) ListenDeliverTx(ctx context.Context, req types
 	return nil
 }
 
+// publishBlock publishes the block data to the indexer.
+func (s *indexerStreamingService) publishBlock(ctx context.Context, req types.RequestEndBlock) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	height := (uint64)(req.GetHeight())
+	timeEndBlock := sdkCtx.BlockTime().UTC()
+	chainId := sdkCtx.ChainID()
+	gasConsumed := sdkCtx.GasMeter().GasConsumed()
+	block := domain.Block{
+		ChainId:     chainId,
+		Height:      height,
+		BlockTime:   timeEndBlock,
+		GasConsumed: gasConsumed,
+	}
+	return s.client.PublishBlock(sdkCtx, block)
+}
+
+// ListenEndBlock implements baseapp.StreamingService.
 func (s *indexerStreamingService) ListenEndBlock(ctx context.Context, req types.RequestEndBlock, res types.ResponseEndBlock) error {
+
+	// Publish the block data
+	err := s.publishBlock(ctx, req)
+	if err != nil {
+		return err
+	}
+
 	// If did not ingest initial data yet, ingest it now
 	if !s.coldStartManager.HasIngestedInitialData() {
+
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 		var err error

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -83,7 +83,6 @@ func (s *indexerStreamingService) publishBlock(ctx context.Context, req types.Re
 
 // ListenEndBlock implements baseapp.StreamingService.
 func (s *indexerStreamingService) ListenEndBlock(ctx context.Context, req types.RequestEndBlock, res types.ResponseEndBlock) error {
-
 	// Publish the block data
 	err := s.publishBlock(ctx, req)
 	if err != nil {
@@ -92,7 +91,6 @@ func (s *indexerStreamingService) ListenEndBlock(ctx context.Context, req types.
 
 	// If did not ingest initial data yet, ingest it now
 	if !s.coldStartManager.HasIngestedInitialData() {
-
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 		var err error


### PR DESCRIPTION
This pull request added block level ingestion and data publishing. We currently publish chainId, height, block timestamp and gas consumption only, but we can add / remove the attributes as reviewed in this pull request.

This PR will fulfill the dexscreener requirements of /latest-block