### PR TITLE
chore(indexer): log start and end of first block ingest

### DIFF
--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -151,7 +151,6 @@ func (s *indexerStreamingService) publishTxn(ctx context.Context, req abci.Reque
 
 // ListenFinalizeBlock updates the streaming service with the latest FinalizeBlock messages
 func (s *indexerStreamingService) ListenFinalizeBlock(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
-
 	// Log the status only for the first block
 	// Avoid subsequent blocks to avoid spamming the logs
 	if s.blockProcessStrategyManager.ShouldPushAllData() {

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -151,6 +151,18 @@ func (s *indexerStreamingService) publishTxn(ctx context.Context, req abci.Reque
 
 // ListenFinalizeBlock updates the streaming service with the latest FinalizeBlock messages
 func (s *indexerStreamingService) ListenFinalizeBlock(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
+
+	// Log the status only for the first block
+	// Avoid subsequent blocks to avoid spamming the logs
+	if s.blockProcessStrategyManager.ShouldPushAllData() {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		sdkCtx.Logger().Info("Starting indexer ingest ListenFinalizeBlock", "height", sdkCtx.BlockHeight())
+
+		defer func() {
+			sdkCtx.Logger().Info("Finished indexer ingest ListenFinalizeBlock", "height", sdkCtx.BlockHeight())
+		}()
+	}
+
 	// Publish the block data
 	var err error
 	err = s.publishBlock(ctx, req)
@@ -170,6 +182,17 @@ func (s *indexerStreamingService) ListenFinalizeBlock(ctx context.Context, req a
 // ListenCommit updates the steaming service with the latest Commit messages and state changes
 func (s *indexerStreamingService) ListenCommit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	// Log the status only for the first block
+	// Avoid subsequent blocks to avoid spamming the logs
+	if s.blockProcessStrategyManager.ShouldPushAllData() {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		sdkCtx.Logger().Info("Starting indexer ingest ListenCommit", "height", sdkCtx.BlockHeight())
+
+		defer func() {
+			sdkCtx.Logger().Info("Finished indexer ingest ListenCommit", "height", sdkCtx.BlockHeight())
+		}()
+	}
 
 	defer func() {
 		// Reset the pool tracker after processing the block.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

When the indexer node cold starts, there is log-lasting ingest process, and it is unclear if the node is stuck or ingest is still in-progress.

This PR adds logs for clear and direct feedback