### PR TITLE
Use alpine again also in this new pipeline

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -154,7 +154,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
-            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_DISTROLESS }}
+            RUNNER_IMAGE=${{ env.RUNNER_BASE_IMAGE_ALPINE }}
             GIT_VERSION=${{ env.VERSION }}
             GIT_COMMIT=${{ github.sha }}
             COSMOVISOR_VERSION=${{ env.COSMOVISOR_VERSION }}


### PR DESCRIPTION

Closes: #8438

Cosmovisor image build was recently enabled and it was producing bad images on the prod repo.
Changing the runner image to alpine should fix it as it is that one used in dev pipeline.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


