### PR TITLE
fix: order txns by fee

### DIFF
--- a/app/lanes.go
+++ b/app/lanes.go
@@ -6,7 +6,6 @@ import (
 
 	signerextraction "github.com/skip-mev/block-sdk/v2/adapters/signer_extraction_adapter"
 	"github.com/skip-mev/block-sdk/v2/block/base"
-	defaultlane "github.com/skip-mev/block-sdk/v2/lanes/base"
 	mevlane "github.com/skip-mev/block-sdk/v2/lanes/mev"
 )
 
@@ -71,10 +70,20 @@ func CreateLanes(app *OsmosisApp, txConfig client.TxConfig) (*mevlane.MEVLane, *
 		mevMatchHandler,
 	)
 
-	defaultLane := defaultlane.NewDefaultLane(
+	options := []base.LaneOption{
+		base.WithMatchHandler(defaultMatchHandler),
+		base.WithMempoolConfigs(defaultConfig, base.NewDefaultTxPriority()),
+	}
+
+	defaultLane, err := base.NewBaseLane(
 		defaultConfig,
-		defaultMatchHandler,
+		"default",
+		options...,
 	)
+
+	if err != nil {
+		panic(err)
+	}
 
 	return mevLane, defaultLane
 }

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -331,6 +331,23 @@ func (s *KeeperTestSuite) TestMempoolFeeDecorator_AnteHandle_MsgTransfer() {
 	}
 }
 
+func (s *KeeperTestSuite) TestCalculatePriorityFromFees() {
+	s.SetupTest(false)
+
+	// Setup test
+	baseDenom, _ := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
+	fees := sdk.NewCoins(sdk.NewInt64Coin(baseDenom, 1000))
+
+	// Create decorator with the app's keeper
+	dfd := keeper.NewDeductFeeDecorator(*s.App.TxFeesKeeper, s.App.AccountKeeper, s.App.BankKeeper, nil)
+
+	// Test priority calculation
+	priority, err := dfd.CalculatePriorityFromFees(s.Ctx, fees)
+
+	s.Require().NoError(err)
+	s.Require().Equal(int64(1000), priority)
+}
+
 func (s *KeeperTestSuite) prepareTx(msg sdk.Msg, txFee sdk.Coins) (sdk.Tx, error) {
 	txBuilder := s.clientCtx.TxConfig.NewTxBuilder()
 	priv0, _, addr0 := testdata.KeyTestPubAddr()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR implements a dynamic transaction priority system based on fees paid, replacing the previous hardcoded priority value of 0. The priority is now calculated by converting transaction fees to uosmo and using the amount as the priority value. This change incentivizes users to pay higher fees for better transaction ordering in the mempool.

## Testing and Verifying

- Added a unit test that validates fees
- tested using in-place-testnet and txn-replayer 