### PR TITLE
Remove slash from refs for docker

### DIFF
--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -66,16 +66,18 @@ jobs:
         name: Create Docker Image Tag for release candidate
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          GITHUB_TAG=${{ github.ref_name }}
+          GITHUB_TAG=${{ github.event.inputs.ref_name || github.ref_name }}
           echo "DOCKER_IMAGE_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
-          echo "OSMOSIS_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "OSMOSIS_VERSION=${{ github.event.inputs.ref_name || github.ref_name }}" >> $GITHUB_ENV
       -
         name: Create Docker Image Tag for vN.x branch
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)
-          echo "DOCKER_IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
-          echo "OSMOSIS_VERSION=${{ github.ref_name }}-$SHORT_SHA" >> $GITHUB_ENV
+          REF_NAME=${{ github.event.inputs.ref_name || github.ref_name }}
+          SAFE_REF_NAME=${REF_NAME//\//-}
+          echo "DOCKER_IMAGE_TAG=${SAFE_REF_NAME}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
+          echo "OSMOSIS_VERSION=${SAFE_REF_NAME}-$SHORT_SHA" >> $GITHUB_ENV
       -
         name: Build and Push Docker Images
         uses: docker/build-push-action@v6

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref_name || github.ref }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## What is the purpose of the change


Use the field manually populated when building a dev docker image
Remove slashes from ref names to give us a valid docker tag