### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/scripts/cl/README.md
+++ b/scripts/cl/README.md
@@ -3,7 +3,7 @@
 ## Context
 
 These scripts exist to estimate the results of the swap
-concentrated liqudity test cases.
+concentrated liquidity test cases.
 
 Each existing test case is estimated by calling the
 respective function in `scripts/cl/main.py` main function.


### PR DESCRIPTION
## What is the purpose of the change

This update addresses a small typo in the codebase where "liqudity" was used instead of the correct spelling "**liquidity**." The error has been corrected to ensure consistency and clarity throughout the project.
This fix doesn't affect any functionality but ensures better readability and professionalism in the code.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A