### PR TITLE
chore: revert optimistic exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### State Compatible
-* [#8393](https://github.com/osmosis-labs/osmosis/pull/8393) Enable optimistic execution
 * [#8831](https://github.com/osmosis-labs/osmosis/pull/8831) chore: bump cometbft
 
 ## v27.0.0

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -1042,7 +1042,6 @@ func newApp(logger log.Logger, db cosmosdb.DB, traceStore io.Writer, appOpts ser
 		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagDisableIAVLFastNode))),
 		baseapp.SetIAVLFastNodeModuleWhitelist(fastNodeModuleWhitelist),
 		baseapp.SetChainID(chainID),
-		baseapp.SetOptimisticExecution(),
 	}
 
 	// If this is an in place testnet, set any new stores that may exist


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Due to an issue with concurrent map writes stemming from the block sdk, we need to revert this PR until we have a patch version of the block sdk, the solution is to "import upstream cosmos-sdk changes to prio-nonce mempool"

see:
https://github.com/skip-mev/block-sdk/pull/355

the halt is sporadic and would not fully halt the chain if validators are using systemd, as systemd would restart the node on fail, the halt looks like this:

```
fatal error: concurrent map writes

goroutine 5967690 [running]:
github.com/skip-mev/block-sdk/v2/block/base.(*PriorityNonceMempool[...]).Remove(0x6fc2fa0, {0x6e9d0e0, 0xc1b5526580?})
	github.com/skip-mev/block-sdk/v2@v2.1.5/block/base/priority_nonce.go:468 +0x2a5
github.com/skip-mev/block-sdk/v2/block/base.(*Mempool[...]).Remove(0x1ef601d?, {0x6e9d0e0?, 0xc1b5526580?})
	github.com/skip-mev/block-sdk/v2@v2.1.5/block/base/mempool.go:67 +0x2f
github.com/skip-mev/block-sdk/v2/block.(*LanedMempool).Remove(0x6ed4918?, {0x6e9d0e0, 0xc1b5526580})
	github.com/skip-mev/block-sdk/v2@v2.1.5/block/mempool.go:127 +0xd3
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0xc001656fc8, 0x7, {0xc1c8813b80, 0x26f, 0x26f})
	github.com/cosmos/cosmos-sdk@v0.50.10/baseapp/baseapp.go:944 +0xf90
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).deliverTx(0xc001656fc8, {0xc1c8813b80?, 0x26f?, 0xc028b8c2c0?})
	github.com/cosmos/cosmos-sdk@v0.50.10/baseapp/baseapp.go:768 +0xb1
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).internalFinalizeBlock(0xc001656fc8, {0x6ed4bc8, 0xc093fefd60}, 0xc028b57080)
	github.com/cosmos/cosmos-sdk@v0.50.10/baseapp/abci.go:793 +0x125c
github.com/cosmos/cosmos-sdk/baseapp/oe.(*OptimisticExecution).Execute.func1()
	github.com/cosmos/cosmos-sdk@v0.50.10/baseapp/oe/optimistic_execution.go:108 +0x84
created by github.com/cosmos/cosmos-sdk/baseapp/oe.(*OptimisticExecution).Execute in goroutine 24944
	github.com/cosmos/cosmos-sdk@v0.50.10/baseapp/oe/optimistic_execution.go:106 +0x545
```

## Testing and Verifying

- review code