### PR TITLE
fix: smart account signing checktx error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8494](https://github.com/osmosis-labs/osmosis/pull/8494) Add additional events in x/lockup, x/superfluid, x/concentratedliquidity
 * [#8543](https://github.com/osmosis-labs/osmosis/pull/8543) Add OTEL wiring and new configs in app.toml
 * [#8566](https://github.com/osmosis-labs/osmosis/pull/8566) Minor speedup to CalcExitCFMM shares
+* [#8665](https://github.com/osmosis-labs/osmosis/pull/8665) fix: smart account signing checktx error
 
 
 ## v25.2.1

--- a/x/smart-account/authenticator/authentication_request.go
+++ b/x/smart-account/authenticator/authentication_request.go
@@ -245,8 +245,8 @@ func GenerateAuthenticationRequest(
 		AuthenticatorParams: nil,
 	}
 
-	// We do not generate the sign bytes if simulate is true
-	if simulate {
+	// We do not generate the sign bytes if simulate is true or isCheckTx is true
+	if simulate && ctx.IsCheckTx() {
 		return authRequest, nil
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Found an issue where checktx would cause the FE to throw an error because check tx will throw an error based on generate sign bytes

if this code path is hit and the txn doen't have any auth data we throw a nil pointer 
https://github.com/osmosis-labs/osmosis/blob/main/x/smart-account/authenticator/authentication_request.go#L253-L257

```
recovered: runtime error: invalid memory address or nil pointer dereference
stack:
goroutine 57378 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x6b
github.com/cosmos/cosmos-sdk/baseapp.newDefaultRecoveryMiddleware.func1({0x702a6a0, 0xa1a68b0})
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/recovery.go:74 +0x35
github.com/cosmos/cosmos-sdk/baseapp.newRecoveryMiddleware.func1({0x702a6a0, 0xa1a68b0})
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/recovery.go:42 +0x51
github.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x702a6a0, 0xa1a68b0}, 0xc00212e648)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/recovery.go:31 +0x71
github.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x702a6a0, 0xa1a68b0}, 0xc0b6ddf698)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/recovery.go:36 +0xf1
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx.func1()
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/baseapp.go:835 +0x10b
panic({0x702a6a0?, 0xa1a68b0?})
	/usr/local/go/src/runtime/panic.go:770 +0x136
github.com/cosmos/cosmos-sdk/x/auth/tx.(*wrapper).GetSigningTxData(0xc0b1e8b200)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/x/auth/tx/adapter.go:63 +0xb6d
github.com/cosmos/cosmos-sdk/x/auth/signing.GetSignBytesAdapter({0x8132380, 0xc0b75bfc08}, 0xc001174720, 0x1, {{0x0, 0x0}, {0xc001a76240, 0x9}, 0x264fb0, 0x1f9, ...}, ...)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/x/auth/signing/adapter.go:37 +0x14e
github.com/osmosis-labs/osmosis/v26/x/smart-account/authenticator.GenerateAuthenticationRequest({{0x8132540, 0xa3e29c0}, {0x81507c8, 0xc0b6dfff40}, {{0x0, 0x0}, {0xc001a76240, 0x9}, 0x13540bf, {0x146b959e, ...}, ...}, ...}, ...)
	/home/ghost/git/osmosis-labs/osmosis/x/smart-account/authenticator/authentication_request.go:254 +0xd65
github.com/osmosis-labs/osmosis/v26/x/smart-account/post.AuthenticatorPostDecorator.PostHandle({_, _, _, _, {_, _}}, {{0x8132540, 0xa3e29c0}, {0x81507c8, 0xc0b6dfff40}, ...}, ...)
	/home/ghost/git/osmosis-labs/osmosis/x/smart-account/post/post.go:102 +0x1016
github.com/cosmos/cosmos-sdk/types.ChainPostDecorators.func2({{0x8132540, 0xa3e29c0}, {0x81507c8, 0xc0b6dfff40}, {{0x0, 0x0}, {0xc001a76240, 0x9}, 0x13540bf, {0x146b959e, ...}, ...}, ...}, ...)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/types/handler.go:76 +0x1c6
github.com/osmosis-labs/osmosis/v26/x/protorev/keeper.ProtoRevDecorator.PostHandle({{{0x814fcd8, 0xc000d029c0}, {0x80f8ed0, 0xc002e7c980}, 0xc002e7ca10, {{0x814fcd8, 0xc000d029c0}, 0xc000131378, {0x80f8ed0, 0xc002e7c800}, ...}, ...}}, ...)
	/home/ghost/git/osmosis-labs/osmosis/x/protorev/keeper/posthandler.go:36 +0x15a
github.com/cosmos/cosmos-sdk/types.ChainPostDecorators.func2({{0x8132540, 0xa3e29c0}, {0x81507c8, 0xc0b6dfff40}, {{0x0, 0x0}, {0xc001a76240, 0x9}, 0x13540bf, {0x146b959e, ...}, ...}, ...}, ...)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/types/handler.go:76 +0x1c6
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0xc001a4efc8, 0x2, {0xc0afa76420, 0x156, 0x160})
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/baseapp.go:966 +0x1c8a
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Simulate(0xc001a4efc8, {0xc0afa76420, 0x156, 0x160})
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/test_helpers.go:28 +0xa5
github.com/cosmos/cosmos-sdk/x/auth/tx.txServer.Simulate({{{0x0, 0x0, 0x0}, {0x8155208, 0xc0019b5110}, 0x0, {0x0, 0x0}, {0x816f488, 0xc0010e8d70}, ...}, ...}, ...)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/x/auth/tx/service.go:98 +0x35a
github.com/cosmos/cosmos-sdk/types/tx._Service_Simulate_Handler.func1({0x8132460, 0xc0b70a3770}, {0x74dcfa0, 0xc0b6da22c0})
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/types/tx/service.pb.go:1443 +0xf1
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func1({0x8132460, 0xc0b70a3770}, {0x74dcfa0, 0xc0b6da22c0}, 0xc0b6da22e0, 0xc0b2871938)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/grpcserver.go:85 +0xd09
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1({0x8132460, 0xc0b6dbcff0}, {0x74dcfa0, 0xc0b6da22c0})
	/home/ghost/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xe3
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1({0x8132460, 0xc0b6dbcff0}, {0x74dcfa0, 0xc0b6da22c0}, 0xc0b6da22e0, 0xc0b6db8380)
	/home/ghost/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x1d6
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2({0x8132460, 0xc0b6dbcff0}, {0x74dcfa0, 0xc0b6da22c0}, 0xc0b6da22e0, 0xc0b2871938)
	/home/ghost/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x223
github.com/cosmos/cosmos-sdk/types/tx._Service_Simulate_Handler({0x749a800, 0xc0007732c0}, {0x8132460, 0xc0b6dbcff0}, 0xc0b1e8af80, 0xc0b6dbd020)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/types/tx/service.pb.go:1445 +0x22c
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2({0x749a800, 0xc0007732c0}, {0x8132460, 0xc0b6dbcff0}, 0xc0b1e8af80, 0x0)
	/home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/grpcserver.go:107 +0x17d
google.golang.org/grpc.(*Server).processUnaryRPC(0xc002814400, {0x8132460, 0xc0b6dbcf00}, {0x814d2a0, 0xc000f7a780}, 0xc0b2879560, 0xc001a26240, 0xc0018d6380, 0x0)
	/home/ghost/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1379 +0x180d
google.golang.org/grpc.(*Server).handleStream(0xc002814400, {0x814d2a0, 0xc000f7a780}, 0xc0b2879560)
	/home/ghost/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1790 +0x1053
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/home/ghost/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1029 +0x178
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 533
	/home/ghost/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1040 +0x1ae
: panic [osmosis-labs/cosmos-sdk@v0.50.6-v26-osmo-2/baseapp/recovery.go:72] with gas used: '359115'
```