### PR TITLE
Fix goreleaser cross missing image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ E2E_UPGRADE_VERSION := "v29"
 
 # Go version to be used in docker images
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+GO_MAJOR_MINOR := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2 | cut -d '.' -f 1-2)
 # currently installed Go version
 GO_MODULE := $(shell cat go.mod | grep "module " | cut -d ' ' -f 2)
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
@@ -211,7 +212,7 @@ go-mock-update:
 ###############################################################################
 ###                                Release                                  ###
 ###############################################################################
-GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
+GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_MAJOR_MINOR)
 COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')
 
 ifdef GITHUB_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,17 @@ release:
 	@echo "Error: GITHUB_TOKEN is not defined. Please define it before running 'make release'."
 endif
 
+release-test:
+	docker run \
+		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/osmosisd \
+		-w /go/src/osmosisd \
+		$(GORELEASER_IMAGE) \
+		release \
+		--snapshot --clean
+
 .PHONY: all build-linux install format lint \
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \
 	test test-all test-build test-cover test-unit test-race benchmark \


### PR DESCRIPTION
## What is the purpose of the change

This fixes this error we see in CI releases with goreleaser:

```
Unable to find image 'ghcr.io/goreleaser/goreleaser-cross:v1.22.11' locally
docker: Error response from daemon: manifest unknown.
See 'docker run --help'.
make: *** [Makefile:219: release] Error 125
```

## Testing and Verifying
Tested with `release-test` target.
