### PR TITLE
fix #9356

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -665,7 +665,6 @@ func initAppConfig() (string, interface{}) {
 		MaxGasWantedPerTx         string `mapstructure:"max-gas-wanted-per-tx"`
 		MinGasPriceForArbitrageTx string `mapstructure:"arbitrage-min-gas-fee"`
 		MinGasPriceForHighGasTx   string `mapstructure:"min-gas-price-for-high-gas-tx"`
-		Mempool1559Enabled        string `mapstructure:"adaptive-fee-enabled"`
 	}
 
 	type CustomAppConfig struct {
@@ -686,7 +685,6 @@ func initAppConfig() (string, interface{}) {
 		MaxGasWantedPerTx:         "60000000",
 		MinGasPriceForArbitrageTx: ".1",
 		MinGasPriceForHighGasTx:   ".0025",
-		Mempool1559Enabled:        "true",
 	}
 	// Optionally allow the chain developer to overwrite the SDK's default
 	// server config.
@@ -724,9 +722,6 @@ arbitrage-min-gas-fee = "{{ .OsmosisMempoolConfig.MinGasPriceForArbitrageTx }}"
 # This is the minimum gas fee any tx with high gas demand should have, denominated in uosmo per gas
 # Default value of ".0025" then means that a tx with 1 million gas costs (.0025 uosmo/gas) * 1_000_000 gas = .0025 osmo
 min-gas-price-for-high-gas-tx = "{{ .OsmosisMempoolConfig.MinGasPriceForHighGasTx }}"
-
-# This parameter enables EIP-1559 like fee market logic in the mempool
-adaptive-fee-enabled = "{{ .OsmosisMempoolConfig.Mempool1559Enabled }}"
 
 ###############################################################################
 ###              Osmosis Sidecar Query Server Configuration                 ###

--- a/x/txfees/types/options.go
+++ b/x/txfees/types/options.go
@@ -23,17 +23,13 @@ var (
 	DefaultMinGasPriceForHighGasTx = osmomath.ZeroDec()
 	DefaultMaxGasWantedPerTx       = uint64(30 * 1000 * 1000)
 	DefaultHighGasTxThreshold      = uint64(2.5 * 1000 * 1000)
-	DefaultMempool1559Enabled      = true
 )
-
-var GlobalMempool1559Enabled = false
 
 type MempoolFeeOptions struct {
 	MaxGasWantedPerTx         uint64
 	MinGasPriceForArbitrageTx osmomath.Dec
 	HighGasTxThreshold        uint64
 	MinGasPriceForHighGasTx   osmomath.Dec
-	Mempool1559Enabled        bool
 }
 
 func NewDefaultMempoolFeeOptions() MempoolFeeOptions {
@@ -42,7 +38,6 @@ func NewDefaultMempoolFeeOptions() MempoolFeeOptions {
 		MinGasPriceForArbitrageTx: DefaultMinGasPriceForArbitrageTx.Clone(),
 		HighGasTxThreshold:        DefaultHighGasTxThreshold,
 		MinGasPriceForHighGasTx:   DefaultMinGasPriceForHighGasTx.Clone(),
-		Mempool1559Enabled:        DefaultMempool1559Enabled,
 	}
 }
 
@@ -52,7 +47,6 @@ func NewMempoolFeeOptions(opts servertypes.AppOptions) MempoolFeeOptions {
 		MinGasPriceForArbitrageTx: parseMinGasPriceForArbitrageTx(opts),
 		HighGasTxThreshold:        DefaultHighGasTxThreshold,
 		MinGasPriceForHighGasTx:   parseMinGasPriceForHighGasTx(opts),
-		Mempool1559Enabled:        parseMempool1559(opts),
 	}
 }
 
@@ -74,11 +68,6 @@ func parseMinGasPriceForArbitrageTx(opts servertypes.AppOptions) osmomath.Dec {
 
 func parseMinGasPriceForHighGasTx(opts servertypes.AppOptions) osmomath.Dec {
 	return parseDecFromConfig(opts, "min-gas-price-for-high-gas-tx", DefaultMinGasPriceForHighGasTx.Clone())
-}
-
-func parseMempool1559(opts servertypes.AppOptions) bool {
-	GlobalMempool1559Enabled = parseBoolFromConfig(opts, "adaptive-fee-enabled", DefaultMempool1559Enabled)
-	return GlobalMempool1559Enabled
 }
 
 func parseDecFromConfig(opts servertypes.AppOptions, optName string, defaultValue osmomath.Dec) osmomath.Dec {


### PR DESCRIPTION
# Remove mempool-1559 as a configuration option, fixes #9356 

At this point, all nodes should be running the 1559 mempool implementation, so we no longer need to maintain the configuration option. This PR removes the `adaptive-fee-enabled` configuration parameter and makes the 1559 mempool behavior the default for all nodes.

## Changes made:

1. Removed `Mempool1559Enabled` field from `MempoolFeeOptions` structure in `x/txfees/types/options.go`
2. Removed `GlobalMempool1559Enabled` variable and `parseMempool1559()` function
3. Removed `Mempool1559Enabled` field from `OsmosisMempoolConfig` structure in `cmd/osmosisd/cmd/root.go`
4. Removed the `adaptive-fee-enabled` configuration option from the app template
5. Updated `feedecorator.go` to always use the 1559 mempool logic without conditional checks
6. Added an entry to `CHANGELOG.md` regarding this change

This change simplifies the codebase by removing unnecessary conditional logic and ensures all nodes have a consistent fee market behavior.
