### PR TITLE
Added public-read on uploaded binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -170,6 +170,7 @@ blobs:
     directory: "binaries/v{{.Version}}"
     endpoint: '{{ .Env.S3_ENDPOINT }}' 
     region: '{{ .Env.S3_REGION }}' 
+    acl: public-read
     ids:
       - zipped
       - binaries


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the `acl: public-read` configuration to the S3 blob settings in the GoReleaser configuration. This setting ensures that all files uploaded to the DigitalOcean Spaces bucket are publicly accessible, allowing users to download the release binaries directly.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A