### PR TITLE
feat: increase consensus min fee to 0.01 uosmo / gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#9420](https://github.com/osmosis-labs/osmosis/pull/9420) chore: update seeds for the init command
 * [#9396](https://github.com/osmosis-labs/osmosis/pull/9396) fix: missing coinbase/rosetta-sdk-go/types dependency 
 * [#9436](https://github.com/osmosis-labs/osmosis/pull/9436) feat: remove authorized quote denom validation
+* [#9440](https://github.com/osmosis-labs/osmosis/pull/9440) feat: increase consensus min fee to 0.01 uosmo / gas
 
 ## v29.0.2
 

--- a/app/apptesting/txfees.go
+++ b/app/apptesting/txfees.go
@@ -34,7 +34,7 @@ func (s *KeeperTestHelper) ExecuteUpgradeFeeTokenProposal(feeToken string, poolI
 
 func (s *KeeperTestHelper) SetupTxFeeAnteHandlerAndChargeFee(clientCtx client.Context, minGasPrices sdk.DecCoins, gasRequested uint64, isCheckTx, isSimulate bool, txFee sdk.Coins) error {
 	mempoolFeeOpts := types.NewDefaultMempoolFeeOptions()
-	mempoolFeeOpts.MinGasPriceForHighGasTx = osmomath.MustNewDecFromStr("0.0025")
+	mempoolFeeOpts.MinGasPriceForHighGasTx = osmomath.MustNewDecFromStr("0.01")
 
 	uionPoolId := s.PrepareBalancerPoolWithCoins(
 		sdk.NewInt64Coin(sdk.DefaultBondDenom, 500),

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -242,8 +242,8 @@ This section contains common "gotchas" that is sometimes very good to know when 
 
 3. Transaction fees.
 
-    Consensus min fee is set to "0.0025". This is how much is charged for 1 unit of gas. By default, we specify the gas limit
-    of `40000`. Therefore, each transaction should take `fee = 0.0025 uosmo / gas * 400000 gas = 1000 fee token.
+    Consensus min fee is set to "0.01". This is how much is charged for 1 unit of gas. By default, we specify the gas limit
+    of `40000`. Therefore, each transaction should take `fee = 0.01 uosmo / gas * 400000 gas = 4000 fee token.
     The fee denom is set in `tests/e2e/initialization/config.go` by the value of `E2EFeeToken`.
     See "Hermes Relayer - Consensus Min Fee" section for the relevant relayer configuration.
 
@@ -261,7 +261,7 @@ We set the following parameters Hermes configs to enable the consensus min fee i
     the denomination of the fee. The specified gas price should always be greater or equal to the `min-gas-price`
     configured on the chain. This is to ensure that at least some minimal price is 
     paid for each unit of gas per transaction.
-    In Osmosis, we set consensus min fee = .0025 uosmo / gas * 400000 gas = 1000
+    In Osmosis, we set consensus min fee = .01 uosmo / gas * 400000 gas = 4000
     See ConsensusMinFee in x/txfees/types/constants.go
 
     - `default_gas` - the gas amount to use when simulation fails.

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -111,8 +111,8 @@ func (n *NodeConfig) CreateConcentratedPool(from, denom1, denom2 string, tickSpa
 func (n *NodeConfig) CreateConcentratedPosition(from, lowerTick, upperTick string, tokens string, token0MinAmt, token1MinAmt int64, poolId uint64) (uint64, osmomath.Dec) {
 	n.LogActionF("creating concentrated position")
 	// gas = 50,000 because e2e  default to 40,000, we hardcoded extra 10k gas to initialize tick
-	// fees = 2500 (because 100,000 * 0.0025 = 1250)
-	cmd := []string{"osmosisd", "tx", "concentratedliquidity", "create-position", fmt.Sprint(poolId), lowerTick, upperTick, tokens, fmt.Sprintf("%d", token0MinAmt), fmt.Sprintf("%d", token1MinAmt), fmt.Sprintf("--from=%s", from), "--gas=1000000", "--fees=2500uosmo", "-o json"}
+	// fees = 10000 (because 100,000 * 0.01 = 10000)
+	cmd := []string{"osmosisd", "tx", "concentratedliquidity", "create-position", fmt.Sprint(poolId), lowerTick, upperTick, tokens, fmt.Sprintf("%d", token0MinAmt), fmt.Sprintf("%d", token1MinAmt), fmt.Sprintf("--from=%s", from), "--gas=1000000", "--fees=10000uosmo", "-o json"}
 	resp, _, err := n.containerManager.ExecTxCmdWithSuccessStringJSON(n.t, n.chainId, n.Name, cmd, "\"code\":0,")
 	require.NoError(n.t, err)
 	response := formatNonJsonResponse(resp.String())

--- a/tests/e2e/configurer/chain/commands.go
+++ b/tests/e2e/configurer/chain/commands.go
@@ -49,14 +49,14 @@ type params struct {
 
 func (n *NodeConfig) SetMaxPoolPointsPerTx(maxPoolPoints int, from string) {
 	n.LogActionF("setting max pool points per tx for protorev at %d points", maxPoolPoints)
-	cmd := []string{"osmosisd", "tx", "protorev", "set-max-pool-points-per-tx", fmt.Sprintf("%d", maxPoolPoints), fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=5000uosmo"}
+	cmd := []string{"osmosisd", "tx", "protorev", "set-max-pool-points-per-tx", fmt.Sprintf("%d", maxPoolPoints), fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=7000uosmo"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
 }
 
 func (n *NodeConfig) CreateBalancerPool(poolFile, from string) uint64 {
 	n.LogActionF("creating balancer pool from file %s", poolFile)
-	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=5000uosmo"}
+	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=7000uosmo"}
 	resp, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
 
@@ -69,7 +69,7 @@ func (n *NodeConfig) CreateBalancerPool(poolFile, from string) uint64 {
 
 func (n *NodeConfig) CreateStableswapPool(poolFile, from string) uint64 {
 	n.LogActionF("creating stableswap pool from file %s", poolFile)
-	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), "--pool-type=stableswap", fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=5000uosmo"}
+	cmd := []string{"osmosisd", "tx", "gamm", "create-pool", fmt.Sprintf("--pool-file=/osmosis/%s", poolFile), "--pool-type=stableswap", fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=7000uosmo"}
 	resp, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
 
@@ -164,7 +164,7 @@ func (n *NodeConfig) StoreWasmCode(wasmFile, from string) int {
 
 func (n *NodeConfig) WithdrawPosition(from, liquidityOut string, positionId uint64) {
 	n.LogActionF("withdrawing liquidity from position %d", positionId)
-	cmd := []string{"osmosisd", "tx", "concentratedliquidity", "withdraw-position", fmt.Sprint(positionId), liquidityOut, fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=5000uosmo"}
+	cmd := []string{"osmosisd", "tx", "concentratedliquidity", "withdraw-position", fmt.Sprint(positionId), liquidityOut, fmt.Sprintf("--from=%s", from), "--gas=700000", "--fees=7000uosmo"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
 	n.LogActionF("successfully withdrew %s liquidity from position %d", liquidityOut, positionId)
@@ -429,14 +429,14 @@ func (n *NodeConfig) SubmitUpgradeProposal(upgradeVersion string, upgradeHeight 
 }
 
 func (n *NodeConfig) SubmitSuperfluidProposal(asset string, isLegacy bool) int {
-	cmd := []string{"set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), "--title=\"superfluid asset prop\"", fmt.Sprintf("--summary=\"%s superfluid asset\"", asset), "--from=val", "--gas=700000", "--fees=5000uosmo"}
+	cmd := []string{"set-superfluid-assets-proposal", fmt.Sprintf("--superfluid-assets=%s", asset), "--title=\"superfluid asset prop\"", fmt.Sprintf("--summary=\"%s superfluid asset\"", asset), "--from=val", "--gas=700000", "--fees=7000uosmo"}
 
 	// TODO: no expedited flag for some reason
 	return n.SubmitProposal(cmd, false, fmt.Sprintf("superfluid proposal for asset %s", asset), isLegacy)
 }
 
 func (n *NodeConfig) SubmitCreateConcentratedPoolProposal(isExpedited, isLegacy bool) int {
-	cmd := []string{"create-concentratedliquidity-pool-proposal", "--pool-records=stake,uosmo,100,0.001", "--title=\"create concentrated pool\"", "--summary=\"create concentrated pool\"", "--from=val", "--gas=400000", "--fees=5000uosmo"}
+	cmd := []string{"create-concentratedliquidity-pool-proposal", "--pool-records=stake,uosmo,100,0.001", "--title=\"create concentrated pool\"", "--summary=\"create concentrated pool\"", "--from=val", "--gas=400000", "--fees=7000uosmo"}
 	return n.SubmitProposal(cmd, isExpedited, "create concentrated liquidity pool", isLegacy)
 }
 
@@ -537,7 +537,7 @@ func (n *NodeConfig) BankSend(amount string, sendAddress string, receiveAddress 
 
 func (n *NodeConfig) FundCommunityPool(sendAddress string, funds string) {
 	n.LogActionF("funding community pool from address %s with %s", sendAddress, funds)
-	cmd := []string{"osmosisd", "tx", "distribution", "fund-community-pool", funds, fmt.Sprintf("--from=%s", sendAddress), "--gas=600000", "--fees=2500uosmo"}
+	cmd := []string{"osmosisd", "tx", "distribution", "fund-community-pool", funds, fmt.Sprintf("--from=%s", sendAddress), "--gas=600000", "--fees=6000uosmo"}
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
 	n.LogActionF("successfully funded community pool from address %s with %s", sendAddress, funds)

--- a/tests/e2e/containers/containers.go
+++ b/tests/e2e/containers/containers.go
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	Fees                 = txfeestypes.ConsensusMinFee.Mul(osmomath.NewDec(GasLimit)).Ceil().TruncateInt64() // We set consensus min fee = .0025 uosmo / gas * 400000 gas = 1000
+	Fees                 = txfeestypes.ConsensusMinFee.Mul(osmomath.NewDec(GasLimit)).Ceil().TruncateInt64() // We set consensus min fee = .01 uosmo / gas * 400000 gas = 4000
 	defaultErrRegex      = regexp.MustCompile(`(E|e)rror`)
 	txArgs               = []string{"--yes", "--keyring-backend=test", "--log_format=json"}
 	txDefaultGasArgs     = []string{fmt.Sprintf("--gas=%d", GasLimit), fmt.Sprintf("--fees=%d", Fees) + initialization.E2EFeeToken} // See ConsensusMinFee in x/txfees/types/constants.go

--- a/tests/e2e/helpers_e2e_test.go
+++ b/tests/e2e/helpers_e2e_test.go
@@ -17,7 +17,7 @@ import (
 	gammtypes "github.com/osmosis-labs/osmosis/v30/x/gamm/types"
 )
 
-var defaultFeePerTx = osmomath.NewInt(1000)
+var defaultFeePerTx = osmomath.NewInt(4000)
 
 // Get balances for address
 func (s *IntegrationTestSuite) addrBalance(node *chain.NodeConfig, address string) sdk.Coins {

--- a/tests/e2e/scripts/hermes_bootstrap.sh
+++ b/tests/e2e/scripts/hermes_bootstrap.sh
@@ -45,7 +45,7 @@ store_prefix = 'ibc'
 max_gas = 10000000
 gas_multiplier = 2
 default_gas = 800000
-gas_price = { price = 0.0025, denom = 'e2e-default-feetoken' }
+gas_price = { price = 0.01, denom = 'e2e-default-feetoken' }
 clock_drift = '1m' # to accommodate docker containers
 trusting_period = '239seconds'
 trust_threshold = { numerator = '1', denominator = '3' }
@@ -61,7 +61,7 @@ store_prefix = 'ibc'
 max_gas = 10000000
 gas_multiplier = 2
 default_gas = 800000
-gas_price = { price = 0.0025, denom = 'e2e-default-feetoken' }
+gas_price = { price = 0.01, denom = 'e2e-default-feetoken' }
 clock_drift = '1m' # to accommodate docker containers
 trusting_period = '239seconds'
 trust_threshold = { numerator = '1', denominator = '3' }

--- a/x/txfees/keeper/feedecorator_test.go
+++ b/x/txfees/keeper/feedecorator_test.go
@@ -30,9 +30,8 @@ func (s *KeeperTestSuite) TestFeeDecorator() {
 	s.SetupTest(false)
 
 	mempoolFeeOpts := types.NewDefaultMempoolFeeOptions()
-	mempoolFeeOpts.MinGasPriceForHighGasTx = osmomath.MustNewDecFromStr("0.0025")
 	baseDenom, _ := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
-	consensusMinFeeAmt := int64(25)
+	consensusMinFeeAmt := int64(100)
 	point1BaseDenomMinGasPrices := sdk.NewDecCoins(sdk.NewDecCoinFromDec(baseDenom,
 		osmomath.MustNewDecFromStr("0.1")))
 
@@ -101,7 +100,7 @@ func (s *KeeperTestSuite) TestFeeDecorator() {
 			},
 			{
 				name:         fmt.Sprintf("%s work with insufficient converted mempool fee in %s", succesType[isCheckTx], txType[isCheckTx]),
-				txFee:        sdk.NewCoins(sdk.NewInt64Coin(uion, 25)), // consensus minimum
+				txFee:        sdk.NewCoins(sdk.NewInt64Coin(uion, consensusMinFeeAmt)), // consensus minimum
 				minGasPrices: point1BaseDenomMinGasPrices,
 				isCheckTx:    isCheckTx == 1,
 				expectPass:   isCheckTx != 1,
@@ -141,7 +140,7 @@ func (s *KeeperTestSuite) TestFeeDecorator() {
 		},
 		{
 			name:         "tx with high gas and enough fee should pass",
-			txFee:        sdk.NewCoins(sdk.NewInt64Coin(uion, 10*1000)),
+			txFee:        sdk.NewCoins(sdk.NewInt64Coin(uion, int64(mempoolFeeOpts.HighGasTxThreshold))),
 			minGasPrices: sdk.NewDecCoins(sdk.NewInt64DecCoin(uion, 1)),
 			gasRequested: mempoolFeeOpts.HighGasTxThreshold,
 			isCheckTx:    true,
@@ -315,7 +314,7 @@ func (s *KeeperTestSuite) TestMempoolFeeDecorator_AnteHandle_MsgTransfer() {
 		s.Run(tc.name, func() {
 			s.Ctx = s.Ctx.WithBlockHeight(1_000_000_000).WithIsCheckTx(tc.isCheckTx)
 			baseDenom, _ := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
-			txFee := sdk.NewCoins(sdk.NewCoin(baseDenom, osmomath.NewInt(250000)))
+			txFee := sdk.NewCoins(sdk.NewCoin(baseDenom, osmomath.NewInt(1000000)))
 			tx, err := s.prepareTx(tc.msg, txFee)
 			s.Require().NoError(err)
 

--- a/x/txfees/keeper/keeper_test.go
+++ b/x/txfees/keeper/keeper_test.go
@@ -60,7 +60,7 @@ func (s *KeeperTestSuite) SetupTest(isCheckTx bool) {
 			sdk.NewCoins(
 				sdk.NewCoin(sdk.DefaultBondDenom, osmomath.NewInt(10000000000)),
 				sdk.NewCoin(appparams.BaseCoinUnit, osmomath.NewInt(100000000000000000)), // Needed for pool creation fee
-				sdk.NewCoin("uion", osmomath.NewInt(10000000)),
+				sdk.NewCoin("uion", osmomath.NewInt(100000000000000)),
 				sdk.NewCoin("atom", osmomath.NewInt(10000000)),
 				sdk.NewCoin("ust", osmomath.NewInt(10000000)),
 				sdk.NewCoin("foo", osmomath.NewInt(10000000)),

--- a/x/txfees/types/constants.go
+++ b/x/txfees/types/constants.go
@@ -5,5 +5,6 @@ import (
 )
 
 // ConsensusMinFee is a governance set parameter from prop 354 (https://www.mintscan.io/osmosis/proposals/354)
-// Its intended to be .0025 uosmo / gas
-var ConsensusMinFee osmomath.Dec = osmomath.NewDecWithPrec(25, 4)
+// It was intended to be .0025 uosmo / gas
+// In v30, we set it to 0.01 uosmo / gas
+var ConsensusMinFee osmomath.Dec = osmomath.NewDecWithPrec(1, 2)


### PR DESCRIPTION
Closes: [CHAIN-1069](https://linear.app/osmosis/issue/CHAIN-1069/migration-increase-default-base-gas-price)

## What is the purpose of the change

Increase consensus min fee to 0.01 uosmo / gas.

## Testing and Verifying

- Updated broken existing tests due to this change. 
- Manually setting lower price than min for sending tx.

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A