### PR TITLE
fix(indexer): rename mapstructure tag for PairTopicId to pair-topic-id

### DIFF
--- a/ingest/indexer/indexer_config.go
+++ b/ingest/indexer/indexer_config.go
@@ -18,7 +18,7 @@ type Config struct {
 	PoolTopicId              string `mapstructure:"pool-topic-id"`
 	TokenSupplyTopicId       string `mapstructure:"token-supply-topic-id"`
 	TokenSupplyOffsetTopicId string `mapstructure:"token-supply-offset-topic-id"`
-	PairTopicId              string `mapstructure:"pair-offset-topic-id"`
+	PairTopicId              string `mapstructure:"pair-topic-id"`
 }
 
 // groupOptName is the name of the indexer options group.


### PR DESCRIPTION

## What is the purpose of the change

Fix the configuration struct tag for `PairTopicId` in `ingest/indexer/indexer_config.go` so that it uses the correct `mapstructure:"pair-topic-id"` key. Before it was `pair-offset-topic-id`, the bug probably came from coping of `token-supply-offset-topic-id` above.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
      - N/A - this is an internal bugfix for configuration parsing.
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?
      - N/A - this does not affect user-facing behavior.

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A