### PR TITLE
 Improve `String()` Output for `UpdateMigrationRecordsProposal`

### DIFF
--- a/x/gamm/types/gov.go
+++ b/x/gamm/types/gov.go
@@ -124,19 +124,17 @@ func (p *UpdateMigrationRecordsProposal) ValidateBasic() error {
 
 // String returns a string containing the migration record's proposal.
 func (p UpdateMigrationRecordsProposal) String() string {
-	// TODO: Make this prettier
-	recordsStr := ""
-	for _, record := range p.Records {
-		recordsStr = recordsStr + fmt.Sprintf("(BalancerPoolID: %d, ClPoolID: %d) ", record.BalancerPoolId, record.ClPoolId)
-	}
-
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf(`Update Migration Records Proposal:
+    var b strings.Builder
+    b.WriteString(fmt.Sprintf(`Update Migration Records Proposal:
   Title:       %s
   Description: %s
-  Records:     %s
-`, p.Title, p.Description, recordsStr))
-	return b.String()
+  Records:
+`, p.Title, p.Description))
+    for _, record := range p.Records {
+	b.WriteString(fmt.Sprintf("    - BalancerPoolID: %d, ClPoolID: %d\n", record.BalancerPoolId, record.ClPoolId))
+    }
+	
+    return b.String()
 }
 
 func NewCreateConcentratedLiquidityPoolsAndLinktoCFMMProposal(title, description string, records []PoolRecordWithCFMMLink) govtypesv1.Content {


### PR DESCRIPTION
This PR improves the string formatting of the `UpdateMigrationRecordsProposal` type.  
It replaces the previously flat and hard-to-read inline formatting of records with a cleaner, line-by-line list format.

✅ **This also resolves the TODO in the method's comment:**
```go
// TODO: Make this prettier
```

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

- The change affects only the `String()` method, used for logging or debugging purposes.
- Struct behavior and serialization remain unchanged.

## Documentation and Release Note

- [x] Does this pull request introduce a new feature or user-facing behavior changes? → No
- [] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? 
