### PR TITLE
fix(dockerfile): match casing between FROM and AS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_TAGS="netgo,ledger,muslc"
 # Builder
 # --------------------------------------------------------
 
-FROM golang:${GO_VERSION}-alpine3.20 as builder
+FROM golang:${GO_VERSION}-alpine3.20 AS builder
 
 ARG GIT_VERSION
 ARG GIT_COMMIT

--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -10,7 +10,7 @@ ARG COSMOVISOR_VERSION="v1.5.0"
 # Builder
 # --------------------------------------------------------
 
-FROM golang:${GO_VERSION}-alpine3.20 as builder
+FROM golang:${GO_VERSION}-alpine3.20 AS builder
 
 ARG GIT_VERSION
 ARG GIT_COMMIT


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This pull request fixes a warning shown during `docker build` due to inconsistent casing between the `FROM` and `as` keywords in the `Dockerfile`.

The warning message was:
```
1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 13)
```

To comply with [Docker's build checks specification](https://docs.docker.com/reference/build-checks/from-as-casing/), this PR updates `as` to `AS` to match the casing of the `FROM` keyword.  
This is a trivial style fix with no functional impact.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?  
        **No, this is a minor style correction**
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?  
        **N/A – no user-facing change**

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A – trivial Dockerfile style fix
