### PR TITLE
feat: [indexer][v25.x] publish created pools

### DIFF
--- a/ingest/common/domain/block_pools.go
+++ b/ingest/common/domain/block_pools.go
@@ -1,8 +1,17 @@
 package commondomain
 
 import (
+	"time"
+
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 )
+
+// PoolCreation contains the information about a pool creation.
+type PoolCreation struct {
+	BlockHeight int64
+	BlockTime   time.Time
+	TxnHash     string
+}
 
 // BlockPools contains the pools to be ingested in a block.
 type BlockPools struct {

--- a/ingest/common/domain/block_pools.go
+++ b/ingest/common/domain/block_pools.go
@@ -8,6 +8,7 @@ import (
 
 // PoolCreation contains the information about a pool creation.
 type PoolCreation struct {
+	PoolId      uint64
 	BlockHeight int64
 	BlockTime   time.Time
 	TxnHash     string

--- a/ingest/common/domain/mocks/pools_extracter_mock.go
+++ b/ingest/common/domain/mocks/pools_extracter_mock.go
@@ -19,6 +19,12 @@ type PoolsExtractorMock struct {
 	ProcessAllBlockDataPanicMsg string
 	// Block pools to return
 	BlockPools commondomain.BlockPools
+	// CreatedPoolIDs is the map of created pool IDs to return when ExtractCreated is called.
+	CreatedPoolIDs map[uint64]commondomain.PoolCreation
+	// CreatedPoolsError is the error to return when ExtractCreated is called.
+	CreatedPoolsError error
+	// IsProcessCreatedCalled is a flag indicating if ProcessCreated was called.
+	IsProcessCreatedCalled bool
 }
 
 var _ commondomain.PoolExtractor = &PoolsExtractorMock{}
@@ -37,4 +43,15 @@ func (p *PoolsExtractorMock) ExtractAll(ctx types.Context) (commondomain.BlockPo
 func (p *PoolsExtractorMock) ExtractChanged(ctx types.Context) (commondomain.BlockPools, error) {
 	p.IsProcessAllChangedDataCalled = true
 	return p.BlockPools, p.ChangedBlockDataError
+}
+
+// ExtractCreated implements commondomain.PoolExtractor.
+func (p *PoolsExtractorMock) ExtractCreated(ctx types.Context) (commondomain.BlockPools, map[uint64]commondomain.PoolCreation, error) {
+	p.IsProcessCreatedCalled = true
+	return p.BlockPools, p.CreatedPoolIDs, p.CreatedPoolsError
+}
+
+// ResetPoolTracker implements commondomain.PoolExtractor.
+func (p *PoolsExtractorMock) ResetPoolTracker(ctx types.Context) {
+	panic("unimplemented")
 }

--- a/ingest/common/domain/mocks/pools_extracter_mock.go
+++ b/ingest/common/domain/mocks/pools_extracter_mock.go
@@ -30,13 +30,13 @@ type PoolsExtractorMock struct {
 var _ commondomain.PoolExtractor = &PoolsExtractorMock{}
 
 // ExtractAll implements commondomain.PoolExtractor.
-func (p *PoolsExtractorMock) ExtractAll(ctx types.Context) (commondomain.BlockPools, error) {
+func (p *PoolsExtractorMock) ExtractAll(ctx types.Context) (commondomain.BlockPools, map[uint64]commondomain.PoolCreation, error) {
 	if p.ProcessAllBlockDataPanicMsg != "" {
 		panic(p.ProcessAllBlockDataPanicMsg)
 	}
 
 	p.IsProcessAllBlockDataCalled = true
-	return p.BlockPools, p.AllBlockDataError
+	return p.BlockPools, p.CreatedPoolIDs, p.AllBlockDataError
 }
 
 // ExtractChanged implements commondomain.PoolExtractor.

--- a/ingest/common/domain/pools.go
+++ b/ingest/common/domain/pools.go
@@ -12,4 +12,9 @@ type PoolExtractor interface {
 	// ExtractChanged extracts the pools that were changed in the block height associated
 	// with the context.
 	ExtractChanged(ctx sdk.Context) (BlockPools, error)
+	// ExtractrCreated extracts the pools that were created in the block height associated
+	// with the context.
+	ExtractCreated(ctx sdk.Context) (BlockPools, map[uint64]PoolCreation, error)
+	// ResetPoolTracker resets the underlying internal pool tracker
+	ResetPoolTracker(ctx sdk.Context)
 }

--- a/ingest/common/domain/pools.go
+++ b/ingest/common/domain/pools.go
@@ -8,7 +8,7 @@ import (
 type PoolExtractor interface {
 	// ExtractAll extracts all the pools available within the height associated
 	// with the context.
-	ExtractAll(ctx sdk.Context) (BlockPools, error)
+	ExtractAll(ctx sdk.Context) (BlockPools, map[uint64]PoolCreation, error)
 	// ExtractChanged extracts the pools that were changed in the block height associated
 	// with the context.
 	ExtractChanged(ctx sdk.Context) (BlockPools, error)

--- a/ingest/common/poolextractor/pool_exractor_test.go
+++ b/ingest/common/poolextractor/pool_exractor_test.go
@@ -66,7 +66,7 @@ func (s *PoolExtractorTestSuite) TestExtractor() {
 	extractor := poolextractor.New(keepers, poolTracker)
 
 	// System under test #1
-	blockPools, err := extractor.ExtractAll(s.Ctx)
+	blockPools, createdPoolIDs, err := extractor.ExtractAll(s.Ctx)
 	s.Require().NoError(err)
 
 	// Validate all pools are extracted

--- a/ingest/common/poolextractor/pool_exractor_test.go
+++ b/ingest/common/poolextractor/pool_exractor_test.go
@@ -54,6 +54,14 @@ func (s *PoolExtractorTestSuite) TestExtractor() {
 	// Track tick change for a concentraed pool.
 	poolTracker.TrackConcentratedPoolIDTickChange(concentratedPoolWithPosition.GetId())
 
+	// Inject a new pool creation and track it
+	poolTracker.TrackCreatedPoolID(commondomain.PoolCreation{
+		PoolId:      concentratedPool.GetId(),
+		BlockHeight: 1000,
+		BlockTime:   s.Ctx.BlockTime(),
+		TxnHash:     "txnhash",
+	})
+
 	// Initialize the extractor
 	extractor := poolextractor.New(keepers, poolTracker)
 
@@ -74,6 +82,15 @@ func (s *PoolExtractorTestSuite) TestExtractor() {
 	// Validate only the changed pools are extracted
 	changedPools := blockPools.GetAll()
 	s.Require().Equal(2, len(changedPools))
+
+	// Validate that the newly created pool is extracted
+	// Since only one newly created pool is injected during the test in the above code earlier,
+	// the length of the createdPoolIDs should be 1.
+	// the length of the pools.GetAll() should be equal to the length of the createdPoolIDs.
+	pools, createdPoolIDs, err := extractor.ExtractCreated(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(len(createdPoolIDs), len(pools.GetAll()))
+	s.Require().Equal(1, len(createdPoolIDs))
 
 	// Validate that the tick change is detected
 	s.Require().Len(blockPools.ConcentratedPoolIDTickChange, 2)

--- a/ingest/common/poolextractor/pool_extractor.go
+++ b/ingest/common/poolextractor/pool_extractor.go
@@ -99,3 +99,54 @@ func (p *poolExtractor) ExtractChanged(ctx sdk.Context) (commondomain.BlockPools
 
 	return changedBlockPools, nil
 }
+
+// ExtractCreated implements commondomain.PoolExtractor.
+func (p *poolExtractor) ExtractCreated(ctx sdk.Context) (commondomain.BlockPools, map[uint64]commondomain.PoolCreation, error) {
+	changedPools, err := p.ExtractChanged(ctx)
+	if err != nil {
+		return commondomain.BlockPools{}, nil, err
+	}
+
+	createdPoolIDs := p.poolTracker.GetCreatedPoolIDs()
+
+	result := commondomain.BlockPools{
+		ConcentratedPoolIDTickChange: make(map[uint64]struct{}),
+	}
+
+	// Copy over the pools that were created in the block
+
+	// CFMM
+	for _, pool := range changedPools.CFMMPools {
+		if _, ok := createdPoolIDs[pool.GetId()]; ok {
+			result.CFMMPools = append(result.CFMMPools, pool)
+		}
+	}
+
+	// CosmWasm
+	for _, pool := range changedPools.CosmWasmPools {
+		if _, ok := createdPoolIDs[pool.GetId()]; ok {
+			result.CosmWasmPools = append(result.CosmWasmPools, pool)
+		}
+	}
+
+	// Concentrated
+	for _, pool := range changedPools.ConcentratedPools {
+		if _, ok := createdPoolIDs[pool.GetId()]; ok {
+			result.ConcentratedPools = append(result.ConcentratedPools, pool)
+		}
+	}
+
+	// Concentrated ticks
+	for poolID := range changedPools.ConcentratedPoolIDTickChange {
+		if _, ok := createdPoolIDs[poolID]; ok {
+			result.ConcentratedPoolIDTickChange[poolID] = struct{}{}
+		}
+	}
+
+	return result, createdPoolIDs, nil
+}
+
+// ResetPoolTracker implements commondomain.PoolExtractor
+func (p *poolExtractor) ResetPoolTracker(ctx sdk.Context) {
+	p.poolTracker.Reset()
+}

--- a/ingest/common/pooltracker/memory_pool_tracker.go
+++ b/ingest/common/pooltracker/memory_pool_tracker.go
@@ -1,8 +1,6 @@
 package pooltracker
 
 import (
-	"time"
-
 	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
 	"github.com/osmosis-labs/osmosis/v25/ingest/sqs/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
@@ -15,10 +13,7 @@ type poolBlockUpdateTracker struct {
 	cfmmPools                     map[uint64]poolmanagertypes.PoolI
 	cosmwasmPools                 map[uint64]poolmanagertypes.PoolI
 	cosmwasmPoolsAddressToPoolMap map[string]poolmanagertypes.PoolI
-
 	// Tracks the pool IDs that were created in the block.
-	// CONTRACT: the caller calls this method only once per pool creation as observed
-	// by poolmanagertypes.TypeEvtPoolCreated
 	createdPoolIDs map[uint64]commondomain.PoolCreation
 }
 
@@ -60,12 +55,8 @@ func (pt *poolBlockUpdateTracker) TrackConcentratedPoolIDTickChange(poolID uint6
 }
 
 // TrackCreatedPoolID implements domain.BlockPoolUpdateTracker.
-func (pt *poolBlockUpdateTracker) TrackCreatedPoolID(poolID uint64, blockHeight int64, blockTime time.Time, txnHash string) {
-	pt.createdPoolIDs[poolID] = commondomain.PoolCreation{
-		BlockHeight: blockHeight,
-		BlockTime:   blockTime,
-		TxnHash:     txnHash,
-	}
+func (pt *poolBlockUpdateTracker) TrackCreatedPoolID(poolCreation commondomain.PoolCreation) {
+	pt.createdPoolIDs[poolCreation.PoolId] = poolCreation
 }
 
 // GetConcentratedPools implements PoolTracker.

--- a/ingest/common/pooltracker/memory_pool_tracker.go
+++ b/ingest/common/pooltracker/memory_pool_tracker.go
@@ -95,7 +95,6 @@ func (pt *poolBlockUpdateTracker) Reset() {
 	pt.cfmmPools = map[uint64]poolmanagertypes.PoolI{}
 	pt.cosmwasmPools = map[uint64]poolmanagertypes.PoolI{}
 	pt.concentratedPoolIDTickChange = map[uint64]struct{}{}
-	pt.cosmwasmPoolsAddressToPoolMap = map[string]poolmanagertypes.PoolI{}
 	pt.createdPoolIDs = map[uint64]commondomain.PoolCreation{}
 }
 

--- a/ingest/indexer/domain/pair.go
+++ b/ingest/indexer/domain/pair.go
@@ -7,14 +7,17 @@ import (
 
 // Pair represents a pair of tokens in a pool and message to be published to PubSub
 type Pair struct {
-	PoolID     uint64    `json:"pool_id"`
-	MultiAsset bool      `json:"multi_asset"`
-	Denom0     string    `json:"denom_0"`
-	IdxDenom0  uint8     `json:"idx_denom_0"`
-	Denom1     string    `json:"denom_1"`
-	IdxDenom1  uint8     `json:"idx_denom_1"`
-	FeeBps     uint64    `json:"fee_bps"`
-	IngestedAt time.Time `json:"ingested_at"`
+	PoolID               uint64    `json:"pool_id"`
+	MultiAsset           bool      `json:"multi_asset"`
+	Denom0               string    `json:"denom_0"`
+	IdxDenom0            uint8     `json:"idx_denom_0"`
+	Denom1               string    `json:"denom_1"`
+	IdxDenom1            uint8     `json:"idx_denom_1"`
+	FeeBps               uint64    `json:"fee_bps"`
+	IngestedAt           time.Time `json:"ingested_at"`
+	PairCreatedAt        time.Time `json:"pair_created_at"`
+	PairCreatedAtHeight  uint64    `json:"pair_created_at_height"`
+	PairCreatedAtTxnHash string    `json:"pair_created_at_txn_hash"`
 }
 
 // ShouldFilterDenom returns true if the given denom should be filtered out.

--- a/ingest/indexer/domain/publisher.go
+++ b/ingest/indexer/domain/publisher.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 )
 
@@ -26,5 +27,9 @@ type Publisher interface {
 // PairPublisher is an interface for publishing pair data.
 type PairPublisher interface {
 	// PublishPoolPairs publishes the given pools as pairs.
-	PublishPoolPairs(ctx sdk.Context, pools []poolmanagertypes.PoolI) error
+	// The difference between this function and PublishPair is:
+	// - PublishPair operates on the pair level and publishes a single pair.
+	// - PublishPoolPairs operates on the pool level and publishes all the pair combo in the pool
+	//   with the taker fee and spread factor, as well as the newly created pool metadata, if any.
+	PublishPoolPairs(ctx sdk.Context, pools []poolmanagertypes.PoolI, createdPoolIDs map[uint64]commondomain.PoolCreation) error
 }

--- a/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy.go
+++ b/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy.go
@@ -105,7 +105,7 @@ func (f *fullIndexerBlockProcessStrategy) processPools(ctx sdk.Context) error {
 	pools := blockPools.GetAll()
 
 	// Process pool pairs
-	if err := f.poolPairPublisher.PublishPoolPairs(ctx, pools); err != nil {
+	if err := f.poolPairPublisher.PublishPoolPairs(ctx, pools, nil); err != nil {
 		return err
 	}
 

--- a/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy.go
+++ b/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy.go
@@ -96,7 +96,7 @@ func (f *fullIndexerBlockProcessStrategy) publishAllSupplies(ctx sdk.Context) {
 
 // processPools publishes all the pools in the block.
 func (f *fullIndexerBlockProcessStrategy) processPools(ctx sdk.Context) error {
-	blockPools, err := f.poolExtractor.ExtractAll(ctx)
+	blockPools, createdPoolIDs, err := f.poolExtractor.ExtractAll(ctx)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (f *fullIndexerBlockProcessStrategy) processPools(ctx sdk.Context) error {
 	pools := blockPools.GetAll()
 
 	// Process pool pairs
-	if err := f.poolPairPublisher.PublishPoolPairs(ctx, pools, nil); err != nil {
+	if err := f.poolPairPublisher.PublishPoolPairs(ctx, pools, createdPoolIDs); err != nil {
 		return err
 	}
 

--- a/ingest/indexer/service/blockprocessor/pair_publisher.go
+++ b/ingest/indexer/service/blockprocessor/pair_publisher.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
 	"github.com/osmosis-labs/osmosis/v25/ingest/indexer/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 )
@@ -39,7 +40,7 @@ func NewPairPublisher(client domain.Publisher, poolManagerKeeper domain.PoolMana
 // Returns error if at least one of the pairs failed to be published.
 // Nil otherwise.
 // TODO: unit test
-func (p PairPublisher) PublishPoolPairs(ctx sdk.Context, pools []poolmanagertypes.PoolI) error {
+func (p PairPublisher) PublishPoolPairs(ctx sdk.Context, pools []poolmanagertypes.PoolI, createdPoolIDs map[uint64]commondomain.PoolCreation) error {
 	result := make(chan error, len(pools))
 
 	// Use map to cache the taker fee for each denom pair
@@ -106,6 +107,11 @@ func (p PairPublisher) PublishPoolPairs(ctx sdk.Context, pools []poolmanagertype
 						Denom1:     denoms[j],
 						IdxDenom1:  uint8(j),
 						FeeBps:     takerFee.Add(spreadFactor).MulInt64(10000).TruncateInt().Uint64(),
+					}
+					if poolCreation, ok := createdPoolIDs[poolID]; ok {
+						pair.PairCreatedAt = poolCreation.BlockTime
+						pair.PairCreatedAtHeight = uint64(poolCreation.BlockHeight)
+						pair.PairCreatedAtTxnHash = poolCreation.TxnHash
 					}
 
 					publishPairWg.Add(1)

--- a/ingest/indexer/service/export_test.go
+++ b/ingest/indexer/service/export_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/cometbft/cometbft/abci/types"
 )
@@ -14,4 +15,8 @@ func (s *indexerStreamingService) AddTokenLiquidity(ctx context.Context, event *
 
 func (s *indexerStreamingService) AdjustTokenInAmountBySpreadFactor(ctx context.Context, event *types.Event) error {
 	return s.adjustTokenInAmountBySpreadFactor(ctx, event)
+}
+
+func (s *indexerStreamingService) TrackCreatedPoolID(event types.Event, blockHeight int64, blockTime time.Time, txHash string) {
+	s.trackCreatedPoolID(event, blockHeight, blockTime, txHash)
 }

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/tmhash"
@@ -229,6 +230,19 @@ func (s *indexerStreamingService) publishTxn(ctx context.Context, req types.Requ
 		if eventType == gammtypes.TypeEvtTokenSwapped || eventType == gammtypes.TypeEvtPoolJoined || eventType == gammtypes.TypeEvtPoolExited || eventType == concentratedliquiditytypes.TypeEvtCreatePosition || eventType == concentratedliquiditytypes.TypeEvtWithdrawPosition {
 			includedEvents = append(includedEvents, domain.EventWrapper{Index: i, Event: *clonedEvent})
 		}
+		// Track the newly created pool ID
+		// IMPORTANT NOTE:
+		// 1. Using event attributes in a transaction, ONLY pool ID of the newly created pool is available and being tracked by the underlying pool tracker.
+		// 2. For the other pool metadata of the newly created pool, such as denoms and fees, they are available and tracked thru OnWrite listeners in the common/writelistener package.
+		// 3. OnWrite callback is triggered AFTER ListenEndBlock callback. As a result, we can't publish the newly created pool data, during ListenEndBlock callback
+		//    of the block where the pool is created, because the pool metadata is not available yet.
+		// 4. Therefore, we DON"T always reset the pool tracker in ListenEndBlock callback.
+		// 5. Instead, We wait until the next block, when both pool ID and pool metadata are available in the pool tracker, to publish the newly created pool data.
+		//    After publishing the newly created pool data, we then reset the pool tracker.
+		// 6. See: block_updates_indexer_block_process_strategy.go::publishCreatedPools for more details.
+		if eventType == poolmanagertypes.TypeEvtPoolCreated {
+			s.trackCreatedPoolID(event, sdkCtx.BlockHeight(), sdkCtx.BlockTime().UTC(), txHash)
+		}
 	}
 
 	// Publish the transaction
@@ -298,11 +312,6 @@ func (s *indexerStreamingService) ListenEndBlock(ctx context.Context, req types.
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	defer func() {
-		// Reset the pool tracker after processing the block.
-		s.poolTracker.Reset()
-	}()
-
 	// Create block processor
 	blockProcessor := blockprocessor.NewBlockProcessor(s.blockProcessStrategyManager, s.client, s.poolExtractor, s.keepers)
 
@@ -330,4 +339,25 @@ func deepCloneEvent(event *types.Event) *types.Event {
 	clone.Attributes = make([]types.EventAttribute, len(event.Attributes))
 	copy(clone.Attributes, event.Attributes)
 	return &clone
+}
+
+// trackCreatedPoolID tracks the created pool ID.
+// If the pool ID is not found in the event attributes, it logs an error.
+// If the pool ID is found, it parses the pool ID to uint64 and tracks it.
+func (s *indexerStreamingService) trackCreatedPoolID(event types.Event, blockHeight int64, blockTime time.Time, txHash string) {
+	if len(event.Attributes) == 0 {
+		s.logger.Error("Event attributes are empty for pool created event")
+		return
+	}
+
+	poolIDAttribute := event.Attributes[0]
+
+	// Parse to uint64
+	createdPoolID, err := strconv.ParseUint(poolIDAttribute.Value, 10, 64)
+	if err != nil {
+		s.logger.Error("Error parsing pool ID from event attributes", err)
+		return
+	}
+
+	s.poolTracker.TrackCreatedPoolID(createdPoolID, blockHeight, blockTime, txHash)
 }

--- a/ingest/sqs/domain/mocks/pools_extractor_mock.go
+++ b/ingest/sqs/domain/mocks/pools_extractor_mock.go
@@ -15,10 +15,16 @@ type PoolsExtractorMock struct {
 	IsProcessAllBlockDataCalled bool
 	// IsProcessAllChangedDataCalled is a flag indicating if ProcessChangedBlockData was called.
 	IsProcessAllChangedDataCalled bool
+	// IsProcessAllCreatedDataCalled is a flag indicating if ProcessAllCreatedDataCalled was called.
+	IsProcessAllCreatedDataCalled bool
+	// IsPoolTrackerReset is a flag indicating if ResetPoolTracker was called.
+	IsPoolTrackerReset bool
 	// If this is non-empty, ProcessAllBlockData(...) will panic with this message.
 	ProcessAllBlockDataPanicMsg string
 	// Block pools to return
 	BlockPools commondomain.BlockPools
+	// CreatedPoolIDs is the map of pool IDs that were created in the block.
+	CreatedPoolIDs map[uint64]commondomain.PoolCreation
 }
 
 var _ commondomain.PoolExtractor = &PoolsExtractorMock{}
@@ -41,10 +47,11 @@ func (p *PoolsExtractorMock) ExtractChanged(ctx types.Context) (commondomain.Blo
 
 // ExtractCreated implements commondomain.PoolExtractor.
 func (p *PoolsExtractorMock) ExtractCreated(ctx types.Context) (commondomain.BlockPools, map[uint64]commondomain.PoolCreation, error) {
-	panic("unimplemented")
+	p.IsProcessAllCreatedDataCalled = true
+	return p.BlockPools, p.CreatedPoolIDs, nil
 }
 
 // ResetPoolTracker implements commondomain.PoolExtractor.
 func (p *PoolsExtractorMock) ResetPoolTracker(ctx types.Context) {
-	panic("unimplemented")
+	p.IsPoolTrackerReset = true
 }

--- a/ingest/sqs/domain/mocks/pools_extractor_mock.go
+++ b/ingest/sqs/domain/mocks/pools_extractor_mock.go
@@ -38,3 +38,13 @@ func (p *PoolsExtractorMock) ExtractChanged(ctx types.Context) (commondomain.Blo
 	p.IsProcessAllChangedDataCalled = true
 	return p.BlockPools, p.ChangedBlockDataError
 }
+
+// ExtractCreated implements commondomain.PoolExtractor.
+func (p *PoolsExtractorMock) ExtractCreated(ctx types.Context) (commondomain.BlockPools, map[uint64]commondomain.PoolCreation, error) {
+	panic("unimplemented")
+}
+
+// ResetPoolTracker implements commondomain.PoolExtractor.
+func (p *PoolsExtractorMock) ResetPoolTracker(ctx types.Context) {
+	panic("unimplemented")
+}

--- a/ingest/sqs/domain/mocks/pools_extractor_mock.go
+++ b/ingest/sqs/domain/mocks/pools_extractor_mock.go
@@ -30,13 +30,13 @@ type PoolsExtractorMock struct {
 var _ commondomain.PoolExtractor = &PoolsExtractorMock{}
 
 // ExtractAll implements commondomain.PoolExtractor.
-func (p *PoolsExtractorMock) ExtractAll(ctx types.Context) (commondomain.BlockPools, error) {
+func (p *PoolsExtractorMock) ExtractAll(ctx types.Context) (commondomain.BlockPools, map[uint64]commondomain.PoolCreation, error) {
 	if p.ProcessAllBlockDataPanicMsg != "" {
 		panic(p.ProcessAllBlockDataPanicMsg)
 	}
 
 	p.IsProcessAllBlockDataCalled = true
-	return p.BlockPools, p.AllBlockDataError
+	return p.BlockPools, p.CreatedPoolIDs, p.AllBlockDataError
 }
 
 // ExtractChanged implements commondomain.PoolExtractor.

--- a/ingest/sqs/domain/service.go
+++ b/ingest/sqs/domain/service.go
@@ -1,8 +1,11 @@
 package domain
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 )
 
@@ -30,6 +33,11 @@ type BlockPoolUpdateTracker interface {
 	// TrackCosmWasmPoolsAddressToPoolMap tracks the CosmWasm pools address to the pool object map.
 	TrackCosmWasmPoolsAddressToPoolMap(pool poolmanagertypes.PoolI)
 
+	// TrackCreatedPoolID tracks whenever a new pool is created.
+	// CONTRACT: the caller calls this method only once per pool creation as observed
+	// by poolmanagertypes.TypeEvtPoolCreated
+	TrackCreatedPoolID(poolID uint64, blockHeight int64, blockTime time.Time, txnHash string)
+
 	// GetConcentratedPools returns the tracked concentrated pools.
 	GetConcentratedPools() []poolmanagertypes.PoolI
 
@@ -44,6 +52,9 @@ type BlockPoolUpdateTracker interface {
 
 	// GetCosmWasmPoolsAddressToIDMap returns the tracked CosmWasm pools address to pool object map.
 	GetCosmWasmPoolsAddressToIDMap() map[string]poolmanagertypes.PoolI
+
+	// GetCreatedPoolIDs returns the tracked pool IDs that were created in the block.
+	GetCreatedPoolIDs() map[uint64]commondomain.PoolCreation
 
 	// Reset clears the internal state.
 	Reset()

--- a/ingest/sqs/domain/service.go
+++ b/ingest/sqs/domain/service.go
@@ -1,8 +1,6 @@
 package domain
 
 import (
-	"time"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	commondomain "github.com/osmosis-labs/osmosis/v25/ingest/common/domain"
@@ -36,7 +34,7 @@ type BlockPoolUpdateTracker interface {
 	// TrackCreatedPoolID tracks whenever a new pool is created.
 	// CONTRACT: the caller calls this method only once per pool creation as observed
 	// by poolmanagertypes.TypeEvtPoolCreated
-	TrackCreatedPoolID(poolID uint64, blockHeight int64, blockTime time.Time, txnHash string)
+	TrackCreatedPoolID(commondomain.PoolCreation)
 
 	// GetConcentratedPools returns the tracked concentrated pools.
 	GetConcentratedPools() []poolmanagertypes.PoolI

--- a/ingest/sqs/service/blockprocessor/full_sqs_block_process_strategy.go
+++ b/ingest/sqs/service/blockprocessor/full_sqs_block_process_strategy.go
@@ -44,7 +44,7 @@ func (f *fullSQSBlockProcessStrategy) ProcessBlock(ctx sdk.Context) (err error) 
 		return domain.ErrNodeIsSyncing
 	}
 
-	pools, err := f.poolExtractor.ExtractAll(ctx)
+	pools, _, err := f.poolExtractor.ExtractAll(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

NOTE TO REVIEWER:
This PR has been reviewed once here with suggestions addressed. 
https://github.com/osmosis-labs/osmosis/pull/8525

## What is the purpose of the change

This PR changes the way pair object is published. Instead of publishing changed pair data upon block creation to the indexer backend (which is not relevant anyway as pair data is static and doesn't change), this commit will publish newly created pair data with creation details, which includes creation height, block timestamp and transaction hash. This is also one of the recommendation from Dexscreener team, which will allow the newly created pair showing up on their "New Pair" page. 

## Testing
- Tested with v25.x using production past data with pool_created event emitted during node sync.
- Will require forward porting to v26.x
- Untested in v26.x but will perform it in the upcoming upgrade test.


