### PR TITLE
Improve grammar and clarity in wording

### DIFF
--- a/x/README.md
+++ b/x/README.md
@@ -5,7 +5,7 @@ Osmosis implements the following custom modules:
 * `epochs` - Makes on-chain timers which other modules can execute code during.
 * `gamm` - Generalized AMM infrastructure, which includes balancer and stableswap
 * `incentives` - Controls specification and distribution of rewards to lockups
-* `lockup` - Enables time-lock escrowing of tokens. (Often called Locking or Bonding)
+* `lockup` - Enables time-lock escrow of tokens. (Often called Locking or Bonding)
 * `mint` - Controls token supply emissions, and what modules they are directed to.
 * `pool-incentives` - Controls how incentives allocated towards "Liquidity Providing" are directed
   * These go towards gauges defined by the `incentives` module

--- a/x/twap/README.md
+++ b/x/twap/README.md
@@ -6,7 +6,7 @@ A time weighted average price is a function that takes a sequence of `(time, pri
 
 ## Arithmetic mean TWAP
 
-Using the arithmetic mean, the TWAP of a sequence `(t_i, p_i)`, from `t_0` to `t_n`, indexed by time in ascending order, is: $$\frac{1}{t_n - t_0}\sum_{i=0}^{n-1} p_i (t_{i+1} - t_i)$$
+Using the arithmetic mean TWAP of a sequence `(t_i, p_i)`, from `t_0` to `t_n`, indexed by time in ascending order, is: $$\frac{1}{t_n - t_0}\sum_{i=0}^{n-1} p_i (t_{i+1} - t_i)$$
 Notice that the latest price `p_n` isn't used, as it has lasted for a time interval of `0` seconds in this range!
 
 To illustrate with an example, given the sequence: `(0s, $1), (4s, $6), (5s, $1)`, the arithmetic mean TWAP is:


### PR DESCRIPTION
Fixed:

Replaced the word "escrowing" with "escrow" for grammatical clarity.
Simplified "Using the arithmetic mean, the" to "Using the arithmetic mean" for better readability and flow.
Why it's useful:
These changes improve the grammar and clarity of the text, making it more concise and easier to understand.