### PR TITLE
chore: Add support streaming to multiple SQS instances

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -384,7 +384,10 @@ func NewOsmosisApp(
 		blockProcessStrategyManager := commondomain.NewBlockProcessStrategyManager()
 
 		// Create sqs grpc client
-		sqsGRPCClient := sqsservice.NewGRPCCLient(sqsConfig.GRPCIngestAddress, sqsConfig.GRPCIngestMaxCallSizeBytes, appCodec)
+		sqsGRPCClients := make([]domain.SQSGRPClient, len(sqsConfig.GRPCIngestAddress))
+		for i, grpcIngestAddress := range sqsConfig.GRPCIngestAddress {
+			sqsGRPCClients[i] = sqsservice.NewGRPCCLient(grpcIngestAddress, sqsConfig.GRPCIngestMaxCallSizeBytes, appCodec)
+		}
 
 		// Create write listeners for the SQS service.
 		writeListeners, storeKeyMap := getSQSServiceWriteListeners(app, appCodec, poolTracker, app.WasmKeeper)
@@ -395,7 +398,7 @@ func NewOsmosisApp(
 			WriteListeners: writeListeners,
 			StoreKeyMap:    storeKeyMap,
 		}
-		sqsStreamingService := sqsservice.New(blockUpdatesProcessUtils, poolExtractor, poolsTransformer, poolTracker, sqsGRPCClient, blockProcessStrategyManager, nodeStatusChecker)
+		sqsStreamingService := sqsservice.New(blockUpdatesProcessUtils, poolExtractor, poolsTransformer, poolTracker, sqsGRPCClients, blockProcessStrategyManager, nodeStatusChecker)
 
 		streamingServices = append(streamingServices, sqsStreamingService)
 	}

--- a/ingest/common/pooltracker/memory_pool_tracker.go
+++ b/ingest/common/pooltracker/memory_pool_tracker.go
@@ -1,6 +1,8 @@
 package pooltracker
 
 import (
+	"sync"
+
 	commondomain "github.com/osmosis-labs/osmosis/v27/ingest/common/domain"
 	"github.com/osmosis-labs/osmosis/v27/ingest/sqs/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v27/x/poolmanager/types"
@@ -8,101 +10,157 @@ import (
 
 // poolBlockUpdateTracker is a struct that tracks the pools that were updated in a block.
 type poolBlockUpdateTracker struct {
-	concentratedPools             map[uint64]poolmanagertypes.PoolI
-	concentratedPoolIDTickChange  map[uint64]struct{}
-	cfmmPools                     map[uint64]poolmanagertypes.PoolI
-	cosmwasmPools                 map[uint64]poolmanagertypes.PoolI
-	cosmwasmPoolsAddressToPoolMap map[string]poolmanagertypes.PoolI
+	concentratedPools             sync.Map
+	concentratedPoolIDTickChange  sync.Map
+	cfmmPools                     sync.Map
+	cosmwasmPools                 sync.Map
+	cosmwasmPoolsAddressToPoolMap sync.Map
 	// Tracks the pool IDs that were created in the block.
-	createdPoolIDs map[uint64]commondomain.PoolCreation
+	createdPoolIDs sync.Map
 }
 
 // NewMemory creates a new memory pool tracker.
 func NewMemory() domain.BlockPoolUpdateTracker {
 	return &poolBlockUpdateTracker{
-		concentratedPools:             map[uint64]poolmanagertypes.PoolI{},
-		concentratedPoolIDTickChange:  map[uint64]struct{}{},
-		cfmmPools:                     map[uint64]poolmanagertypes.PoolI{},
-		cosmwasmPools:                 map[uint64]poolmanagertypes.PoolI{},
-		cosmwasmPoolsAddressToPoolMap: map[string]poolmanagertypes.PoolI{},
-		createdPoolIDs:                map[uint64]commondomain.PoolCreation{},
+		concentratedPools:             sync.Map{},
+		concentratedPoolIDTickChange:  sync.Map{},
+		cfmmPools:                     sync.Map{},
+		cosmwasmPools:                 sync.Map{},
+		cosmwasmPoolsAddressToPoolMap: sync.Map{},
+		createdPoolIDs:                sync.Map{},
 	}
 }
 
 // TrackConcentrated implements PoolTracker.
 func (pt *poolBlockUpdateTracker) TrackConcentrated(pool poolmanagertypes.PoolI) {
-	pt.concentratedPools[pool.GetId()] = pool
+	pt.concentratedPools.Store(pool.GetId(), pool)
 }
 
 // TrackCFMM implements PoolTracker.
 func (pt *poolBlockUpdateTracker) TrackCFMM(pool poolmanagertypes.PoolI) {
-	pt.cfmmPools[pool.GetId()] = pool
+	pt.cfmmPools.Store(pool.GetId(), pool)
 }
 
 // TrackCosmWasm implements PoolTracker.
 func (pt *poolBlockUpdateTracker) TrackCosmWasm(pool poolmanagertypes.PoolI) {
-	pt.cosmwasmPools[pool.GetId()] = pool
+	pt.cosmwasmPools.Store(pool.GetId(), pool)
 }
 
 // TrackCosmWasmPoolsAddressToPoolMap implements PoolTracker.
 func (pt *poolBlockUpdateTracker) TrackCosmWasmPoolsAddressToPoolMap(pool poolmanagertypes.PoolI) {
-	pt.cosmwasmPoolsAddressToPoolMap[pool.GetAddress().String()] = pool
+	pt.cosmwasmPoolsAddressToPoolMap.Store(pool.GetAddress().String(), pool)
 }
 
 // TrackConcentratedPoolIDTickChange implements PoolTracker.
 func (pt *poolBlockUpdateTracker) TrackConcentratedPoolIDTickChange(poolID uint64) {
-	pt.concentratedPoolIDTickChange[poolID] = struct{}{}
+	pt.concentratedPoolIDTickChange.Store(poolID, struct{}{})
 }
 
 // TrackCreatedPoolID implements domain.BlockPoolUpdateTracker.
 func (pt *poolBlockUpdateTracker) TrackCreatedPoolID(poolCreation commondomain.PoolCreation) {
-	pt.createdPoolIDs[poolCreation.PoolId] = poolCreation
+	pt.createdPoolIDs.Store(poolCreation.PoolId, poolCreation)
 }
 
 // GetConcentratedPools implements PoolTracker.
 func (pt *poolBlockUpdateTracker) GetConcentratedPools() []poolmanagertypes.PoolI {
-	return poolMapToSlice(pt.concentratedPools)
+	return poolMapToSlice(&pt.concentratedPools)
 }
 
 // GetConcentratedPoolIDTickChange implements PoolTracker.
 func (pt *poolBlockUpdateTracker) GetConcentratedPoolIDTickChange() map[uint64]struct{} {
-	return pt.concentratedPoolIDTickChange
+	concentratedPoolIDTickChange := make(map[uint64]struct{})
+	pt.concentratedPoolIDTickChange.Range(func(key, value interface{}) bool {
+		k, ok := key.(uint64)
+		if !ok {
+			return true
+		}
+
+		v, ok := value.(struct{})
+		if !ok {
+			return true
+		}
+
+		concentratedPoolIDTickChange[k] = v
+
+		return true
+	})
+	return concentratedPoolIDTickChange
 }
 
 // GetCFMMPools implements PoolTracker.
 func (pt *poolBlockUpdateTracker) GetCFMMPools() []poolmanagertypes.PoolI {
-	return poolMapToSlice(pt.cfmmPools)
+	return poolMapToSlice(&pt.cfmmPools)
 }
 
 // GetCosmWasmPools implements PoolTracker.
 func (pt *poolBlockUpdateTracker) GetCosmWasmPools() []poolmanagertypes.PoolI {
-	return poolMapToSlice(pt.cosmwasmPools)
+	return poolMapToSlice(&pt.cosmwasmPools)
 }
 
 // GetCosmWasmPoolsAddressToIDMap implements PoolTracker.
 func (pt *poolBlockUpdateTracker) GetCosmWasmPoolsAddressToIDMap() map[string]poolmanagertypes.PoolI {
-	return pt.cosmwasmPoolsAddressToPoolMap
+	cosmwasmPoolsAddressToPoolMap := make(map[string]poolmanagertypes.PoolI)
+	pt.cosmwasmPoolsAddressToPoolMap.Range(func(key, value interface{}) bool {
+		k, ok := key.(string)
+		if !ok {
+			return true
+		}
+
+		v, ok := value.(poolmanagertypes.PoolI)
+		if !ok {
+			return true
+		}
+
+		cosmwasmPoolsAddressToPoolMap[k] = v
+
+		return true
+	})
+	return cosmwasmPoolsAddressToPoolMap
 }
 
 // GetCreatedPoolIDs implements domain.BlockPoolUpdateTracker.
 func (pt *poolBlockUpdateTracker) GetCreatedPoolIDs() map[uint64]commondomain.PoolCreation {
-	return pt.createdPoolIDs
+	createdPoolIDs := make(map[uint64]commondomain.PoolCreation)
+	pt.createdPoolIDs.Range(func(key, value interface{}) bool {
+		k, ok := key.(uint64)
+		if !ok {
+			return true
+		}
+
+		v, ok := value.(commondomain.PoolCreation)
+		if !ok {
+			return true
+		}
+
+		createdPoolIDs[k] = v
+
+		return true
+	})
+
+	return createdPoolIDs
 }
 
 // Reset implements PoolTracker.
 func (pt *poolBlockUpdateTracker) Reset() {
-	pt.concentratedPools = map[uint64]poolmanagertypes.PoolI{}
-	pt.cfmmPools = map[uint64]poolmanagertypes.PoolI{}
-	pt.cosmwasmPools = map[uint64]poolmanagertypes.PoolI{}
-	pt.concentratedPoolIDTickChange = map[uint64]struct{}{}
-	pt.createdPoolIDs = map[uint64]commondomain.PoolCreation{}
+	pt.concentratedPools = sync.Map{}
+	pt.cfmmPools = sync.Map{}
+	pt.cosmwasmPools = sync.Map{}
+	pt.concentratedPoolIDTickChange = sync.Map{}
+	pt.createdPoolIDs = sync.Map{}
 }
 
 // poolMapToSlice converts a map of pools to a slice of pools.
-func poolMapToSlice(m map[uint64]poolmanagertypes.PoolI) []poolmanagertypes.PoolI {
-	result := make([]poolmanagertypes.PoolI, 0, len(m))
-	for _, pool := range m {
-		result = append(result, pool)
-	}
+func poolMapToSlice(m *sync.Map) []poolmanagertypes.PoolI {
+	var result []poolmanagertypes.PoolI
+	m.Range(func(_, value interface{}) bool {
+		v, ok := value.(poolmanagertypes.PoolI)
+		if !ok {
+			return true
+		}
+		result = append(result, v)
+
+		return true
+	})
+
 	return result
 }

--- a/ingest/sqs/sqs_config.go
+++ b/ingest/sqs/sqs_config.go
@@ -1,6 +1,8 @@
 package sqs
 
 import (
+	"strings"
+
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
@@ -11,7 +13,7 @@ type Config struct {
 	// IsEnabled defines if the sidecar query server is enabled.
 	IsEnabled bool `mapstructure:"enabled"`
 	// GRPCIngestAddress defines the gRPC address of the sidecar query server ingest.
-	GRPCIngestAddress string `mapstructure:"grpc-ingest-address"`
+	GRPCIngestAddress []string `mapstructure:"grpc-ingest-address"`
 	// GRPCIngestMaxCallSizeBytes defines the maximum size of a gRPC ingest call in bytes.
 	GRPCIngestMaxCallSizeBytes int `mapstructure:"grpc-ingest-max-call-size-bytes"`
 }
@@ -29,7 +31,7 @@ const (
 var DefaultConfig = Config{
 	IsEnabled: false,
 	// Default gRPC address is localhost:50051
-	GRPCIngestAddress: "localhost:50051",
+	GRPCIngestAddress: []string{"localhost:50051"},
 	// 50 MB by default. Our pool data is estimated to be at approximately 15MB.
 	// During normal operation, we should not approach even 1 MB since we are to stream only
 	// modified pools.
@@ -46,7 +48,7 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 		}
 	}
 
-	grpcIngestAddress := osmoutils.ParseString(opts, groupOptName, "grpc-ingest-address")
+	grpcIngestAddress := strings.Split(osmoutils.ParseString(opts, groupOptName, "grpc-ingest-address"), ",")
 
 	grpcIngestMaxCallSizeBytes := osmoutils.ParseInt(opts, groupOptName, "grpc-ingest-max-call-size-bytes")
 


### PR DESCRIPTION
## What is the purpose of the change
> The changes in this ticket will allow supporting multiple sqs instances, with a comma delimited hostname:port in app.toml, e.g. grpc-ingest-address = "localhost:50051,localhost:50052"
This will make scaling up sqs much easier, without always having to have a corresponding osmosis node for each sqs instance.

Originally appeared [Support multiple sqs instances](https://github.com/osmosis-labs/osmosis/pull/8211)

This PR ports original PR code to latest node version ( v24.x to v27.x ) and additionally fixes concurrent writes to memory pool tracker.