### PR TITLE
fix: indexer config reading sqs enabled value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#8420](https://github.com/osmosis-labs/osmosis/pull/8420) Remove further unneeded IBC acknowledgements time from CheckTx/RecheckTx.
 
+### Config
+
+* [#8398](https://github.com/osmosis-labs/osmosis/pull/8398) Fix osmosis-indexer config bug that read osmosis-sqs value 
+
 ## v25.1.2
 
 * [#8415](https://github.com/osmosis-labs/osmosis/pull/8415) Reset cache on pool creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Config
 
-* [#8398](https://github.com/osmosis-labs/osmosis/pull/8398) Fix osmosis-indexer config bug that read osmosis-sqs value 
+* [#8431](https://github.com/osmosis-labs/osmosis/pull/8431) Fix osmosis-indexer config bug that read osmosis-sqs value 
 
 ## v25.1.2
 

--- a/osmoutils/config_parser.go
+++ b/osmoutils/config_parser.go
@@ -12,13 +12,13 @@ import (
 
 // ParseBool parses a boolean value from a server type option.
 func ParseBool(opts servertypes.AppOptions, groupOptName, optName string, defaultValue bool) bool {
-	fullOptName := "osmosis-sqs." + optName
+	fullOptName := groupOptName + "." + optName
 	valueInterface := opts.Get(fullOptName)
 	value := defaultValue
 	if valueInterface != nil {
 		valueStr, ok := valueInterface.(string)
 		if !ok {
-			panic("invalidly configured osmosis-sqs." + optName)
+			panic("invalidly configured " + fullOptName)
 		}
 		valueStr = strings.TrimSpace(valueStr)
 		v, err := strconv.ParseBool(valueStr)
@@ -34,9 +34,10 @@ func ParseBool(opts servertypes.AppOptions, groupOptName, optName string, defaul
 
 // ParseInt parses an integer value from a server type option.
 func ParseInt(opts servertypes.AppOptions, groupOptName, optName string) int {
-	valueInterface := opts.Get(groupOptName + "." + optName)
+	fullOptName := groupOptName + "." + optName
+	valueInterface := opts.Get(fullOptName)
 	if valueInterface == nil {
-		panic("missing config for osmosis-sqs." + optName)
+		panic("missing config for " + fullOptName)
 	}
 	value := cast.ToInt(valueInterface)
 	return value
@@ -86,9 +87,10 @@ func ParseStringToUint64Slice(input string) ([]uint64, error) {
 
 // ParseString parses a string value from a server type option.
 func ParseString(opts servertypes.AppOptions, groupOptName, optName string) string {
-	valueInterface := opts.Get(groupOptName + "." + optName)
+	fullOptName := groupOptName + "." + optName
+	valueInterface := opts.Get(fullOptName)
 	if valueInterface == nil {
-		panic("missing config for osmosis-sqs." + optName)
+		panic("missing config for " + fullOptName)
 	}
 	value := cast.ToString(valueInterface)
 	return value


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Indexer config was reading SQS `is-enabled` value. Fixed here and did more clean ups as a drive-by. Tested locally.