### PR TITLE
fix: whitelisted protorev receiving module addresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -161,6 +161,7 @@ import (
 	poolmanagerclient "github.com/osmosis-labs/osmosis/v27/x/poolmanager/client"
 	superfluidclient "github.com/osmosis-labs/osmosis/v27/x/superfluid/client"
 	txfeesclient "github.com/osmosis-labs/osmosis/v27/x/txfees/client"
+	txfeestypes "github.com/osmosis-labs/osmosis/v27/x/txfees/types"
 )
 
 const appName = "OsmosisApp"
@@ -173,7 +174,7 @@ var (
 	maccPerms = moduleAccountPermissions
 
 	// module accounts that are allowed to receive tokens.
-	allowedReceivingModAcc = map[string]bool{protorevtypes.ModuleName: true}
+	allowedReceivingModAcc = map[string]bool{protorevtypes.ModuleName: true, txfeestypes.NonNativeTxFeeCollectorName: true, txfeestypes.TakerFeeCommunityPoolName: true, txfeestypes.TakerFeeStakersName: true}
 
 	// TODO: Refactor wasm items into a wasm.go file
 	// WasmProposalsEnabled enables all x/wasm proposals when it's value is "true"


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
During epoch the following info log appears:

```bash
10:42AM INF The following non-native tokens were not swapped (see debug logs for further details): [17289527factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB via pool 1642 48586factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO via pool 1461 287430factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo via pool 1643 3350000000000gamm/pool/10 via pool 101 13695769356ibc/0E4FA664327BD40B32803EE84A77F145834C0281B7F82B65521333B3669FA0BA via pool 974 7061231010ibc/447A0DCE83691056289503DDAB8EB08E52E167A73629F2ACC59F056B92F51CE8 via pool 962 1145516399ibc/64D56DF9EC69BE554F49EBCE0199611062FF1137EF105E2F645C1997344F3834 via pool 1584 54612151900ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4 via pool 1635 1434760659870ibc/98BCD43F190C6960D0005BC46BB765C827403A361C9C03C2FF694150A30284B0 via pool 1575 123992804ibc/C25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7 via pool 1572 645417872ibc/DEA3B0BB0006C69E75D2247E8DC57878758790556487067F67748FDC237CE2AE via pool 996 45229325448ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D via pool 1463] module=serve
```

Debugging this and printing the error causing this info log shows the following:

```bash
3:23PM ERR Error swapping non-native fee to denom error="dispatch: submessages: dispatch: submessages: osmo1g7ajkk295vactngp74shkfrprvjrdwn662dg26 is not allowed to receive funds: unauthorized" module=server
```

This is due to the receiving module addresses being blocked by the bank module. These changes add the following three modules to the slice of module addresses that are allowed to receive funds:

- NonNativeTxFeeCollectorName
- TakerFeeCommunityPoolName
- TakerFeeStakersName

**NOTE: This does not completely solve the issue but removes a small amount of them and exposes underlying issues. **

## Testing and Verifying
Tested with an in-place-testnet with frequent epochs and a debugger. 

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A