### PR TITLE
fix: makes the template to use an existing config field

### DIFF
--- a/cmd/osmosisd/cmd/root_test.go
+++ b/cmd/osmosisd/cmd/root_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitAppConfigTemplate(t *testing.T) {
+	// This test validates templates uses existing fields in config
+	appTemplate, appConfig := initAppConfig()
+	tmpl := template.New("appDefaultValues")
+	tmpl, err := tmpl.Parse(appTemplate)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, appConfig)
+	require.NoError(t, err)
+}

--- a/ingest/indexer/indexer_config.go
+++ b/ingest/indexer/indexer_config.go
@@ -17,7 +17,7 @@ type Config struct {
 	PoolTopicId              string `mapstructure:"pool-topic-id"`
 	TokenSupplyTopicId       string `mapstructure:"token-supply-topic-id"`
 	TokenSupplyOffsetTopicId string `mapstructure:"token-supply-offset-topic-id"`
-	PairTopicID              string `mapstructure:"pair-offset-topic-id"`
+	PairTopicId              string `mapstructure:"pair-offset-topic-id"`
 }
 
 // groupOptName is the name of the indexer options group.
@@ -62,12 +62,12 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 		PoolTopicId:              poolTopicId,
 		TokenSupplyTopicId:       tokenSupplyTopicId,
 		TokenSupplyOffsetTopicId: tokenSupplyOffsetTopicId,
-		PairTopicID:              pairTopicID,
+		PairTopicId:              pairTopicID,
 	}
 }
 
 // Initialize initializes the indexer by creating a new PubSubClient and returning a new IndexerIngester.
 func (c Config) Initialize() domain.Publisher {
-	pubSubClient := service.NewPubSubCLient(c.GCPProjectId, c.BlockTopicId, c.TransactionTopicId, c.PoolTopicId, c.TokenSupplyTopicId, c.TokenSupplyOffsetTopicId, c.PairTopicID)
+	pubSubClient := service.NewPubSubCLient(c.GCPProjectId, c.BlockTopicId, c.TransactionTopicId, c.PoolTopicId, c.TokenSupplyTopicId, c.TokenSupplyOffsetTopicId, c.PairTopicId)
 	return NewIndexerPublisher(*pubSubClient)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #8491 

## What is the purpose of the change

This aligns the AppTemplate field name access and the config Field name.


## Testing and Verifying

A unit test has been added to verify the app template access existing field in the config.
