### PR TITLE
fix: update == to .Equal

### DIFF
--- a/x/superfluid/keeper/gov/gov.go
+++ b/x/superfluid/keeper/gov/gov.go
@@ -37,7 +37,7 @@ func HandleRemoveSuperfluidAssetsProposal(ctx sdk.Context, k keeper.Keeper, p *t
 			return err
 		}
 		dummyAsset := types.SuperfluidAsset{}
-		if asset == dummyAsset {
+		if asset.Equal(dummyAsset) {
 			return fmt.Errorf("superfluid asset %s doesn't exist", denom)
 		}
 		k.BeginUnwindSuperfluidAsset(ctx, 0, asset)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Update a small edge case where we use == instead of the recommended .Equal

### Context

- https://github.com/osmosis-labs/osmosis/pull/8564#discussion_r1700892365

### How to test

- `cd x/superfluid`
- `go test ./...`