### PR TITLE
feat: Generate default indexer configs on osmosisd init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Config
 
-* [#8431](https://github.com/osmosis-labs/osmosis/pull/8431) Fix osmosis-indexer config bug that read osmosis-sqs value 
+* [#8431](https://github.com/osmosis-labs/osmosis/pull/8431) Fix osmosis-indexer config bug that read osmosis-sqs value
+* [#8436](https://github.com/osmosis-labs/osmosis/pull/8436) Added default indexer config on `osmosisd init`
 
 ## v25.1.2
 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/params"
 	v23 "github.com/osmosis-labs/osmosis/v25/app/upgrades/v23" // should be automated to be updated to current version every upgrade
+	"github.com/osmosis-labs/osmosis/v25/ingest/indexer"
 	"github.com/osmosis-labs/osmosis/v25/ingest/sqs"
 
 	"cosmossdk.io/log"
@@ -635,6 +636,8 @@ func initAppConfig() (string, interface{}) {
 
 		SidecarQueryServerConfig sqs.Config `mapstructure:"osmosis-sqs"`
 
+		IndexerConfig indexer.Config `mapstructure:"osmosis-indexer"`
+
 		WasmConfig wasmtypes.WasmConfig `mapstructure:"wasm"`
 	}
 
@@ -657,9 +660,11 @@ func initAppConfig() (string, interface{}) {
 
 	sqsCfg := sqs.DefaultConfig
 
+	indexCfg := indexer.DefaultConfig
+
 	wasmCfg := wasmtypes.DefaultWasmConfig()
 
-	OsmosisAppCfg := CustomAppConfig{Config: *srvCfg, OsmosisMempoolConfig: memCfg, SidecarQueryServerConfig: sqsCfg, WasmConfig: wasmCfg}
+	OsmosisAppCfg := CustomAppConfig{Config: *srvCfg, OsmosisMempoolConfig: memCfg, SidecarQueryServerConfig: sqsCfg, IndexerConfig: indexCfg, WasmConfig: wasmCfg}
 
 	OsmosisAppTemplate := serverconfig.DefaultConfigTemplate + `
 ###############################################################################
@@ -695,6 +700,32 @@ is-enabled = "{{ .SidecarQueryServerConfig.IsEnabled }}"
 grpc-ingest-address = "{{ .SidecarQueryServerConfig.GRPCIngestAddress }}"
 # The maximum size of the GRPC message that can be received by the sqs service in bytes.
 grpc-ingest-max-call-size-bytes = "{{ .SidecarQueryServerConfig.GRPCIngestMaxCallSizeBytes }}"
+
+###############################################################################
+###              Osmosis Indexer Configuration                              ###
+###############################################################################
+[osmosis-indexer]
+
+# The indexer service is disabled by default.
+is-enabled = "{{ .IndexerConfig.IsEnabled }}"
+
+# The GCP project id to use for the indexer service.
+gcp-project-id = "{{ .IndexerConfig.GCPProjectId }}"
+
+# The topic id to use for the publishing block data
+block-topic-id = "{{ .IndexerConfig.BlockTopicId }}"
+
+# The topic id to use for the publishing transaction data
+transaction-topic-id = "{{ .IndexerConfig.TransactionTopicId }}"
+
+# The topic id to use for the publishing pool data
+pool-topic-id = "{{ .IndexerConfig.PoolTopicId }}"
+
+# The topic id to use for the publishing token supply data
+token-supply-topic-id = "{{ .IndexerConfig.TokenSupplyTopicId }}"
+
+# The topic id to use for the publishing token supply offset data
+token-supply-offset-topic-id = "{{ .IndexerConfig.TokenSupplyOffsetTopicId }}"
 
 ###############################################################################
 ###                            Wasm Configuration                           ###


### PR DESCRIPTION
With this PR, on "osmosisd init", config group for indexer "osmosis-indexer" and its default, corresponding attributes will be added to app.toml