### PR TITLE
Add missing docker build for cosmovisor-wrapped osmosis binary image

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -34,6 +34,7 @@ on:
 
 env:
   DOCKER_REPOSITORY: osmolabs/osmosis
+  DOCKER_REPOSITORY_COSMOVISOR: osmolabs/osmosis-cosmovisor
   RUNNER_BASE_IMAGE_DISTROLESS: gcr.io/distroless/static-debian11
   RUNNER_BASE_IMAGE_NONROOT: gcr.io/distroless/static-debian11:nonroot
   RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
@@ -157,10 +158,9 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
             COSMOVISOR_VERSION=${{ env.COSMOVISOR_VERSION }}
           tags: |
-            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-cosmovisor
-            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-cosmovisor
-            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-cosmovisor
-
+            ${{ env.DOCKER_REPOSITORY_COSMOVISOR }}:${{ env.MAJOR_VERSION }}
+            ${{ env.DOCKER_REPOSITORY_COSMOVISOR }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
+            ${{ env.DOCKER_REPOSITORY_COSMOVISOR }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
 
   push-iavl-docker-images:
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -38,6 +38,7 @@ env:
   RUNNER_BASE_IMAGE_DISTROLESS: gcr.io/distroless/static-debian11
   RUNNER_BASE_IMAGE_NONROOT: gcr.io/distroless/static-debian11:nonroot
   RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
+  COSMOVISOR_VERSION: v1.5.0
 
 jobs:
   push-docker-images:

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -142,6 +142,25 @@ jobs:
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+      # Cosmovisor image
+      - name: Build and Push Cosmovisor Docker Images
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.cosmovisor
+          context: .
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_DISTROLESS }}
+            GIT_VERSION=${{ env.VERSION }}
+            GIT_COMMIT=${{ github.sha }}
+            COSMOVISOR_VERSION=${{ env.COSMOVISOR_VERSION }}
+          tags: |
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}-cosmovisor
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}-cosmovisor
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-cosmovisor
+
 
   push-iavl-docker-images:
     runs-on: buildjet-4vcpu-ubuntu-2204


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR adds the strategy to build docker images with cosmovisor inside wrapping osmosis binary.

## Testing and Verifying

This image has been released to a development docker registry and has been tested in our node deployments. 
