### PR TITLE
fix: Bidirectional Taker Fee route finding in Protorev

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -882,12 +882,12 @@ func (appKeepers *AppKeepers) SetupHooks() {
 	appKeepers.EpochsKeeper.SetHooks(
 		epochstypes.NewMultiEpochHooks(
 			// insert epoch hooks receivers here
+			appKeepers.ProtoRevKeeper.EpochHooks(),
 			appKeepers.TxFeesKeeper.Hooks(),
 			appKeepers.TwapKeeper.EpochHooks(),
 			appKeepers.SuperfluidKeeper.Hooks(),
 			appKeepers.IncentivesKeeper.Hooks(),
 			appKeepers.MintKeeper.Hooks(),
-			appKeepers.ProtoRevKeeper.EpochHooks(),
 		),
 	)
 

--- a/x/protorev/keeper/protorev.go
+++ b/x/protorev/keeper/protorev.go
@@ -171,7 +171,7 @@ func (k Keeper) GetPoolForDenomPair(ctx sdk.Context, baseDenom, denomToMatch str
 func (k Keeper) GetPoolForDenomPairNoOrder(ctx sdk.Context, tokenA, tokenB string) (uint64, error) {
 	poolId, err := k.GetPoolForDenomPair(ctx, tokenA, tokenB)
 	if err != nil {
-		if errors.Is(err, types.NoPoolForDenomPairError{BaseDenom: tokenA, MatchDenom: tokenB}) {
+		if errors.Is(err, types.NoPoolForDenomPairError{}) {
 			// Attempt changing base and match denoms.
 			poolId, err = k.GetPoolForDenomPair(ctx, tokenB, tokenA)
 			if err != nil {

--- a/x/protorev/types/errors.go
+++ b/x/protorev/types/errors.go
@@ -14,4 +14,10 @@ func (e NoPoolForDenomPairError) Error() string {
 	return fmt.Sprintf("highest liquidity pool between base %s and match denom %s not found", e.BaseDenom, e.MatchDenom)
 }
 
+// Is implements error matching for errors.Is to match any NoPoolForDenomPairError regardless of field values
+func (e NoPoolForDenomPairError) Is(target error) bool {
+	_, ok := target.(NoPoolForDenomPairError)
+	return ok
+}
+
 var ErrRouteDoubleContainsPool = errors.New("cannot be trading on the same pool twice")

--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -434,7 +434,8 @@ func (k Keeper) get2HopRoute(ctx sdk.Context, denomToSwapTo, coinDenom string) (
 // Returns the complete route, true, OR []route{}, false if no path is found.
 func (k Keeper) build2HopsRoute(ctx sdk.Context, inputDenom, intermediaryDenom, denomToSwapTo string) ([]poolmanagertypes.SwapAmountInRoute, bool) {
 	// Find pool for first hop: inputDenom -> intermediaryDenom
-	poolId1, err := k.protorevKeeper.GetPoolForDenomPairNoOrder(ctx, inputDenom, intermediaryDenom)
+	// Try intermediary as base_denom first since these are likely to be registered as the base denoms for route finding.
+	poolId1, err := k.protorevKeeper.GetPoolForDenomPairNoOrder(ctx, intermediaryDenom, inputDenom)
 	if err != nil {
 		return nil, false
 	}


### PR DESCRIPTION
## What is the purpose of the change
Protorev Swaps are not succeeding for all Taker fee swaps to either OSMO or the community pool denom (BTC). This seems to be related to bidirectional registration for these routes not existing due to how ProtoRev handles base denom route finding.

While the original implementation is meant to check both directions, this is not happening.

  1. Error matching failure: errors.Is check in GetPoolForDenomPairNoOrder wasn't properly triggering the reverse
  denom lookup, so routes like CRO→USDC (fails) weren't retrying as USDC→CRO (succeeds).
  2. Suboptimal lookup order: 2-hop route lookups tried less common denoms (e.g., CRO) as base_denom first, when
  protorev routes are typically registered with well-known denoms (OSMO, USDC, ATOM, allBTC) as base_denom, these are also likely to be the destination token.
  3. Stale route data: Protorev's UpdatePools ran after taker fee swaps, creating a 1-epoch lag where newly created
  or updated pools weren't available for fee swaps. While GAMM pools are registered at creation, CL pools are not as they are created without liquidity.

## Changes

  1. Add Is() method to NoPoolForDenomPairError (x/protorev/types/errors.go): Implements proper Go 1.13+ error
  matching to correctly trigger reverse denom lookup fallback.
  2. Optimize 2-hop route lookup order (x/txfees/keeper/hooks.go): Prioritize well-known intermediary and
  destination denoms as base_denom to match how protorev routes are registered.
  3. Reorder epoch hooks (app/keepers/keepers.go): Move ProtoRevKeeper.EpochHooks() before TxFeesKeeper.Hooks() so
  route updates complete before taker fee swaps execute.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?
  - [ ] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A