### PR TITLE
chore: update changelog from unreleased to v30.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v30.0.0
+
 ### State Breaking
 
 * [#9355](https://github.com/osmosis-labs/osmosis/pull/9355) chore: bump go version to v1.23 


### PR DESCRIPTION
## What is the purpose of the change

Update changelog to be v30.0.0 ready.