### PR TITLE
Expose the grpc for relayer connection in the localrelayer test environment

### DIFF
--- a/tests/localrelayer/scripts/setup_chain.sh
+++ b/tests/localrelayer/scripts/setup_chain.sh
@@ -96,6 +96,9 @@ edit_config () {
 
     # Expose the rpc
     dasel put -t string -f $CONFIG_FOLDER/config.toml '.rpc.laddr' -v "tcp://0.0.0.0:26657"
+
+    # Expose the grpc
+    dasel put -t string -f $CONFIG_FOLDER/app.toml -v "0.0.0.0:9090" '.grpc.address'
 }
 
 if [[ ! -d $CONFIG_FOLDER ]]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #8520 

## What is the purpose of the change

*This pull request fixes the localrelayer test environment by exposing the grpc interface so that relayer can connect to validators*

## Testing and Verifying

This change added tests and can be verified as follows:

  - *Manually verified the change by starting the localrelayer test environment*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A