### PR TITLE
chore(x/protorev): use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/x/protorev/client/cli/utils.go
+++ b/x/protorev/client/cli/utils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/x/protorev/client/cli/utils.go
+++ b/x/protorev/client/cli/utils.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -98,7 +99,7 @@ func (release *createArbRoutesInput) extractTokenPairArbRoutes() []types.TokenPa
 // BuildSetHotRoutesMsg builds a MsgSetHotRoutes from the provided json file
 func BuildSetHotRoutesMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("must provide a json file")
+		return nil, errors.New("must provide a json file")
 	}
 
 	// Read the json file
@@ -188,7 +189,7 @@ func (release *createInfoByPoolTypeInput) convertToInfoByPoolType() types.InfoBy
 // BuildSetInfoByPoolTypeMsg builds a MsgSetInfoByPoolType from the provided json file
 func BuildSetInfoByPoolTypeMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("must provide a json file")
+		return nil, errors.New("must provide a json file")
 	}
 
 	// Read the json file
@@ -250,7 +251,7 @@ func (release *createBaseDenomsInput) UnmarshalJSON(data []byte) error {
 // BuildSetBaseDenomsMsg builds a MsgSetBaseDenoms from the provided json file
 func BuildSetBaseDenomsMsg(clientCtx client.Context, args []string, fs *flag.FlagSet) (sdk.Msg, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("must provide a json file")
+		return nil, errors.New("must provide a json file")
 	}
 
 	// Read the json file

--- a/x/protorev/keeper/msg_server.go
+++ b/x/protorev/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -77,7 +78,7 @@ func (m MsgServer) SetMaxPoolPointsPerTx(c context.Context, msg *types.MsgSetMax
 	}
 
 	if msg.MaxPoolPointsPerTx > maxPointsPerBlock {
-		return nil, fmt.Errorf("max pool points per tx cannot be greater than max pool points per block")
+		return nil, errors.New("max pool points per tx cannot be greater than max pool points per block")
 	}
 
 	// Set the max pool points per tx
@@ -103,7 +104,7 @@ func (m MsgServer) SetMaxPoolPointsPerBlock(c context.Context, msg *types.MsgSet
 	}
 
 	if msg.MaxPoolPointsPerBlock < maxPointsPerTx {
-		return nil, fmt.Errorf("max pool points per block cannot be less than max pool points per tx")
+		return nil, errors.New("max pool points per block cannot be less than max pool points per tx")
 	}
 
 	// Set the max pool points per block

--- a/x/protorev/keeper/posthandler.go
+++ b/x/protorev/keeper/posthandler.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
@@ -78,29 +79,29 @@ func (protoRevDec ProtoRevDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simu
 func (k Keeper) AnteHandleCheck(ctx sdk.Context) error {
 	// Only execute the posthandler if the module is enabled
 	if !k.GetProtoRevEnabled(ctx) {
-		return fmt.Errorf("protorev is not enabled")
+		return errors.New("protorev is not enabled")
 	}
 
 	latestBlockHeight, err := k.GetLatestBlockHeight(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get latest block height")
+		return errors.New("failed to get latest block height")
 	}
 
 	currentRouteCount, err := k.GetPointCountForBlock(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current pool point count")
+		return errors.New("failed to get current pool point count")
 	}
 
 	maxRouteCount, err := k.GetMaxPointsPerBlock(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get max pool points per block")
+		return errors.New("failed to get max pool points per block")
 	}
 
 	// Only execute the posthandler if the number of routes to be processed per block has not been reached
 	blockHeight := uint64(ctx.BlockHeight())
 	if blockHeight == latestBlockHeight {
 		if currentRouteCount >= maxRouteCount {
-			return fmt.Errorf("max pool points for the current block has been reached")
+			return errors.New("max pool points for the current block has been reached")
 		}
 	} else {
 		// Reset the current pool point count

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -267,7 +267,7 @@ func (k Keeper) GetDaysSinceModuleGenesis(ctx sdk.Context) (uint64, error) {
 	bz := store.Get(types.KeyPrefixDaysSinceGenesis)
 	if bz == nil {
 		// This should never happen as the module is initialized with 0 days on genesis
-		return 0, fmt.Errorf("days since module genesis not found")
+		return 0, errors.New("days since module genesis not found")
 	}
 
 	daysSinceGenesis := sdk.BigEndianToUint64(bz)
@@ -365,7 +365,7 @@ func (k Keeper) GetPointCountForBlock(ctx sdk.Context) (uint64, error) {
 	bz := store.Get(types.KeyPrefixPointCountForBlock)
 	if bz == nil {
 		// This should never happen as this is set to 0 on genesis
-		return 0, fmt.Errorf("current pool point count has not been set in state")
+		return 0, errors.New("current pool point count has not been set in state")
 	}
 
 	res := sdk.BigEndianToUint64(bz)
@@ -397,7 +397,7 @@ func (k Keeper) GetLatestBlockHeight(ctx sdk.Context) (uint64, error) {
 	bz := store.Get(types.KeyPrefixLatestBlockHeight)
 	if bz == nil {
 		// This should never happen as the module is initialized on genesis and reset in the post handler
-		return 0, fmt.Errorf("block height has not been set in state")
+		return 0, errors.New("block height has not been set in state")
 	}
 
 	res := sdk.BigEndianToUint64(bz)
@@ -431,7 +431,7 @@ func (k Keeper) GetDeveloperAccount(ctx sdk.Context) (sdk.AccAddress, error) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixDeveloperAccount)
 	bz := store.Get(types.KeyPrefixDeveloperAccount)
 	if bz == nil {
-		return nil, fmt.Errorf("developer account not found, it has not been initialized by the admin account")
+		return nil, errors.New("developer account not found, it has not been initialized by the admin account")
 	}
 
 	return sdk.AccAddress(bz), nil
@@ -450,7 +450,7 @@ func (k Keeper) GetMaxPointsPerTx(ctx sdk.Context) (uint64, error) {
 	bz := store.Get(types.KeyPrefixMaxPointsPerTx)
 	if bz == nil {
 		// This should never happen as it is set to the default value on genesis
-		return 0, fmt.Errorf("max pool points per tx has not been set in state")
+		return 0, errors.New("max pool points per tx has not been set in state")
 	}
 
 	res := sdk.BigEndianToUint64(bz)
@@ -478,7 +478,7 @@ func (k Keeper) GetMaxPointsPerBlock(ctx sdk.Context) (uint64, error) {
 	bz := store.Get(types.KeyPrefixMaxPointsPerBlock)
 	if bz == nil {
 		// This should never happen as it is set to the default value on genesis
-		return 0, fmt.Errorf("max pool points per block has not been set in state")
+		return 0, errors.New("max pool points per block has not been set in state")
 	}
 
 	res := sdk.BigEndianToUint64(bz)

--- a/x/protorev/keeper/routes.go
+++ b/x/protorev/keeper/routes.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -258,7 +259,7 @@ func (k Keeper) CalculateRoutePoolPoints(ctx sdk.Context, route poolmanagertypes
 
 			totalWeight += weight
 		default:
-			return 0, fmt.Errorf("invalid pool type")
+			return 0, errors.New("invalid pool type")
 		}
 	}
 

--- a/x/protorev/keeper/statistics.go
+++ b/x/protorev/keeper/statistics.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/store/prefix"
@@ -25,7 +26,7 @@ func (k Keeper) GetNumberOfTrades(ctx sdk.Context) (osmomath.Int, error) {
 
 	bz := store.Get(types.KeyPrefixNumberOfTrades)
 	if len(bz) == 0 {
-		return osmomath.ZeroInt(), fmt.Errorf("no trades have been executed by the protorev module")
+		return osmomath.ZeroInt(), errors.New("no trades have been executed by the protorev module")
 	}
 
 	trades := osmomath.Int{}

--- a/x/protorev/types/errors.go
+++ b/x/protorev/types/errors.go
@@ -1,6 +1,9 @@
 package types
 
-import fmt "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type NoPoolForDenomPairError struct {
 	BaseDenom  string
@@ -11,4 +14,4 @@ func (e NoPoolForDenomPairError) Error() string {
 	return fmt.Sprintf("highest liquidity pool between base %s and match denom %s not found", e.BaseDenom, e.MatchDenom)
 }
 
-var ErrRouteDoubleContainsPool = fmt.Errorf("cannot be trading on the same pool twice")
+var ErrRouteDoubleContainsPool = errors.New("cannot be trading on the same pool twice")

--- a/x/protorev/types/token_pair_arb_routes.go
+++ b/x/protorev/types/token_pair_arb_routes.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -17,7 +18,7 @@ func NewTokenPairArbRoutes(routes []Route, tokenA, tokenB string) TokenPairArbRo
 
 func ValidateTokenPairArbRoutes(tokenPairArbRoutes []TokenPairArbRoutes) error {
 	if tokenPairArbRoutes == nil {
-		return fmt.Errorf("token pair arb routes cannot be nil")
+		return errors.New("token pair arb routes cannot be nil")
 	}
 
 	seenPairs := make(map[string]bool)
@@ -39,22 +40,22 @@ func ValidateTokenPairArbRoutes(tokenPairArbRoutes []TokenPairArbRoutes) error {
 
 func (tp *TokenPairArbRoutes) Validate() error {
 	if tp == nil {
-		return fmt.Errorf("token pair cannot be nil")
+		return errors.New("token pair cannot be nil")
 	}
 
 	// Validate that the token pair is valid
 	if tp.TokenIn == "" || tp.TokenOut == "" {
-		return fmt.Errorf("token names cannot be empty")
+		return errors.New("token names cannot be empty")
 	}
 
 	if tp.ArbRoutes == nil || len(tp.ArbRoutes) == 0 {
-		return fmt.Errorf("there must be at least one route")
+		return errors.New("there must be at least one route")
 	}
 
 	// Iterate through all of the possible routes for this pool
 	for _, route := range tp.ArbRoutes {
 		if route.StepSize.IsNil() || route.StepSize.LT(osmomath.OneInt()) {
-			return fmt.Errorf("step size must be greater than 0")
+			return errors.New("step size must be greater than 0")
 		}
 
 		// Validate that the route is valid
@@ -76,12 +77,12 @@ func (tp *TokenPairArbRoutes) Validate() error {
 func isValidRoute(route Route) error {
 	// support routes of varying length (with the exception of length 1)
 	if len(route.Trades) <= 1 {
-		return fmt.Errorf("there must be at least two trades (hops) per route")
+		return errors.New("there must be at least two trades (hops) per route")
 	}
 
 	// Out and in denoms must match
 	if route.Trades[0].TokenIn != route.Trades[len(route.Trades)-1].TokenOut {
-		return fmt.Errorf("the first and last trades must have matching denoms")
+		return errors.New("the first and last trades must have matching denoms")
 	}
 
 	// Iterate through all of the trades in the route
@@ -89,7 +90,7 @@ func isValidRoute(route Route) error {
 	for _, trade := range route.Trades[1:] {
 		// Validate that the denoms match
 		if prevDenom != trade.TokenIn {
-			return fmt.Errorf("the denoms must match across hops")
+			return errors.New("the denoms must match across hops")
 		}
 
 		// Update the previous denom
@@ -115,11 +116,11 @@ func hasPlaceholderPool(swapInDenom, swapOutDenom string, trades []Trade) error 
 	}
 
 	if !foundPair {
-		return fmt.Errorf("the token pair that is going to be arbitraged must appear in each route")
+		return errors.New("the token pair that is going to be arbitraged must appear in each route")
 	}
 
 	if !foundPlaceholder {
-		return fmt.Errorf("there must be a placeholder pool id of 0 for the token pair that we are arbitraging")
+		return errors.New("there must be a placeholder pool id of 0 for the token pair that we are arbitraging")
 	}
 
 	return nil

--- a/x/protorev/types/validate.go
+++ b/x/protorev/types/validate.go
@@ -1,7 +1,8 @@
 package types
 
 import (
-	fmt "fmt"
+	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -12,11 +13,11 @@ import (
 // Validates the base denoms that are used to generate highest liquidity routes.
 func (base *BaseDenom) Validate() error {
 	if base.Denom == "" {
-		return fmt.Errorf("base denom cannot be empty")
+		return errors.New("base denom cannot be empty")
 	}
 
 	if base.StepSize.IsNil() || base.StepSize.LT(osmomath.OneInt()) {
-		return fmt.Errorf("step size must be greater than 0")
+		return errors.New("step size must be greater than 0")
 	}
 
 	return nil
@@ -26,7 +27,7 @@ func (base *BaseDenom) Validate() error {
 func ValidateBaseDenoms(denoms []BaseDenom) error {
 	// The first base denom must be the Osmosis denomination
 	if len(denoms) == 0 || denoms[0].Denom != OsmosisDenomination {
-		return fmt.Errorf("the first base denom must be the Osmosis denomination")
+		return errors.New("the first base denom must be the Osmosis denomination")
 	}
 
 	seenDenoms := make(map[string]bool)
@@ -48,7 +49,7 @@ func ValidateBaseDenoms(denoms []BaseDenom) error {
 // Validates the information about each pool type that is used throughout the module.
 func (info *InfoByPoolType) Validate() error {
 	if info == nil {
-		return fmt.Errorf("pool type info cannot be nil")
+		return errors.New("pool type info cannot be nil")
 	}
 
 	if err := info.Balancer.Validate(); err != nil {
@@ -73,11 +74,11 @@ func (info *InfoByPoolType) Validate() error {
 // Validates balancer pool information.
 func (b *BalancerPoolInfo) Validate() error {
 	if b == nil {
-		return fmt.Errorf("balancer pool info cannot be nil")
+		return errors.New("balancer pool info cannot be nil")
 	}
 
 	if b.Weight == 0 {
-		return fmt.Errorf("balancer pool weight cannot be 0")
+		return errors.New("balancer pool weight cannot be 0")
 	}
 
 	return nil
@@ -86,11 +87,11 @@ func (b *BalancerPoolInfo) Validate() error {
 // Validates stable pool information.
 func (s *StablePoolInfo) Validate() error {
 	if s == nil {
-		return fmt.Errorf("stable pool info cannot be nil")
+		return errors.New("stable pool info cannot be nil")
 	}
 
 	if s.Weight == 0 {
-		return fmt.Errorf("stable pool weight cannot be 0")
+		return errors.New("stable pool weight cannot be 0")
 	}
 
 	return nil
@@ -99,11 +100,11 @@ func (s *StablePoolInfo) Validate() error {
 // Validates concentrated pool information.
 func (c *ConcentratedPoolInfo) Validate() error {
 	if c == nil {
-		return fmt.Errorf("concentrated pool info cannot be nil")
+		return errors.New("concentrated pool info cannot be nil")
 	}
 
 	if c.Weight == 0 {
-		return fmt.Errorf("concentrated pool weight cannot be 0")
+		return errors.New("concentrated pool weight cannot be 0")
 	}
 
 	if c.MaxTicksCrossed == 0 || c.MaxTicksCrossed > MaxTicksCrossed {
@@ -116,7 +117,7 @@ func (c *ConcentratedPoolInfo) Validate() error {
 // Validates cosmwasm pool information.
 func (c *CosmwasmPoolInfo) Validate() error {
 	if c == nil {
-		return fmt.Errorf("cosmwasm pool info cannot be nil")
+		return errors.New("cosmwasm pool info cannot be nil")
 	}
 
 	for _, weightMap := range c.WeightMaps {

--- a/x/superfluid/client/cli/tx.go
+++ b/x/superfluid/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -440,7 +441,7 @@ func NewUnbondConvertAndStake() *cobra.Command {
 			if len(args) >= 3 {
 				convertedInt, ok := osmomath.NewIntFromString(args[2])
 				if !ok {
-					return fmt.Errorf("Conversion for osmomath.Int failed")
+					return errors.New("Conversion for osmomath.Int failed")
 				}
 				minAmtToStake = convertedInt
 				if len(args) == 4 {

--- a/x/superfluid/keeper/concentrated_liquidity_test.go
+++ b/x/superfluid/keeper/concentrated_liquidity_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank/testutil"

--- a/x/superfluid/keeper/concentrated_liquidity_test.go
+++ b/x/superfluid/keeper/concentrated_liquidity_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -64,7 +65,7 @@ func (s *KeeperTestSuite) TestAddToConcentratedLiquiditySuperfluidPosition() {
 			superfluidDelegated: true,
 			amount0Added:        osmomath.NewInt(100000000),
 			amount1Added:        osmomath.NewInt(100000000),
-			expectedError:       fmt.Errorf("insufficient funds"),
+			expectedError:       errors.New("insufficient funds"),
 		},
 		"error: last position in pool": {
 			superfluidDelegated:  true,

--- a/x/superfluid/keeper/migrate.go
+++ b/x/superfluid/keeper/migrate.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -66,7 +67,7 @@ func (k Keeper) RouteLockedBalancerToConcentratedMigration(ctx sdk.Context, send
 		positionData, migratedPoolIDs, err = k.gk.MigrateUnlockedPositionFromBalancerToConcentrated(ctx, sender, sharesToMigrate, tokenOutMins)
 		concentratedLockId = 0
 	default:
-		return cltypes.CreateFullRangePositionData{}, types.MigrationPoolIDs{}, 0, fmt.Errorf("unsupported migration type")
+		return cltypes.CreateFullRangePositionData{}, types.MigrationPoolIDs{}, 0, errors.New("unsupported migration type")
 	}
 
 	return positionData, migratedPoolIDs, concentratedLockId, err

--- a/x/superfluid/keeper/migrate_test.go
+++ b/x/superfluid/keeper/migrate_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -273,7 +274,7 @@ func (s *KeeperTestSuite) TestMigrateSuperfluidBondedBalancerToConcentrated() {
 		"error: invalid validator address": {
 			overwriteValidatorAddress: true,
 			percentOfSharesToMigrate:  osmomath.MustNewDecFromStr("1"),
-			expectedError:             fmt.Errorf("decoding bech32 failed: invalid checksum"),
+			expectedError:             errors.New("decoding bech32 failed: invalid checksum"),
 		},
 		"error: non-existent lock ID": {
 			overwriteLockId:          true,
@@ -432,7 +433,7 @@ func (s *KeeperTestSuite) TestMigrateSuperfluidUnbondingBalancerToConcentrated()
 		"error: invalid validator address": {
 			overwriteValidatorAddress: true,
 			percentOfSharesToMigrate:  osmomath.MustNewDecFromStr("1"),
-			expectedError:             fmt.Errorf("decoding bech32 failed: invalid checksum"),
+			expectedError:             errors.New("decoding bech32 failed: invalid checksum"),
 		},
 		"error: lock that is superfluid undelegating, not unlocking (full shares), token out mins is more than exit coins": {
 			percentOfSharesToMigrate: osmomath.MustNewDecFromStr("1"),
@@ -628,7 +629,7 @@ func (s *KeeperTestSuite) TestMigrateUnlockedPositionFromBalancerToConcentrated(
 		},
 		"no lock (more shares than own)": {
 			percentOfSharesToMigrate: osmomath.MustNewDecFromStr("1.1"),
-			expectedError:            fmt.Errorf("insufficient funds"),
+			expectedError:            errors.New("insufficient funds"),
 		},
 		"no lock (no shares)": {
 			percentOfSharesToMigrate: osmomath.MustNewDecFromStr("0"),

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -360,10 +361,10 @@ func (k Keeper) SuperfluidUndelegateAndUnbondLock(ctx sdk.Context, lockID uint64
 
 	coins := sdk.Coins{sdk.NewCoin(lock.Coins[0].Denom, amount)}
 	if coins[0].IsZero() {
-		return 0, fmt.Errorf("amount to unlock must be greater than 0")
+		return 0, errors.New("amount to unlock must be greater than 0")
 	}
 	if lock.Coins[0].IsLT(coins[0]) {
-		return 0, fmt.Errorf("requested amount to unlock exceeds locked tokens")
+		return 0, errors.New("requested amount to unlock exceeds locked tokens")
 	}
 
 	// get intermediary account before connection is deleted in SuperfluidUndelegate
@@ -683,7 +684,7 @@ func (k Keeper) UnbondConvertAndStake(ctx sdk.Context, lockID uint64, sender, va
 	} else if migrationType == Unlocked { // liquid gamm shares without locks
 		totalAmtConverted, err = k.convertUnlockedToStake(ctx, senderAddr, valAddr, sharesToConvert, minAmtToStake)
 	} else { // any other types of migration should fail
-		return osmomath.Int{}, fmt.Errorf("unsupported staking conversion type")
+		return osmomath.Int{}, errors.New("unsupported staking conversion type")
 	}
 
 	if err != nil {

--- a/x/superfluid/types/gov.go
+++ b/x/superfluid/types/gov.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -72,7 +73,7 @@ func (p *SetSuperfluidAssetsProposal) ValidateBasic() error {
 				return fmt.Errorf("denom %s must be from CL", asset.Denom)
 			}
 		default:
-			return fmt.Errorf("unsupported superfluid asset type")
+			return errors.New("unsupported superfluid asset type")
 		}
 	}
 
@@ -151,7 +152,7 @@ func (p *UpdateUnpoolWhiteListProposal) ValidateBasic() error {
 
 	for _, id := range p.Ids {
 		if id == 0 {
-			return fmt.Errorf("pool id cannot be 0")
+			return errors.New("pool id cannot be 0")
 		}
 	}
 

--- a/x/superfluid/types/msgs.go
+++ b/x/superfluid/types/msgs.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -41,13 +42,13 @@ func (m MsgSuperfluidDelegate) Route() string { return RouterKey }
 func (m MsgSuperfluidDelegate) Type() string  { return TypeMsgSuperfluidDelegate }
 func (m MsgSuperfluidDelegate) ValidateBasic() error {
 	if m.Sender == "" {
-		return fmt.Errorf("sender should not be an empty address")
+		return errors.New("sender should not be an empty address")
 	}
 	if m.LockId == 0 {
 		return fmt.Errorf("lock id should be positive: %d < 0", m.LockId)
 	}
 	if m.ValAddr == "" {
-		return fmt.Errorf("ValAddr should not be empty")
+		return errors.New("ValAddr should not be empty")
 	}
 	return nil
 }
@@ -71,7 +72,7 @@ func (m MsgSuperfluidUndelegate) Route() string { return RouterKey }
 func (m MsgSuperfluidUndelegate) Type() string  { return TypeMsgSuperfluidUndelegate }
 func (m MsgSuperfluidUndelegate) ValidateBasic() error {
 	if m.Sender == "" {
-		return fmt.Errorf("sender should not be an empty address")
+		return errors.New("sender should not be an empty address")
 	}
 	if m.LockId == 0 {
 		return fmt.Errorf("lock id should be positive: %d < 0", m.LockId)
@@ -99,13 +100,13 @@ func (m MsgSuperfluidUndelegate) GetSigners() []sdk.AccAddress {
 // func (m MsgSuperfluidRedelegate) Type() string  { return TypeMsgSuperfluidRedelegate }
 // func (m MsgSuperfluidRedelegate) ValidateBasic() error {
 // 	if m.Sender == "" {
-// 		return fmt.Errorf("sender should not be an empty address")
+// 		return errors.New("sender should not be an empty address")
 // 	}
 // 	if m.LockId == 0 {
 // 		return fmt.Errorf("lock id should be positive: %d < 0", m.LockId)
 // 	}
 // 	if m.NewValAddr == "" {
-// 		return fmt.Errorf("NewValAddr should not be empty")
+// 		return errors.New("NewValAddr should not be empty")
 // 	}
 // 	return nil
 // }
@@ -131,10 +132,10 @@ func (m MsgSuperfluidUnbondLock) Type() string {
 
 func (m MsgSuperfluidUnbondLock) ValidateBasic() error {
 	if m.Sender == "" {
-		return fmt.Errorf("sender should not be an empty address")
+		return errors.New("sender should not be an empty address")
 	}
 	if m.LockId == 0 {
-		return fmt.Errorf("lockID should be set")
+		return errors.New("lockID should be set")
 	}
 	return nil
 }
@@ -163,13 +164,13 @@ func (m MsgSuperfluidUndelegateAndUnbondLock) Type() string {
 
 func (m MsgSuperfluidUndelegateAndUnbondLock) ValidateBasic() error {
 	if m.Sender == "" {
-		return fmt.Errorf("sender should not be an empty address")
+		return errors.New("sender should not be an empty address")
 	}
 	if m.LockId == 0 {
-		return fmt.Errorf("lockID should be set")
+		return errors.New("lockID should be set")
 	}
 	if !m.Coin.IsValid() {
-		return fmt.Errorf("cannot unlock a zero or negative amount")
+		return errors.New("cannot unlock a zero or negative amount")
 	}
 
 	return nil
@@ -195,7 +196,7 @@ func (m MsgLockAndSuperfluidDelegate) Route() string { return RouterKey }
 func (m MsgLockAndSuperfluidDelegate) Type() string  { return TypeMsgLockAndSuperfluidDelegate }
 func (m MsgLockAndSuperfluidDelegate) ValidateBasic() error {
 	if m.Sender == "" {
-		return fmt.Errorf("sender should not be an empty address")
+		return errors.New("sender should not be an empty address")
 	}
 
 	if m.Coins.Len() != 1 {
@@ -203,7 +204,7 @@ func (m MsgLockAndSuperfluidDelegate) ValidateBasic() error {
 	}
 
 	if m.ValAddr == "" {
-		return fmt.Errorf("ValAddr should not be empty")
+		return errors.New("ValAddr should not be empty")
 	}
 	return nil
 }
@@ -304,11 +305,11 @@ func (msg MsgCreateFullRangePositionAndSuperfluidDelegate) ValidateBasic() error
 	}
 
 	if msg.ValAddr == "" {
-		return fmt.Errorf("ValAddr should not be empty")
+		return errors.New("ValAddr should not be empty")
 	}
 
 	if msg.PoolId < 1 {
-		return fmt.Errorf("pool id must be positive")
+		return errors.New("pool id must be positive")
 	}
 	return nil
 }
@@ -381,7 +382,7 @@ func (msg MsgUnbondConvertAndStake) ValidateBasic() error {
 	}
 
 	if msg.MinAmtToStake.IsNegative() {
-		return fmt.Errorf("Min amount to stake cannot be negative")
+		return errors.New("Min amount to stake cannot be negative")
 	}
 	return nil
 }
@@ -402,7 +403,7 @@ func (msg *MsgSetDenomRiskFactor) ValidateBasic() error {
 		return fmt.Errorf("invalid sender address (%s)", err)
 	}
 	if len(msg.Denom) == 0 {
-		return fmt.Errorf("denom cannot be empty")
+		return errors.New("denom cannot be empty")
 	}
 	return nil
 }
@@ -423,7 +424,7 @@ func (msg *MsgUnsetDenomRiskFactor) ValidateBasic() error {
 		return fmt.Errorf("invalid sender address (%s)", err)
 	}
 	if len(msg.Denom) == 0 {
-		return fmt.Errorf("denom cannot be empty")
+		return errors.New("denom cannot be empty")
 	}
 	return nil
 }

--- a/x/valset-pref/client/cli/tx.go
+++ b/x/valset-pref/client/cli/tx.go
@@ -2,7 +2,6 @@ package valsetprefcli
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/x/valset-pref/client/cli/tx.go
+++ b/x/valset-pref/client/cli/tx.go
@@ -1,6 +1,7 @@
 package valsetprefcli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -131,11 +132,11 @@ func ValidateValAddrAndWeight(args []string) ([]types.ValidatorPreference, error
 	}
 
 	if len(valAddrs) != len(weights) {
-		return nil, fmt.Errorf("the length of validator addresses and weights not matched")
+		return nil, errors.New("the length of validator addresses and weights not matched")
 	}
 
 	if len(valAddrs) == 0 {
-		return nil, fmt.Errorf("records is empty")
+		return nil, errors.New("records is empty")
 	}
 
 	var valset []types.ValidatorPreference

--- a/x/valset-pref/client/query_proto_wrap.go
+++ b/x/valset-pref/client/query_proto_wrap.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 

--- a/x/valset-pref/client/query_proto_wrap.go
+++ b/x/valset-pref/client/query_proto_wrap.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,7 +21,7 @@ func NewQuerier(k validatorprefkeeper.Keeper) Querier {
 func (q Querier) UserValidatorPreferences(ctx sdk.Context, req queryproto.UserValidatorPreferencesRequest) (*queryproto.UserValidatorPreferencesResponse, error) {
 	validatorSet, found := q.K.GetValidatorSetPreference(ctx, req.Address)
 	if !found {
-		return nil, fmt.Errorf("Validator set not found")
+		return nil, errors.New("Validator set not found")
 	}
 
 	return &queryproto.UserValidatorPreferencesResponse{

--- a/x/valset-pref/keeper.go
+++ b/x/valset-pref/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -92,7 +93,7 @@ func (k Keeper) GetValSetPreferencesWithDelegations(ctx sdk.Context, delegator s
 
 	// No existing delegations for a delegator when valSet does not exist
 	if !exists && len(existingDelegations) == 0 {
-		return types.ValidatorSetPreferences{}, fmt.Errorf("No Existing delegation to unbond from")
+		return types.ValidatorSetPreferences{}, errors.New("No Existing delegation to unbond from")
 	}
 
 	// Returning existing valSet when there are no existing delegations

--- a/x/valset-pref/keeper_test.go
+++ b/x/valset-pref/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -110,7 +111,7 @@ func (s *KeeperTestSuite) PrepareExistingDelegations(ctx sdk.Context, valAddrs [
 	for i := 0; i < len(valAddrs); i++ {
 		valAddr, err := sdk.ValAddressFromBech32(valAddrs[i])
 		if err != nil {
-			return fmt.Errorf("validator address not formatted")
+			return errors.New("validator address not formatted")
 		}
 
 		validator, err := s.App.StakingKeeper.GetValidator(ctx, valAddr)

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -56,7 +57,7 @@ func (server msgServer) UndelegateFromValidatorSet(goCtx context.Context, msg *t
 	// 	return nil, err
 	// }
 
-	return &types.MsgUndelegateFromValidatorSetResponse{}, fmt.Errorf("not implemented, utilize UndelegateFromRebalancedValidatorSet instead")
+	return &types.MsgUndelegateFromValidatorSetResponse{}, errors.New("not implemented, utilize UndelegateFromRebalancedValidatorSet instead")
 }
 
 // UndelegateFromRebalancedValidatorSet undelegates {coin} amount from the validator set, utilizing a user's current delegations
@@ -84,7 +85,7 @@ func (server msgServer) RedelegateValidatorSet(goCtx context.Context, msg *types
 	// get existing delegation if there is no valset set, else get valset
 	existingSet, err := server.keeper.GetDelegationPreferences(ctx, msg.Delegator)
 	if err != nil {
-		return nil, fmt.Errorf("user has no delegation")
+		return nil, errors.New("user has no delegation")
 	}
 
 	// Message 1: override the validator set preference set entry

--- a/x/valset-pref/msg_server.go
+++ b/x/valset-pref/msg_server.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 

--- a/x/valset-pref/simulation/sim_msgs.go
+++ b/x/valset-pref/simulation/sim_msgs.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -58,7 +59,7 @@ func RandomMsgUnDelegateFromValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimC
 	// get delegator valset preferences
 	preferences, err := k.GetDelegationPreferences(ctx, delAddr.String())
 	if err != nil {
-		return nil, fmt.Errorf("no delegations found")
+		return nil, errors.New("no delegations found")
 	}
 
 	rand := sim.GetRand()
@@ -66,12 +67,12 @@ func RandomMsgUnDelegateFromValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimC
 	delegation := preferences.Preferences[rand.Intn(len(preferences.Preferences))]
 	val, err := sdk.ValAddressFromBech32(delegation.ValOperAddress)
 	if err != nil {
-		return nil, fmt.Errorf("validator address not formatted")
+		return nil, errors.New("validator address not formatted")
 	}
 
 	validator, err := sim.SDKStakingKeeper().GetValidator(ctx, val)
 	if err != nil {
-		return nil, fmt.Errorf("Validator not found")
+		return nil, errors.New("Validator not found")
 	}
 
 	// check if the user has delegated tokens to the valset
@@ -101,29 +102,29 @@ func RandomMsgReDelegateToValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimCtx
 	// existing delegations
 	delegations, err := k.GetDelegationPreferences(ctx, delAddr.String())
 	if err != nil {
-		return nil, fmt.Errorf("no delegations found")
+		return nil, errors.New("no delegations found")
 	}
 
 	for _, dels := range delegations.Preferences {
 		val, err := sdk.ValAddressFromBech32(dels.ValOperAddress)
 		if err != nil {
-			return nil, fmt.Errorf("validator address not formatted")
+			return nil, errors.New("validator address not formatted")
 		}
 
 		found, err := sim.SDKStakingKeeper().HasReceivingRedelegation(ctx, delAddr, val)
 		if err != nil {
-			return nil, fmt.Errorf("error while checking redelegation")
+			return nil, errors.New("error while checking redelegation")
 		}
 		if !found {
-			return nil, fmt.Errorf("receiving redelegation is not allowed for source validators")
+			return nil, errors.New("receiving redelegation is not allowed for source validators")
 		}
 
 		found, err = sim.SDKStakingKeeper().HasMaxUnbondingDelegationEntries(ctx, delAddr, val)
 		if err != nil {
-			return nil, fmt.Errorf("error while checking redelegation")
+			return nil, errors.New("error while checking redelegation")
 		}
 		if !found {
-			return nil, fmt.Errorf("keeper does have a max unbonding delegation entries")
+			return nil, errors.New("keeper does have a max unbonding delegation entries")
 		}
 
 		// check if the user has delegated tokens to the valset
@@ -144,23 +145,23 @@ func RandomMsgReDelegateToValSet(k valsetkeeper.Keeper, sim *osmosimtypes.SimCtx
 	for _, vals := range preferences {
 		val, err := sdk.ValAddressFromBech32(vals.ValOperAddress)
 		if err != nil {
-			return nil, fmt.Errorf("validator address not formatted")
+			return nil, errors.New("validator address not formatted")
 		}
 
 		found, err := sim.SDKStakingKeeper().HasMaxUnbondingDelegationEntries(ctx, delAddr, val)
 		if err != nil {
-			return nil, fmt.Errorf("keeper does have a max unbonding delegation entries")
+			return nil, errors.New("keeper does have a max unbonding delegation entries")
 		}
 		if !found {
-			return nil, fmt.Errorf("keeper does have a max unbonding delegation entries")
+			return nil, errors.New("keeper does have a max unbonding delegation entries")
 		}
 
 		found, err = sim.SDKStakingKeeper().HasReceivingRedelegation(ctx, delAddr, val)
 		if err != nil {
-			return nil, fmt.Errorf("error while checking redelegation")
+			return nil, errors.New("error while checking redelegation")
 		}
 		if !found {
-			return nil, fmt.Errorf("receiving redelegation is not allowed for target validators")
+			return nil, errors.New("receiving redelegation is not allowed for target validators")
 		}
 	}
 
@@ -191,7 +192,7 @@ func GetRandomValAndWeights(ctx sdk.Context, k valsetkeeper.Keeper, sim *osmosim
 	for remainingWeight.IsPositive() {
 		randValidator := RandomValidator(ctx, sim)
 		if randValidator == nil {
-			return nil, fmt.Errorf("No validator")
+			return nil, errors.New("No validator")
 		}
 
 		randValue := sim.RandomDecAmount(remainingWeight)
@@ -222,7 +223,7 @@ func GetRandomDelegations(ctx sdk.Context, k valsetkeeper.Keeper, sim *osmosimty
 	// Get Valset delegations
 	delegations, err := k.GetDelegationPreferences(ctx, delegatorAddr.String())
 	if err != nil {
-		return nil, fmt.Errorf("No delegations found")
+		return nil, errors.New("No delegations found")
 	}
 
 	return delegations.Preferences, err

--- a/x/valset-pref/types/msgs.go
+++ b/x/valset-pref/types/msgs.go
@@ -1,7 +1,8 @@
 package types
 
 import (
-	fmt "fmt"
+	"errors"
+	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -54,7 +55,7 @@ func (m MsgSetValidatorSetPreference) ValidateBasic() error {
 	// check that all the validator address are unique
 	containsDuplicate := osmoutils.ContainsDuplicate(validatorAddrs)
 	if containsDuplicate {
-		return fmt.Errorf("The validator operator address are duplicated")
+		return errors.New("The validator operator address are duplicated")
 	}
 
 	// Round to 2 digit after the decimal. For ex: 0.999 = 1.0, 0.874 = 0.87, 0.5123 = 0.51
@@ -98,7 +99,7 @@ func (m MsgDelegateToValidatorSet) ValidateBasic() error {
 	}
 
 	if !m.Coin.IsValid() {
-		return fmt.Errorf("The stake coin is not valid")
+		return errors.New("The stake coin is not valid")
 	}
 
 	return nil
@@ -133,7 +134,7 @@ func (m MsgUndelegateFromValidatorSet) ValidateBasic() error {
 	}
 
 	if !m.Coin.IsValid() {
-		return fmt.Errorf("The stake coin is not valid")
+		return errors.New("The stake coin is not valid")
 	}
 
 	return nil
@@ -170,7 +171,7 @@ func (m MsgUndelegateFromRebalancedValidatorSet) ValidateBasic() error {
 	}
 
 	if !m.Coin.IsValid() {
-		return fmt.Errorf("The stake coin is not valid")
+		return errors.New("The stake coin is not valid")
 	}
 
 	return nil
@@ -219,7 +220,7 @@ func (m MsgRedelegateValidatorSet) ValidateBasic() error {
 	// check that all the validator address are unique
 	containsDuplicate := osmoutils.ContainsDuplicate(validatorAddrs)
 	if containsDuplicate {
-		return fmt.Errorf("The validator operator address are duplicated")
+		return errors.New("The validator operator address are duplicated")
 	}
 
 	// Round to 2 digit after the decimal. For ex: 0.999 = 1.0, 0.874 = 0.87, 0.5123 = 0.51

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -62,14 +63,14 @@ func (k Keeper) ValidateValidatorSetPreference(ctx sdk.Context, delegator string
 		// check if the new preferences is the same as the existing preferences
 		isEqual := k.IsValidatorSetEqual(existingValSet.Preferences, preferences)
 		if isEqual {
-			return types.ValidatorSetPreferences{}, fmt.Errorf("The preferences (validator and weights) are the same")
+			return types.ValidatorSetPreferences{}, errors.New("The preferences (validator and weights) are the same")
 		}
 	}
 
 	// checks that all the validators exist on chain
 	valSetPref, err := k.IsPreferenceValid(ctx, preferences)
 	if err != nil {
-		return types.ValidatorSetPreferences{}, fmt.Errorf("The validator preference list is not valid")
+		return types.ValidatorSetPreferences{}, errors.New("The validator preference list is not valid")
 	}
 
 	return types.ValidatorSetPreferences{Preferences: valSetPref}, nil
@@ -497,7 +498,7 @@ func (k Keeper) withdrawExistingValSetStakingPosition(ctx sdk.Context, delegator
 	for _, dels := range delegations {
 		valAddr, err := sdk.ValAddressFromBech32(dels.ValOperAddress)
 		if err != nil {
-			return fmt.Errorf("validator address not formatted")
+			return errors.New("validator address not formatted")
 		}
 
 		_, err = k.distirbutionKeeper.WithdrawDelegationRewards(ctx, delegator, valAddr)
@@ -527,7 +528,7 @@ func (k Keeper) ForceUnlockBondedOsmo(ctx sdk.Context, lockID uint64, delegatorA
 	}
 	// TODO: use found
 	if synthLocks != (lockuptypes.SyntheticLock{}) {
-		return sdk.Coin{}, fmt.Errorf("cannot use DelegateBondedTokens being used for superfluid.")
+		return sdk.Coin{}, errors.New("cannot use DelegateBondedTokens being used for superfluid.")
 	}
 
 	// ForceUnlock ignores lockup duration and unlock tokens immediately.
@@ -546,7 +547,7 @@ func (k Keeper) ForceUnlockBondedOsmo(ctx sdk.Context, lockID uint64, delegatorA
 func (k Keeper) getValAddrAndVal(ctx sdk.Context, valOperAddress string) (sdk.ValAddress, stakingtypes.Validator, error) {
 	valAddr, err := sdk.ValAddressFromBech32(valOperAddress)
 	if err != nil {
-		return nil, stakingtypes.Validator{}, fmt.Errorf("validator address not formatted")
+		return nil, stakingtypes.Validator{}, errors.New("validator address not formatted")
 	}
 
 	validator, err := k.stakingKeeper.GetValidator(ctx, valAddr)
@@ -652,7 +653,7 @@ func (k Keeper) validateLockForForceUnlock(ctx sdk.Context, lockID uint64, deleg
 	// check that lock contains only 1 token
 	coin, err := lock.SingleCoin()
 	if err != nil {
-		return nil, osmomath.Int{}, fmt.Errorf("lock fails to meet expected invariant, it contains multiple coins")
+		return nil, osmomath.Int{}, errors.New("lock fails to meet expected invariant, it contains multiple coins")
 	}
 
 	// check that the lock denom is uosmo
@@ -662,12 +663,12 @@ func (k Keeper) validateLockForForceUnlock(ctx sdk.Context, lockID uint64, deleg
 
 	// check if there is enough uosmo token in the lock
 	if lockedOsmoAmount.LTE(osmomath.NewInt(0)) {
-		return nil, osmomath.Int{}, fmt.Errorf("lock does not contain osmo denom, or there isn't enough osmo to unbond")
+		return nil, osmomath.Int{}, errors.New("lock does not contain osmo denom, or there isn't enough osmo to unbond")
 	}
 
 	// Checks if lock ID is bonded and ensure that the duration is <= 2 weeks
 	if lock.IsUnlocking() || lock.Duration > time.Hour*24*7*2 {
-		return nil, osmomath.Int{}, fmt.Errorf("the tokens have to bonded and the duration has to be <= 2weeks")
+		return nil, osmomath.Int{}, errors.New("the tokens have to bonded and the duration has to be <= 2weeks")
 	}
 
 	return lock, lockedOsmoAmount, nil


### PR DESCRIPTION
`errors.New` is specifically designed to instantiate a new error with a given message, without any formatting overhead. I think this should be the preferred method when we do not need to format the error string.

On the other hand, it saves a couple function calls and a comparison on the error path, although this is tiny diff...