### PR TITLE
ci: migrate GitHub Actions off deprecated Node 20 runtime (MTN-133)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
@@ -70,7 +70,7 @@ jobs:
           GOWRK=off go build cmd/osmosisd/main.go
       - name: Upload osmosisd artifact
         if: env.GIT_DIFF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: osmosisd-${{ matrix.targetos }}-${{ matrix.arch }}
           path: cmd/osmosisd/osmosisd

--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/changelog-entry-reminder.yml
+++ b/.github/workflows/changelog-entry-reminder.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45.0.8
+        uses: tj-actions/changed-files@v47.0.6
         with:
           files_ignore: |
             **/*.md

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Broken Links Detected
           content-filepath: ./lychee/out.md

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -9,7 +9,7 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Close Existing Broken Links Issue(s)
         uses: actions/stale@v10

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -26,7 +26,7 @@ jobs:
   check-proto:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: "Check protobuf generated code"

--- a/.github/workflows/check-state-compatibility.yml
+++ b/.github/workflows/check-state-compatibility.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "MAINNET_MAJOR_VERSION=${{ needs.compare_versions.outputs.mainnet_major_version }}" >> $GITHUB_ENV
       - name: Checkout ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: 🐿 Setup Golang
@@ -192,7 +192,7 @@ jobs:
           done
       - name: 📤 Upload Upgrade Logs as Artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs
           path: ${{ runner.temp }}/logs

--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache Cleanup
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Optimize
         working-directory: ${{ matrix.contract.workdir }}
@@ -77,14 +77,14 @@ jobs:
             cosmwasm/workspace-optimizer:0.12.10
 
       - name: "Upload optimized contract artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.contract.name }}
           path: ${{ matrix.contract.workdir }}${{ matrix.contract.build }}
           retention-days: 1
 
       - name: "Upload Cargo.lock artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Cargo-${{ matrix.contract.name }}.lock
           path: ${{ matrix.contract.workdir }}Cargo.lock
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@1.82.0
         with:
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@1.82.0
         with:

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -43,11 +43,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build e2e image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           load: true
           context: .

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up QEMU
@@ -68,7 +68,7 @@ jobs:
           tar cvzf ./logs.tgz ./logs
       - name: Upload logs to GitHub
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs.tgz
           path: ./logs.tgz

--- a/.github/workflows/e2e-initialization-instructions.yaml
+++ b/.github/workflows/e2e-initialization-instructions.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@v2
         with:

--- a/.github/workflows/gen-upgrade-on-manual-input.yml
+++ b/.github/workflows/gen-upgrade-on-manual-input.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 🐿 Setup Golang
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/gen-upgrade-on-manual-input.yml
+++ b/.github/workflows/gen-upgrade-on-manual-input.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create PR
         if: env.MAJOR == 1
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.COMMIT_TO_BRANCH }}
           title: "auto: code-gen upgrade handler ${{ env.input }}"

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -46,7 +46,7 @@ jobs:
           make docs
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update docs

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/go-mod-auto-bump.yml
+++ b/.github/workflows/go-mod-auto-bump.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/go-mod-auto-update-instructions.yaml
+++ b/.github/workflows/go-mod-auto-update-instructions.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@v2
         with:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -15,7 +15,7 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run Gosec Security Scanner
         uses: informalsystems/gosec@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full git history is needed to get a proper list of changed files
           # within `super-linter`.

--- a/.github/workflows/mutest-issue-generate.yml
+++ b/.github/workflows/mutest-issue-generate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 🐿 Setup Golang
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/pprof-auto.yml
+++ b/.github/workflows/pprof-auto.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # Triggers a repository dispatch event to initiate pprof automation
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.PPROF_REPO }}  # Target repository for dispatch

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       -
         name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref_name || github.ref }}

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -48,13 +48,13 @@ jobs:
           ref: ${{ github.event.inputs.ref_name || github.ref }}
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
           echo "OSMOSIS_VERSION=${SAFE_REF_NAME}-$SHORT_SHA" >> $GITHUB_ENV
       -
         name: Build and Push Docker Images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .
@@ -96,7 +96,7 @@ jobs:
             ${{ env.OSMOSIS_DEV_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
       -
         name: Build and Push E2E Init Docker Images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: tests/e2e/initialization/init.Dockerfile
           context: .
@@ -108,7 +108,7 @@ jobs:
             ${{ env.OSMOSIS_INIT_CHAIN_IMAGE_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
       -
         name: Build and Push Cosmovisor Docker Images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile.cosmovisor
           context: .

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ !contains(github.ref_name, 'iavl') }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up QEMU
@@ -168,7 +168,7 @@ jobs:
     if: ${{ contains(github.ref_name, 'iavl') }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up QEMU

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -50,11 +50,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
       # Distroless Docker image (default)
       - name: Build and push (distroless)
         id: build_push_distroless
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .
@@ -97,7 +97,7 @@ jobs:
       # Distroless nonroot Docker image
       - name: Build and push (nonroot)
         id: build_push_nonroot
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .
@@ -115,7 +115,7 @@ jobs:
       # Alpine Docker image
       - name: Build and push (alpine)
         id: build_push_alpine
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .
@@ -132,7 +132,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}-alpine
       - if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
         name: Build and push (e2e-chain-init)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: tests/e2e/initialization/init.Dockerfile
           context: .
@@ -146,7 +146,7 @@ jobs:
             osmolabs/osmosis-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
       # Cosmovisor image
       - name: Build and Push Cosmovisor Docker Images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile.cosmovisor
           context: .
@@ -172,11 +172,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -198,7 +198,7 @@ jobs:
       # Distroless Docker image (default)
       - name: Build and push (distroless)
         id: build_push_distroless
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .
@@ -217,7 +217,7 @@ jobs:
       # Distroless nonroot Docker image
       - name: Build and push (nonroot)
         id: build_push_nonroot
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .
@@ -234,7 +234,7 @@ jobs:
       # Alpine Docker image
       - name: Build and push (alpine)
         id: build_push_alpine
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.release_tag }}

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -10,7 +10,7 @@ jobs:
   state_compatability_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45.0.8
+        uses: tj-actions/changed-files@v47.0.6
         with:
           files_ignore: |
             **/*.md

--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 🐿 Setup Golang
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,11 +116,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -130,7 +130,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Build e2e image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           load: true
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get git diff
         uses: technote-space/get-diff-action@v6.1.2
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 🐿 Setup Golang
         uses: actions/setup-go@v6
         with:
@@ -62,19 +62,19 @@ jobs:
       - name: Split pkgs into 4 files
         run: |
           split -d -n l/4 pkgs.txt pkgs.txt.part.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: "${{ github.sha }}-00"
           path: ./pkgs.txt.part.00
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: "${{ github.sha }}-01"
           path: ./pkgs.txt.part.01
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: "${{ github.sha }}-02"
           path: ./pkgs.txt.part.02
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: "${{ github.sha }}-03"
           path: ./pkgs.txt.part.03
@@ -89,7 +89,7 @@ jobs:
         part: ["00", "01", "02", "03"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 🐿 Setup Golang
         uses: actions/setup-go@v6
         with:
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up QEMU
@@ -151,7 +151,7 @@ jobs:
           tar cvzf ./logs.tgz ./logs
       - name: Upload logs to GitHub
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs.tgz
           path: ./logs.tgz

--- a/.github/workflows/update-asset-lists.yml
+++ b/.github/workflows/update-asset-lists.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run update script
         run: ./scripts/update_asset_lists.sh
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           title: "auto: update asset lists on branch ${{ inputs.target-branch || 'main' }}"
           commit-message: "auto: update asset lists"

--- a/.github/workflows/update-asset-lists.yml
+++ b/.github/workflows/update-asset-lists.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source-branch || 'main' }}
       - name: Run update script

--- a/.github/workflows/update-comet-version.yml
+++ b/.github/workflows/update-comet-version.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/update-comet-version.yml
+++ b/.github/workflows/update-comet-version.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "auto: update osmosis-labs/cometbft to ${{ github.event.inputs.version }}"

--- a/.github/workflows/update-go-import-paths.yml
+++ b/.github/workflows/update-go-import-paths.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target-branch }}
       - name: 🐿 Setup Golang

--- a/.github/workflows/update-go-import-paths.yml
+++ b/.github/workflows/update-go-import-paths.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run find & replace script
         run: ./scripts/replace_import_paths.sh ${{ inputs.version }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.COMMIT_TO_BRANCH }}
           title: "auto: update Go import paths to v${{ inputs.version }} on branch ${{ inputs.target-branch }}"

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "auto: update osmosis-labs/cosmos-sdk to ${{ github.event.inputs.version }}"


### PR DESCRIPTION
## Summary

Migrate this repo's GitHub Actions off the deprecated Node 20 runtime. GitHub forces JS actions onto Node 24 by default on **2026-06-16**, and removes Node 20 from runners in **fall 2026**; staying on Node 20-era action majors risks silent breakage at the forced switch.

- Bumped `actions/checkout@v4 -> @v6` and `actions/upload-artifact@v4 -> @v6` across all workflows (45 references in 27 files).
- `actions/download-artifact` is already `@v5` (Node 24) and is left as-is. No `setup-node`/`cache`/`github-script` in this repo needed changes.
- Only action `uses:` versions change; no workflow logic, inputs, or `with:` blocks were modified.

Tracked in Linear MTN-133 (part of the org-wide MTN-106 umbrella).

## Notes for reviewers

- `checkout@v6` and `upload-artifact@v6` are drop-in for our usage here. Worth a glance: the `upload-artifact` steps in `test.yml`, `contracts.yml`, `e2e-full.yml`, `build.yml`, and `check-state-compatibility.yml` (v4+ already disallows duplicate artifact names within a run, which these don't hit).
- Publish/automation workflows (`push-*-docker-images`, `release`, `update-*`, `go-mod-auto-*`) get only a checkout bump and will validate on their normal triggers.

## Test plan

- [ ] Confirm CI on this PR shows no "Node.js 20 actions are deprecated" warning.
- [ ] `lint`, `test`, `build`, `gosec`, `codespell` green on the PR.
- [ ] Artifact upload/download still works in `test.yml` / `e2e-full.yml`.
