### PR TITLE
Revised txn ingester for iterating txns in main branch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -403,7 +403,7 @@ func NewOsmosisApp(
 			StoreKeyMap:    storeKeyMap,
 		}
 		poolExtractor := poolextractor.New(poolKeepers, poolTracker)
-		indexerStreamingService := indexerservice.New(blockUpdatesProcessUtils, blockProcessStrategyManager, indexerPublisher, storeKeyMap, poolExtractor, keepers)
+		indexerStreamingService := indexerservice.New(blockUpdatesProcessUtils, blockProcessStrategyManager, indexerPublisher, storeKeyMap, poolExtractor, keepers, app.GetTxConfig().TxDecoder())
 
 		// Register the SQS streaming service with the app.
 		streamingServices = append(streamingServices, indexerStreamingService)

--- a/app/app.go
+++ b/app/app.go
@@ -403,7 +403,7 @@ func NewOsmosisApp(
 			StoreKeyMap:    storeKeyMap,
 		}
 		poolExtractor := poolextractor.New(poolKeepers, poolTracker)
-		indexerStreamingService := indexerservice.New(blockUpdatesProcessUtils, blockProcessStrategyManager, indexerPublisher, storeKeyMap, poolExtractor, keepers, app.GetTxConfig().TxDecoder())
+		indexerStreamingService := indexerservice.New(blockUpdatesProcessUtils, blockProcessStrategyManager, indexerPublisher, storeKeyMap, poolExtractor, keepers, app.GetTxConfig().TxDecoder(), logger)
 
 		// Register the SQS streaming service with the app.
 		streamingServices = append(streamingServices, indexerStreamingService)

--- a/ingest/indexer/domain/transaction.go
+++ b/ingest/indexer/domain/transaction.go
@@ -1,14 +1,28 @@
 package domain
 
-import "time"
+import (
+	"time"
 
-// Transaction represents a transaction in the block
-// Events is a list of events that occurred in the transaction
-// Different event types have different structures and attributes so we use interface{}
-// TO DO: TxHash, TxnIndex, EventIndex to be added
+	"github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// map data type is unsupported by the dataflow / apache beam
+// thus using struct to represent the data
+type EventWrapper struct {
+	Index int         `json:"event_index"`
+	Event types.Event `json:"event"`
+}
+
 type Transaction struct {
-	Height     uint64        `json:"height"`
-	BlockTime  time.Time     `json:"timestamp"`
-	Events     []interface{} `json:"events"`
-	IngestedAt time.Time     `json:"ingested_at"`
+	Height             uint64         `json:"height"`
+	BlockTime          time.Time      `json:"timestamp"`
+	GasWanted          uint64         `json:"gas_wanted"`
+	GasUsed            uint64         `json:"gas_used"`
+	Fees               sdk.Coins      `json:"fees"`
+	MessageType        string         `json:"msg_type"`
+	TransactionHash    string         `json:"tx_hash"`
+	TransactionIndexId int            `json:"tx_index_id"`
+	Events             []EventWrapper `json:"events"`
+	IngestedAt         time.Time      `json:"ingested_at"`
 }

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -2,10 +2,13 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
+	"strings"
 	"sync"
 
 	storetypes "cosmossdk.io/store/types"
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
@@ -28,6 +31,8 @@ type indexerStreamingService struct {
 
 	// extracts the pools from chain state
 	poolExtractor commondomain.PoolExtractor
+
+	txDecoder sdk.TxDecoder
 }
 
 // New creates a new sqsStreamingService.
@@ -35,7 +40,7 @@ type indexerStreamingService struct {
 // sqsIngester is an ingester that ingests the block data into SQS.
 // poolTracker is a tracker that tracks the pools that were changed in the block.
 // nodeStatusChecker is a checker that checks if the node is syncing.
-func New(blockUpdatesProcessUtils commondomain.BlockUpdateProcessUtilsI, blockProcessStrategyManager commondomain.BlockProcessStrategyManager, client domain.Publisher, storeKeyMap map[string]storetypes.StoreKey, poolExtractor commondomain.PoolExtractor, keepers domain.Keepers) storetypes.ABCIListener {
+func New(blockUpdatesProcessUtils commondomain.BlockUpdateProcessUtilsI, blockProcessStrategyManager commondomain.BlockProcessStrategyManager, client domain.Publisher, storeKeyMap map[string]storetypes.StoreKey, poolExtractor commondomain.PoolExtractor, keepers domain.Keepers, txDecoder sdk.TxDecoder) storetypes.ABCIListener {
 	return &indexerStreamingService{
 		blockProcessStrategyManager: blockProcessStrategyManager,
 
@@ -46,6 +51,8 @@ func New(blockUpdatesProcessUtils commondomain.BlockUpdateProcessUtilsI, blockPr
 		keepers: keepers,
 
 		blockUpdatesProcessUtils: blockUpdatesProcessUtils,
+
+		txDecoder: txDecoder,
 	}
 }
 
@@ -70,6 +77,68 @@ func (s *indexerStreamingService) publishBlock(ctx context.Context, req abci.Req
 	return s.client.PublishBlock(sdkCtx, block)
 }
 
+// publishTxn iterates through the transactions in the block and publishes them to the indexer backend.
+func (s *indexerStreamingService) publishTxn(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	txns := req.GetTxs()
+	for txnIndex, txByteArr := range txns {
+		// Decode the transaction
+		tx, err := s.txDecoder(txByteArr)
+		if err != nil {
+			return err
+		}
+		// Calculate the transaction hash
+		txHash := strings.ToUpper(hex.EncodeToString(tmhash.Sum(txByteArr)))
+
+		// Gas data
+		gasWanted := res.TxResults[txnIndex].GasWanted
+		gasUsed := res.TxResults[txnIndex].GasWanted
+
+		// Fee data
+		feeTx, _ := tx.(sdk.FeeTx)
+		fee := feeTx.GetFee()
+
+		// Message type
+		// TO BE VERIFIED - This may not be the correct way to obtain message type
+		txMessages := tx.GetMsgs()
+		msgType := txMessages[0].String()
+
+		// Include these events only:
+		// - token_swapped
+		// - pool_joined
+		// - pool_exited
+		// - create_position
+		// - withdraw_position
+		events := res.GetEvents()
+		var includedEvents []domain.EventWrapper
+		for i, event := range events {
+			eventType := event.Type
+			if eventType == "token_swapped" || eventType == "pool_joined" || eventType == "pool_exited" || eventType == "create_position" || eventType == "withdraw_position" {
+				includedEvents = append(includedEvents, domain.EventWrapper{Index: i, Event: event})
+			}
+		}
+
+		// Publish the transaction
+		txn := domain.Transaction{
+			Height:             uint64(sdkCtx.BlockHeight()),
+			BlockTime:          sdkCtx.BlockTime().UTC(),
+			GasWanted:          uint64(gasWanted),
+			GasUsed:            uint64(gasUsed),
+			Fees:               fee,
+			MessageType:        msgType,
+			TransactionHash:    txHash,
+			TransactionIndexId: txnIndex,
+			Events:             includedEvents,
+		}
+		err = s.client.PublishTransaction(sdkCtx, txn)
+		if err != nil {
+			// if there is an error in publishing the transaction, return the error
+			return err
+		}
+	}
+	return nil
+}
+
 // ListenFinalizeBlock updates the streaming service with the latest FinalizeBlock messages
 func (s *indexerStreamingService) ListenFinalizeBlock(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
 	// Publish the block data
@@ -78,31 +147,12 @@ func (s *indexerStreamingService) ListenFinalizeBlock(ctx context.Context, req a
 	if err != nil {
 		return err
 	}
-	// Publish the transaction data
-	err = s.publishTxn(ctx, res)
+	// Iterate through the transactions in the block and publish them
+	err = s.publishTxn(ctx, req, res)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-// publishTxn publishes the transaction data to the indexer backend.
-// TO DO: Tested if res.GetEvents() is the correct way to get the events in the SDK used in 'main'
-func (s *indexerStreamingService) publishTxn(ctx context.Context, res abci.ResponseFinalizeBlock) error {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	events := res.GetEvents()
-	if len(events) == 0 {
-		return nil
-	}
-	txn := domain.Transaction{
-		Height:    uint64(sdkCtx.BlockHeight()),
-		BlockTime: sdkCtx.BlockTime().UTC(),
-		Events:    make([]interface{}, len(events)),
-	}
-	for i, event := range events {
-		txn.Events[i] = event
-	}
-	return s.client.PublishTransaction(sdkCtx, txn)
 }
 
 // ListenCommit updates the steaming service with the latest Commit messages and state changes


### PR DESCRIPTION
This is a version of transaction ingester which publishes only necessary events to the indexer backend. Untested in main branch and required a full e2e test when main branch is promoted to the next production version. A variation of of this commit is tested v25.x