### PR TITLE
BE-708 | Fix: Once SQS disconnects the node stales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Compatible
 
+* [#9443](https://github.com/osmosis-labs/osmosis/pull/9443) fix: Once SQS disconnects the node stales
 * [#9420](https://github.com/osmosis-labs/osmosis/pull/9420) chore: update seeds for the init command
 * [#9396](https://github.com/osmosis-labs/osmosis/pull/9396) fix: missing coinbase/rosetta-sdk-go/types dependency 
 

--- a/ingest/sqs/domain/ingester.go
+++ b/ingest/sqs/domain/ingester.go
@@ -8,6 +8,8 @@ import (
 	ingesttypes "github.com/osmosis-labs/osmosis/v30/ingest/types"
 
 	commondomain "github.com/osmosis-labs/osmosis/v30/ingest/common/domain"
+
+	"google.golang.org/grpc/connectivity"
 )
 
 // PoolsTransformer is an interface that defines the methods for the pool transformer
@@ -28,4 +30,23 @@ type SQSGRPClient interface {
 	// Note: while there are built-in mechanisms to handle retry such as exponential backoff, they are no suitable for our context.
 	// In our context, we would rather continue attempting to repush the data in the next block instead of blocking the system.
 	PushData(ctx context.Context, height uint64, pools []ingesttypes.PoolI, takerFeesMap ingesttypes.TakerFeeMap) error
+
+	// IsConnected returns nil if the GRPC client is connected to the SQS service.
+	IsConnected() error
+}
+
+// A StateChanger reports state changes, e.g. a grpc.ClientConn.
+type StateChanger interface {
+	// Connect begins connecting the StateChanger.
+	Connect()
+	// GetState returns the current state of the StateChanger.
+	GetState() connectivity.State
+	// WaitForStateChange returns true when the state becomes s, or returns
+	// false if ctx is canceled first.
+	WaitForStateChange(ctx context.Context, s connectivity.State) bool
+}
+
+// ClientConn is a gRPC client connection interface.
+type ClientConn interface {
+	StateChanger
 }

--- a/ingest/sqs/domain/mocks/grpc_client_mock.go
+++ b/ingest/sqs/domain/mocks/grpc_client_mock.go
@@ -2,10 +2,47 @@ package mocks
 
 import (
 	"context"
+	"sync"
 
 	"github.com/osmosis-labs/osmosis/v30/ingest/sqs/domain"
 	ingesttypes "github.com/osmosis-labs/osmosis/v30/ingest/types"
+
+	"google.golang.org/grpc/connectivity"
 )
+
+type ClientConn struct {
+	mu              sync.Mutex
+	State           connectivity.State
+	StateChanges    []connectivity.State
+	waitShouldBlock bool
+}
+
+func (m *ClientConn) GetState() connectivity.State {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.State
+}
+
+func (m *ClientConn) Connect() {}
+
+var _ domain.ClientConn = &ClientConn{}
+
+func (m *ClientConn) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+	if m.waitShouldBlock {
+		<-ctx.Done()
+		return false
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.StateChanges) > 0 {
+		m.State = m.StateChanges[0]
+		m.StateChanges = m.StateChanges[1:]
+	}
+
+	return true
+}
 
 type GRPCClientMock struct {
 	Error error
@@ -15,5 +52,10 @@ var _ domain.SQSGRPClient = &GRPCClientMock{}
 
 // PushData implements domain.SQSGRPClient.
 func (g *GRPCClientMock) PushData(ctx context.Context, height uint64, pools []ingesttypes.PoolI, takerFeesMap ingesttypes.TakerFeeMap) error {
+	return g.Error
+}
+
+// IsConnected implements domain.SQSGRPClient.
+func (g *GRPCClientMock) IsConnected() error {
 	return g.Error
 }

--- a/ingest/sqs/domain/mocks/grpc_client_mock.go
+++ b/ingest/sqs/domain/mocks/grpc_client_mock.go
@@ -17,6 +17,12 @@ type ClientConn struct {
 	waitShouldBlock bool
 }
 
+func (m *ClientConn) SetState(s connectivity.State) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.State = s
+}
+
 func (m *ClientConn) GetState() connectivity.State {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/ingest/sqs/domain/mocks/grpc_client_mock.go
+++ b/ingest/sqs/domain/mocks/grpc_client_mock.go
@@ -39,12 +39,15 @@ func (m *ClientConn) WaitForStateChange(ctx context.Context, sourceState connect
 		return false
 	}
 
+	if ctx.Err() != nil {
+		return false // Context is done, no state change can occur.
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if len(m.StateChanges) > 0 {
-		m.State = m.StateChanges[0]
-		m.StateChanges = m.StateChanges[1:]
+		m.State, m.StateChanges = m.StateChanges[0], m.StateChanges[1:]
 	}
 
 	return true

--- a/ingest/sqs/service/export_test.go
+++ b/ingest/sqs/service/export_test.go
@@ -1,9 +1,30 @@
 package service
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"context"
+	"time"
+
+	"github.com/osmosis-labs/osmosis/v30/ingest/sqs/domain"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 type SQSStreamingService = sqsStreamingService
 
 func (s *sqsStreamingService) ProcessBlockRecoverError(ctx sdk.Context) error {
 	return s.processBlockRecoverError(ctx)
+}
+
+type TimeAfterFunc = timeAfterFunc
+
+func (g *GRPCClient) Connect(ctx context.Context) {
+	g.connect(ctx)
+}
+
+func (g *GRPCClient) SetConn(conn domain.ClientConn) {
+	g.conn = conn
+}
+
+func (g *GRPCClient) SetTimeAfterFunc(timeAfterFunc func(time.Duration) <-chan time.Time) {
+	g.timeAfterFunc = timeAfterFunc
 }

--- a/ingest/sqs/service/grpc_client.go
+++ b/ingest/sqs/service/grpc_client.go
@@ -4,72 +4,80 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/telemetry"
-	"github.com/hashicorp/go-metrics"
 	ingesttypes "github.com/osmosis-labs/osmosis/v30/ingest/types"
 	prototypes "github.com/osmosis-labs/osmosis/v30/ingest/types/proto/types"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 
 	"github.com/osmosis-labs/osmosis/v30/ingest/sqs/domain"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v30/x/poolmanager/types"
 )
 
+// timeAfterFunc is time.AfterFunc
+type timeAfterFunc func(time.Duration) <-chan time.Time
+
 type GRPCClient struct {
-	grpcAddress          string
-	grpcMaxCallSizeBytes int
-	grpcConn             *grpc.ClientConn
-	appCodec             codec.Codec
+	timeAfterFunc     timeAfterFunc
+	connCheckInterval time.Duration
+	grpcAddress       string
+	conn              domain.ClientConn
+	appCodec          codec.Codec
 }
 
-var (
-	_ domain.SQSGRPClient = &GRPCClient{}
-)
+var _ domain.SQSGRPClient = &GRPCClient{}
 
-func NewGRPCCLient(grpcAddress string, grpxMaxCallSizeBytes int, appCodec codec.Codec) *GRPCClient {
-	return &GRPCClient{
-		grpcAddress:          grpcAddress,
-		grpcMaxCallSizeBytes: grpxMaxCallSizeBytes,
-		appCodec:             appCodec,
+// NewGRPCCLient will create a new gRPC client connection to the SQS service and return a GRPCClient instance.
+// Underlying connection is being managed in a separate goroutine to handle reconnections.
+// Clients should call IsConnected() before using the client to ensure the connection is ready for use and cancel the context
+// for graceful shutdown.
+func NewGRPCCLient(ctx context.Context, grpcAddress string, grpcMaxCallSizeBytes int, appCodec codec.Codec) (*GRPCClient, error) {
+	conn, err := grpc.NewClient(
+		grpcAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(grpcMaxCallSizeBytes)),
+		grpc.WithDisableRetry(),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			// Arbitrary choices based on brute-force testing.
+			Backoff: backoff.Config{
+				BaseDelay:  50 * time.Millisecond,
+				Jitter:     0.2,
+				Multiplier: 2,
+				MaxDelay:   10 * time.Second,
+			},
+		}),
+	)
+	if err != nil {
+		return nil, err
 	}
+	client := &GRPCClient{
+		timeAfterFunc:     time.After,
+		grpcAddress:       grpcAddress,
+		conn:              conn,
+		appCodec:          appCodec,
+		connCheckInterval: time.Second,
+	}
+
+	go client.connect(ctx)
+
+	return client, nil
 }
 
 // PushData implements domain.GracefulSQSGRPClient.
 func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingesttypes.PoolI, takerFeesMap ingesttypes.TakerFeeMap) (err error) {
-	// If sqs service is unavailable, we should reset the connection
-	// and attempt to reconnect during the next block.
-	var shouldResetConnection bool
+	if err := g.IsConnected(); err != nil {
+		return err
+	}
 
-	defer func() {
-		if shouldResetConnection {
-			if g.grpcConn != nil {
-				g.grpcConn.Close()
-				g.grpcConn = nil
-			}
-
-			// Increase the counter for the grpc connection error
-			telemetry.IncrCounterWithLabels([]string{domain.SQSGRPCConnectionErrorMetricName}, 1, []metrics.Label{
-				telemetry.NewLabel("height", fmt.Sprintf("%d", height)),
-				telemetry.NewLabel("err", err.Error()),
-			})
-		}
-	}()
-
-	if g.grpcConn == nil {
-		// Note: we disable retries since we have a custom logic to repeat retries in the next block.
-		// Using the built-in GRPC retry back-off logic is likely to halt the serial system.
-		// As a result, we opt in for simply continuing to attempting to process the next block
-		// and retrying the connection and ingest
-		g.grpcConn, err = grpc.NewClient(g.grpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(g.grpcMaxCallSizeBytes)), grpc.WithDisableRetry(), grpc.WithDisableRetry(), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
-		if err != nil {
-			shouldResetConnection = true
-			return err
-		}
+	readyConn, ok := g.conn.(*grpc.ClientConn)
+	if !ok {
+		return fmt.Errorf("failed to cast g.conn to grpc.ClientConn")
 	}
 
 	// Marshal pools
@@ -84,7 +92,7 @@ func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingest
 		return err
 	}
 
-	ingesterClient := prototypes.NewSQSIngesterClient(g.grpcConn)
+	ingesterClient := prototypes.NewSQSIngesterClient(readyConn)
 
 	req := prototypes.ProcessBlockRequest{
 		BlockHeight:  height,
@@ -94,17 +102,45 @@ func (g *GRPCClient) PushData(ctx context.Context, height uint64, pools []ingest
 
 	_, err = ingesterClient.ProcessBlock(ctx, &req)
 	if err != nil {
-		status, ok := status.FromError(err)
-
-		// If the connection is unavailable, we should reset the connection
-		// and attempt to reconnect during the next block.
-		// On any other error, we assume that the connection is still valid so we
-		// do no attempt to recreate it. However, we still return the error to the caller.
-		shouldResetConnection = ok && status.Code() == codes.Unavailable
-
 		return err
 	}
 
+	return nil
+}
+
+// connect manages underlying gRPC connection by checking the connection state and attempting to reconnect when necessary.
+func (g *GRPCClient) connect(ctx context.Context) {
+	for {
+		// Check if the context is done
+		if ctx.Err() != nil {
+			return
+		}
+
+		state := g.conn.GetState()
+		if state != connectivity.Ready {
+			// Attempt to connect
+			g.conn.Connect()
+
+			// Wait for a state change or timeout/cancel
+			if !g.conn.WaitForStateChange(ctx, state) {
+				return // Context done
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				return
+			case <-g.timeAfterFunc(g.connCheckInterval):
+				// Recheck the connection state after interval
+			}
+		}
+	}
+}
+
+// IsConnected returns true if the gRPC connection is ready.
+func (g *GRPCClient) IsConnected() error {
+	if g.conn.GetState() != connectivity.Ready {
+		return fmt.Errorf("SQS gRPC connection to %s is not ready yet", g.grpcAddress)
+	}
 	return nil
 }
 

--- a/ingest/sqs/service/grpc_client_test.go
+++ b/ingest/sqs/service/grpc_client_test.go
@@ -2,106 +2,136 @@ package service_test
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/osmosis-labs/osmosis/v30/ingest/sqs/domain/mocks"
 	sqsservice "github.com/osmosis-labs/osmosis/v30/ingest/sqs/service"
+	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/connectivity"
 )
 
-func TestConnect_HandlesContextDone(t *testing.T) {
+func newClientWithMockConn(initial connectivity.State, transitions []connectivity.State) (*sqsservice.GRPCClient, *mocks.ClientConn) {
 	mock := &mocks.ClientConn{
-		State: connectivity.TransientFailure,
-		StateChanges: []connectivity.State{
-			connectivity.Connecting,
-			connectivity.Ready,
-		},
+		State:        initial,
+		StateChanges: transitions,
 	}
-
 	client := &sqsservice.GRPCClient{}
 	client.SetConn(mock)
+	return client, mock
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+func newClientWithStateChan(initial connectivity.State, transitions []connectivity.State) (*sqsservice.GRPCClient, chan connectivity.State) {
+	stateChan := make(chan connectivity.State)
+	mock := &mocks.ClientConn{
+		State:        initial,
+		StateChanges: transitions,
+	}
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+	client.SetStateChan(stateChan)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		return time.After(time.Millisecond)
+	})
+	return client, stateChan
+}
+
+func shortTimeoutCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 1*time.Millisecond)
+}
+
+func longTimeoutCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 100*time.Millisecond)
+}
+
+func assertFinalState(t *testing.T, got, want connectivity.State) {
+	t.Helper()
+	if got != want {
+		t.Errorf("expected final state %v, got %v", want, got)
+	}
+}
+
+func TestConnect_StateTransitions(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     connectivity.State
+		transitions []connectivity.State
+		expected    connectivity.State
+	}{
+		{"FailureToReady", connectivity.TransientFailure, []connectivity.State{connectivity.Connecting, connectivity.Ready}, connectivity.Ready},
+		{"IdleToReady", connectivity.Idle, []connectivity.State{connectivity.Connecting, connectivity.Ready}, connectivity.Ready},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mock := newClientWithMockConn(tt.initial, tt.transitions)
+			client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+				return time.After(time.Millisecond)
+			})
+			ctx, cancel := shortTimeoutCtx()
+			defer cancel()
+			client.Connect(ctx)
+
+			assertFinalState(t, mock.GetState(), tt.expected)
+		})
+	}
+}
+
+func TestConnect_HandlesContextDone(t *testing.T) {
+	client, mock := newClientWithMockConn(connectivity.TransientFailure, []connectivity.State{
+		connectivity.Connecting,
+		connectivity.Ready,
+	})
+	client.SetConn(mock)
+
+	ctx, cancel := shortTimeoutCtx()
 	cancel()
 
 	client.Connect(ctx)
 
-	if mock.GetState() != connectivity.TransientFailure {
-		t.Errorf("expected final state to be TransientFailure, got %v", mock.GetState())
-	}
-}
-
-func TestConnect_StateTransitionFailureToReady(t *testing.T) {
-	mock := &mocks.ClientConn{
-		State: connectivity.TransientFailure,
-		StateChanges: []connectivity.State{
-			connectivity.Connecting,
-			connectivity.Ready,
-		},
-	}
-
-	client := &sqsservice.GRPCClient{}
-	client.SetConn(mock)
-	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
-		ch := make(chan time.Time, 1)
-		ch <- time.Now()
-		return ch
-	})
-
-	// Simulate connection attempts for 10 milliseconds
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-
-	client.Connect(ctx)
-
-	// Final state should be Ready
-	if mock.GetState() != connectivity.Ready {
-		t.Errorf("expected final state to be Ready, got %v", mock.GetState())
-	}
+	assertFinalState(t, mock.GetState(), connectivity.TransientFailure)
 }
 
 func TestConnect_StateTransitionMultipleReady(t *testing.T) {
-	mock := &mocks.ClientConn{
-		State: connectivity.Ready,
-		StateChanges: []connectivity.State{
-			connectivity.Connecting,
-			connectivity.TransientFailure,
-			connectivity.Ready,
-		},
-	}
-
-	client := &sqsservice.GRPCClient{}
-	client.SetConn(mock)
-	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
-		ch := make(chan time.Time, 1)
-		ch <- time.Now()
-		return ch
+	client, stateChanged := newClientWithStateChan(connectivity.Idle, []connectivity.State{
+		connectivity.Connecting,
+		connectivity.TransientFailure,
+		connectivity.Ready,
 	})
 
-	// Simulate connection attempts for 10 milliseconds
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	// context with time out to allow for state changes
+	ctx, cancel := longTimeoutCtx()
 	defer cancel()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	// Run in the background to allow for state changes
 	go func() {
-		defer wg.Done()
-		client.Connect(ctx)
+		client.Connect(ctx) // in background to allow for state changes
 	}()
 
-	time.Sleep(5 * time.Millisecond)
-	mock.SetState(connectivity.TransientFailure)
-
-	wg.Wait()
-
-	if mock.GetState() != connectivity.Ready {
-		t.Errorf("expected final state to be Ready, got %v", mock.GetState())
+	var states []connectivity.State
+loop:
+	for {
+		select {
+		case state, ok := <-stateChanged:
+			if !ok {
+				break loop // exit the loop when the channel is closed
+			}
+			states = append(states, state)
+		case <-time.After(1 * time.Second):
+			t.Fatal("test timed out")
+		}
 	}
+	states = slices.Compact(states) // Remove duplicates
+
+	// Assert the states collected match the expected sequence
+	require.Equal(t, states, []connectivity.State{
+		connectivity.Idle,
+		connectivity.Connecting,
+		connectivity.TransientFailure,
+		connectivity.Ready,
+	}, "State transitions did not match the expected sequence")
 }
 
 func TestConnect_TimeAfterCall(t *testing.T) {

--- a/ingest/sqs/service/grpc_client_test.go
+++ b/ingest/sqs/service/grpc_client_test.go
@@ -34,13 +34,13 @@ func newClientWithStateChan(initial connectivity.State, transitions []connectivi
 	client.SetConn(mock)
 	client.SetStateChan(stateChan)
 	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
-		return time.After(time.Millisecond)
+		return time.After(10 * time.Millisecond)
 	})
 	return client, stateChan
 }
 
 func shortTimeoutCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 1*time.Millisecond)
+	return context.WithTimeout(context.Background(), 10*time.Millisecond)
 }
 
 func longTimeoutCtx() (context.Context, context.CancelFunc) {

--- a/ingest/sqs/service/grpc_client_test.go
+++ b/ingest/sqs/service/grpc_client_test.go
@@ -95,7 +95,7 @@ func TestConnect_StateTransitionMultipleReady(t *testing.T) {
 	}()
 
 	time.Sleep(5 * time.Millisecond)
-	mock.State = connectivity.TransientFailure
+	mock.SetState(connectivity.TransientFailure)
 
 	wg.Wait()
 

--- a/ingest/sqs/service/grpc_client_test.go
+++ b/ingest/sqs/service/grpc_client_test.go
@@ -1,0 +1,134 @@
+package service_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/osmosis-labs/osmosis/v30/ingest/sqs/domain/mocks"
+	sqsservice "github.com/osmosis-labs/osmosis/v30/ingest/sqs/service"
+
+	"google.golang.org/grpc/connectivity"
+)
+
+func TestConnect_HandlesContextDone(t *testing.T) {
+	mock := &mocks.ClientConn{
+		State: connectivity.TransientFailure,
+		StateChanges: []connectivity.State{
+			connectivity.Connecting,
+			connectivity.Ready,
+		},
+	}
+
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	cancel()
+
+	client.Connect(ctx)
+
+	if mock.GetState() != connectivity.TransientFailure {
+		t.Errorf("expected final state to be TransientFailure, got %v", mock.GetState())
+	}
+}
+
+func TestConnect_StateTransitionFailureToReady(t *testing.T) {
+	mock := &mocks.ClientConn{
+		State: connectivity.TransientFailure,
+		StateChanges: []connectivity.State{
+			connectivity.Connecting,
+			connectivity.Ready,
+		},
+	}
+
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+
+	// Simulate connection attempts for 10 milliseconds
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	client.Connect(ctx)
+
+	// Final state should be Ready
+	if mock.GetState() != connectivity.Ready {
+		t.Errorf("expected final state to be Ready, got %v", mock.GetState())
+	}
+}
+
+func TestConnect_StateTransitionMultipleReady(t *testing.T) {
+	mock := &mocks.ClientConn{
+		State: connectivity.Ready,
+		StateChanges: []connectivity.State{
+			connectivity.Connecting,
+			connectivity.TransientFailure,
+			connectivity.Ready,
+		},
+	}
+
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(mock)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+
+	// Simulate connection attempts for 10 milliseconds
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Run in the background to allow for state changes
+	go func() {
+		defer wg.Done()
+		client.Connect(ctx)
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	mock.State = connectivity.TransientFailure
+
+	wg.Wait()
+
+	if mock.GetState() != connectivity.Ready {
+		t.Errorf("expected final state to be Ready, got %v", mock.GetState())
+	}
+}
+
+func TestConnect_TimeAfterCall(t *testing.T) {
+	client := &sqsservice.GRPCClient{}
+	client.SetConn(&mocks.ClientConn{
+		State: connectivity.Ready,
+	})
+
+	ch := make(chan time.Time, 1)
+	client.SetTimeAfterFunc(func(d time.Duration) <-chan time.Time {
+		return ch
+	})
+
+	// Simulate persistent connection
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Run in the background to allow for state changes
+	go func() {
+		defer wg.Done()
+		client.Connect(ctx)
+	}()
+
+	// Simulate time.After call
+	ch <- time.Now()
+	cancel()
+	wg.Wait()
+}

--- a/ingest/sqs/service/sqs_streaming_service.go
+++ b/ingest/sqs/service/sqs_streaming_service.go
@@ -62,6 +62,7 @@ func (s *sqsStreamingService) ListenFinalizeBlock(goCtx context.Context, req typ
 }
 
 func (s *sqsStreamingService) ListenCommit(ctx context.Context, res types.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	blockProcessStartTime := time.Now()
 	defer func() {
 		// Emit telemetry for the duration of processing the block.
@@ -70,10 +71,19 @@ func (s *sqsStreamingService) ListenCommit(ctx context.Context, res types.Respon
 		s.blockUpdatesProcessUtil.SetChangeSet(nil)
 	}()
 
+	// If the gRPC client is not connected, return early to avoid blocking processing the block data.
+	if err := s.grpcClient.IsConnected(); err != nil {
+		// Due to error mark the block data as not ingested for full processing on the block.
+		s.blockProcessStrategyManager.MarkErrorObserved()
+
+		emitFailureTelemetry(sdkCtx, err, domain.SQSProcessBlockErrorMetricName)
+
+		return nil // avoid breaking consensus
+	}
+
 	// Set the change set on the block update process utils.
 	s.blockUpdatesProcessUtil.SetChangeSet(changeSet)
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// Always return nil to avoid making this consensus breaking.
 	_ = s.processBlockRecoverError(sdkCtx)
 	return nil
@@ -130,7 +140,7 @@ func (s *sqsStreamingService) processBlockRecoverError(ctx sdk.Context) (err err
 }
 
 // emitFailureTelemetry emits telemetry for panics or errors
-func emitFailureTelemetry(ctx sdk.Context, r interface{}, metricName string) {
+func emitFailureTelemetry(ctx sdk.Context, r any, metricName string) {
 	// Panics are silently logged and ignored.
 	ctx.Logger().Error(metricName, "err", r)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [BE-708](https://linear.app/osmosis/issue/BE-708/when-sqs-disconnects-the-node-stales)

## What is the purpose of the change

This PR is a port of #9349: 

> From manual testing, if the node fails to connect to SQS immediately after restart, it will get behind and very likely remain so while returning is_synching: false.

> Initially, the perceived reason was the exponential backoff reconnection retry logic that was attempted to be fixed in https://github.com/osmosis-labs/osmosis/pull/9325.

> However, it was only part of the problem. In addition, whenever a connection error was returned, the node would attempt to repush all pool data into SQS since that is the expectation for the very first block. Reading and processing all of this data is expensive to be done for every block. As an outcome, nodes with the SQS ingester enabled but no SQS running by its side would start falling behind fast.

> This PR fixes the problem by moving the GRPC connection logic into the background. Until the connection is successfully established, the node does not start reading pools from its state and processing them.

> As an outcome, the node stops falling behind while communicating that it is caught up.

> Add a description of the overall background and high level changes that this PR introduces

Changes introduced with this PR moves sqs GRPC reconnection to background. 

## Testing and Verifying

This change added tests and can be verified as follows:

  - *Added unit test that validates re-connection mechanism*
  - *Node instance was built from [back-port branch](https://github.com/osmosis-labs/osmosis/pull/9386) and deployed on stage to monitor and ensure there are no regressions*
  
## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [X] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [X] N/A