### PR TITLE
fix: state export for gov module constitution

### DIFF
--- a/app/upgrades/v27/upgrades.go
+++ b/app/upgrades/v27/upgrades.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 
 	"github.com/osmosis-labs/osmosis/v26/app/keepers"
 	"github.com/osmosis-labs/osmosis/v26/app/upgrades"
@@ -24,6 +26,19 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		err = InitializeConstitutionCollection(sdkCtx, *keepers.GovKeeper)
+		if err != nil {
+			sdkCtx.Logger().Error("Error initializing Constitution Collection:", "message", err.Error())
+		}
+
 		return migrations, nil
 	}
+}
+
+// setting the default constitution for the chain
+// this is in line with cosmos-sdk v5 gov migration: https://github.com/cosmos/cosmos-sdk/blob/v0.50.10/x/gov/migrations/v5/store.go#L57
+func InitializeConstitutionCollection(ctx sdk.Context, govKeeper govkeeper.Keeper) error {
+	return govKeeper.Constitution.Set(ctx, "This chain has no constitution.")
 }

--- a/app/upgrades/v27/upgrades_test.go
+++ b/app/upgrades/v27/upgrades_test.go
@@ -1,0 +1,63 @@
+package v27_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/header"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v26/app/apptesting"
+	v27 "github.com/osmosis-labs/osmosis/v26/app/upgrades/v27"
+
+	"cosmossdk.io/x/upgrade"
+
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+)
+
+const (
+	v27UpgradeHeight = int64(10)
+)
+
+type UpgradeTestSuite struct {
+	apptesting.KeeperTestHelper
+	preModule appmodule.HasPreBlocker
+}
+
+func TestUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+func (s *UpgradeTestSuite) TestUpgrade() {
+	s.Setup()
+	s.preModule = upgrade.NewAppModule(s.App.UpgradeKeeper, addresscodec.NewBech32Codec("osmo"))
+
+	govKeeper := s.App.GovKeeper
+	pre, err := govKeeper.Constitution.Get(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Equal("", pre)
+
+	// Run the upgrade
+	dummyUpgrade(s)
+	s.Require().NotPanics(func() {
+		_, err := s.preModule.PreBlock(s.Ctx)
+		s.Require().NoError(err)
+	})
+	post, err := govKeeper.Constitution.Get(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Equal("This chain has no constitution.", post)
+}
+
+func dummyUpgrade(s *UpgradeTestSuite) {
+	s.Ctx = s.Ctx.WithBlockHeight(v27UpgradeHeight - 1)
+	plan := upgradetypes.Plan{Name: v27.Upgrade.UpgradeName, Height: v27UpgradeHeight}
+	err := s.App.UpgradeKeeper.ScheduleUpgrade(s.Ctx, plan)
+	s.Require().NoError(err)
+	_, err = s.App.UpgradeKeeper.GetUpgradePlan(s.Ctx)
+	s.Require().NoError(err)
+
+	s.Ctx = s.Ctx.WithHeaderInfo(header.Info{Height: v27UpgradeHeight, Time: s.Ctx.BlockTime().Add(time.Second)}).WithBlockHeight(v27UpgradeHeight)
+}

--- a/app/upgrades/v27/upgrades_test.go
+++ b/app/upgrades/v27/upgrades_test.go
@@ -35,10 +35,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	s.Setup()
 	s.preModule = upgrade.NewAppModule(s.App.UpgradeKeeper, addresscodec.NewBech32Codec("osmo"))
 
-	govKeeper := s.App.GovKeeper
-	pre, err := govKeeper.Constitution.Get(s.Ctx)
-	s.Require().NoError(err)
-	s.Require().Equal("", pre)
+	s.PrepareGovModuleConstitutionTest()
 
 	// Run the upgrade
 	dummyUpgrade(s)
@@ -46,9 +43,8 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 		_, err := s.preModule.PreBlock(s.Ctx)
 		s.Require().NoError(err)
 	})
-	post, err := govKeeper.Constitution.Get(s.Ctx)
-	s.Require().NoError(err)
-	s.Require().Equal("This chain has no constitution.", post)
+
+	s.ExecuteGovModuleConstitutionTest()
 }
 
 func dummyUpgrade(s *UpgradeTestSuite) {
@@ -60,4 +56,20 @@ func dummyUpgrade(s *UpgradeTestSuite) {
 	s.Require().NoError(err)
 
 	s.Ctx = s.Ctx.WithHeaderInfo(header.Info{Height: v27UpgradeHeight, Time: s.Ctx.BlockTime().Add(time.Second)}).WithBlockHeight(v27UpgradeHeight)
+}
+
+// PrepareGovModuleConstitutionTest prepares the gov module constitution migration test
+func (s *UpgradeTestSuite) PrepareGovModuleConstitutionTest() {
+	govKeeper := s.App.GovKeeper
+	pre, err := govKeeper.Constitution.Get(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Equal("", pre)
+}
+
+// ExecuteGovModuleConstitutionTest executes the gov module constitution migration test
+func (s *UpgradeTestSuite) ExecuteGovModuleConstitutionTest() {
+	govKeeper := s.App.GovKeeper
+	post, err := govKeeper.Constitution.Get(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Equal("This chain has no constitution.", post)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Currently the export of Osmosis to genesis state isn't working as expected because of the export of gov is missing a gov collection key.

see: https://github.com/cosmos/cosmos-sdk/issues/21887

## Testing and Verifying

Unit test:
- `cd ./app/upgrades/v27`
- `go test ./...`

in-place-testnet:
- do the in-place-testnet dance 
- `osmosisd export --modules-to-export "gov"`

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A