### PR TITLE
Investigate go version app hash difference

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -54,6 +54,7 @@ import (
 	indexerdomain "github.com/osmosis-labs/osmosis/v30/ingest/indexer/domain"
 	indexerservice "github.com/osmosis-labs/osmosis/v30/ingest/indexer/service"
 	indexerwritelistener "github.com/osmosis-labs/osmosis/v30/ingest/indexer/service/writelistener"
+	debugsvc "github.com/osmosis-labs/osmosis/v30/ingest/debug/service"
 	"github.com/osmosis-labs/osmosis/v30/ingest/sqs"
 	"github.com/osmosis-labs/osmosis/v30/ingest/sqs/domain"
 	poolstransformer "github.com/osmosis-labs/osmosis/v30/ingest/sqs/pools/transformer"
@@ -361,6 +362,13 @@ func NewOsmosisApp(
 	}
 
 	streamingServices := []storetypes.ABCIListener{}
+
+	// Optional debug tracer: write per-commit deterministic KV change dumps when enabled.
+	if v := os.Getenv("OSMOSIS_DEBUG_KV_TRACE_DIR"); v != "" {
+		// Register debug tracer first so it always runs.
+		dbg := debugsvc.New(v)
+		streamingServices = append(streamingServices, dbg)
+	}
 
 	// Initialize the SQS ingester if it is enabled.
 	if sqsConfig.IsEnabled {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

This pull request introduces a debug streaming service to trace and dump deterministic KV store changes per commit. This tool helps diagnose AppHash mismatches, specifically the nondeterministic behavior observed when building with Go 1.24 (due to its new Swiss-table map implementation) compared to Go 1.23.

## Testing and Verifying

This change added tests and can be verified as follows:

  - Manually verified the change by:
    - Building with Go 1.23 and setting `OSMOSIS_DEBUG_KV_TRACE_DIR=/path/to/trace-go123`.
    - Building with Go 1.24 and setting `OSMOSIS_DEBUG_KV_TRACE_DIR=/path/to/trace-go124`.
    - Comparing the generated JSON files at each height to find the first divergence, as described in the conversation.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? (N/A - debug tool)
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`? (N/A - debug tool)

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-99daaad4-efa6-4650-954f-f2a324fe98bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99daaad4-efa6-4650-954f-f2a324fe98bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

