### PR TITLE
fix: update enforce sub-authenticator to be greater than 1 error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8628](https://github.com/osmosis-labs/osmosis/pull/8628) chore: add tagged cometbft version: v0.38.11-v26-osmo-1
 * [#8649](https://github.com/osmosis-labs/osmosis/pull/8649) chore: update to tagged submodules
 * [#8663](https://github.com/osmosis-labs/osmosis/pull/8663) fix: protorev throws a nil pointer
+* [#8676](https://github.com/osmosis-labs/osmosis/pull/8676) fix: update enforce sub-authenticator to be greater than 1 error message
 
 ### Config
 

--- a/x/smart-account/authenticator/composite.go
+++ b/x/smart-account/authenticator/composite.go
@@ -49,7 +49,7 @@ func onSubAuthenticatorsAdded(ctx sdk.Context, account sdk.AccAddress, data []by
 	}
 
 	if len(initDatas) <= 1 {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no sub-authenticators provided")
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "at least 2 sub-authenticators must be provided, but got %d", len(initDatas))
 	}
 
 	baseId := authenticatorId


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Update error message according to logic changes in #8375 

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

