### PR TITLE
chore: fix the format of the deprecated comment

### DIFF
--- a/x/protorev/types/keys.go
+++ b/x/protorev/types/keys.go
@@ -51,7 +51,7 @@ var (
 	// KeyPrefixDenomPairToPool is the prefix that is used to store the pool id for a given denom pair (baseDenom, otherDenom)
 	KeyPrefixDenomPairToPool = []byte{prefixDenomPairToPool}
 
-	// DEPRECATED: KeyPrefixDeprecatedBaseDenoms is the prefix that is used to store the base denoms that are used to create cyclic arbitrage routes
+	// Deprecated: KeyPrefixDeprecatedBaseDenoms is the prefix that is used to store the base denoms that are used to create cyclic arbitrage routes
 	KeyPrefixDeprecatedBaseDenoms = []byte{prefixDeprecatedBaseDenoms}
 
 	// -------------- Keys for statistics stores -------------- //


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->



## What is the purpose of the change

I forked the project and added `gocritic` checks and found a warning: `./protorev/types/keys.go:54:2: deprecatedComment: use 'Deprecated: ' (note the casing) instead of 'DEPRECATED: '` 




## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [ ] N/A