### PR TITLE
fix: v25 app hash when syncing

### DIFF
--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -62,8 +62,7 @@ func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	}
 
 	// TODO: In v26, move this code to the correct spot, and make it CheckTX only.
-	bh := ctx.BlockHeight()
-	if bh <= 16841115 || bh >= 17004043 {
+	if ctx.BlockHeight() >= 17004043 {
 		msgs := tx.GetMsgs()
 		for _, msg := range msgs {
 			// If one of the msgs is an IBC Transfer msg, limit it's size due to current spam potential.

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -62,7 +62,8 @@ func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	}
 
 	// TODO: In v26, move this code to the correct spot, and make it CheckTX only.
-	if ctx.BlockHeight() >= 16841116 {
+	bh := ctx.BlockHeight()
+	if bh <= 16841115 || bh >= 17004043 {
 		msgs := tx.GetMsgs()
 		for _, msg := range msgs {
 			// If one of the msgs is an IBC Transfer msg, limit it's size due to current spam potential.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

we see apphash issues with this code path between blocks `16841115` and block `17004043`, we ignore this code path for the purposes of syncing the node 