### PR TITLE
SQS Ingester: Add Orderbook amount in to exhaust liquidity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.13
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.8-0.20240517165907-1625703bc16d
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.14-0.20240517165907-1625703bc16d
-	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240627025931-0926c532e04a
+	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240628061338-6194c204c5c8
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/skip-mev/block-sdk/v2 v2.1.3

--- a/go.sum
+++ b/go.sum
@@ -908,6 +908,8 @@ github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.14-0.20240517165907-1625703bc16
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.14-0.20240517165907-1625703bc16d/go.mod h1:2yjCTFE7+dr2i/meQUPS4Rs5LskIDb5d8c4lePKhmxA=
 github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240627025931-0926c532e04a h1:qQT+2XtJye41ULiYl81KSAQ4UQSJO+ZN2HX3CYUqRBs=
 github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240627025931-0926c532e04a/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240628061338-6194c204c5c8 h1:EdOXZ45+7lgb74BATKTV48TjsNjs3G9DwUZg6kGs0vU=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240628061338-6194c204c5c8/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/ingest/sqs/CHANGELOG.md
+++ b/ingest/sqs/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 -[#8291](https://github.com/osmosis-labs/osmosis/pull/8291) SQS ingester for alloy transmuter
 -[#8389](https://github.com/osmosis-labs/osmosis/pull/8389) SQS ingester for orderbook
+-[#8458](https://github.com/osmosis-labs/osmosis/pull/8458) Add Orderbook amount in to exhaust liquidity
 
 
 ## [sqs-v1.0.0](https://github.com/osmosis-labs/osmosis/releases/tag/v1.0.0) - 2023-12-06

--- a/ingest/sqs/pools/transformer/orderbook.go
+++ b/ingest/sqs/pools/transformer/orderbook.go
@@ -174,3 +174,5 @@ func tickIndexById(ticks []sqscosmwasmpool.OrderbookTick, tickId int64) int {
 	// else return -1
 	return -1
 }
+
+// dirty

--- a/ingest/sqs/pools/transformer/orderbook.go
+++ b/ingest/sqs/pools/transformer/orderbook.go
@@ -174,5 +174,3 @@ func tickIndexById(ticks []sqscosmwasmpool.OrderbookTick, tickId int64) int {
 	// else return -1
 	return -1
 }
-
-// dirty

--- a/ingest/sqs/pools/transformer/orderbook.go
+++ b/ingest/sqs/pools/transformer/orderbook.go
@@ -69,12 +69,24 @@ func (pi *poolTransformer) updateOrderbookInfo(
 	nextBidTickIndex := tickIndexById(ticks, orderbook.NextBidTick)
 	nextAskTickIndex := tickIndexById(ticks, orderbook.NextAskTick)
 
+	bidAmountToExhaustLiquidity, err := sqscosmwasmpool.CalcAmountInToExhaustOrderbookLiquidity(sqscosmwasmpool.BID, nextAskTickIndex, ticks)
+	if err != nil {
+		return fmt.Errorf("error calculating bid amount to exhaust liquidity: %w", err)
+	}
+
+	askAmountToExhaustLiquidity, err := sqscosmwasmpool.CalcAmountInToExhaustOrderbookLiquidity(sqscosmwasmpool.ASK, nextBidTickIndex, ticks)
+	if err != nil {
+		return fmt.Errorf("error calculating ask amount to exhaust liquidity: %w", err)
+	}
+
 	cosmWasmPoolModel.Data.Orderbook = &sqscosmwasmpool.OrderbookData{
-		QuoteDenom:       orderbook.QuoteDenom,
-		BaseDenom:        orderbook.BaseDenom,
-		NextBidTickIndex: nextBidTickIndex,
-		NextAskTickIndex: nextAskTickIndex,
-		Ticks:            ticks,
+		QuoteDenom:                     orderbook.QuoteDenom,
+		BaseDenom:                      orderbook.BaseDenom,
+		NextBidTickIndex:               nextBidTickIndex,
+		NextAskTickIndex:               nextAskTickIndex,
+		BidAmountToExhaustAskLiquidity: bidAmountToExhaustLiquidity,
+		AskAmountToExhaustBidLiquidity: askAmountToExhaustLiquidity,
+		Ticks:                          ticks,
 	}
 
 	return nil

--- a/ingest/sqs/pools/transformer/orderbook.go
+++ b/ingest/sqs/pools/transformer/orderbook.go
@@ -69,14 +69,14 @@ func (pi *poolTransformer) updateOrderbookInfo(
 	nextBidTickIndex := tickIndexById(ticks, orderbook.NextBidTick)
 	nextAskTickIndex := tickIndexById(ticks, orderbook.NextAskTick)
 
-	bidAmountToExhaustLiquidity, err := sqscosmwasmpool.CalcAmountInToExhaustOrderbookLiquidity(sqscosmwasmpool.BID, nextAskTickIndex, ticks)
+	bidAmountToExhaustAskLiquidity, err := sqscosmwasmpool.CalcAmountInToExhaustOrderbookLiquidity(sqscosmwasmpool.BID, nextAskTickIndex, ticks)
 	if err != nil {
-		return fmt.Errorf("error calculating bid amount to exhaust liquidity: %w", err)
+		return fmt.Errorf("error calculating bid amount to exhaust ask liquidity: %w", err)
 	}
 
-	askAmountToExhaustLiquidity, err := sqscosmwasmpool.CalcAmountInToExhaustOrderbookLiquidity(sqscosmwasmpool.ASK, nextBidTickIndex, ticks)
+	askAmountToExhaustBidLiquidity, err := sqscosmwasmpool.CalcAmountInToExhaustOrderbookLiquidity(sqscosmwasmpool.ASK, nextBidTickIndex, ticks)
 	if err != nil {
-		return fmt.Errorf("error calculating ask amount to exhaust liquidity: %w", err)
+		return fmt.Errorf("error calculating ask amount to exhaust bid liquidity: %w", err)
 	}
 
 	cosmWasmPoolModel.Data.Orderbook = &sqscosmwasmpool.OrderbookData{
@@ -84,8 +84,8 @@ func (pi *poolTransformer) updateOrderbookInfo(
 		BaseDenom:                      orderbook.BaseDenom,
 		NextBidTickIndex:               nextBidTickIndex,
 		NextAskTickIndex:               nextAskTickIndex,
-		BidAmountToExhaustAskLiquidity: bidAmountToExhaustLiquidity,
-		AskAmountToExhaustBidLiquidity: askAmountToExhaustLiquidity,
+		BidAmountToExhaustAskLiquidity: bidAmountToExhaustAskLiquidity,
+		AskAmountToExhaustBidLiquidity: askAmountToExhaustBidLiquidity,
 		Ticks:                          ticks,
 	}
 

--- a/ingest/sqs/pools/transformer/orderbook_test.go
+++ b/ingest/sqs/pools/transformer/orderbook_test.go
@@ -10,6 +10,11 @@ import (
 	sqscosmwasmpool "github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 )
 
+const (
+	// Tick Price = 2
+	LARGE_POSITIVE_TICK int64 = 1000000
+)
+
 type PlaceLimitMsg struct {
 	TickID         int64        `json:"tick_id"`
 	OrderDirection string       `json:"order_direction"` // 'bid' | 'ask'
@@ -47,11 +52,13 @@ func (s *PoolTransformerTestSuite) TestUpdateOrderbookInfo() {
 	// Check if the pool has been updated
 	s.Equal(sqscosmwasmpool.CosmWasmPoolData{
 		Orderbook: &sqscosmwasmpool.OrderbookData{
-			QuoteDenom:       USDC,
-			BaseDenom:        UOSMO,
-			NextBidTickIndex: -1,
-			NextAskTickIndex: -1,
-			Ticks:            []sqscosmwasmpool.OrderbookTick{},
+			QuoteDenom:                     USDC,
+			BaseDenom:                      UOSMO,
+			NextBidTickIndex:               -1,
+			NextAskTickIndex:               -1,
+			BidAmountToExhaustAskLiquidity: osmomath.ZeroBigDec(),
+			AskAmountToExhaustBidLiquidity: osmomath.ZeroBigDec(),
+			Ticks:                          []sqscosmwasmpool.OrderbookTick{},
 		},
 	}, cosmWasmPoolModel.Data)
 
@@ -59,7 +66,7 @@ func (s *PoolTransformerTestSuite) TestUpdateOrderbookInfo() {
 	quantity := osmomath.NewInt(10000)
 	msg := ExecuteMsg{
 		PlaceLimit: &PlaceLimitMsg{
-			TickID:         9,
+			TickID:         LARGE_POSITIVE_TICK,
 			OrderDirection: "bid",
 			Quantity:       quantity,
 		},
@@ -77,12 +84,14 @@ func (s *PoolTransformerTestSuite) TestUpdateOrderbookInfo() {
 	s.Equal(sqscosmwasmpool.CosmWasmPoolData{
 		AlloyTransmuter: nil,
 		Orderbook: &sqscosmwasmpool.OrderbookData{
-			QuoteDenom:       USDC,
-			BaseDenom:        UOSMO,
-			NextBidTickIndex: 0,
-			NextAskTickIndex: -1,
+			QuoteDenom:                     USDC,
+			BaseDenom:                      UOSMO,
+			NextBidTickIndex:               0,
+			NextAskTickIndex:               -1,
+			BidAmountToExhaustAskLiquidity: osmomath.ZeroBigDec(),
+			AskAmountToExhaustBidLiquidity: osmomath.BigDecFromSDKInt(quantity).Mul(osmomath.NewBigDec(2)),
 			Ticks: []sqscosmwasmpool.OrderbookTick{{
-				TickId: 9,
+				TickId: LARGE_POSITIVE_TICK,
 				TickLiquidity: sqscosmwasmpool.OrderbookTickLiquidity{
 					AskLiquidity: osmomath.ZeroBigDec(),
 					BidLiquidity: osmomath.BigDecFromSDKInt(quantity),


### PR DESCRIPTION
## What is the purpose of the change
Precompute and ingest `BidAmountToExhaustAskLiquidity` & `AskAmountToExhaustBidLiquidity` through `OrderbookData`. This reduces the need to iterate all the ticks if the requested amount in is over these threshold based on order direction.

## Testing and Verifying
- unit tested for `updateOrderbookInfo` function
- more comprehensive test cases for calculation are already covered in `sqsdomain`
