### PR TITLE
Update chain.json

### DIFF
--- a/networks/cosmoshub-3/chain.json
+++ b/networks/cosmoshub-3/chain.json
@@ -2,7 +2,7 @@
     "status": "killed",
     "network_type": "mainnet",
     "chain_id": "cosmoshub-3",
-    "genesis_url": "https://github.com/cosmos/mainnet/raw/master/genesis.json",
+    "genesis_url": "https://github.com/cosmos/mainnet/blob/master/genesis/genesis.json",
     "bech32_prefix": "cosmos",
     "codebase": {
         "git_repo": "https://github.com/cosmos/gaia",


### PR DESCRIPTION
The link to the genesis.json file was updated to reflect a change in the repository's structure. The path was corrected from /raw/master/genesis.json to /blob/master/genesis/genesis.json. This ensures that the configuration points to the valid and current location of the genesis file, preventing 404 errors and ensuring network information is accurate.