### PR TITLE
feat(mint): supply endpoints and circulating-supply inflation denominator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * [#9676](https://github.com/osmosis-labs/osmosis/pull/9676) chore: bump cometbft version to v0.38.22
-* [#TBD](https://github.com/osmosis-labs/osmosis/pull/TBD) feat(mint): supply endpoints (burned/total/restricted/circulating) and switch the inflation endpoint denominator to circulating supply
+* [#9708](https://github.com/osmosis-labs/osmosis/pull/9708) feat(mint): supply endpoints (burned/total/restricted/circulating) and switch the inflation endpoint denominator to circulating supply
 
 ## v31.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * [#9676](https://github.com/osmosis-labs/osmosis/pull/9676) chore: bump cometbft version to v0.38.22
+* [#TBD](https://github.com/osmosis-labs/osmosis/pull/TBD) feat(mint): supply endpoints (burned/total/restricted/circulating) and switch the inflation endpoint denominator to circulating supply
 
 ## v31.0.0
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -512,6 +512,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.BankKeeper,
 		appKeepers.DistrKeeper,
 		appKeepers.EpochsKeeper,
+		appKeepers.StakingKeeper,
 		authtypes.FeeCollectorName,
 	)
 	appKeepers.MintKeeper = &mintKeeper

--- a/proto/osmosis/mint/v1beta1/query.proto
+++ b/proto/osmosis/mint/v1beta1/query.proto
@@ -24,6 +24,29 @@ service Query {
   rpc Inflation(QueryInflationRequest) returns (QueryInflationResponse) {
     option (google.api.http).get = "/osmosis/mint/v1beta1/inflation";
   }
+
+  // BurnedSupply returns the total amount of burned tokens.
+  rpc BurnedSupply(QueryBurnedRequest) returns (QueryBurnedResponse) {
+    option (google.api.http).get = "/osmosis/mint/v1beta1/burned_supply";
+  }
+
+  // TotalSupply returns the total supply (minted - burned).
+  rpc TotalSupply(QueryTotalSupplyRequest) returns (QueryTotalSupplyResponse) {
+    option (google.api.http).get = "/osmosis/mint/v1beta1/total_supply";
+  }
+
+  // RestrictedSupply returns the supply held in restricted addresses.
+  rpc RestrictedSupply(QueryRestrictedSupplyRequest)
+      returns (QueryRestrictedSupplyResponse) {
+    option (google.api.http).get = "/osmosis/mint/v1beta1/restricted_supply";
+  }
+
+  // CirculatingSupply returns the circulating supply
+  // (minted - burned - restricted).
+  rpc CirculatingSupply(QueryCirculatingSupplyRequest)
+      returns (QueryCirculatingSupplyResponse) {
+    option (google.api.http).get = "/osmosis/mint/v1beta1/circulating_supply";
+  }
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -59,6 +82,62 @@ message QueryInflationResponse {
   // inflation is the current minting inflation value.
   bytes inflation = 1 [
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
+    (gogoproto.nullable) = false
+  ];
+}
+
+// QueryBurnedRequest is the request type for the Query/BurnedSupply RPC method.
+message QueryBurnedRequest {}
+
+// QueryBurnedResponse is the response type for the Query/BurnedSupply RPC
+// method.
+message QueryBurnedResponse {
+  // burned is the total amount of burned tokens.
+  bytes burned = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false
+  ];
+}
+
+// QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
+// method.
+message QueryTotalSupplyRequest {}
+
+// QueryTotalSupplyResponse is the response type for the Query/TotalSupply RPC
+// method.
+message QueryTotalSupplyResponse {
+  // total_supply is the total supply (minted - burned).
+  bytes total_supply = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false
+  ];
+}
+
+// QueryRestrictedSupplyRequest is the request type for the
+// Query/RestrictedSupply RPC method.
+message QueryRestrictedSupplyRequest {}
+
+// QueryRestrictedSupplyResponse is the response type for the
+// Query/RestrictedSupply RPC method.
+message QueryRestrictedSupplyResponse {
+  // restricted_supply is the supply held in restricted addresses.
+  bytes restricted_supply = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false
+  ];
+}
+
+// QueryCirculatingSupplyRequest is the request type for the
+// Query/CirculatingSupply RPC method.
+message QueryCirculatingSupplyRequest {}
+
+// QueryCirculatingSupplyResponse is the response type for the
+// Query/CirculatingSupply RPC method.
+message QueryCirculatingSupplyResponse {
+  // circulating_supply is the circulating supply (minted - burned -
+  // restricted).
+  bytes circulating_supply = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false
   ];
 }

--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -20,6 +20,10 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdQueryParams(),
 		GetCmdQueryEpochProvisions(),
 		GetCmdQueryInflation(),
+		GetCmdQueryBurnedSupply(),
+		GetCmdQueryTotalSupply(),
+		GetCmdQueryRestrictedSupply(),
+		GetCmdQueryCirculatingSupply(),
 	)
 
 	return cmd
@@ -104,6 +108,118 @@ func GetCmdQueryInflation() *cobra.Command {
 			}
 
 			return clientCtx.PrintString(fmt.Sprintf("%s\n", res.Inflation))
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryBurnedSupply implements a command to return the amount of
+// mint-denom held in the burn address.
+func GetCmdQueryBurnedSupply() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "burned-supply",
+		Short: "Query the total amount of burned tokens",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.BurnedSupply(context.Background(), &types.QueryBurnedRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintString(fmt.Sprintf("%s\n", res.Burned))
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryTotalSupply implements a command to return the total supply
+// (minted - burned).
+func GetCmdQueryTotalSupply() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "total-supply",
+		Short: "Query the total supply (minted minus burned)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.TotalSupply(context.Background(), &types.QueryTotalSupplyRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintString(fmt.Sprintf("%s\n", res.TotalSupply))
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryRestrictedSupply implements a command to return the supply held in
+// restricted addresses.
+func GetCmdQueryRestrictedSupply() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restricted-supply",
+		Short: "Query the supply held in restricted addresses",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.RestrictedSupply(context.Background(), &types.QueryRestrictedSupplyRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintString(fmt.Sprintf("%s\n", res.RestrictedSupply))
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryCirculatingSupply implements a command to return the circulating
+// supply (minted - burned - restricted).
+func GetCmdQueryCirculatingSupply() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "circulating-supply",
+		Short: "Query the circulating supply (minted minus burned minus restricted)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.CirculatingSupply(context.Background(), &types.QueryCirculatingSupplyRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintString(fmt.Sprintf("%s\n", res.CirculatingSupply))
 		},
 	}
 

--- a/x/mint/keeper/grpc_query.go
+++ b/x/mint/keeper/grpc_query.go
@@ -47,3 +47,27 @@ func (q Querier) Inflation(c context.Context, _ *types.QueryInflationRequest) (*
 
 	return &types.QueryInflationResponse{Inflation: inflation}, nil
 }
+
+// BurnedSupply returns the amount of mint-denom held in the burn address.
+func (q Querier) BurnedSupply(c context.Context, _ *types.QueryBurnedRequest) (*types.QueryBurnedResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	return &types.QueryBurnedResponse{Burned: q.Keeper.GetBurnedSupply(ctx)}, nil
+}
+
+// TotalSupply returns the total supply (minted - burned).
+func (q Querier) TotalSupply(c context.Context, _ *types.QueryTotalSupplyRequest) (*types.QueryTotalSupplyResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	return &types.QueryTotalSupplyResponse{TotalSupply: q.Keeper.GetTotalSupply(ctx)}, nil
+}
+
+// RestrictedSupply returns the supply held in restricted addresses.
+func (q Querier) RestrictedSupply(c context.Context, _ *types.QueryRestrictedSupplyRequest) (*types.QueryRestrictedSupplyResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	return &types.QueryRestrictedSupplyResponse{RestrictedSupply: q.Keeper.GetRestrictedSupply(ctx)}, nil
+}
+
+// CirculatingSupply returns the circulating supply (minted - burned - restricted).
+func (q Querier) CirculatingSupply(c context.Context, _ *types.QueryCirculatingSupplyRequest) (*types.QueryCirculatingSupplyResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	return &types.QueryCirculatingSupplyResponse{CirculatingSupply: q.Keeper.GetCirculatingSupply(ctx)}, nil
+}

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -11,11 +11,13 @@ import (
 	"github.com/osmosis-labs/osmosis/osmoutils"
 	"github.com/osmosis-labs/osmosis/v31/x/mint/types"
 	poolincentivestypes "github.com/osmosis-labs/osmosis/v31/x/pool-incentives/types"
+	txfeestypes "github.com/osmosis-labs/osmosis/v31/x/txfees/types"
 
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // Keeper of the mint store.
@@ -26,6 +28,7 @@ type Keeper struct {
 	bankKeeper          types.BankKeeper
 	communityPoolKeeper types.CommunityPoolKeeper
 	epochKeeper         types.EpochKeeper
+	stakingKeeper       types.StakingKeeper
 	hooks               types.MintHooks
 	feeCollectorName    string
 }
@@ -53,6 +56,7 @@ const emptyWeightedAddressReceiver = ""
 func NewKeeper(
 	key storetypes.StoreKey, paramSpace paramtypes.Subspace,
 	ak types.AccountKeeper, bk types.BankKeeper, ck types.CommunityPoolKeeper, epochKeeper types.EpochKeeper,
+	sk types.StakingKeeper,
 	feeCollectorName string,
 ) Keeper {
 	// ensure mint module account is set
@@ -72,6 +76,7 @@ func NewKeeper(
 		bankKeeper:          bk,
 		communityPoolKeeper: ck,
 		epochKeeper:         epochKeeper,
+		stakingKeeper:       sk,
 		feeCollectorName:    feeCollectorName,
 	}
 }
@@ -157,7 +162,14 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 }
 
 // GetInflation calculates the current inflation rate.
-// Formula: ((Epoch provisions * (1 - Community Pool proportion)) * 365) / Total Supply
+// Formula: ((Epoch provisions * (1 - Community Pool proportion)) * 365) / Circulating Supply
+//
+// The denominator is circulating supply (minted - burned - restricted), the
+// public-float base used by Coingecko/CMC, rather than offset-adjusted total
+// supply. This is a query-only change (GetInflation is called only from the
+// gRPC querier, never from minting/BeginBlock/EndBlock), so it is point-release
+// safe. Note for integrators: the reported inflation value is higher than under
+// the previous total-supply denominator, since the denominator is now smaller.
 func (k Keeper) GetInflation(ctx sdk.Context) (osmomath.Dec, error) {
 	// Get current epoch provisions
 	minter := k.GetMinter(ctx)
@@ -167,8 +179,8 @@ func (k Keeper) GetInflation(ctx sdk.Context) (osmomath.Dec, error) {
 	params := k.GetParams(ctx)
 	communityPoolProportion := params.DistributionProportions.CommunityPool
 
-	// Get total supply of the mint denom
-	totalSupply := k.bankKeeper.GetSupplyWithOffset(ctx, params.MintDenom)
+	// Get circulating supply of the mint denom
+	circulatingSupply := k.GetCirculatingSupply(ctx)
 
 	// Calculate circulating provisions: epoch provisions * (1 - community pool proportion)
 	oneMinusCommunityPool := osmomath.OneDec().Sub(communityPoolProportion)
@@ -177,13 +189,174 @@ func (k Keeper) GetInflation(ctx sdk.Context) (osmomath.Dec, error) {
 	// Calculate annualized provisions: circulating provisions * 365
 	annualizedProvisions := circulatingProvisions.Mul(osmomath.NewDec(365))
 
-	// Calculate inflation rate: annualized provisions / total supply
-	if totalSupply.Amount.IsPositive() {
-		totalSupplyDec := totalSupply.Amount.ToLegacyDec()
-		return annualizedProvisions.Quo(totalSupplyDec), nil
+	// Calculate inflation rate: annualized provisions / circulating supply
+	if circulatingSupply.IsPositive() {
+		circulatingSupplyDec := circulatingSupply.ToLegacyDec()
+		return annualizedProvisions.Quo(circulatingSupplyDec), nil
 	}
 
 	return osmomath.ZeroDec(), nil
+}
+
+// GetBurnedSupply returns the amount of mint-denom held in the null/burn
+// address (txfeestypes.DefaultNullAddress, the all-zero account). These coins
+// are permanently removed from circulation.
+func (k Keeper) GetBurnedSupply(ctx sdk.Context) osmomath.Int {
+	params := k.GetParams(ctx)
+	burned := k.bankKeeper.GetBalance(ctx, txfeestypes.DefaultNullAddress, params.MintDenom)
+	return burned.Amount
+}
+
+// GetTotalSupply returns the total supply of the mint denom (minted - burned).
+//
+// "minted" is the raw bank supply (GetSupply), which includes the unvested
+// developer-vesting balance exactly once. Total supply is reported before
+// netting out restricted holdings, matching the Coingecko/CMC total-supply
+// methodology.
+func (k Keeper) GetTotalSupply(ctx sdk.Context) osmomath.Int {
+	params := k.GetParams(ctx)
+	mintedSupply := k.bankKeeper.GetSupply(ctx, params.MintDenom)
+	burnedSupply := k.GetBurnedSupply(ctx)
+	return mintedSupply.Amount.Sub(burnedSupply)
+}
+
+// GetCirculatingSupply returns the circulating supply, equivalent to the public
+// float: minted - burned - restricted.
+//
+// All three terms are computed on the same raw-supply base (GetSupply). The
+// developer-vesting balance is included in minted exactly once and subtracted in
+// restricted exactly once, so it nets to zero in circulating supply. Do NOT base
+// this on GetSupplyWithOffset: that already nets out developer vesting, which
+// combined with the restricted-supply subtraction would double-count it.
+func (k Keeper) GetCirculatingSupply(ctx sdk.Context) osmomath.Int {
+	return k.GetTotalSupply(ctx).Sub(k.GetRestrictedSupply(ctx))
+}
+
+// GetRestrictedSupply returns the amount of mint-denom held by known restricted
+// entities and therefore excluded from circulating supply:
+//   - the developer-vesting module account balance (still-unvested dev tokens);
+//   - the community pool;
+//   - the developer-vested reward receiver addresses (balance + staked);
+//   - the curated foundation/investor restricted addresses (balance + staked).
+//
+// Liquid balances and staked (delegated) amounts are both counted, since staked
+// OSMO held by a restricted entity is not part of the public float.
+func (k Keeper) GetRestrictedSupply(ctx sdk.Context) osmomath.Int {
+	params := k.GetParams(ctx)
+	restrictedSupply := osmomath.ZeroInt()
+
+	// seen tracks addresses already counted so that an address appearing in both
+	// the governance param receivers and the curated constant is not
+	// double-counted.
+	seen := make(map[string]struct{})
+
+	// 1. Developer vesting module account balance (unvested dev tokens).
+	devVestingAddr := k.accountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)
+	if devVestingAddr != nil {
+		devVestingBalance := k.bankKeeper.GetBalance(ctx, devVestingAddr, params.MintDenom)
+		restrictedSupply = restrictedSupply.Add(devVestingBalance.Amount)
+	}
+
+	// 2. Community pool balance. Read from the distribution FeePool (the
+	// authoritative community-pool accounting), not the distribution module
+	// account balance. CommunityPool is DecCoins; truncate to Int (rounds down,
+	// so restricted is at most 1 uosmo under-counted per denom).
+	//
+	// The FeePool.Get error is deliberately swallowed: this is a read-only
+	// reporting query, so a failed read degrades the community-pool term to 0
+	// rather than erroring the whole endpoint.
+	if feePool, err := k.communityPoolKeeper.FeePool.Get(ctx); err == nil {
+		for _, coin := range feePool.GetCommunityPool() {
+			if coin.Denom == params.MintDenom {
+				restrictedSupply = restrictedSupply.Add(coin.Amount.TruncateInt())
+				break
+			}
+		}
+	}
+
+	// 3. Developer-vested reward receiver addresses (governance param). Skip
+	// empty addresses (those route to the community pool, already counted).
+	for _, devAddr := range params.WeightedDeveloperRewardsReceivers {
+		if devAddr.Address == emptyWeightedAddressReceiver {
+			continue
+		}
+		addr, err := sdk.AccAddressFromBech32(devAddr.Address)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[addr.String()]; ok {
+			continue
+		}
+		seen[addr.String()] = struct{}{}
+		restrictedSupply = restrictedSupply.Add(k.addressHoldings(ctx, addr, params.MintDenom))
+	}
+
+	// 4. Curated foundation/investor/strategic restricted addresses (compiled-in
+	// constant). Parsed here (not at package init) because the bech32 "osmo"
+	// prefix is set by app params init, which may not have run when the types
+	// package loads. De-duplicated against the param receivers above.
+	for _, addrStr := range types.RestrictedAddresses {
+		addr, err := sdk.AccAddressFromBech32(addrStr)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[addr.String()]; ok {
+			continue
+		}
+		seen[addr.String()] = struct{}{}
+		restrictedSupply = restrictedSupply.Add(k.addressHoldings(ctx, addr, params.MintDenom))
+	}
+
+	return restrictedSupply
+}
+
+// addressHoldings returns an address's liquid balance plus its staked (delegated)
+// amount in the given denom.
+func (k Keeper) addressHoldings(ctx sdk.Context, addr sdk.AccAddress, denom string) osmomath.Int {
+	balance := k.bankKeeper.GetBalance(ctx, addr, denom)
+	staked := k.getStakedAmount(ctx, addr)
+	return balance.Amount.Add(staked)
+}
+
+// getStakedAmount returns the total amount staked by a delegator, converting
+// delegation shares to tokens via each validator's current exchange rate. The
+// share-to-token conversion accounts for slashing, where 1 share is worth less
+// than 1 token.
+//
+// This counts only active delegations. Tokens mid-unbonding or mid-redelegation
+// held by a restricted address are not counted; that is a transient window and
+// negligible at supply-reporting granularity. The validator-not-found fallback
+// (raw shares) only ever over-counts restricted (shares >= tokens), i.e. it is
+// conservative for circulating supply.
+func (k Keeper) getStakedAmount(ctx sdk.Context, delegator sdk.AccAddress) osmomath.Int {
+	totalStaked := osmomath.ZeroInt()
+
+	err := k.stakingKeeper.IterateDelegations(ctx, delegator, func(_ int64, delegation stakingtypes.DelegationI) bool {
+		shares := delegation.GetShares()
+
+		valAddr, err := sdk.ValAddressFromBech32(delegation.GetValidatorAddr())
+		if err != nil {
+			return false // continue iteration
+		}
+
+		validator, err := k.stakingKeeper.GetValidator(ctx, valAddr)
+		if err != nil {
+			// Validator not found (e.g. fully unbonded/removed): fall back to
+			// shares as a token approximation. Such delegations are transient
+			// and negligible for supply reporting.
+			totalStaked = totalStaked.Add(shares.TruncateInt())
+			return false
+		}
+
+		tokens := validator.TokensFromShares(shares)
+		totalStaked = totalStaked.Add(tokens.TruncateInt())
+		return false
+	})
+	if err != nil {
+		return osmomath.ZeroInt()
+	}
+
+	return totalStaked
 }
 
 // getLastReductionEpochNum returns last reduction epoch number.

--- a/x/mint/keeper/supply_test.go
+++ b/x/mint/keeper/supply_test.go
@@ -1,0 +1,245 @@
+package keeper_test
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v31/x/mint/types"
+	txfeestypes "github.com/osmosis-labs/osmosis/v31/x/txfees/types"
+)
+
+// mintDenom is the bond/mint denom used by the app test harness.
+func (s *KeeperTestSuite) mintDenom() string {
+	return s.App.MintKeeper.GetParams(s.Ctx).MintDenom
+}
+
+// rawSupply returns the bank raw supply (GetSupply) of the mint denom.
+func (s *KeeperTestSuite) rawSupply() osmomath.Int {
+	return s.App.BankKeeper.GetSupply(s.Ctx, s.mintDenom()).Amount
+}
+
+// TestGetBurnedSupply asserts burned supply equals the balance of the null
+// (burn) address, and tracks coins sent there.
+func (s *KeeperTestSuite) TestGetBurnedSupply() {
+	s.SetupTest()
+	denom := s.mintDenom()
+
+	// Initially the burn address holds nothing of the mint denom.
+	s.Require().True(s.App.MintKeeper.GetBurnedSupply(s.Ctx).IsZero())
+
+	// Mint to the module, then send a known amount to the burn address.
+	burnAmt := osmomath.NewInt(5_550_000)
+	s.MintCoins(sdk.NewCoins(sdk.NewCoin(denom, burnAmt)))
+	err := s.App.BankKeeper.SendCoinsFromModuleToAccount(
+		s.Ctx, types.ModuleName, txfeestypes.DefaultNullAddress, sdk.NewCoins(sdk.NewCoin(denom, burnAmt)))
+	s.Require().NoError(err)
+
+	s.Require().Equal(burnAmt, s.App.MintKeeper.GetBurnedSupply(s.Ctx))
+}
+
+// TestGetTotalSupply asserts total supply == raw GetSupply - burned.
+func (s *KeeperTestSuite) TestGetTotalSupply() {
+	s.SetupTest()
+	denom := s.mintDenom()
+
+	mintAmt := osmomath.NewInt(100_000_000)
+	burnAmt := osmomath.NewInt(4_000_000)
+	s.MintCoins(sdk.NewCoins(sdk.NewCoin(denom, mintAmt)))
+	rawBefore := s.rawSupply()
+
+	err := s.App.BankKeeper.SendCoinsFromModuleToAccount(
+		s.Ctx, types.ModuleName, txfeestypes.DefaultNullAddress, sdk.NewCoins(sdk.NewCoin(denom, burnAmt)))
+	s.Require().NoError(err)
+
+	// Sending to the burn address does not change raw supply; total = raw - burned.
+	expectedTotal := rawBefore.Sub(burnAmt)
+	s.Require().Equal(expectedTotal, s.App.MintKeeper.GetTotalSupply(s.Ctx))
+}
+
+// TestCirculatingSupplyIdentity asserts the core accounting identity holds for
+// every state we construct: circulating == total - restricted == minted -
+// burned - restricted.
+func (s *KeeperTestSuite) TestCirculatingSupplyIdentity() {
+	s.SetupTest()
+	denom := s.mintDenom()
+
+	s.MintCoins(sdk.NewCoins(sdk.NewCoin(denom, osmomath.NewInt(50_000_000))))
+	err := s.App.BankKeeper.SendCoinsFromModuleToAccount(
+		s.Ctx, types.ModuleName, txfeestypes.DefaultNullAddress, sdk.NewCoins(sdk.NewCoin(denom, osmomath.NewInt(1_000_000))))
+	s.Require().NoError(err)
+
+	total := s.App.MintKeeper.GetTotalSupply(s.Ctx)
+	restricted := s.App.MintKeeper.GetRestrictedSupply(s.Ctx)
+	circulating := s.App.MintKeeper.GetCirculatingSupply(s.Ctx)
+
+	// Identity 1: circulating == total - restricted.
+	s.Require().Equal(total.Sub(restricted), circulating)
+
+	// Identity 2: circulating == minted - burned - restricted.
+	minted := s.rawSupply()
+	burned := s.App.MintKeeper.GetBurnedSupply(s.Ctx)
+	s.Require().Equal(minted.Sub(burned).Sub(restricted), circulating)
+}
+
+// TestRestrictedSupplyIncludesDevVesting asserts the developer-vesting module
+// account balance is part of restricted supply.
+func (s *KeeperTestSuite) TestRestrictedSupplyIncludesDevVesting() {
+	s.SetupTest()
+	denom := s.mintDenom()
+
+	devVestingAddr := s.App.AccountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)
+	s.Require().NotNil(devVestingAddr)
+	devVestingBalance := s.App.BankKeeper.GetBalance(s.Ctx, devVestingAddr, denom).Amount
+
+	restricted := s.App.MintKeeper.GetRestrictedSupply(s.Ctx)
+	// Restricted supply must be at least the dev-vesting balance (other
+	// components are >= 0).
+	s.Require().True(restricted.GTE(devVestingBalance),
+		"restricted (%s) should include dev-vesting balance (%s)", restricted, devVestingBalance)
+}
+
+// TestDevVestingCountedExactlyOnce is the regression guard for the double-count
+// bug. It proves the dev-vesting balance contributes net-zero to circulating
+// supply: it is present once in raw GetSupply (the base for total) and removed
+// once via restricted supply. Equivalently, circulating computed on the raw
+// base must equal (GetSupplyWithOffset - burned - non-devVesting-restricted),
+// NOT (GetSupplyWithOffset - burned - restricted) which would subtract
+// dev-vesting twice.
+func (s *KeeperTestSuite) TestDevVestingCountedExactlyOnce() {
+	s.SetupTest()
+	denom := s.mintDenom()
+
+	devVestingAddr := s.App.AccountKeeper.GetModuleAddress(types.DeveloperVestingModuleAcctName)
+	devVestingBalance := s.App.BankKeeper.GetBalance(s.Ctx, devVestingAddr, denom).Amount
+
+	raw := s.rawSupply()
+	withOffset := s.App.BankKeeper.GetSupplyWithOffset(s.Ctx, denom).Amount
+
+	// Sanity: the offset nets out exactly the current dev-vesting balance once.
+	s.Require().Equal(raw.Sub(devVestingBalance), withOffset,
+		"GetSupplyWithOffset should equal raw supply minus dev-vesting balance")
+
+	circulating := s.App.MintKeeper.GetCirculatingSupply(s.Ctx)
+	restricted := s.App.MintKeeper.GetRestrictedSupply(s.Ctx)
+	burned := s.App.MintKeeper.GetBurnedSupply(s.Ctx)
+
+	// The correct circulating equals raw - burned - restricted.
+	s.Require().Equal(raw.Sub(burned).Sub(restricted), circulating)
+
+	// The buggy circulating (double-count) would be withOffset - burned -
+	// restricted, which is exactly devVestingBalance lower. Assert we are NOT
+	// that value (unless dev-vesting is zero, in which case they coincide).
+	buggy := withOffset.Sub(burned).Sub(restricted)
+	if devVestingBalance.IsPositive() {
+		s.Require().NotEqual(buggy, circulating,
+			"circulating must not double-subtract dev-vesting")
+		s.Require().Equal(circulating.Sub(buggy), devVestingBalance,
+			"the difference between correct and buggy circulating must equal exactly the dev-vesting balance")
+	}
+}
+
+// TestRestrictedSupplyIncludesStakedAmount asserts that OSMO delegated by a
+// restricted entity (here, a dev-reward receiver address) is counted in
+// restricted supply via the share->token conversion, not just its liquid
+// balance.
+func (s *KeeperTestSuite) TestRestrictedSupplyIncludesStakedAmount() {
+	s.SetupTest()
+	denom := s.mintDenom()
+
+	// Stand up a validator to delegate to.
+	valAddr := s.SetupValidator(stakingtypes.Bonded)
+	validator, err := s.App.StakingKeeper.GetValidator(s.Ctx, valAddr)
+	s.Require().NoError(err)
+
+	// Use a dev-reward receiver address as the restricted holder (already part
+	// of restricted accounting), fund it, and delegate.
+	holder := testAddressOne
+	params := s.App.MintKeeper.GetParams(s.Ctx)
+	params.WeightedDeveloperRewardsReceivers = []types.WeightedAddress{
+		{Address: holder.String(), Weight: osmomath.OneDec()},
+	}
+	s.App.MintKeeper.SetParams(s.Ctx, params)
+
+	delegateAmt := osmomath.NewInt(7_000_000)
+	s.FundAcc(holder, sdk.NewCoins(sdk.NewCoin(denom, delegateAmt)))
+
+	restrictedBefore := s.App.MintKeeper.GetRestrictedSupply(s.Ctx)
+
+	_, err = s.App.StakingKeeper.Delegate(s.Ctx, holder, delegateAmt, stakingtypes.Unbonded, validator, true)
+	s.Require().NoError(err)
+
+	restrictedAfter := s.App.MintKeeper.GetRestrictedSupply(s.Ctx)
+
+	// Delegating moves the holder's liquid balance into staked, so the aggregate
+	// (balance + staked) restricted supply must be unchanged within rounding. A
+	// weak lower bound (>= before - 1) would also pass if the staked term were
+	// dropped entirely, so assert near-equality in BOTH directions: restricted
+	// must not have fallen by anywhere near delegateAmt (which is what would
+	// happen if staked weren't counted), and must not have risen either.
+	one := osmomath.OneInt()
+	s.Require().True(restrictedAfter.LTE(restrictedBefore.Add(one)),
+		"restricted should not increase on delegate (before=%s after=%s)", restrictedBefore, restrictedAfter)
+	s.Require().True(restrictedAfter.GTE(restrictedBefore.Sub(one)),
+		"restricted must be flat within rounding; staked amount is counted (before=%s after=%s)", restrictedBefore, restrictedAfter)
+
+	// Belt and suspenders: prove the holder's staked amount is non-zero and is
+	// reflected, i.e. removing the holder's stake would drop restricted by ~the
+	// delegated amount. (If staked weren't counted, restrictedAfter would equal
+	// restrictedBefore - delegateAmt, far outside the +/-1 band asserted above.)
+	dropIfStakeIgnored := restrictedBefore.Sub(delegateAmt)
+	s.Require().True(restrictedAfter.GT(dropIfStakeIgnored.Add(one)),
+		"restricted must include the staked term, not just liquid balance")
+}
+
+// TestSupplyQueryHandlers exercises the four gRPC handlers end to end through
+// the query client.
+func (s *KeeperTestSuite) TestSupplyQueryHandlers() {
+	s.SetupTest()
+
+	burnedRes, err := s.queryClient.BurnedSupply(context.Background(), &types.QueryBurnedRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(s.App.MintKeeper.GetBurnedSupply(s.Ctx), burnedRes.Burned)
+
+	totalRes, err := s.queryClient.TotalSupply(context.Background(), &types.QueryTotalSupplyRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(s.App.MintKeeper.GetTotalSupply(s.Ctx), totalRes.TotalSupply)
+
+	restrictedRes, err := s.queryClient.RestrictedSupply(context.Background(), &types.QueryRestrictedSupplyRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(s.App.MintKeeper.GetRestrictedSupply(s.Ctx), restrictedRes.RestrictedSupply)
+
+	circulatingRes, err := s.queryClient.CirculatingSupply(context.Background(), &types.QueryCirculatingSupplyRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(s.App.MintKeeper.GetCirculatingSupply(s.Ctx), circulatingRes.CirculatingSupply)
+
+	// Handler identity check.
+	s.Require().Equal(
+		totalRes.TotalSupply.Sub(restrictedRes.RestrictedSupply),
+		circulatingRes.CirculatingSupply,
+	)
+}
+
+// TestInflationUsesCirculatingSupply asserts GetInflation now divides by
+// circulating supply (the denominator change), by checking the computed rate
+// matches the hand-derived value against circulating, not offset-total.
+func (s *KeeperTestSuite) TestInflationUsesCirculatingSupply() {
+	s.SetupTest()
+
+	circulating := s.App.MintKeeper.GetCirculatingSupply(s.Ctx)
+	s.Require().True(circulating.IsPositive())
+
+	minter := s.App.MintKeeper.GetMinter(s.Ctx)
+	params := s.App.MintKeeper.GetParams(s.Ctx)
+	oneMinusCommunityPool := osmomath.OneDec().Sub(params.DistributionProportions.CommunityPool)
+	expected := minter.EpochProvisions.
+		Mul(oneMinusCommunityPool).
+		Mul(osmomath.NewDec(365)).
+		Quo(circulating.ToLegacyDec())
+
+	inflation, err := s.App.MintKeeper.GetInflation(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(expected, inflation)
+}

--- a/x/mint/types/expected_keepers.go
+++ b/x/mint/types/expected_keepers.go
@@ -7,6 +7,8 @@ import (
 	epochstypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // AccountKeeper defines the contract required for account APIs.
@@ -28,15 +30,25 @@ type BankKeeper interface {
 	MintCoins(ctx context.Context, name string, amt sdk.Coins) error
 	BurnCoins(ctx context.Context, name string, amt sdk.Coins) error
 	AddSupplyOffset(ctx context.Context, denom string, offsetAmount osmomath.Int)
+	GetSupply(ctx context.Context, denom string) sdk.Coin
 	GetSupplyWithOffset(ctx context.Context, denom string) sdk.Coin
 }
 
-// CommunityPoolKeeper defines the contract needed to be fulfilled for distribution keeper.
-type CommunityPoolKeeper interface {
-	FundCommunityPool(ctx context.Context, amount sdk.Coins, sender sdk.AccAddress) error
-}
+// CommunityPoolKeeper is an alias to the cosmos SDK distribution keeper pointer.
+// The mint module needs both FundCommunityPool (distribution of minted coins)
+// and read access to the FeePool (for restricted-supply accounting). FeePool is
+// a struct field on the concrete keeper, not a method, so it cannot be expressed
+// as a Go interface; aliasing the concrete pointer is the pragmatic contract.
+type CommunityPoolKeeper = *distrkeeper.Keeper
 
 // EpochKeeper defines the contract needed to be fulfilled for epochs keeper.
 type EpochKeeper interface {
 	GetEpochInfo(ctx sdk.Context, identifier string) epochstypes.EpochInfo
+}
+
+// StakingKeeper defines the contract needed to query staking information for
+// restricted-supply accounting (delegations held by restricted addresses).
+type StakingKeeper interface {
+	IterateDelegations(ctx context.Context, delegator sdk.AccAddress, fn func(int64, stakingtypes.DelegationI) bool) error
+	GetValidator(ctx context.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, err error)
 }

--- a/x/mint/types/query.pb.go
+++ b/x/mint/types/query.pb.go
@@ -923,7 +923,6 @@ func _Query_CirculatingSupply_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
-var Query_serviceDesc = _Query_serviceDesc
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "osmosis.mint.v1beta1.Query",
 	HandlerType: (*QueryServer)(nil),

--- a/x/mint/types/query.pb.go
+++ b/x/mint/types/query.pb.go
@@ -268,6 +268,318 @@ func (m *QueryInflationResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryInflationResponse proto.InternalMessageInfo
 
+// QueryBurnedRequest is the request type for the Query/BurnedSupply RPC method.
+type QueryBurnedRequest struct {
+}
+
+func (m *QueryBurnedRequest) Reset()         { *m = QueryBurnedRequest{} }
+func (m *QueryBurnedRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryBurnedRequest) ProtoMessage()    {}
+func (*QueryBurnedRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{6}
+}
+func (m *QueryBurnedRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryBurnedRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryBurnedRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryBurnedRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryBurnedRequest.Merge(m, src)
+}
+func (m *QueryBurnedRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryBurnedRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryBurnedRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryBurnedRequest proto.InternalMessageInfo
+
+// QueryBurnedResponse is the response type for the Query/BurnedSupply RPC
+// method.
+type QueryBurnedResponse struct {
+	// burned is the total amount of burned tokens.
+	Burned cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=burned,proto3,customtype=cosmossdk.io/math.Int" json:"burned"`
+}
+
+func (m *QueryBurnedResponse) Reset()         { *m = QueryBurnedResponse{} }
+func (m *QueryBurnedResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryBurnedResponse) ProtoMessage()    {}
+func (*QueryBurnedResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{7}
+}
+func (m *QueryBurnedResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryBurnedResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryBurnedResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryBurnedResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryBurnedResponse.Merge(m, src)
+}
+func (m *QueryBurnedResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryBurnedResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryBurnedResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryBurnedResponse proto.InternalMessageInfo
+
+// QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
+// method.
+type QueryTotalSupplyRequest struct {
+}
+
+func (m *QueryTotalSupplyRequest) Reset()         { *m = QueryTotalSupplyRequest{} }
+func (m *QueryTotalSupplyRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryTotalSupplyRequest) ProtoMessage()    {}
+func (*QueryTotalSupplyRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{8}
+}
+func (m *QueryTotalSupplyRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryTotalSupplyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryTotalSupplyRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryTotalSupplyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryTotalSupplyRequest.Merge(m, src)
+}
+func (m *QueryTotalSupplyRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryTotalSupplyRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryTotalSupplyRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryTotalSupplyRequest proto.InternalMessageInfo
+
+// QueryTotalSupplyResponse is the response type for the Query/TotalSupply RPC
+// method.
+type QueryTotalSupplyResponse struct {
+	// total_supply is the total supply (minted - burned).
+	TotalSupply cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=total_supply,json=totalSupply,proto3,customtype=cosmossdk.io/math.Int" json:"total_supply"`
+}
+
+func (m *QueryTotalSupplyResponse) Reset()         { *m = QueryTotalSupplyResponse{} }
+func (m *QueryTotalSupplyResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryTotalSupplyResponse) ProtoMessage()    {}
+func (*QueryTotalSupplyResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{9}
+}
+func (m *QueryTotalSupplyResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryTotalSupplyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryTotalSupplyResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryTotalSupplyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryTotalSupplyResponse.Merge(m, src)
+}
+func (m *QueryTotalSupplyResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryTotalSupplyResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryTotalSupplyResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryTotalSupplyResponse proto.InternalMessageInfo
+
+// QueryRestrictedSupplyRequest is the request type for the
+// Query/RestrictedSupply RPC method.
+type QueryRestrictedSupplyRequest struct {
+}
+
+func (m *QueryRestrictedSupplyRequest) Reset()         { *m = QueryRestrictedSupplyRequest{} }
+func (m *QueryRestrictedSupplyRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryRestrictedSupplyRequest) ProtoMessage()    {}
+func (*QueryRestrictedSupplyRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{10}
+}
+func (m *QueryRestrictedSupplyRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryRestrictedSupplyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryRestrictedSupplyRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryRestrictedSupplyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryRestrictedSupplyRequest.Merge(m, src)
+}
+func (m *QueryRestrictedSupplyRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryRestrictedSupplyRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryRestrictedSupplyRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryRestrictedSupplyRequest proto.InternalMessageInfo
+
+// QueryRestrictedSupplyResponse is the response type for the
+// Query/RestrictedSupply RPC method.
+type QueryRestrictedSupplyResponse struct {
+	// restricted_supply is the supply held in restricted addresses.
+	RestrictedSupply cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=restricted_supply,json=restrictedSupply,proto3,customtype=cosmossdk.io/math.Int" json:"restricted_supply"`
+}
+
+func (m *QueryRestrictedSupplyResponse) Reset()         { *m = QueryRestrictedSupplyResponse{} }
+func (m *QueryRestrictedSupplyResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryRestrictedSupplyResponse) ProtoMessage()    {}
+func (*QueryRestrictedSupplyResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{11}
+}
+func (m *QueryRestrictedSupplyResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryRestrictedSupplyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryRestrictedSupplyResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryRestrictedSupplyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryRestrictedSupplyResponse.Merge(m, src)
+}
+func (m *QueryRestrictedSupplyResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryRestrictedSupplyResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryRestrictedSupplyResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryRestrictedSupplyResponse proto.InternalMessageInfo
+
+// QueryCirculatingSupplyRequest is the request type for the
+// Query/CirculatingSupply RPC method.
+type QueryCirculatingSupplyRequest struct {
+}
+
+func (m *QueryCirculatingSupplyRequest) Reset()         { *m = QueryCirculatingSupplyRequest{} }
+func (m *QueryCirculatingSupplyRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryCirculatingSupplyRequest) ProtoMessage()    {}
+func (*QueryCirculatingSupplyRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{12}
+}
+func (m *QueryCirculatingSupplyRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryCirculatingSupplyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryCirculatingSupplyRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryCirculatingSupplyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryCirculatingSupplyRequest.Merge(m, src)
+}
+func (m *QueryCirculatingSupplyRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryCirculatingSupplyRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryCirculatingSupplyRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryCirculatingSupplyRequest proto.InternalMessageInfo
+
+// QueryCirculatingSupplyResponse is the response type for the
+// Query/CirculatingSupply RPC method.
+type QueryCirculatingSupplyResponse struct {
+	// circulating_supply is the circulating supply (minted - burned -
+	// restricted).
+	CirculatingSupply cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=circulating_supply,json=circulatingSupply,proto3,customtype=cosmossdk.io/math.Int" json:"circulating_supply"`
+}
+
+func (m *QueryCirculatingSupplyResponse) Reset()         { *m = QueryCirculatingSupplyResponse{} }
+func (m *QueryCirculatingSupplyResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryCirculatingSupplyResponse) ProtoMessage()    {}
+func (*QueryCirculatingSupplyResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd2f42111e753fbb, []int{13}
+}
+func (m *QueryCirculatingSupplyResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryCirculatingSupplyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryCirculatingSupplyResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryCirculatingSupplyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryCirculatingSupplyResponse.Merge(m, src)
+}
+func (m *QueryCirculatingSupplyResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryCirculatingSupplyResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryCirculatingSupplyResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryCirculatingSupplyResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*QueryParamsRequest)(nil), "osmosis.mint.v1beta1.QueryParamsRequest")
 	proto.RegisterType((*QueryParamsResponse)(nil), "osmosis.mint.v1beta1.QueryParamsResponse")
@@ -275,41 +587,65 @@ func init() {
 	proto.RegisterType((*QueryEpochProvisionsResponse)(nil), "osmosis.mint.v1beta1.QueryEpochProvisionsResponse")
 	proto.RegisterType((*QueryInflationRequest)(nil), "osmosis.mint.v1beta1.QueryInflationRequest")
 	proto.RegisterType((*QueryInflationResponse)(nil), "osmosis.mint.v1beta1.QueryInflationResponse")
+	proto.RegisterType((*QueryBurnedRequest)(nil), "osmosis.mint.v1beta1.QueryBurnedRequest")
+	proto.RegisterType((*QueryBurnedResponse)(nil), "osmosis.mint.v1beta1.QueryBurnedResponse")
+	proto.RegisterType((*QueryTotalSupplyRequest)(nil), "osmosis.mint.v1beta1.QueryTotalSupplyRequest")
+	proto.RegisterType((*QueryTotalSupplyResponse)(nil), "osmosis.mint.v1beta1.QueryTotalSupplyResponse")
+	proto.RegisterType((*QueryRestrictedSupplyRequest)(nil), "osmosis.mint.v1beta1.QueryRestrictedSupplyRequest")
+	proto.RegisterType((*QueryRestrictedSupplyResponse)(nil), "osmosis.mint.v1beta1.QueryRestrictedSupplyResponse")
+	proto.RegisterType((*QueryCirculatingSupplyRequest)(nil), "osmosis.mint.v1beta1.QueryCirculatingSupplyRequest")
+	proto.RegisterType((*QueryCirculatingSupplyResponse)(nil), "osmosis.mint.v1beta1.QueryCirculatingSupplyResponse")
 }
 
 func init() { proto.RegisterFile("osmosis/mint/v1beta1/query.proto", fileDescriptor_cd2f42111e753fbb) }
 
 var fileDescriptor_cd2f42111e753fbb = []byte{
-	// 458 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x93, 0x4f, 0x6f, 0xd3, 0x30,
-	0x18, 0xc6, 0x63, 0xfe, 0x54, 0x9a, 0x41, 0x1a, 0x32, 0xe5, 0x8f, 0xb2, 0x90, 0x8c, 0x80, 0xa0,
-	0x08, 0xb0, 0x49, 0x77, 0xe3, 0x46, 0x05, 0x07, 0x10, 0x42, 0x5b, 0x8f, 0x70, 0x40, 0x4e, 0x30,
-	0xa9, 0x45, 0x13, 0x67, 0xb1, 0x5b, 0xd1, 0x2b, 0x7c, 0x00, 0x90, 0xf8, 0x12, 0x7c, 0x94, 0x89,
-	0xd3, 0x24, 0x2e, 0x88, 0xc3, 0x84, 0x5a, 0x3e, 0x08, 0x8a, 0xe3, 0x04, 0x2d, 0xb3, 0xa6, 0xed,
-	0x56, 0xf9, 0x7d, 0xde, 0xe7, 0xf9, 0xe9, 0x7d, 0x1a, 0xb8, 0x29, 0x64, 0x26, 0x24, 0x97, 0x24,
-	0xe3, 0xb9, 0x22, 0xf3, 0x28, 0x66, 0x8a, 0x46, 0x64, 0x77, 0xc6, 0xca, 0x05, 0x2e, 0x4a, 0xa1,
-	0x04, 0xea, 0x1b, 0x05, 0xae, 0x14, 0xd8, 0x28, 0xdc, 0x7e, 0x2a, 0x52, 0xa1, 0x05, 0xa4, 0xfa,
-	0x55, 0x6b, 0x5d, 0x2f, 0x15, 0x22, 0x9d, 0x32, 0x42, 0x0b, 0x4e, 0x68, 0x9e, 0x0b, 0x45, 0x15,
-	0x17, 0xb9, 0x34, 0xd3, 0xc0, 0x9a, 0xa5, 0x6d, 0xb5, 0x20, 0xec, 0x43, 0xb4, 0x53, 0x25, 0x6f,
-	0xd3, 0x92, 0x66, 0x72, 0xcc, 0x76, 0x67, 0x4c, 0xaa, 0x70, 0x07, 0x5e, 0x3e, 0xf4, 0x2a, 0x0b,
-	0x91, 0x4b, 0x86, 0x1e, 0xc3, 0x5e, 0xa1, 0x5f, 0xae, 0x83, 0x4d, 0x30, 0xb8, 0x30, 0xf4, 0xb0,
-	0x0d, 0x14, 0xd7, 0x5b, 0xa3, 0x73, 0x7b, 0x07, 0x81, 0x33, 0x36, 0x1b, 0xe1, 0x0d, 0xb8, 0xa1,
-	0x2d, 0x9f, 0x15, 0x22, 0x99, 0x6c, 0x97, 0x62, 0xce, 0x65, 0xc5, 0xd9, 0x24, 0xe6, 0xd0, 0xb3,
-	0x8f, 0x4d, 0xf4, 0x2b, 0x78, 0x89, 0x55, 0xa3, 0xb7, 0x45, 0x3b, 0xd3, 0x10, 0x17, 0x47, 0xb7,
-	0xaa, 0x98, 0xdf, 0x07, 0xc1, 0x46, 0xa2, 0x61, 0xe4, 0xbb, 0x0f, 0x98, 0x0b, 0x92, 0x51, 0x35,
-	0xc1, 0x2f, 0x59, 0x4a, 0x93, 0xc5, 0x53, 0x96, 0x8c, 0xd7, 0xd9, 0x61, 0xdf, 0xf0, 0x1a, 0xbc,
-	0xa2, 0xf3, 0x9e, 0xe7, 0xef, 0xa7, 0xfa, 0x62, 0x0d, 0xc8, 0x1b, 0x78, 0xb5, 0x3b, 0x30, 0x08,
-	0x4f, 0xe0, 0x1a, 0x6f, 0x1e, 0x4f, 0x93, 0xfd, 0x7f, 0x6b, 0xf8, 0xe3, 0x2c, 0x3c, 0xaf, 0xdd,
-	0xd1, 0x67, 0x00, 0x7b, 0xf5, 0x9d, 0xd0, 0xc0, 0x7e, 0xc5, 0xa3, 0xb5, 0xb8, 0xf7, 0x4e, 0xa0,
-	0xac, 0x61, 0xc3, 0xdb, 0x9f, 0x7e, 0xfe, 0xfd, 0x76, 0xc6, 0x47, 0x1e, 0xb1, 0xfe, 0x03, 0xea,
-	0x52, 0xd0, 0x77, 0x00, 0xd7, 0x3b, 0x17, 0x47, 0xd1, 0x31, 0x21, 0xf6, 0xf2, 0xdc, 0xe1, 0x69,
-	0x56, 0x0c, 0x20, 0xd6, 0x80, 0x03, 0x74, 0xc7, 0x0e, 0xd8, 0x2d, 0x1b, 0x7d, 0x01, 0x70, 0xad,
-	0xed, 0x04, 0xdd, 0x3f, 0x26, 0xb1, 0x5b, 0xa9, 0xfb, 0xe0, 0x64, 0x62, 0x03, 0x76, 0x57, 0x83,
-	0xdd, 0x44, 0x81, 0x1d, 0xac, 0x2d, 0x73, 0xf4, 0x62, 0x6f, 0xe9, 0x83, 0xfd, 0xa5, 0x0f, 0xfe,
-	0x2c, 0x7d, 0xf0, 0x75, 0xe5, 0x3b, 0xfb, 0x2b, 0xdf, 0xf9, 0xb5, 0xf2, 0x9d, 0xd7, 0x8f, 0x52,
-	0xae, 0x26, 0xb3, 0x18, 0x27, 0x22, 0x6b, 0x4c, 0x1e, 0x4e, 0x69, 0x2c, 0x5b, 0xc7, 0xf9, 0x56,
-	0x44, 0x3e, 0xd6, 0xbe, 0x6a, 0x51, 0x30, 0x19, 0xf7, 0xf4, 0xd7, 0xb8, 0xf5, 0x2f, 0x00, 0x00,
-	0xff, 0xff, 0x28, 0xf1, 0x22, 0x3f, 0x1c, 0x04, 0x00, 0x00,
+	// 711 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x96, 0x41, 0x4f, 0x13, 0x41,
+	0x14, 0xc7, 0xbb, 0x46, 0x1b, 0x79, 0x90, 0x00, 0x23, 0x08, 0x2e, 0x65, 0x8b, 0x0b, 0x4a, 0x01,
+	0xd9, 0xa5, 0xa0, 0x17, 0x4f, 0x5a, 0xf5, 0x00, 0x21, 0x06, 0xaa, 0x27, 0x35, 0x21, 0xdb, 0x65,
+	0x5c, 0x36, 0xb4, 0x3b, 0xcb, 0xce, 0x94, 0xd8, 0xab, 0x7e, 0x00, 0x49, 0xbc, 0xf8, 0x11, 0x3c,
+	0x78, 0xf0, 0x63, 0x70, 0x24, 0xf1, 0x62, 0x38, 0x10, 0x03, 0x7e, 0x10, 0xb3, 0xb3, 0xb3, 0x2d,
+	0xdd, 0x9d, 0x6e, 0xda, 0x5b, 0xf3, 0xde, 0x7f, 0xde, 0xff, 0x97, 0x99, 0xfd, 0xbf, 0x14, 0xe6,
+	0x08, 0x6d, 0x10, 0xea, 0x52, 0xb3, 0xe1, 0x7a, 0xcc, 0x3c, 0x2e, 0xd7, 0x30, 0xb3, 0xca, 0xe6,
+	0x51, 0x13, 0x07, 0x2d, 0xc3, 0x0f, 0x08, 0x23, 0x68, 0x42, 0x28, 0x8c, 0x50, 0x61, 0x08, 0x85,
+	0x3a, 0xe1, 0x10, 0x87, 0x70, 0x81, 0x19, 0xfe, 0x8a, 0xb4, 0x6a, 0xc1, 0x21, 0xc4, 0xa9, 0x63,
+	0xd3, 0xf2, 0x5d, 0xd3, 0xf2, 0x3c, 0xc2, 0x2c, 0xe6, 0x12, 0x8f, 0x8a, 0x6e, 0x51, 0xea, 0xc5,
+	0xc7, 0x72, 0x81, 0x3e, 0x01, 0x68, 0x37, 0x74, 0xde, 0xb1, 0x02, 0xab, 0x41, 0xab, 0xf8, 0xa8,
+	0x89, 0x29, 0xd3, 0x77, 0xe1, 0x4e, 0x57, 0x95, 0xfa, 0xc4, 0xa3, 0x18, 0x3d, 0x85, 0xbc, 0xcf,
+	0x2b, 0xd3, 0xca, 0x9c, 0x52, 0x1a, 0x5e, 0x2f, 0x18, 0x32, 0x50, 0x23, 0x3a, 0x55, 0xb9, 0x79,
+	0x7a, 0x51, 0xcc, 0x55, 0xc5, 0x09, 0x7d, 0x16, 0x66, 0xf8, 0xc8, 0x57, 0x3e, 0xb1, 0x0f, 0x76,
+	0x02, 0x72, 0xec, 0xd2, 0x90, 0x33, 0x76, 0xf4, 0xa0, 0x20, 0x6f, 0x0b, 0xeb, 0xd7, 0x30, 0x86,
+	0xc3, 0xd6, 0x9e, 0xdf, 0xee, 0x71, 0x88, 0x91, 0xca, 0x7c, 0x68, 0x73, 0x7e, 0x51, 0x9c, 0xb1,
+	0x39, 0x0c, 0xdd, 0x3f, 0x34, 0x5c, 0x62, 0x36, 0x2c, 0x76, 0x60, 0x6c, 0x63, 0xc7, 0xb2, 0x5b,
+	0x2f, 0xb1, 0x5d, 0x1d, 0xc5, 0xdd, 0x73, 0xf5, 0x29, 0x98, 0xe4, 0x7e, 0x9b, 0xde, 0xc7, 0x3a,
+	0xbf, 0xb1, 0x18, 0xe4, 0x3d, 0xdc, 0x4d, 0x36, 0x04, 0xc2, 0x73, 0x18, 0x72, 0xe3, 0xe2, 0x20,
+	0xde, 0x9d, 0x53, 0xed, 0xdb, 0xae, 0x34, 0x03, 0x0f, 0xef, 0xc7, 0x96, 0xdb, 0xe2, 0xb6, 0xe3,
+	0xaa, 0xf0, 0x7b, 0x02, 0xf9, 0x1a, 0xaf, 0x08, 0xb3, 0x59, 0x61, 0x36, 0x99, 0x36, 0xdb, 0xf4,
+	0x58, 0x55, 0x88, 0xf5, 0x7b, 0x30, 0xc5, 0xa7, 0xbd, 0x25, 0xcc, 0xaa, 0xbf, 0x69, 0xfa, 0x7e,
+	0xbd, 0x15, 0x1b, 0x7d, 0x80, 0xe9, 0x74, 0x4b, 0xb8, 0x3d, 0x83, 0x11, 0x16, 0x96, 0xf7, 0x28,
+	0xaf, 0xf7, 0xe7, 0x39, 0xcc, 0x3a, 0x93, 0x74, 0x4d, 0x3c, 0x61, 0x15, 0x53, 0x16, 0xb8, 0x36,
+	0xc3, 0xfb, 0xdd, 0xee, 0x87, 0x30, 0xdb, 0xa3, 0x2f, 0x10, 0xb6, 0x60, 0x3c, 0x68, 0xf7, 0x06,
+	0xe2, 0x18, 0x0b, 0x12, 0x33, 0xf5, 0xa2, 0x30, 0x7b, 0xe1, 0x06, 0x76, 0x33, 0xbc, 0x7d, 0xcf,
+	0xe9, 0xa6, 0xf1, 0x40, 0xeb, 0x25, 0x10, 0x38, 0xdb, 0x80, 0xec, 0x4e, 0x73, 0x20, 0x9e, 0x71,
+	0x3b, 0x39, 0x75, 0xfd, 0xfc, 0x36, 0xdc, 0xe2, 0x86, 0xe8, 0x8b, 0x02, 0xf9, 0x28, 0x22, 0xa8,
+	0x24, 0x0f, 0x50, 0x3a, 0x91, 0xea, 0x52, 0x1f, 0xca, 0x88, 0x5b, 0x5f, 0xf8, 0xfc, 0xfb, 0xdf,
+	0xb7, 0x1b, 0x1a, 0x2a, 0x98, 0xd2, 0xf0, 0x47, 0x79, 0x44, 0x3f, 0x14, 0x18, 0x4d, 0x84, 0x0d,
+	0x95, 0x33, 0x4c, 0xe4, 0xb9, 0x55, 0xd7, 0x07, 0x39, 0x22, 0x00, 0x0d, 0x0e, 0x58, 0x42, 0x0f,
+	0xe5, 0x80, 0xc9, 0x9c, 0xa3, 0xaf, 0x0a, 0x0c, 0xb5, 0xe3, 0x88, 0x56, 0x32, 0x1c, 0x93, 0x69,
+	0x56, 0x1f, 0xf5, 0x27, 0x16, 0x60, 0x8b, 0x1c, 0xec, 0x3e, 0x2a, 0xca, 0xc1, 0xda, 0x39, 0x46,
+	0x27, 0x0a, 0x8c, 0x44, 0x69, 0x8d, 0x5e, 0x37, 0xf3, 0x21, 0xbb, 0xc2, 0x9e, 0xf9, 0x90, 0xdd,
+	0x0b, 0x40, 0x5f, 0xe1, 0x38, 0x0f, 0xd0, 0xbc, 0x1c, 0x27, 0xca, 0xbb, 0xf8, 0x2e, 0xd1, 0x77,
+	0x05, 0x86, 0xaf, 0xe5, 0x1a, 0xad, 0x66, 0xf8, 0xa4, 0x57, 0x83, 0x6a, 0xf4, 0x2b, 0x17, 0x6c,
+	0xcb, 0x9c, 0x6d, 0x01, 0xe9, 0x72, 0xb6, 0xeb, 0xab, 0x04, 0xfd, 0x54, 0x60, 0x2c, 0x19, 0x7a,
+	0x94, 0xf5, 0xe1, 0xf4, 0xd8, 0x20, 0xea, 0xc6, 0x40, 0x67, 0x04, 0xa9, 0xc9, 0x49, 0x97, 0xd0,
+	0xa2, 0x9c, 0x34, 0xb5, 0x71, 0xd0, 0x2f, 0x05, 0xc6, 0x53, 0x5b, 0x01, 0x65, 0x79, 0xf7, 0x5a,
+	0x32, 0xea, 0xe3, 0xc1, 0x0e, 0x09, 0xe2, 0x35, 0x4e, 0xbc, 0x8c, 0x4a, 0x72, 0xe2, 0xf4, 0x52,
+	0xaa, 0x6c, 0x9d, 0x5e, 0x6a, 0xca, 0xd9, 0xa5, 0xa6, 0xfc, 0xbd, 0xd4, 0x94, 0x93, 0x2b, 0x2d,
+	0x77, 0x76, 0xa5, 0xe5, 0xfe, 0x5c, 0x69, 0xb9, 0x77, 0x6b, 0x8e, 0xcb, 0x0e, 0x9a, 0x35, 0xc3,
+	0x26, 0x8d, 0x78, 0xda, 0x6a, 0xdd, 0xaa, 0xd1, 0xf6, 0xe8, 0xe3, 0x8d, 0xb2, 0xf9, 0x29, 0x32,
+	0x60, 0x2d, 0x1f, 0xd3, 0x5a, 0x9e, 0xff, 0x31, 0xd8, 0xf8, 0x1f, 0x00, 0x00, 0xff, 0xff, 0xd5,
+	0x19, 0x76, 0xbe, 0xa7, 0x08, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -330,6 +666,15 @@ type QueryClient interface {
 	EpochProvisions(ctx context.Context, in *QueryEpochProvisionsRequest, opts ...grpc.CallOption) (*QueryEpochProvisionsResponse, error)
 	// Inflation returns the current minting inflation value.
 	Inflation(ctx context.Context, in *QueryInflationRequest, opts ...grpc.CallOption) (*QueryInflationResponse, error)
+	// BurnedSupply returns the total amount of burned tokens.
+	BurnedSupply(ctx context.Context, in *QueryBurnedRequest, opts ...grpc.CallOption) (*QueryBurnedResponse, error)
+	// TotalSupply returns the total supply (minted - burned).
+	TotalSupply(ctx context.Context, in *QueryTotalSupplyRequest, opts ...grpc.CallOption) (*QueryTotalSupplyResponse, error)
+	// RestrictedSupply returns the supply held in restricted addresses.
+	RestrictedSupply(ctx context.Context, in *QueryRestrictedSupplyRequest, opts ...grpc.CallOption) (*QueryRestrictedSupplyResponse, error)
+	// CirculatingSupply returns the circulating supply
+	// (minted - burned - restricted).
+	CirculatingSupply(ctx context.Context, in *QueryCirculatingSupplyRequest, opts ...grpc.CallOption) (*QueryCirculatingSupplyResponse, error)
 }
 
 type queryClient struct {
@@ -367,6 +712,42 @@ func (c *queryClient) Inflation(ctx context.Context, in *QueryInflationRequest, 
 	return out, nil
 }
 
+func (c *queryClient) BurnedSupply(ctx context.Context, in *QueryBurnedRequest, opts ...grpc.CallOption) (*QueryBurnedResponse, error) {
+	out := new(QueryBurnedResponse)
+	err := c.cc.Invoke(ctx, "/osmosis.mint.v1beta1.Query/BurnedSupply", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) TotalSupply(ctx context.Context, in *QueryTotalSupplyRequest, opts ...grpc.CallOption) (*QueryTotalSupplyResponse, error) {
+	out := new(QueryTotalSupplyResponse)
+	err := c.cc.Invoke(ctx, "/osmosis.mint.v1beta1.Query/TotalSupply", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) RestrictedSupply(ctx context.Context, in *QueryRestrictedSupplyRequest, opts ...grpc.CallOption) (*QueryRestrictedSupplyResponse, error) {
+	out := new(QueryRestrictedSupplyResponse)
+	err := c.cc.Invoke(ctx, "/osmosis.mint.v1beta1.Query/RestrictedSupply", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) CirculatingSupply(ctx context.Context, in *QueryCirculatingSupplyRequest, opts ...grpc.CallOption) (*QueryCirculatingSupplyResponse, error) {
+	out := new(QueryCirculatingSupplyResponse)
+	err := c.cc.Invoke(ctx, "/osmosis.mint.v1beta1.Query/CirculatingSupply", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Params returns the total set of minting parameters.
@@ -375,6 +756,15 @@ type QueryServer interface {
 	EpochProvisions(context.Context, *QueryEpochProvisionsRequest) (*QueryEpochProvisionsResponse, error)
 	// Inflation returns the current minting inflation value.
 	Inflation(context.Context, *QueryInflationRequest) (*QueryInflationResponse, error)
+	// BurnedSupply returns the total amount of burned tokens.
+	BurnedSupply(context.Context, *QueryBurnedRequest) (*QueryBurnedResponse, error)
+	// TotalSupply returns the total supply (minted - burned).
+	TotalSupply(context.Context, *QueryTotalSupplyRequest) (*QueryTotalSupplyResponse, error)
+	// RestrictedSupply returns the supply held in restricted addresses.
+	RestrictedSupply(context.Context, *QueryRestrictedSupplyRequest) (*QueryRestrictedSupplyResponse, error)
+	// CirculatingSupply returns the circulating supply
+	// (minted - burned - restricted).
+	CirculatingSupply(context.Context, *QueryCirculatingSupplyRequest) (*QueryCirculatingSupplyResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -389,6 +779,18 @@ func (*UnimplementedQueryServer) EpochProvisions(ctx context.Context, req *Query
 }
 func (*UnimplementedQueryServer) Inflation(ctx context.Context, req *QueryInflationRequest) (*QueryInflationResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Inflation not implemented")
+}
+func (*UnimplementedQueryServer) BurnedSupply(ctx context.Context, req *QueryBurnedRequest) (*QueryBurnedResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BurnedSupply not implemented")
+}
+func (*UnimplementedQueryServer) TotalSupply(ctx context.Context, req *QueryTotalSupplyRequest) (*QueryTotalSupplyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TotalSupply not implemented")
+}
+func (*UnimplementedQueryServer) RestrictedSupply(ctx context.Context, req *QueryRestrictedSupplyRequest) (*QueryRestrictedSupplyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RestrictedSupply not implemented")
+}
+func (*UnimplementedQueryServer) CirculatingSupply(ctx context.Context, req *QueryCirculatingSupplyRequest) (*QueryCirculatingSupplyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CirculatingSupply not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -449,6 +851,79 @@ func _Query_Inflation_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_BurnedSupply_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryBurnedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).BurnedSupply(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/osmosis.mint.v1beta1.Query/BurnedSupply",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).BurnedSupply(ctx, req.(*QueryBurnedRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_TotalSupply_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryTotalSupplyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).TotalSupply(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/osmosis.mint.v1beta1.Query/TotalSupply",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).TotalSupply(ctx, req.(*QueryTotalSupplyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_RestrictedSupply_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryRestrictedSupplyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).RestrictedSupply(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/osmosis.mint.v1beta1.Query/RestrictedSupply",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).RestrictedSupply(ctx, req.(*QueryRestrictedSupplyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_CirculatingSupply_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryCirculatingSupplyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).CirculatingSupply(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/osmosis.mint.v1beta1.Query/CirculatingSupply",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).CirculatingSupply(ctx, req.(*QueryCirculatingSupplyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var Query_serviceDesc = _Query_serviceDesc
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "osmosis.mint.v1beta1.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -464,6 +939,22 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Inflation",
 			Handler:    _Query_Inflation_Handler,
+		},
+		{
+			MethodName: "BurnedSupply",
+			Handler:    _Query_BurnedSupply_Handler,
+		},
+		{
+			MethodName: "TotalSupply",
+			Handler:    _Query_TotalSupply_Handler,
+		},
+		{
+			MethodName: "RestrictedSupply",
+			Handler:    _Query_RestrictedSupply_Handler,
+		},
+		{
+			MethodName: "CirculatingSupply",
+			Handler:    _Query_CirculatingSupply_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -638,6 +1129,230 @@ func (m *QueryInflationResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryBurnedRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryBurnedRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryBurnedRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryBurnedResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryBurnedResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryBurnedResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.Burned.Size()
+		i -= size
+		if _, err := m.Burned.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryTotalSupplyRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryTotalSupplyRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryTotalSupplyRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryTotalSupplyResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryTotalSupplyResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryTotalSupplyResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.TotalSupply.Size()
+		i -= size
+		if _, err := m.TotalSupply.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryRestrictedSupplyRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryRestrictedSupplyRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryRestrictedSupplyRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryRestrictedSupplyResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryRestrictedSupplyResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryRestrictedSupplyResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.RestrictedSupply.Size()
+		i -= size
+		if _, err := m.RestrictedSupply.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryCirculatingSupplyRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryCirculatingSupplyRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryCirculatingSupplyRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryCirculatingSupplyResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryCirculatingSupplyResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryCirculatingSupplyResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.CirculatingSupply.Size()
+		i -= size
+		if _, err := m.CirculatingSupply.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -705,6 +1420,86 @@ func (m *QueryInflationResponse) Size() (n int) {
 	var l int
 	_ = l
 	l = m.Inflation.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryBurnedRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryBurnedResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.Burned.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryTotalSupplyRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryTotalSupplyResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.TotalSupply.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryRestrictedSupplyRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryRestrictedSupplyResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.RestrictedSupply.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryCirculatingSupplyRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryCirculatingSupplyResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.CirculatingSupply.Size()
 	n += 1 + l + sovQuery(uint64(l))
 	return n
 }
@@ -1090,6 +1885,538 @@ func (m *QueryInflationResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Inflation.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryBurnedRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryBurnedRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryBurnedRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryBurnedResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryBurnedResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryBurnedResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Burned", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Burned.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryTotalSupplyRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryTotalSupplyRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryTotalSupplyRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryTotalSupplyResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryTotalSupplyResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryTotalSupplyResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalSupply", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.TotalSupply.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryRestrictedSupplyRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryRestrictedSupplyRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryRestrictedSupplyRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryRestrictedSupplyResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryRestrictedSupplyResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryRestrictedSupplyResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RestrictedSupply", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.RestrictedSupply.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryCirculatingSupplyRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryCirculatingSupplyRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryCirculatingSupplyRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryCirculatingSupplyResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryCirculatingSupplyResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryCirculatingSupplyResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CirculatingSupply", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.CirculatingSupply.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/mint/types/query.pb.gw.go
+++ b/x/mint/types/query.pb.gw.go
@@ -87,6 +87,78 @@ func local_request_Query_Inflation_0(ctx context.Context, marshaler runtime.Mars
 
 }
 
+func request_Query_BurnedSupply_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryBurnedRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.BurnedSupply(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_BurnedSupply_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryBurnedRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.BurnedSupply(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_TotalSupply_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryTotalSupplyRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.TotalSupply(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_TotalSupply_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryTotalSupplyRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.TotalSupply(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_RestrictedSupply_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryRestrictedSupplyRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.RestrictedSupply(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_RestrictedSupply_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryRestrictedSupplyRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.RestrictedSupply(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_CirculatingSupply_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryCirculatingSupplyRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.CirculatingSupply(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_CirculatingSupply_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryCirculatingSupplyRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.CirculatingSupply(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -159,6 +231,98 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Inflation_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_BurnedSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_BurnedSupply_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_BurnedSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_TotalSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_TotalSupply_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_TotalSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_RestrictedSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_RestrictedSupply_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_RestrictedSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_CirculatingSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_CirculatingSupply_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_CirculatingSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -263,6 +427,86 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_BurnedSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_BurnedSupply_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_BurnedSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_TotalSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_TotalSupply_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_TotalSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_RestrictedSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_RestrictedSupply_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_RestrictedSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_CirculatingSupply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_CirculatingSupply_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_CirculatingSupply_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -272,6 +516,14 @@ var (
 	pattern_Query_EpochProvisions_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"osmosis", "mint", "v1beta1", "epoch_provisions"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_Inflation_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"osmosis", "mint", "v1beta1", "inflation"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_BurnedSupply_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"osmosis", "mint", "v1beta1", "burned_supply"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_TotalSupply_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"osmosis", "mint", "v1beta1", "total_supply"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_RestrictedSupply_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"osmosis", "mint", "v1beta1", "restricted_supply"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_CirculatingSupply_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"osmosis", "mint", "v1beta1", "circulating_supply"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
@@ -280,4 +532,12 @@ var (
 	forward_Query_EpochProvisions_0 = runtime.ForwardResponseMessage
 
 	forward_Query_Inflation_0 = runtime.ForwardResponseMessage
+
+	forward_Query_BurnedSupply_0 = runtime.ForwardResponseMessage
+
+	forward_Query_TotalSupply_0 = runtime.ForwardResponseMessage
+
+	forward_Query_RestrictedSupply_0 = runtime.ForwardResponseMessage
+
+	forward_Query_CirculatingSupply_0 = runtime.ForwardResponseMessage
 )

--- a/x/mint/types/restricted_addresses.go
+++ b/x/mint/types/restricted_addresses.go
@@ -1,0 +1,57 @@
+package types
+
+// RestrictedAddresses is the curated set of foundation / investor / strategic
+// wallet addresses (bech32) whose liquid balance and staked OSMO are excluded
+// from circulating supply.
+//
+// This list is intentionally a compiled-in constant rather than a governance
+// param: it changes rarely, and keeping it out of consensus state lets the
+// supply endpoints ship as a point release (no migration, no upgrade handler).
+// Updating the list is itself a code change shipped in a point release.
+//
+// The entries are kept as strings (not pre-parsed sdk.AccAddress) on purpose:
+// the bech32 "osmo" prefix is configured by app params init (SetAddressPrefixes),
+// which is not guaranteed to have run when this package initialises in isolation
+// (e.g. in a unit test of the types package). Parsing therefore happens at query
+// time in the mint keeper, where the SDK config is sealed.
+//
+// Composition: the foundation address (the strategic-reserve holder traceable
+// from the airdrop) plus the original genesis developer-rewards receiver set.
+// Those genesis receivers were collapsed by governance into the single current
+// WeightedDeveloperRewardsReceivers entry, so they no longer appear in mint
+// params and are not otherwise counted. The current param receiver is NOT listed
+// here: it is already counted via the params loop in GetRestrictedSupply, and
+// the keeper de-duplicates against the param set to prevent double-counting if
+// an address ever appears in both.
+//
+// MAINTENANCE NOTE: the current WeightedDeveloperRewardsReceivers param entry is
+// intentionally omitted here precisely because the param loop counts it. If
+// governance later removes an address from that param (as it did for this
+// genesis set), that address stops being counted by either path and silently
+// re-enters circulating supply. When dev-rewards receivers change, review
+// whether the outgoing address should be added to this constant.
+//
+// Deliberately excluded (these circulate or are earmarked for sale, per the
+// restricted-supply methodology): liquidity deployments, grant deployments, and
+// community-pool liquidity positions.
+var RestrictedAddresses = []string{
+	// Foundation / strategic reserve.
+	"osmo1ugku28hwyexpljrrmtet05nd6kjlrvr9jz6z00",
+
+	// Original genesis developer-rewards receivers (no longer in mint params).
+	"osmo14kjcwdwcqsujkdt8n5qwpd8x8ty2rys5rjrdjj",
+	"osmo1gw445ta0aqn26suz2rg3tkqfpxnq2hs224d7gq",
+	"osmo13lt0hzc6u3htsk7z5rs6vuurmgg4hh2ecgxqkf",
+	"osmo1kvc3he93ygc0us3ycslwlv2gdqry4ta73vk9hu",
+	"osmo19qgldlsk7hdv3ddtwwpvzff30pxqe9phq9evxf",
+	"osmo19fs55cx4594een7qr8tglrjtt5h9jrxg458htd",
+	"osmo1ssp6px3fs3kwreles3ft6c07mfvj89a544yj9k",
+	"osmo1c5yu8498yzqte9cmfv5zcgtl07lhpjrj0skqdx",
+	"osmo1yhj3r9t9vw7qgeg22cehfzj7enwgklw5k5v7lj",
+	"osmo18nzmtyn5vy5y45dmcdnta8askldyvehx66lqgm",
+	"osmo1z2x9z58cg96ujvhvu6ga07yv9edq2mvkxpgwmc",
+	"osmo1tvf3373skua8e6480eyy38avv8mw3hnt8jcxg9",
+	"osmo1zs0txy03pv5crj2rvty8wemd3zhrka2ne8u05n",
+	"osmo1djgf9p53n7m5a55hcn6gg0cm5mue4r5g3fadee",
+	"osmo1488zldkrn8xcjh3z40v2mexq7d088qkna8ceze",
+}

--- a/x/mint/types/restricted_addresses_test.go
+++ b/x/mint/types/restricted_addresses_test.go
@@ -1,0 +1,30 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osmosis-labs/osmosis/v31/x/mint/types"
+)
+
+// osmoBech32Prefix is the account address prefix configured by the app at boot
+// (app/params.Bech32PrefixAccAddr). The types package cannot import app/params
+// without an import cycle, so it is restated here for the test.
+const osmoBech32Prefix = "osmo"
+
+// TestRestrictedAddressesParse guards the compiled-in restricted address list:
+// under the chain's bech32 prefix, every entry must be valid. The curated list
+// is edited by hand, so this catches a malformed entry at CI time rather than
+// silently skipping it at query time (where GetRestrictedSupply tolerates a bad
+// entry by skipping it).
+func TestRestrictedAddressesParse(t *testing.T) {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(osmoBech32Prefix, osmoBech32Prefix+"pub")
+
+	for _, s := range types.RestrictedAddresses {
+		_, err := sdk.AccAddressFromBech32(s)
+		require.NoError(t, err, "restricted address %q must be valid bech32 under the %q prefix", s, osmoBech32Prefix)
+	}
+}


### PR DESCRIPTION
## Linear
https://linear.app/osmosis/issue/OSMO-30/supply-endpoints

## What is the purpose of the change

Adds onchain supply-reporting endpoints to the mint module so Osmosis supply metrics (used for marketcap / FDV by data providers) can be queried directly from the chain instead of relying on offchain (Numia) computation. Methodology aligns with the Coingecko / CMC public-float definitions.

Four new read-only mint queries (gRPC + REST), plus a change to the existing `/inflation` denominator:

- `/osmosis/mint/v1beta1/burned_supply` — uosmo held in the null/burn address.
- `/osmosis/mint/v1beta1/total_supply` — minted (raw bank `GetSupply`) minus burned.
- `/osmosis/mint/v1beta1/restricted_supply` — uosmo excluded from public float: the developer-vesting module account, the community pool (read from the distribution `FeePool`), the dev-rewards receiver(s) in mint params, and a curated foundation/strategic constant. Each address term counts liquid balance plus staked (delegations converted via `TokensFromShares`).
- `/osmosis/mint/v1beta1/circulating_supply` — total minus restricted (public float).
- `/osmosis/mint/v1beta1/inflation` — denominator changed from offset-adjusted total supply to circulating supply. This is the economically correct base for an inflation rate and is query-only (see notes below).

### Design notes for reviewers

- **Point release, no consensus surface.** All new code is query-only — none of it is reachable from `BeginBlock`/`EndBlock`/`AfterEpochEnd`/minting (the sole caller of `GetInflation` is the gRPC querier). No new proto `Params` field (`Params` max field stays 8), no KVStore prefix change, no migration, no upgrade handler, no events emitted. The restricted-address set is a compiled-in Go constant (`x/mint/types/restricted_addresses.go`), deliberately kept out of consensus state so this can ship as a point release; updating the list is a code change in a future point release.
- **Developer vesting counted exactly once.** All supply math is built on raw bank `GetSupply`, never `GetSupplyWithOffset`. Dev vesting appears in `minted` once (+) and is subtracted in `restricted` once (−), netting to zero in circulating. Building on `GetSupplyWithOffset` would double-subtract it. Guarded by `TestDevVestingCountedExactlyOnce`.
- **No double-counting across the restricted sources.** `GetRestrictedSupply` de-duplicates addresses across the params-receiver loop and the constant, so an address present in both is counted once. The current params receiver is intentionally NOT in the constant (it is counted via the params loop). A code comment documents the maintenance implication: if governance removes an address from the dev-rewards param, review whether it should move into the constant.
- **CosmWasm exposure: none.** The new queries are not added to the Stargate query allowlist (`wasmbinding/stargate_whitelist.go`), so no contract can call them; the `/inflation` denominator change therefore has no contract-facing / determinism surface.
- **`/inflation` value note.** The reported inflation reads higher than before because the denominator (circulating) is smaller than the previous offset-total. Integrators/indexers charting `/inflation` should be aware of the step change. 
- **`total_supply` vs the existing LCD `by_denom`.** `total_supply` reads higher than `/cosmos/bank/.../supply/by_denom` by the dev-vesting offset — by design: the bank query applies the offset, this endpoint reports raw minted minus burned (the CMC/Coingecko total-supply definition).

## Testing and Verifying

This change added tests and was verified against mainnet state:

- Added unit tests in `x/mint/keeper/supply_test.go`: burned, total, the circulating accounting identity (`circulating == total − restricted == minted − burned − restricted`), the dev-vesting-counted-once regression, staked-amount inclusion (delegated OSMO counted via `TokensFromShares`), and all four gRPC handlers end to end.
- Added `x/mint/types/restricted_addresses_test.go`: validates every constant address parses as valid bech32 under the chain prefix.
- **Validated against real mainnet state** (node synced from snapshot): every component of restricted supply (dev-vesting account, community pool, params receiver, foundation, genesis receivers) was independently queried from the live LCD and summed; the node's `restricted_supply` reconciled to within block drift (~0.03%). `burned_supply` matched the LCD null-address balance exactly, and the `total − restricted == circulating` identity held on-node.

| Endpoint | New | Current |  Notes  |       
|-|-|-|-|
|/inflation|2.58%|1.89%|Increases as this becomes linked to Circulating Supply rather than Total supply|
|/total_supply| 810.2M | 977.4M | Replaces https://public-osmosis-api.numia.xyz/supply/v1/metrics?metric=totalSupply with onchain equivalent. Based on actual mintage rather than theoretical 1 billion hard cap|
|/burned_supply| 22.5m| 22.5m| Replaces https://public-osmosis-api.numia.xyz/supply/v1/metrics?metric=burntSupply with onchain equivalent|
|/restricted_supply| 241.9m | N/A | New metric required for Public float calculation |
|/circulating_supply| 568.3m| 777.7m| Replaces https://public-osmosis-api.numia.xyz/supply/v1/metrics?metric=circulatingSupply, moves to a public float calculation onchain. |

## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes?
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [x] Code comments?
  - [ ] N/A

