### PR TITLE
fix: superfluid log for error that should be ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8765, 8768](https://github.com/osmosis-labs/osmosis/pull/8765) fix concurrency issue in go test(x/lockup)
 * [#8563](https://github.com/osmosis-labs/osmosis/pull/8755) [x/concentratedliquidity]: Fix Incorrect Event Emission
 * [#8765](https://github.com/osmosis-labs/osmosis/pull/8765) fix concurrency issue in go test(x/lockup)
+* [#8791](https://github.com/osmosis-labs/osmosis/pull/8791) fix: superfluid log for error that should be ignored
 
 ### State Machine Breaking
 

--- a/x/superfluid/keeper/epoch.go
+++ b/x/superfluid/keeper/epoch.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	cl "github.com/osmosis-labs/osmosis/v26/x/concentrated-liquidity"
@@ -77,6 +78,11 @@ func (k Keeper) MoveSuperfluidDelegationRewardToGauges(ctx sdk.Context, accs []t
 		_ = osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
 			_, err := k.ck.WithdrawDelegationRewards(cacheCtx, addr, valAddr)
 			if errors.Is(err, distributiontypes.ErrEmptyDelegationDistInfo) {
+				ctx.Logger().Debug("no delegations for this (pool, validator) pair, skipping...")
+				// TODO: Remove this account from IntermediaryAccounts that we iterate over
+				return nil
+			} else if errors.Is(err, stakingtypes.ErrNoDelegation) {
+				// NOTE: in v0.50.x the function changed to return a different error
 				ctx.Logger().Debug("no delegations for this (pool, validator) pair, skipping...")
 				// TODO: Remove this account from IntermediaryAccounts that we iterate over
 				return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

When we call the _WithdrawDelegatorRewards_ function, we expect there to be a certain type of error, but this error changed in v50 causing multiple info logs that should be debug logs, making it difficult to understand what's happening with the superfluid epoch.

For v0.50 a function changed to return a different error see:
https://github.com/osmosis-labs/cosmos-sdk/blob/osmo-v27/0.50.10/x/distribution/keeper/keeper.go#L107-L138
 
old v0.47 see:
https://github.com/osmosis-labs/cosmos-sdk/blob/osmo-v25/v0.47.5/x/distribution/keeper/keeper.go#L83-L103

## Testing and Verifying

Run all go tests for superfluid

see (live debug logs):
```
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
> github.com/cosmos/cosmos-sdk/x/distribution/keeper.Keeper.WithdrawDelegationRewards() /home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.10-v26-osmo-2/x/distribution/keeper/keeper.go:118 (PC: 0x540fca4)
   113:		if val == nil {
   114:			return nil, types.ErrNoValidatorDistInfo
   115:		}
   116:	
   117:		del, err := k.stakingKeeper.Delegation(ctx, delAddr, valAddr)
=> 118:		if err != nil {
   119:			return nil, err
   120:		}
   121:	
   122:		if del == nil {
   123:			return nil, types.ErrEmptyDelegationDistInfo
(dlv) p err
error(*cosmossdk.io/errors.Error) *{
	codespace: "staking",
	code: 19,
	desc: "no delegation for (address, validator) tuple",
	grpcCode: Unknown (2),}
```

&&

```
11:14AM ERR no delegation for (address, validator) tuple module=server
11:14AM ERR no delegation for (address, validator) tuple module=server
> github.com/cosmos/cosmos-sdk/x/distribution/keeper.Keeper.WithdrawDelegationRewards() /home/ghost/go/pkg/mod/github.com/osmosis-labs/cosmos-sdk@v0.50.10-v26-osmo-2/x/distribution/keeper/keeper.go:122 (hits goroutine(450):7 total:7) (PC: 0x540fd01)
   117:		del, err := k.stakingKeeper.Delegation(ctx, delAddr, valAddr)
   118:		if err != nil {
   119:			return nil, err
   120:		}
   121:	
=> 122:		if del == nil {
   123:			return nil, types.ErrEmptyDelegationDistInfo
   124:		}
   125:	
```