### PR TITLE
perf: Speedup exit pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#8494](https://github.com/osmosis-labs/osmosis/pull/8494) Add additional events in x/lockup, x/superfluid, x/concentratedliquidity
 * [#8543](https://github.com/osmosis-labs/osmosis/pull/8543) Add OTEL wiring and new configs in app.toml
+* [#8566](https://github.com/osmosis-labs/osmosis/pull/8566) Minor speedup to CalcExitCFMM shares
+
 
 ## v25.2.1
 * [#8546](https://github.com/osmosis-labs/osmosis/pull/8546) feat: reduce commit timeout to 500ms to enable faster blocks, and timeout propose to 1.8s

--- a/x/gamm/pool-models/internal/cfmm_common/lp.go
+++ b/x/gamm/pool-models/internal/cfmm_common/lp.go
@@ -26,7 +26,7 @@ func CalcExitPool(ctx sdk.Context, pool types.CFMMPoolI, exitingShares osmomath.
 	var refundedShares osmomath.Dec
 	if !exitFee.IsZero() {
 		// exitingShares * (1 - exit fee)
-		oneSubExitFee := osmomath.OneDec().Sub(exitFee)
+		oneSubExitFee := osmomath.OneDec().SubMut(exitFee)
 		refundedShares = oneSubExitFee.MulIntMut(exitingShares)
 	} else {
 		refundedShares = exitingShares.ToLegacyDec()
@@ -34,8 +34,8 @@ func CalcExitPool(ctx sdk.Context, pool types.CFMMPoolI, exitingShares osmomath.
 
 	shareOutRatio := refundedShares.QuoInt(totalShares)
 	// exitedCoins = shareOutRatio * pool liquidity
-	exitedCoins := sdk.Coins{}
 	poolLiquidity := pool.GetTotalPoolLiquidity(ctx)
+	exitedCoins := make(sdk.Coins, 0, len(poolLiquidity))
 
 	for _, asset := range poolLiquidity {
 		// round down here, due to not wanting to over-exit
@@ -46,7 +46,7 @@ func CalcExitPool(ctx sdk.Context, pool types.CFMMPoolI, exitingShares osmomath.
 		if exitAmt.GTE(asset.Amount) {
 			return sdk.Coins{}, errors.New("too many shares out")
 		}
-		exitedCoins = exitedCoins.Add(sdk.NewCoin(asset.Denom, exitAmt))
+		exitedCoins = append(exitedCoins, sdk.Coin{Denom: asset.Denom, Amount: exitAmt})
 	}
 
 	return exitedCoins, nil


### PR DESCRIPTION
We saw this was taking a noticeable amount of time in some SQS queries.

This saves ~15% of the relevant time. (Though the better solution will involve re-implementation in SQS for a 10x)