### PR TITLE
Add additional events in x/lockup, x/superfluid, x/concentratedliquidity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8375](https://github.com/osmosis-labs/osmosis/pull/8375) Enforce sub-authenticator to be greater than 1
 
 ### State Compatible
+* [#8494](https://github.com/osmosis-labs/osmosis/pull/8494) Add additional events in x/lockup, x/superfluid, x/concentratedliquidity
 
 ## v25.2.0
 

--- a/x/concentrated-liquidity/lp.go
+++ b/x/concentrated-liquidity/lp.go
@@ -458,6 +458,7 @@ func (k Keeper) addToPosition(ctx sdk.Context, owner sdk.AccAddress, positionId 
 			types.TypeEvtAddToPosition,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, owner.String()),
+			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(positionId, 10)),
 			sdk.NewAttribute(types.AttributeKeyPositionId, strconv.FormatUint(positionId, 10)),
 			sdk.NewAttribute(types.AttributeKeyNewPositionId, strconv.FormatUint(newPositionData.ID, 10)),
 			sdk.NewAttribute(types.AttributeAmount0, newPositionData.Amount0.String()),

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -139,6 +139,8 @@ func createBeginUnlockEvent(lock *types.PeriodLock) sdk.Event {
 		types.TypeEvtBeginUnlock,
 		sdk.NewAttribute(types.AttributePeriodLockID, osmoutils.Uint64ToString(lock.ID)),
 		sdk.NewAttribute(types.AttributePeriodLockOwner, lock.Owner),
+		sdk.NewAttribute(types.AttributePeriodLockDenom, lock.Coins[0].Denom),
+		sdk.NewAttribute(types.AttributePeriodLockAmount, lock.Coins[0].Amount.String()),
 		sdk.NewAttribute(types.AttributePeriodLockDuration, lock.Duration.String()),
 		sdk.NewAttribute(types.AttributePeriodLockUnlockTime, lock.EndTime.String()),
 	)

--- a/x/lockup/types/events.go
+++ b/x/lockup/types/events.go
@@ -10,6 +10,7 @@ const (
 	AttributePeriodLockID         = "period_lock_id"
 	AttributePeriodLockOwner      = "owner"
 	AttributePeriodLockAmount     = "amount"
+	AttributePeriodLockDenom      = "denom"
 	AttributePeriodLockDuration   = "duration"
 	AttributePeriodLockUnlockTime = "unlock_time"
 	AttributeUnlockedCoins        = "unlocked_coins"

--- a/x/superfluid/keeper/concentrated_liquidity.go
+++ b/x/superfluid/keeper/concentrated_liquidity.go
@@ -129,6 +129,7 @@ func (k Keeper) addToConcentratedLiquiditySuperfluidPosition(ctx sdk.Context, se
 		sdk.NewEvent(
 			types.TypeEvtAddToConcentratedLiquiditySuperfluidPosition,
 			sdk.NewAttribute(sdk.AttributeKeySender, sender.String()),
+			sdk.NewAttribute(types.AttributeKeyPoolId, strconv.FormatUint(position.PoolId, 10)),
 			sdk.NewAttribute(types.AttributePositionId, strconv.FormatUint(positionId, 10)),
 			sdk.NewAttribute(types.AttributeNewPositionId, strconv.FormatUint(positionData.ID, 10)),
 			sdk.NewAttribute(types.AttributeAmount0, positionData.Amount0.String()),

--- a/x/superfluid/keeper/internal/events/emit.go
+++ b/x/superfluid/keeper/internal/events/emit.go
@@ -44,20 +44,22 @@ func newRemoveSuperfluidAssetEvent(denom string) sdk.Event {
 	)
 }
 
-func EmitSuperfluidDelegateEvent(ctx sdk.Context, lockId uint64, valAddress string) {
+func EmitSuperfluidDelegateEvent(ctx sdk.Context, lockId uint64, valAddress string, lockCoins sdk.Coins) {
 	if ctx.EventManager() == nil {
 		return
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		newSuperfluidDelegateEvent(lockId, valAddress),
+		newSuperfluidDelegateEvent(lockId, valAddress, lockCoins),
 	})
 }
 
-func newSuperfluidDelegateEvent(lockId uint64, valAddress string) sdk.Event {
+func newSuperfluidDelegateEvent(lockId uint64, valAddress string, lockCoins sdk.Coins) sdk.Event {
 	return sdk.NewEvent(
 		types.TypeEvtSuperfluidDelegate,
 		sdk.NewAttribute(types.AttributeLockId, osmoutils.Uint64ToString(lockId)),
+		sdk.NewAttribute(types.AttributeLockAmount, lockCoins[0].Amount.String()),
+		sdk.NewAttribute(types.AttributeLockDenom, lockCoins[0].Denom),
 		sdk.NewAttribute(types.AttributeValidator, valAddress),
 	)
 }
@@ -99,20 +101,22 @@ func newSuperfluidIncreaseDelegationEvent(lockId uint64, amount sdk.Coins) sdk.E
 	)
 }
 
-func EmitSuperfluidUndelegateEvent(ctx sdk.Context, lockId uint64) {
+func EmitSuperfluidUndelegateEvent(ctx sdk.Context, lockId uint64, lockCoins sdk.Coins) {
 	if ctx.EventManager() == nil {
 		return
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		newSuperfluidUndelegateEvent(lockId),
+		newSuperfluidUndelegateEvent(lockId, lockCoins),
 	})
 }
 
-func newSuperfluidUndelegateEvent(lockId uint64) sdk.Event {
+func newSuperfluidUndelegateEvent(lockId uint64, lockCoins sdk.Coins) sdk.Event {
 	return sdk.NewEvent(
 		types.TypeEvtSuperfluidUndelegate,
 		sdk.NewAttribute(types.AttributeLockId, fmt.Sprintf("%d", lockId)),
+		sdk.NewAttribute(types.AttributeLockAmount, lockCoins[0].Amount.String()),
+		sdk.NewAttribute(types.AttributeLockDenom, lockCoins[0].Denom),
 	)
 }
 

--- a/x/superfluid/keeper/internal/events/emit_test.go
+++ b/x/superfluid/keeper/internal/events/emit_test.go
@@ -115,14 +115,16 @@ func (suite *SuperfluidEventsTestSuite) TestEmitRemoveSuperfluidAsset() {
 
 func (suite *SuperfluidEventsTestSuite) TestEmitSuperfluidDelegateEvent() {
 	testcases := map[string]struct {
-		ctx     sdk.Context
-		lockID  uint64
-		valAddr string
+		ctx       sdk.Context
+		lockID    uint64
+		valAddr   string
+		lockCoins sdk.Coins
 	}{
 		"basic valid": {
-			ctx:     suite.CreateTestContext(),
-			lockID:  1,
-			valAddr: sdk.AccAddress([]byte(addressString)).String(),
+			ctx:       suite.CreateTestContext(),
+			lockID:    1,
+			valAddr:   sdk.AccAddress([]byte(addressString)).String(),
+			lockCoins: sdk.NewCoins(sdk.NewInt64Coin("foo", 10)),
 		},
 		"context with no event manager": {
 			ctx: sdk.Context{},
@@ -131,25 +133,26 @@ func (suite *SuperfluidEventsTestSuite) TestEmitSuperfluidDelegateEvent() {
 
 	for name, tc := range testcases {
 		suite.Run(name, func() {
-			expectedEvents := sdk.Events{
-				sdk.NewEvent(
-					types.TypeEvtSuperfluidDelegate,
-					sdk.NewAttribute(types.AttributeLockId, fmt.Sprintf("%d", tc.lockID)),
-					sdk.NewAttribute(types.AttributeValidator, tc.valAddr),
-				),
-			}
 
 			hasNoEventManager := tc.ctx.EventManager() == nil
 
 			// System under test.
-			events.EmitSuperfluidDelegateEvent(tc.ctx, tc.lockID, tc.valAddr)
+			events.EmitSuperfluidDelegateEvent(tc.ctx, tc.lockID, tc.valAddr, tc.lockCoins)
 
 			// Assertions
 			if hasNoEventManager {
 				// If there is no event manager on context, this is a no-op.
 				return
 			}
-
+			expectedEvents := sdk.Events{
+				sdk.NewEvent(
+					types.TypeEvtSuperfluidDelegate,
+					sdk.NewAttribute(types.AttributeLockId, fmt.Sprintf("%d", tc.lockID)),
+					sdk.NewAttribute(types.AttributeLockAmount, tc.lockCoins[0].Amount.String()),
+					sdk.NewAttribute(types.AttributeLockDenom, tc.lockCoins[0].Denom),
+					sdk.NewAttribute(types.AttributeValidator, tc.valAddr),
+				),
+			}
 			eventManager := tc.ctx.EventManager()
 			actualEvents := eventManager.Events()
 			suite.Equal(expectedEvents, actualEvents)
@@ -255,12 +258,14 @@ func (suite *SuperfluidEventsTestSuite) TestEmitSuperfluidIncreaseDelegationEven
 
 func (suite *SuperfluidEventsTestSuite) TestEmitSuperfluidUndelegateEvent() {
 	testcases := map[string]struct {
-		ctx    sdk.Context
-		lockID uint64
+		ctx       sdk.Context
+		lockID    uint64
+		lockCoins sdk.Coins
 	}{
 		"basic valid": {
-			ctx:    suite.CreateTestContext(),
-			lockID: 1,
+			ctx:       suite.CreateTestContext(),
+			lockID:    1,
+			lockCoins: sdk.NewCoins(sdk.NewInt64Coin("foo", 10)),
 		},
 		"context with no event manager": {
 			ctx: sdk.Context{},
@@ -269,22 +274,24 @@ func (suite *SuperfluidEventsTestSuite) TestEmitSuperfluidUndelegateEvent() {
 
 	for name, tc := range testcases {
 		suite.Run(name, func() {
-			expectedEvents := sdk.Events{
-				sdk.NewEvent(
-					types.TypeEvtSuperfluidUndelegate,
-					sdk.NewAttribute(types.AttributeLockId, fmt.Sprintf("%d", tc.lockID)),
-				),
-			}
-
 			hasNoEventManager := tc.ctx.EventManager() == nil
 
 			// System under test.
-			events.EmitSuperfluidUndelegateEvent(tc.ctx, tc.lockID)
+			events.EmitSuperfluidUndelegateEvent(tc.ctx, tc.lockID, tc.lockCoins)
 
 			// Assertions
 			if hasNoEventManager {
 				// If there is no event manager on context, this is a no-op.
 				return
+			}
+
+			expectedEvents := sdk.Events{
+				sdk.NewEvent(
+					types.TypeEvtSuperfluidUndelegate,
+					sdk.NewAttribute(types.AttributeLockId, fmt.Sprintf("%d", tc.lockID)),
+					sdk.NewAttribute(types.AttributeLockAmount, tc.lockCoins[0].Amount.String()),
+					sdk.NewAttribute(types.AttributeLockDenom, tc.lockCoins[0].Denom),
+				),
 			}
 
 			eventManager := tc.ctx.EventManager()

--- a/x/superfluid/keeper/msg_server.go
+++ b/x/superfluid/keeper/msg_server.go
@@ -47,7 +47,11 @@ func (server msgServer) SuperfluidDelegate(goCtx context.Context, msg *types.Msg
 
 	err := server.keeper.SuperfluidDelegate(ctx, msg.Sender, msg.LockId, msg.ValAddr)
 	if err == nil {
-		events.EmitSuperfluidDelegateEvent(ctx, msg.LockId, msg.ValAddr)
+		lock, err := server.keeper.lk.GetLockByID(ctx, msg.LockId)
+		if err != nil {
+			return &types.MsgSuperfluidDelegateResponse{}, err
+		}
+		events.EmitSuperfluidDelegateEvent(ctx, msg.LockId, msg.ValAddr, lock.Coins)
 	}
 	return &types.MsgSuperfluidDelegateResponse{}, err
 }

--- a/x/superfluid/keeper/msg_server.go
+++ b/x/superfluid/keeper/msg_server.go
@@ -66,7 +66,11 @@ func (server msgServer) SuperfluidUndelegate(goCtx context.Context, msg *types.M
 
 	err := server.keeper.SuperfluidUndelegate(ctx, msg.Sender, msg.LockId)
 	if err == nil {
-		events.EmitSuperfluidUndelegateEvent(ctx, msg.LockId)
+		lock, err := server.keeper.lk.GetLockByID(ctx, msg.LockId)
+		if err != nil {
+			return &types.MsgSuperfluidUndelegateResponse{}, err
+		}
+		events.EmitSuperfluidUndelegateEvent(ctx, msg.LockId, lock.Coins)
 	}
 	return &types.MsgSuperfluidUndelegateResponse{}, err
 }

--- a/x/superfluid/types/events.go
+++ b/x/superfluid/types/events.go
@@ -30,6 +30,8 @@ const (
 	AttributeDenom               = "denom"
 	AttributeSuperfluidAssetType = "superfluid_asset_type"
 	AttributeLockId              = "lock_id"
+	AttributeLockAmount          = "lock_amount"
+	AttributeLockDenom           = "lock_denom"
 	AttributeValidator           = "validator"
 	AttributeAmount              = "amount"
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
This PR adds additional events that were missing. The list of events being added are as below

- pool Id addition in 
   - MsgAddToPosition 
   - MsgAddToConcentratedLiquiditySuperfluidPosition
- locked token amount & denom addition in 
    - MsgBeginUnlocking
    -  MsgSuperfluidDelegate
    -  MsgSuperfluidUndelegate  
    - 
## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A