### PR TITLE
feat: transfer top of block auction funds to community pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#9420](https://github.com/osmosis-labs/osmosis/pull/9420) chore: update seeds for the init command
 * [#9396](https://github.com/osmosis-labs/osmosis/pull/9396) fix: missing coinbase/rosetta-sdk-go/types dependency 
 * [#9436](https://github.com/osmosis-labs/osmosis/pull/9436) feat: remove authorized quote denom validation
+* [#9456](https://github.com/osmosis-labs/osmosis/pull/9456) feat: transfer top of block auction funds to community pool
 
 ## v29.0.2
 

--- a/app/upgrades/v30/upgrades.go
+++ b/app/upgrades/v30/upgrades.go
@@ -59,6 +59,7 @@ func setAuthorizedQuoteDenomsAsCommunityPoolDenomWhitelist(ctx sdk.Context, pool
 	poolManagerKeeper.SetParam(ctx, types.KeyCommunityPoolDenomWhitelist, authorizedQuoteDenoms)
 }
 
+// see: https://daodao.zone/dao/osmosis/proposals/958
 func transferTopOfBlockAuctionFundsToCommunityPool(ctx sdk.Context, accountKeeper *authkeeper.AccountKeeper, bankKeeper *bankkeeper.BaseKeeper, distrKeeper *distrkeeper.Keeper) error {
 	auctionModuleAccountAddr := accountKeeper.GetModuleAccount(ctx, auctiontypes.ModuleName).GetAddress()
 	usdcDenom := "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"

--- a/app/upgrades/v30/upgrades.go
+++ b/app/upgrades/v30/upgrades.go
@@ -61,6 +61,7 @@ func setAuthorizedQuoteDenomsAsCommunityPoolDenomWhitelist(ctx sdk.Context, pool
 
 // see: https://daodao.zone/dao/osmosis/proposals/958
 func transferTopOfBlockAuctionFundsToCommunityPool(ctx sdk.Context, accountKeeper *authkeeper.AccountKeeper, bankKeeper *bankkeeper.BaseKeeper, distrKeeper *distrkeeper.Keeper) error {
+	// https://www.mintscan.io/osmosis/address/osmo1j4yzhgjm00ch3h0p9kel7g8sp6g045qfnc9kmc
 	auctionModuleAccountAddr := accountKeeper.GetModuleAccount(ctx, auctiontypes.ModuleName).GetAddress()
 	usdcDenom := "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
 

--- a/app/upgrades/v30/upgrades_test.go
+++ b/app/upgrades/v30/upgrades_test.go
@@ -71,8 +71,8 @@ func (s *UpgradeTestSuite) TestTopOfBlockAuctionFundTransferUpgrade() {
 	auctionModuleBalance := s.App.BankKeeper.GetBalance(s.Ctx, auctionModuleAccountAddr, usdcDenom)
 	distributionModuleBalance := s.App.BankKeeper.GetBalance(s.Ctx, distributionModuleAccountAddr, usdcDenom)
 
-	s.Require().Equal(sdk.NewCoins(), auctionModuleBalance)
-	s.Require().Equal(auctionRev, distributionModuleBalance)
+	s.Require().Equal(sdk.NewCoin(usdcDenom, osmomath.NewInt(0)), auctionModuleBalance)
+	s.Require().Equal(sdk.NewCoin(usdcDenom, osmomath.NewInt(999999999999999999)), distributionModuleBalance)
 }
 
 func (s *UpgradeTestSuite) TestUpgradeWithCustomAuthorizedQuoteDenoms() {


### PR DESCRIPTION
Closes: [CHAIN-1072](https://linear.app/osmosis/issue/CHAIN-1072/migration-transfer-top-of-block-funds-from-module-account-to-community)

## What is the purpose of the change

Transfer top-of-block auction funds to community pool in v30 upgrade.

## Testing and Verifying

- unit tested
- in-place-testnet tested

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A