### PR TITLE
fix untracked tokenfactory ibc-rate-limit inflow

### DIFF
--- a/x/ibc-rate-limit/contracts/rate-limiter/src/packet.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/packet.rs
@@ -159,6 +159,9 @@ impl Packet {
             if split[0] == unprefixed {
                 // This is a native token. Return the unprefixed token
                 unprefixed.to_string()
+            } else if split[0] == "factory" {
+                // This is a tokenfactory token
+                split.join("/")
             } else {
                 // This is a non-native that was sent to the counterparty.
                 // We need to hash it.
@@ -275,6 +278,18 @@ pub mod tests {
             0_u128.into(),
         );
         assert_eq!(packet.local_denom(&FlowType::In), "uosmo");
+    }
+
+    #[test]
+    fn receive_tokenfactory_token() {
+        // The counterparty chain sends us back our native token that they had wrapped
+        let packet = Packet::mock(
+            "channel-42-counterparty".to_string(), // The counterparty's channel is the source here
+            "channel-17-local".to_string(),        // Our channel is the dest channel
+            "transfer/channel-42-counterparty/factory/osmo1em6xs47hd82806f5cxgyufguxrrc7l0aqx7nzzptjuqgswczk8csavdxek/alloyed/allUSDT".to_string(),
+            0_u128.into(),
+        );
+        assert_eq!(packet.local_denom(&FlowType::In), "factory/osmo1em6xs47hd82806f5cxgyufguxrrc7l0aqx7nzzptjuqgswczk8csavdxek/alloyed/allUSDT");
     }
 
     // Let's assume we have two chains A and B (local and counterparty) connected in the following way:


### PR DESCRIPTION
## What is the purpose of the change

Recv denom doesn't detect tokenfactory token as native and hashed it as ibc token so inflow is untracked. This PR fixes it.