### PR TITLE
refactor: custom backoff strategy for sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#9006](https://github.com/osmosis-labs/osmosis/pull/9006) feat: CosmWasm Pool raw state query
 * [#9021](https://github.com/osmosis-labs/osmosis/pull/9021) chore: slightly increase blocktime 
 * [#9050](https://github.com/osmosis-labs/osmosis/pull/9050) chore: bump ibc-go to v8.7.0 
+* [#9051](https://github.com/osmosis-labs/osmosis/pull/9051) [sqs] set custom backoff reconnection strategy for sqs
 
 ## v28.0.4
 

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/btree v1.7.0
 	github.com/tidwall/gjson v1.18.0
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0
 	go.opentelemetry.io/otel/sdk v1.34.0
@@ -162,6 +161,7 @@ require (
 	github.com/zimmski/go-mutesting v0.0.0-20210610104036-6d9217011a00 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect

--- a/ingest/sqs/service/grpc_client.go
+++ b/ingest/sqs/service/grpc_client.go
@@ -81,7 +81,7 @@ func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingest
 		// Instead, we will attempt to reconnect every `blocksBeforeRetryConnection` blocks.
 		if g.blocksBeforeRetryConnection > 0 {
 			g.blocksBeforeRetryConnection--
-			return nil
+			return fmt.Errorf("grpc connection is not ready")
 		}
 
 		// Note: we disable retries since we have a custom logic to repeat retries in the next block.

--- a/ingest/sqs/service/grpc_client.go
+++ b/ingest/sqs/service/grpc_client.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/hashicorp/go-metrics"
-	ingesttypes "github.com/osmosis-labs/osmosis/v29/ingest/types"
-	prototypes "github.com/osmosis-labs/osmosis/v29/ingest/types/proto/types"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+
+	ingesttypes "github.com/osmosis-labs/osmosis/v29/ingest/types"
+	prototypes "github.com/osmosis-labs/osmosis/v29/ingest/types/proto/types"
 
 	"github.com/osmosis-labs/osmosis/v29/ingest/sqs/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v29/x/poolmanager/types"
@@ -65,7 +68,25 @@ func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingest
 		// Using the built-in GRPC retry back-off logic is likely to halt the serial system.
 		// As a result, we opt in for simply continuing to attempting to process the next block
 		// and retrying the connection and ingest
-		g.grpcConn, err = grpc.NewClient(g.grpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(g.grpcMaxCallSizeBytes)), grpc.WithDisableRetry(), grpc.WithDisableRetry(), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+		g.grpcConn, err = grpc.NewClient(
+			g.grpcAddress,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(g.grpcMaxCallSizeBytes)),
+			grpc.WithDisableRetry(),
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				// Note: this exists as to avoid node falling behind when SQS is not running
+				// but config enables it. In that case, every block, the node will attempt to reconnect
+				// and retry with exponential backoff. By setting max delay under block time (~1.++ second)
+				// we ensure that the node will not fall behind.
+				Backoff: backoff.Config{
+					BaseDelay:  100 * time.Millisecond,
+					Jitter:     0.2,
+					Multiplier: 2,
+					MaxDelay:   1 * time.Second,
+				},
+			}),
+		)
 		if err != nil {
 			shouldResetConnection = true
 			return err

--- a/ingest/sqs/service/grpc_client.go
+++ b/ingest/sqs/service/grpc_client.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
@@ -28,7 +29,17 @@ type GRPCClient struct {
 	grpcMaxCallSizeBytes int
 	grpcConn             *grpc.ClientConn
 	appCodec             codec.Codec
+
+	// If an error during connection occurs, we will attempt to reconnect every `blocksBeforeRetryConnection` blocks
+	// as to avoid the node falling behind due to the retry logic of grpc.
+	blocksBeforeRetryConnection int64
 }
+
+const (
+	// initialBlocksBeforeRetryConnection is the number of blocks to wait before attempting to reconnect
+	// to the SQS service in case of an error.
+	initialBlocksBeforeRetryConnection = 5
+)
 
 var (
 	_ domain.SQSGRPClient = &GRPCClient{}
@@ -36,9 +47,10 @@ var (
 
 func NewGRPCCLient(grpcAddress string, grpxMaxCallSizeBytes int, appCodec codec.Codec) *GRPCClient {
 	return &GRPCClient{
-		grpcAddress:          grpcAddress,
-		grpcMaxCallSizeBytes: grpxMaxCallSizeBytes,
-		appCodec:             appCodec,
+		grpcAddress:                 grpcAddress,
+		grpcMaxCallSizeBytes:        grpxMaxCallSizeBytes,
+		appCodec:                    appCodec,
+		blocksBeforeRetryConnection: 0,
 	}
 }
 
@@ -64,6 +76,14 @@ func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingest
 	}()
 
 	if g.grpcConn == nil {
+		// If we are in the retry mode, we should not attempt to reconnect
+		// for every block to avoid the node falling behind.
+		// Instead, we will attempt to reconnect every `blocksBeforeRetryConnection` blocks.
+		if g.blocksBeforeRetryConnection > 0 {
+			g.blocksBeforeRetryConnection--
+			return nil
+		}
+
 		// Note: we disable retries since we have a custom logic to repeat retries in the next block.
 		// Using the built-in GRPC retry back-off logic is likely to halt the serial system.
 		// As a result, we opt in for simply continuing to attempting to process the next block
@@ -83,13 +103,44 @@ func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingest
 					BaseDelay:  100 * time.Millisecond,
 					Jitter:     0.2,
 					Multiplier: 2,
-					MaxDelay:   1 * time.Second,
+
+					MaxDelay: 400 * time.Millisecond,
 				},
 			}),
 		)
 		if err != nil {
 			shouldResetConnection = true
+
+			g.blocksBeforeRetryConnection = initialBlocksBeforeRetryConnection
+
 			return err
+		}
+
+		// Attempt to connect to the SQS service
+		// Note: this operation is non-blocking
+		// As a result, we have an exponential backoff below to validate if the connection is ready
+		g.grpcConn.Connect()
+
+		initialSleep := time.Millisecond * 100
+		shouldFail := true
+		for i := 0; i < 3; i++ {
+			// If the connection is ready, we can break and continue
+			if g.grpcConn.GetState() == connectivity.Ready {
+				shouldFail = false
+				break
+			}
+
+			// If the connection is not ready, we should sleep and retry
+			// with an exponential backoff
+			time.Sleep(initialSleep)
+			initialSleep *= 2
+		}
+
+		// If we failed to connect to the SQS service after several attempts, we should return an error
+		if shouldFail {
+			shouldResetConnection = true
+			g.blocksBeforeRetryConnection = initialBlocksBeforeRetryConnection
+			return fmt.Errorf("grpc connection is not ready")
 		}
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

We noticed that in cases where you have SQS enabled in `app.toml` but the service not running, the node would start falling behind.

This is suboptimal ux for development.

The reason for falling behind was node attempting to reconnect every block with exponential backoff, blocking the main loop.

This PR sets the max delay to be under block time so that there is sufficient opportunity or a node to catch up

## Testing and Verifying

- Tested locally