### PR TITLE
refactor(gamm): change CalcOutAmtGivenIn to take sdk.Coin instead of sdk.Coins

### DIFF
--- a/tests/mocks/cfmm_pool.go
+++ b/tests/mocks/cfmm_pool.go
@@ -114,7 +114,7 @@ func (mr *MockCFMMPoolIMockRecorder) CalcJoinPoolShares(ctx, tokensIn, spreadFac
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
+func (m *MockCFMMPoolI) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -482,7 +482,7 @@ func (mr *MockPoolAmountOutExtensionMockRecorder) CalcJoinPoolShares(ctx, tokens
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
+func (m *MockPoolAmountOutExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)
@@ -907,7 +907,7 @@ func (mr *MockWeightedPoolExtensionMockRecorder) CalcJoinPoolShares(ctx, tokensI
 }
 
 // CalcOutAmtGivenIn mocks base method.
-func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
+func (m *MockWeightedPoolExtension) CalcOutAmtGivenIn(ctx types.Context, tokenIn types.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (types.Coin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcOutAmtGivenIn", ctx, tokenIn, tokenOutDenom, spreadFactor)
 	ret0, _ := ret[0].(types.Coin)

--- a/x/gamm/keeper/swap.go
+++ b/x/gamm/keeper/swap.go
@@ -158,7 +158,7 @@ func (k Keeper) CalcOutAmtGivenIn(
 	if err != nil {
 		return sdk.Coin{}, err
 	}
-	return cfmmPool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(tokenIn), tokenOutDenom, spreadFactor)
+	return cfmmPool.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, spreadFactor)
 }
 
 // CalcInAmtGivenOut calculates the amount of tokenIn given tokenOut and the pool's current state.

--- a/x/gamm/pool-models/internal/test_helpers/test_helpers.go
+++ b/x/gamm/pool-models/internal/test_helpers/test_helpers.go
@@ -50,7 +50,7 @@ func TestCalculateAmountOutAndIn_InverseRelationship(
 	// we expect that any output less than 1 will always be rounded up
 	require.True(t, actualTokenIn.Amount.GTE(osmomath.OneInt()))
 
-	inverseTokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(actualTokenIn), assetOutDenom, spreadFactor)
+	inverseTokenOut, err := pool.CalcOutAmtGivenIn(ctx, actualTokenIn, assetOutDenom, spreadFactor)
 	require.NoError(t, err)
 
 	require.Equal(t, initialOut.Denom, inverseTokenOut.Denom)
@@ -100,14 +100,14 @@ func TestSlippageRelationOutGivenIn(
 	fee := curPool.GetSpreadFactor(ctx)
 
 	curLiquidity := initLiquidity
-	curOutAmount, err := curPool.CalcOutAmtGivenIn(ctx, swapInAmt, swapOutDenom, fee)
+	curOutAmount, err := curPool.CalcOutAmtGivenIn(ctx, swapInAmt[0], swapOutDenom, fee)
 	require.NoError(t, err)
 	for i := 0; i < 50; i++ {
 		newLiquidity := curLiquidity.Add(curLiquidity...)
 		curPool = createPoolWithLiquidity(ctx, newLiquidity)
 
 		// ensure out amount goes down as liquidity increases
-		newOutAmount, err := curPool.CalcOutAmtGivenIn(ctx, swapInAmt, swapOutDenom, fee)
+		newOutAmount, err := curPool.CalcOutAmtGivenIn(ctx, swapInAmt[0], swapOutDenom, fee)
 		require.NoError(t, err)
 		require.True(t, newOutAmount.Amount.GTE(curOutAmount.Amount),
 			"%s: swap with new liquidity %s yielded less than swap with old liquidity %s."+

--- a/x/gamm/pool-models/stableswap/pool.go
+++ b/x/gamm/pool-models/stableswap/pool.go
@@ -239,11 +239,8 @@ func (p *Pool) updatePoolForJoin(tokensIn sdk.Coins, newShares osmomath.Int) {
 
 // TODO: These should all get moved to amm.go
 // CalcOutAmtGivenIn calculates expected output amount given input token
-func (p Pool) CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (tokenOut sdk.Coin, err error) {
-	if tokenIn.Len() != 1 {
-		return sdk.Coin{}, errors.New("stableswap CalcOutAmtGivenIn: tokenIn is of wrong length")
-	}
-	outAmtDec, err := p.calcOutAmtGivenIn(tokenIn[0], tokenOutDenom, spreadFactor)
+func (p Pool) CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (tokenOut sdk.Coin, err error) {
+	outAmtDec, err := p.calcOutAmtGivenIn(tokenIn, tokenOutDenom, spreadFactor)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -259,11 +256,15 @@ func (p Pool) CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDeno
 
 // SwapOutAmtGivenIn executes a swap given a desired input amount
 func (p *Pool) SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (tokenOut sdk.Coin, err error) {
+	if tokenIn.Len() != 1 {
+		return sdk.Coin{}, errors.New("stableswap SwapOutAmtGivenIn: tokenIn is of wrong length")
+	}
+	
 	if err = validatePoolLiquidity(p.PoolLiquidity.Add(tokenIn...), p.ScalingFactors); err != nil {
 		return sdk.Coin{}, err
 	}
 
-	tokenOut, err = p.CalcOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, spreadFactor)
+	tokenOut, err = p.CalcOutAmtGivenIn(ctx, tokenIn[0], tokenOutDenom, spreadFactor)
 	if err != nil {
 		return sdk.Coin{}, err
 	}

--- a/x/gamm/simulation/sim_msgs.go
+++ b/x/gamm/simulation/sim_msgs.go
@@ -159,7 +159,7 @@ func RandomSwapExactAmountIn(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Cont
 	amountInAfterSubTakerFee := randomCoinSubset[0].Amount.ToLegacyDec().Mul(osmomath.OneDec().Sub(takerFee))
 	tokenInAfterSubTakerFee := sdk.NewCoin(randomCoinSubset[0].Denom, amountInAfterSubTakerFee.TruncateInt())
 
-	tokenOutMin, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(tokenInAfterSubTakerFee), coinOut.Denom, pool.GetSpreadFactor(ctx))
+	tokenOutMin, err := pool.CalcOutAmtGivenIn(ctx, tokenInAfterSubTakerFee, coinOut.Denom, pool.GetSpreadFactor(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func RandomSwapExactAmountOut(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.Con
 	randomCoinInSubset := sdk.NewCoins(coinIn).Min(sdk.NewCoins(accCoin))
 
 	// utilize CalcOutAmtGivenIn to calculate tokenOut and use tokenOut to calculate tokenInMax
-	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, randomCoinInSubset, coinOut.Denom, pool.GetSpreadFactor(ctx))
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, randomCoinInSubset[0], coinOut.Denom, pool.GetSpreadFactor(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func RandomExitSwapExternAmountOut(k keeper.Keeper, sim *simtypes.SimCtx, ctx sd
 
 	// get amount of coinIn from exitedCoins and calculate how much of tokenOut you should get from that
 	exitedCoinsIn := exitedCoins.AmountOf(coinIn.Denom)
-	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewCoin(coinIn.Denom, exitedCoinsIn)), coinOut.Denom, pool.GetSpreadFactor(ctx))
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoin(coinIn.Denom, exitedCoinsIn), coinOut.Denom, pool.GetSpreadFactor(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func RandomExitSwapShareAmountIn(k keeper.Keeper, sim *simtypes.SimCtx, ctx sdk.
 
 	// get amount of coinIn from exitedCoins and calculate how much of tokenOut you should get from that
 	exitedCoinsIn := exitedCoins.AmountOf(coinIn.Denom)
-	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoins(sdk.NewCoin(coinIn.Denom, exitedCoinsIn)), coinOut.Denom, pool.GetSpreadFactor(ctx))
+	tokenOut, err := pool.CalcOutAmtGivenIn(ctx, sdk.NewCoin(coinIn.Denom, exitedCoinsIn), coinOut.Denom, pool.GetSpreadFactor(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/x/gamm/types/pool.go
+++ b/x/gamm/types/pool.go
@@ -43,7 +43,7 @@ type CFMMPoolI interface {
 	SwapOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (tokenOut sdk.Coin, err error)
 	// CalcOutAmtGivenIn returns how many coins SwapOutAmtGivenIn would return on these arguments.
 	// This does not mutate the pool, or state.
-	CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coins, tokenOutDenom string, spreadFactor osmomath.Dec) (tokenOut sdk.Coin, err error)
+	CalcOutAmtGivenIn(ctx sdk.Context, tokenIn sdk.Coin, tokenOutDenom string, spreadFactor osmomath.Dec) (tokenOut sdk.Coin, err error)
 
 	// SwapInAmtGivenOut swaps exactly enough tokensIn against the pool, to get the provided tokenOut amount out of the pool.
 	// Balance transfers are done in the keeper, but this method updates the internal pool state.

--- a/x/txfees/keeper/hooks_test.go
+++ b/x/txfees/keeper/hooks_test.go
@@ -119,7 +119,7 @@ func (s *KeeperTestSuite) TestTxFeesAfterEpochEnd() {
 				s.Require().True(ok)
 
 				expectedOutput, err := pool.CalcOutAmtGivenIn(s.Ctx,
-					sdk.Coins{sdk.Coin{Denom: tc.denoms[i], Amount: coin.Amount}},
+					sdk.Coin{Denom: tc.denoms[i], Amount: coin.Amount},
 					tc.baseDenom,
 					tc.spreadFactor)
 				s.NoError(err)


### PR DESCRIPTION
This refactors the CFMMPoolI interface and its implementations to use sdk.Coin instead of sdk.Coins for the tokenIn parameter in CalcOutAmtGivenIn, which is more appropriate as only a single input token is supported.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>
