### PR TITLE
feat(SQS): alloyed transmuter rate limiter info propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.13
 	github.com/osmosis-labs/osmosis/x/epochs v0.0.8-0.20240517165907-1625703bc16d
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.14-0.20240517165907-1625703bc16d
-	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240726185641-db760a4fe9f1
+	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240804234936-efe4db2eb803
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/skip-mev/block-sdk/v2 v2.1.5

--- a/go.sum
+++ b/go.sum
@@ -909,8 +909,8 @@ github.com/osmosis-labs/osmosis/x/epochs v0.0.8-0.20240517165907-1625703bc16d h1
 github.com/osmosis-labs/osmosis/x/epochs v0.0.8-0.20240517165907-1625703bc16d/go.mod h1:SgzJ247NQ6lDDXCHiTKjaq713TSedVQTLgB4E+zGbhg=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.14-0.20240517165907-1625703bc16d h1:NNjrEQ2TCF26WLn0zGzr/xptXyz4sVgrfYamWY69W1Q=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.14-0.20240517165907-1625703bc16d/go.mod h1:2yjCTFE7+dr2i/meQUPS4Rs5LskIDb5d8c4lePKhmxA=
-github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240726185641-db760a4fe9f1 h1:i2vu2mbIyOjlF3dBLmGVyM1em57hwZ6mO+SEvoWiRSc=
-github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240726185641-db760a4fe9f1/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240804234936-efe4db2eb803 h1:bSJyloY2tkj7Ikn7IOu2yW+7MbJkifKlREurnRdB1xs=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240804234936-efe4db2eb803/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/ingest/sqs/pools/transformer/alloy_transmuter.go
+++ b/ingest/sqs/pools/transformer/alloy_transmuter.go
@@ -13,6 +13,7 @@ import (
 const (
 	listAssetConfigsQueryString = `{"list_asset_configs":{}}`
 	getShareDenomQueryString    = `{"get_share_denom":{}}`
+	listLimitersQueryString     = `{"list_limiters":{}}`
 )
 
 // updateAlloyTransmuterInfo updates cosmwasmPoolModel with alloyed transmuter specific info.
@@ -37,12 +38,18 @@ func (pi *poolTransformer) updateAlloyTransmuterInfo(
 		return err
 	}
 
+	rateLimiterData, err := alloyTransmuterListLimiters(ctx, pi.wasmKeeper, poolId, contractAddress)
+	if err != nil {
+		return err
+	}
+
 	// append alloyed denom to denoms
 	*poolDenoms = append(*poolDenoms, alloyedDenom)
 
 	cosmWasmPoolModel.Data.AlloyTransmuter = &sqscosmwasmpool.AlloyTransmuterData{
-		AlloyedDenom: alloyedDenom,
-		AssetConfigs: assetConfigs,
+		AlloyedDenom:      alloyedDenom,
+		AssetConfigs:      assetConfigs,
+		RateLimiterConfig: rateLimiterData,
 	}
 
 	return nil
@@ -103,4 +110,77 @@ func alloyTransmuterGetShareDenom(
 	}
 
 	return getShareDenomResponse.ShareDenom, nil
+}
+
+type listLimitersResponse struct {
+	Limiters [][2]json.RawMessage `json:"limiters"`
+}
+
+type LimiterInfo [2]string
+
+type LimiterValue struct {
+	StaticLimiter *sqscosmwasmpool.StaticLimiter `json:"static_limiter,omitempty"`
+	ChangeLimiter *sqscosmwasmpool.ChangeLimiter `json:"change_limiter,omitempty"`
+}
+
+// alloyTransmuterListLimiters queries the limiters of the alloyed transmuter contract.
+func alloyTransmuterListLimiters(
+	ctx sdk.Context,
+	wasmKeeper commondomain.WasmKeeper,
+	poolId uint64,
+	contractAddress sdk.AccAddress,
+) (sqscosmwasmpool.AlloyedRateLimiter, error) {
+	bz, err := wasmKeeper.QuerySmart(ctx, contractAddress, []byte(listLimitersQueryString))
+	if err != nil {
+		return sqscosmwasmpool.AlloyedRateLimiter{}, fmt.Errorf(
+			"error querying list_limiters for pool (%d) contrat_address (%s): %w",
+			poolId, contractAddress, err,
+		)
+	}
+
+	listLimtersResponseData := listLimitersResponse{}
+
+	if err := json.Unmarshal(bz, &listLimtersResponseData); err != nil {
+		return sqscosmwasmpool.AlloyedRateLimiter{}, fmt.Errorf(
+			"error unmarshalling limiters for pool (%d) contrat_address (%s): %w",
+			poolId, contractAddress, err,
+		)
+	}
+
+	staticLimiters := make(map[string]sqscosmwasmpool.StaticLimiter, 0)
+	changeLimiters := make(map[string]sqscosmwasmpool.ChangeLimiter, 0)
+
+	for _, limiterRaw := range listLimtersResponseData.Limiters {
+		var info LimiterInfo
+		err := json.Unmarshal(limiterRaw[0], &info)
+		if err != nil {
+			ctx.Logger().Error("Error unmarshaling info:", "err", err, "pool_id", poolId)
+			continue
+		}
+
+		var value LimiterValue
+		err = json.Unmarshal(limiterRaw[1], &value)
+		if err != nil {
+			ctx.Logger().Error("Error unmarshaling value:", "err", err, "pool_id", poolId)
+			continue
+		}
+
+		// First element of info is the denom
+		if len(info) < 1 {
+			ctx.Logger().Error("Error parsing limiter info", "pool_id", poolId)
+		}
+
+		denom := info[0]
+
+		if value.StaticLimiter != nil {
+			staticLimiters[denom] = *value.StaticLimiter
+		} else if value.ChangeLimiter != nil {
+			changeLimiters[denom] = *value.ChangeLimiter
+		}
+	}
+
+	return sqscosmwasmpool.AlloyedRateLimiter{
+		StaticLimiterByDenomMap: staticLimiters,
+		ChangeLimiterByDenomMap: changeLimiters,
+	}, nil
 }

--- a/ingest/sqs/pools/transformer/alloy_transmuter_test.go
+++ b/ingest/sqs/pools/transformer/alloy_transmuter_test.go
@@ -1,13 +1,43 @@
 package poolstransformer_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sqscosmwasmpool "github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+	"github.com/stretchr/testify/require"
+
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
-	sqscosmwasmpool "github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
+	poolstransformer "github.com/osmosis-labs/osmosis/v25/ingest/sqs/pools/transformer"
 )
+
+type mockWasmKeeper struct {
+	QueryRawFn   func(ctx context.Context, contractAddress sdk.AccAddress, key []byte) []byte
+	QuerySmartFn func(ctx context.Context, contractAddress sdk.AccAddress, req []byte) ([]byte, error)
+}
+
+// QueryRaw implements commondomain.WasmKeeper.
+func (m *mockWasmKeeper) QueryRaw(ctx context.Context, contractAddress sdk.AccAddress, key []byte) []byte {
+	if m.QueryRawFn != nil {
+		return m.QueryRawFn(ctx, contractAddress, key)
+	}
+	panic("unimplemented")
+}
+
+// QuerySmart implements commondomain.WasmKeeper.
+func (m *mockWasmKeeper) QuerySmart(ctx context.Context, contractAddress sdk.AccAddress, req []byte) ([]byte, error) {
+	if m.QuerySmartFn != nil {
+		return m.QuerySmartFn(ctx, contractAddress, req)
+	}
+	panic("unimplemented")
+}
+
+var _ commondomain.WasmKeeper = &mockWasmKeeper{}
 
 func (s *PoolTransformerTestSuite) TestUpdateAlloyedTransmuterPool() {
 	s.Setup()
@@ -47,6 +77,10 @@ func (s *PoolTransformerTestSuite) TestUpdateAlloyedTransmuterPool() {
 				{Denom: apptesting.DefaultTransmuterDenomA, NormalizationFactor: osmomath.NewInt(apptesting.DefaultTransmuterDenomANormFactor)},
 				{Denom: apptesting.DefaultTransmuterDenomB, NormalizationFactor: osmomath.NewInt(apptesting.DefaultTransmuterDenomBNormFactor)},
 				{Denom: alloyedDenom, NormalizationFactor: osmomath.NewInt(apptesting.DefaultAlloyedDenomNormFactor)}},
+			RateLimiterConfig: sqscosmwasmpool.AlloyedRateLimiter{
+				StaticLimiterByDenomMap: map[string]sqscosmwasmpool.StaticLimiter{},
+				ChangeLimiterByDenomMap: map[string]sqscosmwasmpool.ChangeLimiter{},
+			},
 		},
 	}, cosmWasmPoolModel.Data)
 
@@ -55,4 +89,107 @@ func (s *PoolTransformerTestSuite) TestUpdateAlloyedTransmuterPool() {
 		apptesting.DefaultTransmuterDenomB,
 		alloyedDenom,
 	}, poolDenoms)
+}
+
+func (s *PoolTransformerTestSuite) TestAlloyTransmuterListLimiters() {
+	tests := []struct {
+		name            string
+		poolID          uint64
+		contractAddress string
+		mockQueryResult []byte
+		mockQueryError  error
+		expectedResult  sqscosmwasmpool.AlloyedRateLimiter
+		expectedError   bool
+	}{
+		{
+			name:            "Success with static limiters",
+			poolID:          1,
+			contractAddress: "osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3",
+			mockQueryResult: []byte(`{
+    "limiters": [
+        [
+            ["denom1", "Static Limiter 1"],
+            {"static_limiter": {"upper_limit": "0.2"}}
+        ],
+        [
+            ["denom2", "Static Limiter 2"],
+            {"static_limiter": {"upper_limit": "0.3"}}
+        ]
+    ]
+}`),
+			expectedResult: sqscosmwasmpool.AlloyedRateLimiter{
+				StaticLimiterByDenomMap: map[string]sqscosmwasmpool.StaticLimiter{
+					"denom1": {UpperLimit: "0.2"},
+					"denom2": {UpperLimit: "0.3"},
+				},
+				ChangeLimiterByDenomMap: map[string]sqscosmwasmpool.ChangeLimiter{},
+			},
+		},
+		{
+			name:            "Success with change limiters",
+			poolID:          2,
+			contractAddress: "osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3",
+			mockQueryResult: []byte(`{
+    "limiters": [
+        [
+            ["denom3", "Change Limiter 1"],
+            {"change_limiter": {
+                "latest_value": "0.1",
+                "window_config": {"window_size": 1000, "division_count": 10},
+                "boundary_offset": "0.05"
+            }}
+        ]
+    ]
+}`),
+			expectedResult: sqscosmwasmpool.AlloyedRateLimiter{
+				StaticLimiterByDenomMap: map[string]sqscosmwasmpool.StaticLimiter{},
+				ChangeLimiterByDenomMap: map[string]sqscosmwasmpool.ChangeLimiter{
+					"denom3": {
+						LatestValue:    "0.1",
+						WindowConfig:   sqscosmwasmpool.WindowConfig{WindowSize: 1000, DivisionCount: 10},
+						BoundaryOffset: "0.05",
+					},
+				},
+			},
+		},
+		{
+			name:            "Query error",
+			poolID:          3,
+			contractAddress: "osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3",
+			mockQueryError:  errors.New("query failed"),
+			expectedError:   true,
+		},
+		{
+			name:            "Unmarshal error",
+			poolID:          4,
+			contractAddress: "osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3",
+			mockQueryResult: []byte(`invalid json`),
+			expectedError:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		s.T().Run(tc.name, func(t *testing.T) {
+
+			s.Setup()
+
+			mockWasmKeeper := &mockWasmKeeper{
+				QuerySmartFn: func(ctx context.Context, contractAddress sdk.AccAddress, req []byte) ([]byte, error) {
+					return tc.mockQueryResult, tc.mockQueryError
+				},
+			}
+
+			contractAddr, err := sdk.AccAddressFromBech32(tc.contractAddress)
+			require.NoError(t, err)
+
+			result, err := poolstransformer.AlloyTransmuterListLimiters(s.Ctx, mockWasmKeeper, tc.poolID, contractAddr)
+
+			if tc.expectedError {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().Equal(tc.expectedResult, result)
+			}
+		})
+	}
 }

--- a/ingest/sqs/pools/transformer/export_test.go
+++ b/ingest/sqs/pools/transformer/export_test.go
@@ -73,3 +73,12 @@ func (pi *poolTransformer) InitCosmWasmPoolModel(
 func TickIndexById(ticks []sqscosmwasmpool.OrderbookTick, tickId int64) int {
 	return tickIndexById(ticks, tickId)
 }
+
+func AlloyTransmuterListLimiters(
+	ctx sdk.Context,
+	wasmKeeper commondomain.WasmKeeper,
+	poolId uint64,
+	contractAddress sdk.AccAddress,
+) (sqscosmwasmpool.AlloyedRateLimiter, error) {
+	return alloyTransmuterListLimiters(ctx, wasmKeeper, poolId, contractAddress)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixing the transmuter alloyed rate limiter bug.

We noticed that SQS does not account for rate limiting in the alloyed transmitters. As a result, it returns routes that are rate-limited, failing user swaps.

This PR propagates the rate-limiting data by retrieving it from the smart contract and pushing into SQS

This is what SQS receives:
![image](https://github.com/user-attachments/assets/70067609-099e-442d-9bca-b5586acf8a5c)

It can then use the data as needed to manage the rate limits.

## Testing and Verifying

- Tested that the ingestion works as intended
- Added unit test

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A