### PR TITLE
fix: mempool filter ibc spam

### DIFF
--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"bytes"
 	"fmt"
 	"path/filepath"
 
@@ -159,7 +158,7 @@ func (mfd MempoolFeeDecorator) getMinBaseGasPrice(ctx sdk.Context, baseDenom str
 	// If we are in CheckTx, a separate function is ran locally to ensure sufficient fees for entering our mempool.
 	// So we ensure that the provided fees meet a minimum threshold for the validator
 	if (ctx.IsCheckTx() || ctx.IsReCheckTx()) && !simulate {
-		minBaseGasPrice = osmomath.MaxDec(minBaseGasPrice, mfd.GetMinBaseGasPriceForTx(ctx, baseDenom, feeTx))
+		minBaseGasPrice = sdk.MaxDec(minBaseGasPrice, mfd.GetMinBaseGasPriceForTx(ctx, baseDenom, feeTx))
 	}
 	// If we are in genesis or are simulating a tx, then we actually override all of the above, to set it to 0.
 	if ctx.BlockHeight() == 0 || simulate {
@@ -201,18 +200,18 @@ func (mfd MempoolFeeDecorator) GetMinBaseGasPriceForTx(ctx sdk.Context, baseDeno
 	cfgMinGasPrice := ctx.MinGasPrices().AmountOf(baseDenom)
 	// the check below prevents tx gas from getting over HighGasTxThreshold which is default to 1_000_000
 	if tx.GetGas() >= mfd.Opts.HighGasTxThreshold {
-		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForHighGasTx)
+		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForHighGasTx)
 	}
 	if txfee_filters.IsArbTxLoose(tx) {
-		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForArbitrageTx)
+		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForArbitrageTx)
 	}
 	// Initial tx only, no recheck
 	if is1559enabled && ctx.IsCheckTx() && !ctx.IsReCheckTx() {
-		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurBaseFee())
+		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurBaseFee())
 	}
 	// RecheckTx only
 	if is1559enabled && ctx.IsReCheckTx() {
-		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurRecheckBaseFee())
+		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurRecheckBaseFee())
 	}
 	return cfgMinGasPrice
 }
@@ -266,7 +265,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	if feeGranter != nil {
 		if dfd.feegrantKeeper == nil {
 			return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "fee grants is not enabled")
-		} else if !bytes.Equal(feeGranter, feePayer) {
+		} else if !feeGranter.Equals(feePayer) {
 			err := dfd.feegrantKeeper.UseGrantedFees(ctx, feeGranter, feePayer, fee, tx.GetMsgs())
 			if err != nil {
 				return ctx, errorsmod.Wrapf(err, "%s not allowed to pay fees from %s", feeGranter, feePayer)

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -1,12 +1,16 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	appparams "github.com/osmosis-labs/osmosis/v25/app/params"
@@ -55,6 +59,40 @@ func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 		if feeTx.GetGas() > mfd.Opts.MaxGasWantedPerTx {
 			msg := "Too much gas wanted: %d, maximum is %d"
 			return ctx, errorsmod.Wrapf(sdkerrors.ErrOutOfGas, msg, feeTx.GetGas(), mfd.Opts.MaxGasWantedPerTx)
+		}
+	}
+
+	msgs := tx.GetMsgs()
+	for _, msg := range msgs {
+		// If one of the msgs is an IBC Transfer msg, limit it's size due to current spam potential.
+		// 500KB for entire msg
+		// 400KB for memo
+		// 65KB for receiver
+		if transferMsg, ok := msg.(*transfertypes.MsgTransfer); ok {
+			if transferMsg.Size() > 500000 { // 500KB
+				return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "msg size is too large")
+			}
+
+			if len([]byte(transferMsg.Memo)) > 400000 { // 400KB
+				return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "memo is too large")
+			}
+
+			if len(transferMsg.Receiver) > 65000 { // 65KB
+				return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "receiver address is too large")
+			}
+		}
+
+		// If one of the msgs is from ICA, limit it's size due to current spam potential.
+		// 500KB for packet data
+		// 65KB for sender
+		if icaMsg, ok := msg.(*icacontrollertypes.MsgSendTx); ok {
+			if icaMsg.PacketData.Size() > 500000 { // 500KB
+				return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "packet data is too large")
+			}
+
+			if len([]byte(icaMsg.Owner)) > 65000 { // 65KB
+				return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "owner address is too large")
+			}
 		}
 	}
 
@@ -121,7 +159,7 @@ func (mfd MempoolFeeDecorator) getMinBaseGasPrice(ctx sdk.Context, baseDenom str
 	// If we are in CheckTx, a separate function is ran locally to ensure sufficient fees for entering our mempool.
 	// So we ensure that the provided fees meet a minimum threshold for the validator
 	if (ctx.IsCheckTx() || ctx.IsReCheckTx()) && !simulate {
-		minBaseGasPrice = sdk.MaxDec(minBaseGasPrice, mfd.GetMinBaseGasPriceForTx(ctx, baseDenom, feeTx))
+		minBaseGasPrice = osmomath.MaxDec(minBaseGasPrice, mfd.GetMinBaseGasPriceForTx(ctx, baseDenom, feeTx))
 	}
 	// If we are in genesis or are simulating a tx, then we actually override all of the above, to set it to 0.
 	if ctx.BlockHeight() == 0 || simulate {
@@ -163,18 +201,18 @@ func (mfd MempoolFeeDecorator) GetMinBaseGasPriceForTx(ctx sdk.Context, baseDeno
 	cfgMinGasPrice := ctx.MinGasPrices().AmountOf(baseDenom)
 	// the check below prevents tx gas from getting over HighGasTxThreshold which is default to 1_000_000
 	if tx.GetGas() >= mfd.Opts.HighGasTxThreshold {
-		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForHighGasTx)
+		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForHighGasTx)
 	}
 	if txfee_filters.IsArbTxLoose(tx) {
-		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForArbitrageTx)
+		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mfd.Opts.MinGasPriceForArbitrageTx)
 	}
 	// Initial tx only, no recheck
 	if is1559enabled && ctx.IsCheckTx() && !ctx.IsReCheckTx() {
-		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurBaseFee())
+		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurBaseFee())
 	}
 	// RecheckTx only
 	if is1559enabled && ctx.IsReCheckTx() {
-		cfgMinGasPrice = sdk.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurRecheckBaseFee())
+		cfgMinGasPrice = osmomath.MaxDec(cfgMinGasPrice, mempool1559.CurEipState.GetCurRecheckBaseFee())
 	}
 	return cfgMinGasPrice
 }
@@ -228,7 +266,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	if feeGranter != nil {
 		if dfd.feegrantKeeper == nil {
 			return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "fee grants is not enabled")
-		} else if !feeGranter.Equals(feePayer) {
+		} else if !bytes.Equal(feeGranter, feePayer) {
 			err := dfd.feegrantKeeper.UseGrantedFees(ctx, feeGranter, feePayer, fee, tx.GetMsgs())
 			if err != nil {
 				return ctx, errorsmod.Wrapf(err, "%s not allowed to pay fees from %s", feeGranter, feePayer)

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -237,7 +237,7 @@ func (s *KeeperTestSuite) TestMempoolFeeDecorator_AnteHandle_MsgTransfer() {
 			expectedErr: errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "memo is too large"),
 		},
 		{
-			name: "MsgTransfer with reciever too large",
+			name: "MsgTransfer with receiver too large",
 			msg: &transfertypes.MsgTransfer{
 				SourcePort:       "transfer",
 				SourceChannel:    "channel-0",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Limits IBC Transfer messages to the following:
* transferMsg.Size() > 500000 // 500KB
* transferMsg.Memo> 400000 // 400KB
* transferMsg.Receiver > 65000 // 65KB

Limit ICA Send message to the following:
* icaMsg.PacketData.Size() > 500000 // 500KB
* icaMsg.Owner > 65000 // 65KB

I opted to hard code these since adding them to the config would be deprecated in the next release. LMK if you think I should add them as config params.