### PR TITLE
Remove program execution blocking by not waiting for pubsub message publishing

### DIFF
--- a/ingest/indexer/service/client/pubsub_client.go
+++ b/ingest/indexer/service/client/pubsub_client.go
@@ -55,15 +55,9 @@ func (p *PubSubClient) publish(ctx context.Context, message any, topicId string)
 
 	// Publish message to topic
 	topic := p.pubsubClient.Topic(topicId)
-	result := topic.Publish(ctx, &pubsub.Message{
+	topic.Publish(ctx, &pubsub.Message{
 		Data: msgBytes,
 	})
-
-	// Block until message is published
-	_, err = result.Get(ctx)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
In current implementation, for every message handled by pubsub client, it blocks program execution while waiting for message publishing to finish. This increases block time when indexer option is enabled. This PR is to address the issue by removing the wait and let the messaging publishing to continue its own execution without blocking the caller.