### PR TITLE
feat: [indexer] add test cases to full_indexer_block_process_strategy

### DIFF
--- a/ingest/indexer/domain/mocks/publisher_mock.go
+++ b/ingest/indexer/domain/mocks/publisher_mock.go
@@ -8,45 +8,55 @@ import (
 
 // PublisherMock is a mock for Publisher.
 type PublisherMock struct {
-	CalledWithPair  indexerdomain.Pair
-	CalledWithBlock indexerdomain.Block
-	// CalledWithPools             []types.PoolI
-	CalledWithTokenSupply       indexerdomain.TokenSupply
-	CalledWithTokenSupplyOffset indexerdomain.TokenSupplyOffset
-	CalledWithTransaction       indexerdomain.Transaction
-	ForcePairError              error
-	ForceBlockError             error
-	// ForcePoolError              error
-	// ForcePoolsError             error
-	ForceTokenSupplyError       error
-	ForceTokenSupplyOffsetError error
-	ForceTransactionError       error
+	CalledWithPair                   indexerdomain.Pair
+	CalledWithBlock                  indexerdomain.Block
+	CalledWithTokenSupply            indexerdomain.TokenSupply
+	CalledWithTokenSupplyOffset      indexerdomain.TokenSupplyOffset
+	CalledWithTransaction            indexerdomain.Transaction
+	NumPublishPairCalls              int
+	NumPublishBlockCalls             int
+	NumPublishTokenSupplyCalls       int
+	NumPublishTokenSupplyOffsetCalls int
+	NumPublishTransactionCalls       int
+	ForcePairError                   error
+	ForceBlockError                  error
+	ForceTokenSupplyError            error
+	ForceTokenSupplyOffsetError      error
+	ForceTransactionError            error
 }
 
 // PublishPair implements domain.Publisher.
 func (p *PublisherMock) PublishPair(ctx context.Context, pair indexerdomain.Pair) error {
+	p.CalledWithPair = pair
+	p.NumPublishPairCalls++
 	return p.ForcePairError
 }
 
 // PublishBlock implements domain.Publisher.
 func (p *PublisherMock) PublishBlock(ctx context.Context, block indexerdomain.Block) error {
+	p.CalledWithBlock = block
+	p.NumPublishBlockCalls++
 	return p.ForceBlockError
 }
 
 // PublishTokenSupply implements domain.Publisher.
 func (p *PublisherMock) PublishTokenSupply(ctx context.Context, tokenSupply indexerdomain.TokenSupply) error {
 	p.CalledWithTokenSupply = tokenSupply
+	p.NumPublishTokenSupplyCalls++
 	return p.ForceTokenSupplyError
 }
 
 // PublishTokenSupplyOffset implements domain.Publisher.
 func (p *PublisherMock) PublishTokenSupplyOffset(ctx context.Context, tokenSupplyOffset indexerdomain.TokenSupplyOffset) error {
 	p.CalledWithTokenSupplyOffset = tokenSupplyOffset
+	p.NumPublishTokenSupplyOffsetCalls++
 	return p.ForceTokenSupplyOffsetError
 }
 
 // PublishTransaction implements domain.Publisher.
 func (p *PublisherMock) PublishTransaction(ctx context.Context, txn indexerdomain.Transaction) error {
+	p.CalledWithTransaction = txn
+	p.NumPublishTransactionCalls++
 	return p.ForceTransactionError
 }
 

--- a/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy_test.go
+++ b/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy_test.go
@@ -39,7 +39,6 @@ func TestFullIndexerBlockProcessStrategyTestSuite(t *testing.T) {
 // - 8 calls to PublishTokenSupply
 // - 1 call to PublishTokenSupplyOffset
 func (s *FullIndexerBlockProcessStrategyTestSuite) TestPublishAllSupplies() {
-	//
 	tests := []struct {
 		name                                     string
 		expectedNumPublishTokenSupplyCalls       int
@@ -107,6 +106,16 @@ func (s *FullIndexerBlockProcessStrategyTestSuite) TestPublishAllSupplies() {
 // The difference is full_indexer_block_process_strategy_test always publishes all pool pairs,
 // while block_updates_indexer_block_process_strategy_test only publishes when there is a creation data.
 func (s *FullIndexerBlockProcessStrategyTestSuite) TestProcessPools() {
+
+	concentratedPoolId := uint64(1)
+	concentratedPoolHeight := int64(12345)
+	concentratedPoolTime := time.Now()
+	concentratedPoolTxnHash := "txhash"
+	cfmmPoolId := uint64(2)
+	cfmmPoolHeight := int64(12346)
+	cfmmPoolTime := time.Now()
+	cfmmPoolTxnHash := "txhash2"
+
 	tests := []struct {
 		name                             string
 		createdPoolIDs                   map[uint64]commondomain.PoolCreation
@@ -117,11 +126,11 @@ func (s *FullIndexerBlockProcessStrategyTestSuite) TestProcessPools() {
 		{
 			name: "happy path with one pool creation",
 			createdPoolIDs: map[uint64]commondomain.PoolCreation{
-				1: {
-					PoolId:      1,
-					BlockHeight: 12345,
-					BlockTime:   time.Now(),
-					TxnHash:     "txhash",
+				concentratedPoolId: {
+					PoolId:      concentratedPoolId,
+					BlockHeight: concentratedPoolHeight,
+					BlockTime:   concentratedPoolTime,
+					TxnHash:     concentratedPoolTxnHash,
 				},
 			},
 			expectedPublishPoolPairsCalled:   true,
@@ -131,17 +140,17 @@ func (s *FullIndexerBlockProcessStrategyTestSuite) TestProcessPools() {
 		{
 			name: "happy path with multiple pool creation",
 			createdPoolIDs: map[uint64]commondomain.PoolCreation{
-				1: {
-					PoolId:      1,
-					BlockHeight: 12345,
-					BlockTime:   time.Now(),
-					TxnHash:     "txhash1",
+				concentratedPoolId: {
+					PoolId:      concentratedPoolId,
+					BlockHeight: concentratedPoolHeight,
+					BlockTime:   concentratedPoolTime,
+					TxnHash:     concentratedPoolTxnHash,
 				},
-				2: {
-					PoolId:      2,
-					BlockHeight: 12346,
-					BlockTime:   time.Now(),
-					TxnHash:     "txhash2",
+				cfmmPoolId: {
+					PoolId:      cfmmPoolId,
+					BlockHeight: cfmmPoolHeight,
+					BlockTime:   cfmmPoolTime,
+					TxnHash:     cfmmPoolTxnHash,
 				},
 			},
 			expectedPublishPoolPairsCalled:   true,

--- a/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy_test.go
+++ b/ingest/indexer/service/blockprocessor/full_indexer_block_process_strategy_test.go
@@ -1,0 +1,234 @@
+package blockprocessor_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v26/app/apptesting"
+	commondomain "github.com/osmosis-labs/osmosis/v26/ingest/common/domain"
+	commonmocks "github.com/osmosis-labs/osmosis/v26/ingest/common/domain/mocks"
+	indexerdomain "github.com/osmosis-labs/osmosis/v26/ingest/indexer/domain"
+	indexermocks "github.com/osmosis-labs/osmosis/v26/ingest/indexer/domain/mocks"
+	"github.com/osmosis-labs/osmosis/v26/ingest/indexer/service/blockprocessor"
+)
+
+type FullIndexerBlockProcessStrategyTestSuite struct {
+	apptesting.ConcentratedKeeperTestHelper
+}
+
+func TestFullIndexerBlockProcessStrategyTestSuite(t *testing.T) {
+	suite.Run(t, new(FullIndexerBlockProcessStrategyTestSuite))
+}
+
+// The purpose of this test is to verify that the PublishAllSupplies method correctly publishes
+// the token supplies and offsets based on the primed data from the state.
+
+// Token supplies and offsets are primed in the test, thru PrepareAllSupportedPools():
+// - axlusdc 100001000000000
+// - bar 40005000000
+// - baz 40005000000
+// - factory/osmo1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqvlx82r/alloyed/allusdc 20000000000
+// - foo 40005000000
+// - gravusdc 100001000000000
+// - stake 225000001000000, with offset -225000000000000
+// - uosmo 51005000000
+//
+// Therefore, we expect the following:
+// - 8 calls to PublishTokenSupply
+// - 1 call to PublishTokenSupplyOffset
+func (s *FullIndexerBlockProcessStrategyTestSuite) TestPublishAllSupplies() {
+	//
+	tests := []struct {
+		name                                     string
+		expectedNumPublishTokenSupplyCalls       int
+		expectedNumPublishTokenSupplyOffsetCalls int
+	}{
+		{
+			name:                                     "happy path with the primed data from state",
+			expectedNumPublishTokenSupplyCalls:       8,
+			expectedNumPublishTokenSupplyOffsetCalls: 1,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.Setup()
+
+			// Initialized chain pools
+			s.PrepareAllSupportedPools()
+
+			// Get all chain pools from state for asserting later
+			// pool id 1 created below
+			concentratedPools, err := s.App.ConcentratedLiquidityKeeper.GetPools(s.Ctx)
+			s.Require().NoError(err)
+			// pool id 2, 3 created below
+			cfmmPools, err := s.App.GAMMKeeper.GetPools(s.Ctx)
+			s.Require().NoError(err)
+			// pool id 4, 5 created below
+			cosmWasmPools, err := s.App.CosmwasmPoolKeeper.GetPoolsWithWasmKeeper(s.Ctx)
+			s.Require().NoError(err)
+			blockPools := commondomain.BlockPools{
+				ConcentratedPools: concentratedPools,
+				CFMMPools:         cfmmPools,
+				CosmWasmPools:     cosmWasmPools,
+			}
+
+			// Mock out pool extractor
+			poolsExtracter := &commonmocks.PoolsExtractorMock{
+				BlockPools: blockPools,
+			}
+
+			// Mock out publisher
+			publisherMock := &indexermocks.PublisherMock{}
+
+			// Mock out pair publisher
+			pairPublisherMock := &indexermocks.MockPairPublisher{}
+
+			// Initialize keepers
+			keepers := indexerdomain.Keepers{
+				PoolManagerKeeper: s.App.PoolManagerKeeper,
+				BankKeeper:        s.App.BankKeeper,
+			}
+
+			blockProcessor := blockprocessor.NewFullIndexerBlockProcessStrategy(publisherMock, keepers, poolsExtracter, pairPublisherMock)
+
+			blockProcessor.PublishAllSupplies(s.Ctx)
+			s.Require().Equal(test.expectedNumPublishTokenSupplyCalls, publisherMock.NumPublishTokenSupplyCalls)
+			s.Require().Equal(test.expectedNumPublishTokenSupplyOffsetCalls, publisherMock.NumPublishTokenSupplyOffsetCalls)
+		})
+	}
+}
+
+// The purpose of this test is to verify that the ProcessPools method correctly publishes
+// the full set of pool pairs, regardless of whether they have creation data or not.
+// See also: block_updates_indexer_block_process_strategy_test::TestPublishCreatedPools,
+// The difference is full_indexer_block_process_strategy_test always publishes all pool pairs,
+// while block_updates_indexer_block_process_strategy_test only publishes when there is a creation data.
+func (s *FullIndexerBlockProcessStrategyTestSuite) TestProcessPools() {
+	tests := []struct {
+		name                             string
+		createdPoolIDs                   map[uint64]commondomain.PoolCreation
+		expectedPublishPoolPairsCalled   bool
+		expectedNumPoolsPublished        int
+		expectedNumPoolsWithCreationData int
+	}{
+		{
+			name: "happy path with one pool creation",
+			createdPoolIDs: map[uint64]commondomain.PoolCreation{
+				1: {
+					PoolId:      1,
+					BlockHeight: 12345,
+					BlockTime:   time.Now(),
+					TxnHash:     "txhash",
+				},
+			},
+			expectedPublishPoolPairsCalled:   true,
+			expectedNumPoolsPublished:        5,
+			expectedNumPoolsWithCreationData: 1,
+		},
+		{
+			name: "happy path with multiple pool creation",
+			createdPoolIDs: map[uint64]commondomain.PoolCreation{
+				1: {
+					PoolId:      1,
+					BlockHeight: 12345,
+					BlockTime:   time.Now(),
+					TxnHash:     "txhash1",
+				},
+				2: {
+					PoolId:      2,
+					BlockHeight: 12346,
+					BlockTime:   time.Now(),
+					TxnHash:     "txhash2",
+				},
+			},
+			expectedPublishPoolPairsCalled:   true,
+			expectedNumPoolsPublished:        5,
+			expectedNumPoolsWithCreationData: 2,
+		},
+		{
+			name:                             "should publish even when there is no pool creation data",
+			createdPoolIDs:                   map[uint64]commondomain.PoolCreation{},
+			expectedPublishPoolPairsCalled:   true,
+			expectedNumPoolsPublished:        5,
+			expectedNumPoolsWithCreationData: 0,
+		},
+		{
+			name: "should still publish but without creation data when pool creation data has no match in the pool list",
+			createdPoolIDs: map[uint64]commondomain.PoolCreation{
+				999: {
+					PoolId:      999,
+					BlockHeight: 12345,
+					BlockTime:   time.Now(),
+					TxnHash:     "txhash",
+				},
+			},
+			expectedPublishPoolPairsCalled:   true,
+			expectedNumPoolsPublished:        5,
+			expectedNumPoolsWithCreationData: 0,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.Setup()
+
+			// Initialized chain pools
+			s.PrepareAllSupportedPools()
+
+			// Get all chain pools from state for asserting later
+			// pool id 1 created below
+			concentratedPools, err := s.App.ConcentratedLiquidityKeeper.GetPools(s.Ctx)
+			s.Require().NoError(err)
+			// pool id 2, 3 created below
+			cfmmPools, err := s.App.GAMMKeeper.GetPools(s.Ctx)
+			s.Require().NoError(err)
+			// pool id 4, 5 created below
+			cosmWasmPools, err := s.App.CosmwasmPoolKeeper.GetPoolsWithWasmKeeper(s.Ctx)
+			s.Require().NoError(err)
+			blockPools := commondomain.BlockPools{
+				ConcentratedPools: concentratedPools,
+				CFMMPools:         cfmmPools,
+				CosmWasmPools:     cosmWasmPools,
+			}
+
+			// Mock out pool extractor
+			poolsExtracter := &commonmocks.PoolsExtractorMock{
+				BlockPools:     blockPools,
+				CreatedPoolIDs: test.createdPoolIDs,
+			}
+
+			// Mock out publisher
+			publisherMock := &indexermocks.PublisherMock{}
+
+			// Mock out pair publisher
+			pairPublisherMock := &indexermocks.MockPairPublisher{}
+
+			// Initialize keepers
+			keepers := indexerdomain.Keepers{
+				PoolManagerKeeper: s.App.PoolManagerKeeper,
+				BankKeeper:        s.App.BankKeeper,
+			}
+
+			blockProcessor := blockprocessor.NewFullIndexerBlockProcessStrategy(publisherMock, keepers, poolsExtracter, pairPublisherMock)
+
+			err = blockProcessor.ProcessPools(s.Ctx)
+			s.Require().NoError(err)
+
+			// Check that the pair publisher is called correctly
+			s.Require().Equal(test.expectedPublishPoolPairsCalled, pairPublisherMock.PublishPoolPairsCalled)
+			if test.expectedPublishPoolPairsCalled {
+				// Check that the number of pools published
+				s.Require().Equal(test.expectedNumPoolsPublished, pairPublisherMock.NumPoolPairPublished)
+				// Check that the pools and created pool IDs are set correctly
+				s.Require().Equal(blockPools.GetAll(), pairPublisherMock.CalledWithPools)
+				s.Require().Equal(test.createdPoolIDs, pairPublisherMock.CalledWithCreatedPoolIDs)
+				// Check that the number of pools with creation data
+				s.Require().Equal(test.expectedNumPoolsWithCreationData, pairPublisherMock.NumPoolPairWithCreationData)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR adds test cases for the following:

1. Verify that the `PublishAllSupplies` method correctly publishes the token supplies and offsets based on the primed data from the state.

2. Verify that the `ProcessPools` method correctly publishes the full set of pool pairs, regardless of whether they have creation data or not. See also: `block_updates_indexer_block_process_strategy_test::TestPublishCreatedPools`, The difference is `full_indexer_block_process_strategy` always publishes all pool pairs, while `block_updates_indexer_block_process_strategy` only publishes when there is a creation data.