### PR TITLE
CHAIN-1041 | Update seeds for the init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+* [#9420](https://github.com/osmosis-labs/osmosis/pull/9420) chore: update seeds for the init command
 * [#9396](https://github.com/osmosis-labs/osmosis/pull/9396) fix: missing coinbase/rosetta-sdk-go/types dependency 
 
 ## v29.0.2

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -245,7 +245,7 @@ func CreateEnvFile(cmd *cobra.Command) error {
 			// Create ./osmosisd if not exist
 			if _, err = os.Stat(app.DefaultNodeHome); err != nil {
 				if os.IsNotExist(err) {
-					err = os.MkdirAll(app.DefaultNodeHome, 0o777)
+					err = os.MkdirAll(app.DefaultNodeHome, 0777)
 					if err != nil {
 						return err
 					}
@@ -321,7 +321,7 @@ func downloadGenesis(config *tmcfg.Config) error {
 	}
 
 	// Write the body to the destination genesis file
-	err = os.WriteFile(genFilePath, body, 0o644)
+	err = os.WriteFile(genFilePath, body, 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to write genesis file to destination")
 	}

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -97,16 +97,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			// P2P
 			seeds := []string{
-				"21d7539792ee2e0d650b199bf742c56ae0cf499e@162.55.132.230:2000",                             // Notional
-				"44ff091135ef2c69421eacfa136860472ac26e60@65.21.141.212:2000",                              // Notional
-				"ec4d3571bf709ab78df61716e47b5ac03d077a1a@65.108.43.26:2000",                               // Notional
-				"4cb8e1e089bdf44741b32638591944dc15b7cce3@65.108.73.18:2000",                               // Notional
-				"f515a8599b40f0e84dfad935ba414674ab11a668@osmosis.blockpane.com:26656",                     // [ block pane ]
-				"6bcdbcfd5d2c6ba58460f10dbcfde58278212833@osmosis.artifact-staking.io:26656",               // Artifact Staking
-				"77bb5fb9b6964d6e861e91c1d55cf82b67d838b5@bd-osmosis-seed-mainnet-us-01.bdnodes.net:26656", // Blockdaemon US
-				"3243426ab56b67f794fa60a79cc7f11bc7aa752d@bd-osmosis-seed-mainnet-eu-02.bdnodes.net:26656", // Blockdaemon EU
-				"ebc272824924ea1a27ea3183dd0b9ba713494f83@osmosis-mainnet-seed.autostake.com:26716",        // AutoStake.com
-				"7c66126b64cd66bafd9ccfc721f068df451d31a3@osmosis-seed.sunshinevalidation.io:9393",         // Sunshine Validation
+				"4557c0e0d90aa17b9c36b1e89fcb27cf23aa3e4c@seed.osmosis.zone:26656",  // Osmosis Seed
+				"ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:12556", // PolkaChu
 			}
 			config.P2P.Seeds = strings.Join(seeds, ",")
 			config.P2P.MaxNumInboundPeers = 80
@@ -253,7 +245,7 @@ func CreateEnvFile(cmd *cobra.Command) error {
 			// Create ./osmosisd if not exist
 			if _, err = os.Stat(app.DefaultNodeHome); err != nil {
 				if os.IsNotExist(err) {
-					err = os.MkdirAll(app.DefaultNodeHome, 0777)
+					err = os.MkdirAll(app.DefaultNodeHome, 0o777)
 					if err != nil {
 						return err
 					}
@@ -329,7 +321,7 @@ func downloadGenesis(config *tmcfg.Config) error {
 	}
 
 	// Write the body to the destination genesis file
-	err = os.WriteFile(genFilePath, body, 0644)
+	err = os.WriteFile(genFilePath, body, 0o644)
 	if err != nil {
 		return errors.Wrap(err, "failed to write genesis file to destination")
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [CHAIN-1041](https://linear.app/osmosis/issue/CHAIN-1041/add-seeds-to-the-init-command)

## What is the purpose of the change

This pull request updates seeds for the init command.

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage and can be tested manually:

```
go run cmd/osmosisd/main.go init test --home ./.osmosisd
```

```
❯ cat .osmosisd/config/config.toml | grep seeds
# Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
seeds = "4557c0e0d90aa17b9c36b1e89fcb27cf23aa3e4c@seed.osmosis.zone:26656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:12556"
```

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [X] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [X] N/A