### PR TITLE
fix: add cosmwasm_1_3 feature

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -581,6 +581,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		"osmosis",
 		"cosmwasm_1_1",
 		"cosmwasm_1_2",
+		"cosmwasm_1_3",
 		"cosmwasm_1_4",
 		"cosmwasm_2_0",
 		"cosmwasm_2_1",


### PR DESCRIPTION
Closes: #8758 

## What is the purpose of the change

Currently osmosis doesn't have the cosmwasm_1_3 feature enabled (not sure if it was forgotten). This feature is required for cosmwasm_1_4, cosmwasm_2_0 and cosmwasm_2_1 (and more to come) so any contract which is built enabling any of these flags can't be uploaded to the chain at the moment.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A