### PR TITLE
fix: forceprune logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+* [#8978](https://github.com/osmosis-labs/osmosis/pull/8895) fix: forceprune logic
+
+## v28.0.3
+
+### State Breaking
+
+### State Compatible
+
+* [#8968](https://github.com/osmosis-labs/osmosis/pull/8968) fix: use forked block-sdk patch
 * [#8895](https://github.com/osmosis-labs/osmosis/pull/8895) (xcs) feat: support XCS final hop memos
 
 ## v28.0.2

--- a/cmd/osmosisd/cmd/forceprune.go
+++ b/cmd/osmosisd/cmd/forceprune.go
@@ -74,7 +74,7 @@ which would keep blockchain and state data of last 188000 blocks (approximately 
 				return err
 			}
 
-			startHeight, currentHeight, err := pruneBlockStoreAndGetHeights(dbPath, fullHeight)
+			startHeight, currentHeight, err := pruneBlockStoreAndGetHeights(clientCtx.HomeDir, dbPath, fullHeight)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ which would keep blockchain and state data of last 188000 blocks (approximately 
 }
 
 // pruneBlockStoreAndGetHeights prunes blockstore and returns the startHeight and currentHeight.
-func pruneBlockStoreAndGetHeights(dbPath string, fullHeight int64) (
+func pruneBlockStoreAndGetHeights(homeDir, dbPath string, fullHeight int64) (
 	startHeight int64, currentHeight int64, err error,
 ) {
 	opts := opt.Options{
@@ -119,6 +119,7 @@ func pruneBlockStoreAndGetHeights(dbPath string, fullHeight int64) (
 	currentHeight = bs.Height()
 
 	defaultConfig := cmtcfg.DefaultConfig()
+	defaultConfig.SetRoot(homeDir)
 
 	stateDB, err := cmtcfg.DefaultDBProvider(&cmtcfg.DBContext{ID: "state", Config: defaultConfig})
 	if err != nil {
@@ -128,6 +129,7 @@ func pruneBlockStoreAndGetHeights(dbPath string, fullHeight int64) (
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 		DiscardABCIResponses: defaultConfig.Storage.DiscardABCIResponses,
 	})
+	defer stateStore.Close()
 
 	// Can use blank string for genesis file since state will not be empty if we are pruning, and therefore is not used.
 	state, err := stateStore.LoadFromDBOrGenesisFile("")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixes the `osmosisd forceprune` command

### How to test

- run `osmosisd forceprune` on main => see error
- run `osmosisd forceprune` on this branch => fixed