### PR TITLE
feat: [indexer] added multi_asset field in the pubsub message for pair

### DIFF
--- a/ingest/indexer/domain/pair.go
+++ b/ingest/indexer/domain/pair.go
@@ -4,8 +4,10 @@ import (
 	"time"
 )
 
+// Pair represents a pair of tokens in a pool and message to be published to PubSub
 type Pair struct {
 	PoolID     uint64    `json:"pool_id"`
+	MultiAsset bool      `json:"multi_asset"`
 	Denom0     string    `json:"denom_0"`
 	IdxDenom0  uint8     `json:"idx_denom_0"`
 	Denom1     string    `json:"denom_1"`

--- a/ingest/indexer/domain/token_supply.go
+++ b/ingest/indexer/domain/token_supply.go
@@ -23,3 +23,8 @@ type TokenSupplyOffset struct {
 func ShouldFilterDenom(denom string) bool {
 	return strings.Contains(denom, "cl/pool") || strings.Contains(denom, "gamm/pool")
 }
+
+// IsMultiDenom returns true if the given denoms has >2 denoms
+func IsMultiDenom(denoms []string) bool {
+	return len(denoms) > 2
+}

--- a/ingest/indexer/service/blockprocessor/pair_publisher.go
+++ b/ingest/indexer/service/blockprocessor/pair_publisher.go
@@ -97,14 +97,15 @@ func (p PairPublisher) PublishPoolPairs(ctx sdk.Context, pools []poolmanagertype
 						mu.Unlock()
 					}
 
-					// Create pair
+					// Create pair struct and publish it
 					pair := domain.Pair{
-						PoolID:    poolID,
-						Denom0:    denomI,
-						IdxDenom0: uint8(i),
-						Denom1:    denoms[j],
-						IdxDenom1: uint8(j),
-						FeeBps:    takerFee.Add(spreadFactor).MulInt64(10000).TruncateInt().Uint64(),
+						PoolID:     poolID,
+						MultiAsset: domain.IsMultiDenom(denoms),
+						Denom0:     denomI,
+						IdxDenom0:  uint8(i),
+						Denom1:     denoms[j],
+						IdxDenom1:  uint8(j),
+						FeeBps:     takerFee.Add(spreadFactor).MulInt64(10000).TruncateInt().Uint64(),
 					}
 
 					publishPairWg.Add(1)


### PR DESCRIPTION
This commit is to add an additional field multi_asset to indicate that the pool supports >2 tokens. This is to address the dexscreener requirement that for those 2 tokens pool, the pair_id should remain be 1234, not 1234-0-1