### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/go-mod-auto-bump.yml
+++ b/.github/workflows/go-mod-auto-bump.yml
@@ -37,13 +37,17 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Fetch branches and checkout target
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
         run: |
-          git fetch origin ${{ inputs.target-branch }}
-          git checkout ${{ inputs.target-branch }}
+          git fetch origin "$TARGET_BRANCH"
+          git checkout "$TARGET_BRANCH"
 
       - name: Run script
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
         run: |
-          LATEST_TARGET_COMMIT=$(git rev-parse ${{ inputs.target-branch }})
+          LATEST_TARGET_COMMIT=$(git rev-parse "$TARGET_BRANCH")
           bash ./scripts/update-go-mod.sh $LATEST_TARGET_COMMIT
 
       - name: Add Changes
@@ -54,6 +58,8 @@ jobs:
 
       - name: Commit and Push Changes
         if: ${{ steps.add_changes.outputs.ANY_CHANGES_ADDED != '' }}
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
         run: |
-          git commit -m "Auto: update go.mod after push to ${{ inputs.target-branch }} that modified dependencies locally"
-          git push origin ${{ inputs.target-branch }}
+          git commit -m "Auto: update go.mod after push to ${TARGET_BRANCH} that modified dependencies locally"
+          git push origin "$TARGET_BRANCH"

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -66,10 +66,12 @@ jobs:
       -
         name: Create Docker Image Tag for release candidate
         if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          OSMOSIS_VERSION_INPUT: ${{ github.event.inputs.ref_name || github.ref_name }}
         run: |
           GITHUB_TAG=${{ github.event.inputs.ref_name || github.ref_name }}
           echo "DOCKER_IMAGE_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
-          echo "OSMOSIS_VERSION=${{ github.event.inputs.ref_name || github.ref_name }}" >> $GITHUB_ENV
+          echo "OSMOSIS_VERSION=${OSMOSIS_VERSION_INPUT}" >> $GITHUB_ENV
       -
         name: Create Docker Image Tag for vN.x branch
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/update-go-import-paths.yml
+++ b/.github/workflows/update-go-import-paths.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Display go version
         run: go version
       - name: Run find & replace script
-        run: ./scripts/replace_import_paths.sh ${{ inputs.version }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: ./scripts/replace_import_paths.sh "$VERSION"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
## Summary
- Bind `inputs.version` through `env:` before `replace_import_paths.sh`.
- Bind `github.event.inputs.ref_name` through `env:` before OSMOSIS_VERSION export in push-dev-docker-images.
- Bind `inputs.target-branch` through `env:` before git fetch/checkout/rev-parse/push in go-mod-auto-bump.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] update-go-import-paths still runs replace script with configured version
- [ ] push-dev-docker-images still resolves OSMOSIS_VERSION from dispatch/ref
- [ ] go-mod-auto-bump still checks out and pushes the target branch


Made with [Cursor](https://cursor.com)