### PR TITLE
fix: increase unauthenticated gas to fix fee token issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8535](https://github.com/osmosis-labs/osmosis/pull/8535) Prevent Setting Invalid Before Send Hook
 * [#8310](https://github.com/osmosis-labs/osmosis/pull/8310) Taker fee share
 * [#8494](https://github.com/osmosis-labs/osmosis/pull/8494) Add additional events in x/lockup, x/superfluid, x/concentratedliquidity
+* [#8573](https://github.com/osmosis-labs/osmosis/pull/8573) fix: increase unauthenticated gas to fix fee token issue
 
 ### Config
 

--- a/app/upgrades/v26/constants.go
+++ b/app/upgrades/v26/constants.go
@@ -8,7 +8,12 @@ import (
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v26 upgrade.
-const UpgradeName = "v26"
+const (
+	UpgradeName = "v26"
+
+	// MaximumUnauthenticatedGas for smart account transactions to verify the fee payer
+	MaximumUnauthenticatedGas = uint64(200_000)
+)
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,

--- a/app/upgrades/v26/constants.go
+++ b/app/upgrades/v26/constants.go
@@ -12,7 +12,7 @@ const (
 	UpgradeName = "v26"
 
 	// MaximumUnauthenticatedGas for smart account transactions to verify the fee payer
-	MaximumUnauthenticatedGas = uint64(200_000)
+	MaximumUnauthenticatedGas = uint64(250_000)
 )
 
 var Upgrade = upgrades.Upgrade{

--- a/app/upgrades/v26/upgrades.go
+++ b/app/upgrades/v26/upgrades.go
@@ -55,6 +55,11 @@ func CreateUpgradeHandler(
 			keepers.PoolManagerKeeper.SetDenomPairTakerFee(ctx, tradingPairTakerFee.TokenOutDenom, tradingPairTakerFee.TokenInDenom, tradingPairTakerFee.TakerFee)
 		}
 
+		// Set the authenticator params in the store
+		authenticatorParams := keepers.SmartAccountKeeper.GetParams(ctx)
+		authenticatorParams.MaximumUnauthenticatedGas = MaximumUnauthenticatedGas
+		keepers.SmartAccountKeeper.SetParams(ctx, authenticatorParams)
+
 		return migrations, nil
 	}
 }

--- a/app/upgrades/v26/upgrades_test.go
+++ b/app/upgrades/v26/upgrades_test.go
@@ -48,6 +48,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	s.preModule = upgrade.NewAppModule(s.App.UpgradeKeeper, addresscodec.NewBech32Codec("osmo"))
 
 	s.PrepareTradingPairTakerFeeTest()
+	s.PrepareIncreaseUnauthenticatedGasTest()
 
 	// Run the upgrade
 	dummyUpgrade(s)
@@ -57,6 +58,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	})
 
 	s.ExecuteTradingPairTakerFeeTest()
+	s.ExecuteIncreaseUnauthenticatedGasTest()
 }
 
 func dummyUpgrade(s *UpgradeTestSuite) {
@@ -100,4 +102,16 @@ func (s *UpgradeTestSuite) ExecuteTradingPairTakerFeeTest() {
 	s.Require().NoError(err)
 	s.Require().Len(allTradingPairTakerFees, 4)
 	s.Require().Equal(expectedTradingPairTakerFees, allTradingPairTakerFees)
+}
+
+func (s *UpgradeTestSuite) PrepareIncreaseUnauthenticatedGasTest() {
+	// Set the unauthenticator gas parameter to 1
+	authenticatorParams := s.App.SmartAccountKeeper.GetParams(s.Ctx)
+	authenticatorParams.MaximumUnauthenticatedGas = 1
+	s.App.SmartAccountKeeper.SetParams(s.Ctx, authenticatorParams)
+}
+
+func (s *UpgradeTestSuite) ExecuteIncreaseUnauthenticatedGasTest() {
+	authenticatorParams := s.App.SmartAccountKeeper.GetParams(s.Ctx)
+	s.Require().Equal(authenticatorParams.MaximumUnauthenticatedGas, v26.MaximumUnauthenticatedGas)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The current estimate for unauthenticated gas is far to low, the node ran into issues when we tried to execute transaction using fee tokens other than `uosmo` as the was another read from the store.

We increase the unauthenticated gas from 120_000 => 200_000 to enable multiple fee tokens

### How to test

- 1 run `in-place-testnet`
- `osmosisd q smartaccount params`

- 2 run tests in the v26 upgrade folder
- `cd ./app/upgrades/v26`
- `go test ./...`