### PR TITLE
Fix: Check gas remaining in the parent context's gas meter wasm call with gas limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#9456](https://github.com/osmosis-labs/osmosis/pull/9456) feat: transfer top of block auction funds to community pool
 * [#9457](https://github.com/osmosis-labs/osmosis/pull/9457) chore: bump submodules
 * [#9460](https://github.com/osmosis-labs/osmosis/pull/9460) fix: mempool-1559 min base fee to match consensus min fee 
-
+* [#9465](https://github.com/osmosis-labs/osmosis/pull/9465) Fix: Check gas remaining in the parent context's gas meter for tokenfactory hook 
 ## v29.0.2
 
 ### State Breaking

--- a/osmoutils/cosmwasm/helpers.go
+++ b/osmoutils/cosmwasm/helpers.go
@@ -58,7 +58,9 @@ func Query[T any, K any](ctx sdk.Context, wasmKeeper WasmKeeper, contractAddress
 		return response, err
 	}
 
-	childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(wasmKeeper.QueryGasLimit()))
+	// Check remaining gas in parent context and use the lesser of the query gas limit and remaining gas
+	gasLimit := min(ctx.GasMeter().GasRemaining(), wasmKeeper.QueryGasLimit())
+	childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(gasLimit))
 	responseBz, err := wasmKeeper.QuerySmart(childCtx, sdk.MustAccAddressFromBech32(contractAddress), bz)
 	if err != nil {
 		return response, err

--- a/x/concentrated-liquidity/pool_hooks.go
+++ b/x/concentrated-liquidity/pool_hooks.go
@@ -126,7 +126,9 @@ func (k Keeper) callPoolActionListener(ctx sdk.Context, msgBuilderFn msgBuilderF
 	//
 	// We ensure this limit only applies to this call by creating a child context with a gas
 	// limit and then metering the gas used in parent context once the operation is completed.
-	childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(k.GetParams(ctx).HookGasLimit))
+	// Check remaining gas in parent context and use the lesser of the hook gas limit and remaining gas
+	gasLimit := min(ctx.GasMeter().GasRemaining(), k.GetParams(ctx).HookGasLimit)
+	childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(gasLimit))
 	_, err = k.contractKeeper.Sudo(childCtx.WithEventManager(em), cwAddr, msgBz)
 	if err != nil {
 		return err

--- a/x/smart-account/ante/ante.go
+++ b/x/smart-account/ante/ante.go
@@ -80,7 +80,9 @@ func (ad AuthenticatorDecorator) AnteHandle(
 	// As long as the gas consumption remains below the fee payer gas limit, exceeding
 	// the original limit should be acceptable.
 	authenticatorParams := ad.smartAccountKeeper.GetParams(ctx)
-	payerGasMeter := storetypes.NewGasMeter(authenticatorParams.MaximumUnauthenticatedGas)
+	// Check remaining gas in parent context and use the lesser of the maximum unauthenticated gas and remaining gas
+	gasLimit := min(originalGasMeter.GasRemaining(), authenticatorParams.MaximumUnauthenticatedGas)
+	payerGasMeter := storetypes.NewGasMeter(gasLimit)
 	ctx = ctx.WithGasMeter(payerGasMeter)
 
 	// Recover from any OutOfGas panic to return an error with information of the gas limit having been reduced

--- a/x/tokenfactory/keeper/before_send.go
+++ b/x/tokenfactory/keeper/before_send.go
@@ -162,7 +162,14 @@ func (k Keeper) callBeforeSendListener(context context.Context, from, to sdk.Acc
 			}
 			em := sdk.NewEventManager()
 
-			childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(types.BeforeSendHookGasLimit))
+			// Check remaining gas in parent context and use the lesser of the fixed limit and remaining gas
+			remainingGas := ctx.GasMeter().GasRemaining()
+			gasLimit := types.BeforeSendHookGasLimit
+			if remainingGas < gasLimit {
+				gasLimit = remainingGas
+			}
+
+			childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(gasLimit))
 			_, err = k.contractKeeper.Sudo(childCtx.WithEventManager(em), cwAddr, msgBz)
 			if err != nil {
 				if strings.Contains(err.Error(), "no such contract") {

--- a/x/tokenfactory/keeper/before_send.go
+++ b/x/tokenfactory/keeper/before_send.go
@@ -163,11 +163,7 @@ func (k Keeper) callBeforeSendListener(context context.Context, from, to sdk.Acc
 			em := sdk.NewEventManager()
 
 			// Check remaining gas in parent context and use the lesser of the fixed limit and remaining gas
-			remainingGas := ctx.GasMeter().GasRemaining()
-			gasLimit := types.BeforeSendHookGasLimit
-			if remainingGas < gasLimit {
-				gasLimit = remainingGas
-			}
+			gasLimit := min(ctx.GasMeter().GasRemaining(), types.BeforeSendHookGasLimit)
 
 			childCtx := ctx.WithGasMeter(storetypes.NewGasMeter(gasLimit))
 			_, err = k.contractKeeper.Sudo(childCtx.WithEventManager(em), cwAddr, msgBz)


### PR DESCRIPTION
## What is the purpose of the change

Check gas remaining in the parent context's gas meter for tokenfactory hook.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A