### PR TITLE
chore: force undelegate and clean up superfluid state

### DIFF
--- a/app/upgrades/v31/upgrades.go
+++ b/app/upgrades/v31/upgrades.go
@@ -2,7 +2,9 @@ package v31
 
 import (
 	"context"
+	"fmt"
 
+	"cosmossdk.io/store/prefix"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
@@ -14,6 +16,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v30/app/keepers"
 	"github.com/osmosis-labs/osmosis/v30/app/upgrades"
 	poolmanager "github.com/osmosis-labs/osmosis/v30/x/poolmanager"
+	superfuidtypes "github.com/osmosis-labs/osmosis/v30/x/superfluid/types"
 	txfeestypes "github.com/osmosis-labs/osmosis/v30/x/txfees/types"
 )
 
@@ -34,6 +37,12 @@ func CreateUpgradeHandler(
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 		err = updateTakerFeeDistribution(sdkCtx, keepers.PoolManagerKeeper, keepers.AccountKeeper)
+		if err != nil {
+			return nil, err
+		}
+
+		// Undelegate all remaining superfluid stake and clean up all superfluid storage
+		err = cleanupSuperfluid(sdkCtx, keepers)
 		if err != nil {
 			return nil, err
 		}
@@ -64,5 +73,231 @@ func updateTakerFeeDistribution(ctx sdk.Context, poolManagerKeeper *poolmanager.
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// cleanupSuperfluid undelegates all remaining superfluid stake and removes all superfluid storage.
+// This is the main entry point that orchestrates the complete cleanup in three phases:
+// 1. Undelegate all intermediary account positions
+// 2. Delete all synthetic locks
+// 3. Delete all superfluid storage
+func cleanupSuperfluid(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	ctx.Logger().Info("Starting superfluid cleanup: undelegating all positions and removing all state")
+
+	// Undelegate all intermediary account positions
+	// This must happen first to properly handle the actual staking delegations
+	if err := undelegateAllIntermediaryAccounts(ctx, keepers); err != nil {
+		return err
+	}
+
+	// Delete all synthetic locks
+	// This removes the overlay tracking before deleting the mappings
+	if err := deleteAllSyntheticLocks(ctx, keepers); err != nil {
+		return err
+	}
+
+	// Delete all superfluid storage
+	// Finally clean up all references and configuration
+	if err := deleteAllSuperfluidStorage(ctx, keepers); err != nil {
+		return err
+	}
+
+	ctx.Logger().Info("Superfluid cleanup completed successfully")
+	return nil
+}
+
+// undelegateAllIntermediaryAccounts undelegates and burns all tokens from intermediary accounts.
+// Intermediary accounts are special accounts that hold the actual staking delegations on behalf
+// of users' locked LP shares. For each intermediary account:
+// 1. Calculate the delegated OSMO amount
+// 2. Perform instant undelegation (bypass 21-day unbonding)
+// 3. Burn the undelegated OSMO tokens (these were synthetically minted during delegation)
+// 4. Adjust the supply offset to maintain proper accounting
+//
+// Reference: x/superfluid/keeper/stake.go:462-542 (mintOsmoTokensAndDelegate, forceUndelegateAndBurnOsmoTokens)
+func undelegateAllIntermediaryAccounts(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	intermediaryAccounts := keepers.SuperfluidKeeper.GetAllIntermediaryAccounts(ctx)
+	ctx.Logger().Info(fmt.Sprintf("Found %d intermediary accounts to clean up", len(intermediaryAccounts)))
+
+	for _, intermediaryAcc := range intermediaryAccounts {
+		if err := undelegateSingleIntermediaryAccount(ctx, keepers, intermediaryAcc); err != nil {
+			// Log error but continue with other accounts
+			ctx.Logger().Error(fmt.Sprintf("Failed to undelegate intermediary account %s: %v",
+				intermediaryAcc.GetAccAddress().String(), err))
+			continue
+		}
+	}
+
+	return nil
+}
+
+// undelegateSingleIntermediaryAccount handles the undelegation and burning for a single intermediary account.
+func undelegateSingleIntermediaryAccount(ctx sdk.Context, keepers *keepers.AppKeepers, intermediaryAcc superfuidtypes.SuperfluidIntermediaryAccount) error {
+	// Get validator address
+	valAddr, err := sdk.ValAddressFromBech32(intermediaryAcc.ValAddr)
+	if err != nil {
+		return fmt.Errorf("invalid validator address %s: %w", intermediaryAcc.ValAddr, err)
+	}
+
+	// Check if there's a delegation from this intermediary account
+	delegation, err := keepers.StakingKeeper.GetDelegation(ctx, intermediaryAcc.GetAccAddress(), valAddr)
+	if err != nil {
+		// No delegation found, skip
+		return nil
+	}
+
+	// Get validator to calculate tokens from shares
+	validator, err := keepers.StakingKeeper.GetValidator(ctx, valAddr)
+	if err != nil {
+		return fmt.Errorf("validator not found for %s: %w", intermediaryAcc.ValAddr, err)
+	}
+
+	// Calculate the amount of tokens to undelegate
+	tokens := validator.TokensFromShares(delegation.Shares)
+	osmoAmount := tokens.RoundInt()
+
+	if !osmoAmount.IsPositive() {
+		return nil
+	}
+
+	// Validate unbond amount and get shares
+	shares, err := keepers.StakingKeeper.ValidateUnbondAmount(ctx, intermediaryAcc.GetAccAddress(), valAddr, osmoAmount)
+	if err != nil {
+		return fmt.Errorf("failed to validate unbond amount: %w", err)
+	}
+
+	// Instant undelegate (bypass normal 21-day unbonding period)
+	undelegatedCoins, err := keepers.StakingKeeper.InstantUndelegate(ctx, intermediaryAcc.GetAccAddress(), valAddr, shares)
+	if err != nil {
+		return fmt.Errorf("failed to instant undelegate: %w", err)
+	}
+
+	// Send coins to superfluid module
+	err = keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, intermediaryAcc.GetAccAddress(), superfuidtypes.ModuleName, undelegatedCoins)
+	if err != nil {
+		return fmt.Errorf("failed to send coins to module: %w", err)
+	}
+
+	// Burn the coins (these were synthetically minted during superfluid delegation)
+	err = keepers.BankKeeper.BurnCoins(ctx, superfuidtypes.ModuleName, undelegatedCoins)
+	if err != nil {
+		return fmt.Errorf("failed to burn coins: %w", err)
+	}
+
+	// Adjust supply offset to maintain proper total supply accounting
+	bondDenom, err := keepers.StakingKeeper.BondDenom(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get bond denom: %w", err)
+	}
+	keepers.BankKeeper.AddSupplyOffset(ctx, bondDenom, undelegatedCoins.AmountOf(bondDenom))
+
+	ctx.Logger().Info(fmt.Sprintf("Undelegated and burned %s from intermediary account %s (validator: %s)",
+		undelegatedCoins.String(), intermediaryAcc.GetAccAddress().String(), intermediaryAcc.ValAddr))
+
+	return nil
+}
+
+// deleteAllSyntheticLocks deletes all synthetic locks associated with superfluid staking
+// and unlocks the underlying locks to return gamm tokens to delegators.
+// Synthetic locks are overlay locks that track superfluid staking status. There are two types:
+// - Staking locks: {denom}/superbonding/{valAddr} - tracks active superfluid stake
+// - Unstaking locks: {denom}/superunbonding/{valAddr} - tracks undelegating positions
+// Both types must be cleaned up and the underlying locks must be unlocked.
+func deleteAllSyntheticLocks(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	connections := keepers.SuperfluidKeeper.GetAllLockIdIntermediaryAccountConnections(ctx)
+	ctx.Logger().Info(fmt.Sprintf("Found %d lock-intermediary connections to clean up", len(connections)))
+
+	for _, connection := range connections {
+		if err := deleteSyntheticLockAndUnlock(ctx, keepers, connection); err != nil {
+			// Log error but continue with other locks
+			ctx.Logger().Error(fmt.Sprintf("Failed to delete synthetic locks for lock %d: %v", connection.LockId, err))
+			continue
+		}
+	}
+
+	return nil
+}
+
+// deleteSyntheticLockAndUnlock deletes both staking and unstaking synthetic locks for a single lock
+// and unlocks the underlying lock to return gamm tokens to the delegator.
+func deleteSyntheticLockAndUnlock(ctx sdk.Context, keepers *keepers.AppKeepers, connection superfuidtypes.LockIdIntermediaryAccountConnection) error {
+	// Get the lock
+	lock, err := keepers.LockupKeeper.GetLockByID(ctx, connection.LockId)
+	if err != nil {
+		return fmt.Errorf("failed to get lock %d: %w", connection.LockId, err)
+	}
+
+	// Get intermediary account
+	accAddr, err := sdk.AccAddressFromBech32(connection.IntermediaryAccount)
+	if err != nil {
+		return fmt.Errorf("invalid intermediary account address %s: %w", connection.IntermediaryAccount, err)
+	}
+
+	store := ctx.KVStore(keepers.GetKey(superfuidtypes.StoreKey))
+	prefixStore := prefix.NewStore(store, superfuidtypes.KeyPrefixIntermediaryAccount)
+	intermediaryAccBytes := prefixStore.Get(accAddr)
+	if intermediaryAccBytes == nil {
+		return fmt.Errorf("intermediary account not found for lock %d", connection.LockId)
+	}
+
+	var intermediaryAcc superfuidtypes.SuperfluidIntermediaryAccount
+	err = intermediaryAcc.Unmarshal(intermediaryAccBytes)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal intermediary account: %w", err)
+	}
+
+	// Delete both staking and unstaking synthetic locks if they exist
+	if len(lock.Coins) > 0 {
+		denom := lock.Coins[0].Denom
+
+		// Try to delete staking synthetic lock: {denom}/superbonding/{valAddr}
+		stakingSynthDenom := fmt.Sprintf("%s/superbonding/%s", denom, intermediaryAcc.ValAddr)
+		if err := keepers.LockupKeeper.DeleteSyntheticLockup(ctx, connection.LockId, stakingSynthDenom); err != nil {
+			// Log but don't fail - synthetic lock might not exist
+			ctx.Logger().Info(fmt.Sprintf("Could not delete staking synthetic lock for lock %d: %v (may not exist)", connection.LockId, err))
+		}
+
+		// Try to delete unstaking synthetic lock: {denom}/superunbonding/{valAddr}
+		unstakingSynthDenom := fmt.Sprintf("%s/superunbonding/%s", denom, intermediaryAcc.ValAddr)
+		if err := keepers.LockupKeeper.DeleteSyntheticLockup(ctx, connection.LockId, unstakingSynthDenom); err != nil {
+			// Log but don't fail - synthetic lock might not exist
+			ctx.Logger().Info(fmt.Sprintf("Could not delete unstaking synthetic lock for lock %d: %v (may not exist)", connection.LockId, err))
+		}
+	}
+
+	// Force unlock the underlying lock to return gamm tokens to the delegator
+	err = keepers.LockupKeeper.ForceUnlock(ctx, *lock)
+	if err != nil {
+		return fmt.Errorf("failed to force unlock lock %d: %w", connection.LockId, err)
+	}
+
+	ctx.Logger().Info(fmt.Sprintf("Unlocked lock %d, returned %s to delegator %s",
+		lock.ID, lock.Coins.String(), lock.Owner))
+
+	return nil
+}
+
+// deleteAllSuperfluidStorage deletes all superfluid-related storage from the KV store.
+// This includes:
+// 1. Lock-intermediary account connections (KeyPrefixLockIntermediaryAccAddr = 0x05)
+// 2. Intermediary accounts (KeyPrefixIntermediaryAccount = 0x04)
+// 3. Superfluid assets (KeyPrefixSuperfluidAsset = 0x01)
+// 4. OSMO equivalent multipliers (KeyPrefixTokenMultiplier = 0x03)
+// 5. Unpool allowed pools (KeyUnpoolAllowedPools = 0x06)
+func deleteAllSuperfluidStorage(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	store := ctx.KVStore(keepers.GetKey(superfuidtypes.StoreKey))
+
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	keysToDelete := [][]byte{}
+	for ; iterator.Valid(); iterator.Next() {
+		keysToDelete = append(keysToDelete, iterator.Key())
+	}
+
+	for _, key := range keysToDelete {
+		store.Delete(key)
+	}
+
 	return nil
 }

--- a/app/upgrades/v31/upgrades_test.go
+++ b/app/upgrades/v31/upgrades_test.go
@@ -11,10 +11,13 @@ import (
 	"cosmossdk.io/x/upgrade"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v30/app/apptesting"
 	v31 "github.com/osmosis-labs/osmosis/v30/app/upgrades/v31"
+	gammtypes "github.com/osmosis-labs/osmosis/v30/x/gamm/types"
+	superfuidtypes "github.com/osmosis-labs/osmosis/v30/x/superfluid/types"
 	txfeestypes "github.com/osmosis-labs/osmosis/v30/x/txfees/types"
 )
 
@@ -105,4 +108,219 @@ func (s *UpgradeTestSuite) ExecuteTakerFeeDistributionTest() {
 	takerFeeBurnModuleAccount := s.App.AccountKeeper.GetModuleAccount(s.Ctx, txfeestypes.TakerFeeBurnName)
 	s.Require().Equal(txfeestypes.TakerFeeBurnName, takerFeeBurnModuleAccount.GetName())
 	s.Require().Nil(takerFeeBurnModuleAccount.GetPermissions())
+}
+
+func (s *UpgradeTestSuite) TestSuperfluidCleanup() {
+	s.Setup()
+	s.preModule = upgrade.NewAppModule(s.App.UpgradeKeeper, addresscodec.NewBech32Codec("osmo"))
+
+	// Prepare test by setting up some superfluid state
+	s.PrepareSuperfluidCleanupTest()
+
+	// Run the upgrade
+	dummyUpgrade(s)
+	s.Require().NotPanics(func() {
+		_, err := s.preModule.PreBlock(s.Ctx)
+		s.Require().NoError(err)
+	})
+
+	// Verify all superfluid state was cleaned up
+	s.ExecuteSuperfluidCleanupTest()
+}
+
+// PrepareSuperfluidCleanupTest sets up some superfluid state to be cleaned up
+func (s *UpgradeTestSuite) PrepareSuperfluidCleanupTest() {
+	// Create a superfluid asset
+	denom := "gamm/pool/1"
+	asset := superfuidtypes.SuperfluidAsset{
+		Denom:     denom,
+		AssetType: superfuidtypes.SuperfluidAssetTypeLPShare,
+	}
+	s.App.SuperfluidKeeper.SetSuperfluidAsset(s.Ctx, asset)
+
+	// Create an intermediary account with a test validator address
+	valAddr := sdk.ValAddress([]byte("testvaraddr1"))
+	intermediaryAcc := superfuidtypes.NewSuperfluidIntermediaryAccount(denom, valAddr.String(), 1)
+	s.App.SuperfluidKeeper.SetIntermediaryAccount(s.Ctx, intermediaryAcc)
+
+	// Create a lock for testing
+	lockOwner := s.TestAccs[0]
+	coins := sdk.NewCoins(sdk.NewCoin(denom, osmomath.NewInt(1000000)))
+
+	// Fund the account with the required coins
+	err := s.App.BankKeeper.MintCoins(s.Ctx, gammtypes.ModuleName, coins)
+	s.Require().NoError(err)
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, gammtypes.ModuleName, lockOwner, coins)
+	s.Require().NoError(err)
+
+	// Create the lock (longer than unbonding period to allow synthetic locks)
+	lock, err := s.App.LockupKeeper.CreateLock(s.Ctx, lockOwner, coins, time.Hour*24*21)
+	s.Require().NoError(err)
+
+	// Set lock-intermediary connection
+	s.App.SuperfluidKeeper.SetLockIdIntermediaryAccountConnection(s.Ctx, lock.ID, intermediaryAcc)
+
+	// Create synthetic lock for superbonding (active superfluid staking)
+	stakingParams, err := s.App.StakingKeeper.GetParams(s.Ctx)
+	s.Require().NoError(err)
+	unbondingDuration := stakingParams.UnbondingTime
+
+	stakingSynthDenom := denom + "/superbonding/" + valAddr.String()
+	err = s.App.LockupKeeper.CreateSyntheticLockup(s.Ctx, lock.ID, stakingSynthDenom, unbondingDuration, false)
+	s.Require().NoError(err)
+
+	// Create a second lock with superunbonding (undelegating superfluid stake)
+	coins2 := sdk.NewCoins(sdk.NewCoin(denom, osmomath.NewInt(500000)))
+
+	// Fund the account for the second lock
+	err = s.App.BankKeeper.MintCoins(s.Ctx, gammtypes.ModuleName, coins2)
+	s.Require().NoError(err)
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, gammtypes.ModuleName, lockOwner, coins2)
+	s.Require().NoError(err)
+
+	// Create the second lock (longer than unbonding period to allow synthetic locks)
+	lock2, err := s.App.LockupKeeper.CreateLock(s.Ctx, lockOwner, coins2, time.Hour*24*21)
+	s.Require().NoError(err)
+
+	// Set lock-intermediary connection for second lock
+	s.App.SuperfluidKeeper.SetLockIdIntermediaryAccountConnection(s.Ctx, lock2.ID, intermediaryAcc)
+
+	// Create synthetic lock for superunbonding (undelegating superfluid stake)
+	unstakingSynthDenom := denom + "/superunbonding/" + valAddr.String()
+	err = s.App.LockupKeeper.CreateSyntheticLockup(s.Ctx, lock2.ID, unstakingSynthDenom, unbondingDuration, true)
+	s.Require().NoError(err)
+
+	// Set an osmo equivalent multiplier
+	s.App.SuperfluidKeeper.SetOsmoEquivalentMultiplier(s.Ctx, 1, denom, osmomath.NewDec(2))
+
+	// Set unpool allowed pools
+	s.App.SuperfluidKeeper.SetUnpoolAllowedPools(s.Ctx, []uint64{1, 2, 3})
+
+	// Verify all state was set up correctly
+
+	// Verify superfluid assets
+	assets := s.App.SuperfluidKeeper.GetAllSuperfluidAssets(s.Ctx)
+	s.Require().Equal(1, len(assets))
+	s.Require().Equal(denom, assets[0].Denom)
+
+	// Verify intermediary accounts
+	intermediaryAccounts := s.App.SuperfluidKeeper.GetAllIntermediaryAccounts(s.Ctx)
+	s.Require().Equal(1, len(intermediaryAccounts))
+	s.Require().Equal(denom, intermediaryAccounts[0].Denom)
+	s.Require().Equal(valAddr.String(), intermediaryAccounts[0].ValAddr)
+
+	// Verify lock-intermediary connections
+	connections := s.App.SuperfluidKeeper.GetAllLockIdIntermediaryAccountConnections(s.Ctx)
+	s.Require().Equal(2, len(connections))
+	lockIds := []uint64{connections[0].LockId, connections[1].LockId}
+	s.Require().Contains(lockIds, lock.ID)
+	s.Require().Contains(lockIds, lock2.ID)
+
+	// Verify osmo equivalent multipliers
+	multipliers := s.App.SuperfluidKeeper.GetAllOsmoEquivalentMultipliers(s.Ctx)
+	s.Require().Equal(1, len(multipliers))
+	s.Require().Equal(denom, multipliers[0].Denom)
+	s.Require().Equal(osmomath.NewDec(2), multipliers[0].Multiplier)
+
+	// Verify unpool allowed pools
+	unpoolPools := s.App.SuperfluidKeeper.GetUnpoolAllowedPools(s.Ctx)
+	s.Require().Equal(3, len(unpoolPools))
+	s.Require().Equal([]uint64{1, 2, 3}, unpoolPools)
+
+	// Verify the lock exists
+	retrievedLock, err := s.App.LockupKeeper.GetLockByID(s.Ctx, lock.ID)
+	s.Require().NoError(err)
+	s.Require().Equal(lockOwner.String(), retrievedLock.Owner)
+	s.Require().Equal(coins, retrievedLock.Coins)
+
+	// Verify synthetic locks were created (both superbonding and superunbonding)
+	allSynthLocks := s.App.LockupKeeper.GetAllSyntheticLockups(s.Ctx)
+	s.Require().Equal(2, len(allSynthLocks))
+
+	// Verify we have one superbonding and one superunbonding
+	superbondingCount := 0
+	superunbondingCount := 0
+	for _, synthLock := range allSynthLocks {
+		switch synthLock.SynthDenom {
+		case stakingSynthDenom:
+			superbondingCount++
+			s.Require().Equal(lock.ID, synthLock.UnderlyingLockId)
+			s.Require().False(synthLock.EndTime.After(s.Ctx.BlockTime()))
+		case unstakingSynthDenom:
+			superunbondingCount++
+			s.Require().Equal(lock2.ID, synthLock.UnderlyingLockId)
+			s.Require().True(synthLock.EndTime.After(s.Ctx.BlockTime()))
+		}
+	}
+	s.Require().Equal(1, superbondingCount)
+	s.Require().Equal(1, superunbondingCount)
+}
+
+// ExecuteSuperfluidCleanupTest verifies all superfluid state was cleaned up
+func (s *UpgradeTestSuite) ExecuteSuperfluidCleanupTest() {
+	// Verify all superfluid assets were deleted
+	assets := s.App.SuperfluidKeeper.GetAllSuperfluidAssets(s.Ctx)
+	s.Require().Equal(0, len(assets))
+
+	// Verify all intermediary accounts were deleted
+	intermediaryAccounts := s.App.SuperfluidKeeper.GetAllIntermediaryAccounts(s.Ctx)
+	s.Require().Equal(0, len(intermediaryAccounts))
+
+	// Verify all lock-intermediary connections were deleted
+	connections := s.App.SuperfluidKeeper.GetAllLockIdIntermediaryAccountConnections(s.Ctx)
+	s.Require().Equal(0, len(connections))
+
+	// Verify all osmo equivalent multipliers were deleted
+	multipliers := s.App.SuperfluidKeeper.GetAllOsmoEquivalentMultipliers(s.Ctx)
+	s.Require().Equal(0, len(multipliers))
+
+	// Verify unpool allowed pools were deleted
+	unpoolPools := s.App.SuperfluidKeeper.GetUnpoolAllowedPools(s.Ctx)
+	s.Require().Equal(0, len(unpoolPools))
+
+	// Verify the underlying locks were unlocked and gamm tokens returned to delegator
+	lockOwner := s.TestAccs[0]
+	denom := "gamm/pool/1"
+
+	// Check that account has no locked coins at all
+	lockedCoins := s.App.LockupKeeper.GetAccountLockedCoins(s.Ctx, lockOwner)
+	s.Require().True(lockedCoins.IsZero())
+
+	// Verify gamm tokens were returned to delegator's wallet
+	delegatorBalance := s.App.BankKeeper.GetBalance(s.Ctx, lockOwner, denom)
+	expectedAmount := osmomath.NewInt(1000000).Add(osmomath.NewInt(500000)) // lock + lock2
+	s.Require().Equal(expectedAmount, delegatorBalance.Amount)
+
+	// Check that no synthetic locks with superfluid denoms exist
+	allSyntheticLocks := s.App.LockupKeeper.GetAllSyntheticLockups(s.Ctx)
+	for _, synthLock := range allSyntheticLocks {
+		// Verify no superbonding or superunbonding synthetic locks exist
+		s.Require().NotContains(synthLock.SynthDenom, "superbonding")
+		s.Require().NotContains(synthLock.SynthDenom, "superunbonding")
+	}
+
+	// Verify superfluid module has no unexpected balance
+	// (some dust might remain due to rounding, but should be minimal)
+	moduleAddr := s.App.AccountKeeper.GetModuleAddress(superfuidtypes.ModuleName)
+	moduleBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, moduleAddr)
+
+	// Module should have zero balance
+	s.Require().Len(moduleBalance, 0)
+
+	// Verify no delegations exist from any address that looks like an intermediary account
+	// Intermediary accounts follow a specific pattern, we check there are no delegations from them
+	allDelegations, err := s.App.StakingKeeper.GetAllDelegations(s.Ctx)
+	s.Require().NoError(err)
+
+	for _, delegation := range allDelegations {
+		delegatorAddr, err := sdk.AccAddressFromBech32(delegation.DelegatorAddress)
+		s.Require().NoError(err)
+
+		// Check if this looks like an intermediary account by trying to get it from the keeper
+		// Since we deleted all intermediary accounts, GetIntermediaryAccount should return empty
+		intermediaryAcc := s.App.SuperfluidKeeper.GetIntermediaryAccount(s.Ctx, delegatorAddr)
+
+		// If we get a non-empty intermediary account, it means there's orphaned state
+		s.Require().Empty(intermediaryAcc.Denom, "Found orphaned delegation from intermediary account: %s", delegatorAddr.String())
+	}
 }


### PR DESCRIPTION
Closes: [CHAIN-1040](https://linear.app/osmosis/issue/CHAIN-1040/investigate-the-removal-of-superfluid)

## What is the purpose of the change

Force undelegate and remove superfluid staking state to prepare for the full module removal.

## Testing and Verifying

Unit tested and manually observing in-place testnet.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A