### PR TITLE
fix: fixed improper character removal when using -r with jq

### DIFF
--- a/scripts/empty_upgrade_handler_gen.sh
+++ b/scripts/empty_upgrade_handler_gen.sh
@@ -29,9 +29,8 @@ UPGRADES_FILE=$new_file/upgrades.go
 touch $CONSTANTS_FILE
 touch $UPGRADES_FILE
 
-module=$(go mod edit -json | jq ".Module.Path")
-module=${module%?}
-path=${module%???}
+module=$(go mod edit -json | jq -r ".Module.Path")
+path=$module
 
 bracks='"'
 # set packages


### PR DESCRIPTION
## **Description:**  
I noticed that using `-r` with `jq` strips quotes correctly, making the additional `${module%?}` and `${module%???}` manipulations unnecessary. This update removes those extra character deletions to ensure accurate output handling.  

## What is the purpose of the change  
This change fixes an issue where characters were incorrectly removed from the output. Since `-r` with `jq` already handles quote removal, the additional string manipulations are redundant and can cause incorrect results.  

## Testing and Verifying  
Manually verified the output with and without the fix using various input cases. The output is now accurate, with no unintended character loss.  

## Documentation and Release Note  

- [ ] Does this pull request introduce a new feature or user-facing behavior changes?  
- [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?  

Where is the change documented?  
- [ ] Specification (`x/{module}/README.md`)  
- [ ] Osmosis documentation site  
- [ ] Code comments?  
- [x] N/A