### PR TITLE
chore: fix event emission for smart account module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* [#8858](https://github.com/osmosis-labs/osmosis/pull/8858) chore: fix event emission for smart account module
+
+## v27.0.1
+
 ### State Compatible
 * [#8831](https://github.com/osmosis-labs/osmosis/pull/8831) chore: bump cometbft
 

--- a/x/smart-account/ante/pubkey.go
+++ b/x/smart-account/ante/pubkey.go
@@ -48,10 +48,15 @@ func (spkd EmitPubKeyDecoratorEvents) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 	}
 
 	var events sdk.Events
+
 	for i, sig := range sigs {
+		signerStr, err := spkd.ak.AddressCodec().BytesToString(signers[i])
+		if err != nil {
+			return sdk.Context{}, err
+		}
 		events = append(events, sdk.NewEvent(sdk.EventTypeTx,
-			sdk.NewAttribute(sdk.AttributeKeyAccountSequence, fmt.Sprintf("%s/%d", signers[i], sig.Sequence)),
-			sdk.NewAttribute(smartaccounttypes.AttributeKeyAccountSequenceAuthenticator, fmt.Sprintf("%s/%d", signers[i], sig.Sequence)),
+			sdk.NewAttribute(sdk.AttributeKeyAccountSequence, fmt.Sprintf("%s/%d", signerStr, sig.Sequence)),
+			sdk.NewAttribute(smartaccounttypes.AttributeKeyAccountSequenceAuthenticator, fmt.Sprintf("%s/%d", signerStr, sig.Sequence)),
 		))
 
 		sigBzs, err := signatureDataToBz(sig.Data)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Events are being formatted incorrectly when being emitted, this PR fixes that

## Testing and Verifying

Review code

## Query the osmosis rpc endpoints

- `osmosisd q tx C603B5E501D2812F888232A24403E86CCCED23AFAB8B1ADCCD21E25759B16E00 --output json --node https://rpc.osmosis.zone:443 | jq`

Check these events:
```
 "events": [
    {
      "type": "tx",
      "attributes": [
        {
          "key": "acc_seq",
          "value": "�a\"�p���\u007f}��Z��\"gCٺ/5829",
          "index": true
        },
        {
          "key": "authenticator_acc_seq",
          "value": "�a\"�p���\u007f}��Z��\"gCٺ/5829",
          "index": true
        }
      ]
    },
```

run this branch: 

- `osmosisd q tx C603B5E501D2812F888232A24403E86CCCED23AFAB8B1ADCCD21E25759B16E00 --output json | jq`

Check these events:
```
  "events": [
    {
      "type": "tx",
      "attributes": [
        {
          "key": "acc_seq",
          "value": "osmo1efsj9hrsuhcu6lmamm544n7syfn58kd68d30k4/5829",
          "index": true
        },
        {
          "key": "authenticator_acc_seq",
          "value": "osmo1efsj9hrsuhcu6lmamm544n7syfn58kd68d30k4/5829",
          "index": true
        }
      ]
    },
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A