### PR TITLE
Typos fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,7 +831,7 @@ Fixes mainnet bugs w/ incorrect accumulation sumtrees, and CL handling for a bal
 
 * [#5534](https://github.com/osmosis-labs/osmosis/pull/5534) fix: fix the account number of x/tokenfactory module account
 * [#5750](https://github.com/osmosis-labs/osmosis/pull/5750) feat: add cli command for converting proto structs to proto marshalled bytes
-* [#5889](https://github.com/osmosis-labs/osmosis/pull/5889) provides an API for protorev to determine max amountIn that can be swapped based on max ticks willing to be traversed
+* [#5889](https://github.com/osmosis-labs/osmosis/pull/5889) provides an API for protorev to determine max amounting, amount in that can be swapped based on max ticks willing to be traversed
 * [#5849](https://github.com/osmosis-labs/osmosis/pull/5849) CL: Lower gas for leaving a position and withdrawing rewards
 * [#5855](https://github.com/osmosis-labs/osmosis/pull/5855) feat(x/cosmwasmpool): Sending token_in_max_amount to the contract before running contract msg
 * [#5893](https://github.com/osmosis-labs/osmosis/pull/5893) Export createPosition method in CL so other modules can use it in testing


### PR DESCRIPTION
### Changes

1. **File:** `/CHANGELOG.md`
    - Fixed `amountIn` to `amounting, amount in` (Line 834)
1. **File:** `/client/docs/statik/statik.go`
    - Fixed `jsUT` to `just` (Line 11)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.