### PR TITLE
fix: tally grpc query

### DIFF
--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -581,45 +581,46 @@ func (k Keeper) IterateDelegations(context context.Context, delegator sdk.AccAdd
 		// get locked coin from the lock ID
 		interim, ok := k.GetIntermediaryAccountFromLockId(ctx, lock.UnderlyingLockId)
 		if !ok {
-			return fmt.Errorf("intermediary account not found for lock id %d", lock.UnderlyingLockId)
+			ctx.Logger().Error("intermediary account not found for lock id %d", lock.UnderlyingLockId)
+			continue
 		}
 
 		lock, err := k.lk.GetLockByID(ctx, lock.UnderlyingLockId)
 		if err != nil {
 			ctx.Logger().Error("lockup retrieval failed with underlying lock", "Lock", lock, "Error", err)
-			return err
+			continue
 		}
 
 		coin, err := lock.SingleCoin()
 		if err != nil {
 			ctx.Logger().Error("lock fails to meet expected invariant, it contains multiple coins", "Lock", lock, "Error", err)
-			return err
+			continue
 		}
 
 		// get osmo-equivalent token amount
 		amount, err := k.GetSuperfluidOSMOTokens(ctx, interim.Denom, coin.Amount)
 		if err != nil {
 			ctx.Logger().Error("failed to get osmo equivalent of token", "Denom", interim.Denom, "Amount", coin.Amount, "Error", err)
-			return err
+			continue
 		}
 
 		// get validator shares equivalent to the token amount
 		valAddr, err := sdk.ValAddressFromBech32(interim.ValAddr)
 		if err != nil {
 			ctx.Logger().Error("failed to decode validator address", "Intermediary", interim.ValAddr, "LockID", lock.ID, "Error", err)
-			return err
+			continue
 		}
 
 		validator, err := k.sk.GetValidator(ctx, valAddr)
 		if err != nil {
 			ctx.Logger().Error("validator does not exist for lock", "Validator", valAddr, "LockID", lock.ID)
-			return err
+			continue
 		}
 
 		shares, err := validator.SharesFromTokens(amount)
 		if err != nil {
 			// tokens are not valid. continue.
-			return err
+			continue
 		}
 
 		// construct delegation and call callback

--- a/x/superfluid/keeper/stake.go
+++ b/x/superfluid/keeper/stake.go
@@ -581,7 +581,7 @@ func (k Keeper) IterateDelegations(context context.Context, delegator sdk.AccAdd
 		// get locked coin from the lock ID
 		interim, ok := k.GetIntermediaryAccountFromLockId(ctx, lock.UnderlyingLockId)
 		if !ok {
-			ctx.Logger().Error("intermediary account not found for lock id %d", lock.UnderlyingLockId)
+			ctx.Logger().Error("intermediary account not found for lock id", "lockID", lock.UnderlyingLockId)
 			continue
 		}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

For the grpc query, we used to just log errors and continue. During the sdk v50 upgrade, we for some reason changed to returning errors. This brings back the old logic.

Pre sdk v50 logic for comparison https://github.com/osmosis-labs/osmosis/blob/8c89343e3b09dcba9a0f45ce0ea872fc4d8fe2a8/x/superfluid/keeper/stake.go#L551-L594