### PR TITLE
fix: [indexer] remove sorting in pair publisher and maintain the original denom order

### DIFF
--- a/ingest/indexer/service/blockprocessor/pair_publisher.go
+++ b/ingest/indexer/service/blockprocessor/pair_publisher.go
@@ -3,7 +3,6 @@ package blockprocessor
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"sync"
 
 	"sync/atomic"

--- a/ingest/indexer/service/blockprocessor/pair_publisher.go
+++ b/ingest/indexer/service/blockprocessor/pair_publisher.go
@@ -53,9 +53,6 @@ func (p PairPublisher) PublishPoolPairs(ctx sdk.Context, pools []poolmanagertype
 		go func(pool poolmanagertypes.PoolI) {
 			denoms := pool.GetPoolDenoms(ctx)
 
-			// Sort for order consistency
-			sort.Strings(denoms)
-
 			spreadFactor := pool.GetSpreadFactor(ctx)
 			poolID := pool.GetId()
 


### PR DESCRIPTION
The change is to remove the sorting and maintain the original denom sorting order in constructing the pair-id, which is in the format of {pool-id}-{index of denoms}-{index of denoms}. Tested in v25.x.