### PR TITLE
Fix typos in documentation

### DIFF
--- a/networks/genesis-validators.md
+++ b/networks/genesis-validators.md
@@ -275,7 +275,7 @@ osmosisd gentx <key_name> 1000000uosmo \
   --chain-id="osmosis-1" \
   --moniker=osmosiswhale \
   --website="https://osmosis.zone" \
-  --details="We love Osmossis" \
+  --details="We love Osmosis" \
   --commission-rate="0.1" \
   --commission-max-rate="0.20" \
   --commission-max-change-rate="0.01" \
@@ -586,7 +586,7 @@ Guide"](https://github.com/osmosis-labs/networks/blob/main/genesis-validators.md
 is a derivative of ["Agoric Validator
 Guide"](https://github.com/Agoric/agoric-sdk/wiki/Validator-Guide) used
 under [CC BY](http://creativecommons.org/licenses/by/4.0/). The Agoric
-validator gudie is itself is a derivative of ["Validating Kava
+validator guide is itself is a derivative of ["Validating Kava
 Mainnet"](https://medium.com/kava-labs/validating-kava-mainnet-72fa1b6ea579)
 by [Kevin Davis](https://medium.com/@kevin_35106), used under [CC
 BY](http://creativecommons.org/licenses/by/4.0/). "Osmosis Validator

--- a/simulation/simtypes/randmanager_test.go
+++ b/simulation/simtypes/randmanager_test.go
@@ -35,7 +35,7 @@ func randInstancesEqual(rands []*rand.Rand) bool {
 func TestRandManagerGetRandIndependence(t *testing.T) {
 	rms := getKDefaultRandManager(3)
 	expectedEqualRands := []*rand.Rand{}
-	// We want to test that in each of the the following three scenarios, r2 is equal:
+	// We want to test that in each of the following three scenarios, r2 is equal:
 	// 1) r1 := rm.GetRand(); r2 := rm.GetRand();
 	// 2) r1 := rm.GetRand(); r2 := rm.GetRand(); _ = r1.Int()
 	// 3) r1 := rm.GetRand(); r1.Int(); r2 := rm.GetRand();
@@ -62,7 +62,7 @@ func TestRandManagerGetRandIndependence(t *testing.T) {
 func TestRandManagerSameSeedGetSeededRand(t *testing.T) {
 	rms := getKDefaultRandManager(3)
 	seed := "test seed"
-	// We want to test that in each of the the following three scenarios, we generated the same 'trace' of values.
+	// We want to test that in each of the following three scenarios, we generated the same 'trace' of values.
 	// 1) r1 := rm.GetSeededRand(seed); r1.Int(); r2 := rm.GetSeededRand(seed); r2.Int();
 	// 2) r1 := rm.GetSeededRand(seed); r2 := rm.GetSeededRand(seed); r1.Int(); r2.Int();
 	// 3) r1 := rm.GetSeededRand(seed); r2 := rm.GetSeededRand(seed); r2.Int(); r1.Int();

--- a/x/poolmanager/README.md
+++ b/x/poolmanager/README.md
@@ -518,7 +518,7 @@ Lets go through the lifecycle to better understand how taker fee works in a vari
 
 ### Example 1: Non OSMO taker fee
 
-A user makes a swap of USDC to OSMO. First, the protocol checks the KVStore to determine if the the denom pair has a taker fee override. If the pair exists in the KVStore, the taker fee override is used. If the pair does not exist, the defaultTakerFee is used. It is important to note that the order of the denom pair now matters, so if a denom pair taker fee override exists for OSMO to USDC but not USDC to OSMO, the default taker fee will instead be used.
+A user makes a swap of USDC to OSMO. First, the protocol checks the KVStore to determine if the denom pair has a taker fee override. If the pair exists in the KVStore, the taker fee override is used. If the pair does not exist, the defaultTakerFee is used. It is important to note that the order of the denom pair now matters, so if a denom pair taker fee override exists for OSMO to USDC but not USDC to OSMO, the default taker fee will instead be used.
 
 In this example, defaultTakerFee is 0.02%. A USDC->OSMO KVStore exists with an override of 0.01%. Therefore, 0.01% is used.
 


### PR DESCRIPTION


Changes Made:

1. networks/genesis-validators.md:
- Fixed: "Osmossis" → "Osmosis" in example command
- Fixed: "gudie" → "guide" in license section

Reason:
These documentation-only fixes improve readability and maintain consistent project name spelling throughout the docs. No functional code changes.