### PR TITLE
Fix `.goreleaser.yaml and Makefile targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,70 +6,12 @@ env:
   - CGO_ENABLED=1
 
 builds:
-  - id: osmosisd-darwin-amd64
-    main: ./cmd/osmosisd/main.go
-    binary: osmosisd
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
-    env:
-      - CC=o64-clang
-      - CGO_LDFLAGS=-L/lib
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    flags:
-      - -mod=readonly
-      - -trimpath
-    ldflags:
-      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
-      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
-      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
-      - -w -s
-      - -linkmode=external
-    tags:
-      - netgo
-      - ledger
-      - static_wasm
-
-  - id: osmosisd-darwin-arm64
-    main: ./cmd/osmosisd/main.go
-    binary: osmosisd
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
-    env:
-      - CC=oa64-clang
-      - CGO_LDFLAGS=-L/lib
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    flags:
-      - -mod=readonly
-      - -trimpath
-    ldflags:
-      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
-      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
-      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
-      - -w -s
-      - -linkmode=external
-    tags:
-      - netgo
-      - ledger
-      - static_wasm
-
   - id: osmosisd-linux-amd64
     main: ./cmd/osmosisd
     binary: osmosisd
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/libwasmvm_muslc.x86_64.a
     goos:
       - linux
     goarch:
@@ -87,7 +29,7 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc,osusergo
       - -w -s
       - -linkmode=external
-      - -extldflags '-Wl,-z,muldefs -static -lm'
+      - -extldflags '-L/usr/lib -lwasmvm_muslc.x86_64 -Wl,-z,muldefs -static -lm'
     tags:
       - netgo
       - ledger
@@ -99,7 +41,7 @@ builds:
     binary: osmosisd
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/lib/libwasmvm_muslc.aarch64.a
     goos:
       - linux
     goarch:
@@ -117,39 +59,26 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc,osusergo
       - -w -s
       - -linkmode=external
-      - -extldflags '-Wl,-z,muldefs -static -lm'
+      - -extldflags '-L/usr/lib -lwasmvm_muslc.aarch64 -Wl,-z,muldefs -static -lm'
     tags:
       - netgo
       - ledger
       - muslc
       - osusergo
 
-universal_binaries:
-  - id: osmosisd-darwin-universal
-    ids:
-      - osmosisd-darwin-amd64
-      - osmosisd-darwin-arm64
-    replace: false
-
 archives:
   - id: zipped
     builds:
-      # - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-      # - osmosisd-darwin-amd64
-      # - osmosisd-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     files:
       - none*
   - id: binaries
     builds:
-      # - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
-      # - osmosisd-darwin-amd64
-      # - osmosisd-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:

--- a/scripts/makefiles/release.mk
+++ b/scripts/makefiles/release.mk
@@ -24,7 +24,7 @@ release-dry-run:
 		$(GORELEASER_IMAGE) \
 		release \
 		--clean \
-		--skip-publish
+		--skip=publish
 
 release-snapshot:
 	docker run \
@@ -37,5 +37,4 @@ release-snapshot:
 		release \
 		--clean \
 		--snapshot \
-		--skip-validate \
-		--skip-publish
+		--skip=publish,validate


### PR DESCRIPTION
## What is the purpose of the change

This PR:

- Removes darwin builds from the `.goreleaser.yaml` as we are no longer publishing them
- Updated `linux-amd64` and `linux-arm64` builds to fetch `libwasmvm` in specific paths
- Remove deprecated `--skip-publish` and `--skip-validate` 

## Testing and Verifying

I have tested the build locally on an Ubuntu machine, and it is working. However, it is not working on my ARM MacBook.

I encounter the following warnings during the build process:

```bash
_/GOROOT/src/plugin/plugin_dlopen.go:19: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
library/std/src/sys/pal/unix/os.rs:732: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
library/std/src/sys_common/net.rs:207: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking cmd=[go build -mod=readonly -trimpath -tags=netgo,ledger,muslc,osusergo -ldflags=-X github.com/cosmos/cosmos-sdk/version.Name=osmosis -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd -X github.com/cosmos/cosmos-sdk/version.Version=28.0.0-rc1-SNAPSHOT-fed374b1c -X github.com/cosmos/cosmos-sdk/version.Commit=fed374b1c87228496a0f47798ddbaed97c769f46 -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc,osusergo -w -s -linkmode=external -extldflags '-L/usr/lib -lwasmvm_muslc.aarch64 -Wl,-z,muldefs -static -lm' -o /go/src/osmosisd/dist/osmosisd-linux-arm64_linux_arm64/osmosisd ./cmd/osmosisd]
    • # github.com/osmosis-labs/osmosis/v28/cmd/osmosisd
/usr/bin/ld: /tmp/go-link-2404304271/000008.o: in function `pluginOpen':
/_/GOROOT/src/plugin/plugin_dlopen.go:19: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /usr/lib/libwasmvm_muslc.x86_64.a(std-742797dd06d019e7.std.e4c3ebae17ee837d-cgu.0.rcgu.o): in function `std::sys::pal::unix::os::home_dir::fallback':
/rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys/pal/unix/os.rs:732: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking 
...
```

To address these warnings, we would need to use `musl` libraries instead of `glib`. However, the `musl-gcc` compiler is not available in the goreleaser-cross container.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A