### PR TITLE
Updates actions/checkout to the latest stable version v4 

### DIFF
--- a/x/tokenfactory/keeper/testcontracts/contracts/infinite-track-beforesend/.github/workflows/Basic.yml
+++ b/x/tokenfactory/keeper/testcontracts/contracts/infinite-track-beforesend/.github/workflows/Basic.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/x/tokenfactory/keeper/testcontracts/contracts/infinite-track-beforesend/.github/workflows/Release.yml
+++ b/x/tokenfactory/keeper/testcontracts/contracts/infinite-track-beforesend/.github/workflows/Release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install cargo-run-script
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:

Updates all instances of actions/checkout@v2 to actions/checkout@v4

Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.