### PR TITLE
feat: uni-directional trading pair taker fee support (sqs ingester)

### DIFF
--- a/ingest/sqs/pools/transformer/taker_fee.go
+++ b/ingest/sqs/pools/transformer/taker_fee.go
@@ -9,23 +9,29 @@ import (
 )
 
 // retrieveTakerFeeToMapIfNotExists retrieves the taker fee for the denom pair if it does not exist in the map
-// Mutates the map with the taker fee for every uniquer denom pair in the denoms list.
+// Mutates the map with the taker fee for every uniquer denom pair combination in the denoms list.
+// Since bi-directional taker fee is supported, the taker fee for a denom pair is stored in both directions.
+// For example, the taker fees for a pair of denoms (A, B) is stored BOTH as (A, B) and (B, A).
 // If the taker fee for a denom pair already exists in the map, it is not retrieved again.
 // Note that the denoms in denomPair must always be lexicographically sorted to avoid duplicates.
 // Returns error if fails to retrieve taker fee from chain. Nil otherwise
 func retrieveTakerFeeToMapIfNotExists(ctx sdk.Context, denoms []string, denomPairToTakerFeeMap sqsdomain.TakerFeeMap, poolManagerKeeper commondomain.PoolManagerKeeper) error {
-	for i, denomI := range denoms {
-		for j := i + 1; j < len(denoms); j++ {
-			if !denomPairToTakerFeeMap.Has(denomI, denoms[j]) {
-				takerFee, err := poolManagerKeeper.GetTradingPairTakerFee(ctx, denomI, denoms[j])
-				if err != nil {
-					// This error should not happen. As a result, we do not skip it
-					return err
-				}
 
-				denomPairToTakerFeeMap.SetTakerFee(denomI, denoms[j], takerFee)
+	for i, denomI := range denoms {
+		for j, denomJ := range denoms {
+			if i != j {
+				if !denomPairToTakerFeeMap.Has(denomI, denomJ) {
+					takerFee, err := poolManagerKeeper.GetTradingPairTakerFee(ctx, denomI, denomJ)
+					if err != nil {
+						// This error should not happen. As a result, we do not skip it
+						return err
+					}
+
+					denomPairToTakerFeeMap.SetTakerFee(denomI, denomJ, takerFee)
+				}
 			}
 		}
 	}
+
 	return nil
 }

--- a/ingest/sqs/pools/transformer/taker_fee.go
+++ b/ingest/sqs/pools/transformer/taker_fee.go
@@ -16,7 +16,6 @@ import (
 // Note that the denoms in denomPair must always be lexicographically sorted to avoid duplicates.
 // Returns error if fails to retrieve taker fee from chain. Nil otherwise
 func retrieveTakerFeeToMapIfNotExists(ctx sdk.Context, denoms []string, denomPairToTakerFeeMap sqsdomain.TakerFeeMap, poolManagerKeeper commondomain.PoolManagerKeeper) error {
-
 	for i, denomI := range denoms {
 		for j, denomJ := range denoms {
 			if i != j {

--- a/ingest/sqs/pools/transformer/taker_fee.go
+++ b/ingest/sqs/pools/transformer/taker_fee.go
@@ -13,7 +13,6 @@ import (
 // Since bi-directional taker fee is supported, the taker fee for a denom pair is stored in both directions.
 // For example, the taker fees for a pair of denoms (A, B) is stored BOTH as (A, B) and (B, A).
 // If the taker fee for a denom pair already exists in the map, it is not retrieved again.
-// Note that the denoms in denomPair must always be lexicographically sorted to avoid duplicates.
 // Returns error if fails to retrieve taker fee from chain. Nil otherwise
 func retrieveTakerFeeToMapIfNotExists(ctx sdk.Context, denoms []string, denomPairToTakerFeeMap sqsdomain.TakerFeeMap, poolManagerKeeper commondomain.PoolManagerKeeper) error {
 	for i, denomI := range denoms {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This commit builds on the work done in [PR 8344](https://github.com/osmosis-labs/osmosis/pull/8344), but specifically on the data ingester for SQS.

Now, the taker fee can be set independently for each trade direction. For example, in a trading pair (A, B), the taker fee for A → B can be P, while the fee for B → A can be Q. With this change, there’s no need to lexicographically sort the pair denominations before storing or retrieving taker fee data. Instead, the taker fee map will now contain two separate entries: one for the pair (A, B) with value P, and another for the pair (B, A) with value Q.

Additionally, adjustments have been made to the sqs-side logic, For more details, refer to [PR 510](https://github.com/osmosis-labs/sqs/pull/510).

Tested in v26 with the following scenario:

1. Create v26 in-place testnet node
2. Start v26 node
3. Start v26 sqs
4. Run `make sqs-update-mainnet-state` in sqs project to capture updated taker fee data for step 5.
5. Run 'make test-unit` in sqs

