### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/x/lockup/keeper/genesis_test.go
+++ b/x/lockup/keeper/genesis_test.go
@@ -145,11 +145,7 @@ func TestExportGenesis(t *testing.T) {
 
 func TestMarshalUnmarshalGenesis(t *testing.T) {
 	// Create a unique temporary directory for each test
-	dirName, err := os.MkdirTemp("", "osmoapp_test")
-	require.NoError(t, err)
-
-	// Ensure the directory is cleaned up after the test completes
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 
 	// Setup the app with the custom directory
 	app := osmoapp.SetupWithCustomHome(false, dirName)
@@ -171,8 +167,6 @@ func TestMarshalUnmarshalGenesis(t *testing.T) {
 	// Export genesis state
 	genesisExported := am.ExportGenesis(ctx, appCodec)
 
-	// After removing the temp directory, the app should no longer have access to it
-	os.RemoveAll(dirName)
 
 	// Ensure no panic occurs when initializing genesis in a fresh app
 	assert.NotPanics(t, func() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir



## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A