### PR TITLE
Bound the number of lockups that can be opened / block

### DIFF
--- a/x/lockup/abci.go
+++ b/x/lockup/abci.go
@@ -12,16 +12,21 @@ import (
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 }
 
+var (
+	numLocksToDelete = 1_000
+)
+
 // Called every block to automatically unlock matured locks.
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) []abci.ValidatorUpdate {
-	if ctx.BlockHeight()%30 == 0 {
+	if ctx.BlockHeight()%120 == 0 {
 		// TODO: Change this logic to "know" when the next unbonding time is, and only unlock at that time.
 		// At each unbond, do an iterate to find the next unbonding time and wait until then.
 		// delete synthetic locks matured before lockup deletion
 		k.DeleteAllMaturedSyntheticLocks(ctx)
 
-		// withdraw and delete locks
-		k.WithdrawAllMaturedLocks(ctx)
+		// withdraw and delete locks. Requires the corresponding synthetic locks to be deleted.
+		// This is guaranteed, as we delete _ALL_ synthetic locks before withdrawing a bounded number of native locks.
+		k.WithdrawMaturedLocks(ctx, numLocksToDelete)
 	}
 	return []abci.ValidatorUpdate{}
 }

--- a/x/lockup/keeper/grpc_query_test.go
+++ b/x/lockup/keeper/grpc_query_test.go
@@ -21,7 +21,7 @@ func (s *KeeperTestSuite) BeginUnlocking(addr sdk.AccAddress) {
 }
 
 func (s *KeeperTestSuite) WithdrawAllMaturedLocks() {
-	s.querier.WithdrawAllMaturedLocks(s.Ctx)
+	s.querier.WithdrawMaturedLocks(s.Ctx, 0)
 }
 
 func (s *KeeperTestSuite) TestModuleBalance() {

--- a/x/lockup/keeper/iterator.go
+++ b/x/lockup/keeper/iterator.go
@@ -194,13 +194,18 @@ func (k Keeper) getLocksFromIterator(ctx sdk.Context, iterator db.Iterator) []ty
 }
 
 // unlockFromIterator gets locks from the iterator, then unlocks all matured locks. Returns locks unlocked and sum of coins unlocked.
-func (k Keeper) unlockFromIterator(ctx sdk.Context, iterator db.Iterator) ([]types.PeriodLock, sdk.Coins) {
+func (k Keeper) unlockFromIterator(ctx sdk.Context, numToUnlock int, iterator db.Iterator) ([]types.PeriodLock, sdk.Coins) {
 	// Note: this function is only used for an account
 	// and this has no conflicts with synthetic lockups
 
 	coins := sdk.Coins{}
 	locks := k.getLocksFromIterator(ctx, iterator)
+	count := 0
 	for _, lock := range locks {
+		if numToUnlock > 0 && count >= numToUnlock {
+			break
+		}
+		count++
 		err := k.UnlockMaturedLock(ctx, lock.ID)
 		if err != nil {
 			panic(err)

--- a/x/lockup/keeper/lock.go
+++ b/x/lockup/keeper/lock.go
@@ -20,10 +20,10 @@ import (
 	"github.com/osmosis-labs/osmosis/v29/x/lockup/types"
 )
 
-// WithdrawAllMaturedLocks withdraws every lock that's in the process of unlocking, and has finished unlocking by
+// WithdrawMaturedLocks withdraws `numToWithdraw` locks that are the process of unlocking, and has finished unlocking by
 // the current block time.
-func (k Keeper) WithdrawAllMaturedLocks(ctx sdk.Context) {
-	k.unlockFromIterator(ctx, k.LockIteratorBeforeTime(ctx, ctx.BlockTime()))
+func (k Keeper) WithdrawMaturedLocks(ctx sdk.Context, numToWithdraw int) {
+	k.unlockFromIterator(ctx, numToWithdraw, k.LockIteratorBeforeTime(ctx, ctx.BlockTime()))
 }
 
 // GetModuleBalance returns full balance of the module.

--- a/x/lockup/keeper/lock_test.go
+++ b/x/lockup/keeper/lock_test.go
@@ -1145,14 +1145,14 @@ func (s *KeeperTestSuite) TestEndblockerWithdrawAllMaturedLockups() {
 	setupInitLocks()
 
 	// try withdrawing before mature
-	s.App.LockupKeeper.WithdrawAllMaturedLocks(s.Ctx)
+	s.App.LockupKeeper.WithdrawMaturedLocks(s.Ctx, 0)
 	locks, err := s.App.LockupKeeper.GetPeriodLocks(s.Ctx)
 	s.Require().NoError(err)
 	s.Require().Len(locks, 3)
 
 	// withdraw at 1 sec, 3 sec, and 5 sec intervals, check automatically withdrawn
 	for i := 0; i < len(times); i++ {
-		s.App.LockupKeeper.WithdrawAllMaturedLocks(s.Ctx.WithBlockTime(unbondBlockTimes[i]))
+		s.App.LockupKeeper.WithdrawMaturedLocks(s.Ctx.WithBlockTime(unbondBlockTimes[i]), 0)
 		locks, err = s.App.LockupKeeper.GetPeriodLocks(s.Ctx)
 		s.Require().NoError(err)
 		s.Require().Len(locks, len(times)-i-1)
@@ -1170,7 +1170,7 @@ func (s *KeeperTestSuite) TestEndblockerWithdrawAllMaturedLockups() {
 	s.SetupTest()
 	setupInitLocks()
 	// now withdraw all locks and ensure all got withdrawn
-	s.App.LockupKeeper.WithdrawAllMaturedLocks(s.Ctx.WithBlockTime(unbondBlockTimes[len(times)-1]))
+	s.App.LockupKeeper.WithdrawMaturedLocks(s.Ctx.WithBlockTime(unbondBlockTimes[len(times)-1]), 0)
 	s.Require().Len(locks, 0)
 }
 

--- a/x/superfluid/keeper/stake_test.go
+++ b/x/superfluid/keeper/stake_test.go
@@ -653,7 +653,7 @@ func (s *KeeperTestSuite) TestSuperfluidUnbondLock() {
 
 		// check that SuperfluidUnbondLock makes underlying lock start unlocking
 		// we run WithdrawAllMaturedLocks to ensure that lock isn't getting finished immediately
-		s.App.LockupKeeper.WithdrawAllMaturedLocks(s.Ctx)
+		s.App.LockupKeeper.WithdrawMaturedLocks(s.Ctx, 0)
 		updatedLock, err := s.App.LockupKeeper.GetLockByID(s.Ctx, lock.ID)
 		s.Require().NoError(err)
 		s.Require().True(updatedLock.IsUnlocking())
@@ -665,7 +665,7 @@ func (s *KeeperTestSuite) TestSuperfluidUnbondLock() {
 		// test that synth lock finish does not mean underlying lock is finished
 		s.Ctx = s.Ctx.WithBlockTime((startTime.Add(unbondingDuration)))
 		s.App.LockupKeeper.DeleteAllMaturedSyntheticLocks(s.Ctx)
-		s.App.LockupKeeper.WithdrawAllMaturedLocks(s.Ctx)
+		s.App.LockupKeeper.WithdrawMaturedLocks(s.Ctx, 0)
 		_, err = s.App.LockupKeeper.GetSyntheticLockup(s.Ctx, lock.ID, keeper.UnstakingSyntheticDenom(lock.Coins[0].Denom, valAddr))
 		s.Require().Error(err)
 		updatedLock, err = s.App.LockupKeeper.GetLockByID(s.Ctx, lock.ID)
@@ -674,7 +674,7 @@ func (s *KeeperTestSuite) TestSuperfluidUnbondLock() {
 
 		// test after SuperfluidUnbondLock + lockup unbonding duration, lock is finished and does not exist
 		s.Ctx = s.Ctx.WithBlockTime(unbondLockStartTime.Add(unbondingDuration))
-		s.App.LockupKeeper.WithdrawAllMaturedLocks(s.Ctx)
+		s.App.LockupKeeper.WithdrawMaturedLocks(s.Ctx, 0)
 		_, err = s.App.LockupKeeper.GetLockByID(s.Ctx, lock.ID)
 		s.Require().Error(err)
 


### PR DESCRIPTION
This PR limits the number of lockups that can be opened in a single block, within the EndBlock logic