### PR TITLE
fix nhooyr.io/websocket dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8543](https://github.com/osmosis-labs/osmosis/pull/8543) Add OTEL wiring and new configs in app.toml
 * [#8566](https://github.com/osmosis-labs/osmosis/pull/8566) Minor speedup to CalcExitCFMM shares
 * [#8665](https://github.com/osmosis-labs/osmosis/pull/8665) fix: smart account signing checktx error
+* [#](https://github.com/osmosis-labs/osmosis/pull/) fix: nhooyr.io/websocket dependency (moved permanently)
 
 ## v25.2.1
 * [#8546](https://github.com/osmosis-labs/osmosis/pull/8546) feat: reduce commit timeout to 500ms to enable faster blocks, and timeout propose to 1.8s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8563](https://github.com/osmosis-labs/osmosis/pull/8755) [x/concentratedliquidity]: Fix Incorrect Event Emission
 * [#8765](https://github.com/osmosis-labs/osmosis/pull/8765) fix concurrency issue in go test(x/lockup)
 * [#8791](https://github.com/osmosis-labs/osmosis/pull/8791) fix: superfluid log for error that should be ignored
+* [#8803](https://github.com/osmosis-labs/osmosis/pull/8803) fix: nhooyr.io/websocket dependency (moved permanently)
 
 ### State Machine Breaking
 
@@ -110,7 +111,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#8543](https://github.com/osmosis-labs/osmosis/pull/8543) Add OTEL wiring and new configs in app.toml
 * [#8566](https://github.com/osmosis-labs/osmosis/pull/8566) Minor speedup to CalcExitCFMM shares
 * [#8665](https://github.com/osmosis-labs/osmosis/pull/8665) fix: smart account signing checktx error
-* [#](https://github.com/osmosis-labs/osmosis/pull/) fix: nhooyr.io/websocket dependency (moved permanently)
 
 ## v25.2.1
 * [#8546](https://github.com/osmosis-labs/osmosis/pull/8546) feat: reduce commit timeout to 500ms to enable faster blocks, and timeout propose to 1.8s

--- a/go.mod
+++ b/go.mod
@@ -294,6 +294,8 @@ replace (
 	// replace as directed by sdk upgrading.md https://github.com/cosmos/cosmos-sdk/blob/393de266c8675dc16cc037c1a15011b1e990975f/UPGRADING.md?plain=1#L713
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 
+	nhooyr.io/websocket => github.com/coder/websocket v1.8.10
+
 // // Local replaces commented for development
 // github.com/osmosis-labs/osmosis/osmomath => ./osmomath
 // github.com/osmosis-labs/osmosis/osmoutils => ./osmoutils


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

When cleaning a go cache and trying to compile the project, we can observe the following errors:

```
go: nhooyr.io/websocket@v1.8.7: reading nhooyr.io/websocket/go.mod at revision v1.8.7: unknown revision v1.8.7
ante/sendblock.go:6:2: nhooyr.io/websocket@v1.8.7: reading nhooyr.io/websocket/go.mod at revision v1.8.7: unknown revision v1.8.7
ante/sendblock.go:11:2: nhooyr.io/websocket@v1.8.7: reading nhooyr.io/websocket/go.mod at revision v1.8.7: unknown revision v1.8.7
...
```

This is because the resource moved permanently:
```
curl nhooyr.io/websocket
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

## Testing and Verifying

```
make build
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A