### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/app/apptesting/events.go
+++ b/app/apptesting/events.go
@@ -3,7 +3,7 @@ package apptesting
 import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // AssertEventEmitted asserts that ctx's event manager has emitted the given number of events

--- a/x/concentrated-liquidity/incentives.go
+++ b/x/concentrated-liquidity/incentives.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/osmoutils"


### PR DESCRIPTION
# Description
These experimental packages are now available in the Go standard library since Go 1.21 and Go 1.23:

`golang.org/x/exp/slices` -> slices [[https://go.dev/doc/go1.21#slices]](https://go.dev/doc/go1.21#slices)