### PR TITLE
Fix Typo and Improve Proto Comments in DowntimeDetector and ValsetPref Modules

### DIFF
--- a/proto/osmosis/downtimedetector/v1beta1/query.proto
+++ b/proto/osmosis/downtimedetector/v1beta1/query.proto
@@ -35,5 +35,5 @@ message RecoveredSinceDowntimeOfLengthRequest {
 }
 
 message RecoveredSinceDowntimeOfLengthResponse {
-  bool succesfully_recovered = 1;
+  bool successfully_recovered = 1;
 }

--- a/proto/osmosis/valsetpref/v1beta1/tx.proto
+++ b/proto/osmosis/valsetpref/v1beta1/tx.proto
@@ -28,7 +28,7 @@ service Msg {
   rpc UndelegateFromValidatorSet(MsgUndelegateFromValidatorSet)
       returns (MsgUndelegateFromValidatorSetResponse);
 
-  // UndelegateFromRebalancedValidatorSet undelegates the proivded amount from
+  // UndelegateFromRebalancedValidatorSet undelegates the provided amount from
   // the validator set, but takes into consideration the current delegations
   // to the user's validator set to determine the weights assigned to each.
   rpc UndelegateFromRebalancedValidatorSet(


### PR DESCRIPTION


**Description:**  
- Corrected a typo in the `successfully_recovered` field in DowntimeDetector proto.
- Fixed spelling and improved clarity in ValsetPref proto comments.
- Minor proto message renaming for consistency.