### PR TITLE
feat & fix: fix data duplication issue, skip failed transaction 

### DIFF
--- a/ingest/indexer/service/indexer_streaming_service.go
+++ b/ingest/indexer/service/indexer_streaming_service.go
@@ -191,6 +191,10 @@ func (s *indexerStreamingService) publishTxn(ctx context.Context, req abci.Reque
 		var includedEvents []domain.EventWrapper
 		txResults := res.GetTxResults()
 		for _, txResult := range txResults {
+			if txResult.IsErr() {
+				// Skip if the transaction is not successful, so that its corresponding events are not included in the publishing and not counted in by the dexscreener
+				continue
+			}
 			events := txResult.GetEvents()
 			// Iterate through the events in the transaction
 			// Include these events only:


### PR DESCRIPTION
This commit addresses two issues and one of them is reported in production:

1. Data duplication - the current implementation includes all events for each transaction in a block, vs only the transaction's events should be included.

2. Failed transaction should be skipped.

Tested in v26.x.