### PR TITLE
fix concurrency issue in go test(x/lockup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8731](https://github.com/osmosis-labs/osmosis/pull/8731) fix: in place testnet logs
 * [#8728](https://github.com/osmosis-labs/osmosis/pull/8728) fix unsupported sign-mode issue
 * [#8743](https://github.com/osmosis-labs/osmosis/pull/8743) chore: bump sdk and cometbft
+* [#8765](https://github.com/osmosis-labs/osmosis/pull/8765) fix concurrency issue in go test(x/lockup)
 
 ### State Machine Breaking
 

--- a/x/lockup/keeper/genesis_test.go
+++ b/x/lockup/keeper/genesis_test.go
@@ -144,9 +144,17 @@ func TestExportGenesis(t *testing.T) {
 }
 
 func TestMarshalUnmarshalGenesis(t *testing.T) {
-	dirName := fmt.Sprintf("%d", rand.Int())
+	// Create a unique temporary directory for each test
+	dirName, err := os.MkdirTemp("", "osmoapp_test")
+	require.NoError(t, err)
+
+	// Ensure the directory is cleaned up after the test completes
+	defer os.RemoveAll(dirName)
+
+	// Setup the app with the custom directory
 	app := osmoapp.SetupWithCustomHome(false, dirName)
 
+	// Continue with the rest of your test setup
 	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{})
 	ctx = ctx.WithBlockTime(now.Add(time.Second))
 
@@ -154,17 +162,26 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 	appCodec := encodingConfig.Marshaler
 	am := lockup.NewAppModule(*app.LockupKeeper, app.AccountKeeper, app.BankKeeper)
 
-	err := testutil.FundAccount(ctx, app.BankKeeper, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
+	// Fund account and create lock
+	err = testutil.FundAccount(ctx, app.BankKeeper, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)})
 	require.NoError(t, err)
 	_, err = app.LockupKeeper.CreateLock(ctx, acc2, sdk.Coins{sdk.NewInt64Coin("foo", 5000000)}, time.Second*5)
 	require.NoError(t, err)
 
+	// Export genesis state
 	genesisExported := am.ExportGenesis(ctx, appCodec)
+
+	// After removing the temp directory, the app should no longer have access to it
 	os.RemoveAll(dirName)
+
+	// Ensure no panic occurs when initializing genesis in a fresh app
 	assert.NotPanics(t, func() {
+		// Setup a new app instance
 		app := osmoapp.Setup(false)
 		ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{})
 		ctx = ctx.WithBlockTime(now.Add(time.Second))
+
+		// Initialize genesis with the exported state
 		am := lockup.NewAppModule(*app.LockupKeeper, app.AccountKeeper, app.BankKeeper)
 		am.InitGenesis(ctx, appCodec, genesisExported)
 	})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
We have observed  couple of failures in go tests, and this has been due to concurrency issues within testing. 

This fix should fix the issues we have been facing.

## Testing and Verifying


This change is a trivial rework / code cleanup without any test coverage.



## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A