### PR TITLE
Prototype a pool cache for CL

### DIFF
--- a/osmoutils/conv_helper.go
+++ b/osmoutils/conv_helper.go
@@ -1,15 +1,8 @@
 package osmoutils
 
 import (
-	"encoding/binary"
 	"strconv"
 )
-
-func Uint64ToBytes(i uint64) []byte {
-	key := make([]byte, 8)
-	binary.LittleEndian.PutUint64(key, i)
-	return key
-}
 
 func Uint64ToString(i uint64) string {
 	return strconv.FormatUint(i, 10)

--- a/osmoutils/store_helper.go
+++ b/osmoutils/store_helper.go
@@ -153,13 +153,13 @@ func noStopFn([]byte) bool {
 
 // MustSet runs store.Set(key, proto.Marshal(value))
 // but panics on any error.
-func MustSet(storeObj storetypes.KVStore, key []byte, value proto.Message) {
+func MustSet(store storetypes.KVStore, key []byte, value proto.Message) {
 	bz, err := proto.Marshal(value)
 	if err != nil {
 		panic(err)
 	}
 
-	storeObj.Set(key, bz)
+	store.Set(key, bz)
 }
 
 // MustGet gets key from store by mutating result
@@ -252,6 +252,17 @@ func GetWithCache(store storetypes.KVStore, key []byte, cache *lru.Cache, result
 	cache.Add(cacheKey, clone)
 
 	return true, nil
+}
+func SetWithCache(store storetypes.KVStore, key []byte, cache *lru.Cache, value proto.Message) {
+	bz, err := proto.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+
+	// TODO: Use unsafe string conversion to avoid allocation
+	cache.Add(string(bz), proto.Clone(value))
+
+	store.Set(key, bz)
 }
 
 // DeleteAllKeysFromPrefix deletes all store records that contains the given prefixKey.

--- a/x/concentrated-liquidity/keeper.go
+++ b/x/concentrated-liquidity/keeper.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v29/x/concentrated-liquidity/types"
+
+	lru "github.com/hashicorp/golang-lru"
 )
 
 type Keeper struct {
@@ -29,6 +31,8 @@ type Keeper struct {
 	lockupKeeper         types.LockupKeeper
 	communityPoolKeeper  types.CommunityPoolKeeper
 	contractKeeper       types.ContractKeeper
+
+	poolCache map[uint64]*lru.Cache
 }
 
 func NewKeeper(cdc codec.BinaryCodec, storeKey storetypes.StoreKey, accountKeeper types.AccountKeeper, bankKeeper types.BankKeeper, gammKeeper types.GAMMKeeper, poolIncentivesKeeper types.PoolIncentivesKeeper, incentivesKeeper types.IncentivesKeeper, lockupKeeper types.LockupKeeper, communityPoolKeeper types.CommunityPoolKeeper, contractKeeper types.ContractKeeper, paramSpace paramtypes.Subspace) *Keeper {
@@ -48,6 +52,8 @@ func NewKeeper(cdc codec.BinaryCodec, storeKey storetypes.StoreKey, accountKeepe
 		lockupKeeper:         lockupKeeper,
 		communityPoolKeeper:  communityPoolKeeper,
 		contractKeeper:       contractKeeper,
+
+		poolCache: make(map[uint64]*lru.Cache),
 	}
 }
 

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -18,6 +18,8 @@ import (
 	types "github.com/osmosis-labs/osmosis/v29/x/concentrated-liquidity/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v29/x/lockup/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v29/x/poolmanager/types"
+
+	lru "github.com/hashicorp/golang-lru"
 )
 
 // InitializePool initializes a new concentrated liquidity pool with the given PoolI interface and creator address.
@@ -112,6 +114,18 @@ func (k Keeper) GetPool(ctx sdk.Context, poolId uint64) (poolmanagertypes.PoolI,
 		return nil, err
 	}
 	return poolI, nil
+}
+
+func (k Keeper) getPoolLruCache(ctx sdk.Context, poolId uint64) *lru.Cache {
+	cache, ok := k.poolCache[poolId]
+	if !ok {
+		cache, err := lru.New(5)
+		if err != nil {
+			panic(err)
+		}
+		k.poolCache[poolId] = cache
+	}
+	return cache
 }
 
 // getPoolById returns a concentratedPoolExtension that corresponds to the requested pool id. Returns error if pool id is not found.

--- a/x/concentrated-liquidity/pool.go
+++ b/x/concentrated-liquidity/pool.go
@@ -133,7 +133,8 @@ func (k Keeper) getPoolById(ctx sdk.Context, poolId uint64) (types.ConcentratedP
 	store := ctx.KVStore(k.storeKey)
 	pool := model.Pool{}
 	key := types.KeyPool(poolId)
-	found, err := osmoutils.Get(store, key, &pool)
+	cache := k.getPoolLruCache(ctx, poolId)
+	found, err := osmoutils.GetWithCache(store, key, cache, &pool)
 	if err != nil {
 		panic(err)
 	}
@@ -165,7 +166,8 @@ func (k Keeper) setPool(ctx sdk.Context, pool types.ConcentratedPoolExtension) e
 	}
 	store := ctx.KVStore(k.storeKey)
 	key := types.KeyPool(pool.GetId())
-	osmoutils.MustSet(store, key, poolModel)
+	cache := k.getPoolLruCache(ctx, pool.GetId())
+	osmoutils.SetWithCache(store, key, cache, poolModel)
 	return nil
 }
 


### PR DESCRIPTION
This is likely not worth taking to production, as its an incremental speedup to blocksync. Used this as an example to try out claude code on a real codebase.

If successful, would speedup the state machine on my last profile (tbh a long time ago) by ~1%. This is primarily from eliminating protorev overheads. 