### PR TITLE
Change `LiquidityNetInDirection` return type to sdk math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8169](https://github.com/osmosis-labs/osmosis/pull/8169) [#8250](https://github.com/osmosis-labs/osmosis/pull/8250) [#8276](https://github.com/osmosis-labs/osmosis/pull/8276) [#8320](https://github.com/osmosis-labs/osmosis/pull/8320) Support non-pool assets in superfluid staking
 * [#8274](https://github.com/osmosis-labs/osmosis/pull/8274) SDK v50 and Comet v0.38 upgrade
 * [#8375](https://github.com/osmosis-labs/osmosis/pull/8375) Enforce sub-authenticator to be greater than 1
+* [#8509](https://github.com/osmosis-labs/osmosis/pull/8509) Change LiquidityNetInDirection return type to sdk math
 
 ### State Compatible
 

--- a/x/concentrated-liquidity/types/cl_pool_extensionI.go
+++ b/x/concentrated-liquidity/types/cl_pool_extensionI.go
@@ -3,6 +3,7 @@ package types
 import (
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -21,7 +22,7 @@ type ConcentratedPoolExtension interface {
 	GetCurrentTick() int64
 	GetExponentAtPriceOne() int64
 	GetTickSpacing() uint64
-	GetLiquidity() osmomath.Dec
+	GetLiquidity() sdkmath.LegacyDec
 	GetLastLiquidityUpdate() time.Time
 	SetCurrentSqrtPrice(newSqrtPrice osmomath.BigDec)
 	SetCurrentTick(newTick int64)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#8469](https://github.com/osmosis-labs/osmosis/issues/8469)

## What is the purpose of the change

Changes return value for pool.GetLiquidity, as it was returning osmomath.LegacyDec thus was not able to be unmarshalled when being returned as result for the query. 

## Testing and Verifying



This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A