### PR TITLE
fix: updated slip-route-swap-exact cli commands to parse with osmomath ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#9006](https://github.com/osmosis-labs/osmosis/pull/9006) feat: CosmWasm Pool raw state query
 * [#9021](https://github.com/osmosis-labs/osmosis/pull/9021) chore: slightly increase blocktime 
 * [#9050](https://github.com/osmosis-labs/osmosis/pull/9050) chore: bump ibc-go to v8.7.0 
+* [#9061](https://github.com/osmosis-labs/osmosis/pull/9061) fix: split-route-swap-exact-amount-in/out cli commands 
 
 ## v28.0.4
 

--- a/x/poolmanager/client/cli/flags.go
+++ b/x/poolmanager/client/cli/flags.go
@@ -62,12 +62,12 @@ type RoutesOut struct {
 
 type SwapAmountInSplitRoute struct {
 	Pools         []types.SwapAmountInRoute `json:"swap_amount_in_route"`
-	TokenInAmount int64                     `json:"token_in_amount"`
+	TokenInAmount string                    `json:"token_in_amount"`
 }
 
 type SwapAmountOutSplitRoute struct {
 	Pools          []types.SwapAmountOutRoute `json:"swap_amount_out_route"`
-	TokenOutAmount int64                      `json:"token_out_amount"`
+	TokenOutAmount string                     `json:"token_out_amount"`
 }
 
 func FlagSetMultihopSwapRoutes() *flag.FlagSet {

--- a/x/poolmanager/client/cli/tx.go
+++ b/x/poolmanager/client/cli/tx.go
@@ -89,7 +89,7 @@ func NewSplitRouteSwapExactAmountIn() (*osmocli.TxCliDesc, *types.MsgSplitRouteS
 				"token_out_denom": "uosmo"
 				}
 			  ],
-			  "token_in_amount": 1000
+			  "token_in_amount": "1000"
 			  },
 			  {
 			  "swap_amount_in_route": [
@@ -102,7 +102,7 @@ func NewSplitRouteSwapExactAmountIn() (*osmocli.TxCliDesc, *types.MsgSplitRouteS
 				"token_out_denom": "uosmo"
 				}
 			  ],
-			  "token_in_amount": 999
+			  "token_in_amount": "999"
 			  }
 			]
 		}
@@ -135,7 +135,7 @@ func NewSplitRouteSwapExactAmountOut() (*osmocli.TxCliDesc, *types.MsgSplitRoute
 					"token_in_denom": "uosmo"
 					}
 				],
-				"token_out_amount": 1000
+				"token_out_amount": "1000"
 				},
 				{
 				"swap_amount_out_route": [
@@ -148,7 +148,7 @@ func NewSplitRouteSwapExactAmountOut() (*osmocli.TxCliDesc, *types.MsgSplitRoute
 					"token_in_denom": "uosmo"
 					}
 				],
-				"token_out_amount": 999
+				"token_out_amount": "999"
 				}
 			]
 			}
@@ -181,8 +181,12 @@ func NewMsgNewSplitRouteSwapExactAmountOut(fs *flag.FlagSet) ([]types.SwapAmount
 
 	var splitRouteProto []types.SwapAmountOutSplitRoute
 	for _, route := range splitRouteJSONdata.Route {
+		tokenOutAmount, ok := osmomath.NewIntFromString(route.TokenOutAmount)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert token_out_amount %s to osmomath.Int", route.TokenOutAmount)
+		}
 		protoRoute := types.SwapAmountOutSplitRoute{
-			TokenOutAmount: osmomath.NewInt(route.TokenOutAmount),
+			TokenOutAmount: tokenOutAmount,
 		}
 		protoRoute.Pools = append(protoRoute.Pools, route.Pools...)
 		splitRouteProto = append(splitRouteProto, protoRoute)
@@ -210,8 +214,12 @@ func NewMsgNewSplitRouteSwapExactAmountIn(fs *flag.FlagSet) ([]types.SwapAmountI
 
 	var splitRouteProto []types.SwapAmountInSplitRoute
 	for _, route := range splitRouteJSONdata.Route {
+		tokenInAmount, ok := osmomath.NewIntFromString(route.TokenInAmount)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert token_in_amount %s to osmomath.Int", route.TokenInAmount)
+		}
 		protoRoute := types.SwapAmountInSplitRoute{
-			TokenInAmount: osmomath.NewInt(route.TokenInAmount),
+			TokenInAmount: tokenInAmount,
 		}
 		protoRoute.Pools = append(protoRoute.Pools, route.Pools...)
 		splitRouteProto = append(splitRouteProto, protoRoute)


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change
The current cli commands for `split-route-swap-exact-amount-in/out` parse the token in/out amounts from the routes.json as go int64's. However, with EVM based chain, the amounts can easily exceed the max int size (e.g. `10 DYDX` is `10000000000000000000adydx` - which exceeds the max int size). 

The actual message types for each of these transactions correctly uses osmomath.Int's, so the change is as simple as fixing the cli parser to accept strings in the routes.json and convert directly to osmomath.Int's. 

## Testing and Verifying
This is a non-consensus breaking change, so I verified by just testing a swap on mainnet.

```jsonc
// in-routes.json
{
    "route": [
         {
            "swap_amount_in_route": [
                {"pool_id": 1245, "token_out_denom": "uosmo"},
                {"pool_id": 1464, "token_out_denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"}
             ],
             "token_in_amount": 10000000000000000000
          }
     ]
}
```

```jsonc
// out-routes.json
{
    "route": [
        {
            "swap_amount_out_route": [
                {"pool_id": 2745, "token_in_denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"},
                {"pool_id": 2709, "token_in_denom": "factory/osmo1zem8r6dv6u38f6qpg546zy30946av8h5srgug0s4gcyy6cfecf3seac083/alloyed/allDYDX"}
            ],
            "token_out_amount": 10000000000000000000
        }
    ]
}
```

Before Change: 
```bash
>>> osmosisd tx poolmanager split-route-swap-exact-amount-in ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4 1 --routes-file=in-routes.json
Error: json: cannot unmarshal number 10000000000000000000 into Go struct field SwapAmountInSplitRoute.route.token_in_amount of type int64

>>> osmosisd tx poolmanager split-route-swap-exact-amount-out {token_in_denom} 1 --routes-file=out-routes.json
Error: json: cannot unmarshal number 10000000000000000000 into Go struct field SwapAmountOutSplitRoute.route.token_out_amount of type int64
```

Then built the new binary, change the int types to strings in the JSON, and the swaps succeeded w/o error.

## Documentation and Release Note
  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [X] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A