### PR TITLE
cli: rename begin-unlock-tokens command to unlock-all

### DIFF
--- a/x/lockup/client/cli/tx.go
+++ b/x/lockup/client/cli/tx.go
@@ -31,10 +31,10 @@ func NewLockTokensCmd() (*osmocli.TxCliDesc, *types.MsgLockTokens) {
 	}, &types.MsgLockTokens{}
 }
 
-// TODO: We should change the Use string to be unlock-all
+// NewBeginUnlockingAllCmd unlocks all tokens from lockup pool for sender.
 func NewBeginUnlockingAllCmd() (*osmocli.TxCliDesc, *types.MsgBeginUnlockingAll) {
 	return &osmocli.TxCliDesc{
-		Use:   "begin-unlock-tokens",
+		Use:   "unlock-all",
 		Short: "begin unlock not unlocking tokens from lockup pool for sender",
 	}, &types.MsgBeginUnlockingAll{}
 }


### PR DESCRIPTION
### What is the purpose of the change
This pull request improves the CLI interface in the lockup module by making the command name more intuitive and consistent with its functionality. The command begin-unlock-tokens has been renamed to unlock-all to better reflect its purpose - unlocking all tokens from the lockup pool for the sender.
The change includes:
- Updating the Use string in NewBeginUnlockingAllCmd
- Adding a more descriptive function comment
- Removing the related TODO comment
This change makes the CLI interface more user-friendly and self-explanatory, improving the overall developer experience.
### Testing and Verifying
This change is a trivial rework / code cleanup without any test coverage.
The change only affects the command name string and documentation, not the underlying functionality. The existing integration tests will continue to work as the message type and handler remain unchanged.
### Documentation and Release Note
- [x] Does this pull request introduce a new feature or user-facing behavior changes? (Yes - CLI command name change)
- [x] Changelog entry added to Unreleased section of CHANGELOG.md?
Where is the change documented?
- [x] Code comments
- [ ] Specification (x/{module}/README.md) (N/A - simple CLI command rename)
- [ ] Osmosis documentation site (N/A - simple CLI command rename)
- [ ] N/A