### PR TITLE
Calvin/sqs multi instances support 2 (#8862) ( backport )

### DIFF
--- a/ingest/sqs/sqs_config.go
+++ b/ingest/sqs/sqs_config.go
@@ -1,6 +1,8 @@
 package sqs
 
 import (
+	"strings"
+
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
@@ -11,7 +13,7 @@ type Config struct {
 	// IsEnabled defines if the sidecar query server is enabled.
 	IsEnabled bool `mapstructure:"enabled"`
 	// GRPCIngestAddress defines the gRPC address of the sidecar query server ingest.
-	GRPCIngestAddress string `mapstructure:"grpc-ingest-address"`
+	GRPCIngestAddress []string `mapstructure:"grpc-ingest-address"`
 	// GRPCIngestMaxCallSizeBytes defines the maximum size of a gRPC ingest call in bytes.
 	GRPCIngestMaxCallSizeBytes int `mapstructure:"grpc-ingest-max-call-size-bytes"`
 }
@@ -29,7 +31,7 @@ const (
 var DefaultConfig = Config{
 	IsEnabled: false,
 	// Default gRPC address is localhost:50051
-	GRPCIngestAddress: "localhost:50051",
+	GRPCIngestAddress: []string{"localhost:50051"},
 	// 50 MB by default. Our pool data is estimated to be at approximately 15MB.
 	// During normal operation, we should not approach even 1 MB since we are to stream only
 	// modified pools.
@@ -46,7 +48,7 @@ func NewConfigFromOptions(opts servertypes.AppOptions) Config {
 		}
 	}
 
-	grpcIngestAddress := osmoutils.ParseString(opts, groupOptName, "grpc-ingest-address")
+	grpcIngestAddress := strings.Split(osmoutils.ParseString(opts, groupOptName, "grpc-ingest-address"), ",")
 
 	grpcIngestMaxCallSizeBytes := osmoutils.ParseInt(opts, groupOptName, "grpc-ingest-max-call-size-bytes")
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Backports https://github.com/osmosis-labs/osmosis/pull/8862 to `v28.x`

## Testing and Verifying

This change is already covered by existing tests.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [X] N/A