### PR TITLE
fix: protorev throws a nil pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8616](https://github.com/osmosis-labs/osmosis/pull/8616) chore: upgrade wasmd to v0.53.0 and wasmvm to v2.1.2
 * [#8628](https://github.com/osmosis-labs/osmosis/pull/8628) chore: add tagged cometbft version: v0.38.11-v26-osmo-1
 * [#8649](https://github.com/osmosis-labs/osmosis/pull/8649) chore: update to tagged submodules
+* [#8663](https://github.com/osmosis-labs/osmosis/pull/8663) fix: protorev throws a nil pointer
 
 ### Config
 

--- a/x/poolmanager/taker_fee.go
+++ b/x/poolmanager/taker_fee.go
@@ -134,7 +134,7 @@ func (k Keeper) chargeTakerFee(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom 
 
 	// Determine if eligible to bypass taker fee.
 	if osmoutils.Contains(reducedFeeWhitelist, sender.String()) {
-		return tokenIn, sdk.Coin{}, nil
+		return tokenIn, sdk.NewCoin(tokenIn.Denom, osmomath.ZeroInt()), nil
 	}
 
 	takerFee, err := k.GetTradingPairTakerFee(ctx, tokenIn.Denom, tokenOutDenom)

--- a/x/poolmanager/taker_fee.go
+++ b/x/poolmanager/taker_fee.go
@@ -16,6 +16,8 @@ import (
 	txfeestypes "github.com/osmosis-labs/osmosis/v26/x/txfees/types"
 )
 
+var zero = osmomath.ZeroInt()
+
 func (k *Keeper) GetDefaultTakerFee(ctx sdk.Context) osmomath.Dec {
 	defaultTakerFeeBz := k.paramSpace.GetRaw(ctx, types.KeyDefaultTakerFee)
 	if !bytes.Equal(defaultTakerFeeBz, k.defaultTakerFeeBz) {
@@ -134,7 +136,7 @@ func (k Keeper) chargeTakerFee(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom 
 
 	// Determine if eligible to bypass taker fee.
 	if osmoutils.Contains(reducedFeeWhitelist, sender.String()) {
-		return tokenIn, sdk.NewCoin(tokenIn.Denom, osmomath.ZeroInt()), nil
+		return tokenIn, sdk.Coin{Denom: tokenIn.Denom, Amount: zero}, nil
 	}
 
 	takerFee, err := k.GetTradingPairTakerFee(ctx, tokenIn.Denom, tokenOutDenom)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fix the nil pointer exception in protorev:
`ERR ProtoRevTrade failed with error: protorev failed due to internal reason: runtime error: invalid memory address or nil pointer dereference module=server`

This error happens as the protorev account is not charged taker fees.

We return sdk.Coin{} => https://github.com/osmosis-labs/osmosis/blob/main/x/poolmanager/taker_fee.go#L137

We should return `sdk.Coin("denom",0)`

Here it's returned => https://github.com/osmosis-labs/osmosis/blob/v26.x/x/poolmanager/router.go#L78

We then call `.Add` on a nil value causing a panic => https://github.com/osmosis-labs/osmosis/blob/v26.x/x/poolmanager/router.go#L87 

Then panic is caught in protorev

### How to test

- run in place testnet and replay txns from mainnet on the node => https://github.com/PaddyMc/osmosis-txn-replayer
- see error above
- rebuild on this branch, error is gone
