### PR TITLE
fix: unmatched exact amount out should result in error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* [9297](https://github.com/osmosis-labs/osmosis/pull/9297) fix: unmatched exact amount out should result in error 
 
 ### State Breaking
 

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -242,7 +242,7 @@ func (s *KeeperTestSuite) swapNearTickBoundary(r *rand.Rand, pool types.Concentr
 
 	// Decide if below, exactly, or above target tick
 
-	poolSpotPrice := pool.GetCurrentSqrtPrice().Power(osmomath.NewBigDec(2))
+	poolSpotPrice := pool.GetCurrentSqrtPrice().PowerInteger(2)
 	fmt.Printf("pool: tick %d, spot price: %s, liq %s \n", pool.GetCurrentTick(), poolSpotPrice, curLiquidity)
 
 	amountInRequired = tickAmtChange(r, amountInRequired)

--- a/x/concentrated-liquidity/pool_test.go
+++ b/x/concentrated-liquidity/pool_test.go
@@ -827,7 +827,7 @@ func (s *KeeperTestSuite) TestMigrateIncentivesAccumulatorToScalingFactor() {
 
 	// Cross next right tick to update the tick accumulator by swapping
 	amtIn, _, _ := s.computeSwapAmounts(poolID, concentratedPool.GetCurrentSqrtPrice(), currentTick+100, false, false)
-	s.swapOneForZeroRight(poolID, sdk.NewCoin(USDC, amtIn.Ceil().TruncateInt()))
+	s.swapOneForZeroRight(poolID, sdk.NewCoin(USDC, amtIn.Ceil().TruncateInt()), false)
 
 	// Sync acccumulator
 	err = s.App.ConcentratedLiquidityKeeper.UpdatePoolUptimeAccumulatorsToNow(s.Ctx, poolID)
@@ -895,7 +895,7 @@ func (s *KeeperTestSuite) TestMigrateIncentivesAccumulatorToScalingFactor() {
 
 	// Cross next right tick to update the tick accumulator by swapping
 	amtIn, _, _ = s.computeSwapAmounts(poolID, concentratedPool.GetCurrentSqrtPrice(), currentTick+100, false, false)
-	s.swapOneForZeroRight(poolID, sdk.NewCoin(USDC, amtIn.Ceil().TruncateInt()))
+	s.swapOneForZeroRight(poolID, sdk.NewCoin(USDC, amtIn.Ceil().TruncateInt()), false)
 
 	claimableIncentivesCompareOneAfterMigration, _, err := s.App.ConcentratedLiquidityKeeper.GetClaimableIncentives(s.Ctx, positionOneCompareID)
 

--- a/x/concentrated-liquidity/position_test.go
+++ b/x/concentrated-liquidity/position_test.go
@@ -2086,7 +2086,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	// Update expected incentive rewards
 	expectedTotalIncentiveRewards = expectedTotalIncentiveRewards.Add(rewardsPerSecond)
 
-	s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor)
+	s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor, false)
 
 	// Refetch pool
 	pool, err = s.Clk.GetPoolById(s.Ctx, poolId)
@@ -2103,7 +2103,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 	// Update expected incentive rewards
 	expectedTotalIncentiveRewards = expectedTotalIncentiveRewards.Add(rewardsPerSecond)
 
-	s.swapOneForZeroRightWithSpread(poolId, coinOneIn, spreadFactor)
+	s.swapOneForZeroRightWithSpread(poolId, coinOneIn, spreadFactor, false)
 
 	// Increase block time
 	s.Ctx = s.Ctx.WithBlockTime(s.Ctx.BlockTime().Add(time.Second))
@@ -2151,7 +2151,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 		expectedTotalIncentiveRewards = expectedTotalIncentiveRewards.Add(rewardsPerSecond)
 
 		// Move current tick to be below the expected position
-		s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor)
+		s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor, false)
 
 		// Assert global invariants
 		s.assertGlobalInvariants(ExpectedGlobalRewardValues{
@@ -2180,7 +2180,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 		expectedTotalIncentiveRewards = expectedTotalIncentiveRewards.Add(rewardsPerSecond)
 
 		// Move current tick to be inside of the new position
-		s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor)
+		s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor, false)
 
 		// Assert global invariants
 		s.assertGlobalInvariants(ExpectedGlobalRewardValues{
@@ -2209,7 +2209,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 		expectedTotalIncentiveRewards = expectedTotalIncentiveRewards.Add(rewardsPerSecond)
 
 		// Swap inside the new position so that it accumulates rewards
-		s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor)
+		s.swapZeroForOneLeftWithSpread(poolId, coinZeroIn, spreadFactor, false)
 
 		// Estimate the next swap to be approximately until DefaultCurrTick + 150
 		coinOneIn := estimateCoinOneIn(DefaultCurrTick + 150)
@@ -2223,7 +2223,7 @@ func (s *KeeperTestSuite) TestNegativeTickRange_SpreadFactor() {
 		expectedTotalIncentiveRewards = expectedTotalIncentiveRewards.Add(rewardsPerSecond)
 
 		// Swap back to take current tick be above the new position
-		s.swapOneForZeroRightWithSpread(poolId, coinOneIn, spreadFactor)
+		s.swapOneForZeroRightWithSpread(poolId, coinOneIn, spreadFactor, false)
 
 		// Assert global invariants
 		s.assertGlobalInvariants(ExpectedGlobalRewardValues{

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -674,7 +674,7 @@ func (k Keeper) computeInAmtGivenOut(
 	// if the amount specified remaining is greater than 0, this means the expected out amount is less than the amount specified
 	// return an error
 	if swapState.amountSpecifiedRemaining.GT(osmomath.ZeroDec()) {
-		return SwapResult{}, PoolUpdates{}, fmt.Errorf("remaining amount specified (%s) is greater than zero, indicating a mismatch between the amount specified and the amount calculated", swapState.amountSpecifiedRemaining)
+		return SwapResult{}, PoolUpdates{}, types.UnableToFulfillExactOutError{AmountSpecifiedRemaining: swapState.amountSpecifiedRemaining}
 	}
 
 	// Note, this should be impossible to reach but we leave it as a defense-in-depth measure.

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -671,6 +671,12 @@ func (k Keeper) computeInAmtGivenOut(
 		}
 	}
 
+	// if the amount specified remaining is greater than 0, this means the expected out amount is less than the amount specified
+	// return an error
+	if swapState.amountSpecifiedRemaining.GT(osmomath.ZeroDec()) {
+		return SwapResult{}, PoolUpdates{}, fmt.Errorf("remaining amount specified (%s) is greater than zero, indicating a mismatch between the amount specified and the amount calculated", swapState.amountSpecifiedRemaining)
+	}
+
 	// Note, this should be impossible to reach but we leave it as a defense-in-depth measure.
 	if swapState.amountSpecifiedRemaining.IsNegative() {
 		return SwapResult{}, PoolUpdates{}, fmt.Errorf("over charged problem swap in given out by %s", swapState.amountSpecifiedRemaining)

--- a/x/concentrated-liquidity/swaps_test.go
+++ b/x/concentrated-liquidity/swaps_test.go
@@ -3073,6 +3073,11 @@ func (s *KeeperTestSuite) TestComputeInAmtGivenOut() {
 				s.Ctx,
 				test.TokenOut, test.TokenInDenom,
 				test.SpreadFactor, test.PriceLimit, poolBeforeCalc.GetId(), true)
+
+			if test.ExpectErr {
+				s.Require().Error(err)
+				return
+			}
 			s.Require().NoError(err)
 
 			// check that the pool has not been modified after performing calc

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -879,6 +879,14 @@ func (e OverChargeSwapOutGivenInError) Error() string {
 	return fmt.Sprintf("over charge problem swap out given in by (%s)", e.AmountSpecifiedRemaining)
 }
 
+type UnableToFulfillExactOutError struct {
+	AmountSpecifiedRemaining osmomath.Dec
+}
+
+func (e UnableToFulfillExactOutError) Error() string {
+	return fmt.Sprintf("unable to fulfill exact out swap, amount specified remaining: (%s)", e.AmountSpecifiedRemaining)
+}
+
 type ComputedSqrtPriceInequalityError struct {
 	IsZeroForOne                 bool
 	NextInitializedTickSqrtPrice osmomath.BigDec


### PR DESCRIPTION
## What is the purpose of the change

For the case where exact out swap goes beyond max or min price tick, it resulted in success calculation or swap but the amount out is less than specified. This could lead to confusion as it breaks the expectation from exact out when behaves normally.

This PR returns error if such case happens.

## Testing and Verifying

unit & fuzz tested

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

