### PR TITLE
Implement Taker Fee Burn Mechanism

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -134,6 +134,7 @@ var moduleAccountPermissions = map[string][]string{
 	txfeestypes.NonNativeTxFeeCollectorName:  nil,
 	txfeestypes.TakerFeeStakersName:          nil,
 	txfeestypes.TakerFeeCommunityPoolName:    nil,
+	txfeestypes.TakerFeeBurnName:             nil,
 	txfeestypes.TakerFeeCollectorName:        nil,
 	wasmtypes.ModuleName:                     {authtypes.Burner},
 	tokenfactorytypes.ModuleName:             {authtypes.Minter, authtypes.Burner},

--- a/proto/osmosis/poolmanager/v1beta1/genesis.proto
+++ b/proto/osmosis/poolmanager/v1beta1/genesis.proto
@@ -123,12 +123,20 @@ message TakerFeeDistributionPercentage {
     (gogoproto.moretags) = "yaml:\"community_pool\"",
     (gogoproto.nullable) = false
   ];
+  string burn = 3 [
+
+    (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
+    (gogoproto.moretags) = "yaml:\"burn\"",
+    (gogoproto.nullable) = false
+  ];
 }
 
 message TakerFeesTracker {
   repeated cosmos.base.v1beta1.Coin taker_fees_to_stakers = 1
       [ (gogoproto.nullable) = false ];
   repeated cosmos.base.v1beta1.Coin taker_fees_to_community_pool = 2
+      [ (gogoproto.nullable) = false ];
+  repeated cosmos.base.v1beta1.Coin taker_fees_burned = 4
       [ (gogoproto.nullable) = false ];
   int64 height_accounting_starts_from = 3
       [ (gogoproto.moretags) = "yaml:\"height_accounting_starts_from\"" ];

--- a/x/poolmanager/protorev.go
+++ b/x/poolmanager/protorev.go
@@ -43,6 +43,23 @@ func (k Keeper) UpdateTakerFeeTrackerForCommunityPoolByDenom(ctx sdk.Context, de
 	return osmoutils.IncreaseCoinByDenomFromPrefix(ctx, k.storeKey, types.KeyTakerFeeCommunityPoolProtoRevArray, denom, increasedAmt)
 }
 
+// GetTakerFeeTrackerForBurn returns the taker fee for burn tracker for all denoms that has been
+// collected since the accounting height.
+func (k Keeper) GetTakerFeeTrackerForBurn(ctx sdk.Context) []sdk.Coin {
+	return osmoutils.GetCoinArrayFromPrefix(ctx, k.storeKey, types.KeyTakerFeeBurnProtoRevArray)
+}
+
+// GetTakerFeeTrackerForBurnByDenom returns the taker fee for burn tracker for the specified denom that has been
+// collected since the accounting height. If the denom is not found, a zero coin is returned.
+func (k Keeper) GetTakerFeeTrackerForBurnByDenom(ctx sdk.Context, denom string) (sdk.Coin, error) {
+	return osmoutils.GetCoinByDenomFromPrefix(ctx, k.storeKey, types.KeyTakerFeeBurnProtoRevArray, denom)
+}
+
+// UpdateTakerFeeTrackerForBurnByDenom increases the take fee for burn tracker for the specified denom by the specified amount.
+func (k Keeper) UpdateTakerFeeTrackerForBurnByDenom(ctx sdk.Context, denom string, increasedAmt osmomath.Int) error {
+	return osmoutils.IncreaseCoinByDenomFromPrefix(ctx, k.storeKey, types.KeyTakerFeeBurnProtoRevArray, denom, increasedAmt)
+}
+
 // GetTakerFeeTrackerStartHeight gets the height from which we started accounting for taker fees.
 func (k Keeper) GetTakerFeeTrackerStartHeight(ctx sdk.Context) int64 {
 	startHeight := gogotypes.Int64Value{}

--- a/x/poolmanager/types/genesis.pb.go
+++ b/x/poolmanager/types/genesis.pb.go
@@ -302,6 +302,7 @@ func (m *TakerFeeParams) GetReducedFeeWhitelist() []string {
 type TakerFeeDistributionPercentage struct {
 	StakingRewards cosmossdk_io_math.LegacyDec `protobuf:"bytes,1,opt,name=staking_rewards,json=stakingRewards,proto3,customtype=cosmossdk.io/math.LegacyDec" json:"staking_rewards" yaml:"staking_rewards"`
 	CommunityPool  cosmossdk_io_math.LegacyDec `protobuf:"bytes,2,opt,name=community_pool,json=communityPool,proto3,customtype=cosmossdk.io/math.LegacyDec" json:"community_pool" yaml:"community_pool"`
+	Burn           cosmossdk_io_math.LegacyDec `protobuf:"bytes,3,opt,name=burn,proto3,customtype=cosmossdk.io/math.LegacyDec" json:"burn" yaml:"burn"`
 }
 
 func (m *TakerFeeDistributionPercentage) Reset()         { *m = TakerFeeDistributionPercentage{} }

--- a/x/poolmanager/types/keys.go
+++ b/x/poolmanager/types/keys.go
@@ -49,6 +49,9 @@ var (
 	// KeyTakerFeeCommunityPoolProtoRevArray defines key to store the taker fee for community pool tracker coin array.
 	KeyTakerFeeCommunityPoolProtoRevArray = []byte{0x09}
 
+	// KeyTakerFeeBurnProtoRevArray defines key to store the taker fee for burn tracker coin array.
+	KeyTakerFeeBurnProtoRevArray = []byte{0x0B}
+
 	// TakerFeeSkimAccrualPrefix defines the prefix to store taker fee skim accrual data.
 	TakerFeeSkimAccrualPrefix = []byte{0x0A}
 

--- a/x/txfees/types/expected_keepers.go
+++ b/x/txfees/types/expected_keepers.go
@@ -54,6 +54,7 @@ type PoolManager interface {
 	) (price osmomath.BigDec, err error)
 	UpdateTakerFeeTrackerForCommunityPoolByDenom(ctx sdk.Context, denom string, increasedAmt osmomath.Int) error
 	UpdateTakerFeeTrackerForStakersByDenom(ctx sdk.Context, denom string, increasedAmt osmomath.Int) error
+	UpdateTakerFeeTrackerForBurnByDenom(ctx sdk.Context, denom string, increasedAmt osmomath.Int) error
 	GetAllTakerFeeShareAccumulators(ctx sdk.Context) ([]poolmanagertypes.TakerFeeSkimAccumulator, error)
 	GetTakerFeeShareAgreementFromDenomNoCache(ctx sdk.Context, takerFeeShareDenom string) (poolmanagertypes.TakerFeeShareAgreement, bool)
 	DeleteAllTakerFeeShareAccumulatorsForTakerFeeShareDenom(ctx sdk.Context, takerFeeShareDenom string)

--- a/x/txfees/types/keys.go
+++ b/x/txfees/types/keys.go
@@ -25,6 +25,11 @@ const (
 	// This is done so that, in the event of a failed swap, the funds slated for stakers are not grouped back with the rest of the taker fees in the next epoch.
 	TakerFeeStakersName = "non_native_fee_collector_stakers"
 
+	// TakerFeeBurnName is the name of the module account that collects non-native taker fees, swaps, and sends them to the burn address.
+	// Note, all taker fees initially get sent to the TakerFeeCollectorName, and then prior to the taker fees slated for burning being swapped and sent to burn address, they are sent to this account.
+	// This is done so that, in the event of a failed swap, the funds slated for burning are not grouped back with the rest of the taker fees in the next epoch.
+	TakerFeeBurnName = "non_native_fee_collector_burn"
+
 	// TakerFeeCollectorName is the module account name for the taker fee collector account address. It collects both native and non-native taker fees.
 	TakerFeeCollectorName = "taker_fee_collector"
 

--- a/x/txfees/types/telemetry.go
+++ b/x/txfees/types/telemetry.go
@@ -35,6 +35,13 @@ var (
 	// * match_denom - the match denom to swap to.
 	// * err - the error occurred
 	TakerFeeNoSkipRouteMetricName = formatTxFeesMetricName("takerfee_no_skip_route")
+	// txfees_takerfee_failed_burn_update
+	//
+	// counter that is increased if taker fee burn distribution fails
+	// Has the following labels:
+	// * coins - the coins that fail to be sent.
+	// * err - the error occurred
+	TakerFeeFailedBurnUpdateMetricName = formatTxFeesMetricName("takerfee_failed_burn_update")
 )
 
 // formatTxFeesMetricName formats the tx fees module metric name.


### PR DESCRIPTION
## What is the purpose of the change
This PR implements a new burn mechanism for taker fees as requested by the community. Currently, taker fees are distributed between staking rewards and the community pool. This change adds a third option to burn a portion of the taker fees by sending them to a null address, providing a more significant burn mechanism than the existing ProtoRev feature.
Closes #8921
## Key changes:
- Added "burn" field to the TakerFeeDistributionPercentage proto and Go structs
- Added taker_fees_burned field to TakerFeesTracker
- Added functions to track burned taker fees in the poolmanager module
- Created a new TakerFeeBurnName module account for handling non-whitelisted taker fees
- Updated the fee distribution logic in hooks.go to handle burning of:
- - OSMO taker fees
- - Whitelisted non-OSMO taker fees
- - Non-whitelisted non-OSMO taker fees (with swapping to OSMO first)
## Testing and Verifying
This change can be verified as follows:
- Unit tests can be added to test the burn mechanism by setting a burn percentage in the parameters and verifying tokens are sent to the null address
- Integration tests can verify that the correct amounts are burned during epoch distribution
- Manually verified by setting up a local testnet, configuring taker fee distribution params with a burn portion, and verifying the funds are properly sent to the null address
## Documentation and Release Note
- [x] Does this pull request introduce a new feature or user-facing behavior changes?
- [x] Changelog entry added to Unreleased section of CHANGELOG.md?
## Where is the change documented?
- [x] Specification (x/poolmanager/README.md) - Documentation will be updated to describe the burn mechanism
- [ ] Osmosis documentation site
- [x] Code comments? - Added comments explaining the burn mechanism implementation
- [ ] N/A