### PR TITLE
Bump alpine versions to get golang 1.22.4 support

### DIFF
--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -24,7 +24,7 @@ on:
       - v[0-9]+.x-iavl-v1
 
 env:
-  RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.20
   OSMOSIS_DEV_IMAGE_REPOSITORY: osmolabs/osmosis-dev
   OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY: osmolabs/osmosis-e2e-init-chain
   OSMOSIS_DEV_IMAGE_COSMOVISOR_REPOSITORY: osmolabs/osmosis-dev-cosmovisor

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -37,7 +37,7 @@ env:
   DOCKER_REPOSITORY_COSMOVISOR: osmolabs/osmosis-cosmovisor
   RUNNER_BASE_IMAGE_DISTROLESS: gcr.io/distroless/static-debian11
   RUNNER_BASE_IMAGE_NONROOT: gcr.io/distroless/static-debian11:nonroot
-  RUNNER_BASE_IMAGE_ALPINE: alpine:3.17
+  RUNNER_BASE_IMAGE_ALPINE: alpine:3.20
   COSMOVISOR_VERSION: v1.5.0
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_TAGS="netgo,ledger,muslc"
 # Builder
 # --------------------------------------------------------
 
-FROM golang:${GO_VERSION}-alpine3.18 as builder
+FROM golang:${GO_VERSION}-alpine3.20 as builder
 
 ARG GIT_VERSION
 ARG GIT_COMMIT

--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -10,7 +10,7 @@ ARG COSMOVISOR_VERSION="v1.5.0"
 # Builder
 # --------------------------------------------------------
 
-FROM golang:${GO_VERSION}-alpine3.18 as builder
+FROM golang:${GO_VERSION}-alpine3.20 as builder
 
 ARG GIT_VERSION
 ARG GIT_COMMIT


### PR DESCRIPTION
This change is already covered by existing tests, such as docker based build.
