### PR TITLE
code-Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ ARG GIT_COMMIT
 ARG BUILD_TAGS
 
 RUN apk add --no-cache \
-    ca-certificates \
+    binutils-gold \
     build-base \
-    linux-headers \
-    binutils-gold
+    ca-certificates \
+    linux-headers
+
 
 # Download go dependencies
 WORKDIR /osmosis


### PR DESCRIPTION
# Fix: Sorted package names alphanumerically in Dockerfile

## Changes
- Sorted package names in the `RUN apk add` command to follow best practices and improve maintainability.

  - **Before**:
    ```dockerfile
    RUN apk add --no-cache \
        ca-certificates \
        build-base \
        linux-headers \
        binutils-gold
    ```

  - **After**:
    ```dockerfile
    RUN apk add --no-cache \
        binutils-gold \
        build-base \
        ca-certificates \
        linux-headers
    ```

## Purpose
- Improved readability and maintainability of the Dockerfile by sorting package names alphabetically.
- Resolved SonarQube warning regarding unsorted package names.
