### PR TITLE
fix: prevent setting invalid before send hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8274](https://github.com/osmosis-labs/osmosis/pull/8274) SDK v50 and Comet v0.38 upgrade
 * [#8375](https://github.com/osmosis-labs/osmosis/pull/8375) Enforce sub-authenticator to be greater than 1
 * [#8509](https://github.com/osmosis-labs/osmosis/pull/8509) Change LiquidityNetInDirection return type to sdk math
+* [#8535](https://github.com/osmosis-labs/osmosis/pull/8535) Prevent Setting Invalid Before Send Hook
 
 ### State Compatible
 * [#8494](https://github.com/osmosis-labs/osmosis/pull/8494) Add additional events in x/lockup, x/superfluid, x/concentratedliquidity

--- a/x/tokenfactory/keeper/before_send_test.go
+++ b/x/tokenfactory/keeper/before_send_test.go
@@ -6,10 +6,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/x/tokenfactory/types"
-
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 type SendMsgTestCase struct {
@@ -136,6 +136,52 @@ func (s *KeeperTestSuite) TestBeforeSendHook() {
 				}
 
 			}
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestInvalidSetBeforeSendHook() {
+	s.SkipIfWSL()
+	for _, tc := range []struct {
+		desc     string
+		wasmFile string
+	}{
+		{
+			desc:     "should not allow sending 100 amount of *any* denom",
+			wasmFile: "./testdata/no100.wasm",
+		},
+	} {
+		s.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			// setup test
+			s.SetupTest()
+
+			// upload and instantiate wasm code
+			wasmCode, err := os.ReadFile(tc.wasmFile)
+			s.Require().NoError(err, "test: %v", tc.desc)
+			codeID, _, err := s.contractKeeper.Create(s.Ctx, s.TestAccs[0], wasmCode, nil)
+			s.Require().NoError(err, "test: %v", tc.desc)
+			_, _, err = s.contractKeeper.Instantiate(s.Ctx, codeID, s.TestAccs[0], s.TestAccs[0], []byte("{}"), "", sdk.NewCoins())
+			s.Require().NoError(err, "test: %v", tc.desc)
+
+			// create new denom
+			res, err := s.msgServer.CreateDenom(s.Ctx, types.NewMsgCreateDenom(s.TestAccs[0].String(), "bitcoin"))
+			s.Require().NoError(err, "test: %v", tc.desc)
+			denom := res.GetNewTokenDenom()
+
+			// mint enough coins to the creator
+			_, err = s.msgServer.Mint(s.Ctx, types.NewMsgMint(s.TestAccs[0].String(), sdk.NewInt64Coin(denom, 1000000000)))
+			s.Require().NoError(err)
+			// mint some non token factory denom coins for testing
+			s.FundAcc(sdk.MustAccAddressFromBech32(s.TestAccs[0].String()), sdk.Coins{sdk.NewInt64Coin("foo", 100000000000)})
+
+			// set an invalid beforesend hook to the new denom
+			invalidAddress := sdk.AccAddress([]byte("addr1---------------"))
+			_, err = s.msgServer.SetBeforeSendHook(s.Ctx, types.NewMsgSetBeforeSendHook(s.TestAccs[0].String(), denom, invalidAddress.String()))
+			s.Require().Error(err)
+
+			denoms, beforeSendHooks := s.App.TokenFactoryKeeper.GetAllBeforeSendHooks(s.Ctx)
+			s.Require().Equal(beforeSendHooks, []string{})
+			s.Require().Equal(denoms, []string{})
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
Blocks Setting invalid setting before send hooks

## Testing and Verifying
This change added new etest
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A