### PR TITLE
chore: fix typo: "migitate" → "mitigate"

### DIFF
--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -751,7 +751,7 @@ grpc-ingest-max-call-size-bytes = "{{ .SidecarQueryServerConfig.GRPCIngestMaxCal
 is-enabled = "{{ .IndexerConfig.IsEnabled }}"
 
 # Max publish delay in seconds for the indexer service.
-# Migitate the issue of messages remaining pending when the publishing rate is low,
+# Mitigate the issue of messages remaining pending when the publishing rate is low,
 # ensuring timely delivery and preventing messages from appearing undelivered
 max-publish-delay = "{{ .IndexerConfig.MaxPublishDelay }}"
 


### PR DESCRIPTION
## What is the purpose of the change

<img width="665" height="24" alt="Снимок экрана 2025-09-28 в 14 22 24" src="https://github.com/user-attachments/assets/42afe2a1-c647-4831-bdf3-7a4ec9f8fd1b" />

fix a typo: "Migitate" → "Mitigate".
no functional changes.

## Testing and Verifying

checked that all references are updated and code still runs as before.

## Documentation and Release Note

* [ ] Does this pull request introduce a new feature or user-facing behavior changes?
* [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?

* [ ] Specification (`x/{module}/README.md`)
* [ ] Osmosis documentation site
* [ ] Code comments?
* [x] N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a typo in the Osmosis indexer config comment in `cmd/osmosisd/cmd/root.go` ("Migitate" → "Mitigate"); no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58c7c39b83f0b9c9d16de007cd16b357f4aebd6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->