### PR TITLE
fix: [indexer] adjust token in amount for spread factor for CL pools only

### DIFF
--- a/ingest/indexer/domain/keepers.go
+++ b/ingest/indexer/domain/keepers.go
@@ -5,10 +5,13 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 )
 
 type PoolManagerKeeperI interface {
 	GetTradingPairTakerFee(ctx sdk.Context, denom0, denom1 string) (osmomath.Dec, error)
+	GetPool(ctx sdk.Context, poolId uint64) (types.PoolI, error)
+	GetPoolType(ctx sdk.Context, poolId uint64) (types.PoolType, error)
 }
 
 type Keepers struct {


### PR DESCRIPTION
This PR addresses the issue that in the case of towen_swapped event in CL pools, the tokens_in amount is AFTER spread factor calculation, thus we need to adjust it back to BEFORE spread factor amount before the event data is published to the indexer backend. Tested in v25.x and to be tested in sdk v50.