### PR TITLE
refactor(twap): implement strategy pattern for accumulator updates

### DIFF
--- a/x/twap/api.go
+++ b/x/twap/api.go
@@ -98,11 +98,11 @@ func (k Keeper) getTwap(
 	} else if endTime.After(ctx.BlockTime()) {
 		return osmomath.Dec{}, types.EndTimeInFutureError{EndTime: endTime, BlockTime: ctx.BlockTime()}
 	}
-	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom)
+	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom, strategy)
 	if err != nil {
 		return osmomath.Dec{}, err
 	}
-	endRecord, err := k.getInterpolatedRecord(ctx, poolId, endTime, baseAssetDenom, quoteAssetDenom)
+	endRecord, err := k.getInterpolatedRecord(ctx, poolId, endTime, baseAssetDenom, quoteAssetDenom, strategy)
 	if err != nil {
 		return osmomath.Dec{}, err
 	}
@@ -124,7 +124,7 @@ func (k Keeper) getTwapToNow(
 		return osmomath.Dec{}, types.StartTimeAfterEndTimeError{StartTime: startTime, EndTime: ctx.BlockTime()}
 	}
 
-	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom)
+	startRecord, err := k.getInterpolatedRecord(ctx, poolId, startTime, baseAssetDenom, quoteAssetDenom, strategy)
 	if err != nil {
 		return osmomath.Dec{}, err
 	}

--- a/x/twap/export_test.go
+++ b/x/twap/export_test.go
@@ -45,7 +45,11 @@ func (k Keeper) PruneRecordsBeforeTimeButNewest(ctx sdk.Context, state types.Pru
 }
 
 func (k Keeper) GetInterpolatedRecord(ctx sdk.Context, poolId uint64, asset0Denom string, asset1Denom string, t time.Time) (types.TwapRecord, error) {
-	return k.getInterpolatedRecord(ctx, poolId, t, asset0Denom, asset1Denom)
+	return k.getInterpolatedRecord(ctx, poolId, t, asset0Denom, asset1Denom, k.GetArithmeticStrategy())
+}
+
+func (k Keeper) GetInterpolatedRecordWithStrategy(ctx sdk.Context, poolId uint64, asset0Denom string, asset1Denom string, t time.Time, strategy TwapStrategy) (types.TwapRecord, error) {
+	return k.getInterpolatedRecord(ctx, poolId, t, asset0Denom, asset1Denom, strategy)
 }
 
 func ComputeTwap(startRecord types.TwapRecord, endRecord types.TwapRecord, quoteAsset string, strategy twapStrategy) (osmomath.Dec, error) {
@@ -62,6 +66,10 @@ func (s geometric) ComputeTwap(startRecord types.TwapRecord, endRecord types.Twa
 
 func RecordWithUpdatedAccumulators(record types.TwapRecord, t time.Time) types.TwapRecord {
 	return recordWithUpdatedAccumulators(record, t)
+}
+
+func UpdateAccumulatorsWithStrategy(record types.TwapRecord, t time.Time, strategy TwapStrategy) types.TwapRecord {
+	return strategy.updateAccumulators(record, t)
 }
 
 func NewTwapRecord(k types.PoolManagerInterface, ctx sdk.Context, poolId uint64, denom0, denom1 string) (types.TwapRecord, error) {


### PR DESCRIPTION
This commit refactors the TWAP module to use the strategy pattern more thoroughly for its accumulator updates. Previously, the strategy pattern was only used for TWAP computation but not for the accumulator updates.

Key changes:
- Add `updateAccumulators` method to the twapStrategy interface
- Implement strategy-specific accumulator update logic for both arithmetic and geometric strategies
- Modify `getInterpolatedRecord` to use the provided strategy's accumulator update method
- Update remaining code to use the appropriate strategy for accumulator updates
- Maintain backward compatibility in exported functions and existing code paths

With this change, geometric accumulator calculations are now only performed when using the geometric strategy, making the system more efficient by avoiding unnecessary calculations for the arithmetic strategy.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>

Closes: #7113 