### PR TITLE
fix: ingester change set not propagated due to missing registration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -741,7 +741,7 @@ func getPoolWriteListeners(app *OsmosisApp, appCodec codec.Codec, blockPoolUpdat
 }
 
 // registerStoreKeys register the store keys from the given store key map
-// on the app's commit multi store so that the chang sets from these stores are propagated
+// on the app's commit multi store so that the change sets from these stores are propagated
 // in ListenCommit().
 func registerStoreKeys(app *OsmosisApp, storeKeyMap map[string]storetypes.StoreKey) {
 	// Register all applicable keys as listeners

--- a/ingest/indexer/service/blockprocessor/block_process_indexer_factory.go
+++ b/ingest/indexer/service/blockprocessor/block_process_indexer_factory.go
@@ -6,7 +6,7 @@ import (
 )
 
 // NewBlockProcessor creates a new block process strategy.
-func NewBlockProcessor(blockProcessStrategyManager commondomain.BlockProcessStrategyManager, client domain.Publisher, poolExtractor commondomain.PoolExtractor, keepers domain.Keepers) commondomain.BlockProcessor {
+func NewBlockProcessor(blockProcessStrategyManager commondomain.BlockProcessStrategyManager, client domain.Publisher, poolExtractor commondomain.PoolExtractor, keepers domain.Keepers, blockUpdateProcessUtils commondomain.BlockUpdateProcessUtilsI) commondomain.BlockProcessor {
 	// Initialize the pool pair publisher
 	poolPairPublisher := NewPairPublisher(client, keepers.PoolManagerKeeper)
 
@@ -24,8 +24,9 @@ func NewBlockProcessor(blockProcessStrategyManager commondomain.BlockProcessStra
 	}
 
 	return &blockUpdatesIndexerBlockProcessStrategy{
-		client:            client,
-		poolExtractor:     poolExtractor,
-		poolPairPublisher: poolPairPublisher,
+		client:                  client,
+		poolExtractor:           poolExtractor,
+		poolPairPublisher:       poolPairPublisher,
+		blockUpdateProcessUtils: blockUpdateProcessUtils,
 	}
 }

--- a/ingest/indexer/service/blockprocessor/block_process_indexer_factory_test.go
+++ b/ingest/indexer/service/blockprocessor/block_process_indexer_factory_test.go
@@ -56,7 +56,7 @@ func (suite *IndexerBlockProcessorTestSuite) TestNewBlockProcessor() {
 			}
 
 			// System under test
-			newBlockProcessor := blockprocessor.NewBlockProcessor(blockStrategyManager, publisherMock, poolsExtracter, domain.Keepers{})
+			newBlockProcessor := blockprocessor.NewBlockProcessor(blockStrategyManager, publisherMock, poolsExtracter, domain.Keepers{}, nil)
 
 			// Check if the block processor is a full block processor
 			isFullBlockProcessor := newBlockProcessor.IsFullBlockProcessor()

--- a/ingest/indexer/service/blockprocessor/block_updates_indexer_block_process_strategy.go
+++ b/ingest/indexer/service/blockprocessor/block_updates_indexer_block_process_strategy.go
@@ -8,9 +8,10 @@ import (
 )
 
 type blockUpdatesIndexerBlockProcessStrategy struct {
-	client            domain.Publisher
-	poolExtractor     commondomain.PoolExtractor
-	poolPairPublisher domain.PairPublisher
+	client                  domain.Publisher
+	poolExtractor           commondomain.PoolExtractor
+	poolPairPublisher       domain.PairPublisher
+	blockUpdateProcessUtils commondomain.BlockUpdateProcessUtilsI
 }
 
 var _ commondomain.BlockProcessor = &blockUpdatesIndexerBlockProcessStrategy{}
@@ -32,6 +33,10 @@ func (f *blockUpdatesIndexerBlockProcessStrategy) ProcessBlock(ctx types.Context
 
 // publishChangedPools publishes the pools that were changed in the block.
 func (f *blockUpdatesIndexerBlockProcessStrategy) publishChangedPools(ctx types.Context) error {
+	err := f.blockUpdateProcessUtils.ProcessBlockChangeSet()
+	if err != nil {
+		return err
+	}
 	// Extract the pools that were changed in the block
 	blockPools, err := f.poolExtractor.ExtractChanged(ctx)
 	if err != nil {

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -315,10 +315,16 @@ func (s *indexerStreamingService) ListenCommit(ctx context.Context, res abci.Res
 	defer func() {
 		// Reset the pool tracker after processing the block.
 		s.poolTracker.Reset()
+		// Reset change set upon processing the block.
+		s.blockUpdatesProcessUtils.SetChangeSet(nil)
 	}()
 
+	// Set change set on the block updates process utils.
+	// These are processed in PrpcessBlock(...) assumming "block updates" strategy.
+	s.blockUpdatesProcessUtils.SetChangeSet(changeSet)
+
 	// Create block processor
-	blockProcessor := blockprocessor.NewBlockProcessor(s.blockProcessStrategyManager, s.client, s.poolExtractor, s.keepers)
+	blockProcessor := blockprocessor.NewBlockProcessor(s.blockProcessStrategyManager, s.client, s.poolExtractor, s.keepers, s.blockUpdatesProcessUtils)
 
 	// Process block.
 	if err := blockProcessor.ProcessBlock(sdkCtx); err != nil {

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -320,7 +320,7 @@ func (s *indexerStreamingService) ListenCommit(ctx context.Context, res abci.Res
 	}()
 
 	// Set change set on the block updates process utils.
-	// These are processed in PrpcessBlock(...) assumming "block updates" strategy.
+	// These are processed in PrpcessBlock(...) assuming "block updates" strategy.
 	s.blockUpdatesProcessUtils.SetChangeSet(changeSet)
 
 	// Create block processor

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -320,7 +320,7 @@ func (s *indexerStreamingService) ListenCommit(ctx context.Context, res abci.Res
 	}()
 
 	// Set change set on the block updates process utils.
-	// These are processed in PrpcessBlock(...) assuming "block updates" strategy.
+	// These are processed in ProcessBlock(...) assuming "block updates" strategy.
 	s.blockUpdatesProcessUtils.SetChangeSet(changeSet)
 
 	// Create block processor


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

There are 2 fixes here:
1. Missing registration of the kv store keys to push state updates to the streaming listeners

Affects both SQS and ingester. We need to register listeners on the commit multi-store. This was a change in the v50 that was missed.

This was masked due to the following:
* We use two different strategies 1) full block process and 2) updates only and this was affected only 2)  
* When we start-up the node, 1) correctly runs populating the data but 2) never happens
* Due to lack of traffic on testnets this was non-trivial to catch

2. Affects indexer only. We need to correctly process the change sets when received from the stores in ListenCommit

## Testing and Verifying

- Tested that change sets now propagate correctly with `v26.x` in-place-testnet

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A