### PR TITLE
Update block-sdk version with DefaultMempool that keep no duplicated tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### State Compatible
 * [#9467](https://github.com/osmosis-labs/osmosis/pull/9467) fix: protorev returns incorrect values in posthandler
 * [#9476](https://github.com/osmosis-labs/osmosis/pull/9476) fix: update DefaultBaseFee and cap CurBaseFee when loaded 
+* [#9488](https://github.com/osmosis-labs/osmosis/pull/9488) chore: bump block-sdk to v2.1.8-mempool
 
 ## v30.0.1
 

--- a/app/lanes.go
+++ b/app/lanes.go
@@ -71,9 +71,15 @@ func CreateLanes(app *OsmosisApp, txConfig client.TxConfig) (*mevlane.MEVLane, *
 		mevMatchHandler,
 	)
 
-	defaultLane := defaultlane.NewDefaultLane(
+	defaultMempool := base.NewMempoolWithDefaultOrdering(
+		base.DefaultTxPriority(),
+		defaultConfig.SignerExtractor,
+		defaultConfig.MaxTxs,
+	)
+	defaultLane := defaultlane.NewDefaultLaneWithMempool(
 		defaultConfig,
 		defaultMatchHandler,
+		defaultMempool,
 	)
 
 	return mevLane, defaultLane

--- a/go.mod
+++ b/go.mod
@@ -320,9 +320,9 @@ replace (
 
 	// The block-sdk is no longer maintained by Skip, instead we use the osmosis-labs fork.
 	// Direct block-sdk branch link: https://github.com/osmosis-labs/block-sdk/tree/release/v2.x.x, current branch: release/v2.x.x
-	// Direct commit link: https://github.com/osmosis-labs/block-sdk/commit/a86e729f843d36392393a8ff6a14c9fbc15f2fcc
-	// Direct tag link: https://github.com/osmosis-labs/block-sdk/releases/tag/v2.1.6
-	github.com/skip-mev/block-sdk/v2 => github.com/osmosis-labs/block-sdk/v2 v2.1.6
+	// Direct commit link: https://github.com/osmosis-labs/block-sdk/commit/4200fca089ca5112d390c6f107cbdd17d1642b8c
+	// Direct tag link: https://github.com/osmosis-labs/block-sdk/releases/tag/v2.1.8-mempool
+	github.com/skip-mev/block-sdk/v2 => github.com/osmosis-labs/block-sdk/v2 v2.1.8-mempool
 
 	// replace as directed by sdk upgrading.md https://github.com/cosmos/cosmos-sdk/blob/393de266c8675dc16cc037c1a15011b1e990975f/UPGRADING.md?plain=1#L713
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -953,8 +953,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.11.0 h1:OiHcxKAvSDUwsEVh2BjxQQc/5EHz9n0va9awCtNGuyA=
 github.com/ory/dockertest/v3 v3.11.0/go.mod h1:VIPxS1gwT9NpPOrfD3rACs8Y9Z7yhzO4SB194iUDnUI=
-github.com/osmosis-labs/block-sdk/v2 v2.1.6 h1:zMZADGm5sUB45CJzf5Y24fY7jgGeQrwAjdXYKgYZnrA=
-github.com/osmosis-labs/block-sdk/v2 v2.1.6/go.mod h1:E8SvITZUdxkes3gI3+kgESZL+NLffkcLKnowUgYTOf4=
+github.com/osmosis-labs/block-sdk/v2 v2.1.8-mempool h1:9tAnEHjtwkYZQKTWPAc8RcR1N2QLPtW9Xyh+WZOctZw=
+github.com/osmosis-labs/block-sdk/v2 v2.1.8-mempool/go.mod h1:E8SvITZUdxkes3gI3+kgESZL+NLffkcLKnowUgYTOf4=
 github.com/osmosis-labs/cometbft v0.38.17-v28-osmo-1 h1:0xPd6S6mCsVT0IKP0xIUmg6sgo12iHMu5H6vxwrrIo0=
 github.com/osmosis-labs/cometbft v0.38.17-v28-osmo-1/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
 github.com/osmosis-labs/cosmos-sdk v0.50.14-v30-osmo h1:2SMqYSaLg07GcQf4ZLsG2kHDpnVoezzfJDWxEPkqJN4=


### PR DESCRIPTION
## What is the purpose of the change

Fix previous version of block-sdk that resulted in frequent `failed to insert tx into mempool: pool reached max tx capacity` error due to missing duplicated tx detection.