### PR TITLE
fix: update DefaultBaseFee and cap CurBaseFee when loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### State Compatible
+* [#9476](https://github.com/osmosis-labs/osmosis/pull/9476) fix: update DefaultBaseFee and cap CurBaseFee when loaded 
 
 ## v30.0.1
 

--- a/x/txfees/keeper/mempool-1559/code.go
+++ b/x/txfees/keeper/mempool-1559/code.go
@@ -46,7 +46,7 @@ import (
 var (
 	// We expect wallet multiplier * DefaultBaseFee < MinBaseFee * RecheckFeeConstant
 	// conservatively assume a wallet multiplier of at least 7%.
-	DefaultBaseFee = osmomath.MustNewDecFromStr("0.0060")
+	DefaultBaseFee = osmomath.MustNewDecFromStr("0.0250")
 	MinBaseFee     = types.ConsensusMinFee
 	MaxBaseFee     = osmomath.MustNewDecFromStr("5")
 	ResetInterval  = int64(6000)
@@ -242,5 +242,13 @@ func (e *EipState) tryLoad(logger log.Logger) osmomath.Dec {
 	}
 
 	logger.Info("Loaded eip1559 state", "CurBaseFee", loaded.CurBaseFee)
+	if loaded.CurBaseFee.LT(MinBaseFee) {
+		logger.Debug("CurBaseFee is less than MinBaseFee, setting to MinBaseFee", "CurBaseFee", loaded.CurBaseFee, "MinBaseFee", MinBaseFee)
+		return MinBaseFee.Clone()
+	}
+	if loaded.CurBaseFee.GT(MaxBaseFee) {
+		logger.Debug("CurBaseFee is greater than MaxBaseFee, setting to MaxBaseFee", "CurBaseFee", loaded.CurBaseFee, "MaxBaseFee", MaxBaseFee)
+		return MaxBaseFee.Clone()
+	}
 	return loaded.CurBaseFee.Clone()
 }


### PR DESCRIPTION
## What is the purpose of the change

Due to changes in #9461 which increased `MinBaseFee`, it makes
- previous `DefaultBaseFee` value obsolete -> updated it to be aligned with updated `MinBaseFee`
- when restarting node, it picks up eip state backup file, which could have `CurBaseFee` outside capped range. -> cap `CurBaseFee` when loaded.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [ ] Code comments?
  - [x] N/A