### PR TITLE
chore(docker): expose port 9090 for SQS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ WORKDIR $HOME
 EXPOSE 26656
 EXPOSE 26657
 EXPOSE 1317
+EXPOSE 9090
 # Note: uncomment the line below if you need pprof in localosmosis
 # We disable it by default in out main Dockerfile for security reasons
 # EXPOSE 6060


### PR DESCRIPTION
SQS now relies on port 9090 of the node. Adjusting the image accordingly