### PR TITLE
Update .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,19 +66,90 @@ builds:
       - muslc
       - osusergo
 
+  - id: osmosisd-darwin-amd64
+    main: ./cmd/osmosisd/main.go
+    binary: osmosisd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    env:
+      - CC=o64-clang
+      - CGO_LDFLAGS=-L/lib
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+      - -w -s
+      - -linkmode=external
+    tags:
+      - netgo
+      - ledger
+      - static_wasm
+
+  - id: osmosisd-darwin-arm64
+    main: ./cmd/osmosisd/main.go
+    binary: osmosisd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    env:
+      - CC=oa64-clang
+      - CGO_LDFLAGS=-L/lib
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=osmosisd
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+      - -w -s
+      - -linkmode=external
+    tags:
+      - netgo
+      - ledger
+      - static_wasm
+
+universal_binaries:
+  - id: osmosisd-darwin-universal
+    ids:
+      - osmosisd-darwin-amd64
+      - osmosisd-darwin-arm64
+    replace: false
+
 archives:
   - id: zipped
     builds:
+      - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
+      - osmosisd-darwin-amd64
+      - osmosisd-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     files:
       - none*
   - id: binaries
     builds:
+      - osmosisd-darwin-universal
       - osmosisd-linux-amd64
       - osmosisd-linux-arm64
+      - osmosisd-darwin-amd64
+      - osmosisd-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,7 +74,8 @@ builds:
         - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     env:
       - CC=o64-clang
-      - CGO_LDFLAGS=-L/lib
+      - CGO_CFLAGS=-mmacosx-version-min=10.12
+      - CGO_LDFLAGS=-L/lib -mmacosx-version-min=10.12
     goos:
       - darwin
     goarch:


### PR DESCRIPTION
## What is the purpose of the change

This pull request updates the `.goreleaser.yaml` configuration to improve support for building osmosisd on macOS, including both amd64 and arm64 architectures. 

It introduces the following changes:

- Adds new build configurations for: `osmosisd-darwin-amd64`, `osmosisd-darwin-arm64`
- Introduces a universal binary for macOS (`osmosisd-darwin-universal`) that combines amd64 and arm64.

## Testing and Verifying

Tested locally.

To replicate:

```bash
# cd /path/to/osmosis/repo
git checkout v28.0.1 
make release-snapshot
```

Goreleaser output : https://pastebin.com/raw/DbKh5R1V 

There are some linking warning on darwin that I am trying to address. 

```bash
ld: warning: object file (/lib/libwasmvmstatic_darwin.a(gimli-3aee6fc6c4f36d9b.gimli.769b31d871e5515-cgu.14.rcgu.o)) was built for newer macOS version (10.12) than being linked (10.9)
ld: warning: object file (/lib/libwasmvmstatic_darwin.a(gimli-3aee6fc6c4f36d9b.gimli.769b31d871e5515-cgu.12.rcgu.o)) was built for newer macOS version (10.12) than being linked (10.9)
ld: warning: object file (/lib/libwasmvmstatic_darwin.a(once_cell-afbaf97cf3763645.once_cell.cbfb600dc59cf680-cgu.1.rcgu.o)) was built for newer macOS version (10.12) than being linked (10.9)
```


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A