### PR TITLE
fix: apphash during v25 sync. forward porting it to v26

### DIFF
--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -63,7 +63,11 @@ func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	}
 
 	// Local mempool filter for improper ibc packets
-	if ctx.IsCheckTx() {
+	// Perform this only if
+	// 1. We are in CheckTx, and
+	// 2. Block height is NOT in the range of 16841115 to 17004043 exclusively, where AppHash happened during v25 sync.
+	bh := ctx.BlockHeight()
+	if ctx.IsCheckTx() && (bh <= 16841115 || bh >= 17004043) {
 		msgs := tx.GetMsgs()
 		for _, msg := range msgs {
 			// If one of the msgs is an IBC Transfer msg, limit it's size due to current spam potential.


### PR DESCRIPTION
## What is the purpose of the change

This commit forward-ports the fix about AppHash issue during v25 sync.
See: https://github.com/osmosis-labs/osmosis/pull/8577

Tested in v25.x and already in production in indexer environment.