### PR TITLE
fix: create temp folder with looser perms

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -355,7 +354,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithHomeDir(homeDir).
 		WithViper("OSMOSIS")
 
-	tempDir := fmt.Sprintf("%s%d", ".temp-osmosis", rand.Int())
+	tempDir := tempDir()
 	tempApp := osmosis.NewOsmosisApp(log.NewNopLogger(), cosmosdb.NewMemDB(), nil, true, map[int64]bool{}, tempDir, 5, sims.EmptyAppOptions{}, osmosis.EmptyWasmOpts, baseapp.SetChainID("osmosis-1"))
 
 	// Allows you to add extra params to your client.toml
@@ -473,9 +472,19 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	if err := autoCliOpts(initClientCtx, tempApp).EnhanceRootCommand(rootCmd); err != nil {
 		panic(err)
 	}
-	os.RemoveAll(tempDir)
 
 	return rootCmd, encodingConfig
+}
+
+// tempDir create a temporary directory to initialize the command line client
+func tempDir() string {
+	dir, err := os.MkdirTemp("", "osmosisd")
+	if err != nil {
+		dir = osmosis.DefaultNodeHome
+	}
+	defer os.RemoveAll(dir)
+
+	return dir
 }
 
 // overwriteConfigTomlValues overwrites config.toml values. Returns error if config.toml does not exist


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

During the testnet upgrade multiple node runners failed to upgrade their nodes as there was an issue when creating a new folder to populated command, this PR leverages the go `os.MkdirTemp()` function to initialise the folder with looser perms and in the `/tmp` folder, allowing it to be created and deleted by all system users.

## See
- https://discordapp.com/channels/798583171548840026/888527640099688458/1280562695740850289
- https://discordapp.com/channels/798583171548840026/888527640099688458/1280566026680926208

## How to test

- `cd /`
- `osmosisd` <= this won't work on the `v26.0.0-rc3` branch