### PR TITLE
fix: CL unmatched calc exact amount out should result in error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* [#9331](https://github.com/osmosis-labs/osmosis/pull/9331) fix: CL unmatched calc exact amount out should result in error
+
 ### State Breaking
 
 * [#8996](https://github.com/osmosis-labs/osmosis/pull/8996) chore: upgrade pfm to v8.1.1 

--- a/x/concentrated-liquidity/fuzz_test.go
+++ b/x/concentrated-liquidity/fuzz_test.go
@@ -242,7 +242,7 @@ func (s *KeeperTestSuite) swapNearTickBoundary(r *rand.Rand, pool types.Concentr
 
 	// Decide if below, exactly, or above target tick
 
-	poolSpotPrice := pool.GetCurrentSqrtPrice().Power(osmomath.NewBigDec(2))
+	poolSpotPrice := pool.GetCurrentSqrtPrice().PowerInteger(2)
 	fmt.Printf("pool: tick %d, spot price: %s, liq %s \n", pool.GetCurrentTick(), poolSpotPrice, curLiquidity)
 
 	amountInRequired = tickAmtChange(r, amountInRequired)

--- a/x/concentrated-liquidity/swaps.go
+++ b/x/concentrated-liquidity/swaps.go
@@ -352,6 +352,12 @@ func (k Keeper) CalcInAmtGivenOut(
 ) (sdk.Coin, error) {
 	cacheCtx, _ := ctx.CacheContext()
 	swapResult, _, err := k.computeInAmtGivenOut(cacheCtx, tokenOut, tokenInDenom, spreadFactor, unboundedPriceLimit, poolI.GetId(), false)
+
+	// check if the swapResult tokenOut matched the tokenOut provided, if not return an error
+	if !swapResult.AmountOut.Equal(tokenOut.Amount) {
+		return sdk.Coin{}, types.ExactAmountOutMismatchError{ExpectedAmountOut: tokenOut.Amount, CalculatedAmountOut: swapResult.AmountOut}
+	}
+
 	if err != nil {
 		return sdk.Coin{}, err
 	}

--- a/x/concentrated-liquidity/types/errors.go
+++ b/x/concentrated-liquidity/types/errors.go
@@ -501,6 +501,15 @@ func (e InvalidAmountCalculatedError) Error() string {
 	return fmt.Sprintf("invalid amount calculated, must be >= 1, was (%s)", e.Amount)
 }
 
+type ExactAmountOutMismatchError struct {
+	ExpectedAmountOut   osmomath.Int
+	CalculatedAmountOut osmomath.Int
+}
+
+func (e ExactAmountOutMismatchError) Error() string {
+	return fmt.Sprintf("exact amount out mismatch, expected (%s), calculated (%s)", e.ExpectedAmountOut, e.CalculatedAmountOut)
+}
+
 type InvalidNextPositionIdError struct {
 	NextPositionId uint64
 }


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

For the case where exact out swap query goes right into max or min price tick, it resulted in success calculation or swap but the amount out is less than specified. This could lead to confusion as it breaks the expectation from exact out when behaves normally.

We decided to only return error in the query, not actual swap as #9297 to reduce potential issue in CL and make it non-state breaking.

This PR returns error if such case happens.

## Testing and Verifying

Unit tested

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?
