### PR TITLE
fix: multiple temp directories on command executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### State Compatible
 
 * [#8563](https://github.com/osmosis-labs/osmosis/pull/8563) Add additional queries in x/gauges
+* [#8726](https://github.com/osmosis-labs/osmosis/pull/8726) fix: multiple temp directories on command executions
 
 ## v26.0.0
 

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -356,6 +356,14 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 
 	tempDir := tempDir()
 	tempApp := osmosis.NewOsmosisApp(log.NewNopLogger(), cosmosdb.NewMemDB(), nil, true, map[int64]bool{}, tempDir, 5, sims.EmptyAppOptions{}, osmosis.EmptyWasmOpts, baseapp.SetChainID("osmosis-1"))
+	defer func() {
+		if err := tempApp.Close(); err != nil {
+			panic(err)
+		}
+		if tempDir != osmosis.DefaultNodeHome {
+			os.RemoveAll(tempDir)
+		}
+	}()
 
 	// Allows you to add extra params to your client.toml
 	// gas, gas-price, gas-adjustment, and human-readable-denoms
@@ -480,7 +488,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 func tempDir() string {
 	dir, err := os.MkdirTemp("", "osmosisd")
 	if err != nil {
-		dir = osmosis.DefaultNodeHome
+		panic(fmt.Sprintf("failed creating temp directory: %s", err.Error()))
 	}
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
Closes: #8725

## What is the purpose of the change

This pull request fix issue with temp directories and stops creating multiple temp directories
 also gives panic if node is unable to create a temp directory instead of returning node default home directory which leads to erasing of entire node data
