### PR TITLE
replace dead cosmos link chain.json

### DIFF
--- a/networks/cosmoshub-3/chain.json
+++ b/networks/cosmoshub-3/chain.json
@@ -2,7 +2,7 @@
     "status": "killed",
     "network_type": "mainnet",
     "chain_id": "cosmoshub-3",
-    "genesis_url": "https://github.com/cosmos/mainnet/raw/master/genesis.json",
+    "genesis_url": "https://github.com/cosmos/mainnet/blob/master/genesis/genesis.json",
     "bech32_prefix": "cosmos",
     "codebase": {
         "git_repo": "https://github.com/cosmos/gaia",


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL


https://github.com/cosmos/mainnet/raw/master/genesis.json - dead link
https://github.com/cosmos/mainnet/blob/master/genesis/genesis.json - new link