### PR TITLE
fix: return negotiated version from ibc-hooks OnChanOpenInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * [#9676](https://github.com/osmosis-labs/osmosis/pull/9676) chore: bump cometbft version to v0.38.22
+* [#9722](https://github.com/osmosis-labs/osmosis/pull/9722) fix: return the version negotiated by the underlying application from ibc-hooks `OnChanOpenInit`.
 
 ## v31.0.0
 

--- a/x/ibc-hooks/go.mod
+++ b/x/ibc-hooks/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/osmosis-labs/osmosis/osmomath v0.0.19
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.19
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.4
 )
@@ -166,7 +167,6 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/x/ibc-hooks/ibc_module.go
+++ b/x/ibc-hooks/ibc_module.go
@@ -50,7 +50,10 @@ func (im IBCMiddleware) OnChanOpenInit(
 	if hook, ok := im.ICS4Middleware.Hooks.(OnChanOpenInitAfterHooks); ok {
 		hook.OnChanOpenInitAfterHook(ctx, order, connectionHops, portID, channelID, channelCap, counterparty, version, finalVersion, err)
 	}
-	return version, err
+	// Return the version negotiated by the underlying application, core IBC
+	// writes the returned version onto the channel, echoing the proposed one
+	// would discard the negotiation.
+	return finalVersion, err
 }
 
 // OnChanOpenTry implements the IBCMiddleware interface

--- a/x/ibc-hooks/ibc_module_test.go
+++ b/x/ibc-hooks/ibc_module_test.go
@@ -1,0 +1,51 @@
+package ibc_hooks_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
+
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
+
+	ibchooks "github.com/osmosis-labs/osmosis/x/ibc-hooks"
+)
+
+type mockApp struct {
+	porttypes.IBCModule
+
+	negotiatedVersion string
+}
+
+func (m mockApp) OnChanOpenInit(
+	_ sdk.Context,
+	_ channeltypes.Order,
+	_ []string,
+	_, _ string,
+	_ *capabilitytypes.Capability,
+	_ channeltypes.Counterparty,
+	_ string,
+) (string, error) {
+	return m.negotiatedVersion, nil
+}
+
+func TestOnChanOpenInitReturnsNegotiatedVersion(t *testing.T) {
+	const negotiated = "ics20-1"
+	ics4 := ibchooks.NewICS4Middleware(nil, nil)
+	middleware := ibchooks.NewIBCMiddleware(mockApp{negotiatedVersion: negotiated}, &ics4)
+	version, err := middleware.OnChanOpenInit(
+		sdk.Context{},
+		channeltypes.UNORDERED,
+		[]string{"connection-0"},
+		"transfer",
+		"channel-0",
+		nil,
+		channeltypes.Counterparty{},
+		"",
+	)
+	require.NoError(t, err)
+	require.Equal(t, negotiated, version)
+}


### PR DESCRIPTION
return underlying application's negotiated version instead of caller's proposed version

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/9721

## What is the purpose of the change

`OnChanOpenInit` captured the underlying application's negotiated version as `finalVersion`, passed it to the after-hook, then returned the caller's proposed `version` instead.

```diff
-	return version, err
+	return finalVersion, err
```

Core IBC writes the returned version onto the channel, so a `ChanOpenInit` with an empty proposed version over a hooks-wrapped transfer stack wrote `""` while transfer had negotiated `ics20-1` — the version the counterparty validates later in the handshake. ibc-go's own middlewares (callbacks, PFM, ICA controller) all return the application's version.

Not an API or state-machine change: the signature is unchanged, and the after-hook already received both `version` and `finalVersion`, so hook implementations see no difference. Only stacks whose underlying app rewrites the version observe a different return value.

## Testing and Verifying

This change added tests and can be verified as follows:

  - Added `x/ibc-hooks/ibc_module_test.go` (first test in this module): the middleware is wired over a stub app that negotiates `ics20-1` from an empty proposal, and must return the negotiated version. It fails against the old code with `expected: "ics20-1", actual: ""` and passes with the fix.
  - `go mod tidy` promotes `stretchr/testify` to a direct dependency in `x/ibc-hooks/go.mod`.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? **No** — bug fix only.
  - [x] Changelog entry added to `Unreleased` section of `CHANGELOG.md`?

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Osmosis documentation site
  - [x] Code comments?
  - [ ] N/A
