### PR TITLE
fix: correct spelling in comments and tests

### DIFF
--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -166,7 +166,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 					// Set chainID to osmosis-1 in the case of a blank chainID
 					chainID = "osmosis-1"
 
-					// We dont print the app state for mainnet nodes because it's massive
+					// We don't print the app state for mainnet nodes because it's massive
 					fmt.Println("Not printing app state for mainnet node due to verbosity")
 					toPrint = newPrintInfo(config.Moniker, chainID, nodeID, "", nil)
 				}

--- a/simulation/executor/internal/executortypes/simmanager.go
+++ b/simulation/executor/internal/executortypes/simmanager.go
@@ -105,7 +105,7 @@ func (m Manager) legacyActions(seed int64, cdc codec.JSONCodec) []simtypes.Actio
 		if simModule, ok := m.legacyModules[moduleName]; ok {
 			// UNFORKINGNOTE: Figure out how to call RandomizedParams and ProposalContents if we decide to revive simulator
 			//
-			// Printing so we dont need to uncomment more, just delete the prints later
+			// Printing so we don't need to uncomment more, just delete the prints later
 			// simState.LegacyParamChange = append(simState.LegacyParamChange, simModule.RandomizedParams(r)...)
 			// simState.LegacyProposalContents = append(simState.LegacyProposalContents, simModule.ProposalContents(simState)...)
 			fmt.Println("simState.LegacyParamChange", simModule, r)

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/integration_tests.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/integration_tests.rs
@@ -443,7 +443,7 @@ fn test_execute_add_path() {
     };
 
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -497,7 +497,7 @@ fn test_execute_remove_path() {
         denom: "denom".to_string(),
     };
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -548,7 +548,7 @@ fn test_execute_reset_path_quota() {
         quota_id: "daily".to_string(),
     };
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -610,7 +610,7 @@ fn test_execute_grant_and_revoke_role() {
         roles: vec![Roles::GrantRole],
     };
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -707,7 +707,7 @@ fn test_execute_edit_path_quota() {
         },
     };
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -754,7 +754,7 @@ fn test_execute_remove_message() {
         roles: vec![Roles::GrantRole],
     };
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -769,7 +769,7 @@ fn test_execute_remove_message() {
     };
 
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke as insufficient permissions
+    // non gov can't invoke as insufficient permissions
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -833,7 +833,7 @@ fn test_execute_process_messages() {
     };
 
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke
+    // non gov can't invoke
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());
@@ -848,7 +848,7 @@ fn test_execute_process_messages() {
     };
 
     let cosmos_msg = cw_rate_limit_contract.call(management_msg).unwrap();
-    // non gov cant invoke as insufficient permissions
+    // non gov can't invoke as insufficient permissions
     assert!(app
         .execute(Addr::unchecked("foobar"), cosmos_msg.clone())
         .is_err());

--- a/x/valset-pref/validator_set.go
+++ b/x/valset-pref/validator_set.go
@@ -104,7 +104,7 @@ func (k Keeper) DelegateToValidatorSet(ctx sdk.Context, delegatorAddr string, co
 			return err
 		}
 
-		// in the last valset iteration we dont calculate it from shares using decimals and truncation,
+		// in the last valset iteration we don't calculate it from shares using decimals and truncation,
 		// we use what's remaining to get more accurate value
 		if len(existingSet.Preferences)-1 == i {
 			tokenAmt = coin.Amount.Sub(totalDelAmt).ToLegacyDec().TruncateInt()


### PR DESCRIPTION
## Description
Fixed spelling errors in comments and test files.

⚠️ **Note:** Comment and test changes only. No functional code modified.

## Changes
- Fix 'cant' → 'can't'
- Fix 'dont' → 'don't'

## Impact
- Comment clarity improvement only
- No functional changes