### PR TITLE
feat(osmoutils): replace index-based loop with range in ContainsDupli…

### DIFF
--- a/osmoutils/slice_helper.go
+++ b/osmoutils/slice_helper.go
@@ -42,11 +42,11 @@ func ReverseSlice[T any](s []T) []T {
 // elements in the slice.
 func ContainsDuplicate[T any](arr []T) bool {
 	visited := make(map[any]bool, 0)
-	for i := 0; i < len(arr); i++ {
-		if visited[arr[i]] {
+	for _, item := range arr {
+		if visited[item] {
 			return true
 		} else {
-			visited[arr[i]] = true
+			visited[item] = true
 		}
 	}
 	return false


### PR DESCRIPTION
Replace the classic index-based for loop with the more idiomatic Go range loop in the ContainsDuplicate function. This change improves code readability, follows Go best practices, and reduces the potential for index-related errors while maintaining identical functionality