### PR TITLE
chore: migrate BuildJet runners to GitHub-hosted runners

### DIFF
--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
   check_state_compatibility:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     needs: compare_versions
     timeout-minutes: 30
     if: ${{ needs.compare_versions.outputs.should_i_run == 'true'}}
@@ -92,7 +92,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 🐿 Setup Golang
-        uses: buildjet/setup-go@v5
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: 🔨 Build the osmosisd binary

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -35,7 +35,7 @@ jobs:
   e2e:
     needs: get_diff
     if: needs.get_diff.outputs.git_diff
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out repository

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   push-docker-images:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       -
         name: Check out repo

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   push-docker-images:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, 'iavl') }}
     steps:
       - name: Check out the repo
@@ -164,7 +164,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY_COSMOVISOR }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
 
   push-iavl-docker-images:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     if: ${{ contains(github.ref_name, 'iavl') }}
     steps:
       - name: Check out the repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release:
     name: Create release
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   get_diff:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
   go-split-test-files:
     needs: get_diff
     if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]' }}
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
   go:
     needs: [go-split-test-files, get_diff]
     if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]' }}
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
   e2e:
     needs: get_diff
     if: ${{ needs.get_diff.outputs.git_diff || github.actor == 'dependabot[bot]' || github.actor == 'mergify[bot]' }}
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out repository


### PR DESCRIPTION
  BuildJet shut down on March 31, 2026. Replace all BuildJet
  runner labels with GitHub-hosted equivalents and buildjet/setup-go
  with actions/setup-go.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->