### PR TITLE
Raise timeout in check-state-compatibility to 30 min

### DIFF
--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -81,7 +81,7 @@ jobs:
   check_state_compatibility:
     runs-on: buildjet-4vcpu-ubuntu-2204
     needs: compare_versions
-    timeout-minutes: 20
+    timeout-minutes: 30
     if: ${{ needs.compare_versions.outputs.should_i_run == 'true'}}
     steps:
       - name: Get chain major version


### PR DESCRIPTION
## What is the purpose of the change

This PR raises the timeout of the state compatibility check CI pipeline to 30 minutes to avoid timeout

## Testing and Verifying

This will be tested live post merge
