### PR TITLE
fix: update `make release` help message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 	@echo "  make lint                  Show available lint commands"
 	@echo "  make localnet              Show available localnet commands"
 	@echo "  make proto                 Show available proto commands"
-	@echo "  make release               Show available release commands"
+	@echo "  make release               Use goreleaser to build and release cross-platform osmosisd binary version"
 	@echo "  make release-help          Show available release commands"
 	@echo "  make run-querygen          Generating GRPC queries, and queryproto logic"
 	@echo "  make sqs                   Show available sqs commands"


### PR DESCRIPTION
## What is the purpose of the change

Since the target `release` won't print the available subcommands, we need to update it.

![image](https://github.com/user-attachments/assets/4636cf4a-4f83-4094-99d4-839616c0be9d)

