### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,11 @@ jobs:
       - name: Build osmosisd
         if: env.GIT_DIFF
         run: |
-          GOWRK=off go build cmd/osmosisd/main.go
+          GOWRK=off go build -o cmd/osmosisd/osmosisd cmd/osmosisd/main.go
       - name: Upload osmosisd artifact
         if: env.GIT_DIFF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: osmosisd-${{ matrix.targetos }}-${{ matrix.arch }}
+          overwrite: true
           path: cmd/osmosisd/osmosisd


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR aims to solve two problems:
1. "Build osmosisd" is creating artifact named `main`, making `Upload osmosisd artifact` has nothing to upload, for example in https://github.com/osmosis-labs/osmosis/actions/runs/12410803689, this PR adds `-o cmd/osmosisd/osmosisd` to make sure it's built in specified location.
![](https://github.com/user-attachments/assets/ac062c11-204e-446c-91c3-4508c988d59d)
2. `Upload osmosisd artifact` is using `actions/upload-artifact@v3`, which is deprecated now.

https://github.com/actions/upload-artifact

> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024.

PR is made according to migration note at https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md.

## Testing and Verifying

This PR is CI related so it seems no need for testing and verifying on code.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A