### PR TITLE
fix: dead link in documentation 

### DIFF
--- a/docs/protocol/src/osmosis.md
+++ b/docs/protocol/src/osmosis.md
@@ -5,7 +5,7 @@ interchain assets that allows the creation and management of
 non-custodial, self-balancing, interchain token index similar to one of
 Balancer.
 
-Inspired by [Balancer](http://balancer.finance/whitepaper) and Sunny
+Inspired by [Balancer](https://docs.balancer.fi/whitepaper.pdf) and Sunny
 Aggarwal's '[DAOfying Uniswap Automated Market Maker
 Pools](https://www.sunnya97.com/blog/daoifying-uniswap-automated-market-maker-pools)',
 the goal for Osmosis is to provide the best-in-class tools that extend


### PR DESCRIPTION
This pull request fixes a dead link in the Osmosis protocol documentation. The outdated HTTP link to the Balancer whitepaper was replaced with a working HTTPS version, ensuring the reference is accessible and secure.

dead link - https://balancer.fi/whitepaper.pdf
correct one - https://docs.balancer.fi/whitepaper.pdf