### PR TITLE
Remove IBC-rate limits descendant recheck calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+* [#8420](https://github.com/osmosis-labs/osmosis/pull/8420) Remove further unneeded IBC acknowledgements time from CheckTx/RecheckTx.
+
 ## v25.1.2
 
 * [#8415](https://github.com/osmosis-labs/osmosis/pull/8415) Reset cache on pool creation

--- a/x/ibc-rate-limit/ibc_module.go
+++ b/x/ibc-rate-limit/ibc_module.go
@@ -162,7 +162,8 @@ func (im *IBCModule) OnAcknowledgementPacket(
 	relayer sdk.AccAddress,
 ) error {
 	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
-		return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
+		return nil
+		// return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
 	var ack channeltypes.Acknowledgement
 	if err := json.Unmarshal(acknowledgement, &ack); err != nil {


### PR DESCRIPTION
Please note that this is generally, not the best solution, but all we risk is wasted compute getting on-chain at the trade-off of better mempools.

I have whitebox examined, that for Acknowledgement we are gaining nothing. This is running all of PFM's logic and all of the main IBC-go logic. This is not needed for the redundant relay goal.

![image](https://github.com/osmosis-labs/osmosis/assets/6440154/a7e3c681-b266-4d89-993e-a9475355de20)
