### PR TITLE
BE-708 | Fix: Once SQS disconnects the node stales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,14 @@ go.work.sum
 .idea/**/dictionaries
 .idea/**/shelf
 
+# Vim backup, undo files
+*.orig
+*~
+
+# Vim swap files
+.*.swp
+.*.swo
+
 # Generated files
 .idea/**/contentModel.xml
 

--- a/app/app.go
+++ b/app/app.go
@@ -359,6 +359,7 @@ func NewOsmosisApp(
 		nodeStatusChecker = commonservice.NewNodeStatusChecker(rpcAddress)
 	}
 
+	streamingCtx := context.Background()
 	streamingServices := []storetypes.ABCIListener{}
 
 	// Initialize the SQS ingester if it is enabled.
@@ -376,7 +377,12 @@ func NewOsmosisApp(
 		// Create sqs grpc client
 		sqsGRPCClients := make([]domain.SQSGRPClient, len(sqsConfig.GRPCIngestAddress))
 		for i, grpcIngestAddress := range sqsConfig.GRPCIngestAddress {
-			sqsGRPCClients[i] = sqsservice.NewGRPCCLient(grpcIngestAddress, sqsConfig.GRPCIngestMaxCallSizeBytes, appCodec)
+			grpcClient, err := sqsservice.NewGRPCCLient(streamingCtx, grpcIngestAddress, sqsConfig.GRPCIngestMaxCallSizeBytes, appCodec)
+			if err != nil {
+				panic(fmt.Errorf("failed to create SQS grpc client: %w", err))
+			}
+
+			sqsGRPCClients[i] = grpcClient
 		}
 
 		for _, grpcClient := range sqsGRPCClients {

--- a/ingest/sqs/domain/ingester.go
+++ b/ingest/sqs/domain/ingester.go
@@ -8,6 +8,8 @@ import (
 	ingesttypes "github.com/osmosis-labs/osmosis/v29/ingest/types"
 
 	commondomain "github.com/osmosis-labs/osmosis/v29/ingest/common/domain"
+
+	"google.golang.org/grpc/connectivity"
 )
 
 // PoolsTransformer is an interface that defines the methods for the pool transformer
@@ -28,4 +30,23 @@ type SQSGRPClient interface {
 	// Note: while there are built-in mechanisms to handle retry such as exponential backoff, they are no suitable for our context.
 	// In our context, we would rather continue attempting to repush the data in the next block instead of blocking the system.
 	PushData(ctx context.Context, height uint64, pools []ingesttypes.PoolI, takerFeesMap ingesttypes.TakerFeeMap) error
+
+	// IsConnected returns nil if the GRPC client is connected to the SQS service.
+	IsConnected() error
+}
+
+// A StateChanger reports state changes, e.g. a grpc.ClientConn.
+type StateChanger interface {
+	// Connect begins connecting the StateChanger.
+	Connect()
+	// GetState returns the current state of the StateChanger.
+	GetState() connectivity.State
+	// WaitForStateChange returns true when the state becomes s, or returns
+	// false if ctx is canceled first.
+	WaitForStateChange(ctx context.Context, s connectivity.State) bool
+}
+
+// ClientConn is a gRPC client connection interface.
+type ClientConn interface {
+	StateChanger
 }

--- a/ingest/sqs/domain/mocks/grpc_client_mock.go
+++ b/ingest/sqs/domain/mocks/grpc_client_mock.go
@@ -1,11 +1,48 @@
 package mocks
 
 import (
+	"sync"
 	"context"
 
 	"github.com/osmosis-labs/osmosis/v29/ingest/sqs/domain"
 	ingesttypes "github.com/osmosis-labs/osmosis/v29/ingest/types"
+
+	"google.golang.org/grpc/connectivity"
 )
+
+type ClientConn struct {
+	mu              sync.Mutex
+	State           connectivity.State
+	StateChanges    []connectivity.State
+	waitShouldBlock bool
+}
+
+func (m *ClientConn) GetState() connectivity.State {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.State
+}
+
+func (m *ClientConn) Connect() {}
+
+var _ domain.ClientConn = &ClientConn{}
+
+func (m *ClientConn) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+	if m.waitShouldBlock {
+		<-ctx.Done()
+		return false
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.StateChanges) > 0 {
+		m.State = m.StateChanges[0]
+		m.StateChanges = m.StateChanges[1:]
+	}
+
+	return true
+}
 
 type GRPCClientMock struct {
 	Error error
@@ -15,5 +52,10 @@ var _ domain.SQSGRPClient = &GRPCClientMock{}
 
 // PushData implements domain.SQSGRPClient.
 func (g *GRPCClientMock) PushData(ctx context.Context, height uint64, pools []ingesttypes.PoolI, takerFeesMap ingesttypes.TakerFeeMap) error {
+	return g.Error
+}
+
+// IsConnected implements domain.SQSGRPClient.
+func (g *GRPCClientMock) IsConnected() error {
 	return g.Error
 }

--- a/ingest/sqs/service/export_test.go
+++ b/ingest/sqs/service/export_test.go
@@ -1,9 +1,30 @@
 package service
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"context"
+	"time"
+
+	"github.com/osmosis-labs/osmosis/v29/ingest/sqs/domain"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 type SQSStreamingService = sqsStreamingService
 
 func (s *sqsStreamingService) ProcessBlockRecoverError(ctx sdk.Context) error {
 	return s.processBlockRecoverError(ctx)
+}
+
+type TimeAfterFunc = timeAfterFunc
+
+func (g *GRPCClient) Connect(ctx context.Context) {
+	g.connect(ctx)
+}
+
+func (g *GRPCClient) SetConn(conn domain.ClientConn) {
+	g.conn = conn
+}
+
+func (g *GRPCClient) SetTimeAfterFunc(timeAfterFunc func(time.Duration) <-chan time.Time) {
+	g.timeAfterFunc = timeAfterFunc
 }

--- a/ingest/sqs/service/grpc_client_test.go
+++ b/ingest/sqs/service/grpc_client_test.go
@@ -1,0 +1,134 @@
+package service_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/osmosis-labs/osmosis/v29/ingest/sqs/domain/mocks"
+	sqsservice "github.com/osmosis-labs/osmosis/v29/ingest/sqs/service"
+
+	"google.golang.org/grpc/connectivity"
+)
+
+func TestConnect_HandlesContextDone(t *testing.T) {
+	mock := &mocks.ClientConn{
+		State: connectivity.TransientFailure,
+		StateChanges: []connectivity.State{
+			connectivity.Connecting,
+			connectivity.Ready,
+		},
+	}
+
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	cancel()
+
+	client.Connect(ctx)
+
+	if mock.GetState() != connectivity.TransientFailure {
+		t.Errorf("expected final state to be TransientFailure, got %v", mock.GetState())
+	}
+}
+
+func TestConnect_StateTransitionFailureToReady(t *testing.T) {
+	mock := &mocks.ClientConn{
+		State: connectivity.TransientFailure,
+		StateChanges: []connectivity.State{
+			connectivity.Connecting,
+			connectivity.Ready,
+		},
+	}
+
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+
+	// Simulate connection attempts for 10 milliseconds
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	client.Connect(ctx)
+
+	// Final state should be Ready
+	if mock.GetState() != connectivity.Ready {
+		t.Errorf("expected final state to be Ready, got %v", mock.GetState())
+	}
+}
+
+func TestConnect_StateTransitionMultipleReady(t *testing.T) {
+	mock := &mocks.ClientConn{
+		State: connectivity.Ready,
+		StateChanges: []connectivity.State{
+			connectivity.Connecting,
+			connectivity.TransientFailure,
+			connectivity.Ready,
+		},
+	}
+
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+
+	// Simulate connection attempts for 10 milliseconds
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Run in the background to allow for state changes
+	go func() {
+		defer wg.Done()
+		client.Connect(ctx)
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	mock.State = connectivity.TransientFailure
+
+	wg.Wait()
+
+	if mock.GetState() != connectivity.Ready {
+		t.Errorf("expected final state to be Ready, got %v", mock.GetState())
+	}
+}
+
+func TestConnect_TimeAfterCall(t *testing.T) {
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(&mocks.ClientConn{
+		State: connectivity.Ready,
+	})
+
+	ch := make(chan time.Time, 1)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		return ch
+	})
+
+	// Simulate persistent connection
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Run in the background to allow for state changes
+	go func() {
+		defer wg.Done()
+		client.Connect(ctx)
+	}()
+
+	// Simulate time.After call
+	ch <- time.Now()
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: BE-708

## What is the purpose of the change

This PR is a port of #9349: 

> From manual testing, if the node fails to connect to SQS immediately after restart, it will get behind and very likely remain so while returning is_synching: false.

> Initially, the perceived reason was the exponential backoff reconnection retry logic that was attempted to be fixed in https://github.com/osmosis-labs/osmosis/pull/9325.

> However, it was only part of the problem. In addition, whenever a connection error was returned, the node would attempt to repush all pool data into SQS since that is the expectation for the very first block. Reading and processing all of this data is expensive to be done for every block. As an outcome, nodes with the SQS ingester enabled but no SQS running by its side would start falling behind fast.

> This PR fixes the problem by moving the GRPC connection logic into the background. Until the connection is successfully established, the node does not start reading pools from its state and processing them.

> As an outcome, the node stops falling behind while communicating that it is caught up.


> Add a description of the overall background and high level changes that this PR introduces

Changes introduced with this PR moves sqs GRPC reconnection to background. 

## Testing and Verifying

This change added tests and can be verified as follows:

  - *Added unit test that validates re-connection mechanism*
  
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A