### PR TITLE
chore: bump cometbft/cosmos-sdk versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8682](https://github.com/osmosis-labs/osmosis/pull/8682) chore: bump cosmwasm-optimizer
 * [#8734](https://github.com/osmosis-labs/osmosis/pull/8734) chore: update cosmwasm vm
 * [#8764](https://github.com/osmosis-labs/osmosis/pull/8764) chore: add cosmwasm 1_3 feature
+* [#8779](https://github.com/osmosis-labs/osmosis/pull/8779) chore: bump cometbft/cosmos-sdk versions
 
 ### Config
 

--- a/go.mod
+++ b/go.mod
@@ -282,15 +282,15 @@ replace (
 	// Also, snapshot nodes need to have all fast nodes enabled in order to prune quickly.
 	cosmossdk.io/store => github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728
 
-	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v26/v0.38.12, current branch: osmo-v26/v0.38.12
-	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/3f71114d937296cdc7bcb585d56182d1f17432e1
-	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v26-osmo-2
-	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2
+	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v27/0.38.12, current branch: osmo-v27/v0.38.12
+	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/2305cecebc3aadee694c6d5e05f9d34b5630f564
+	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v27-osmo-1
+	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1
 
-	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v26/v0.50.10, current branch: osmo-v26/v0.50.10
-	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5a045895704de7fdc69d144895dcd9f162481502
-	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v26-osmo-2
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2
+	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v27/0.50.10, current branch: osmo-v27/0.50.10
+	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/33e0aaf2b1840a8bca4f1b2292700b6f15e5fad7
+	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v27-osmo-1
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1
 
 	// replace as directed by sdk upgrading.md https://github.com/cosmos/cosmos-sdk/blob/393de266c8675dc16cc037c1a15011b1e990975f/UPGRADING.md?plain=1#L713
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -910,10 +910,10 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.11.0 h1:OiHcxKAvSDUwsEVh2BjxQQc/5EHz9n0va9awCtNGuyA=
 github.com/ory/dockertest/v3 v3.11.0/go.mod h1:VIPxS1gwT9NpPOrfD3rACs8Y9Z7yhzO4SB194iUDnUI=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2 h1:9X9qTF0nXgn/U/jb6BV1kgRg5t/CdTHHOmx9cwsiDdw=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2 h1:R0ahhobLCJ+GIA/RxC6NzNapQcwAilT7779Mep0Uu4o=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1 h1:rQgVL3+kX65PSXQ8//o7F8gUfOQyQnYvA6c3D5hD/5U=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1 h1:h15nNpKcnNOpijSJLBsieD2P5NUmlMDk9ovDeGCW2t0=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
 github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728 h1:AMz4HWC+WA/MwBQdsb11yIF9ForIvSLYYVy/jyhJ3/I=
 github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728/go.mod h1:gjE3DZe4t/+VeIk6CmrouyqiuDbZ7QOVDDq3nLqBTpg=
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:YlmchqTmlwdWSmrRmXKR+PcU96ntOd8u10vTaTZdcNY=

--- a/osmomath/go.mod
+++ b/osmomath/go.mod
@@ -105,7 +105,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v26/v0.50.10, current branch: osmo-v26/v0.50.10
-// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5a045895704de7fdc69d144895dcd9f162481502
-// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v26-osmo-2
-replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2
+// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v27/0.50.10, current branch: osmo-v27/0.50.10
+// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/33e0aaf2b1840a8bca4f1b2292700b6f15e5fad7
+// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v27-osmo-1
+replace github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1

--- a/osmomath/go.sum
+++ b/osmomath/go.sum
@@ -334,8 +334,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
 github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2 h1:R0ahhobLCJ+GIA/RxC6NzNapQcwAilT7779Mep0Uu4o=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1 h1:h15nNpKcnNOpijSJLBsieD2P5NUmlMDk9ovDeGCW2t0=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/osmoutils/go.mod
+++ b/osmoutils/go.mod
@@ -181,15 +181,15 @@ replace (
 	// Needs to be replaced due to iavlFastNodeModuleWhitelist feature
 	cosmossdk.io/store => github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728
 
-	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v26/v0.38.12, current branch: osmo-v26/v0.38.12
-	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/3f71114d937296cdc7bcb585d56182d1f17432e1
-	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v26-osmo-2
-	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2
+	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v27/0.38.12, current branch: osmo-v27/v0.38.12
+	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/2305cecebc3aadee694c6d5e05f9d34b5630f564
+	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v27-osmo-1
+	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1
 
-	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v26/v0.50.10, current branch: osmo-v26/v0.50.10
-	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5a045895704de7fdc69d144895dcd9f162481502
-	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v26-osmo-2
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2
+	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v27/0.50.10, current branch: osmo-v27/0.50.10
+	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/33e0aaf2b1840a8bca4f1b2292700b6f15e5fad7
+	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v27-osmo-1
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1
 
 	github.com/osmosis-labs/osmosis/osmomath => github.com/osmosis-labs/osmosis/osmomath v0.0.14
 

--- a/osmoutils/go.sum
+++ b/osmoutils/go.sum
@@ -827,10 +827,10 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2 h1:9X9qTF0nXgn/U/jb6BV1kgRg5t/CdTHHOmx9cwsiDdw=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2 h1:R0ahhobLCJ+GIA/RxC6NzNapQcwAilT7779Mep0Uu4o=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1 h1:rQgVL3+kX65PSXQ8//o7F8gUfOQyQnYvA6c3D5hD/5U=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1 h1:h15nNpKcnNOpijSJLBsieD2P5NUmlMDk9ovDeGCW2t0=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
 github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728 h1:AMz4HWC+WA/MwBQdsb11yIF9ForIvSLYYVy/jyhJ3/I=
 github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728/go.mod h1:gjE3DZe4t/+VeIk6CmrouyqiuDbZ7QOVDDq3nLqBTpg=
 github.com/osmosis-labs/osmosis/osmomath v0.0.14 h1:L8EMgKjfbLUxjV5THSpGqJG9UBmwMGk21JKacB/tcCg=

--- a/x/epochs/go.mod
+++ b/x/epochs/go.mod
@@ -176,15 +176,15 @@ require (
 )
 
 replace (
-	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v26/v0.38.12, current branch: osmo-v26/v0.38.12
-	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/3f71114d937296cdc7bcb585d56182d1f17432e1
-	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v26-osmo-2
-	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2
+	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v27/0.38.12, current branch: osmo-v27/v0.38.12
+	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/2305cecebc3aadee694c6d5e05f9d34b5630f564
+	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v27-osmo-1
+	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1
 
-	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v26/v0.50.10, current branch: osmo-v26/v0.50.10
-	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5a045895704de7fdc69d144895dcd9f162481502
-	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v26-osmo-2
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2
+	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v27/0.50.10, current branch: osmo-v27/0.50.10
+	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/33e0aaf2b1840a8bca4f1b2292700b6f15e5fad7
+	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v27-osmo-1
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1
 
 	github.com/osmosis-labs/osmosis/osmomath => github.com/osmosis-labs/osmosis/osmomath v0.0.14
 	github.com/osmosis-labs/osmosis/osmoutils => github.com/osmosis-labs/osmosis/osmoutils v0.0.14

--- a/x/epochs/go.sum
+++ b/x/epochs/go.sum
@@ -594,10 +594,10 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2 h1:9X9qTF0nXgn/U/jb6BV1kgRg5t/CdTHHOmx9cwsiDdw=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2 h1:R0ahhobLCJ+GIA/RxC6NzNapQcwAilT7779Mep0Uu4o=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1 h1:rQgVL3+kX65PSXQ8//o7F8gUfOQyQnYvA6c3D5hD/5U=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1 h1:h15nNpKcnNOpijSJLBsieD2P5NUmlMDk9ovDeGCW2t0=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
 github.com/osmosis-labs/osmosis/osmomath v0.0.14 h1:L8EMgKjfbLUxjV5THSpGqJG9UBmwMGk21JKacB/tcCg=
 github.com/osmosis-labs/osmosis/osmomath v0.0.14/go.mod h1:hbw0oWTlkv3ls2S/4jBHlqZUdrejCQOGLhYeDm/CUgU=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.14 h1:TukuqS2qPMMH/LrQAV/BYIeuQGKkrD5VGM15pLM8GlA=

--- a/x/ibc-hooks/go.mod
+++ b/x/ibc-hooks/go.mod
@@ -204,15 +204,15 @@ require (
 )
 
 replace (
-	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v26/v0.38.12, current branch: osmo-v26/v0.38.12
-	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/3f71114d937296cdc7bcb585d56182d1f17432e1
-	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v26-osmo-2
-	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2
+	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v27/0.38.12, current branch: osmo-v27/v0.38.12
+	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/2305cecebc3aadee694c6d5e05f9d34b5630f564
+	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v27-osmo-1
+	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1
 
-	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v26/v0.50.10, current branch: osmo-v26/v0.50.10
-	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5a045895704de7fdc69d144895dcd9f162481502
-	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v26-osmo-2
-	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2
+	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v27/0.50.10, current branch: osmo-v27/0.50.10
+	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/33e0aaf2b1840a8bca4f1b2292700b6f15e5fad7
+	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v27-osmo-1
+	github.com/cosmos/cosmos-sdk => github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1
 
 // Local replaces commented for development
 // github.com/osmosis-labs/osmosis/osmoutils => ../../osmoutils

--- a/x/ibc-hooks/go.sum
+++ b/x/ibc-hooks/go.sum
@@ -846,10 +846,10 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2 h1:9X9qTF0nXgn/U/jb6BV1kgRg5t/CdTHHOmx9cwsiDdw=
-github.com/osmosis-labs/cometbft v0.38.12-v26-osmo-2/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2 h1:R0ahhobLCJ+GIA/RxC6NzNapQcwAilT7779Mep0Uu4o=
-github.com/osmosis-labs/cosmos-sdk v0.50.10-v26-osmo-2/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1 h1:rQgVL3+kX65PSXQ8//o7F8gUfOQyQnYvA6c3D5hD/5U=
+github.com/osmosis-labs/cometbft v0.38.12-v27-osmo-1/go.mod h1:a8NBI2IdO283RZdpH0MuXlze3j+lv6PXuzOtTCq4YGE=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1 h1:h15nNpKcnNOpijSJLBsieD2P5NUmlMDk9ovDeGCW2t0=
+github.com/osmosis-labs/cosmos-sdk v0.50.10-v27-osmo-1/go.mod h1:sYSfC78jZEx6m0WOprklQJG4PMGSmNJ0Y8lYrsv/MfU=
 github.com/osmosis-labs/osmosis/osmomath v0.0.12-0.20240517165907-1625703bc16d h1:Wbf/4tR1ibsQWiBPBcAKS54eipmKGoC2bFp9rxxhnQQ=
 github.com/osmosis-labs/osmosis/osmomath v0.0.12-0.20240517165907-1625703bc16d/go.mod h1:dztmzd8WPUjybmWJ0lj8aarBWvGC6IumV2gjpZNRQeQ=
 github.com/osmosis-labs/osmosis/osmoutils v0.0.12-0.20240814114813-131c58911ab6 h1:XorJ9FG/yPgEfaLGIL8ET6JL+YQCL7lCzZ0HSofQ4zk=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Bumping cometbft and cosmos sdk to the lastest versions:

comet => https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.12-v27-osmo-1
cosmossdk => https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.10-v27-osmo-1