### PR TITLE
feat: fine-tune pubsub sdk to avoid idling message at the sdk level

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -712,6 +712,11 @@ grpc-ingest-max-call-size-bytes = "{{ .SidecarQueryServerConfig.GRPCIngestMaxCal
 # The indexer service is disabled by default.
 is-enabled = "{{ .IndexerConfig.IsEnabled }}"
 
+# Max publish delay in seconds for the indexer service.
+# Migitate the issue of messages remaining pending when the publishing rate is low,
+# ensuring timely delivery and preventing messages from appearing undelivered
+max-publish-delay = "{{ .IndexerConfig.MaxPublishDelay }}"
+
 # The GCP project id to use for the indexer service.
 gcp-project-id = "{{ .IndexerConfig.GCPProjectId }}"
 

--- a/ingest/indexer/indexer_config.go
+++ b/ingest/indexer/indexer_config.go
@@ -11,6 +11,7 @@ import (
 // Config defines the config for the indexer.
 type Config struct {
 	IsEnabled                bool   `mapstructure:"enabled"`
+	MaxPublishDelay          int    `mapstructure:"max-publish-delay"`
 	GCPProjectId             string `mapstructure:"gcp-project-id"`
 	BlockTopicId             string `mapstructure:"block-topic-id"`
 	TransactionTopicId       string `mapstructure:"transaction-topic-id"`
@@ -28,6 +29,7 @@ const (
 // DefaultConfig defines the default config for the indexer client.
 var DefaultConfig = Config{
 	IsEnabled:                false,
+	MaxPublishDelay:          4,
 	GCPProjectId:             "",
 	BlockTopicId:             "",
 	TransactionTopicId:       "",
@@ -46,6 +48,7 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 		}
 	}
 
+	maxPublishDelay := osmoutils.ParseInt(opts, groupOptName, "max-publish-delay")
 	gcpProjectId := osmoutils.ParseString(opts, groupOptName, "gcp-project-id")
 	blockTopicId := osmoutils.ParseString(opts, groupOptName, "block-topic-id")
 	transactionTopicId := osmoutils.ParseString(opts, groupOptName, "transaction-topic-id")
@@ -56,6 +59,7 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 
 	return Config{
 		IsEnabled:                isEnabled,
+		MaxPublishDelay:          maxPublishDelay,
 		GCPProjectId:             gcpProjectId,
 		BlockTopicId:             blockTopicId,
 		TransactionTopicId:       transactionTopicId,
@@ -68,6 +72,6 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 
 // Initialize initializes the indexer by creating a new PubSubClient and returning a new IndexerIngester.
 func (c Config) Initialize() domain.Publisher {
-	pubSubClient := service.NewPubSubCLient(c.GCPProjectId, c.BlockTopicId, c.TransactionTopicId, c.PoolTopicId, c.TokenSupplyTopicId, c.TokenSupplyOffsetTopicId, c.PairTopicId)
+	pubSubClient := service.NewPubSubCLient(c.MaxPublishDelay, c.GCPProjectId, c.BlockTopicId, c.TransactionTopicId, c.PoolTopicId, c.TokenSupplyTopicId, c.TokenSupplyOffsetTopicId, c.PairTopicId)
 	return NewIndexerPublisher(*pubSubClient)
 }

--- a/ingest/indexer/service/client/pubsub_client.go
+++ b/ingest/indexer/service/client/pubsub_client.go
@@ -24,10 +24,6 @@ type PubSubClient struct {
 	pubsubClient             *pubsub.Client
 }
 
-const (
-	MAX_PUBLISH_DELAY = 4 * time.Second
-)
-
 // NewPubSubCLient creates a new PubSubClient.
 func NewPubSubCLient(maxPublishDelay int, projectId, blockTopicId, transactionTopicId, poolTopicId, tokenSupplyTopicId, tokenSupplyOffsetTopicId, pairTopicID string) *PubSubClient {
 	return &PubSubClient{

--- a/ingest/indexer/service/client/pubsub_client.go
+++ b/ingest/indexer/service/client/pubsub_client.go
@@ -58,7 +58,7 @@ func (p *PubSubClient) publish(ctx context.Context, message any, topicId string)
 	}
 
 	// Publish message to the topic. When the message publishing rate is very low, messages may remain pending and stale within the Pub/Sub SDK.
-	// For example, if only one message is published over a span of several minutes, the default DelayThreshold and CountThreshold values 
+	// For example, if only one message is published over a span of several minutes, the default DelayThreshold and CountThreshold values
 	// are high enough that the message may seem undelivered or lost.
 	// To mitigate this, it's essential to reduce the DelayThreshold to a lower value, such as 4 seconds, to ensure timely delivery.
 	topic := p.pubsubClient.Topic(topicId)

--- a/ingest/indexer/service/client/pubsub_client.go
+++ b/ingest/indexer/service/client/pubsub_client.go
@@ -13,6 +13,7 @@ import (
 
 // PubSubClient is a client for publishing messages to a PubSub topic.
 type PubSubClient struct {
+	maxPublishDelay          int
 	projectId                string
 	blockTopicId             string
 	transactionTopicId       string
@@ -28,8 +29,9 @@ const (
 )
 
 // NewPubSubCLient creates a new PubSubClient.
-func NewPubSubCLient(projectId, blockTopicId, transactionTopicId, poolTopicId, tokenSupplyTopicId, tokenSupplyOffsetTopicId, pairTopicID string) *PubSubClient {
+func NewPubSubCLient(maxPublishDelay int, projectId, blockTopicId, transactionTopicId, poolTopicId, tokenSupplyTopicId, tokenSupplyOffsetTopicId, pairTopicID string) *PubSubClient {
 	return &PubSubClient{
+		maxPublishDelay:          maxPublishDelay,
 		projectId:                projectId,
 		blockTopicId:             blockTopicId,
 		transactionTopicId:       transactionTopicId,
@@ -62,7 +64,7 @@ func (p *PubSubClient) publish(ctx context.Context, message any, topicId string)
 	// are high enough that the message may seem undelivered or lost.
 	// To mitigate this, it's essential to reduce the DelayThreshold to a lower value, such as 4 seconds, to ensure timely delivery.
 	topic := p.pubsubClient.Topic(topicId)
-	topic.PublishSettings.DelayThreshold = MAX_PUBLISH_DELAY
+	topic.PublishSettings.DelayThreshold = time.Duration(p.maxPublishDelay) * time.Second
 	topic.Publish(ctx, &pubsub.Message{
 		Data: msgBytes,
 	})


### PR DESCRIPTION
This commit addresses an issue observed where a message getting published using PubSub sdk on the publisher side but such message is not received and read on the consumer side. It is because when the message publishing rate is very low, messages may remain pending and stale within the Pub/Sub SDK. For example, if only one message is published over a span of several minutes, the default DelayThreshold and CountThreshold values are high enough that the message may seem undelivered or lost. To mitigate this, it's essential to reduce the DelayThreshold to a lower value, such as 4 seconds, to ensure timely delivery.

Tested in v25.x. Will be tested in v26.x