### PR TITLE
chore: bump block sdk to latest version

### DIFF
--- a/app/lanes.go
+++ b/app/lanes.go
@@ -6,7 +6,7 @@ import (
 
 	signerextraction "github.com/skip-mev/block-sdk/v2/adapters/signer_extraction_adapter"
 	"github.com/skip-mev/block-sdk/v2/block/base"
-	defaultlane "github.com/skip-mev/block-sdk/v2/lanes/base"
+	baselane "github.com/skip-mev/block-sdk/v2/lanes/base"
 	mevlane "github.com/skip-mev/block-sdk/v2/lanes/mev"
 )
 
@@ -71,9 +71,17 @@ func CreateLanes(app *OsmosisApp, txConfig client.TxConfig) (*mevlane.MEVLane, *
 		mevMatchHandler,
 	)
 
-	defaultLane := defaultlane.NewDefaultLane(
+	// Create a default mempool for the base lane
+	defaultMempool := base.NewMempoolWithDefaultOrdering(
+		base.DefaultTxPriority(),
+		signerAdapter,
+		maxTxPerDefaultLane,
+	)
+
+	defaultLane := baselane.NewDefaultLaneWithMempool(
 		defaultConfig,
 		defaultMatchHandler,
+		defaultMempool,
 	)
 
 	return mevLane, defaultLane

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/CosmWasm/wasmd v0.53.2
 	github.com/CosmWasm/wasmvm/v2 v2.1.5
 	github.com/Masterminds/semver v1.5.0
-	github.com/cometbft/cometbft v0.38.13
+	github.com/cometbft/cometbft v0.38.17
 	github.com/cometbft/cometbft-db v0.14.1
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
@@ -294,11 +294,6 @@ replace (
 	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/store/v1.1.1-v0.50.11-v28-osmo-2
 	cosmossdk.io/store => github.com/osmosis-labs/cosmos-sdk/store v1.1.1-v0.50.11-v28-osmo-2
 
-	// Direct cometbft branch link: https://github.com/osmosis-labs/cometbft/tree/osmo-v28/0.38.17, current branch: osmo-v28/v0.38.17
-	// Direct commit link: https://github.com/osmosis-labs/cometbft/commit/58bfcdcb2fdd81655586678c2062cdc51adbdf0d
-	// Direct tag link: https://github.com/osmosis-labs/cometbft/releases/tag/v0.38.17-v28-osmo-1
-	github.com/cometbft/cometbft => github.com/osmosis-labs/cometbft v0.38.17-v28-osmo-1
-
 	// Direct cosmos-sdk branch link: https://github.com/osmosis-labs/cosmos-sdk/tree/osmo-v28/0.50.11, current branch: osmo-v28/0.50.11
 	// Direct commit link: https://github.com/osmosis-labs/cosmos-sdk/commit/5b4e03484cf88e7d1fce003ba75b4fdc5c81f15f
 	// Direct tag link: https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.50.11-v28-osmo-3
@@ -308,7 +303,7 @@ replace (
 	// Direct block-sdk branch link: https://github.com/osmosis-labs/block-sdk/tree/release/v2.x.x, current branch: release/v2.x.x
 	// Direct commit link: https://github.com/osmosis-labs/block-sdk/commit/a86e729f843d36392393a8ff6a14c9fbc15f2fcc
 	// Direct tag link: https://github.com/osmosis-labs/block-sdk/releases/tag/v2.1.6
-	github.com/skip-mev/block-sdk/v2 => github.com/osmosis-labs/block-sdk/v2 v2.1.6
+	github.com/skip-mev/block-sdk/v2 => github.com/osmosis-labs/block-sdk/v2 v2.1.7-0.20250611135306-7aca335f5a4c
 
 	// replace as directed by sdk upgrading.md https://github.com/cosmos/cosmos-sdk/blob/393de266c8675dc16cc037c1a15011b1e990975f/UPGRADING.md?plain=1#L713
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.mod
+++ b/go.mod
@@ -301,9 +301,9 @@ replace (
 
 	// The block-sdk is no longer maintained by Skip, instead we use the osmosis-labs fork.
 	// Direct block-sdk branch link: https://github.com/osmosis-labs/block-sdk/tree/release/v2.x.x, current branch: release/v2.x.x
-	// Direct commit link: https://github.com/osmosis-labs/block-sdk/commit/a86e729f843d36392393a8ff6a14c9fbc15f2fcc
-	// Direct tag link: https://github.com/osmosis-labs/block-sdk/releases/tag/v2.1.6
-	github.com/skip-mev/block-sdk/v2 => github.com/osmosis-labs/block-sdk/v2 v2.1.7-0.20250611135306-7aca335f5a4c
+	// Direct commit link: https://github.com/osmosis-labs/block-sdk/commit/3684c82f9673c3210ca89c1a3b4511b62cafe637
+	// Direct tag link: https://github.com/osmosis-labs/block-sdk/releases/tag/v2.1.7-mempool
+	github.com/skip-mev/block-sdk/v2 => github.com/osmosis-labs/block-sdk/v2 v2.1.7-mempool
 
 	// replace as directed by sdk upgrading.md https://github.com/cosmos/cosmos-sdk/blob/393de266c8675dc16cc037c1a15011b1e990975f/UPGRADING.md?plain=1#L713
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -926,8 +926,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.11.0 h1:OiHcxKAvSDUwsEVh2BjxQQc/5EHz9n0va9awCtNGuyA=
 github.com/ory/dockertest/v3 v3.11.0/go.mod h1:VIPxS1gwT9NpPOrfD3rACs8Y9Z7yhzO4SB194iUDnUI=
-github.com/osmosis-labs/block-sdk/v2 v2.1.7-0.20250611135306-7aca335f5a4c h1:XVklujydH/TrdEksNUG9c6sHdeOZEAKRxWnwXY9jIgE=
-github.com/osmosis-labs/block-sdk/v2 v2.1.7-0.20250611135306-7aca335f5a4c/go.mod h1:E8SvITZUdxkes3gI3+kgESZL+NLffkcLKnowUgYTOf4=
+github.com/osmosis-labs/block-sdk/v2 v2.1.7-mempool h1:X+ZlcvAfpz8KCuSHHRsZZ9g1ii5OYB9TzmG126RCQ2k=
+github.com/osmosis-labs/block-sdk/v2 v2.1.7-mempool/go.mod h1:E8SvITZUdxkes3gI3+kgESZL+NLffkcLKnowUgYTOf4=
 github.com/osmosis-labs/cosmos-sdk v0.50.11-v28-osmo-3 h1:BfJdINqLa6SHlWgfPPYTAzx/HuY88pA8yiSPeB/4zhI=
 github.com/osmosis-labs/cosmos-sdk v0.50.11-v28-osmo-3/go.mod h1:KO0mBgNmkMA+yVkq13GeHWzR2F2iwjkfevywmPUhCVY=
 github.com/osmosis-labs/cosmos-sdk/store v1.1.1-v0.50.11-v28-osmo-2 h1:1DjjPo2kkmyOUp6CKLyqSZsdwa906UrQHYH9m9kjw00=

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
+github.com/cometbft/cometbft v0.38.17 h1:FkrQNbAjiFqXydeAO81FUzriL4Bz0abYxN/eOHrQGOk=
+github.com/cometbft/cometbft v0.38.17/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
 github.com/cometbft/cometbft-db v0.14.1 h1:SxoamPghqICBAIcGpleHbmoPqy+crij/++eZz3DlerQ=
 github.com/cometbft/cometbft-db v0.14.1/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=
@@ -924,10 +926,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.11.0 h1:OiHcxKAvSDUwsEVh2BjxQQc/5EHz9n0va9awCtNGuyA=
 github.com/ory/dockertest/v3 v3.11.0/go.mod h1:VIPxS1gwT9NpPOrfD3rACs8Y9Z7yhzO4SB194iUDnUI=
-github.com/osmosis-labs/block-sdk/v2 v2.1.6 h1:zMZADGm5sUB45CJzf5Y24fY7jgGeQrwAjdXYKgYZnrA=
-github.com/osmosis-labs/block-sdk/v2 v2.1.6/go.mod h1:E8SvITZUdxkes3gI3+kgESZL+NLffkcLKnowUgYTOf4=
-github.com/osmosis-labs/cometbft v0.38.17-v28-osmo-1 h1:0xPd6S6mCsVT0IKP0xIUmg6sgo12iHMu5H6vxwrrIo0=
-github.com/osmosis-labs/cometbft v0.38.17-v28-osmo-1/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
+github.com/osmosis-labs/block-sdk/v2 v2.1.7-0.20250611135306-7aca335f5a4c h1:XVklujydH/TrdEksNUG9c6sHdeOZEAKRxWnwXY9jIgE=
+github.com/osmosis-labs/block-sdk/v2 v2.1.7-0.20250611135306-7aca335f5a4c/go.mod h1:E8SvITZUdxkes3gI3+kgESZL+NLffkcLKnowUgYTOf4=
 github.com/osmosis-labs/cosmos-sdk v0.50.11-v28-osmo-3 h1:BfJdINqLa6SHlWgfPPYTAzx/HuY88pA8yiSPeB/4zhI=
 github.com/osmosis-labs/cosmos-sdk v0.50.11-v28-osmo-3/go.mod h1:KO0mBgNmkMA+yVkq13GeHWzR2F2iwjkfevywmPUhCVY=
 github.com/osmosis-labs/cosmos-sdk/store v1.1.1-v0.50.11-v28-osmo-2 h1:1DjjPo2kkmyOUp6CKLyqSZsdwa906UrQHYH9m9kjw00=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Updating the mempool ordering to the default cometbft ordering

See block-sdk PR:
https://github.com/osmosis-labs/block-sdk/pull/2

## Validator running this version on testnet

- https://www.mintscan.io/osmosis-testnet/validators/osmovaloper19r5dj0ztqcutlnunguw3a3dmapp9r5k3l8hkyg?sector=proposed-blocks
- 