### PR TITLE
feat: publish spot price for token swap event

### DIFF
--- a/ingest/indexer/domain/keepers.go
+++ b/ingest/indexer/domain/keepers.go
@@ -12,6 +12,7 @@ type PoolManagerKeeperI interface {
 	GetTradingPairTakerFee(ctx sdk.Context, denom0, denom1 string) (osmomath.Dec, error)
 	GetTotalPoolLiquidity(ctx sdk.Context, poolId uint64) (sdk.Coins, error)
 	GetPool(ctx sdk.Context, poolId uint64) (types.PoolI, error)
+	RouteCalculateSpotPrice(ctx sdk.Context, poolId uint64, quoteAssetDenom string, baseAssetDenom string) (price osmomath.BigDec, err error)
 }
 
 type Keepers struct {

--- a/ingest/indexer/service/export_test.go
+++ b/ingest/indexer/service/export_test.go
@@ -20,3 +20,7 @@ func (s *indexerStreamingService) AdjustTokenInAmountBySpreadFactor(ctx context.
 func (s *indexerStreamingService) TrackCreatedPoolID(event abci.Event, blockHeight int64, blockTime time.Time, txHash string) error {
 	return s.trackCreatedPoolID(event, blockHeight, blockTime, txHash)
 }
+
+func (s *indexerStreamingService) SetSpotPrice(ctx context.Context, event *abci.Event) error {
+	return s.setSpotPrice(ctx, event)
+}

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -108,7 +108,7 @@ func (s *indexerStreamingService) publishBlock(ctx context.Context, req abci.Req
 
 // setSpotPrice sets the spot price for the token swapped event in the event's attributes map
 // This approach ensures a reliable and consistent way to provide PriceNative data for token_swapped events.
-// Using the event's token amount may introduce rounding errors, especially with small amounts.
+// Using the event's token amount to provide priceNative may introduce rounding errors, especially with small amounts.
 // Additionally, determining PriceNative from pool reserves is not applicable to all pool types (e.g., CL pools).
 // Please note the spot price is set in the event's attributes map, keyed by "quote_tokenin_base_tokenout",
 // which means it's a quote using tokenin denom using tokenout as the base denom, it may require reversing in the /events endpoint

--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -106,6 +106,61 @@ func (s *indexerStreamingService) publishBlock(ctx context.Context, req abci.Req
 	return s.client.PublishBlock(sdkCtx, block)
 }
 
+// setSpotPrice sets the spot price for the token swapped event in the event's attributes map
+// This approach ensures a reliable and consistent way to provide PriceNative data for token_swapped events.
+// Using the event's token amount may introduce rounding errors, especially with small amounts.
+// Additionally, determining PriceNative from pool reserves is not applicable to all pool types (e.g., CL pools).
+// Please note the spot price is set in the event's attributes map, keyed by "quote_tokenin_base_tokenout",
+// which means it's a quote using tokenin denom using tokenout as the base denom, it may require reversing in the /events endpoint
+func (s *indexerStreamingService) setSpotPrice(ctx context.Context, event *abci.Event) error {
+	var poolId string
+	var tokensIn sdk.Coin
+	var tokensOut sdk.Coin
+	// Find the pool id, tokens in and tokens out from the event attributes
+	for _, attribute := range event.Attributes {
+		if attribute.Key == concentratedliquiditytypes.AttributeKeyPoolId {
+			poolId = attribute.Value
+		}
+		if attribute.Key == concentratedliquiditytypes.AttributeKeyTokensIn {
+			var err error
+			tokensIn, err = sdk.ParseCoinNormalized(attribute.Value)
+			if err != nil {
+				s.logger.Error("Error parsing tokens in", "error", err)
+				continue
+			}
+		}
+		if attribute.Key == concentratedliquiditytypes.AttributeKeyTokensOut {
+			var err error
+			tokensOut, err = sdk.ParseCoinNormalized(attribute.Value)
+			if err != nil {
+				s.logger.Error("Error parsing tokens out", "error", err)
+				continue
+			}
+		}
+		if !tokensIn.IsNil() && !tokensOut.IsNil() && poolId != "" {
+			break
+		}
+	}
+	if poolId == "" || tokensIn.IsNil() || tokensOut.IsNil() {
+		return fmt.Errorf("pool ID, tokens in, or tokens out not found in token_swapped event")
+	}
+	poolIdUint, err := strconv.ParseUint(poolId, 10, 64)
+	if err != nil {
+		return fmt.Errorf("error parsing pool ID %v", err)
+	}
+	// Get the spot price from the pool manager keeper
+	spotPrice, err := s.keepers.PoolManagerKeeper.RouteCalculateSpotPrice(sdk.UnwrapSDKContext(ctx), poolIdUint, tokensIn.Denom, tokensOut.Denom)
+	if err != nil {
+		return fmt.Errorf("error getting spot price %v", err)
+	}
+	// Set the spot price in the event's attributes map
+	event.Attributes = append(event.Attributes, abci.EventAttribute{
+		Key:   "quote_tokenin_base_tokenout",
+		Value: spotPrice.String(),
+	})
+	return nil
+}
+
 // publishTxn iterates through the transactions in the block and publishes them to the indexer backend.
 func (s *indexerStreamingService) publishTxn(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
@@ -158,6 +213,14 @@ func (s *indexerStreamingService) publishTxn(ctx context.Context, req abci.Reque
 					continue
 				}
 				eventType := clonedEvent.Type
+				if eventType == gammtypes.TypeEvtTokenSwapped {
+					// Set the spot price for the token swapped event in the event's attributes map
+					err := s.setSpotPrice(ctx, clonedEvent)
+					if err != nil {
+						s.logger.Error("Error setting spot price", "error", err)
+						continue
+					}
+				}
 				if eventType == gammtypes.TypeEvtTokenSwapped || eventType == gammtypes.TypeEvtPoolJoined || eventType == gammtypes.TypeEvtPoolExited || eventType == concentratedliquiditytypes.TypeEvtCreatePosition || eventType == concentratedliquiditytypes.TypeEvtWithdrawPosition {
 					includedEvents = append(includedEvents, domain.EventWrapper{Index: i, Event: *clonedEvent})
 				}

--- a/ingest/indexer/service/indexer_streaming_service_test.go
+++ b/ingest/indexer/service/indexer_streaming_service_test.go
@@ -473,12 +473,13 @@ func (s *IndexerServiceTestSuite) TestSetSpotPrice() {
 		s.Run(tc.name, func() {
 			s.Setup()
 
-			// This test suite is to test the AddTokenLiquidity method in the indexer streaming service.
+			// This test suite is to test the SetSpotPrice method in the indexer streaming service.
 			// where it applies to: token_swapped event only, i.e. gammtypes.TypeEvtTokenSwapped
-			// It then looks for the pool_id attribute (concentratedliquiditytypes.AttributeKeyPoolId) in the
-			// event attribute map.  With the pool_id, it then fetches the pool liquidity thru
-			// keepers.PoolManagerKeeper.GetTotalPoolLiquidity function. The pool liquidity data is then appended
-			// to the event attribute map with the key "liquidity_{denom}", value being the pool liquidity.
+			// It then looks for the pool_id, token_in, and token_out attributes, i.e.
+			// (concentratedliquiditytypes.AttributeKeyPoolId, concentratedliquiditytypes.AttributeKeyTokensIn, and concentratedliquiditytypes.AttributeKeyTokensOut)
+			// in the event attribute map. With the pool_id, token in and out denom, it then fetches the spot price thru
+			// keepers.PoolManagerKeeper::RouteCalculateSpotPrice function. The spot price data is then appended
+			// to the event attribute map with the key "quote_tokenin_base_tokenout", value being the spot price.
 
 			// Initialized chain pools
 			s.PrepareAllSupportedPools()


### PR DESCRIPTION
This commit resolves the issue where the priceNative data published to Dexscreener occasionally displayed incorrect values due to potential rounding errors. Instead of relying on the token in/out amounts from the token_swapped event to determine the priceNative value, this commit utilizes on-chain spot price data. This data will be published to the indexer backend and made available through the /events endpoint.