### PR TITLE
Keep OSMO taker fee dust in the main collector

### DIFF
--- a/x/txfees/keeper/hooks.go
+++ b/x/txfees/keeper/hooks.go
@@ -170,6 +170,12 @@ func (k Keeper) calculateDistributeAndTrackTakerFees(ctx sdk.Context, defaultFee
 
 	// Loop through all remaining tokens in the taker fee module account.
 	for _, takerFeeCoin := range takerFeeModuleAccountCoins {
+		// Base-denom dust from truncated OSMO splits should stay here and be included
+		// in the next epoch's OSMO distribution, not routed through the non-native flow.
+		if takerFeeCoin.Denom == defaultFeesDenom {
+			continue
+		}
+
 		// Store original amount to calculate percentages from the total, not from remaining amounts
 		originalAmount := takerFeeCoin.Amount
 
@@ -261,7 +267,15 @@ func (k Keeper) calculateDistributeAndTrackTakerFees(ctx sdk.Context, defaultFee
 	// We do this in the event that the swap fails, we can still track the amount of non-native taker fees that were intended for stakers.
 	var remainingTakerFeeModuleAccBal sdk.Coins
 	applyFuncIfNoErrorAndLog(ctx, func(cacheCtx sdk.Context) error {
-		remainingTakerFeeModuleAccBal = k.bankKeeper.GetAllBalances(ctx, takerFeeModuleAccount)
+		for _, coin := range k.bankKeeper.GetAllBalances(ctx, takerFeeModuleAccount) {
+			if coin.Denom == defaultFeesDenom {
+				continue
+			}
+			remainingTakerFeeModuleAccBal = remainingTakerFeeModuleAccBal.Add(coin)
+		}
+		if remainingTakerFeeModuleAccBal.IsZero() {
+			return nil
+		}
 		err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, takerFeeModuleAccount, txfeestypes.TakerFeeStakersName, remainingTakerFeeModuleAccBal)
 		return err
 	}, txfeestypes.TakerFeeFailedNativeRewardUpdateMetricName, remainingTakerFeeModuleAccBal)

--- a/x/txfees/keeper/hooks_test.go
+++ b/x/txfees/keeper/hooks_test.go
@@ -957,6 +957,35 @@ func (s *KeeperTestSuite) TestOsmoTakerFeeBurnMechanism() {
 	s.Require().Equal(initialAmount, totalDistributed, "Total distributed amount should equal initial amount")
 }
 
+// TestOsmoTakerFeeDustRemainsInCollector ensures base-denom dust created by truncation
+// stays in the main taker fee collector for the next epoch instead of entering the non-native path.
+func (s *KeeperTestSuite) TestOsmoTakerFeeDustRemainsInCollector() {
+	s.Setup()
+
+	baseDenom, _ := s.App.TxFeesKeeper.GetBaseDenom(s.Ctx)
+	takerFeeCollectorAddr := s.App.AccountKeeper.GetModuleAddress(types.TakerFeeCollectorName)
+	takerFeeStakersAddr := s.App.AccountKeeper.GetModuleAddress(types.TakerFeeStakersName)
+
+	poolManagerParams := s.App.PoolManagerKeeper.GetParams(s.Ctx)
+	poolManagerParams.TakerFeeParams.OsmoTakerFeeDistribution = poolmanagertypes.TakerFeeDistributionPercentage{
+		StakingRewards: osmomath.MustNewDecFromStr("0.3"),
+		CommunityPool:  osmomath.ZeroDec(),
+		Burn:           osmomath.MustNewDecFromStr("0.7"),
+	}
+	s.App.PoolManagerKeeper.SetParams(s.Ctx, poolManagerParams)
+
+	s.FundModuleAcc(types.TakerFeeCollectorName, sdk.NewCoins(sdk.NewCoin(baseDenom, osmomath.OneInt())))
+
+	err := s.App.TxFeesKeeper.AfterEpochEnd(s.Ctx, "week", 1)
+	s.Require().NoError(err)
+
+	collectorBalance := s.App.BankKeeper.GetBalance(s.Ctx, takerFeeCollectorAddr, baseDenom)
+	s.Require().Equal(osmomath.OneInt(), collectorBalance.Amount, "dust OSMO should remain in the taker fee collector for the next epoch")
+
+	stakersBalance := s.App.BankKeeper.GetBalance(s.Ctx, takerFeeStakersAddr, baseDenom)
+	s.Require().True(stakersBalance.IsZero(), "dust OSMO must not be routed through the non-native stakers module path")
+}
+
 // TestNonOsmoTakerFeeBurnMechanism tests the burn functionality for non-OSMO taker fees
 // Non-OSMO tokens should be swapped to OSMO before being sent to the burn address
 // Tests multiple denoms and failed swap recovery scenarios


### PR DESCRIPTION
Closes #9643

This keeps base-denom taker fee dust in `TakerFeeCollectorName` so it can be distributed on the next epoch instead of being routed through the non-native path.

- skip the base denom in the non-native taker fee loop
- keep the later transfer to `TakerFeeStakersName` restricted to non-base-denom balances
- add a regression test for the `1 uosmo` truncation-dust case

Step | Before fix | After fix
--- | --- | ---
Reproduction command | `GOTOOLCHAIN=go1.23.4 GOWORK=off go test ./x/txfees/keeper -run TestKeeperTestSuite/TestOsmoTakerFeeDustRemainsInCollector -count=1` | `GOTOOLCHAIN=go1.23.4 GOWORK=off go test ./x/txfees/keeper -run TestKeeperTestSuite/TestOsmoTakerFeeDustRemainsInCollector -count=1`
Key output | `FAIL` with `expected: 1` and `actual  : 0` | `ok   github.com/osmosis-labs/osmosis/v31/x/txfees/keeper`
Test result | dust OSMO left the main collector and the new regression test failed | regression test passed; `TestOsmoTakerFeeBurnMechanism` and `TestStakingRewardSmoothing` also passed

Verification:

```bash
GOTOOLCHAIN=go1.23.4 GOWORK=off go test ./x/txfees/keeper -run TestKeeperTestSuite/TestOsmoTakerFeeDustRemainsInCollector -count=1
/tmp/osmosis_keeper.test -test.run '^TestKeeperTestSuite/TestOsmoTakerFeeBurnMechanism$' -test.v
/tmp/osmosis_keeper.test -test.run '^TestKeeperTestSuite/TestStakingRewardSmoothing$' -test.v
GOTOOLCHAIN=go1.23.4 GOWORK=off go build -o build/osmosisd ./cmd/osmosisd
./build/osmosisd version --long
```
