### PR TITLE
fix(poolmanager): only write to cache in finalize execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#9006](https://github.com/osmosis-labs/osmosis/pull/9006) feat: CosmWasm Pool raw state query
 * [#9021](https://github.com/osmosis-labs/osmosis/pull/9021) chore: slightly increase blocktime 
 * [#9050](https://github.com/osmosis-labs/osmosis/pull/9050) chore: bump ibc-go to v8.7.0 
+* [#9332](https://github.com/osmosis-labs/osmosis/pull/9332) fix(poolmanager): only write to cache in finalize execution mode
 
 ## v28.0.4
 

--- a/x/poolmanager/create_pool.go
+++ b/x/poolmanager/create_pool.go
@@ -150,6 +150,19 @@ func (k Keeper) getNextPoolIdAndIncrement(ctx sdk.Context) uint64 {
 	return nextPoolId
 }
 
+func (k *Keeper) getPoolRouteRaw(ctx sdk.Context, poolId uint64) (*types.ModuleRoute, error) {
+	store := ctx.KVStore(k.storeKey)
+	moduleRoute := &types.ModuleRoute{}
+	found, err := osmoutils.Get(store, types.FormatModuleRouteKey(poolId), moduleRoute)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, types.FailedToFindRouteError{PoolId: poolId}
+	}
+	return moduleRoute, nil
+}
+
 func (k *Keeper) SetPoolRoute(ctx sdk.Context, poolId uint64, poolType types.PoolType) {
 	store := ctx.KVStore(k.storeKey)
 	osmoutils.MustSet(store, types.FormatModuleRouteKey(poolId), &types.ModuleRoute{PoolType: poolType})
@@ -167,11 +180,11 @@ type poolModuleCacheValue struct {
 func (k *Keeper) GetPoolType(ctx sdk.Context, poolId uint64) (types.PoolType, error) {
 	poolModuleCandidate, cacheHit := k.cachedPoolModules.Load(poolId)
 	if !cacheHit {
-		_, err := k.GetPoolModule(ctx, poolId)
+		moduleRoute, err := k.getPoolRouteRaw(ctx, poolId)
 		if err != nil {
 			return 0, err
 		}
-		poolModuleCandidate, _ = k.cachedPoolModules.Load(poolId)
+		return moduleRoute.PoolType, nil
 	}
 	v, _ := poolModuleCandidate.(poolModuleCacheValue)
 	if cacheHit {

--- a/x/poolmanager/create_pool.go
+++ b/x/poolmanager/create_pool.go
@@ -212,13 +212,15 @@ func (k *Keeper) GetPoolModule(ctx sdk.Context, poolId uint64) (types.PoolModule
 		return nil, types.UndefinedRouteError{PoolType: moduleRoute.PoolType, PoolId: poolId}
 	}
 
-	k.cachedPoolModules.Store(poolId, poolModuleCacheValue{
-		pooltype: moduleRoute.PoolType,
-		module:   swapModule,
-		gasFlat:  gasFlat,
-		gasKey:   gasKey,
-		gasValue: gasVal,
-	})
+	if ctx.ExecMode() == sdk.ExecModeFinalize {
+		k.cachedPoolModules.Store(poolId, poolModuleCacheValue{
+			pooltype: moduleRoute.PoolType,
+			module:   swapModule,
+			gasFlat:  gasFlat,
+			gasKey:   gasKey,
+			gasValue: gasVal,
+		})
+	}
 
 	return swapModule, nil
 }


### PR DESCRIPTION
Prevents the cache from being written to during other execution modes like CheckTx, which can lead to inconsistent state during transaction processing. The cache should only be populated during the final execution phase.
