### PR TITLE
fix: transaction index counter should not be incremented in ListenBeginBlock callback

### DIFF
--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -72,7 +72,6 @@ func (s *indexerStreamingService) Close() error {
 
 // ListenBeginBlock implements baseapp.StreamingService.
 func (s *indexerStreamingService) ListenBeginBlock(ctx context.Context, req types.RequestBeginBlock, res types.ResponseBeginBlock) error {
-	s.txnIndexId++
 	return nil
 }
 


### PR DESCRIPTION
This fix is applicable to v25.x only. The transaction index counter is currently incremented at ListenDeliverTx and it shouldn't be incremented at ListenBeginBlock.